### PR TITLE
Fix: editor-5 + button assigns random pid to new cells (#144)

### DIFF
--- a/notebooks/@tomlarkworthy_atlas.html
+++ b/notebooks/@tomlarkworthy_atlas.html
@@ -5639,7 +5639,7 @@ export default function define(runtime, observer) {
 >
 e30K
 </script>
-<script id="@tomlarkworthy/editor-5" 
+<script id="@tomlarkworthy/editor-5"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -6818,43 +6818,47 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1ju14cq = function _compile_and_update(compile,runtime,repositionSetElement){return(
-(source, variables = [], cell) => {
-    try {
-        debugger;
-        let reposition = false, insertionIndex = -1;
-        const newVariables = compile(source);
-        if (!variables || variables.length !== newVariables.length) {
-            reposition = true;
-            variables.forEach(v => v.delete());
-            variables.length = 0;
-            for (let i = 0; i < newVariables.length; i++) {
-                const newVariable = cell.module.module.variable({});
-                variables.push(newVariable);
+const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+{
+    return (source, variables = [], cell) => {
+        try {
+            debugger;
+            let reposition = false, insertionIndex = -1;
+            const newVariables = compile(source);
+            if (!variables || variables.length !== newVariables.length) {
+                reposition = true;
+                variables.forEach(v => v.delete());
+                variables.length = 0;
+                for (let i = 0; i < newVariables.length; i++) {
+                    const newVariable = cell.module.module.variable({});
+                    // Assign a random pid up-front so blank/identical new cells don't
+                    // collide via persistentId's contentHash. See lopecode#144.
+                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+                    variables.push(newVariable);
+                }
             }
-        }
-        if (reposition) {
-            insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-        }
-        newVariables.forEach((v, i) => {
-            const variable = variables[i];
-            let _fn;
-            eval('_fn = ' + v._definition);
-            if (v._name) {
-                variable.define(v._name, v._inputs, _fn);
-            } else {
-                variable.define(v._inputs, _fn);
+            if (reposition) {
+                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
-            if (reposition)
-                repositionSetElement(runtime._variables, variable, insertionIndex + i);
-        });
-        return variables;
-    } catch (e) {
-        console.error(e);
-        debugger;
-    }
-}
-)};
+            newVariables.forEach((v, i) => {
+                const variable = variables[i];
+                let _fn;
+                eval('_fn = ' + v._definition);
+                if (v._name) {
+                    variable.define(v._name, v._inputs, _fn);
+                } else {
+                    variable.define(v._inputs, _fn);
+                }
+                if (reposition)
+                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
+            });
+            return variables;
+        } catch (e) {
+            console.error(e);
+            debugger;
+        }
+    };
+};
 const _1jqs8in = function _91(md){return(
 md`### Remove Cells`
 )};
@@ -7044,7 +7048,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1ju14cq", "compile_and_update", ["compile","runtime","repositionSetElement"], _1ju14cq);  
+  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -7091,7 +7095,8 @@ export default function define(runtime, observer) {
   main.define("navHref", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("navHref", _));  
   main.define("cellsToClipboard", ["module @tomlarkworthy/cells-to-clipboard", "@variable"], (_, v) => v.import("cellsToClipboard", _));
   return main;
-}</script>
+}
+</script>
 <script id="@tomlarkworthy/escodegen/escodegen.browser.min.js.gz" 
   type="text/plain"
   data-encoding="base64"

--- a/notebooks/@tomlarkworthy_atproto-comments.html
+++ b/notebooks/@tomlarkworthy_atproto-comments.html
@@ -4838,7 +4838,7 @@ export default function define(runtime, observer) {
 >
 e30K
 </script>
-<script id="@tomlarkworthy/editor-5" 
+<script id="@tomlarkworthy/editor-5"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -4885,7 +4885,6 @@ md`## TODO
 const _1ociws4 = function _6(md){return(
 md`## Sync editors`
 )};
-const _1vq49kx = (_, v) => v.import("syncers", _);
 const _hdieof = function _editors(){return(
 new Map()
 )};
@@ -4963,12 +4962,12 @@ Inputs.toggle({
   value: !isOnObservableCom()
 })
 )};
+const _1oaz8r1 = (G, _) => G.input(_);
 const _16ks4jz = function _12(md){return(
 md`## \`cellEditor\` component
 
 Using Dataflow templating to create reusable Hotbar Component builder`
 )};
-const _1deps8p = (_, v) => v.import("cloneDataflow", _);
 const _199ztvl = function _hotbarTemplate(lookupVariable,editorModule){return(
 lookupVariable(
   [
@@ -5205,6 +5204,7 @@ md`## Hotbar Prototype`
 const _1o2h65s = function _editedCell(Inputs){return(
 Inputs.input(null)
 )};
+const _7g3h7h = (G, _) => G.input(_);
 const _1urs1md = function _findCell($0,modules){return(
 (variable, dom = undefined) => {
   if (variable) {
@@ -5364,9 +5364,11 @@ Inputs.toggle({
   value: true
 })
 )};
+const _1h8337z = (G, _) => G.input(_);
 const _tct2nf = function _edit(Inputs){return(
 Inputs.toggle({ label: "edit" })
 )};
+const _7izj7k = (G, _) => G.input(_);
 const _1fwb5jc = function _toolbar(htl,reversibleAttach,combine,$0,$1,$2,$3,$4,$5,$6,$7){return(
 htl.html`<div
     class="toolbar"
@@ -5394,11 +5396,13 @@ Inputs.button("➕", {
   }
 })
 )};
+const _1aii9ps = (G, _) => G.input(_);
 const _1bn860e = function _remove(Inputs,deleteCell,$0){return(
 Inputs.button("🗑️", {
   reduce: () => deleteCell({ cell: $0.value })
 })
 )};
+const _1ad0xr8 = (G, _) => G.input(_);
 const _tw1j7n = function _apply(Inputs,compile_and_update,states,editedCell)
 {
   const button = Inputs.button("▶️", {
@@ -5417,11 +5421,13 @@ const _tw1j7n = function _apply(Inputs,compile_and_update,states,editedCell)
   button.onmousedown = (e) => e.preventDefault();
   return button;
 };
+const _1cjyuqm = (G, _) => G.input(_);
 const _14rfku9 = function _up(Inputs,moveCell,$0){return(
 Inputs.button("⬆", {
   reduce: () => moveCell($0.value, -1)
 })
 )};
+const _frzs5d = (G, _) => G.input(_);
 const _9pymuj = function _paste(Inputs,readObservableClipboardCells,pasteObservableCellsIntoModule,editedCell){return(
 Inputs.button("📋", {
   reduce: async () => {
@@ -5430,11 +5436,13 @@ Inputs.button("📋", {
   }
 })
 )};
+const _1whsszt = (G, _) => G.input(_);
 const _corxwl = function _down(Inputs,moveCell,$0){return(
 Inputs.button("⬇", {
   reduce: () => moveCell($0.value, 1)
 })
 )};
+const _1to28po = (G, _) => G.input(_);
 const _gia2ci = function _copy(Inputs,html,$0,decompile,$1,getOption,cellsToClipboard){return(
 Inputs.button(
   html`<span style="font-size: .875em; margin-right: .125em; position: relative; top: -.25em; left: -.125em">
@@ -5476,6 +5484,7 @@ Inputs.button(
   }
 )
 )};
+const _fw41wt = (G, _) => G.input(_);
 const _srtw8o = function _module(editedCell){return(
 editedCell.module.module
 )};
@@ -5530,6 +5539,7 @@ md`## API handler`
 const _d7ouqx = function _command(flowQueue){return(
 flowQueue()
 )};
+const _118qt2v = (G, _) => G.input(_);
 const _19l2nem = function _54(command){return(
 command
 )};
@@ -5802,10 +5812,10 @@ const _rtf009 = function _select(editedCell,Inputs,getOption,setOption){return(
   return el;
 })()
 )};
+const _14mwbuc = (G, _) => G.input(_);
 const _l4sbcd = function _70(md){return(
 md`## Pinning`
 )};
-const _1sxszb9 = (_, v) => v.import("getFileAttachment", _);
 const _ezl7wk = function _72(FileAttachment){return(
 FileAttachment("cell_options.json")
 )};
@@ -5815,6 +5825,7 @@ getFileAttachment("cell_options.json", editorModule)
 const _760ozq = async function _options(Inputs,optionsFile){return(
 Inputs.input(await optionsFile.json())
 )};
+const _4rh26k = (G, _) => G.input(_);
 const _1lqy7cs = function _setOption(findCell,_,$0,Event){return(
 (variable, option, value) => {
   const cell = findCell(variable);
@@ -5994,6 +6005,7 @@ const _1j3c2uf = function _decompiled(editedCell,decompile)
 const _w5q3yf = function _editorModule(thisModule){return(
 thisModule()
 )};
+const _18kaj2p = (G, _) => G.input(_);
 const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_options)
 {
   //editedCell;
@@ -6005,43 +6017,47 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1ju14cq = function _compile_and_update(compile,runtime,repositionSetElement){return(
-(source, variables = [], cell) => {
-    try {
-        debugger;
-        let reposition = false, insertionIndex = -1;
-        const newVariables = compile(source);
-        if (!variables || variables.length !== newVariables.length) {
-            reposition = true;
-            variables.forEach(v => v.delete());
-            variables.length = 0;
-            for (let i = 0; i < newVariables.length; i++) {
-                const newVariable = cell.module.module.variable({});
-                variables.push(newVariable);
+const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+{
+    return (source, variables = [], cell) => {
+        try {
+            debugger;
+            let reposition = false, insertionIndex = -1;
+            const newVariables = compile(source);
+            if (!variables || variables.length !== newVariables.length) {
+                reposition = true;
+                variables.forEach(v => v.delete());
+                variables.length = 0;
+                for (let i = 0; i < newVariables.length; i++) {
+                    const newVariable = cell.module.module.variable({});
+                    // Assign a random pid up-front so blank/identical new cells don't
+                    // collide via persistentId's contentHash. See lopecode#144.
+                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+                    variables.push(newVariable);
+                }
             }
-        }
-        if (reposition) {
-            insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-        }
-        newVariables.forEach((v, i) => {
-            const variable = variables[i];
-            let _fn;
-            eval('_fn = ' + v._definition);
-            if (v._name) {
-                variable.define(v._name, v._inputs, _fn);
-            } else {
-                variable.define(v._inputs, _fn);
+            if (reposition) {
+                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
-            if (reposition)
-                repositionSetElement(runtime._variables, variable, insertionIndex + i);
-        });
-        return variables;
-    } catch (e) {
-        console.error(e);
-        debugger;
-    }
-}
-)};
+            newVariables.forEach((v, i) => {
+                const variable = variables[i];
+                let _fn;
+                eval('_fn = ' + v._definition);
+                if (v._name) {
+                    variable.define(v._name, v._inputs, _fn);
+                } else {
+                    variable.define(v._inputs, _fn);
+                }
+                if (reposition)
+                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
+            });
+            return variables;
+        } catch (e) {
+            console.error(e);
+            debugger;
+        }
+    };
+};
 const _1jqs8in = function _91(md){return(
 md`### Remove Cells`
 )};
@@ -6060,6 +6076,7 @@ Inputs.radio(editedCell.variables, {
   value: editedCell.variables[0]
 })
 )};
+const _11gvkq4 = (G, _) => G.input(_);
 const _r5nvms = function _name(variable){return(
 variable._name
 )};
@@ -6073,6 +6090,7 @@ Inputs.textarea({
   rows: 10
 })
 )};
+const _b4rsn5 = (G, _) => G.input(_);
 const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
@@ -6086,22 +6104,12 @@ Inputs.button("update variable", {
 const _1q557s = function _99(md){return(
 md`### Editor Libraries`
 )};
-const _192vvs7 = (_, v) => v.import("descendants", _);
-const _3va6tf = (_, v) => v.import("EditorState", _);
-const _lmqjiv = (_, v) => v.import("decompile", _);
 const _1d94dks = function _javascriptPlugin(codemirror){return(
 codemirror
 )};
 const _ar9tao = function _104(md){return(
 md`### Libraries`
 )};
-const _viogn = (_, v) => v.import("reversibleAttach", _);
-const _nxg8mr = (_, v) => v.import("moduleMap", _);
-const _14a94d = (_, v) => v.import("flowQueue", _);
-const _gurtwb = (_, v) => v.import("viewof liveCellMap", _);
-const _19ebgtz = (_, v) => v.import("hash", _);
-const _n2vgkz = (_, v) => v.import("extractNotebookAndCell", _);
-const _1qucevb = (_, v) => v.import("cellsToClipboard", _);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -6115,22 +6123,34 @@ export default function define(runtime, observer) {
     return [name, {url: blob_url, mimeType: mime}]
   }));
   main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
+  main.define("module @tomlarkworthy/dataflow-templating", async () => runtime.module((await import("/@tomlarkworthy/dataflow-templating.js?v=4")).default));  
+  main.define("module @tomlarkworthy/fileattachments", async () => runtime.module((await import("/@tomlarkworthy/fileattachments.js?v=4")).default));  
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/codemirror-6-v2", async () => runtime.module((await import("/@tomlarkworthy/codemirror-6-v2.js?v=4")).default));  
+  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
+  main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
+  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
+  main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
+  main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
+  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
+  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
+  main.define("module @tomlarkworthy/cells-to-clipboard", async () => runtime.module((await import("/@tomlarkworthy/cells-to-clipboard.js?v=4")).default));  
   $def("_1tdjp0a", "title", ["md"], _1tdjp0a);  
   $def("_dm53bx", null, ["md"], _dm53bx);  
   $def("_61oxjf", "title_variable", ["lookupVariable","editorModule"], _61oxjf);  
   $def("_15uilf0", null, ["cellEditor","title_variable"], _15uilf0);  
   $def("_3x695f", null, ["md"], _3x695f);  
   $def("_1ociws4", null, ["md"], _1ociws4);  
-  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
   $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
-  main.variable(observer("attachContextManu")).define("attachContextManu", ["Generators", "viewof attachContextManu"], (G, _) => G.input(_));  
+  $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
   $def("_16ks4jz", null, ["md"], _16ks4jz);  
-  main.define("module @tomlarkworthy/dataflow-templating", async () => runtime.module((await import("/@tomlarkworthy/dataflow-templating.js?v=4")).default));  
   main.define("cloneDataflow", ["module @tomlarkworthy/dataflow-templating", "@variable"], (_, v) => v.import("cloneDataflow", _));  
   main.define("lookupVariable", ["module @tomlarkworthy/dataflow-templating", "@variable"], (_, v) => v.import("lookupVariable", _));  
   $def("_199ztvl", "hotbarTemplate", ["lookupVariable","editorModule"], _199ztvl);  
@@ -6141,7 +6161,7 @@ export default function define(runtime, observer) {
   $def("_110gwi7", "editorTemplate", ["lookupVariable","editorModule"], _110gwi7);  
   $def("_16rqzgl", null, ["md"], _16rqzgl);  
   $def("_1o2h65s", "viewof editedCell", ["Inputs"], _1o2h65s);  
-  main.variable(observer("editedCell")).define("editedCell", ["Generators", "viewof editedCell"], (G, _) => G.input(_));  
+  $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
   $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
@@ -6156,24 +6176,24 @@ export default function define(runtime, observer) {
   $def("_mrrmx3", null, ["md"], _mrrmx3);  
   $def("_14b1byw", null, ["md"], _14b1byw);  
   $def("_1j1loxx", "viewof combine", ["Inputs"], _1j1loxx);  
-  main.variable(observer("combine")).define("combine", ["Generators", "viewof combine"], (G, _) => G.input(_));  
+  $def("_1h8337z", "combine", ["Generators","viewof combine"], _1h8337z);  
   $def("_tct2nf", "viewof edit", ["Inputs"], _tct2nf);  
-  main.variable(observer("edit")).define("edit", ["Generators", "viewof edit"], (G, _) => G.input(_));  
+  $def("_7izj7k", "edit", ["Generators","viewof edit"], _7izj7k);  
   $def("_1fwb5jc", "toolbar", ["htl","reversibleAttach","combine","viewof select","viewof up","viewof down","viewof remove","viewof addCells","viewof apply","viewof copy","viewof paste"], _1fwb5jc);  
   $def("_yej3hb", "viewof addCells", ["Inputs","createCell","viewof editedCell"], _yej3hb);  
-  main.variable(observer("addCells")).define("addCells", ["Generators", "viewof addCells"], (G, _) => G.input(_));  
+  $def("_1aii9ps", "addCells", ["Generators","viewof addCells"], _1aii9ps);  
   $def("_1bn860e", "viewof remove", ["Inputs","deleteCell","viewof editedCell"], _1bn860e);  
-  main.variable(observer("remove")).define("remove", ["Generators", "viewof remove"], (G, _) => G.input(_));  
+  $def("_1ad0xr8", "remove", ["Generators","viewof remove"], _1ad0xr8);  
   $def("_tw1j7n", "viewof apply", ["Inputs","compile_and_update","states","editedCell"], _tw1j7n);  
-  main.variable(observer("apply")).define("apply", ["Generators", "viewof apply"], (G, _) => G.input(_));  
+  $def("_1cjyuqm", "apply", ["Generators","viewof apply"], _1cjyuqm);  
   $def("_14rfku9", "viewof up", ["Inputs","moveCell","viewof editedCell"], _14rfku9);  
-  main.variable(observer("up")).define("up", ["Generators", "viewof up"], (G, _) => G.input(_));  
+  $def("_frzs5d", "up", ["Generators","viewof up"], _frzs5d);  
   $def("_9pymuj", "viewof paste", ["Inputs","readObservableClipboardCells","pasteObservableCellsIntoModule","editedCell"], _9pymuj);  
-  main.variable(observer("paste")).define("paste", ["Generators", "viewof paste"], (G, _) => G.input(_));  
+  $def("_1whsszt", "paste", ["Generators","viewof paste"], _1whsszt);  
   $def("_corxwl", "viewof down", ["Inputs","moveCell","viewof editedCell"], _corxwl);  
-  main.variable(observer("down")).define("down", ["Generators", "viewof down"], (G, _) => G.input(_));  
+  $def("_1to28po", "down", ["Generators","viewof down"], _1to28po);  
   $def("_gia2ci", "viewof copy", ["Inputs","html","viewof editedCell","decompile","viewof liveCellMap","getOption","cellsToClipboard"], _gia2ci);  
-  main.variable(observer("copy")).define("copy", ["Generators", "viewof copy"], (G, _) => G.input(_));  
+  $def("_fw41wt", "copy", ["Generators","viewof copy"], _fw41wt);  
   $def("_srtw8o", "module", ["editedCell"], _srtw8o);  
   $def("_rv7t7x", "code_editor_view", ["EditorView"], _rv7t7x);  
   $def("_xvo1n6", "code_editor", ["code_editor_view"], _xvo1n6);  
@@ -6183,7 +6203,7 @@ export default function define(runtime, observer) {
   $def("_d9nzys", "deleteCell", ["viewof command"], _d9nzys);  
   $def("_c1u9w8", null, ["md"], _c1u9w8);  
   $def("_d7ouqx", "viewof command", ["flowQueue"], _d7ouqx);  
-  main.variable(observer("command")).define("command", ["Generators", "viewof command"], (G, _) => G.input(_));  
+  $def("_118qt2v", "command", ["Generators","viewof command"], _118qt2v);  
   $def("_19l2nem", null, ["command"], _19l2nem);  
   $def("_1f6v167", "findCellByVariable", [], _1f6v167);  
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
@@ -6200,9 +6220,8 @@ export default function define(runtime, observer) {
   $def("_dvne2z", "replaceCodeMirrorDoc", [], _dvne2z);  
   $def("_1fpqfm0", null, ["md"], _1fpqfm0);  
   $def("_rtf009", "viewof select", ["editedCell","Inputs","getOption","setOption"], _rtf009);  
-  main.variable(observer("select")).define("select", ["Generators", "viewof select"], (G, _) => G.input(_));  
+  $def("_14mwbuc", "select", ["Generators","viewof select"], _14mwbuc);  
   $def("_l4sbcd", null, ["md"], _l4sbcd);  
-  main.define("module @tomlarkworthy/fileattachments", async () => runtime.module((await import("/@tomlarkworthy/fileattachments.js?v=4")).default));  
   main.define("getFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachment", _));  
   main.define("setFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("setFileAttachment", _));  
   main.define("removeFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("removeFileAttachment", _));  
@@ -6211,7 +6230,7 @@ export default function define(runtime, observer) {
   $def("_ezl7wk", null, ["FileAttachment"], _ezl7wk);  
   $def("_kygz54", "optionsFile", ["getFileAttachment","editorModule"], _kygz54);  
   $def("_760ozq", "viewof options", ["Inputs","optionsFile"], _760ozq);  
-  main.variable(observer("options")).define("options", ["Generators", "viewof options"], (G, _) => G.input(_));  
+  $def("_4rh26k", "options", ["Generators","viewof options"], _4rh26k);  
   $def("_1lqy7cs", "setOption", ["findCell","_","viewof options","Event"], _1lqy7cs);  
   $def("_1oxe5ee", "getOption", ["findCell","_","viewof options"], _1oxe5ee);  
   $def("_kwq69p", "save_options", ["setFileAttachment","jsonFileAttachment","options","editorModule"], _kwq69p);  
@@ -6225,22 +6244,21 @@ export default function define(runtime, observer) {
   $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
   $def("_1j3c2uf", "decompiled", ["editedCell","decompile"], _1j3c2uf);  
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
-  main.variable(observer("editorModule")).define("editorModule", ["Generators", "viewof editorModule"], (G, _) => G.input(_));  
+  $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1ju14cq", "compile_and_update", ["compile","runtime","repositionSetElement"], _1ju14cq);  
+  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
   $def("_rwez9", "viewof variable", ["Inputs","editedCell"], _rwez9);  
-  main.variable(observer("variable")).define("variable", ["Generators", "viewof variable"], (G, _) => G.input(_));  
+  $def("_11gvkq4", "variable", ["Generators","viewof variable"], _11gvkq4);  
   $def("_r5nvms", "name", ["variable"], _r5nvms);  
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
-  main.variable(observer("definition")).define("definition", ["Generators", "viewof definition"], (G, _) => G.input(_));  
+  $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
   $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
   $def("_1q557s", null, ["md"], _1q557s);  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -6251,12 +6269,10 @@ export default function define(runtime, observer) {
   main.define("isnode", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("isnode", _));  
   main.define("repositionSetElement", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("repositionSetElement", _));  
   main.define("onCodeChange", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("onCodeChange", _));  
-  main.define("module @tomlarkworthy/codemirror-6-v2", async () => runtime.module((await import("/@tomlarkworthy/codemirror-6-v2.js?v=4")).default));  
   main.define("EditorState", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("EditorState", _));  
   main.define("EditorView", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("EditorView", _));  
   main.define("codemirror", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("codemirror", _));  
   main.define("myDefaultTheme", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("myDefaultTheme", _));  
-  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
   main.define("decompile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("decompile", _));  
   main.define("compile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("compile", _));  
   main.define("cellMap", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("cellMap", _));  
@@ -6265,27 +6281,21 @@ export default function define(runtime, observer) {
   main.define("parser", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("parser", _));  
   $def("_1d94dks", "javascriptPlugin", ["codemirror"], _1d94dks);  
   $def("_ar9tao", null, ["md"], _ar9tao);  
-  main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
   main.define("reversibleAttach", ["module @tomlarkworthy/reversible-attachment", "@variable"], (_, v) => v.import("reversibleAttach", _));  
-  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
   main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
-  main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
   main.define("flowQueue", ["module @tomlarkworthy/flow-queue", "@variable"], (_, v) => v.import("flowQueue", _));  
-  main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
   main.define("viewof liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("viewof liveCellMap", _));  
   main.define("liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("liveCellMap", _));  
-  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
   main.define("hash", ["module d/57d79353bac56631@44", "@variable"], (_, v) => v.import("hash", _));  
-  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
   main.define("extractNotebookAndCell", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("extractNotebookAndCell", _));  
   main.define("navHref", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("navHref", _));  
-  main.define("module @tomlarkworthy/cells-to-clipboard", async () => runtime.module((await import("/@tomlarkworthy/cells-to-clipboard.js?v=4")).default));  
   main.define("cellsToClipboard", ["module @tomlarkworthy/cells-to-clipboard", "@variable"], (_, v) => v.import("cellsToClipboard", _));
   return main;
-}</script>
+}
+</script>
 <script id="@tomlarkworthy/escodegen/escodegen.browser.min.js.gz" 
   type="text/plain"
   data-encoding="base64"

--- a/notebooks/@tomlarkworthy_blank-notebook.html
+++ b/notebooks/@tomlarkworthy_blank-notebook.html
@@ -4729,7 +4729,7 @@ export default function define(runtime, observer) {
 >
 e30K
 </script>
-<script id="@tomlarkworthy/editor-5" 
+<script id="@tomlarkworthy/editor-5"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -4776,7 +4776,6 @@ md`## TODO
 const _1ociws4 = function _6(md){return(
 md`## Sync editors`
 )};
-const _1vq49kx = (_, v) => v.import("syncers", _);
 const _hdieof = function _editors(){return(
 new Map()
 )};
@@ -4854,12 +4853,12 @@ Inputs.toggle({
   value: !isOnObservableCom()
 })
 )};
+const _1oaz8r1 = (G, _) => G.input(_);
 const _16ks4jz = function _12(md){return(
 md`## \`cellEditor\` component
 
 Using Dataflow templating to create reusable Hotbar Component builder`
 )};
-const _1deps8p = (_, v) => v.import("cloneDataflow", _);
 const _199ztvl = function _hotbarTemplate(lookupVariable,editorModule){return(
 lookupVariable(
   [
@@ -5096,6 +5095,7 @@ md`## Hotbar Prototype`
 const _1o2h65s = function _editedCell(Inputs){return(
 Inputs.input(null)
 )};
+const _7g3h7h = (G, _) => G.input(_);
 const _1urs1md = function _findCell($0,modules){return(
 (variable, dom = undefined) => {
   if (variable) {
@@ -5255,9 +5255,11 @@ Inputs.toggle({
   value: true
 })
 )};
+const _1h8337z = (G, _) => G.input(_);
 const _tct2nf = function _edit(Inputs){return(
 Inputs.toggle({ label: "edit" })
 )};
+const _7izj7k = (G, _) => G.input(_);
 const _1fwb5jc = function _toolbar(htl,reversibleAttach,combine,$0,$1,$2,$3,$4,$5,$6,$7){return(
 htl.html`<div
     class="toolbar"
@@ -5285,11 +5287,13 @@ Inputs.button("➕", {
   }
 })
 )};
+const _1aii9ps = (G, _) => G.input(_);
 const _1bn860e = function _remove(Inputs,deleteCell,$0){return(
 Inputs.button("🗑️", {
   reduce: () => deleteCell({ cell: $0.value })
 })
 )};
+const _1ad0xr8 = (G, _) => G.input(_);
 const _tw1j7n = function _apply(Inputs,compile_and_update,states,editedCell)
 {
   const button = Inputs.button("▶️", {
@@ -5308,11 +5312,13 @@ const _tw1j7n = function _apply(Inputs,compile_and_update,states,editedCell)
   button.onmousedown = (e) => e.preventDefault();
   return button;
 };
+const _1cjyuqm = (G, _) => G.input(_);
 const _14rfku9 = function _up(Inputs,moveCell,$0){return(
 Inputs.button("⬆", {
   reduce: () => moveCell($0.value, -1)
 })
 )};
+const _frzs5d = (G, _) => G.input(_);
 const _9pymuj = function _paste(Inputs,readObservableClipboardCells,pasteObservableCellsIntoModule,editedCell){return(
 Inputs.button("📋", {
   reduce: async () => {
@@ -5321,11 +5327,13 @@ Inputs.button("📋", {
   }
 })
 )};
+const _1whsszt = (G, _) => G.input(_);
 const _corxwl = function _down(Inputs,moveCell,$0){return(
 Inputs.button("⬇", {
   reduce: () => moveCell($0.value, 1)
 })
 )};
+const _1to28po = (G, _) => G.input(_);
 const _gia2ci = function _copy(Inputs,html,$0,decompile,$1,getOption,cellsToClipboard){return(
 Inputs.button(
   html`<span style="font-size: .875em; margin-right: .125em; position: relative; top: -.25em; left: -.125em">
@@ -5367,6 +5375,7 @@ Inputs.button(
   }
 )
 )};
+const _fw41wt = (G, _) => G.input(_);
 const _srtw8o = function _module(editedCell){return(
 editedCell.module.module
 )};
@@ -5421,6 +5430,7 @@ md`## API handler`
 const _d7ouqx = function _command(flowQueue){return(
 flowQueue()
 )};
+const _118qt2v = (G, _) => G.input(_);
 const _19l2nem = function _54(command){return(
 command
 )};
@@ -5693,10 +5703,10 @@ const _rtf009 = function _select(editedCell,Inputs,getOption,setOption){return(
   return el;
 })()
 )};
+const _14mwbuc = (G, _) => G.input(_);
 const _l4sbcd = function _70(md){return(
 md`## Pinning`
 )};
-const _1sxszb9 = (_, v) => v.import("getFileAttachment", _);
 const _ezl7wk = function _72(FileAttachment){return(
 FileAttachment("cell_options.json")
 )};
@@ -5706,6 +5716,7 @@ getFileAttachment("cell_options.json", editorModule)
 const _760ozq = async function _options(Inputs,optionsFile){return(
 Inputs.input(await optionsFile.json())
 )};
+const _4rh26k = (G, _) => G.input(_);
 const _1lqy7cs = function _setOption(findCell,_,$0,Event){return(
 (variable, option, value) => {
   const cell = findCell(variable);
@@ -5885,6 +5896,7 @@ const _1j3c2uf = function _decompiled(editedCell,decompile)
 const _w5q3yf = function _editorModule(thisModule){return(
 thisModule()
 )};
+const _18kaj2p = (G, _) => G.input(_);
 const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_options)
 {
   //editedCell;
@@ -5896,43 +5908,47 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1ju14cq = function _compile_and_update(compile,runtime,repositionSetElement){return(
-(source, variables = [], cell) => {
-    try {
-        debugger;
-        let reposition = false, insertionIndex = -1;
-        const newVariables = compile(source);
-        if (!variables || variables.length !== newVariables.length) {
-            reposition = true;
-            variables.forEach(v => v.delete());
-            variables.length = 0;
-            for (let i = 0; i < newVariables.length; i++) {
-                const newVariable = cell.module.module.variable({});
-                variables.push(newVariable);
+const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+{
+    return (source, variables = [], cell) => {
+        try {
+            debugger;
+            let reposition = false, insertionIndex = -1;
+            const newVariables = compile(source);
+            if (!variables || variables.length !== newVariables.length) {
+                reposition = true;
+                variables.forEach(v => v.delete());
+                variables.length = 0;
+                for (let i = 0; i < newVariables.length; i++) {
+                    const newVariable = cell.module.module.variable({});
+                    // Assign a random pid up-front so blank/identical new cells don't
+                    // collide via persistentId's contentHash. See lopecode#144.
+                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+                    variables.push(newVariable);
+                }
             }
-        }
-        if (reposition) {
-            insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-        }
-        newVariables.forEach((v, i) => {
-            const variable = variables[i];
-            let _fn;
-            eval('_fn = ' + v._definition);
-            if (v._name) {
-                variable.define(v._name, v._inputs, _fn);
-            } else {
-                variable.define(v._inputs, _fn);
+            if (reposition) {
+                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
-            if (reposition)
-                repositionSetElement(runtime._variables, variable, insertionIndex + i);
-        });
-        return variables;
-    } catch (e) {
-        console.error(e);
-        debugger;
-    }
-}
-)};
+            newVariables.forEach((v, i) => {
+                const variable = variables[i];
+                let _fn;
+                eval('_fn = ' + v._definition);
+                if (v._name) {
+                    variable.define(v._name, v._inputs, _fn);
+                } else {
+                    variable.define(v._inputs, _fn);
+                }
+                if (reposition)
+                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
+            });
+            return variables;
+        } catch (e) {
+            console.error(e);
+            debugger;
+        }
+    };
+};
 const _1jqs8in = function _91(md){return(
 md`### Remove Cells`
 )};
@@ -5951,6 +5967,7 @@ Inputs.radio(editedCell.variables, {
   value: editedCell.variables[0]
 })
 )};
+const _11gvkq4 = (G, _) => G.input(_);
 const _r5nvms = function _name(variable){return(
 variable._name
 )};
@@ -5964,6 +5981,7 @@ Inputs.textarea({
   rows: 10
 })
 )};
+const _b4rsn5 = (G, _) => G.input(_);
 const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
@@ -5977,22 +5995,12 @@ Inputs.button("update variable", {
 const _1q557s = function _99(md){return(
 md`### Editor Libraries`
 )};
-const _192vvs7 = (_, v) => v.import("descendants", _);
-const _3va6tf = (_, v) => v.import("EditorState", _);
-const _lmqjiv = (_, v) => v.import("decompile", _);
 const _1d94dks = function _javascriptPlugin(codemirror){return(
 codemirror
 )};
 const _ar9tao = function _104(md){return(
 md`### Libraries`
 )};
-const _viogn = (_, v) => v.import("reversibleAttach", _);
-const _nxg8mr = (_, v) => v.import("moduleMap", _);
-const _14a94d = (_, v) => v.import("flowQueue", _);
-const _gurtwb = (_, v) => v.import("viewof liveCellMap", _);
-const _19ebgtz = (_, v) => v.import("hash", _);
-const _n2vgkz = (_, v) => v.import("extractNotebookAndCell", _);
-const _1qucevb = (_, v) => v.import("cellsToClipboard", _);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -6006,22 +6014,34 @@ export default function define(runtime, observer) {
     return [name, {url: blob_url, mimeType: mime}]
   }));
   main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
+  main.define("module @tomlarkworthy/dataflow-templating", async () => runtime.module((await import("/@tomlarkworthy/dataflow-templating.js?v=4")).default));  
+  main.define("module @tomlarkworthy/fileattachments", async () => runtime.module((await import("/@tomlarkworthy/fileattachments.js?v=4")).default));  
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/codemirror-6-v2", async () => runtime.module((await import("/@tomlarkworthy/codemirror-6-v2.js?v=4")).default));  
+  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
+  main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
+  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
+  main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
+  main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
+  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
+  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
+  main.define("module @tomlarkworthy/cells-to-clipboard", async () => runtime.module((await import("/@tomlarkworthy/cells-to-clipboard.js?v=4")).default));  
   $def("_1tdjp0a", "title", ["md"], _1tdjp0a);  
   $def("_dm53bx", null, ["md"], _dm53bx);  
   $def("_61oxjf", "title_variable", ["lookupVariable","editorModule"], _61oxjf);  
   $def("_15uilf0", null, ["cellEditor","title_variable"], _15uilf0);  
   $def("_3x695f", null, ["md"], _3x695f);  
   $def("_1ociws4", null, ["md"], _1ociws4);  
-  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
   $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
-  main.variable(observer("attachContextManu")).define("attachContextManu", ["Generators", "viewof attachContextManu"], (G, _) => G.input(_));  
+  $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
   $def("_16ks4jz", null, ["md"], _16ks4jz);  
-  main.define("module @tomlarkworthy/dataflow-templating", async () => runtime.module((await import("/@tomlarkworthy/dataflow-templating.js?v=4")).default));  
   main.define("cloneDataflow", ["module @tomlarkworthy/dataflow-templating", "@variable"], (_, v) => v.import("cloneDataflow", _));  
   main.define("lookupVariable", ["module @tomlarkworthy/dataflow-templating", "@variable"], (_, v) => v.import("lookupVariable", _));  
   $def("_199ztvl", "hotbarTemplate", ["lookupVariable","editorModule"], _199ztvl);  
@@ -6032,7 +6052,7 @@ export default function define(runtime, observer) {
   $def("_110gwi7", "editorTemplate", ["lookupVariable","editorModule"], _110gwi7);  
   $def("_16rqzgl", null, ["md"], _16rqzgl);  
   $def("_1o2h65s", "viewof editedCell", ["Inputs"], _1o2h65s);  
-  main.variable(observer("editedCell")).define("editedCell", ["Generators", "viewof editedCell"], (G, _) => G.input(_));  
+  $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
   $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
@@ -6047,24 +6067,24 @@ export default function define(runtime, observer) {
   $def("_mrrmx3", null, ["md"], _mrrmx3);  
   $def("_14b1byw", null, ["md"], _14b1byw);  
   $def("_1j1loxx", "viewof combine", ["Inputs"], _1j1loxx);  
-  main.variable(observer("combine")).define("combine", ["Generators", "viewof combine"], (G, _) => G.input(_));  
+  $def("_1h8337z", "combine", ["Generators","viewof combine"], _1h8337z);  
   $def("_tct2nf", "viewof edit", ["Inputs"], _tct2nf);  
-  main.variable(observer("edit")).define("edit", ["Generators", "viewof edit"], (G, _) => G.input(_));  
+  $def("_7izj7k", "edit", ["Generators","viewof edit"], _7izj7k);  
   $def("_1fwb5jc", "toolbar", ["htl","reversibleAttach","combine","viewof select","viewof up","viewof down","viewof remove","viewof addCells","viewof apply","viewof copy","viewof paste"], _1fwb5jc);  
   $def("_yej3hb", "viewof addCells", ["Inputs","createCell","viewof editedCell"], _yej3hb);  
-  main.variable(observer("addCells")).define("addCells", ["Generators", "viewof addCells"], (G, _) => G.input(_));  
+  $def("_1aii9ps", "addCells", ["Generators","viewof addCells"], _1aii9ps);  
   $def("_1bn860e", "viewof remove", ["Inputs","deleteCell","viewof editedCell"], _1bn860e);  
-  main.variable(observer("remove")).define("remove", ["Generators", "viewof remove"], (G, _) => G.input(_));  
+  $def("_1ad0xr8", "remove", ["Generators","viewof remove"], _1ad0xr8);  
   $def("_tw1j7n", "viewof apply", ["Inputs","compile_and_update","states","editedCell"], _tw1j7n);  
-  main.variable(observer("apply")).define("apply", ["Generators", "viewof apply"], (G, _) => G.input(_));  
+  $def("_1cjyuqm", "apply", ["Generators","viewof apply"], _1cjyuqm);  
   $def("_14rfku9", "viewof up", ["Inputs","moveCell","viewof editedCell"], _14rfku9);  
-  main.variable(observer("up")).define("up", ["Generators", "viewof up"], (G, _) => G.input(_));  
+  $def("_frzs5d", "up", ["Generators","viewof up"], _frzs5d);  
   $def("_9pymuj", "viewof paste", ["Inputs","readObservableClipboardCells","pasteObservableCellsIntoModule","editedCell"], _9pymuj);  
-  main.variable(observer("paste")).define("paste", ["Generators", "viewof paste"], (G, _) => G.input(_));  
+  $def("_1whsszt", "paste", ["Generators","viewof paste"], _1whsszt);  
   $def("_corxwl", "viewof down", ["Inputs","moveCell","viewof editedCell"], _corxwl);  
-  main.variable(observer("down")).define("down", ["Generators", "viewof down"], (G, _) => G.input(_));  
+  $def("_1to28po", "down", ["Generators","viewof down"], _1to28po);  
   $def("_gia2ci", "viewof copy", ["Inputs","html","viewof editedCell","decompile","viewof liveCellMap","getOption","cellsToClipboard"], _gia2ci);  
-  main.variable(observer("copy")).define("copy", ["Generators", "viewof copy"], (G, _) => G.input(_));  
+  $def("_fw41wt", "copy", ["Generators","viewof copy"], _fw41wt);  
   $def("_srtw8o", "module", ["editedCell"], _srtw8o);  
   $def("_rv7t7x", "code_editor_view", ["EditorView"], _rv7t7x);  
   $def("_xvo1n6", "code_editor", ["code_editor_view"], _xvo1n6);  
@@ -6074,7 +6094,7 @@ export default function define(runtime, observer) {
   $def("_d9nzys", "deleteCell", ["viewof command"], _d9nzys);  
   $def("_c1u9w8", null, ["md"], _c1u9w8);  
   $def("_d7ouqx", "viewof command", ["flowQueue"], _d7ouqx);  
-  main.variable(observer("command")).define("command", ["Generators", "viewof command"], (G, _) => G.input(_));  
+  $def("_118qt2v", "command", ["Generators","viewof command"], _118qt2v);  
   $def("_19l2nem", null, ["command"], _19l2nem);  
   $def("_1f6v167", "findCellByVariable", [], _1f6v167);  
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
@@ -6091,9 +6111,8 @@ export default function define(runtime, observer) {
   $def("_dvne2z", "replaceCodeMirrorDoc", [], _dvne2z);  
   $def("_1fpqfm0", null, ["md"], _1fpqfm0);  
   $def("_rtf009", "viewof select", ["editedCell","Inputs","getOption","setOption"], _rtf009);  
-  main.variable(observer("select")).define("select", ["Generators", "viewof select"], (G, _) => G.input(_));  
+  $def("_14mwbuc", "select", ["Generators","viewof select"], _14mwbuc);  
   $def("_l4sbcd", null, ["md"], _l4sbcd);  
-  main.define("module @tomlarkworthy/fileattachments", async () => runtime.module((await import("/@tomlarkworthy/fileattachments.js?v=4")).default));  
   main.define("getFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachment", _));  
   main.define("setFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("setFileAttachment", _));  
   main.define("removeFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("removeFileAttachment", _));  
@@ -6102,7 +6121,7 @@ export default function define(runtime, observer) {
   $def("_ezl7wk", null, ["FileAttachment"], _ezl7wk);  
   $def("_kygz54", "optionsFile", ["getFileAttachment","editorModule"], _kygz54);  
   $def("_760ozq", "viewof options", ["Inputs","optionsFile"], _760ozq);  
-  main.variable(observer("options")).define("options", ["Generators", "viewof options"], (G, _) => G.input(_));  
+  $def("_4rh26k", "options", ["Generators","viewof options"], _4rh26k);  
   $def("_1lqy7cs", "setOption", ["findCell","_","viewof options","Event"], _1lqy7cs);  
   $def("_1oxe5ee", "getOption", ["findCell","_","viewof options"], _1oxe5ee);  
   $def("_kwq69p", "save_options", ["setFileAttachment","jsonFileAttachment","options","editorModule"], _kwq69p);  
@@ -6116,22 +6135,21 @@ export default function define(runtime, observer) {
   $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
   $def("_1j3c2uf", "decompiled", ["editedCell","decompile"], _1j3c2uf);  
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
-  main.variable(observer("editorModule")).define("editorModule", ["Generators", "viewof editorModule"], (G, _) => G.input(_));  
+  $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1ju14cq", "compile_and_update", ["compile","runtime","repositionSetElement"], _1ju14cq);  
+  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
   $def("_rwez9", "viewof variable", ["Inputs","editedCell"], _rwez9);  
-  main.variable(observer("variable")).define("variable", ["Generators", "viewof variable"], (G, _) => G.input(_));  
+  $def("_11gvkq4", "variable", ["Generators","viewof variable"], _11gvkq4);  
   $def("_r5nvms", "name", ["variable"], _r5nvms);  
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
-  main.variable(observer("definition")).define("definition", ["Generators", "viewof definition"], (G, _) => G.input(_));  
+  $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
   $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
   $def("_1q557s", null, ["md"], _1q557s);  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -6142,12 +6160,10 @@ export default function define(runtime, observer) {
   main.define("isnode", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("isnode", _));  
   main.define("repositionSetElement", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("repositionSetElement", _));  
   main.define("onCodeChange", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("onCodeChange", _));  
-  main.define("module @tomlarkworthy/codemirror-6-v2", async () => runtime.module((await import("/@tomlarkworthy/codemirror-6-v2.js?v=4")).default));  
   main.define("EditorState", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("EditorState", _));  
   main.define("EditorView", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("EditorView", _));  
   main.define("codemirror", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("codemirror", _));  
   main.define("myDefaultTheme", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("myDefaultTheme", _));  
-  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
   main.define("decompile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("decompile", _));  
   main.define("compile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("compile", _));  
   main.define("cellMap", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("cellMap", _));  
@@ -6156,27 +6172,21 @@ export default function define(runtime, observer) {
   main.define("parser", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("parser", _));  
   $def("_1d94dks", "javascriptPlugin", ["codemirror"], _1d94dks);  
   $def("_ar9tao", null, ["md"], _ar9tao);  
-  main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
   main.define("reversibleAttach", ["module @tomlarkworthy/reversible-attachment", "@variable"], (_, v) => v.import("reversibleAttach", _));  
-  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
   main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
-  main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
   main.define("flowQueue", ["module @tomlarkworthy/flow-queue", "@variable"], (_, v) => v.import("flowQueue", _));  
-  main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
   main.define("viewof liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("viewof liveCellMap", _));  
   main.define("liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("liveCellMap", _));  
-  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
   main.define("hash", ["module d/57d79353bac56631@44", "@variable"], (_, v) => v.import("hash", _));  
-  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
   main.define("extractNotebookAndCell", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("extractNotebookAndCell", _));  
   main.define("navHref", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("navHref", _));  
-  main.define("module @tomlarkworthy/cells-to-clipboard", async () => runtime.module((await import("/@tomlarkworthy/cells-to-clipboard.js?v=4")).default));  
   main.define("cellsToClipboard", ["module @tomlarkworthy/cells-to-clipboard", "@variable"], (_, v) => v.import("cellsToClipboard", _));
   return main;
-}</script>
+}
+</script>
 <script id="@tomlarkworthy/escodegen/escodegen.browser.min.js.gz" 
   type="text/plain"
   data-encoding="base64"

--- a/notebooks/@tomlarkworthy_bulk-jumpgate.html
+++ b/notebooks/@tomlarkworthy_bulk-jumpgate.html
@@ -5582,7 +5582,7 @@ export default function define(runtime, observer) {
 >
 e30K
 </script>
-<script id="@tomlarkworthy/editor-5" 
+<script id="@tomlarkworthy/editor-5"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -6761,43 +6761,47 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1ju14cq = function _compile_and_update(compile,runtime,repositionSetElement){return(
-(source, variables = [], cell) => {
-    try {
-        debugger;
-        let reposition = false, insertionIndex = -1;
-        const newVariables = compile(source);
-        if (!variables || variables.length !== newVariables.length) {
-            reposition = true;
-            variables.forEach(v => v.delete());
-            variables.length = 0;
-            for (let i = 0; i < newVariables.length; i++) {
-                const newVariable = cell.module.module.variable({});
-                variables.push(newVariable);
+const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+{
+    return (source, variables = [], cell) => {
+        try {
+            debugger;
+            let reposition = false, insertionIndex = -1;
+            const newVariables = compile(source);
+            if (!variables || variables.length !== newVariables.length) {
+                reposition = true;
+                variables.forEach(v => v.delete());
+                variables.length = 0;
+                for (let i = 0; i < newVariables.length; i++) {
+                    const newVariable = cell.module.module.variable({});
+                    // Assign a random pid up-front so blank/identical new cells don't
+                    // collide via persistentId's contentHash. See lopecode#144.
+                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+                    variables.push(newVariable);
+                }
             }
-        }
-        if (reposition) {
-            insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-        }
-        newVariables.forEach((v, i) => {
-            const variable = variables[i];
-            let _fn;
-            eval('_fn = ' + v._definition);
-            if (v._name) {
-                variable.define(v._name, v._inputs, _fn);
-            } else {
-                variable.define(v._inputs, _fn);
+            if (reposition) {
+                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
-            if (reposition)
-                repositionSetElement(runtime._variables, variable, insertionIndex + i);
-        });
-        return variables;
-    } catch (e) {
-        console.error(e);
-        debugger;
-    }
-}
-)};
+            newVariables.forEach((v, i) => {
+                const variable = variables[i];
+                let _fn;
+                eval('_fn = ' + v._definition);
+                if (v._name) {
+                    variable.define(v._name, v._inputs, _fn);
+                } else {
+                    variable.define(v._inputs, _fn);
+                }
+                if (reposition)
+                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
+            });
+            return variables;
+        } catch (e) {
+            console.error(e);
+            debugger;
+        }
+    };
+};
 const _1jqs8in = function _91(md){return(
 md`### Remove Cells`
 )};
@@ -6987,7 +6991,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1ju14cq", "compile_and_update", ["compile","runtime","repositionSetElement"], _1ju14cq);  
+  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -7034,7 +7038,8 @@ export default function define(runtime, observer) {
   main.define("navHref", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("navHref", _));  
   main.define("cellsToClipboard", ["module @tomlarkworthy/cells-to-clipboard", "@variable"], (_, v) => v.import("cellsToClipboard", _));
   return main;
-}</script>
+}
+</script>
 <script id="@tomlarkworthy/escodegen/escodegen.browser.min.js.gz" 
   type="text/plain"
   data-encoding="base64"

--- a/notebooks/@tomlarkworthy_cells-to-clipboard.html
+++ b/notebooks/@tomlarkworthy_cells-to-clipboard.html
@@ -4690,7 +4690,7 @@ export default function define(runtime, observer) {
 >
 e30K
 </script>
-<script id="@tomlarkworthy/editor-5" 
+<script id="@tomlarkworthy/editor-5"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -4737,7 +4737,6 @@ md`## TODO
 const _1ociws4 = function _6(md){return(
 md`## Sync editors`
 )};
-const _1vq49kx = (_, v) => v.import("syncers", _);
 const _hdieof = function _editors(){return(
 new Map()
 )};
@@ -4815,12 +4814,12 @@ Inputs.toggle({
   value: !isOnObservableCom()
 })
 )};
+const _1oaz8r1 = (G, _) => G.input(_);
 const _16ks4jz = function _12(md){return(
 md`## \`cellEditor\` component
 
 Using Dataflow templating to create reusable Hotbar Component builder`
 )};
-const _1deps8p = (_, v) => v.import("cloneDataflow", _);
 const _199ztvl = function _hotbarTemplate(lookupVariable,editorModule){return(
 lookupVariable(
   [
@@ -5057,6 +5056,7 @@ md`## Hotbar Prototype`
 const _1o2h65s = function _editedCell(Inputs){return(
 Inputs.input(null)
 )};
+const _7g3h7h = (G, _) => G.input(_);
 const _1urs1md = function _findCell($0,modules){return(
 (variable, dom = undefined) => {
   if (variable) {
@@ -5216,9 +5216,11 @@ Inputs.toggle({
   value: true
 })
 )};
+const _1h8337z = (G, _) => G.input(_);
 const _tct2nf = function _edit(Inputs){return(
 Inputs.toggle({ label: "edit" })
 )};
+const _7izj7k = (G, _) => G.input(_);
 const _1fwb5jc = function _toolbar(htl,reversibleAttach,combine,$0,$1,$2,$3,$4,$5,$6,$7){return(
 htl.html`<div
     class="toolbar"
@@ -5246,11 +5248,13 @@ Inputs.button("➕", {
   }
 })
 )};
+const _1aii9ps = (G, _) => G.input(_);
 const _1bn860e = function _remove(Inputs,deleteCell,$0){return(
 Inputs.button("🗑️", {
   reduce: () => deleteCell({ cell: $0.value })
 })
 )};
+const _1ad0xr8 = (G, _) => G.input(_);
 const _tw1j7n = function _apply(Inputs,compile_and_update,states,editedCell)
 {
   const button = Inputs.button("▶️", {
@@ -5269,11 +5273,13 @@ const _tw1j7n = function _apply(Inputs,compile_and_update,states,editedCell)
   button.onmousedown = (e) => e.preventDefault();
   return button;
 };
+const _1cjyuqm = (G, _) => G.input(_);
 const _14rfku9 = function _up(Inputs,moveCell,$0){return(
 Inputs.button("⬆", {
   reduce: () => moveCell($0.value, -1)
 })
 )};
+const _frzs5d = (G, _) => G.input(_);
 const _9pymuj = function _paste(Inputs,readObservableClipboardCells,pasteObservableCellsIntoModule,editedCell){return(
 Inputs.button("📋", {
   reduce: async () => {
@@ -5282,11 +5288,13 @@ Inputs.button("📋", {
   }
 })
 )};
+const _1whsszt = (G, _) => G.input(_);
 const _corxwl = function _down(Inputs,moveCell,$0){return(
 Inputs.button("⬇", {
   reduce: () => moveCell($0.value, 1)
 })
 )};
+const _1to28po = (G, _) => G.input(_);
 const _gia2ci = function _copy(Inputs,html,$0,decompile,$1,getOption,cellsToClipboard){return(
 Inputs.button(
   html`<span style="font-size: .875em; margin-right: .125em; position: relative; top: -.25em; left: -.125em">
@@ -5328,6 +5336,7 @@ Inputs.button(
   }
 )
 )};
+const _fw41wt = (G, _) => G.input(_);
 const _srtw8o = function _module(editedCell){return(
 editedCell.module.module
 )};
@@ -5382,6 +5391,7 @@ md`## API handler`
 const _d7ouqx = function _command(flowQueue){return(
 flowQueue()
 )};
+const _118qt2v = (G, _) => G.input(_);
 const _19l2nem = function _54(command){return(
 command
 )};
@@ -5654,10 +5664,10 @@ const _rtf009 = function _select(editedCell,Inputs,getOption,setOption){return(
   return el;
 })()
 )};
+const _14mwbuc = (G, _) => G.input(_);
 const _l4sbcd = function _70(md){return(
 md`## Pinning`
 )};
-const _1sxszb9 = (_, v) => v.import("getFileAttachment", _);
 const _ezl7wk = function _72(FileAttachment){return(
 FileAttachment("cell_options.json")
 )};
@@ -5667,6 +5677,7 @@ getFileAttachment("cell_options.json", editorModule)
 const _760ozq = async function _options(Inputs,optionsFile){return(
 Inputs.input(await optionsFile.json())
 )};
+const _4rh26k = (G, _) => G.input(_);
 const _1lqy7cs = function _setOption(findCell,_,$0,Event){return(
 (variable, option, value) => {
   const cell = findCell(variable);
@@ -5846,6 +5857,7 @@ const _1j3c2uf = function _decompiled(editedCell,decompile)
 const _w5q3yf = function _editorModule(thisModule){return(
 thisModule()
 )};
+const _18kaj2p = (G, _) => G.input(_);
 const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_options)
 {
   //editedCell;
@@ -5857,43 +5869,47 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1ju14cq = function _compile_and_update(compile,runtime,repositionSetElement){return(
-(source, variables = [], cell) => {
-    try {
-        debugger;
-        let reposition = false, insertionIndex = -1;
-        const newVariables = compile(source);
-        if (!variables || variables.length !== newVariables.length) {
-            reposition = true;
-            variables.forEach(v => v.delete());
-            variables.length = 0;
-            for (let i = 0; i < newVariables.length; i++) {
-                const newVariable = cell.module.module.variable({});
-                variables.push(newVariable);
+const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+{
+    return (source, variables = [], cell) => {
+        try {
+            debugger;
+            let reposition = false, insertionIndex = -1;
+            const newVariables = compile(source);
+            if (!variables || variables.length !== newVariables.length) {
+                reposition = true;
+                variables.forEach(v => v.delete());
+                variables.length = 0;
+                for (let i = 0; i < newVariables.length; i++) {
+                    const newVariable = cell.module.module.variable({});
+                    // Assign a random pid up-front so blank/identical new cells don't
+                    // collide via persistentId's contentHash. See lopecode#144.
+                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+                    variables.push(newVariable);
+                }
             }
-        }
-        if (reposition) {
-            insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-        }
-        newVariables.forEach((v, i) => {
-            const variable = variables[i];
-            let _fn;
-            eval('_fn = ' + v._definition);
-            if (v._name) {
-                variable.define(v._name, v._inputs, _fn);
-            } else {
-                variable.define(v._inputs, _fn);
+            if (reposition) {
+                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
-            if (reposition)
-                repositionSetElement(runtime._variables, variable, insertionIndex + i);
-        });
-        return variables;
-    } catch (e) {
-        console.error(e);
-        debugger;
-    }
-}
-)};
+            newVariables.forEach((v, i) => {
+                const variable = variables[i];
+                let _fn;
+                eval('_fn = ' + v._definition);
+                if (v._name) {
+                    variable.define(v._name, v._inputs, _fn);
+                } else {
+                    variable.define(v._inputs, _fn);
+                }
+                if (reposition)
+                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
+            });
+            return variables;
+        } catch (e) {
+            console.error(e);
+            debugger;
+        }
+    };
+};
 const _1jqs8in = function _91(md){return(
 md`### Remove Cells`
 )};
@@ -5912,6 +5928,7 @@ Inputs.radio(editedCell.variables, {
   value: editedCell.variables[0]
 })
 )};
+const _11gvkq4 = (G, _) => G.input(_);
 const _r5nvms = function _name(variable){return(
 variable._name
 )};
@@ -5925,6 +5942,7 @@ Inputs.textarea({
   rows: 10
 })
 )};
+const _b4rsn5 = (G, _) => G.input(_);
 const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
@@ -5938,22 +5956,12 @@ Inputs.button("update variable", {
 const _1q557s = function _99(md){return(
 md`### Editor Libraries`
 )};
-const _192vvs7 = (_, v) => v.import("descendants", _);
-const _3va6tf = (_, v) => v.import("EditorState", _);
-const _lmqjiv = (_, v) => v.import("decompile", _);
 const _1d94dks = function _javascriptPlugin(codemirror){return(
 codemirror
 )};
 const _ar9tao = function _104(md){return(
 md`### Libraries`
 )};
-const _viogn = (_, v) => v.import("reversibleAttach", _);
-const _nxg8mr = (_, v) => v.import("moduleMap", _);
-const _14a94d = (_, v) => v.import("flowQueue", _);
-const _gurtwb = (_, v) => v.import("viewof liveCellMap", _);
-const _19ebgtz = (_, v) => v.import("hash", _);
-const _n2vgkz = (_, v) => v.import("extractNotebookAndCell", _);
-const _1qucevb = (_, v) => v.import("cellsToClipboard", _);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -5967,22 +5975,34 @@ export default function define(runtime, observer) {
     return [name, {url: blob_url, mimeType: mime}]
   }));
   main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
+  main.define("module @tomlarkworthy/dataflow-templating", async () => runtime.module((await import("/@tomlarkworthy/dataflow-templating.js?v=4")).default));  
+  main.define("module @tomlarkworthy/fileattachments", async () => runtime.module((await import("/@tomlarkworthy/fileattachments.js?v=4")).default));  
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/codemirror-6-v2", async () => runtime.module((await import("/@tomlarkworthy/codemirror-6-v2.js?v=4")).default));  
+  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
+  main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
+  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
+  main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
+  main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
+  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
+  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
+  main.define("module @tomlarkworthy/cells-to-clipboard", async () => runtime.module((await import("/@tomlarkworthy/cells-to-clipboard.js?v=4")).default));  
   $def("_1tdjp0a", "title", ["md"], _1tdjp0a);  
   $def("_dm53bx", null, ["md"], _dm53bx);  
   $def("_61oxjf", "title_variable", ["lookupVariable","editorModule"], _61oxjf);  
   $def("_15uilf0", null, ["cellEditor","title_variable"], _15uilf0);  
   $def("_3x695f", null, ["md"], _3x695f);  
   $def("_1ociws4", null, ["md"], _1ociws4);  
-  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
   $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
-  main.variable(observer("attachContextManu")).define("attachContextManu", ["Generators", "viewof attachContextManu"], (G, _) => G.input(_));  
+  $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
   $def("_16ks4jz", null, ["md"], _16ks4jz);  
-  main.define("module @tomlarkworthy/dataflow-templating", async () => runtime.module((await import("/@tomlarkworthy/dataflow-templating.js?v=4")).default));  
   main.define("cloneDataflow", ["module @tomlarkworthy/dataflow-templating", "@variable"], (_, v) => v.import("cloneDataflow", _));  
   main.define("lookupVariable", ["module @tomlarkworthy/dataflow-templating", "@variable"], (_, v) => v.import("lookupVariable", _));  
   $def("_199ztvl", "hotbarTemplate", ["lookupVariable","editorModule"], _199ztvl);  
@@ -5993,7 +6013,7 @@ export default function define(runtime, observer) {
   $def("_110gwi7", "editorTemplate", ["lookupVariable","editorModule"], _110gwi7);  
   $def("_16rqzgl", null, ["md"], _16rqzgl);  
   $def("_1o2h65s", "viewof editedCell", ["Inputs"], _1o2h65s);  
-  main.variable(observer("editedCell")).define("editedCell", ["Generators", "viewof editedCell"], (G, _) => G.input(_));  
+  $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
   $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
@@ -6008,24 +6028,24 @@ export default function define(runtime, observer) {
   $def("_mrrmx3", null, ["md"], _mrrmx3);  
   $def("_14b1byw", null, ["md"], _14b1byw);  
   $def("_1j1loxx", "viewof combine", ["Inputs"], _1j1loxx);  
-  main.variable(observer("combine")).define("combine", ["Generators", "viewof combine"], (G, _) => G.input(_));  
+  $def("_1h8337z", "combine", ["Generators","viewof combine"], _1h8337z);  
   $def("_tct2nf", "viewof edit", ["Inputs"], _tct2nf);  
-  main.variable(observer("edit")).define("edit", ["Generators", "viewof edit"], (G, _) => G.input(_));  
+  $def("_7izj7k", "edit", ["Generators","viewof edit"], _7izj7k);  
   $def("_1fwb5jc", "toolbar", ["htl","reversibleAttach","combine","viewof select","viewof up","viewof down","viewof remove","viewof addCells","viewof apply","viewof copy","viewof paste"], _1fwb5jc);  
   $def("_yej3hb", "viewof addCells", ["Inputs","createCell","viewof editedCell"], _yej3hb);  
-  main.variable(observer("addCells")).define("addCells", ["Generators", "viewof addCells"], (G, _) => G.input(_));  
+  $def("_1aii9ps", "addCells", ["Generators","viewof addCells"], _1aii9ps);  
   $def("_1bn860e", "viewof remove", ["Inputs","deleteCell","viewof editedCell"], _1bn860e);  
-  main.variable(observer("remove")).define("remove", ["Generators", "viewof remove"], (G, _) => G.input(_));  
+  $def("_1ad0xr8", "remove", ["Generators","viewof remove"], _1ad0xr8);  
   $def("_tw1j7n", "viewof apply", ["Inputs","compile_and_update","states","editedCell"], _tw1j7n);  
-  main.variable(observer("apply")).define("apply", ["Generators", "viewof apply"], (G, _) => G.input(_));  
+  $def("_1cjyuqm", "apply", ["Generators","viewof apply"], _1cjyuqm);  
   $def("_14rfku9", "viewof up", ["Inputs","moveCell","viewof editedCell"], _14rfku9);  
-  main.variable(observer("up")).define("up", ["Generators", "viewof up"], (G, _) => G.input(_));  
+  $def("_frzs5d", "up", ["Generators","viewof up"], _frzs5d);  
   $def("_9pymuj", "viewof paste", ["Inputs","readObservableClipboardCells","pasteObservableCellsIntoModule","editedCell"], _9pymuj);  
-  main.variable(observer("paste")).define("paste", ["Generators", "viewof paste"], (G, _) => G.input(_));  
+  $def("_1whsszt", "paste", ["Generators","viewof paste"], _1whsszt);  
   $def("_corxwl", "viewof down", ["Inputs","moveCell","viewof editedCell"], _corxwl);  
-  main.variable(observer("down")).define("down", ["Generators", "viewof down"], (G, _) => G.input(_));  
+  $def("_1to28po", "down", ["Generators","viewof down"], _1to28po);  
   $def("_gia2ci", "viewof copy", ["Inputs","html","viewof editedCell","decompile","viewof liveCellMap","getOption","cellsToClipboard"], _gia2ci);  
-  main.variable(observer("copy")).define("copy", ["Generators", "viewof copy"], (G, _) => G.input(_));  
+  $def("_fw41wt", "copy", ["Generators","viewof copy"], _fw41wt);  
   $def("_srtw8o", "module", ["editedCell"], _srtw8o);  
   $def("_rv7t7x", "code_editor_view", ["EditorView"], _rv7t7x);  
   $def("_xvo1n6", "code_editor", ["code_editor_view"], _xvo1n6);  
@@ -6035,7 +6055,7 @@ export default function define(runtime, observer) {
   $def("_d9nzys", "deleteCell", ["viewof command"], _d9nzys);  
   $def("_c1u9w8", null, ["md"], _c1u9w8);  
   $def("_d7ouqx", "viewof command", ["flowQueue"], _d7ouqx);  
-  main.variable(observer("command")).define("command", ["Generators", "viewof command"], (G, _) => G.input(_));  
+  $def("_118qt2v", "command", ["Generators","viewof command"], _118qt2v);  
   $def("_19l2nem", null, ["command"], _19l2nem);  
   $def("_1f6v167", "findCellByVariable", [], _1f6v167);  
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
@@ -6052,9 +6072,8 @@ export default function define(runtime, observer) {
   $def("_dvne2z", "replaceCodeMirrorDoc", [], _dvne2z);  
   $def("_1fpqfm0", null, ["md"], _1fpqfm0);  
   $def("_rtf009", "viewof select", ["editedCell","Inputs","getOption","setOption"], _rtf009);  
-  main.variable(observer("select")).define("select", ["Generators", "viewof select"], (G, _) => G.input(_));  
+  $def("_14mwbuc", "select", ["Generators","viewof select"], _14mwbuc);  
   $def("_l4sbcd", null, ["md"], _l4sbcd);  
-  main.define("module @tomlarkworthy/fileattachments", async () => runtime.module((await import("/@tomlarkworthy/fileattachments.js?v=4")).default));  
   main.define("getFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachment", _));  
   main.define("setFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("setFileAttachment", _));  
   main.define("removeFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("removeFileAttachment", _));  
@@ -6063,7 +6082,7 @@ export default function define(runtime, observer) {
   $def("_ezl7wk", null, ["FileAttachment"], _ezl7wk);  
   $def("_kygz54", "optionsFile", ["getFileAttachment","editorModule"], _kygz54);  
   $def("_760ozq", "viewof options", ["Inputs","optionsFile"], _760ozq);  
-  main.variable(observer("options")).define("options", ["Generators", "viewof options"], (G, _) => G.input(_));  
+  $def("_4rh26k", "options", ["Generators","viewof options"], _4rh26k);  
   $def("_1lqy7cs", "setOption", ["findCell","_","viewof options","Event"], _1lqy7cs);  
   $def("_1oxe5ee", "getOption", ["findCell","_","viewof options"], _1oxe5ee);  
   $def("_kwq69p", "save_options", ["setFileAttachment","jsonFileAttachment","options","editorModule"], _kwq69p);  
@@ -6077,22 +6096,21 @@ export default function define(runtime, observer) {
   $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
   $def("_1j3c2uf", "decompiled", ["editedCell","decompile"], _1j3c2uf);  
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
-  main.variable(observer("editorModule")).define("editorModule", ["Generators", "viewof editorModule"], (G, _) => G.input(_));  
+  $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1ju14cq", "compile_and_update", ["compile","runtime","repositionSetElement"], _1ju14cq);  
+  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
   $def("_rwez9", "viewof variable", ["Inputs","editedCell"], _rwez9);  
-  main.variable(observer("variable")).define("variable", ["Generators", "viewof variable"], (G, _) => G.input(_));  
+  $def("_11gvkq4", "variable", ["Generators","viewof variable"], _11gvkq4);  
   $def("_r5nvms", "name", ["variable"], _r5nvms);  
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
-  main.variable(observer("definition")).define("definition", ["Generators", "viewof definition"], (G, _) => G.input(_));  
+  $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
   $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
   $def("_1q557s", null, ["md"], _1q557s);  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -6103,12 +6121,10 @@ export default function define(runtime, observer) {
   main.define("isnode", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("isnode", _));  
   main.define("repositionSetElement", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("repositionSetElement", _));  
   main.define("onCodeChange", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("onCodeChange", _));  
-  main.define("module @tomlarkworthy/codemirror-6-v2", async () => runtime.module((await import("/@tomlarkworthy/codemirror-6-v2.js?v=4")).default));  
   main.define("EditorState", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("EditorState", _));  
   main.define("EditorView", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("EditorView", _));  
   main.define("codemirror", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("codemirror", _));  
   main.define("myDefaultTheme", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("myDefaultTheme", _));  
-  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
   main.define("decompile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("decompile", _));  
   main.define("compile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("compile", _));  
   main.define("cellMap", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("cellMap", _));  
@@ -6117,27 +6133,21 @@ export default function define(runtime, observer) {
   main.define("parser", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("parser", _));  
   $def("_1d94dks", "javascriptPlugin", ["codemirror"], _1d94dks);  
   $def("_ar9tao", null, ["md"], _ar9tao);  
-  main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
   main.define("reversibleAttach", ["module @tomlarkworthy/reversible-attachment", "@variable"], (_, v) => v.import("reversibleAttach", _));  
-  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
   main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
-  main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
   main.define("flowQueue", ["module @tomlarkworthy/flow-queue", "@variable"], (_, v) => v.import("flowQueue", _));  
-  main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
   main.define("viewof liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("viewof liveCellMap", _));  
   main.define("liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("liveCellMap", _));  
-  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
   main.define("hash", ["module d/57d79353bac56631@44", "@variable"], (_, v) => v.import("hash", _));  
-  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
   main.define("extractNotebookAndCell", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("extractNotebookAndCell", _));  
   main.define("navHref", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("navHref", _));  
-  main.define("module @tomlarkworthy/cells-to-clipboard", async () => runtime.module((await import("/@tomlarkworthy/cells-to-clipboard.js?v=4")).default));  
   main.define("cellsToClipboard", ["module @tomlarkworthy/cells-to-clipboard", "@variable"], (_, v) => v.import("cellsToClipboard", _));
   return main;
-}</script>
+}
+</script>
 <script id="@tomlarkworthy/escodegen/escodegen.browser.min.js.gz" 
   type="text/plain"
   data-encoding="base64"

--- a/notebooks/@tomlarkworthy_claude-code-pairing.html
+++ b/notebooks/@tomlarkworthy_claude-code-pairing.html
@@ -4667,7 +4667,7 @@ export default function define(runtime, observer) {
 >
 e30K
 </script>
-<script id="@tomlarkworthy/editor-5" 
+<script id="@tomlarkworthy/editor-5"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -5846,43 +5846,47 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1ju14cq = function _compile_and_update(compile,runtime,repositionSetElement){return(
-(source, variables = [], cell) => {
-    try {
-        debugger;
-        let reposition = false, insertionIndex = -1;
-        const newVariables = compile(source);
-        if (!variables || variables.length !== newVariables.length) {
-            reposition = true;
-            variables.forEach(v => v.delete());
-            variables.length = 0;
-            for (let i = 0; i < newVariables.length; i++) {
-                const newVariable = cell.module.module.variable({});
-                variables.push(newVariable);
+const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+{
+    return (source, variables = [], cell) => {
+        try {
+            debugger;
+            let reposition = false, insertionIndex = -1;
+            const newVariables = compile(source);
+            if (!variables || variables.length !== newVariables.length) {
+                reposition = true;
+                variables.forEach(v => v.delete());
+                variables.length = 0;
+                for (let i = 0; i < newVariables.length; i++) {
+                    const newVariable = cell.module.module.variable({});
+                    // Assign a random pid up-front so blank/identical new cells don't
+                    // collide via persistentId's contentHash. See lopecode#144.
+                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+                    variables.push(newVariable);
+                }
             }
-        }
-        if (reposition) {
-            insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-        }
-        newVariables.forEach((v, i) => {
-            const variable = variables[i];
-            let _fn;
-            eval('_fn = ' + v._definition);
-            if (v._name) {
-                variable.define(v._name, v._inputs, _fn);
-            } else {
-                variable.define(v._inputs, _fn);
+            if (reposition) {
+                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
-            if (reposition)
-                repositionSetElement(runtime._variables, variable, insertionIndex + i);
-        });
-        return variables;
-    } catch (e) {
-        console.error(e);
-        debugger;
-    }
-}
-)};
+            newVariables.forEach((v, i) => {
+                const variable = variables[i];
+                let _fn;
+                eval('_fn = ' + v._definition);
+                if (v._name) {
+                    variable.define(v._name, v._inputs, _fn);
+                } else {
+                    variable.define(v._inputs, _fn);
+                }
+                if (reposition)
+                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
+            });
+            return variables;
+        } catch (e) {
+            console.error(e);
+            debugger;
+        }
+    };
+};
 const _1jqs8in = function _91(md){return(
 md`### Remove Cells`
 )};
@@ -6072,7 +6076,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1ju14cq", "compile_and_update", ["compile","runtime","repositionSetElement"], _1ju14cq);  
+  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -6119,7 +6123,8 @@ export default function define(runtime, observer) {
   main.define("navHref", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("navHref", _));  
   main.define("cellsToClipboard", ["module @tomlarkworthy/cells-to-clipboard", "@variable"], (_, v) => v.import("cellsToClipboard", _));
   return main;
-}</script>
+}
+</script>
 <script id="@tomlarkworthy/escodegen/escodegen.browser.min.js.gz" 
   type="text/plain"
   data-encoding="base64"

--- a/notebooks/@tomlarkworthy_codemirror-6-v2.html
+++ b/notebooks/@tomlarkworthy_codemirror-6-v2.html
@@ -4690,7 +4690,7 @@ export default function define(runtime, observer) {
 >
 e30K
 </script>
-<script id="@tomlarkworthy/editor-5" 
+<script id="@tomlarkworthy/editor-5"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -4737,7 +4737,6 @@ md`## TODO
 const _1ociws4 = function _6(md){return(
 md`## Sync editors`
 )};
-const _1vq49kx = (_, v) => v.import("syncers", _);
 const _hdieof = function _editors(){return(
 new Map()
 )};
@@ -4815,12 +4814,12 @@ Inputs.toggle({
   value: !isOnObservableCom()
 })
 )};
+const _1oaz8r1 = (G, _) => G.input(_);
 const _16ks4jz = function _12(md){return(
 md`## \`cellEditor\` component
 
 Using Dataflow templating to create reusable Hotbar Component builder`
 )};
-const _1deps8p = (_, v) => v.import("cloneDataflow", _);
 const _199ztvl = function _hotbarTemplate(lookupVariable,editorModule){return(
 lookupVariable(
   [
@@ -5057,6 +5056,7 @@ md`## Hotbar Prototype`
 const _1o2h65s = function _editedCell(Inputs){return(
 Inputs.input(null)
 )};
+const _7g3h7h = (G, _) => G.input(_);
 const _1urs1md = function _findCell($0,modules){return(
 (variable, dom = undefined) => {
   if (variable) {
@@ -5216,9 +5216,11 @@ Inputs.toggle({
   value: true
 })
 )};
+const _1h8337z = (G, _) => G.input(_);
 const _tct2nf = function _edit(Inputs){return(
 Inputs.toggle({ label: "edit" })
 )};
+const _7izj7k = (G, _) => G.input(_);
 const _1fwb5jc = function _toolbar(htl,reversibleAttach,combine,$0,$1,$2,$3,$4,$5,$6,$7){return(
 htl.html`<div
     class="toolbar"
@@ -5246,11 +5248,13 @@ Inputs.button("➕", {
   }
 })
 )};
+const _1aii9ps = (G, _) => G.input(_);
 const _1bn860e = function _remove(Inputs,deleteCell,$0){return(
 Inputs.button("🗑️", {
   reduce: () => deleteCell({ cell: $0.value })
 })
 )};
+const _1ad0xr8 = (G, _) => G.input(_);
 const _tw1j7n = function _apply(Inputs,compile_and_update,states,editedCell)
 {
   const button = Inputs.button("▶️", {
@@ -5269,11 +5273,13 @@ const _tw1j7n = function _apply(Inputs,compile_and_update,states,editedCell)
   button.onmousedown = (e) => e.preventDefault();
   return button;
 };
+const _1cjyuqm = (G, _) => G.input(_);
 const _14rfku9 = function _up(Inputs,moveCell,$0){return(
 Inputs.button("⬆", {
   reduce: () => moveCell($0.value, -1)
 })
 )};
+const _frzs5d = (G, _) => G.input(_);
 const _9pymuj = function _paste(Inputs,readObservableClipboardCells,pasteObservableCellsIntoModule,editedCell){return(
 Inputs.button("📋", {
   reduce: async () => {
@@ -5282,11 +5288,13 @@ Inputs.button("📋", {
   }
 })
 )};
+const _1whsszt = (G, _) => G.input(_);
 const _corxwl = function _down(Inputs,moveCell,$0){return(
 Inputs.button("⬇", {
   reduce: () => moveCell($0.value, 1)
 })
 )};
+const _1to28po = (G, _) => G.input(_);
 const _gia2ci = function _copy(Inputs,html,$0,decompile,$1,getOption,cellsToClipboard){return(
 Inputs.button(
   html`<span style="font-size: .875em; margin-right: .125em; position: relative; top: -.25em; left: -.125em">
@@ -5328,6 +5336,7 @@ Inputs.button(
   }
 )
 )};
+const _fw41wt = (G, _) => G.input(_);
 const _srtw8o = function _module(editedCell){return(
 editedCell.module.module
 )};
@@ -5382,6 +5391,7 @@ md`## API handler`
 const _d7ouqx = function _command(flowQueue){return(
 flowQueue()
 )};
+const _118qt2v = (G, _) => G.input(_);
 const _19l2nem = function _54(command){return(
 command
 )};
@@ -5654,10 +5664,10 @@ const _rtf009 = function _select(editedCell,Inputs,getOption,setOption){return(
   return el;
 })()
 )};
+const _14mwbuc = (G, _) => G.input(_);
 const _l4sbcd = function _70(md){return(
 md`## Pinning`
 )};
-const _1sxszb9 = (_, v) => v.import("getFileAttachment", _);
 const _ezl7wk = function _72(FileAttachment){return(
 FileAttachment("cell_options.json")
 )};
@@ -5667,6 +5677,7 @@ getFileAttachment("cell_options.json", editorModule)
 const _760ozq = async function _options(Inputs,optionsFile){return(
 Inputs.input(await optionsFile.json())
 )};
+const _4rh26k = (G, _) => G.input(_);
 const _1lqy7cs = function _setOption(findCell,_,$0,Event){return(
 (variable, option, value) => {
   const cell = findCell(variable);
@@ -5846,6 +5857,7 @@ const _1j3c2uf = function _decompiled(editedCell,decompile)
 const _w5q3yf = function _editorModule(thisModule){return(
 thisModule()
 )};
+const _18kaj2p = (G, _) => G.input(_);
 const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_options)
 {
   //editedCell;
@@ -5857,43 +5869,47 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1ju14cq = function _compile_and_update(compile,runtime,repositionSetElement){return(
-(source, variables = [], cell) => {
-    try {
-        debugger;
-        let reposition = false, insertionIndex = -1;
-        const newVariables = compile(source);
-        if (!variables || variables.length !== newVariables.length) {
-            reposition = true;
-            variables.forEach(v => v.delete());
-            variables.length = 0;
-            for (let i = 0; i < newVariables.length; i++) {
-                const newVariable = cell.module.module.variable({});
-                variables.push(newVariable);
+const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+{
+    return (source, variables = [], cell) => {
+        try {
+            debugger;
+            let reposition = false, insertionIndex = -1;
+            const newVariables = compile(source);
+            if (!variables || variables.length !== newVariables.length) {
+                reposition = true;
+                variables.forEach(v => v.delete());
+                variables.length = 0;
+                for (let i = 0; i < newVariables.length; i++) {
+                    const newVariable = cell.module.module.variable({});
+                    // Assign a random pid up-front so blank/identical new cells don't
+                    // collide via persistentId's contentHash. See lopecode#144.
+                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+                    variables.push(newVariable);
+                }
             }
-        }
-        if (reposition) {
-            insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-        }
-        newVariables.forEach((v, i) => {
-            const variable = variables[i];
-            let _fn;
-            eval('_fn = ' + v._definition);
-            if (v._name) {
-                variable.define(v._name, v._inputs, _fn);
-            } else {
-                variable.define(v._inputs, _fn);
+            if (reposition) {
+                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
-            if (reposition)
-                repositionSetElement(runtime._variables, variable, insertionIndex + i);
-        });
-        return variables;
-    } catch (e) {
-        console.error(e);
-        debugger;
-    }
-}
-)};
+            newVariables.forEach((v, i) => {
+                const variable = variables[i];
+                let _fn;
+                eval('_fn = ' + v._definition);
+                if (v._name) {
+                    variable.define(v._name, v._inputs, _fn);
+                } else {
+                    variable.define(v._inputs, _fn);
+                }
+                if (reposition)
+                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
+            });
+            return variables;
+        } catch (e) {
+            console.error(e);
+            debugger;
+        }
+    };
+};
 const _1jqs8in = function _91(md){return(
 md`### Remove Cells`
 )};
@@ -5912,6 +5928,7 @@ Inputs.radio(editedCell.variables, {
   value: editedCell.variables[0]
 })
 )};
+const _11gvkq4 = (G, _) => G.input(_);
 const _r5nvms = function _name(variable){return(
 variable._name
 )};
@@ -5925,6 +5942,7 @@ Inputs.textarea({
   rows: 10
 })
 )};
+const _b4rsn5 = (G, _) => G.input(_);
 const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
@@ -5938,22 +5956,12 @@ Inputs.button("update variable", {
 const _1q557s = function _99(md){return(
 md`### Editor Libraries`
 )};
-const _192vvs7 = (_, v) => v.import("descendants", _);
-const _3va6tf = (_, v) => v.import("EditorState", _);
-const _lmqjiv = (_, v) => v.import("decompile", _);
 const _1d94dks = function _javascriptPlugin(codemirror){return(
 codemirror
 )};
 const _ar9tao = function _104(md){return(
 md`### Libraries`
 )};
-const _viogn = (_, v) => v.import("reversibleAttach", _);
-const _nxg8mr = (_, v) => v.import("moduleMap", _);
-const _14a94d = (_, v) => v.import("flowQueue", _);
-const _gurtwb = (_, v) => v.import("viewof liveCellMap", _);
-const _19ebgtz = (_, v) => v.import("hash", _);
-const _n2vgkz = (_, v) => v.import("extractNotebookAndCell", _);
-const _1qucevb = (_, v) => v.import("cellsToClipboard", _);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -5967,22 +5975,34 @@ export default function define(runtime, observer) {
     return [name, {url: blob_url, mimeType: mime}]
   }));
   main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
+  main.define("module @tomlarkworthy/dataflow-templating", async () => runtime.module((await import("/@tomlarkworthy/dataflow-templating.js?v=4")).default));  
+  main.define("module @tomlarkworthy/fileattachments", async () => runtime.module((await import("/@tomlarkworthy/fileattachments.js?v=4")).default));  
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/codemirror-6-v2", async () => runtime.module((await import("/@tomlarkworthy/codemirror-6-v2.js?v=4")).default));  
+  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
+  main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
+  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
+  main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
+  main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
+  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
+  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
+  main.define("module @tomlarkworthy/cells-to-clipboard", async () => runtime.module((await import("/@tomlarkworthy/cells-to-clipboard.js?v=4")).default));  
   $def("_1tdjp0a", "title", ["md"], _1tdjp0a);  
   $def("_dm53bx", null, ["md"], _dm53bx);  
   $def("_61oxjf", "title_variable", ["lookupVariable","editorModule"], _61oxjf);  
   $def("_15uilf0", null, ["cellEditor","title_variable"], _15uilf0);  
   $def("_3x695f", null, ["md"], _3x695f);  
   $def("_1ociws4", null, ["md"], _1ociws4);  
-  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
   $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
-  main.variable(observer("attachContextManu")).define("attachContextManu", ["Generators", "viewof attachContextManu"], (G, _) => G.input(_));  
+  $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
   $def("_16ks4jz", null, ["md"], _16ks4jz);  
-  main.define("module @tomlarkworthy/dataflow-templating", async () => runtime.module((await import("/@tomlarkworthy/dataflow-templating.js?v=4")).default));  
   main.define("cloneDataflow", ["module @tomlarkworthy/dataflow-templating", "@variable"], (_, v) => v.import("cloneDataflow", _));  
   main.define("lookupVariable", ["module @tomlarkworthy/dataflow-templating", "@variable"], (_, v) => v.import("lookupVariable", _));  
   $def("_199ztvl", "hotbarTemplate", ["lookupVariable","editorModule"], _199ztvl);  
@@ -5993,7 +6013,7 @@ export default function define(runtime, observer) {
   $def("_110gwi7", "editorTemplate", ["lookupVariable","editorModule"], _110gwi7);  
   $def("_16rqzgl", null, ["md"], _16rqzgl);  
   $def("_1o2h65s", "viewof editedCell", ["Inputs"], _1o2h65s);  
-  main.variable(observer("editedCell")).define("editedCell", ["Generators", "viewof editedCell"], (G, _) => G.input(_));  
+  $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
   $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
@@ -6008,24 +6028,24 @@ export default function define(runtime, observer) {
   $def("_mrrmx3", null, ["md"], _mrrmx3);  
   $def("_14b1byw", null, ["md"], _14b1byw);  
   $def("_1j1loxx", "viewof combine", ["Inputs"], _1j1loxx);  
-  main.variable(observer("combine")).define("combine", ["Generators", "viewof combine"], (G, _) => G.input(_));  
+  $def("_1h8337z", "combine", ["Generators","viewof combine"], _1h8337z);  
   $def("_tct2nf", "viewof edit", ["Inputs"], _tct2nf);  
-  main.variable(observer("edit")).define("edit", ["Generators", "viewof edit"], (G, _) => G.input(_));  
+  $def("_7izj7k", "edit", ["Generators","viewof edit"], _7izj7k);  
   $def("_1fwb5jc", "toolbar", ["htl","reversibleAttach","combine","viewof select","viewof up","viewof down","viewof remove","viewof addCells","viewof apply","viewof copy","viewof paste"], _1fwb5jc);  
   $def("_yej3hb", "viewof addCells", ["Inputs","createCell","viewof editedCell"], _yej3hb);  
-  main.variable(observer("addCells")).define("addCells", ["Generators", "viewof addCells"], (G, _) => G.input(_));  
+  $def("_1aii9ps", "addCells", ["Generators","viewof addCells"], _1aii9ps);  
   $def("_1bn860e", "viewof remove", ["Inputs","deleteCell","viewof editedCell"], _1bn860e);  
-  main.variable(observer("remove")).define("remove", ["Generators", "viewof remove"], (G, _) => G.input(_));  
+  $def("_1ad0xr8", "remove", ["Generators","viewof remove"], _1ad0xr8);  
   $def("_tw1j7n", "viewof apply", ["Inputs","compile_and_update","states","editedCell"], _tw1j7n);  
-  main.variable(observer("apply")).define("apply", ["Generators", "viewof apply"], (G, _) => G.input(_));  
+  $def("_1cjyuqm", "apply", ["Generators","viewof apply"], _1cjyuqm);  
   $def("_14rfku9", "viewof up", ["Inputs","moveCell","viewof editedCell"], _14rfku9);  
-  main.variable(observer("up")).define("up", ["Generators", "viewof up"], (G, _) => G.input(_));  
+  $def("_frzs5d", "up", ["Generators","viewof up"], _frzs5d);  
   $def("_9pymuj", "viewof paste", ["Inputs","readObservableClipboardCells","pasteObservableCellsIntoModule","editedCell"], _9pymuj);  
-  main.variable(observer("paste")).define("paste", ["Generators", "viewof paste"], (G, _) => G.input(_));  
+  $def("_1whsszt", "paste", ["Generators","viewof paste"], _1whsszt);  
   $def("_corxwl", "viewof down", ["Inputs","moveCell","viewof editedCell"], _corxwl);  
-  main.variable(observer("down")).define("down", ["Generators", "viewof down"], (G, _) => G.input(_));  
+  $def("_1to28po", "down", ["Generators","viewof down"], _1to28po);  
   $def("_gia2ci", "viewof copy", ["Inputs","html","viewof editedCell","decompile","viewof liveCellMap","getOption","cellsToClipboard"], _gia2ci);  
-  main.variable(observer("copy")).define("copy", ["Generators", "viewof copy"], (G, _) => G.input(_));  
+  $def("_fw41wt", "copy", ["Generators","viewof copy"], _fw41wt);  
   $def("_srtw8o", "module", ["editedCell"], _srtw8o);  
   $def("_rv7t7x", "code_editor_view", ["EditorView"], _rv7t7x);  
   $def("_xvo1n6", "code_editor", ["code_editor_view"], _xvo1n6);  
@@ -6035,7 +6055,7 @@ export default function define(runtime, observer) {
   $def("_d9nzys", "deleteCell", ["viewof command"], _d9nzys);  
   $def("_c1u9w8", null, ["md"], _c1u9w8);  
   $def("_d7ouqx", "viewof command", ["flowQueue"], _d7ouqx);  
-  main.variable(observer("command")).define("command", ["Generators", "viewof command"], (G, _) => G.input(_));  
+  $def("_118qt2v", "command", ["Generators","viewof command"], _118qt2v);  
   $def("_19l2nem", null, ["command"], _19l2nem);  
   $def("_1f6v167", "findCellByVariable", [], _1f6v167);  
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
@@ -6052,9 +6072,8 @@ export default function define(runtime, observer) {
   $def("_dvne2z", "replaceCodeMirrorDoc", [], _dvne2z);  
   $def("_1fpqfm0", null, ["md"], _1fpqfm0);  
   $def("_rtf009", "viewof select", ["editedCell","Inputs","getOption","setOption"], _rtf009);  
-  main.variable(observer("select")).define("select", ["Generators", "viewof select"], (G, _) => G.input(_));  
+  $def("_14mwbuc", "select", ["Generators","viewof select"], _14mwbuc);  
   $def("_l4sbcd", null, ["md"], _l4sbcd);  
-  main.define("module @tomlarkworthy/fileattachments", async () => runtime.module((await import("/@tomlarkworthy/fileattachments.js?v=4")).default));  
   main.define("getFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachment", _));  
   main.define("setFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("setFileAttachment", _));  
   main.define("removeFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("removeFileAttachment", _));  
@@ -6063,7 +6082,7 @@ export default function define(runtime, observer) {
   $def("_ezl7wk", null, ["FileAttachment"], _ezl7wk);  
   $def("_kygz54", "optionsFile", ["getFileAttachment","editorModule"], _kygz54);  
   $def("_760ozq", "viewof options", ["Inputs","optionsFile"], _760ozq);  
-  main.variable(observer("options")).define("options", ["Generators", "viewof options"], (G, _) => G.input(_));  
+  $def("_4rh26k", "options", ["Generators","viewof options"], _4rh26k);  
   $def("_1lqy7cs", "setOption", ["findCell","_","viewof options","Event"], _1lqy7cs);  
   $def("_1oxe5ee", "getOption", ["findCell","_","viewof options"], _1oxe5ee);  
   $def("_kwq69p", "save_options", ["setFileAttachment","jsonFileAttachment","options","editorModule"], _kwq69p);  
@@ -6077,22 +6096,21 @@ export default function define(runtime, observer) {
   $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
   $def("_1j3c2uf", "decompiled", ["editedCell","decompile"], _1j3c2uf);  
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
-  main.variable(observer("editorModule")).define("editorModule", ["Generators", "viewof editorModule"], (G, _) => G.input(_));  
+  $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1ju14cq", "compile_and_update", ["compile","runtime","repositionSetElement"], _1ju14cq);  
+  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
   $def("_rwez9", "viewof variable", ["Inputs","editedCell"], _rwez9);  
-  main.variable(observer("variable")).define("variable", ["Generators", "viewof variable"], (G, _) => G.input(_));  
+  $def("_11gvkq4", "variable", ["Generators","viewof variable"], _11gvkq4);  
   $def("_r5nvms", "name", ["variable"], _r5nvms);  
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
-  main.variable(observer("definition")).define("definition", ["Generators", "viewof definition"], (G, _) => G.input(_));  
+  $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
   $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
   $def("_1q557s", null, ["md"], _1q557s);  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -6103,12 +6121,10 @@ export default function define(runtime, observer) {
   main.define("isnode", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("isnode", _));  
   main.define("repositionSetElement", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("repositionSetElement", _));  
   main.define("onCodeChange", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("onCodeChange", _));  
-  main.define("module @tomlarkworthy/codemirror-6-v2", async () => runtime.module((await import("/@tomlarkworthy/codemirror-6-v2.js?v=4")).default));  
   main.define("EditorState", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("EditorState", _));  
   main.define("EditorView", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("EditorView", _));  
   main.define("codemirror", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("codemirror", _));  
   main.define("myDefaultTheme", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("myDefaultTheme", _));  
-  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
   main.define("decompile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("decompile", _));  
   main.define("compile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("compile", _));  
   main.define("cellMap", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("cellMap", _));  
@@ -6117,27 +6133,21 @@ export default function define(runtime, observer) {
   main.define("parser", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("parser", _));  
   $def("_1d94dks", "javascriptPlugin", ["codemirror"], _1d94dks);  
   $def("_ar9tao", null, ["md"], _ar9tao);  
-  main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
   main.define("reversibleAttach", ["module @tomlarkworthy/reversible-attachment", "@variable"], (_, v) => v.import("reversibleAttach", _));  
-  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
   main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
-  main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
   main.define("flowQueue", ["module @tomlarkworthy/flow-queue", "@variable"], (_, v) => v.import("flowQueue", _));  
-  main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
   main.define("viewof liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("viewof liveCellMap", _));  
   main.define("liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("liveCellMap", _));  
-  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
   main.define("hash", ["module d/57d79353bac56631@44", "@variable"], (_, v) => v.import("hash", _));  
-  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
   main.define("extractNotebookAndCell", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("extractNotebookAndCell", _));  
   main.define("navHref", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("navHref", _));  
-  main.define("module @tomlarkworthy/cells-to-clipboard", async () => runtime.module((await import("/@tomlarkworthy/cells-to-clipboard.js?v=4")).default));  
   main.define("cellsToClipboard", ["module @tomlarkworthy/cells-to-clipboard", "@variable"], (_, v) => v.import("cellsToClipboard", _));
   return main;
-}</script>
+}
+</script>
 <script id="@tomlarkworthy/escodegen/escodegen.browser.min.js.gz" 
   type="text/plain"
   data-encoding="base64"

--- a/notebooks/@tomlarkworthy_dataflow-templating.html
+++ b/notebooks/@tomlarkworthy_dataflow-templating.html
@@ -4690,7 +4690,7 @@ export default function define(runtime, observer) {
 >
 e30K
 </script>
-<script id="@tomlarkworthy/editor-5" 
+<script id="@tomlarkworthy/editor-5"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -4737,7 +4737,6 @@ md`## TODO
 const _1ociws4 = function _6(md){return(
 md`## Sync editors`
 )};
-const _1vq49kx = (_, v) => v.import("syncers", _);
 const _hdieof = function _editors(){return(
 new Map()
 )};
@@ -4815,12 +4814,12 @@ Inputs.toggle({
   value: !isOnObservableCom()
 })
 )};
+const _1oaz8r1 = (G, _) => G.input(_);
 const _16ks4jz = function _12(md){return(
 md`## \`cellEditor\` component
 
 Using Dataflow templating to create reusable Hotbar Component builder`
 )};
-const _1deps8p = (_, v) => v.import("cloneDataflow", _);
 const _199ztvl = function _hotbarTemplate(lookupVariable,editorModule){return(
 lookupVariable(
   [
@@ -5057,6 +5056,7 @@ md`## Hotbar Prototype`
 const _1o2h65s = function _editedCell(Inputs){return(
 Inputs.input(null)
 )};
+const _7g3h7h = (G, _) => G.input(_);
 const _1urs1md = function _findCell($0,modules){return(
 (variable, dom = undefined) => {
   if (variable) {
@@ -5216,9 +5216,11 @@ Inputs.toggle({
   value: true
 })
 )};
+const _1h8337z = (G, _) => G.input(_);
 const _tct2nf = function _edit(Inputs){return(
 Inputs.toggle({ label: "edit" })
 )};
+const _7izj7k = (G, _) => G.input(_);
 const _1fwb5jc = function _toolbar(htl,reversibleAttach,combine,$0,$1,$2,$3,$4,$5,$6,$7){return(
 htl.html`<div
     class="toolbar"
@@ -5246,11 +5248,13 @@ Inputs.button("➕", {
   }
 })
 )};
+const _1aii9ps = (G, _) => G.input(_);
 const _1bn860e = function _remove(Inputs,deleteCell,$0){return(
 Inputs.button("🗑️", {
   reduce: () => deleteCell({ cell: $0.value })
 })
 )};
+const _1ad0xr8 = (G, _) => G.input(_);
 const _tw1j7n = function _apply(Inputs,compile_and_update,states,editedCell)
 {
   const button = Inputs.button("▶️", {
@@ -5269,11 +5273,13 @@ const _tw1j7n = function _apply(Inputs,compile_and_update,states,editedCell)
   button.onmousedown = (e) => e.preventDefault();
   return button;
 };
+const _1cjyuqm = (G, _) => G.input(_);
 const _14rfku9 = function _up(Inputs,moveCell,$0){return(
 Inputs.button("⬆", {
   reduce: () => moveCell($0.value, -1)
 })
 )};
+const _frzs5d = (G, _) => G.input(_);
 const _9pymuj = function _paste(Inputs,readObservableClipboardCells,pasteObservableCellsIntoModule,editedCell){return(
 Inputs.button("📋", {
   reduce: async () => {
@@ -5282,11 +5288,13 @@ Inputs.button("📋", {
   }
 })
 )};
+const _1whsszt = (G, _) => G.input(_);
 const _corxwl = function _down(Inputs,moveCell,$0){return(
 Inputs.button("⬇", {
   reduce: () => moveCell($0.value, 1)
 })
 )};
+const _1to28po = (G, _) => G.input(_);
 const _gia2ci = function _copy(Inputs,html,$0,decompile,$1,getOption,cellsToClipboard){return(
 Inputs.button(
   html`<span style="font-size: .875em; margin-right: .125em; position: relative; top: -.25em; left: -.125em">
@@ -5328,6 +5336,7 @@ Inputs.button(
   }
 )
 )};
+const _fw41wt = (G, _) => G.input(_);
 const _srtw8o = function _module(editedCell){return(
 editedCell.module.module
 )};
@@ -5382,6 +5391,7 @@ md`## API handler`
 const _d7ouqx = function _command(flowQueue){return(
 flowQueue()
 )};
+const _118qt2v = (G, _) => G.input(_);
 const _19l2nem = function _54(command){return(
 command
 )};
@@ -5654,10 +5664,10 @@ const _rtf009 = function _select(editedCell,Inputs,getOption,setOption){return(
   return el;
 })()
 )};
+const _14mwbuc = (G, _) => G.input(_);
 const _l4sbcd = function _70(md){return(
 md`## Pinning`
 )};
-const _1sxszb9 = (_, v) => v.import("getFileAttachment", _);
 const _ezl7wk = function _72(FileAttachment){return(
 FileAttachment("cell_options.json")
 )};
@@ -5667,6 +5677,7 @@ getFileAttachment("cell_options.json", editorModule)
 const _760ozq = async function _options(Inputs,optionsFile){return(
 Inputs.input(await optionsFile.json())
 )};
+const _4rh26k = (G, _) => G.input(_);
 const _1lqy7cs = function _setOption(findCell,_,$0,Event){return(
 (variable, option, value) => {
   const cell = findCell(variable);
@@ -5846,6 +5857,7 @@ const _1j3c2uf = function _decompiled(editedCell,decompile)
 const _w5q3yf = function _editorModule(thisModule){return(
 thisModule()
 )};
+const _18kaj2p = (G, _) => G.input(_);
 const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_options)
 {
   //editedCell;
@@ -5857,43 +5869,47 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1ju14cq = function _compile_and_update(compile,runtime,repositionSetElement){return(
-(source, variables = [], cell) => {
-    try {
-        debugger;
-        let reposition = false, insertionIndex = -1;
-        const newVariables = compile(source);
-        if (!variables || variables.length !== newVariables.length) {
-            reposition = true;
-            variables.forEach(v => v.delete());
-            variables.length = 0;
-            for (let i = 0; i < newVariables.length; i++) {
-                const newVariable = cell.module.module.variable({});
-                variables.push(newVariable);
+const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+{
+    return (source, variables = [], cell) => {
+        try {
+            debugger;
+            let reposition = false, insertionIndex = -1;
+            const newVariables = compile(source);
+            if (!variables || variables.length !== newVariables.length) {
+                reposition = true;
+                variables.forEach(v => v.delete());
+                variables.length = 0;
+                for (let i = 0; i < newVariables.length; i++) {
+                    const newVariable = cell.module.module.variable({});
+                    // Assign a random pid up-front so blank/identical new cells don't
+                    // collide via persistentId's contentHash. See lopecode#144.
+                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+                    variables.push(newVariable);
+                }
             }
-        }
-        if (reposition) {
-            insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-        }
-        newVariables.forEach((v, i) => {
-            const variable = variables[i];
-            let _fn;
-            eval('_fn = ' + v._definition);
-            if (v._name) {
-                variable.define(v._name, v._inputs, _fn);
-            } else {
-                variable.define(v._inputs, _fn);
+            if (reposition) {
+                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
-            if (reposition)
-                repositionSetElement(runtime._variables, variable, insertionIndex + i);
-        });
-        return variables;
-    } catch (e) {
-        console.error(e);
-        debugger;
-    }
-}
-)};
+            newVariables.forEach((v, i) => {
+                const variable = variables[i];
+                let _fn;
+                eval('_fn = ' + v._definition);
+                if (v._name) {
+                    variable.define(v._name, v._inputs, _fn);
+                } else {
+                    variable.define(v._inputs, _fn);
+                }
+                if (reposition)
+                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
+            });
+            return variables;
+        } catch (e) {
+            console.error(e);
+            debugger;
+        }
+    };
+};
 const _1jqs8in = function _91(md){return(
 md`### Remove Cells`
 )};
@@ -5912,6 +5928,7 @@ Inputs.radio(editedCell.variables, {
   value: editedCell.variables[0]
 })
 )};
+const _11gvkq4 = (G, _) => G.input(_);
 const _r5nvms = function _name(variable){return(
 variable._name
 )};
@@ -5925,6 +5942,7 @@ Inputs.textarea({
   rows: 10
 })
 )};
+const _b4rsn5 = (G, _) => G.input(_);
 const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
@@ -5938,22 +5956,12 @@ Inputs.button("update variable", {
 const _1q557s = function _99(md){return(
 md`### Editor Libraries`
 )};
-const _192vvs7 = (_, v) => v.import("descendants", _);
-const _3va6tf = (_, v) => v.import("EditorState", _);
-const _lmqjiv = (_, v) => v.import("decompile", _);
 const _1d94dks = function _javascriptPlugin(codemirror){return(
 codemirror
 )};
 const _ar9tao = function _104(md){return(
 md`### Libraries`
 )};
-const _viogn = (_, v) => v.import("reversibleAttach", _);
-const _nxg8mr = (_, v) => v.import("moduleMap", _);
-const _14a94d = (_, v) => v.import("flowQueue", _);
-const _gurtwb = (_, v) => v.import("viewof liveCellMap", _);
-const _19ebgtz = (_, v) => v.import("hash", _);
-const _n2vgkz = (_, v) => v.import("extractNotebookAndCell", _);
-const _1qucevb = (_, v) => v.import("cellsToClipboard", _);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -5967,22 +5975,34 @@ export default function define(runtime, observer) {
     return [name, {url: blob_url, mimeType: mime}]
   }));
   main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
+  main.define("module @tomlarkworthy/dataflow-templating", async () => runtime.module((await import("/@tomlarkworthy/dataflow-templating.js?v=4")).default));  
+  main.define("module @tomlarkworthy/fileattachments", async () => runtime.module((await import("/@tomlarkworthy/fileattachments.js?v=4")).default));  
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/codemirror-6-v2", async () => runtime.module((await import("/@tomlarkworthy/codemirror-6-v2.js?v=4")).default));  
+  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
+  main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
+  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
+  main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
+  main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
+  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
+  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
+  main.define("module @tomlarkworthy/cells-to-clipboard", async () => runtime.module((await import("/@tomlarkworthy/cells-to-clipboard.js?v=4")).default));  
   $def("_1tdjp0a", "title", ["md"], _1tdjp0a);  
   $def("_dm53bx", null, ["md"], _dm53bx);  
   $def("_61oxjf", "title_variable", ["lookupVariable","editorModule"], _61oxjf);  
   $def("_15uilf0", null, ["cellEditor","title_variable"], _15uilf0);  
   $def("_3x695f", null, ["md"], _3x695f);  
   $def("_1ociws4", null, ["md"], _1ociws4);  
-  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
   $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
-  main.variable(observer("attachContextManu")).define("attachContextManu", ["Generators", "viewof attachContextManu"], (G, _) => G.input(_));  
+  $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
   $def("_16ks4jz", null, ["md"], _16ks4jz);  
-  main.define("module @tomlarkworthy/dataflow-templating", async () => runtime.module((await import("/@tomlarkworthy/dataflow-templating.js?v=4")).default));  
   main.define("cloneDataflow", ["module @tomlarkworthy/dataflow-templating", "@variable"], (_, v) => v.import("cloneDataflow", _));  
   main.define("lookupVariable", ["module @tomlarkworthy/dataflow-templating", "@variable"], (_, v) => v.import("lookupVariable", _));  
   $def("_199ztvl", "hotbarTemplate", ["lookupVariable","editorModule"], _199ztvl);  
@@ -5993,7 +6013,7 @@ export default function define(runtime, observer) {
   $def("_110gwi7", "editorTemplate", ["lookupVariable","editorModule"], _110gwi7);  
   $def("_16rqzgl", null, ["md"], _16rqzgl);  
   $def("_1o2h65s", "viewof editedCell", ["Inputs"], _1o2h65s);  
-  main.variable(observer("editedCell")).define("editedCell", ["Generators", "viewof editedCell"], (G, _) => G.input(_));  
+  $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
   $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
@@ -6008,24 +6028,24 @@ export default function define(runtime, observer) {
   $def("_mrrmx3", null, ["md"], _mrrmx3);  
   $def("_14b1byw", null, ["md"], _14b1byw);  
   $def("_1j1loxx", "viewof combine", ["Inputs"], _1j1loxx);  
-  main.variable(observer("combine")).define("combine", ["Generators", "viewof combine"], (G, _) => G.input(_));  
+  $def("_1h8337z", "combine", ["Generators","viewof combine"], _1h8337z);  
   $def("_tct2nf", "viewof edit", ["Inputs"], _tct2nf);  
-  main.variable(observer("edit")).define("edit", ["Generators", "viewof edit"], (G, _) => G.input(_));  
+  $def("_7izj7k", "edit", ["Generators","viewof edit"], _7izj7k);  
   $def("_1fwb5jc", "toolbar", ["htl","reversibleAttach","combine","viewof select","viewof up","viewof down","viewof remove","viewof addCells","viewof apply","viewof copy","viewof paste"], _1fwb5jc);  
   $def("_yej3hb", "viewof addCells", ["Inputs","createCell","viewof editedCell"], _yej3hb);  
-  main.variable(observer("addCells")).define("addCells", ["Generators", "viewof addCells"], (G, _) => G.input(_));  
+  $def("_1aii9ps", "addCells", ["Generators","viewof addCells"], _1aii9ps);  
   $def("_1bn860e", "viewof remove", ["Inputs","deleteCell","viewof editedCell"], _1bn860e);  
-  main.variable(observer("remove")).define("remove", ["Generators", "viewof remove"], (G, _) => G.input(_));  
+  $def("_1ad0xr8", "remove", ["Generators","viewof remove"], _1ad0xr8);  
   $def("_tw1j7n", "viewof apply", ["Inputs","compile_and_update","states","editedCell"], _tw1j7n);  
-  main.variable(observer("apply")).define("apply", ["Generators", "viewof apply"], (G, _) => G.input(_));  
+  $def("_1cjyuqm", "apply", ["Generators","viewof apply"], _1cjyuqm);  
   $def("_14rfku9", "viewof up", ["Inputs","moveCell","viewof editedCell"], _14rfku9);  
-  main.variable(observer("up")).define("up", ["Generators", "viewof up"], (G, _) => G.input(_));  
+  $def("_frzs5d", "up", ["Generators","viewof up"], _frzs5d);  
   $def("_9pymuj", "viewof paste", ["Inputs","readObservableClipboardCells","pasteObservableCellsIntoModule","editedCell"], _9pymuj);  
-  main.variable(observer("paste")).define("paste", ["Generators", "viewof paste"], (G, _) => G.input(_));  
+  $def("_1whsszt", "paste", ["Generators","viewof paste"], _1whsszt);  
   $def("_corxwl", "viewof down", ["Inputs","moveCell","viewof editedCell"], _corxwl);  
-  main.variable(observer("down")).define("down", ["Generators", "viewof down"], (G, _) => G.input(_));  
+  $def("_1to28po", "down", ["Generators","viewof down"], _1to28po);  
   $def("_gia2ci", "viewof copy", ["Inputs","html","viewof editedCell","decompile","viewof liveCellMap","getOption","cellsToClipboard"], _gia2ci);  
-  main.variable(observer("copy")).define("copy", ["Generators", "viewof copy"], (G, _) => G.input(_));  
+  $def("_fw41wt", "copy", ["Generators","viewof copy"], _fw41wt);  
   $def("_srtw8o", "module", ["editedCell"], _srtw8o);  
   $def("_rv7t7x", "code_editor_view", ["EditorView"], _rv7t7x);  
   $def("_xvo1n6", "code_editor", ["code_editor_view"], _xvo1n6);  
@@ -6035,7 +6055,7 @@ export default function define(runtime, observer) {
   $def("_d9nzys", "deleteCell", ["viewof command"], _d9nzys);  
   $def("_c1u9w8", null, ["md"], _c1u9w8);  
   $def("_d7ouqx", "viewof command", ["flowQueue"], _d7ouqx);  
-  main.variable(observer("command")).define("command", ["Generators", "viewof command"], (G, _) => G.input(_));  
+  $def("_118qt2v", "command", ["Generators","viewof command"], _118qt2v);  
   $def("_19l2nem", null, ["command"], _19l2nem);  
   $def("_1f6v167", "findCellByVariable", [], _1f6v167);  
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
@@ -6052,9 +6072,8 @@ export default function define(runtime, observer) {
   $def("_dvne2z", "replaceCodeMirrorDoc", [], _dvne2z);  
   $def("_1fpqfm0", null, ["md"], _1fpqfm0);  
   $def("_rtf009", "viewof select", ["editedCell","Inputs","getOption","setOption"], _rtf009);  
-  main.variable(observer("select")).define("select", ["Generators", "viewof select"], (G, _) => G.input(_));  
+  $def("_14mwbuc", "select", ["Generators","viewof select"], _14mwbuc);  
   $def("_l4sbcd", null, ["md"], _l4sbcd);  
-  main.define("module @tomlarkworthy/fileattachments", async () => runtime.module((await import("/@tomlarkworthy/fileattachments.js?v=4")).default));  
   main.define("getFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachment", _));  
   main.define("setFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("setFileAttachment", _));  
   main.define("removeFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("removeFileAttachment", _));  
@@ -6063,7 +6082,7 @@ export default function define(runtime, observer) {
   $def("_ezl7wk", null, ["FileAttachment"], _ezl7wk);  
   $def("_kygz54", "optionsFile", ["getFileAttachment","editorModule"], _kygz54);  
   $def("_760ozq", "viewof options", ["Inputs","optionsFile"], _760ozq);  
-  main.variable(observer("options")).define("options", ["Generators", "viewof options"], (G, _) => G.input(_));  
+  $def("_4rh26k", "options", ["Generators","viewof options"], _4rh26k);  
   $def("_1lqy7cs", "setOption", ["findCell","_","viewof options","Event"], _1lqy7cs);  
   $def("_1oxe5ee", "getOption", ["findCell","_","viewof options"], _1oxe5ee);  
   $def("_kwq69p", "save_options", ["setFileAttachment","jsonFileAttachment","options","editorModule"], _kwq69p);  
@@ -6077,22 +6096,21 @@ export default function define(runtime, observer) {
   $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
   $def("_1j3c2uf", "decompiled", ["editedCell","decompile"], _1j3c2uf);  
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
-  main.variable(observer("editorModule")).define("editorModule", ["Generators", "viewof editorModule"], (G, _) => G.input(_));  
+  $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1ju14cq", "compile_and_update", ["compile","runtime","repositionSetElement"], _1ju14cq);  
+  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
   $def("_rwez9", "viewof variable", ["Inputs","editedCell"], _rwez9);  
-  main.variable(observer("variable")).define("variable", ["Generators", "viewof variable"], (G, _) => G.input(_));  
+  $def("_11gvkq4", "variable", ["Generators","viewof variable"], _11gvkq4);  
   $def("_r5nvms", "name", ["variable"], _r5nvms);  
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
-  main.variable(observer("definition")).define("definition", ["Generators", "viewof definition"], (G, _) => G.input(_));  
+  $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
   $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
   $def("_1q557s", null, ["md"], _1q557s);  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -6103,12 +6121,10 @@ export default function define(runtime, observer) {
   main.define("isnode", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("isnode", _));  
   main.define("repositionSetElement", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("repositionSetElement", _));  
   main.define("onCodeChange", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("onCodeChange", _));  
-  main.define("module @tomlarkworthy/codemirror-6-v2", async () => runtime.module((await import("/@tomlarkworthy/codemirror-6-v2.js?v=4")).default));  
   main.define("EditorState", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("EditorState", _));  
   main.define("EditorView", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("EditorView", _));  
   main.define("codemirror", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("codemirror", _));  
   main.define("myDefaultTheme", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("myDefaultTheme", _));  
-  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
   main.define("decompile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("decompile", _));  
   main.define("compile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("compile", _));  
   main.define("cellMap", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("cellMap", _));  
@@ -6117,27 +6133,21 @@ export default function define(runtime, observer) {
   main.define("parser", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("parser", _));  
   $def("_1d94dks", "javascriptPlugin", ["codemirror"], _1d94dks);  
   $def("_ar9tao", null, ["md"], _ar9tao);  
-  main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
   main.define("reversibleAttach", ["module @tomlarkworthy/reversible-attachment", "@variable"], (_, v) => v.import("reversibleAttach", _));  
-  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
   main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
-  main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
   main.define("flowQueue", ["module @tomlarkworthy/flow-queue", "@variable"], (_, v) => v.import("flowQueue", _));  
-  main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
   main.define("viewof liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("viewof liveCellMap", _));  
   main.define("liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("liveCellMap", _));  
-  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
   main.define("hash", ["module d/57d79353bac56631@44", "@variable"], (_, v) => v.import("hash", _));  
-  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
   main.define("extractNotebookAndCell", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("extractNotebookAndCell", _));  
   main.define("navHref", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("navHref", _));  
-  main.define("module @tomlarkworthy/cells-to-clipboard", async () => runtime.module((await import("/@tomlarkworthy/cells-to-clipboard.js?v=4")).default));  
   main.define("cellsToClipboard", ["module @tomlarkworthy/cells-to-clipboard", "@variable"], (_, v) => v.import("cellsToClipboard", _));
   return main;
-}</script>
+}
+</script>
 <script id="@tomlarkworthy/escodegen/escodegen.browser.min.js.gz" 
   type="text/plain"
   data-encoding="base64"

--- a/notebooks/@tomlarkworthy_debugger.html
+++ b/notebooks/@tomlarkworthy_debugger.html
@@ -5103,7 +5103,7 @@ export default function define(runtime, observer) {
 >
 e30K
 </script>
-<script id="@tomlarkworthy/editor-5" 
+<script id="@tomlarkworthy/editor-5"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -5150,7 +5150,6 @@ md`## TODO
 const _1ociws4 = function _6(md){return(
 md`## Sync editors`
 )};
-const _1vq49kx = (_, v) => v.import("syncers", _);
 const _hdieof = function _editors(){return(
 new Map()
 )};
@@ -5228,12 +5227,12 @@ Inputs.toggle({
   value: !isOnObservableCom()
 })
 )};
+const _1oaz8r1 = (G, _) => G.input(_);
 const _16ks4jz = function _12(md){return(
 md`## \`cellEditor\` component
 
 Using Dataflow templating to create reusable Hotbar Component builder`
 )};
-const _1deps8p = (_, v) => v.import("cloneDataflow", _);
 const _199ztvl = function _hotbarTemplate(lookupVariable,editorModule){return(
 lookupVariable(
   [
@@ -5470,6 +5469,7 @@ md`## Hotbar Prototype`
 const _1o2h65s = function _editedCell(Inputs){return(
 Inputs.input(null)
 )};
+const _7g3h7h = (G, _) => G.input(_);
 const _1urs1md = function _findCell($0,modules){return(
 (variable, dom = undefined) => {
   if (variable) {
@@ -5629,9 +5629,11 @@ Inputs.toggle({
   value: true
 })
 )};
+const _1h8337z = (G, _) => G.input(_);
 const _tct2nf = function _edit(Inputs){return(
 Inputs.toggle({ label: "edit" })
 )};
+const _7izj7k = (G, _) => G.input(_);
 const _1fwb5jc = function _toolbar(htl,reversibleAttach,combine,$0,$1,$2,$3,$4,$5,$6,$7){return(
 htl.html`<div
     class="toolbar"
@@ -5659,11 +5661,13 @@ Inputs.button("➕", {
   }
 })
 )};
+const _1aii9ps = (G, _) => G.input(_);
 const _1bn860e = function _remove(Inputs,deleteCell,$0){return(
 Inputs.button("🗑️", {
   reduce: () => deleteCell({ cell: $0.value })
 })
 )};
+const _1ad0xr8 = (G, _) => G.input(_);
 const _tw1j7n = function _apply(Inputs,compile_and_update,states,editedCell)
 {
   const button = Inputs.button("▶️", {
@@ -5682,11 +5686,13 @@ const _tw1j7n = function _apply(Inputs,compile_and_update,states,editedCell)
   button.onmousedown = (e) => e.preventDefault();
   return button;
 };
+const _1cjyuqm = (G, _) => G.input(_);
 const _14rfku9 = function _up(Inputs,moveCell,$0){return(
 Inputs.button("⬆", {
   reduce: () => moveCell($0.value, -1)
 })
 )};
+const _frzs5d = (G, _) => G.input(_);
 const _9pymuj = function _paste(Inputs,readObservableClipboardCells,pasteObservableCellsIntoModule,editedCell){return(
 Inputs.button("📋", {
   reduce: async () => {
@@ -5695,11 +5701,13 @@ Inputs.button("📋", {
   }
 })
 )};
+const _1whsszt = (G, _) => G.input(_);
 const _corxwl = function _down(Inputs,moveCell,$0){return(
 Inputs.button("⬇", {
   reduce: () => moveCell($0.value, 1)
 })
 )};
+const _1to28po = (G, _) => G.input(_);
 const _gia2ci = function _copy(Inputs,html,$0,decompile,$1,getOption,cellsToClipboard){return(
 Inputs.button(
   html`<span style="font-size: .875em; margin-right: .125em; position: relative; top: -.25em; left: -.125em">
@@ -5741,6 +5749,7 @@ Inputs.button(
   }
 )
 )};
+const _fw41wt = (G, _) => G.input(_);
 const _srtw8o = function _module(editedCell){return(
 editedCell.module.module
 )};
@@ -5795,6 +5804,7 @@ md`## API handler`
 const _d7ouqx = function _command(flowQueue){return(
 flowQueue()
 )};
+const _118qt2v = (G, _) => G.input(_);
 const _19l2nem = function _54(command){return(
 command
 )};
@@ -6067,10 +6077,10 @@ const _rtf009 = function _select(editedCell,Inputs,getOption,setOption){return(
   return el;
 })()
 )};
+const _14mwbuc = (G, _) => G.input(_);
 const _l4sbcd = function _70(md){return(
 md`## Pinning`
 )};
-const _1sxszb9 = (_, v) => v.import("getFileAttachment", _);
 const _ezl7wk = function _72(FileAttachment){return(
 FileAttachment("cell_options.json")
 )};
@@ -6080,6 +6090,7 @@ getFileAttachment("cell_options.json", editorModule)
 const _760ozq = async function _options(Inputs,optionsFile){return(
 Inputs.input(await optionsFile.json())
 )};
+const _4rh26k = (G, _) => G.input(_);
 const _1lqy7cs = function _setOption(findCell,_,$0,Event){return(
 (variable, option, value) => {
   const cell = findCell(variable);
@@ -6259,6 +6270,7 @@ const _1j3c2uf = function _decompiled(editedCell,decompile)
 const _w5q3yf = function _editorModule(thisModule){return(
 thisModule()
 )};
+const _18kaj2p = (G, _) => G.input(_);
 const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_options)
 {
   //editedCell;
@@ -6270,43 +6282,47 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1ju14cq = function _compile_and_update(compile,runtime,repositionSetElement){return(
-(source, variables = [], cell) => {
-    try {
-        debugger;
-        let reposition = false, insertionIndex = -1;
-        const newVariables = compile(source);
-        if (!variables || variables.length !== newVariables.length) {
-            reposition = true;
-            variables.forEach(v => v.delete());
-            variables.length = 0;
-            for (let i = 0; i < newVariables.length; i++) {
-                const newVariable = cell.module.module.variable({});
-                variables.push(newVariable);
+const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+{
+    return (source, variables = [], cell) => {
+        try {
+            debugger;
+            let reposition = false, insertionIndex = -1;
+            const newVariables = compile(source);
+            if (!variables || variables.length !== newVariables.length) {
+                reposition = true;
+                variables.forEach(v => v.delete());
+                variables.length = 0;
+                for (let i = 0; i < newVariables.length; i++) {
+                    const newVariable = cell.module.module.variable({});
+                    // Assign a random pid up-front so blank/identical new cells don't
+                    // collide via persistentId's contentHash. See lopecode#144.
+                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+                    variables.push(newVariable);
+                }
             }
-        }
-        if (reposition) {
-            insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-        }
-        newVariables.forEach((v, i) => {
-            const variable = variables[i];
-            let _fn;
-            eval('_fn = ' + v._definition);
-            if (v._name) {
-                variable.define(v._name, v._inputs, _fn);
-            } else {
-                variable.define(v._inputs, _fn);
+            if (reposition) {
+                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
-            if (reposition)
-                repositionSetElement(runtime._variables, variable, insertionIndex + i);
-        });
-        return variables;
-    } catch (e) {
-        console.error(e);
-        debugger;
-    }
-}
-)};
+            newVariables.forEach((v, i) => {
+                const variable = variables[i];
+                let _fn;
+                eval('_fn = ' + v._definition);
+                if (v._name) {
+                    variable.define(v._name, v._inputs, _fn);
+                } else {
+                    variable.define(v._inputs, _fn);
+                }
+                if (reposition)
+                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
+            });
+            return variables;
+        } catch (e) {
+            console.error(e);
+            debugger;
+        }
+    };
+};
 const _1jqs8in = function _91(md){return(
 md`### Remove Cells`
 )};
@@ -6325,6 +6341,7 @@ Inputs.radio(editedCell.variables, {
   value: editedCell.variables[0]
 })
 )};
+const _11gvkq4 = (G, _) => G.input(_);
 const _r5nvms = function _name(variable){return(
 variable._name
 )};
@@ -6338,6 +6355,7 @@ Inputs.textarea({
   rows: 10
 })
 )};
+const _b4rsn5 = (G, _) => G.input(_);
 const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
@@ -6351,22 +6369,12 @@ Inputs.button("update variable", {
 const _1q557s = function _99(md){return(
 md`### Editor Libraries`
 )};
-const _192vvs7 = (_, v) => v.import("descendants", _);
-const _3va6tf = (_, v) => v.import("EditorState", _);
-const _lmqjiv = (_, v) => v.import("decompile", _);
 const _1d94dks = function _javascriptPlugin(codemirror){return(
 codemirror
 )};
 const _ar9tao = function _104(md){return(
 md`### Libraries`
 )};
-const _viogn = (_, v) => v.import("reversibleAttach", _);
-const _nxg8mr = (_, v) => v.import("moduleMap", _);
-const _14a94d = (_, v) => v.import("flowQueue", _);
-const _gurtwb = (_, v) => v.import("viewof liveCellMap", _);
-const _19ebgtz = (_, v) => v.import("hash", _);
-const _n2vgkz = (_, v) => v.import("extractNotebookAndCell", _);
-const _1qucevb = (_, v) => v.import("cellsToClipboard", _);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -6380,22 +6388,34 @@ export default function define(runtime, observer) {
     return [name, {url: blob_url, mimeType: mime}]
   }));
   main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
+  main.define("module @tomlarkworthy/dataflow-templating", async () => runtime.module((await import("/@tomlarkworthy/dataflow-templating.js?v=4")).default));  
+  main.define("module @tomlarkworthy/fileattachments", async () => runtime.module((await import("/@tomlarkworthy/fileattachments.js?v=4")).default));  
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/codemirror-6-v2", async () => runtime.module((await import("/@tomlarkworthy/codemirror-6-v2.js?v=4")).default));  
+  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
+  main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
+  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
+  main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
+  main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
+  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
+  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
+  main.define("module @tomlarkworthy/cells-to-clipboard", async () => runtime.module((await import("/@tomlarkworthy/cells-to-clipboard.js?v=4")).default));  
   $def("_1tdjp0a", "title", ["md"], _1tdjp0a);  
   $def("_dm53bx", null, ["md"], _dm53bx);  
   $def("_61oxjf", "title_variable", ["lookupVariable","editorModule"], _61oxjf);  
   $def("_15uilf0", null, ["cellEditor","title_variable"], _15uilf0);  
   $def("_3x695f", null, ["md"], _3x695f);  
   $def("_1ociws4", null, ["md"], _1ociws4);  
-  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
   $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
-  main.variable(observer("attachContextManu")).define("attachContextManu", ["Generators", "viewof attachContextManu"], (G, _) => G.input(_));  
+  $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
   $def("_16ks4jz", null, ["md"], _16ks4jz);  
-  main.define("module @tomlarkworthy/dataflow-templating", async () => runtime.module((await import("/@tomlarkworthy/dataflow-templating.js?v=4")).default));  
   main.define("cloneDataflow", ["module @tomlarkworthy/dataflow-templating", "@variable"], (_, v) => v.import("cloneDataflow", _));  
   main.define("lookupVariable", ["module @tomlarkworthy/dataflow-templating", "@variable"], (_, v) => v.import("lookupVariable", _));  
   $def("_199ztvl", "hotbarTemplate", ["lookupVariable","editorModule"], _199ztvl);  
@@ -6406,7 +6426,7 @@ export default function define(runtime, observer) {
   $def("_110gwi7", "editorTemplate", ["lookupVariable","editorModule"], _110gwi7);  
   $def("_16rqzgl", null, ["md"], _16rqzgl);  
   $def("_1o2h65s", "viewof editedCell", ["Inputs"], _1o2h65s);  
-  main.variable(observer("editedCell")).define("editedCell", ["Generators", "viewof editedCell"], (G, _) => G.input(_));  
+  $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
   $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
@@ -6421,24 +6441,24 @@ export default function define(runtime, observer) {
   $def("_mrrmx3", null, ["md"], _mrrmx3);  
   $def("_14b1byw", null, ["md"], _14b1byw);  
   $def("_1j1loxx", "viewof combine", ["Inputs"], _1j1loxx);  
-  main.variable(observer("combine")).define("combine", ["Generators", "viewof combine"], (G, _) => G.input(_));  
+  $def("_1h8337z", "combine", ["Generators","viewof combine"], _1h8337z);  
   $def("_tct2nf", "viewof edit", ["Inputs"], _tct2nf);  
-  main.variable(observer("edit")).define("edit", ["Generators", "viewof edit"], (G, _) => G.input(_));  
+  $def("_7izj7k", "edit", ["Generators","viewof edit"], _7izj7k);  
   $def("_1fwb5jc", "toolbar", ["htl","reversibleAttach","combine","viewof select","viewof up","viewof down","viewof remove","viewof addCells","viewof apply","viewof copy","viewof paste"], _1fwb5jc);  
   $def("_yej3hb", "viewof addCells", ["Inputs","createCell","viewof editedCell"], _yej3hb);  
-  main.variable(observer("addCells")).define("addCells", ["Generators", "viewof addCells"], (G, _) => G.input(_));  
+  $def("_1aii9ps", "addCells", ["Generators","viewof addCells"], _1aii9ps);  
   $def("_1bn860e", "viewof remove", ["Inputs","deleteCell","viewof editedCell"], _1bn860e);  
-  main.variable(observer("remove")).define("remove", ["Generators", "viewof remove"], (G, _) => G.input(_));  
+  $def("_1ad0xr8", "remove", ["Generators","viewof remove"], _1ad0xr8);  
   $def("_tw1j7n", "viewof apply", ["Inputs","compile_and_update","states","editedCell"], _tw1j7n);  
-  main.variable(observer("apply")).define("apply", ["Generators", "viewof apply"], (G, _) => G.input(_));  
+  $def("_1cjyuqm", "apply", ["Generators","viewof apply"], _1cjyuqm);  
   $def("_14rfku9", "viewof up", ["Inputs","moveCell","viewof editedCell"], _14rfku9);  
-  main.variable(observer("up")).define("up", ["Generators", "viewof up"], (G, _) => G.input(_));  
+  $def("_frzs5d", "up", ["Generators","viewof up"], _frzs5d);  
   $def("_9pymuj", "viewof paste", ["Inputs","readObservableClipboardCells","pasteObservableCellsIntoModule","editedCell"], _9pymuj);  
-  main.variable(observer("paste")).define("paste", ["Generators", "viewof paste"], (G, _) => G.input(_));  
+  $def("_1whsszt", "paste", ["Generators","viewof paste"], _1whsszt);  
   $def("_corxwl", "viewof down", ["Inputs","moveCell","viewof editedCell"], _corxwl);  
-  main.variable(observer("down")).define("down", ["Generators", "viewof down"], (G, _) => G.input(_));  
+  $def("_1to28po", "down", ["Generators","viewof down"], _1to28po);  
   $def("_gia2ci", "viewof copy", ["Inputs","html","viewof editedCell","decompile","viewof liveCellMap","getOption","cellsToClipboard"], _gia2ci);  
-  main.variable(observer("copy")).define("copy", ["Generators", "viewof copy"], (G, _) => G.input(_));  
+  $def("_fw41wt", "copy", ["Generators","viewof copy"], _fw41wt);  
   $def("_srtw8o", "module", ["editedCell"], _srtw8o);  
   $def("_rv7t7x", "code_editor_view", ["EditorView"], _rv7t7x);  
   $def("_xvo1n6", "code_editor", ["code_editor_view"], _xvo1n6);  
@@ -6448,7 +6468,7 @@ export default function define(runtime, observer) {
   $def("_d9nzys", "deleteCell", ["viewof command"], _d9nzys);  
   $def("_c1u9w8", null, ["md"], _c1u9w8);  
   $def("_d7ouqx", "viewof command", ["flowQueue"], _d7ouqx);  
-  main.variable(observer("command")).define("command", ["Generators", "viewof command"], (G, _) => G.input(_));  
+  $def("_118qt2v", "command", ["Generators","viewof command"], _118qt2v);  
   $def("_19l2nem", null, ["command"], _19l2nem);  
   $def("_1f6v167", "findCellByVariable", [], _1f6v167);  
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
@@ -6465,9 +6485,8 @@ export default function define(runtime, observer) {
   $def("_dvne2z", "replaceCodeMirrorDoc", [], _dvne2z);  
   $def("_1fpqfm0", null, ["md"], _1fpqfm0);  
   $def("_rtf009", "viewof select", ["editedCell","Inputs","getOption","setOption"], _rtf009);  
-  main.variable(observer("select")).define("select", ["Generators", "viewof select"], (G, _) => G.input(_));  
+  $def("_14mwbuc", "select", ["Generators","viewof select"], _14mwbuc);  
   $def("_l4sbcd", null, ["md"], _l4sbcd);  
-  main.define("module @tomlarkworthy/fileattachments", async () => runtime.module((await import("/@tomlarkworthy/fileattachments.js?v=4")).default));  
   main.define("getFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachment", _));  
   main.define("setFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("setFileAttachment", _));  
   main.define("removeFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("removeFileAttachment", _));  
@@ -6476,7 +6495,7 @@ export default function define(runtime, observer) {
   $def("_ezl7wk", null, ["FileAttachment"], _ezl7wk);  
   $def("_kygz54", "optionsFile", ["getFileAttachment","editorModule"], _kygz54);  
   $def("_760ozq", "viewof options", ["Inputs","optionsFile"], _760ozq);  
-  main.variable(observer("options")).define("options", ["Generators", "viewof options"], (G, _) => G.input(_));  
+  $def("_4rh26k", "options", ["Generators","viewof options"], _4rh26k);  
   $def("_1lqy7cs", "setOption", ["findCell","_","viewof options","Event"], _1lqy7cs);  
   $def("_1oxe5ee", "getOption", ["findCell","_","viewof options"], _1oxe5ee);  
   $def("_kwq69p", "save_options", ["setFileAttachment","jsonFileAttachment","options","editorModule"], _kwq69p);  
@@ -6490,22 +6509,21 @@ export default function define(runtime, observer) {
   $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
   $def("_1j3c2uf", "decompiled", ["editedCell","decompile"], _1j3c2uf);  
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
-  main.variable(observer("editorModule")).define("editorModule", ["Generators", "viewof editorModule"], (G, _) => G.input(_));  
+  $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1ju14cq", "compile_and_update", ["compile","runtime","repositionSetElement"], _1ju14cq);  
+  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
   $def("_rwez9", "viewof variable", ["Inputs","editedCell"], _rwez9);  
-  main.variable(observer("variable")).define("variable", ["Generators", "viewof variable"], (G, _) => G.input(_));  
+  $def("_11gvkq4", "variable", ["Generators","viewof variable"], _11gvkq4);  
   $def("_r5nvms", "name", ["variable"], _r5nvms);  
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
-  main.variable(observer("definition")).define("definition", ["Generators", "viewof definition"], (G, _) => G.input(_));  
+  $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
   $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
   $def("_1q557s", null, ["md"], _1q557s);  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -6516,12 +6534,10 @@ export default function define(runtime, observer) {
   main.define("isnode", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("isnode", _));  
   main.define("repositionSetElement", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("repositionSetElement", _));  
   main.define("onCodeChange", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("onCodeChange", _));  
-  main.define("module @tomlarkworthy/codemirror-6-v2", async () => runtime.module((await import("/@tomlarkworthy/codemirror-6-v2.js?v=4")).default));  
   main.define("EditorState", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("EditorState", _));  
   main.define("EditorView", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("EditorView", _));  
   main.define("codemirror", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("codemirror", _));  
   main.define("myDefaultTheme", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("myDefaultTheme", _));  
-  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
   main.define("decompile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("decompile", _));  
   main.define("compile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("compile", _));  
   main.define("cellMap", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("cellMap", _));  
@@ -6530,27 +6546,21 @@ export default function define(runtime, observer) {
   main.define("parser", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("parser", _));  
   $def("_1d94dks", "javascriptPlugin", ["codemirror"], _1d94dks);  
   $def("_ar9tao", null, ["md"], _ar9tao);  
-  main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
   main.define("reversibleAttach", ["module @tomlarkworthy/reversible-attachment", "@variable"], (_, v) => v.import("reversibleAttach", _));  
-  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
   main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
-  main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
   main.define("flowQueue", ["module @tomlarkworthy/flow-queue", "@variable"], (_, v) => v.import("flowQueue", _));  
-  main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
   main.define("viewof liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("viewof liveCellMap", _));  
   main.define("liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("liveCellMap", _));  
-  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
   main.define("hash", ["module d/57d79353bac56631@44", "@variable"], (_, v) => v.import("hash", _));  
-  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
   main.define("extractNotebookAndCell", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("extractNotebookAndCell", _));  
   main.define("navHref", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("navHref", _));  
-  main.define("module @tomlarkworthy/cells-to-clipboard", async () => runtime.module((await import("/@tomlarkworthy/cells-to-clipboard.js?v=4")).default));  
   main.define("cellsToClipboard", ["module @tomlarkworthy/cells-to-clipboard", "@variable"], (_, v) => v.import("cellsToClipboard", _));
   return main;
-}</script>
+}
+</script>
 <script id="@tomlarkworthy/escodegen/escodegen.browser.min.js.gz" 
   type="text/plain"
   data-encoding="base64"

--- a/notebooks/@tomlarkworthy_dom-view.html
+++ b/notebooks/@tomlarkworthy_dom-view.html
@@ -4690,7 +4690,7 @@ export default function define(runtime, observer) {
 >
 e30K
 </script>
-<script id="@tomlarkworthy/editor-5" 
+<script id="@tomlarkworthy/editor-5"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -4737,7 +4737,6 @@ md`## TODO
 const _1ociws4 = function _6(md){return(
 md`## Sync editors`
 )};
-const _1vq49kx = (_, v) => v.import("syncers", _);
 const _hdieof = function _editors(){return(
 new Map()
 )};
@@ -4815,12 +4814,12 @@ Inputs.toggle({
   value: !isOnObservableCom()
 })
 )};
+const _1oaz8r1 = (G, _) => G.input(_);
 const _16ks4jz = function _12(md){return(
 md`## \`cellEditor\` component
 
 Using Dataflow templating to create reusable Hotbar Component builder`
 )};
-const _1deps8p = (_, v) => v.import("cloneDataflow", _);
 const _199ztvl = function _hotbarTemplate(lookupVariable,editorModule){return(
 lookupVariable(
   [
@@ -5057,6 +5056,7 @@ md`## Hotbar Prototype`
 const _1o2h65s = function _editedCell(Inputs){return(
 Inputs.input(null)
 )};
+const _7g3h7h = (G, _) => G.input(_);
 const _1urs1md = function _findCell($0,modules){return(
 (variable, dom = undefined) => {
   if (variable) {
@@ -5216,9 +5216,11 @@ Inputs.toggle({
   value: true
 })
 )};
+const _1h8337z = (G, _) => G.input(_);
 const _tct2nf = function _edit(Inputs){return(
 Inputs.toggle({ label: "edit" })
 )};
+const _7izj7k = (G, _) => G.input(_);
 const _1fwb5jc = function _toolbar(htl,reversibleAttach,combine,$0,$1,$2,$3,$4,$5,$6,$7){return(
 htl.html`<div
     class="toolbar"
@@ -5246,11 +5248,13 @@ Inputs.button("➕", {
   }
 })
 )};
+const _1aii9ps = (G, _) => G.input(_);
 const _1bn860e = function _remove(Inputs,deleteCell,$0){return(
 Inputs.button("🗑️", {
   reduce: () => deleteCell({ cell: $0.value })
 })
 )};
+const _1ad0xr8 = (G, _) => G.input(_);
 const _tw1j7n = function _apply(Inputs,compile_and_update,states,editedCell)
 {
   const button = Inputs.button("▶️", {
@@ -5269,11 +5273,13 @@ const _tw1j7n = function _apply(Inputs,compile_and_update,states,editedCell)
   button.onmousedown = (e) => e.preventDefault();
   return button;
 };
+const _1cjyuqm = (G, _) => G.input(_);
 const _14rfku9 = function _up(Inputs,moveCell,$0){return(
 Inputs.button("⬆", {
   reduce: () => moveCell($0.value, -1)
 })
 )};
+const _frzs5d = (G, _) => G.input(_);
 const _9pymuj = function _paste(Inputs,readObservableClipboardCells,pasteObservableCellsIntoModule,editedCell){return(
 Inputs.button("📋", {
   reduce: async () => {
@@ -5282,11 +5288,13 @@ Inputs.button("📋", {
   }
 })
 )};
+const _1whsszt = (G, _) => G.input(_);
 const _corxwl = function _down(Inputs,moveCell,$0){return(
 Inputs.button("⬇", {
   reduce: () => moveCell($0.value, 1)
 })
 )};
+const _1to28po = (G, _) => G.input(_);
 const _gia2ci = function _copy(Inputs,html,$0,decompile,$1,getOption,cellsToClipboard){return(
 Inputs.button(
   html`<span style="font-size: .875em; margin-right: .125em; position: relative; top: -.25em; left: -.125em">
@@ -5328,6 +5336,7 @@ Inputs.button(
   }
 )
 )};
+const _fw41wt = (G, _) => G.input(_);
 const _srtw8o = function _module(editedCell){return(
 editedCell.module.module
 )};
@@ -5382,6 +5391,7 @@ md`## API handler`
 const _d7ouqx = function _command(flowQueue){return(
 flowQueue()
 )};
+const _118qt2v = (G, _) => G.input(_);
 const _19l2nem = function _54(command){return(
 command
 )};
@@ -5654,10 +5664,10 @@ const _rtf009 = function _select(editedCell,Inputs,getOption,setOption){return(
   return el;
 })()
 )};
+const _14mwbuc = (G, _) => G.input(_);
 const _l4sbcd = function _70(md){return(
 md`## Pinning`
 )};
-const _1sxszb9 = (_, v) => v.import("getFileAttachment", _);
 const _ezl7wk = function _72(FileAttachment){return(
 FileAttachment("cell_options.json")
 )};
@@ -5667,6 +5677,7 @@ getFileAttachment("cell_options.json", editorModule)
 const _760ozq = async function _options(Inputs,optionsFile){return(
 Inputs.input(await optionsFile.json())
 )};
+const _4rh26k = (G, _) => G.input(_);
 const _1lqy7cs = function _setOption(findCell,_,$0,Event){return(
 (variable, option, value) => {
   const cell = findCell(variable);
@@ -5846,6 +5857,7 @@ const _1j3c2uf = function _decompiled(editedCell,decompile)
 const _w5q3yf = function _editorModule(thisModule){return(
 thisModule()
 )};
+const _18kaj2p = (G, _) => G.input(_);
 const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_options)
 {
   //editedCell;
@@ -5857,43 +5869,47 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1ju14cq = function _compile_and_update(compile,runtime,repositionSetElement){return(
-(source, variables = [], cell) => {
-    try {
-        debugger;
-        let reposition = false, insertionIndex = -1;
-        const newVariables = compile(source);
-        if (!variables || variables.length !== newVariables.length) {
-            reposition = true;
-            variables.forEach(v => v.delete());
-            variables.length = 0;
-            for (let i = 0; i < newVariables.length; i++) {
-                const newVariable = cell.module.module.variable({});
-                variables.push(newVariable);
+const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+{
+    return (source, variables = [], cell) => {
+        try {
+            debugger;
+            let reposition = false, insertionIndex = -1;
+            const newVariables = compile(source);
+            if (!variables || variables.length !== newVariables.length) {
+                reposition = true;
+                variables.forEach(v => v.delete());
+                variables.length = 0;
+                for (let i = 0; i < newVariables.length; i++) {
+                    const newVariable = cell.module.module.variable({});
+                    // Assign a random pid up-front so blank/identical new cells don't
+                    // collide via persistentId's contentHash. See lopecode#144.
+                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+                    variables.push(newVariable);
+                }
             }
-        }
-        if (reposition) {
-            insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-        }
-        newVariables.forEach((v, i) => {
-            const variable = variables[i];
-            let _fn;
-            eval('_fn = ' + v._definition);
-            if (v._name) {
-                variable.define(v._name, v._inputs, _fn);
-            } else {
-                variable.define(v._inputs, _fn);
+            if (reposition) {
+                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
-            if (reposition)
-                repositionSetElement(runtime._variables, variable, insertionIndex + i);
-        });
-        return variables;
-    } catch (e) {
-        console.error(e);
-        debugger;
-    }
-}
-)};
+            newVariables.forEach((v, i) => {
+                const variable = variables[i];
+                let _fn;
+                eval('_fn = ' + v._definition);
+                if (v._name) {
+                    variable.define(v._name, v._inputs, _fn);
+                } else {
+                    variable.define(v._inputs, _fn);
+                }
+                if (reposition)
+                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
+            });
+            return variables;
+        } catch (e) {
+            console.error(e);
+            debugger;
+        }
+    };
+};
 const _1jqs8in = function _91(md){return(
 md`### Remove Cells`
 )};
@@ -5912,6 +5928,7 @@ Inputs.radio(editedCell.variables, {
   value: editedCell.variables[0]
 })
 )};
+const _11gvkq4 = (G, _) => G.input(_);
 const _r5nvms = function _name(variable){return(
 variable._name
 )};
@@ -5925,6 +5942,7 @@ Inputs.textarea({
   rows: 10
 })
 )};
+const _b4rsn5 = (G, _) => G.input(_);
 const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
@@ -5938,22 +5956,12 @@ Inputs.button("update variable", {
 const _1q557s = function _99(md){return(
 md`### Editor Libraries`
 )};
-const _192vvs7 = (_, v) => v.import("descendants", _);
-const _3va6tf = (_, v) => v.import("EditorState", _);
-const _lmqjiv = (_, v) => v.import("decompile", _);
 const _1d94dks = function _javascriptPlugin(codemirror){return(
 codemirror
 )};
 const _ar9tao = function _104(md){return(
 md`### Libraries`
 )};
-const _viogn = (_, v) => v.import("reversibleAttach", _);
-const _nxg8mr = (_, v) => v.import("moduleMap", _);
-const _14a94d = (_, v) => v.import("flowQueue", _);
-const _gurtwb = (_, v) => v.import("viewof liveCellMap", _);
-const _19ebgtz = (_, v) => v.import("hash", _);
-const _n2vgkz = (_, v) => v.import("extractNotebookAndCell", _);
-const _1qucevb = (_, v) => v.import("cellsToClipboard", _);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -5967,22 +5975,34 @@ export default function define(runtime, observer) {
     return [name, {url: blob_url, mimeType: mime}]
   }));
   main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
+  main.define("module @tomlarkworthy/dataflow-templating", async () => runtime.module((await import("/@tomlarkworthy/dataflow-templating.js?v=4")).default));  
+  main.define("module @tomlarkworthy/fileattachments", async () => runtime.module((await import("/@tomlarkworthy/fileattachments.js?v=4")).default));  
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/codemirror-6-v2", async () => runtime.module((await import("/@tomlarkworthy/codemirror-6-v2.js?v=4")).default));  
+  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
+  main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
+  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
+  main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
+  main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
+  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
+  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
+  main.define("module @tomlarkworthy/cells-to-clipboard", async () => runtime.module((await import("/@tomlarkworthy/cells-to-clipboard.js?v=4")).default));  
   $def("_1tdjp0a", "title", ["md"], _1tdjp0a);  
   $def("_dm53bx", null, ["md"], _dm53bx);  
   $def("_61oxjf", "title_variable", ["lookupVariable","editorModule"], _61oxjf);  
   $def("_15uilf0", null, ["cellEditor","title_variable"], _15uilf0);  
   $def("_3x695f", null, ["md"], _3x695f);  
   $def("_1ociws4", null, ["md"], _1ociws4);  
-  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
   $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
-  main.variable(observer("attachContextManu")).define("attachContextManu", ["Generators", "viewof attachContextManu"], (G, _) => G.input(_));  
+  $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
   $def("_16ks4jz", null, ["md"], _16ks4jz);  
-  main.define("module @tomlarkworthy/dataflow-templating", async () => runtime.module((await import("/@tomlarkworthy/dataflow-templating.js?v=4")).default));  
   main.define("cloneDataflow", ["module @tomlarkworthy/dataflow-templating", "@variable"], (_, v) => v.import("cloneDataflow", _));  
   main.define("lookupVariable", ["module @tomlarkworthy/dataflow-templating", "@variable"], (_, v) => v.import("lookupVariable", _));  
   $def("_199ztvl", "hotbarTemplate", ["lookupVariable","editorModule"], _199ztvl);  
@@ -5993,7 +6013,7 @@ export default function define(runtime, observer) {
   $def("_110gwi7", "editorTemplate", ["lookupVariable","editorModule"], _110gwi7);  
   $def("_16rqzgl", null, ["md"], _16rqzgl);  
   $def("_1o2h65s", "viewof editedCell", ["Inputs"], _1o2h65s);  
-  main.variable(observer("editedCell")).define("editedCell", ["Generators", "viewof editedCell"], (G, _) => G.input(_));  
+  $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
   $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
@@ -6008,24 +6028,24 @@ export default function define(runtime, observer) {
   $def("_mrrmx3", null, ["md"], _mrrmx3);  
   $def("_14b1byw", null, ["md"], _14b1byw);  
   $def("_1j1loxx", "viewof combine", ["Inputs"], _1j1loxx);  
-  main.variable(observer("combine")).define("combine", ["Generators", "viewof combine"], (G, _) => G.input(_));  
+  $def("_1h8337z", "combine", ["Generators","viewof combine"], _1h8337z);  
   $def("_tct2nf", "viewof edit", ["Inputs"], _tct2nf);  
-  main.variable(observer("edit")).define("edit", ["Generators", "viewof edit"], (G, _) => G.input(_));  
+  $def("_7izj7k", "edit", ["Generators","viewof edit"], _7izj7k);  
   $def("_1fwb5jc", "toolbar", ["htl","reversibleAttach","combine","viewof select","viewof up","viewof down","viewof remove","viewof addCells","viewof apply","viewof copy","viewof paste"], _1fwb5jc);  
   $def("_yej3hb", "viewof addCells", ["Inputs","createCell","viewof editedCell"], _yej3hb);  
-  main.variable(observer("addCells")).define("addCells", ["Generators", "viewof addCells"], (G, _) => G.input(_));  
+  $def("_1aii9ps", "addCells", ["Generators","viewof addCells"], _1aii9ps);  
   $def("_1bn860e", "viewof remove", ["Inputs","deleteCell","viewof editedCell"], _1bn860e);  
-  main.variable(observer("remove")).define("remove", ["Generators", "viewof remove"], (G, _) => G.input(_));  
+  $def("_1ad0xr8", "remove", ["Generators","viewof remove"], _1ad0xr8);  
   $def("_tw1j7n", "viewof apply", ["Inputs","compile_and_update","states","editedCell"], _tw1j7n);  
-  main.variable(observer("apply")).define("apply", ["Generators", "viewof apply"], (G, _) => G.input(_));  
+  $def("_1cjyuqm", "apply", ["Generators","viewof apply"], _1cjyuqm);  
   $def("_14rfku9", "viewof up", ["Inputs","moveCell","viewof editedCell"], _14rfku9);  
-  main.variable(observer("up")).define("up", ["Generators", "viewof up"], (G, _) => G.input(_));  
+  $def("_frzs5d", "up", ["Generators","viewof up"], _frzs5d);  
   $def("_9pymuj", "viewof paste", ["Inputs","readObservableClipboardCells","pasteObservableCellsIntoModule","editedCell"], _9pymuj);  
-  main.variable(observer("paste")).define("paste", ["Generators", "viewof paste"], (G, _) => G.input(_));  
+  $def("_1whsszt", "paste", ["Generators","viewof paste"], _1whsszt);  
   $def("_corxwl", "viewof down", ["Inputs","moveCell","viewof editedCell"], _corxwl);  
-  main.variable(observer("down")).define("down", ["Generators", "viewof down"], (G, _) => G.input(_));  
+  $def("_1to28po", "down", ["Generators","viewof down"], _1to28po);  
   $def("_gia2ci", "viewof copy", ["Inputs","html","viewof editedCell","decompile","viewof liveCellMap","getOption","cellsToClipboard"], _gia2ci);  
-  main.variable(observer("copy")).define("copy", ["Generators", "viewof copy"], (G, _) => G.input(_));  
+  $def("_fw41wt", "copy", ["Generators","viewof copy"], _fw41wt);  
   $def("_srtw8o", "module", ["editedCell"], _srtw8o);  
   $def("_rv7t7x", "code_editor_view", ["EditorView"], _rv7t7x);  
   $def("_xvo1n6", "code_editor", ["code_editor_view"], _xvo1n6);  
@@ -6035,7 +6055,7 @@ export default function define(runtime, observer) {
   $def("_d9nzys", "deleteCell", ["viewof command"], _d9nzys);  
   $def("_c1u9w8", null, ["md"], _c1u9w8);  
   $def("_d7ouqx", "viewof command", ["flowQueue"], _d7ouqx);  
-  main.variable(observer("command")).define("command", ["Generators", "viewof command"], (G, _) => G.input(_));  
+  $def("_118qt2v", "command", ["Generators","viewof command"], _118qt2v);  
   $def("_19l2nem", null, ["command"], _19l2nem);  
   $def("_1f6v167", "findCellByVariable", [], _1f6v167);  
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
@@ -6052,9 +6072,8 @@ export default function define(runtime, observer) {
   $def("_dvne2z", "replaceCodeMirrorDoc", [], _dvne2z);  
   $def("_1fpqfm0", null, ["md"], _1fpqfm0);  
   $def("_rtf009", "viewof select", ["editedCell","Inputs","getOption","setOption"], _rtf009);  
-  main.variable(observer("select")).define("select", ["Generators", "viewof select"], (G, _) => G.input(_));  
+  $def("_14mwbuc", "select", ["Generators","viewof select"], _14mwbuc);  
   $def("_l4sbcd", null, ["md"], _l4sbcd);  
-  main.define("module @tomlarkworthy/fileattachments", async () => runtime.module((await import("/@tomlarkworthy/fileattachments.js?v=4")).default));  
   main.define("getFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachment", _));  
   main.define("setFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("setFileAttachment", _));  
   main.define("removeFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("removeFileAttachment", _));  
@@ -6063,7 +6082,7 @@ export default function define(runtime, observer) {
   $def("_ezl7wk", null, ["FileAttachment"], _ezl7wk);  
   $def("_kygz54", "optionsFile", ["getFileAttachment","editorModule"], _kygz54);  
   $def("_760ozq", "viewof options", ["Inputs","optionsFile"], _760ozq);  
-  main.variable(observer("options")).define("options", ["Generators", "viewof options"], (G, _) => G.input(_));  
+  $def("_4rh26k", "options", ["Generators","viewof options"], _4rh26k);  
   $def("_1lqy7cs", "setOption", ["findCell","_","viewof options","Event"], _1lqy7cs);  
   $def("_1oxe5ee", "getOption", ["findCell","_","viewof options"], _1oxe5ee);  
   $def("_kwq69p", "save_options", ["setFileAttachment","jsonFileAttachment","options","editorModule"], _kwq69p);  
@@ -6077,22 +6096,21 @@ export default function define(runtime, observer) {
   $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
   $def("_1j3c2uf", "decompiled", ["editedCell","decompile"], _1j3c2uf);  
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
-  main.variable(observer("editorModule")).define("editorModule", ["Generators", "viewof editorModule"], (G, _) => G.input(_));  
+  $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1ju14cq", "compile_and_update", ["compile","runtime","repositionSetElement"], _1ju14cq);  
+  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
   $def("_rwez9", "viewof variable", ["Inputs","editedCell"], _rwez9);  
-  main.variable(observer("variable")).define("variable", ["Generators", "viewof variable"], (G, _) => G.input(_));  
+  $def("_11gvkq4", "variable", ["Generators","viewof variable"], _11gvkq4);  
   $def("_r5nvms", "name", ["variable"], _r5nvms);  
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
-  main.variable(observer("definition")).define("definition", ["Generators", "viewof definition"], (G, _) => G.input(_));  
+  $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
   $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
   $def("_1q557s", null, ["md"], _1q557s);  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -6103,12 +6121,10 @@ export default function define(runtime, observer) {
   main.define("isnode", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("isnode", _));  
   main.define("repositionSetElement", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("repositionSetElement", _));  
   main.define("onCodeChange", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("onCodeChange", _));  
-  main.define("module @tomlarkworthy/codemirror-6-v2", async () => runtime.module((await import("/@tomlarkworthy/codemirror-6-v2.js?v=4")).default));  
   main.define("EditorState", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("EditorState", _));  
   main.define("EditorView", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("EditorView", _));  
   main.define("codemirror", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("codemirror", _));  
   main.define("myDefaultTheme", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("myDefaultTheme", _));  
-  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
   main.define("decompile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("decompile", _));  
   main.define("compile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("compile", _));  
   main.define("cellMap", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("cellMap", _));  
@@ -6117,27 +6133,21 @@ export default function define(runtime, observer) {
   main.define("parser", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("parser", _));  
   $def("_1d94dks", "javascriptPlugin", ["codemirror"], _1d94dks);  
   $def("_ar9tao", null, ["md"], _ar9tao);  
-  main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
   main.define("reversibleAttach", ["module @tomlarkworthy/reversible-attachment", "@variable"], (_, v) => v.import("reversibleAttach", _));  
-  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
   main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
-  main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
   main.define("flowQueue", ["module @tomlarkworthy/flow-queue", "@variable"], (_, v) => v.import("flowQueue", _));  
-  main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
   main.define("viewof liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("viewof liveCellMap", _));  
   main.define("liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("liveCellMap", _));  
-  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
   main.define("hash", ["module d/57d79353bac56631@44", "@variable"], (_, v) => v.import("hash", _));  
-  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
   main.define("extractNotebookAndCell", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("extractNotebookAndCell", _));  
   main.define("navHref", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("navHref", _));  
-  main.define("module @tomlarkworthy/cells-to-clipboard", async () => runtime.module((await import("/@tomlarkworthy/cells-to-clipboard.js?v=4")).default));  
   main.define("cellsToClipboard", ["module @tomlarkworthy/cells-to-clipboard", "@variable"], (_, v) => v.import("cellsToClipboard", _));
   return main;
-}</script>
+}
+</script>
 <script id="@tomlarkworthy/escodegen/escodegen.browser.min.js.gz" 
   type="text/plain"
   data-encoding="base64"

--- a/notebooks/@tomlarkworthy_editor-5.html
+++ b/notebooks/@tomlarkworthy_editor-5.html
@@ -2326,7 +2326,7 @@ export default function define(runtime, observer) {
   return main;
 }</script>
 
-<script id="@tomlarkworthy/claude-code-pairing"
+<script id="@tomlarkworthy/claude-code-pairing" 
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -4042,8 +4042,7 @@ export default function define(runtime, observer) {
   main.define("syncEnabled", ["module @tomlarkworthy/file-sync", "@variable"], (_, v) => v.import("syncEnabled", _));  
   main.define("syncStatus", ["module @tomlarkworthy/file-sync", "@variable"], (_, v) => v.import("syncStatus", _));
   return main;
-}
-</script>
+}</script>
 <script id="@tomlarkworthy/codemirror-6-v2/codemirror_javascript%405.js.gz" 
   type="text/plain"
   data-encoding="base64"
@@ -5847,43 +5846,47 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1ju14cq = function _compile_and_update(compile,runtime,repositionSetElement){return(
-(source, variables = [], cell) => {
-    try {
-        debugger;
-        let reposition = false, insertionIndex = -1;
-        const newVariables = compile(source);
-        if (!variables || variables.length !== newVariables.length) {
-            reposition = true;
-            variables.forEach(v => v.delete());
-            variables.length = 0;
-            for (let i = 0; i < newVariables.length; i++) {
-                const newVariable = cell.module.module.variable({});
-                variables.push(newVariable);
+const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+{
+    return (source, variables = [], cell) => {
+        try {
+            debugger;
+            let reposition = false, insertionIndex = -1;
+            const newVariables = compile(source);
+            if (!variables || variables.length !== newVariables.length) {
+                reposition = true;
+                variables.forEach(v => v.delete());
+                variables.length = 0;
+                for (let i = 0; i < newVariables.length; i++) {
+                    const newVariable = cell.module.module.variable({});
+                    // Assign a random pid up-front so blank/identical new cells don't
+                    // collide via persistentId's contentHash. See lopecode#144.
+                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+                    variables.push(newVariable);
+                }
             }
-        }
-        if (reposition) {
-            insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-        }
-        newVariables.forEach((v, i) => {
-            const variable = variables[i];
-            let _fn;
-            eval('_fn = ' + v._definition);
-            if (v._name) {
-                variable.define(v._name, v._inputs, _fn);
-            } else {
-                variable.define(v._inputs, _fn);
+            if (reposition) {
+                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
-            if (reposition)
-                repositionSetElement(runtime._variables, variable, insertionIndex + i);
-        });
-        return variables;
-    } catch (e) {
-        console.error(e);
-        debugger;
-    }
-}
-)};
+            newVariables.forEach((v, i) => {
+                const variable = variables[i];
+                let _fn;
+                eval('_fn = ' + v._definition);
+                if (v._name) {
+                    variable.define(v._name, v._inputs, _fn);
+                } else {
+                    variable.define(v._inputs, _fn);
+                }
+                if (reposition)
+                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
+            });
+            return variables;
+        } catch (e) {
+            console.error(e);
+            debugger;
+        }
+    };
+};
 const _1jqs8in = function _91(md){return(
 md`### Remove Cells`
 )};
@@ -6073,7 +6076,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1ju14cq", "compile_and_update", ["compile","runtime","repositionSetElement"], _1ju14cq);  
+  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -7143,15 +7146,52 @@ module => {
     return fileMap;
 }
 )};
-const _pvnegh = async function _book(lopebook,task,module_specs)
+const _1x463u7 = function _book(task,inlineModule,inlineGzipModule,es_module_shims,runtime_gz,inspector_gz,module_specs,lopemodule,lopebook){return(
+(async () => {
+    const cssBlocks = task.options.style.map(([url, content]) => inlineModule(url, content, { mime: 'text/css' })).join('\n');
+    const cssUrls = task.options.style.map(([url]) => url);
+    const systemBlocks = [
+        inlineGzipModule('es-module-shims@2.6.2', es_module_shims),
+        inlineGzipModule('@observablehq/runtime@6.0.0', runtime_gz),
+        inlineGzipModule('@observablehq/inspector@5.0.1', inspector_gz)
+    ].join('\n');
+    const userBlocks = (await Promise.all([...module_specs.values()].sort((a, b) => a.url.localeCompare(b.url)).map(m => lopemodule(m)))).join('');
+    const bootloader = task.options.bootloader || '@tomlarkworthy/bootloader';
+    const bootconfBlock = `<script id="bootconf.json"
+        type="text/plain"
+        data-mime="application/json"
+>
 {
-    const book = await lopebook({
-        url: task.notebook,
-        modules: module_specs
-    }, { ...task.options });
-    console.log('book', book);
-    return book;
-};
+  "mains": ${ JSON.stringify([...task.mains.keys()]) },
+  "hash": "${ task.options.hash || '' }",
+  "headless": ${ !!task.options.headless }
+}
+</scr` + `ipt>`;
+    const bootloaderBlock = inlineModule(bootloader, await (await fetch(`https://api.observablehq.com/${ bootloader }.js?v=4`)).text());
+    const blocks = [
+        '<!-- CSS -->',
+        cssBlocks,
+        `<style>
+body .inputs-3a86ea-table thead th {
+  background: var(--theme-foreground-faintest);
+}
+</style>`,
+        '<!-- System Modules -->',
+        systemBlocks,
+        userBlocks,
+        '<!-- Bootloader -->',
+        bootconfBlock,
+        bootloaderBlock
+    ].join('\n');
+    return lopebook({
+        blocks,
+        cssUrls,
+        bootloader,
+        title: task.options.title || 'Lopecode notebook',
+        head: task.options.head
+    });
+})()
+)};
 const _18javdl = function _47(Inputs,module_specs){return(
 Inputs.table([...module_specs.entries().map(([name, spec]) => ({
         name,
@@ -7200,9 +7240,68 @@ const _4x0qc2 = function _tomlarkworthy_exporter_task(book,report,exporter_modul
     exporter_module;
     return $0.resolve(result);
 };
-const _t4uzwq = function _51(md){return(
-md`### Module Source Generator`
+const _1exq2jt = function _51(md){return(
+md`## Module Source Generator`
 )};
+const _fctoc0 = function _52(md){return(
+md`### exportModuleJS
+
+Serialize a single module from the live runtime to a \`.js\` module source string. Unlike \`module_specs\` (which serializes all modules as part of the full HTML export pipeline), \`exportModuleJS\` works on-demand against the live runtime with no \`task\` dependency.
+
+\`\`\`js
+import {exportModuleJS} from "@tomlarkworthy/exporter-3"
+\`\`\`
+
+\`\`\`js
+const {source, fileAttachments} = await exportModuleJS(moduleId, {runtime, moduleNamesFn})
+\`\`\`
+
+**Parameters**
+- \`moduleId\` — module name string, e.g. \`"@tomlarkworthy/flow-queue"\`
+- \`options.runtime\` — Observable runtime instance (default: \`_runtime\`)
+- \`options.moduleNamesFn\` — function to build module name map (default: \`buildModuleNames\`)
+
+**Returns** \`{source, fileAttachments}\`
+- \`source\` — full \`.js\` module source with \`export default function define(runtime, observer)\`
+- \`fileAttachments\` — \`Map<name, {url, mimeType}>\` of the module's file attachments
+`
+)};
+const _85q15a = function _exportModuleJS(_runtime,buildModuleNames,isModuleVar,isDynamicVar,getFileAttachments,generate_module_source)
+{
+  const fn = async (
+    moduleId,
+    { runtime = _runtime, moduleNamesFn = buildModuleNames } = {}
+  ) => {
+    const names = moduleNamesFn(runtime);
+    let targetModule = null;
+    for (const [module, info] of names) {
+      if (info.name === moduleId) {
+        targetModule = module;
+        break;
+      }
+    }
+    if (!targetModule) throw new Error(`Module not found: ${moduleId}`);
+    const variables = [...runtime._variables].filter(
+      (v) =>
+        v._module === targetModule &&
+        (v._type === 1 || isModuleVar(v)) &&
+        !isDynamicVar(v)
+    );
+    const fileAttachments = getFileAttachments(targetModule) || new Map();
+    const spec = { name: moduleId };
+    const source = await generate_module_source(
+      spec,
+      variables,
+      fileAttachments,
+      { moduleNames: names }
+    );
+    return {
+      source,
+      fileAttachments
+    };
+  };
+  return fn;
+};
 const _udwrns = function _generate_module_source(generate_definitions,generate_define){return(
 async (spec, variables, fileAttachments, {moduleNames} = {}) => `
 ${ generate_definitions(variables) }
@@ -7326,7 +7425,7 @@ const _1g36je3 = function _variableToDefine(isLiveImport,isDynamicVar,isModuleVa
         return [`  $def("${ pid(v) }", ${ name_literal }, ${ deps }, ${ pid(v) });`];
     };
 };
-const _1k6s7eq = function _58(md){return(
+const _1bux505 = function _60(md){return(
 md`## Assemble `
 )};
 const _g33g3u = function _es_module_shims(){return(
@@ -7596,8 +7695,11 @@ const _1pcnq22 = function _networking_script(normalize,isNotebook){return(
     }
   })();`
 )};
-const _13sd8x8 = function _lopebook(diskDataUrl,networking_script,task,inlineModule,inlineGzipModule,es_module_shims,runtime_gz,inspector_gz,lopemodule){return(
-async (bundle, {title, head, bootloader, headless = false, hash} = {}) => `<!DOCTYPE html>
+const _1crzwh0 = function _lopebook(diskDataUrl,networking_script){return(
+({blocks = '', cssUrls = [], bootloader = '@tomlarkworthy/bootloader', title = 'Lopecode notebook', head} = {}) => {
+    const styleImports = cssUrls.map((url, i) => `  const style${ i } = await importShim(${ JSON.stringify(url) }, { with: { type: 'css' } });`).join('\n');
+    const styleAdopt = cssUrls.map((_, i) => `style${ i }.default`).join(',');
+    return `<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
@@ -7606,52 +7708,10 @@ async (bundle, {title, head, bootloader, headless = false, hash} = {}) => `<!DOC
   ${ head ? head : `<link rel="icon" href="${ diskDataUrl }">` }
 </head>
 <body>
-<!-- Networking -->
 <script id="networking_script">${ networking_script }
 </scr\ipt>
 
-<!-- CSS -->
-<!-- Style sheets from https://github.com/observablehq/notebook-kit
-Copyright 2025 Observable, Inc.
-
-Permission to use, copy, modify, and/or distribute this software for any purpose
-with or without fee is hereby granted, provided that the above copyright notice
-and this permission notice appear in all copies.
-
-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
-REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
-FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
-INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
-OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
-TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
-THIS SOFTWARE.
--->
-${ task.options.style.map(([url, content]) => inlineModule(url, content, { mime: 'text/css' })).join('\n') }
-<style>
-body .inputs-3a86ea-table thead th {
-  background: var(--theme-foreground-faintest);
-}
-</style>
-
-<!-- System Modules -->
-${ inlineGzipModule('es-module-shims@2.6.2', es_module_shims) }
-${ inlineGzipModule('@observablehq/runtime@6.0.0', runtime_gz) }
-${ inlineGzipModule('@observablehq/inspector@5.0.1', inspector_gz) }
-
-${ (await Promise.all([...bundle.modules.values()].sort((a, b) => a.url.localeCompare(b.url)).map(module => lopemodule(module)))).join('') }
-
-<!-- Bootloader -->
-<script id="bootconf.json" 
-        type="text/plain"
-        data-mime="application/json"
->
-{
-  "mains": ${ JSON.stringify([...task.mains.keys()]) },
-  "hash": "${ hash }",
-  "headless": ${ headless }
-}
-</scr\ipt>
-${ inlineModule(bootloader, await (await fetch(`https://api.observablehq.com/${ bootloader }.js?v=4`)).text()) }
+${ blocks }
 
 <script type="module" id="main">
   await window.esmsInitOptions.fetch("file://es-module-shims@2.6.2").text().then(src => {
@@ -7660,19 +7720,20 @@ ${ inlineModule(bootloader, await (await fetch(`https://api.observablehq.com/${ 
     document.head.appendChild(script);
   });
 
-${ task.options.style.map(([url, content], i) => `  const style${ i } = await importShim("${ url }", { with: { type: 'css' } });`).join('\n') }
-  document.adoptedStyleSheets = [${ task.options.style.map(([url, content], i) => `style${ i }.default`) }];
-  
+${ styleImports }
+  document.adoptedStyleSheets = [${ styleAdopt }];
+
   const { Runtime } = await importShim("@observablehq/runtime@6.0.0");
   const { Inspector } = await importShim("@observablehq/inspector@5.0.1");
   const notebook = document.querySelector("notebook");
   const runtime = new Runtime({__ojs_runtime: () => runtime, __ojs_observer: () => observer});
   const observer = Inspector.into(document.body);
-  const {default: define} = await importShim("${ bootloader }");
+  const {default: define} = await importShim(${ JSON.stringify(bootloader) });
   runtime.bootloader = runtime.module(define, () => ({}));
 </scr\ipt>
 </body>
-</html>`
+</html>`;
+}
 )};
 const _1tiwgkp = function _lopemodule(TRACE_MODULE,CSS,arrayBufferToBase64,inlineModule,escapeScriptTags)
 {
@@ -7719,10 +7780,10 @@ async function arrayBufferToBase64(buffer) {
     return btoa(binary);
 }
 )};
-const _1ec4qnw = function _71(md){return(
+const _1p6pb2e = function _73(md){return(
 md`### Global Output`
 )};
-const _qdnvhv = function _72(md){return(
+const _1yismpd = function _74(md){return(
 md`## Utils`
 )};
 const _t237wb = function _getCompactISODate(){return(
@@ -7737,7 +7798,7 @@ function getCompactISODate() {
     return `${ year }${ month }${ day }T${ hours }${ minutes }${ seconds }Z`;
 }
 )};
-const _czi7zg = function _74(md){return(
+const _4t2ire = function _76(md){return(
 md`## Additional Tests`
 )};
 const _8765p8 = function _diskDataUrl(disk_svg){return(
@@ -7819,19 +7880,21 @@ export default function define(runtime, observer) {
   $def("_1y5e5x8", "module_specs", ["task","included_modules","TRACE_MODULE","task_runtime","isModuleVar","isDynamicVar","getFileAttachments","main","generate_module_source","moduleNames"], _1y5e5x8);  
   $def("_1r3eg9r", "findImports", [], _1r3eg9r);  
   $def("_ipv4ft", "getFileAttachments", [], _ipv4ft);  
-  $def("_pvnegh", "book", ["lopebook","task","module_specs"], _pvnegh);  
+  $def("_1x463u7", "book", ["task","inlineModule","inlineGzipModule","es_module_shims","runtime_gz","inspector_gz","module_specs","lopemodule","lopebook"], _1x463u7);  
   $def("_18javdl", null, ["Inputs","module_specs"], _18javdl);  
   $def("_1gb47v", null, ["md"], _1gb47v);  
   $def("_5m8hbe", "report", ["DOMParser","book"], _5m8hbe);  
   $def("_4x0qc2", "tomlarkworthy_exporter_task", ["book","report","exporter_module","viewof task"], _4x0qc2);  
-  $def("_t4uzwq", null, ["md"], _t4uzwq);  
+  $def("_1exq2jt", null, ["md"], _1exq2jt);  
+  $def("_fctoc0", null, ["md"], _fctoc0);  
+  $def("_85q15a", "exportModuleJS", ["_runtime","buildModuleNames","isModuleVar","isDynamicVar","getFileAttachments","generate_module_source"], _85q15a);  
   $def("_udwrns", "generate_module_source", ["generate_definitions","generate_define"], _udwrns);  
   $def("_19ft5zb", "generate_definitions", ["variableToDefinition"], _19ft5zb);  
   $def("_7nr512", "generate_define", ["variableToDefine"], _7nr512);  
   $def("_1hslsmt", "isLiveImport", [], _1hslsmt);  
   $def("_18sa1aj", "variableToDefinition", ["isModuleVar","isImportBridged","isLiveImport","isDynamicVar","pid"], _18sa1aj);  
   $def("_1g36je3", "variableToDefine", ["isLiveImport","isDynamicVar","isModuleVar","isImportBridged","findImportedName3","pid"], _1g36je3);  
-  $def("_1k6s7eq", null, ["md"], _1k6s7eq);  
+  $def("_1bux505", null, ["md"], _1bux505);  
   $def("_g33g3u", "es_module_shims", [], _g33g3u);  
   $def("_1na8qih", "inspector_gz", [], _1na8qih);  
   $def("_3naqgd", "inlineModule", [], _3naqgd);  
@@ -7840,14 +7903,14 @@ export default function define(runtime, observer) {
   $def("_eoywzy", "test_normalize", ["expect","normalize"], _eoywzy);  
   $def("_1vgrzwk", "isNotebook", [], _1vgrzwk);  
   $def("_1pcnq22", "networking_script", ["normalize","isNotebook"], _1pcnq22);  
-  $def("_13sd8x8", "lopebook", ["diskDataUrl","networking_script","task","inlineModule","inlineGzipModule","es_module_shims","runtime_gz","inspector_gz","lopemodule"], _13sd8x8);  
+  $def("_1crzwh0", "lopebook", ["diskDataUrl","networking_script"], _1crzwh0);  
   $def("_1tiwgkp", "lopemodule", ["TRACE_MODULE","CSS","arrayBufferToBase64","inlineModule","escapeScriptTags"], _1tiwgkp);  
   $def("_19l1umr", "escapeScriptTags", [], _19l1umr);  
   $def("_1hwkszj", "arrayBufferToBase64", [], _1hwkszj);  
-  $def("_1ec4qnw", null, ["md"], _1ec4qnw);  
-  $def("_qdnvhv", null, ["md"], _qdnvhv);  
+  $def("_1p6pb2e", null, ["md"], _1p6pb2e);  
+  $def("_1yismpd", null, ["md"], _1yismpd);  
   $def("_t237wb", "getCompactISODate", [], _t237wb);  
-  $def("_czi7zg", null, ["md"], _czi7zg);  
+  $def("_4t2ire", null, ["md"], _4t2ire);  
   $def("_8765p8", "diskDataUrl", ["disk_svg"], _8765p8);  
   $def("_z4k2or", "viewof task", ["flowQueue"], _z4k2or);  
   $def("_ngmf1x", "task", ["Generators","viewof task"], _ngmf1x);  
@@ -7893,7 +7956,1062 @@ export default function define(runtime, observer) {
   return main;
 }</script>
 
-<script id="@tomlarkworthy/fileattachments"
+<script id="@tomlarkworthy/file-sync" 
+  type="text/plain"
+  data-mime="application/javascript"
+>
+const _1th1rci = function _1(md){return(
+md`# File Sync
+
+Two-way sync between the Observable runtime and module \`.js\` files on disk.`
+)};
+const _1t1i3ml = function _directory(notebookId,htl,hashParam,location,history)
+{
+    const IDB_NAME = 'lopecode-file-sync';
+    const STORE = 'handles';
+    const key = notebookId;
+    const openDB = () => new Promise((resolve, reject) => {
+        const req = window.indexedDB.open(IDB_NAME, 1);
+        req.onupgradeneeded = () => req.result.createObjectStore(STORE);
+        req.onsuccess = () => resolve(req.result);
+        req.onerror = () => reject(req.error);
+    });
+    const idbGet = async () => {
+        const db = await openDB();
+        return new Promise((resolve, reject) => {
+            const r = db.transaction(STORE, 'readonly').objectStore(STORE).get(key);
+            r.onsuccess = () => resolve(r.result);
+            r.onerror = () => reject(r.error);
+        });
+    };
+    const idbPut = async handle => {
+        const db = await openDB();
+        return new Promise((resolve, reject) => {
+            const tx = db.transaction(STORE, 'readwrite');
+            tx.objectStore(STORE).put(handle, key);
+            tx.oncomplete = () => resolve();
+            tx.onerror = () => reject(tx.error);
+        });
+    };
+    const idbDelete = async () => {
+        const db = await openDB();
+        return new Promise((resolve, reject) => {
+            const tx = db.transaction(STORE, 'readwrite');
+            tx.objectStore(STORE).delete(key);
+            tx.oncomplete = () => resolve();
+            tx.onerror = () => reject(tx.error);
+        });
+    };
+    const container = htl.html`<div>
+    <button class="main" style="padding: 8px 16px; font-size: 14px; cursor: pointer;">Loading\u2026</button>
+    <button class="forget" style="padding: 4px 8px; font-size: 12px; cursor: pointer; margin-left: 4px; display: none;">Forget</button>
+  </div>`;
+    const btn = container.querySelector('.main');
+    const forget = container.querySelector('.forget');
+    container.value = null;
+    const emit = () => container.dispatchEvent(new window.Event('input', { bubbles: true }));
+    const pickLabel = () => hashParam ? 'Pick directory for: ' + hashParam : 'Pick sync directory';
+    const setSyncing = handle => {
+        container.value = handle;
+        btn.textContent = '\u25CF Syncing: ' + handle.name;
+        btn.style.background = '#d4edda';
+        btn.onclick = null;
+        forget.style.display = '';
+        if (!hashParam) {
+            const param = 'filesync=' + encodeURIComponent(handle.name);
+            const h = location.hash;
+            history.replaceState(null, '', h ? h + '&' + param : '#' + param);
+        }
+        emit();
+    };
+    const setPickMode = () => {
+        container.value = null;
+        btn.textContent = pickLabel();
+        btn.style.background = '';
+        btn.onclick = pickNew;
+        forget.style.display = 'none';
+        emit();
+    };
+    const setReconnectMode = handle => {
+        btn.textContent = '\u21BB Reconnect: ' + handle.name;
+        btn.style.background = '#fff3cd';
+        forget.style.display = '';
+        btn.onclick = async () => {
+            try {
+                const result = await handle.requestPermission({ mode: 'readwrite' });
+                if (result === 'granted')
+                    setSyncing(handle);
+                else
+                    setPickMode();
+            } catch (e) {
+                setPickMode();
+            }
+        };
+    };
+    async function pickNew() {
+        try {
+            const handle = await window.showDirectoryPicker({ mode: 'readwrite' });
+            await idbPut(handle).catch(() => {
+            });
+            setSyncing(handle);
+        } catch (e) {
+            if (e.name !== 'AbortError')
+                throw e;
+        }
+    }
+    forget.onclick = async () => {
+        await idbDelete().catch(() => {
+        });
+        setPickMode();
+    };
+    (async () => {
+        const saved = await idbGet().catch(() => null);
+        if (saved) {
+            const perm = await saved.queryPermission({ mode: 'readwrite' }).catch(() => 'denied');
+            if (perm === 'granted')
+                setSyncing(saved);
+            else
+                setReconnectMode(saved);
+        } else {
+            setPickMode();
+        }
+    })();
+    return container;
+};
+const _jnt0bt = (G, _) => G.input(_);
+const _yqx7l8 = function _syncEnabled(notebookId,htl)
+{
+    const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
+    const initial = window.localStorage.getItem(KEY) === '1';
+    const container = htl.html`<label style="display:inline-flex;align-items:center;gap:6px;padding:8px 12px;font-size:13px;cursor:pointer;"><input type="checkbox"> Sync enabled</label>`;
+    const cb = container.querySelector('input');
+    cb.checked = initial;
+    container.value = initial;
+    cb.onchange = () => {
+        container.value = cb.checked;
+        window.localStorage.setItem(KEY, cb.checked ? '1' : '0');
+        container.dispatchEvent(new window.Event('input', { bubbles: true }));
+    };
+    return container;
+};
+const _xltqf6 = (G, _) => G.input(_);
+const _122juai = function _disassemble(htl,directory,notebookId,manifestWriter,readFile,writeFile,syncableModules,exportModuleJS,hashSource)
+{
+    const container = htl.html`<div>
+    <button style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Disassemble to disk</button>
+    <pre style="font-size: 12px; max-height: 300px; overflow-y: auto; margin-top: 8px;"></pre>
+  </div>`;
+    const btn = container.querySelector('button');
+    const status = container.querySelector('pre');
+    if (directory)
+        btn.disabled = false;
+    const log = msg => {
+        status.textContent += msg + '\n';
+        status.scrollTop = status.scrollHeight;
+    };
+    const prefix = notebookId + '/';
+    btn.onclick = async () => {
+        if (!directory)
+            return;
+        btn.disabled = true;
+        btn.textContent = 'Disassembling...';
+        let ok = 0, fail = 0;
+        const manifestUpdates = {};
+        await manifestWriter(directory, prefix, null, readFile, writeFile);
+        log('cleared manifest');
+        for (const moduleId of syncableModules) {
+            try {
+                log('Exporting ' + moduleId + '...');
+                const result = await exportModuleJS(moduleId);
+                const source = result.source;
+                const fileAttachments = result.fileAttachments;
+                const path = prefix + moduleId + '.js';
+                await writeFile(directory, path, source);
+                manifestUpdates[moduleId] = hashSource(source);
+                log('  wrote ' + path + ' (' + source.length + ' bytes)');
+                if (fileAttachments && fileAttachments.size) {
+                    for (const [name, entry] of fileAttachments) {
+                        try {
+                            const resp = await fetch(entry.url);
+                            const bytes = await resp.arrayBuffer();
+                            await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
+                            log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
+                        } catch (e) {
+                            log('  attachment FAILED: ' + name + ' - ' + e.message);
+                        }
+                    }
+                }
+                ok++;
+            } catch (e) {
+                log('  FAILED: ' + moduleId + ' - ' + e.message);
+                fail++;
+            }
+        }
+        try {
+            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+        } catch (e) {
+            log('manifest write FAILED: ' + e.message);
+        }
+        try {
+            const bootconf = document.querySelector('script[id="bootconf.json"]');
+            if (bootconf) {
+                await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
+                log('wrote ' + prefix + 'bootconf.json');
+            }
+        } catch (e) {
+            log('bootconf.json FAILED: ' + e.message);
+        }
+        log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
+        btn.textContent = 'Disassembled ' + ok + ' modules';
+        btn.disabled = false;
+    };
+    container.value = undefined;
+    return container;
+};
+const _eoa5ga = (G, _) => G.input(_);
+const _1jyon1g = function _syncStatus(htl,directory,syncableModules,notebookToFiles,filesToNotebook){return(
+htl.html`<div style="font-family:monospace; font-size:12px; padding:8px 12px; background:#f8f8f8; border:1px solid #ddd; border-radius:4px; line-height:1.8;">
+  <div><strong>Directory:</strong> ${ directory ? directory.name : '\u2014 (not set)' }</div>
+  <div><strong>Modules:</strong> ${ syncableModules.length } syncable</div>
+  <div><strong>Notebook\u2192Files:</strong> ${ notebookToFiles }</div>
+  <div><strong>Files\u2192Notebook:</strong> ${ filesToNotebook }</div>
+</div>`
+)};
+const _1dl3i63 = function _6(md){return(
+md`## Overview
+
+File Sync provides **bidirectional, live synchronization** between the Observable runtime and a directory of \`.js\` module files on disk. This enables agents (Claude Code, etc.) and external editors to modify notebook code using standard file-editing tools while seeing changes reflected in the browser in real time.
+
+**What gets synced:**
+- Each module in the runtime becomes a \`.js\` file containing its cell definitions
+- File attachments are synced as binary files alongside their module (e.g. images, gzipped JS, CSV)
+- Changes flow both ways: edit on disk and the runtime updates within 1 second; edit in the browser and the disk file updates within 200ms
+- File attachment changes on disk are detected and hot-swapped into the runtime\\'s \`FileAttachment\` map
+
+**What does NOT get synced:**
+- The \`bootloader\` and \`builtin\` modules (infrastructure, not user code)
+- Import bridges and implicit variables (managed by the runtime, not by module source)`
+)};
+const _19lc4kb = function _7(md){return(
+md`## File Structure
+
+\`\`\`
+sync-dir/
+\u251c\u2500\u2500 tomlarkworthy.lopecode.dev/    # notebook identified by domain
+\u2502   \u251c\u2500\u2500 bootconf.json               # notebook boot configuration
+\u2502   \u251c\u2500\u2500 @tomlarkworthy/
+\u2502   \u2502   \u251c\u2500\u2500 my-notebook.js          # module source (cells + define function)
+\u2502   \u2502   \u251c\u2500\u2500 my-notebook/             # file attachments (if any)
+\u2502   \u2502   \u2502   \u251c\u2500\u2500 image.png
+\u2502   \u2502   \u2502   \u2514\u2500\u2500 data.csv
+\u2502   \u2502   \u251c\u2500\u2500 runtime-sdk.js
+\u2502   \u2502   \u2514\u2500\u2500 editor-5.js
+\u2502   \u2514\u2500\u2500 @observablehq/
+\u2502       \u2514\u2500\u2500 ...
+\u2514\u2500\u2500 other-notebook.lopecode.dev/    # another notebook, isolated
+    \u251c\u2500\u2500 bootconf.json
+    \u2514\u2500\u2500 ...
+\`\`\`
+
+Each notebook gets its own subdirectory named by \`location.hostname\` (the domain the notebook is served from). Modules and file attachments live inside, preventing cross-notebook contamination. Each \`.js\` file is a standard ES module with an \`export default function define(runtime, observer)\` entry point. Cells are named functions with persistent ID hashes (pids) that survive renames and reordering.`
+)};
+const _m8q656 = function _notebookId(location){return(
+location.hostname || location.pathname.split('/').pop().replace(/\.html$/, '')
+)};
+const _1gxl72e = function _hashParam(location){return(
+(() => {
+    const m = location.hash.match(/[#&]filesync=([^&]*)/);
+    return m ? decodeURIComponent(m[1]) : null;
+})()
+)};
+const _8mu9u = function _writeFile(){return(
+async (dirHandle, path, content) => {
+    const parts = path.split('/');
+    let current = dirHandle;
+    for (const dir of parts.slice(0, -1)) {
+        current = await current.getDirectoryHandle(dir, { create: true });
+    }
+    const fileHandle = await current.getFileHandle(parts[parts.length - 1], { create: true });
+    const writable = await fileHandle.createWritable();
+    await writable.write(content);
+    await writable.close();
+}
+)};
+const _18kj49o = function _readFile(){return(
+async (dirHandle, path) => {
+    const parts = path.split('/');
+    let current = dirHandle;
+    for (const dir of parts.slice(0, -1)) {
+        current = await current.getDirectoryHandle(dir);
+    }
+    const fileHandle = await current.getFileHandle(parts[parts.length - 1]);
+    const file = await fileHandle.getFile();
+    return file;
+}
+)};
+const _3ysbyb = function _SKIP_MODULES(){return(
+new Set([
+    'bootloader',
+    'builtin'
+])
+)};
+const _gzzwmc = function _syncableModules(currentModules,SKIP_MODULES){return(
+(() => {
+    const result = [];
+    for (const [mod, info] of currentModules) {
+        if (SKIP_MODULES.has(info.name))
+            continue;
+        if (!info.name.includes('/') && !info.name.startsWith('d/'))
+            continue;
+        result.push(info.name);
+    }
+    return result;
+})()
+)};
+const _nf3bte = function _probeDefine()
+{
+    return function probeDefine(defineFn) {
+        const cells = [];
+        const makeVar = observed => ({
+            define(...args) {
+                // Observable define(name?, inputs?, defn) — name may be null (explicit anonymous)
+                const name = typeof args[0] === 'string' || args[0] === null ? args.shift() : null;
+                const inputs = Array.isArray(args[0]) ? args.shift() : [];
+                const defn = args[0];
+                const cell = {
+                    name,
+                    inputs,
+                    definition: defn,
+                    observed
+                };
+                cells.push(cell);
+                return {
+                    set pid(v) {
+                        cell.pid = v;
+                    }
+                };    // capture pid for anonymous cells
+            },
+            import(remote, alias, from) {
+                cells.push({
+                    type: 'import',
+                    remote,
+                    alias,
+                    from
+                });
+                return this;
+            }
+        });
+        const fakeModule = {
+            variable(observer) {
+                return makeVar(!!observer);
+            },
+            // main.define(...) calls bypass variable() — handle them too
+            define(...args) {
+                const name = typeof args[0] === 'string' || args[0] === null ? args.shift() : null;
+                const inputs = Array.isArray(args[0]) ? args.shift() : [];
+                const defn = args[0];
+                const cell = {
+                    name,
+                    inputs,
+                    definition: defn,
+                    observed: false
+                };
+                cells.push(cell);
+                return {
+                    set pid(v) {
+                        cell.pid = v;
+                    }
+                };
+            }
+        };
+        const fakeRuntime = {
+            module() {
+                return fakeModule;
+            },
+            fileAttachments(fn) {
+                return fn;
+            }
+        };
+        defineFn(fakeRuntime, name => name ? {} : null);
+        return cells;
+    };
+};
+const _7ajapw = function _hashSource(){return(
+s => {
+    let h = 2166136261;
+    for (let i = 0; i < s.length; i++) {
+        h ^= s.charCodeAt(i);
+        h = Math.imul(h, 16777619);
+    }
+    return (h >>> 0).toString(36);
+}
+)};
+const _ujgc0c = function _manifestWriter(){return(
+(() => {
+    let lock = Promise.resolve();
+    return (directory, prefix, updates, readFile, writeFile) => {
+        lock = lock.then(async () => {
+            let manifest;
+            try {
+                const file = await readFile(directory, prefix + '.file-sync.json');
+                manifest = JSON.parse(await file.text());
+            } catch (e) {
+                manifest = null;
+            }
+            if (!manifest || typeof manifest !== 'object')
+                manifest = {};
+            if (!manifest.modules)
+                manifest.modules = {};
+            if (updates === null) {
+                manifest.modules = {};
+            } else {
+                for (const [k, v] of Object.entries(updates)) {
+                    if (v === null)
+                        delete manifest.modules[k];
+                    else
+                        manifest.modules[k] = v;
+                }
+            }
+            manifest.lastUpdated = Date.now();
+            await writeFile(directory, prefix + '.file-sync.json', JSON.stringify(manifest, null, 2));
+        }).catch(e => console.error('[file-sync] manifest write failed:', e));
+        return lock;
+    };
+})()
+)};
+const _1cy7bqk = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
+{
+    const disableToggle = reason => {
+        console.warn('[file-sync] auto-disabled: ' + reason);
+        const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
+        window.localStorage.setItem(KEY, '0');
+        if ($0 && $0.querySelector) {
+            const cb = $0.querySelector('input');
+            if (cb && cb.checked) {
+                cb.checked = false;
+                $0.value = false;
+                $0.dispatchEvent(new window.Event('input', { bubbles: true }));
+            }
+        }
+    };
+    if (!directory)
+        return Promise.resolve({
+            armed: false,
+            reason: 'No directory'
+        });
+    if (!syncEnabled)
+        return Promise.resolve({
+            armed: false,
+            reason: 'Sync disabled'
+        });
+    const prefix = notebookId + '/';
+    return (async () => {
+        let manifest;
+        try {
+            const file = await readFile(directory, prefix + '.file-sync.json');
+            manifest = JSON.parse(await file.text());
+        } catch (e) {
+            manifest = null;
+        }
+        if (!manifest || !manifest.modules || Object.keys(manifest.modules).length === 0) {
+            disableToggle('no manifest \u2014 run Disassemble to initialize');
+            return {
+                armed: false,
+                reason: 'No manifest \u2014 click Disassemble'
+            };
+        }
+        for (const [moduleId, expectedHash] of Object.entries(manifest.modules)) {
+            let result;
+            try {
+                result = await exportModuleJS(moduleId);
+            } catch (e) {
+                disableToggle('cannot export ' + moduleId);
+                return {
+                    armed: false,
+                    reason: 'Export failed: ' + moduleId
+                };
+            }
+            const actualHash = hashSource(result.source);
+            if (actualHash !== expectedHash) {
+                disableToggle('runtime drift on ' + moduleId);
+                return {
+                    armed: false,
+                    reason: 'Runtime drift: ' + moduleId
+                };
+            }
+        }
+        return { armed: true };
+    })();
+};
+const _17r1jfs = function _notebookToFiles(directory,syncArmed,currentModules,notebookId,exportModuleJS,writeFile,manifestWriter,hashSource,readFile,onCodeChange,invalidation)
+{
+    if (!directory)
+        return 'Waiting for directory...';
+    if (!syncArmed || !syncArmed.armed)
+        return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
+    // Compute syncable modules inline — avoid depending on syncableModules/SKIP_MODULES reactively,
+    // which would restart this cell (cancelling pending writes) every time SKIP_MODULES changes.
+    const SKIP = new Set([
+        'bootloader',
+        'builtin'
+    ]);
+    const syncableSet = new Set();
+    for (const [mod, info] of currentModules) {
+        if (SKIP.has(info.name))
+            continue;
+        if (!info.name.includes('/') && !info.name.startsWith('d/'))
+            continue;
+        syncableSet.add(info.name);
+    }
+    const syncableCount = syncableSet.size;
+    const pendingTimers = new Map();
+    // Build reverse lookup: module object → module name
+    const moduleToName = new Map();
+    for (const [mod, info] of currentModules) {
+        moduleToName.set(info.module, info.name);
+    }
+    const prefix = notebookId + '/';
+    const writeModule = async moduleId => {
+        try {
+            const result = await exportModuleJS(moduleId);
+            await writeFile(directory, prefix + moduleId + '.js', result.source);
+            await manifestWriter(directory, prefix, { [moduleId]: hashSource(result.source) }, readFile, writeFile);
+            console.log('[file-sync] wrote ' + prefix + moduleId + '.js (' + result.source.length + ' bytes)');
+            // Also write file attachments
+            if (result.fileAttachments && result.fileAttachments.size) {
+                for (const [name, entry] of result.fileAttachments) {
+                    try {
+                        const resp = await fetch(entry.url);
+                        const bytes = await resp.arrayBuffer();
+                        await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
+                    } catch (e) {
+                        console.error('[file-sync] attachment write failed: ' + moduleId + '/' + name, e);
+                    }
+                }
+            }
+        } catch (e) {
+            console.error('[file-sync] write failed: ' + moduleId, e);
+        }
+    };
+    const unsub = onCodeChange(({variable, previous, t}) => {
+        // Echo suppression: skip changes we caused
+        const prov = variable._definition && variable._definition.__provenance;
+        if (prov && prov.source === 'file-sync')
+            return;
+        // Find which module this variable belongs to
+        const moduleName = moduleToName.get(variable._module);
+        if (!moduleName || !syncableSet.has(moduleName))
+            return;
+        // Debounce 200ms per module
+        if (pendingTimers.has(moduleName)) {
+            clearTimeout(pendingTimers.get(moduleName));
+        }
+        pendingTimers.set(moduleName, setTimeout(() => {
+            pendingTimers.delete(moduleName);
+            writeModule(moduleName);
+        }, 200));
+    });
+    invalidation.then(() => {
+        unsub();
+        for (const timer of pendingTimers.values())
+            clearTimeout(timer);
+        pendingTimers.clear();
+    });
+    return 'Watching ' + syncableCount + ' modules for changes...';
+};
+const _1bf1rb4 = function _fileSyncLastSeen(directory)
+{
+    void directory;
+    return new window.Map();
+};
+const _1srrp0d = function _filesToNotebook(directory,syncArmed,currentModules,fileSyncLastSeen,notebookId,runtime,probeDefine,tag,readFile,exportModuleJS,manifestWriter,hashSource,writeFile,getFileAttachmentsMap,invalidation)
+{
+  if (!directory) return "Waiting for directory...";
+  if (!syncArmed || !syncArmed.armed)
+    return "Sync inactive: " + ((syncArmed && syncArmed.reason) || "unknown");
+  // Compute syncable modules inline — avoid depending on syncableModules/SKIP_MODULES reactively,
+  // which would restart this cell every time SKIP_MODULES changes.
+  const SKIP = new Set(["bootloader", "builtin"]);
+  const syncableModules = [];
+  for (const [mod, info] of currentModules) {
+    if (SKIP.has(info.name)) continue;
+    if (!info.name.includes("/") && !info.name.startsWith("d/")) continue;
+    syncableModules.push(info.name);
+  }
+  const syncableSet = new Set(syncableModules);
+  // Use stable lastSeen map that survives restarts — only resets when directory changes
+  const lastSeen = fileSyncLastSeen;
+  const POLL_MS = 1000;
+  const prefix = notebookId + "/";
+  // Build lookup: module name → module object (the Observable Module instance)
+  const nameToModule = new window.Map();
+  // Build lookup: module name → Map of pid key → variable
+  const nameToVars = new window.Map();
+  for (const [mod, info] of currentModules) {
+    if (!syncableSet.has(info.name)) continue;
+    nameToModule.set(info.name, info.module);
+    const vars = new window.Map();
+    for (const v of runtime._variables) {
+      if (v._module !== info.module) continue;
+      if (v._name) vars.set(v._name, v);
+      if (v.pid) vars.set("__pid__" + v.pid, v);
+    }
+    nameToVars.set(info.name, vars);
+  }
+  let pollTimer;
+  // Track pids seen from .js files — only delete pids we've previously seen
+  const knownFilePids = new window.Map();
+  // Track modules found on disk — for detecting additions and removals
+  let knownDiskModules = null;
+  // null = first scan (no deletions)
+  // FileAttachment helpers
+  const getModuleFA = (mod) => {
+    for (const v of runtime._variables) {
+      if (v._module === mod && v._name === "FileAttachment" && v._value)
+        return v._value;
+    }
+    return null;
+  };
+  const getSubDir = async (dirHandle, path) => {
+    let current = dirHandle;
+    for (const part of path.split("/").filter(Boolean)) {
+      current = await current.getDirectoryHandle(part);
+    }
+    return current;
+  };
+  const applyModule = (moduleId, defineFn) => {
+    const mod = nameToModule.get(moduleId);
+    if (!mod) return;
+    const existingVars = nameToVars.get(moduleId) || new window.Map();
+    const cells = probeDefine(defineFn);
+    let redefinedSelf = false;
+    const seenPids = new Set();
+    for (const cell of cells) {
+      if (cell.type === "import") continue;
+      if (!cell.pid) continue;
+      seenPids.add(cell.pid);
+      const existing = existingVars.get("__pid__" + cell.pid);
+      if (!existing) {
+        // CREATE new cell — always unobserved; lopepage visualizer will pick it up
+        const taggedDefn = cell.definition
+          ? tag(cell.definition, { source: "file-sync" })
+          : cell.definition;
+        var v = mod.variable();
+        v.define(cell.name, cell.inputs, taggedDefn);
+        v.pid = cell.pid;
+        existingVars.set("__pid__" + cell.pid, v);
+        if (cell.name) existingVars.set(cell.name, v);
+        console.log(
+          "[file-sync] created cell",
+          cell.pid,
+          cell.name || "(anonymous)"
+        );
+        continue;
+      }
+      // UPDATE existing cell — skip if definition and inputs are unchanged
+      if (existing._definition) {
+        const existingInputNames = existing._inputs.map(function (v) {
+          return typeof v === "string" ? v : v._name;
+        });
+        const inputsMatch =
+          JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+        const defnMatch =
+          existing._definition.toString() ===
+          (cell.definition ? cell.definition.toString() : "");
+        if (inputsMatch && defnMatch) continue;
+      }
+      const taggedDefn = cell.definition
+        ? tag(cell.definition, { source: "file-sync" })
+        : cell.definition;
+      existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      if (
+        moduleId === "@tomlarkworthy/file-sync" &&
+        cell.name === "filesToNotebook"
+      ) {
+        redefinedSelf = true;
+      }
+    }
+    // DELETE: only remove pids that were in a PREVIOUS probeDefine but are now absent.
+    // This ensures we never touch variables we didn't create (implicits, import bridges, etc.)
+    const prevKnown = knownFilePids.get(moduleId);
+    if (prevKnown) {
+      for (const pid of prevKnown) {
+        if (seenPids.has(pid)) continue;
+        const v = existingVars.get("__pid__" + pid);
+        if (!v) continue;
+        console.log("[file-sync] deleting cell", pid, v._name || "(anonymous)");
+        v.delete();
+        existingVars.delete("__pid__" + pid);
+        if (v._name) existingVars.delete(v._name);
+      }
+    }
+    knownFilePids.set(moduleId, seenPids);
+    const ordered = [];
+    for (const cell of cells) {
+      if (!cell.pid) continue;
+      const v = existingVars.get("__pid__" + cell.pid);
+      if (v) ordered.push(v);
+    }
+    if (ordered.length) {
+      const orderedSet = new Set(ordered);
+      const others = [];
+      for (const v of runtime._variables) {
+        if (!orderedSet.has(v)) others.push(v);
+      }
+      runtime._variables.clear();
+      for (const v of others) runtime._variables.add(v);
+      for (const v of ordered) runtime._variables.add(v);
+    }
+    if (redefinedSelf) {
+      clearInterval(pollTimer);
+      console.log(
+        "[file-sync] filesToNotebook redefined \u2014 stopping old poll timer"
+      );
+    }
+  };
+  const pollModule = async (moduleId) => {
+    // --- Module source (.js) ---
+    try {
+      let file;
+      try {
+        file = await readFile(directory, prefix + moduleId + ".js");
+      } catch (e) {
+        // .js file doesn't exist on disk — skip source sync
+        file = null;
+      }
+      if (file) {
+        const prev = lastSeen.get(moduleId);
+        const changed = !prev || file.lastModified !== prev.lastModified;
+        if (changed) {
+          lastSeen.set(moduleId, { lastModified: file.lastModified });
+          const diskText = await file.text();
+          let needsApply = true;
+          try {
+            const runtimeResult = await exportModuleJS(moduleId);
+            if (runtimeResult.source === diskText) needsApply = false;
+          } catch (e) {}
+          if (needsApply) {
+            const blob = new window.Blob([diskText], {
+              type: "text/javascript"
+            });
+            const url = window.URL.createObjectURL(blob);
+            try {
+              const mod = await importShim(url, 'https://api.observablehq.com/@tomlarkworthy/file-sync.js?v=4');
+              if (typeof mod.default === "function") {
+                applyModule(moduleId, mod.default);
+                console.log("[file-sync] applied " + moduleId + " from disk");
+                try {
+                  const after = await exportModuleJS(moduleId);
+                  await manifestWriter(
+                    directory,
+                    prefix,
+                    { [moduleId]: hashSource(after.source) },
+                    readFile,
+                    writeFile
+                  );
+                } catch (e) {
+                  await manifestWriter(
+                    directory,
+                    prefix,
+                    { [moduleId]: hashSource(diskText) },
+                    readFile,
+                    writeFile
+                  );
+                }
+              }
+            } finally {
+              window.URL.revokeObjectURL(url);
+            }
+          }
+        }
+      }
+    } catch (e) {
+      console.error("[file-sync] poll error for " + moduleId + ":", e);
+    }
+    // --- File attachments ---
+    try {
+      const attachDir = await getSubDir(directory, prefix + moduleId);
+      const mod = nameToModule.get(moduleId);
+      const FA = mod ? getModuleFA(mod) : null;
+      const faMap = FA ? getFileAttachmentsMap(FA) : null;
+      if (faMap) {
+        for (const key of [...faMap.keys()]) {
+          if (key.endsWith(".crswap") || key.startsWith(".")) faMap.delete(key);
+        }
+      }
+      for await (const [name, handle] of attachDir) {
+        if (handle.kind !== "file") continue;
+        if (name.endsWith(".crswap") || name.startsWith(".")) continue;
+        const file = await handle.getFile();
+        const attKey = "__att__" + moduleId + "/" + name;
+        const prevA = lastSeen.get(attKey);
+        if (prevA && file.lastModified === prevA.lastModified) continue;
+        lastSeen.set(attKey, { lastModified: file.lastModified });
+        // Read file and create blob URL
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        const blob = new window.Blob([bytes], {
+          type: file.type || "application/octet-stream"
+        });
+        const blobUrl = window.URL.createObjectURL(blob);
+        // Update runtime FileAttachment map
+        if (faMap) {
+          faMap.set(name, {
+            url: blobUrl,
+            mimeType: file.type || "application/octet-stream"
+          });
+          console.log(
+            "[file-sync] updated attachment " + moduleId + "/" + name
+          );
+        }
+        // Update DOM script tag so re-exports pick up the change
+        const scriptId = moduleId + "/" + encodeURIComponent(name);
+        const script = document.getElementById(scriptId);
+        if (script) {
+          const b64 = btoa(String.fromCharCode.apply(null, bytes));
+          script.textContent = b64;
+          script.setAttribute("data-encoding", "base64");
+          script.setAttribute(
+            "data-mime",
+            file.type || "application/octet-stream"
+          );
+        }
+      }
+    } catch (e) {
+      if (e.name !== "NotFoundError") {
+        console.error(
+          "[file-sync] attachment scan error for " + moduleId + ":",
+          e
+        );
+      }
+    }
+  };
+  // Scan the notebook directory for all .js module files
+  const scanDiskModules = async () => {
+    const diskModules = new Set();
+    try {
+      const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
+      for await (const [orgName, orgHandle] of notebookDir) {
+        if (orgHandle.kind !== "directory") continue;
+        if (orgName.startsWith("@")) {
+          // Scoped modules: @org/name
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === "file" && fname.endsWith(".js")) {
+              diskModules.add(orgName + "/" + fname.slice(0, -3));
+            }
+          }
+        } else if (orgName === "d") {
+          // Observable hash modules: d/hash@version
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === "file" && fname.endsWith(".js")) {
+              diskModules.add("d/" + fname.slice(0, -3));
+            }
+          }
+        }
+      }
+    } catch (e) {}
+    return diskModules;
+  };
+  const poll = async () => {
+    // Poll existing syncable modules
+    for (const moduleId of syncableModules) {
+      await pollModule(moduleId);
+    }
+    // Scan disk for new/removed modules
+    const diskModules = await scanDiskModules();
+    // ADD: new modules on disk not in the runtime
+    const newOnDisk = [...diskModules].filter(
+      (m) => !syncableSet.has(m) && !nameToModule.has(m)
+    );
+    if (newOnDisk.length)
+      console.log("[file-sync] new modules on disk:", newOnDisk);
+    for (const moduleId of diskModules) {
+      if (syncableSet.has(moduleId)) continue;
+      // already known
+      if (nameToModule.has(moduleId)) continue;
+      // already added by a previous scan
+      try {
+        const file = await readFile(directory, prefix + moduleId + ".js");
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: "text/javascript" });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const imported = await importShim(url, 'https://api.observablehq.com/@tomlarkworthy/file-sync.js?v=4');
+          if (typeof imported.default === "function") {
+            // Create a new runtime module — unobserved (lopepage visualizer discovers it)
+            const newMod = runtime.module(imported.default, () => null);
+            runtime.mains.set(moduleId, newMod);
+            nameToModule.set(moduleId, newMod);
+            syncableModules.push(moduleId);
+            syncableSet.add(moduleId);
+            // Index its variables for future pid tracking
+            const vars = new window.Map();
+            for (const v of runtime._variables) {
+              if (v._module !== newMod) continue;
+              if (v._name) vars.set(v._name, v);
+              if (v.pid) vars.set("__pid__" + v.pid, v);
+            }
+            nameToVars.set(moduleId, vars);
+            console.log("[file-sync] added new module from disk: " + moduleId);
+            try {
+              await manifestWriter(
+                directory,
+                prefix,
+                { [moduleId]: hashSource(diskText) },
+                readFile,
+                writeFile
+              );
+            } catch (e) {
+              console.error(
+                "[file-sync] manifest update for new module failed:",
+                e
+              );
+            }
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
+        }
+      } catch (e) {
+        console.error("[file-sync] failed to add module " + moduleId + ":", e);
+      }
+    }
+    // REMOVE: modules previously on disk but now gone
+    if (knownDiskModules) {
+      for (const moduleId of knownDiskModules) {
+        if (diskModules.has(moduleId)) continue;
+        if (!nameToModule.has(moduleId)) continue;
+        const mod = nameToModule.get(moduleId);
+        // Delete all variables in this module
+        for (const v of [...runtime._variables]) {
+          if (v._module === mod) {
+            v.delete();
+          }
+        }
+        runtime.mains.delete(moduleId);
+        nameToModule.delete(moduleId);
+        nameToVars.delete(moduleId);
+        knownFilePids.delete(moduleId);
+        const idx = syncableModules.indexOf(moduleId);
+        if (idx !== -1) syncableModules.splice(idx, 1);
+        syncableSet.delete(moduleId);
+        console.log("[file-sync] removed module: " + moduleId);
+        try {
+          await manifestWriter(
+            directory,
+            prefix,
+            { [moduleId]: null },
+            readFile,
+            writeFile
+          );
+        } catch (e) {
+          console.error("[file-sync] manifest remove failed:", e);
+        }
+      }
+    }
+    knownDiskModules = diskModules;
+  };
+  pollTimer = setInterval(poll, POLL_MS);
+  poll();
+  invalidation.then(() => clearInterval(pollTimer));
+  return (
+    "Polling " + syncableModules.length + " modules every " + POLL_MS + "ms..."
+  );
+};
+const _1b4kluo = function _21(md){return(
+md`## How It Works
+
+### Disassemble (one-shot export)
+Iterates all syncable modules via \`moduleMap\`, calls \`exportModuleJS(moduleId)\` from exporter-3 to serialize each module to a \`.js\` file, and writes file attachments as decoded binary files.
+
+### Runtime \u2192 Files (live)
+Subscribes to \`onCodeChange\` from runtime-sdk. When a cell definition changes:
+1. Checks \`__provenance.source\` on the definition \u2014 skips if \`"file-sync"\` (echo suppression)
+2. Identifies the module via a reverse lookup (\`variable._module\` \u2192 module name)
+3. Debounces 200ms per module, then calls \`exportModuleJS\` and writes the \`.js\` file and any file attachments
+
+### Files \u2192 Runtime (live)
+Polls the sync directory every 1 second:
+1. **Fast path**: compares \`file.lastModified\` against \`fileSyncLastSeen\` map \u2014 skips unchanged files
+2. **Delta check**: reads file text and compares against \`exportModuleJS\` output \u2014 skips if identical
+3. **Apply**: dynamic-imports the \`.js\` file via blob URL, runs \`probeDefine\` to extract cells, then:
+   - **Update**: matches cells to runtime variables by persistent ID (pid), redefines if changed
+   - **Create**: new pids get \`mod.variable().define()\` \u2014 lopepage visualizer auto-discovers them
+   - **Delete**: pids previously seen but now absent get \`variable.delete()\`
+4. Tags all applied definitions with \`{source: "file-sync"}\` via \`tag()\` for echo suppression
+5. **Attachments**: independently scans each module\\'s attachment subdirectory for changed files, creates new blob URLs, updates the runtime \`FileAttachment\` map via \`getFileAttachmentsMap\` (imported from \`@tomlarkworthy/fileattachments\`), and patches the DOM \`<script>\` tags so notebook re-exports persist the changes
+
+### File Attachments
+Each module can have a subdirectory of the same name containing binary file attachments (images, gzipped JS libraries, data files). These are synced bidirectionally:
+- **Runtime\\u2192Files**: when \`writeModule\` fires, \`exportModuleJS\` returns a \`fileAttachments\` map; each entry is fetched and written to disk
+- **Files\\u2192Runtime**: the poller scans the attachment subdirectory for each module, detects changed files via \`lastModified\`, reads them into blob URLs, and hot-swaps entries in the module\\'s \`FileAttachment\` resolver map
+
+### Module Add/Remove
+After polling existing modules, the poller scans the notebook directory for all \`.js\` files. New modules (not in the runtime) are loaded via \`runtime.module(defineFn, () => null)\` and registered in \`runtime.mains\`. Removed modules (previously on disk but now deleted) have all their variables deleted and are unregistered from \`runtime.mains\`. The first scan only records — no deletions — matching the \`knownFilePids\` safety pattern.
+
+### Echo Suppression
+Prevents feedback loops between the two sync directions. When file-sync applies a change from disk, it tags the definition with \`__provenance: {source: "file-sync"}\`. The runtime\u2192files listener checks this tag and skips changes it caused.
+
+### Persistent IDs (pids)
+Each cell has a content-hash-based pid (e.g. \`_4ie7s1\`) that survives renames and reordering. All matching is pid-first. Cells without pids (import bridges, builtins) are never managed by file-sync.
+
+### Restart Tolerance
+\`fileSyncLastSeen\` is a separate cell that only depends on \`directory\`. When \`filesToNotebook\` restarts due to reactive dependency changes, the lastSeen map persists, preventing the poller from re-applying stale disk content.`
+)};
+const _1h2nj16 = function _22(md){return(
+md`## TODO
+
+- **Notebook re-export handling**: detect when the notebook HTML is re-exported and reconcile
+- **Import cell validation**: verify import bridges survive round-trip correctly
+- **Conflict resolution**: when both disk and runtime edit the same cell simultaneously, detect and surface the conflict instead of last-write-wins`
+)};
+
+export default function define(runtime, observer) {
+  const main = runtime.module();
+  const $def = (pid, name, deps, fn) => {
+    main.variable(observer(name)).define(name, deps, fn).pid = pid;
+  };
+
+  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
+  main.define("module @tomlarkworthy/exporter-3", async () => runtime.module((await import("/@tomlarkworthy/exporter-3.js?v=4")).default));  
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/local-change-history", async () => runtime.module((await import("/@tomlarkworthy/local-change-history.js?v=4")).default));  
+  main.define("module @tomlarkworthy/fileattachments", async () => runtime.module((await import("/@tomlarkworthy/fileattachments.js?v=4")).default));  
+  $def("_1th1rci", null, ["md"], _1th1rci);  
+  $def("_1t1i3ml", "viewof directory", ["notebookId","htl","hashParam","location","history"], _1t1i3ml);  
+  $def("_jnt0bt", "directory", ["Generators","viewof directory"], _jnt0bt);  
+  $def("_yqx7l8", "viewof syncEnabled", ["notebookId","htl"], _yqx7l8);  
+  $def("_xltqf6", "syncEnabled", ["Generators","viewof syncEnabled"], _xltqf6);  
+  $def("_122juai", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource"], _122juai);  
+  $def("_eoa5ga", "disassemble", ["Generators","viewof disassemble"], _eoa5ga);  
+  $def("_1jyon1g", "syncStatus", ["htl","directory","syncableModules","notebookToFiles","filesToNotebook"], _1jyon1g);  
+  $def("_1dl3i63", null, ["md"], _1dl3i63);  
+  $def("_19lc4kb", null, ["md"], _19lc4kb);  
+  $def("_m8q656", "notebookId", ["location"], _m8q656);  
+  $def("_1gxl72e", "hashParam", ["location"], _1gxl72e);  
+  $def("_8mu9u", "writeFile", [], _8mu9u);  
+  $def("_18kj49o", "readFile", [], _18kj49o);  
+  $def("_3ysbyb", "SKIP_MODULES", [], _3ysbyb);  
+  $def("_gzzwmc", "syncableModules", ["currentModules","SKIP_MODULES"], _gzzwmc);  
+  $def("_nf3bte", "probeDefine", [], _nf3bte);  
+  $def("_7ajapw", "hashSource", [], _7ajapw);  
+  $def("_ujgc0c", "manifestWriter", [], _ujgc0c);  
+  $def("_1cy7bqk", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1cy7bqk);  
+  $def("_17r1jfs", "notebookToFiles", ["directory","syncArmed","currentModules","notebookId","exportModuleJS","writeFile","manifestWriter","hashSource","readFile","onCodeChange","invalidation"], _17r1jfs);  
+  $def("_1bf1rb4", "fileSyncLastSeen", ["directory"], _1bf1rb4);  
+  $def("_1srrp0d", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _1srrp0d);  
+  $def("_1b4kluo", null, ["md"], _1b4kluo);  
+  $def("_1h2nj16", null, ["md"], _1h2nj16);  
+  main.define("viewof currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("viewof currentModules", _));  
+  main.define("currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("currentModules", _));  
+  main.define("exportModuleJS", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("exportModuleJS", _));  
+  main.define("onCodeChange", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("onCodeChange", _));  
+  main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
+  main.define("tag", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("tag", _));  
+  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));
+  return main;
+}</script>
+
+<script id="@tomlarkworthy/fileattachments" 
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -8200,8 +9318,7 @@ export default function define(runtime, observer) {
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
   main.define("thisModule", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("thisModule", _));
   return main;
-}
-</script>
+}</script>
 <script id="@tomlarkworthy/flow-queue/flowQuery%401.svg" 
   type="text/plain"
   data-encoding="base64"
@@ -9556,7 +10673,7 @@ export default function define(runtime, observer) {
   return main;
 }</script>
 
-<script id="@tomlarkworthy/local-change-history"
+<script id="@tomlarkworthy/local-change-history" 
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -9565,104 +10682,13 @@ md`# Local Change History
 
 `
 )};
-const _e1f5vn = function _temporal(Inputs){return(
-Inputs.select(["temporal", "discrete"], {
-  label: "y-axis",
-  value: "discrete"
-})
+const _lprfj9 = function _2(rewind,Inputs,rewindToTime,md){return(
+rewind ? Inputs.button(`rewind to ${ new Date(rewind).toISOString() }`, { reduce: () => rewindToTime(rewind) }) : md`⚠️ pick a time to rewind`
 )};
-const _d0qi2e = (G, _) => G.input(_);
-const _11s75oi = function _rewind(Plot,width,temporal,d3,history,timeline)
-{
-  return Plot.plot({
-    marginLeft: 200,
-    width,
-    y: {
-      type: temporal == "temporal" ? "time" : "point",
-      reverse: true,
-      tickFormat: (f) => new Date(f)
-    },
-    marks: [
-      Plot.ruleY([d3.max(history, (d) => d.t)], {
-        stroke: "green"
-      }),
-      Plot.ruleX(history, {
-        x: (h) => h.pid,
-        strokeDasharray: [1, 10]
-      }),
-      Plot.dot(history, {
-        x: (h) => h.pid,
-        y: "t",
-        symbol: "op",
-        stroke: (h) => h.pid,
-        channels: {
-          name: "_name",
-          definition: "_definition"
-        },
-        tip: {
-          format: {
-            y: false,
-            symbol: true,
-            stroke: false,
-            x: false,
-            name: true
-          }
-        }
-      }),
-
-      Plot.ruleY(
-        temporal == "temporal" ? timeline : history.map((e) => e.t),
-        Plot.pointerY({ stroke: "red" })
-      )
-    ]
-  });
-};
-const _apj797 = (G, _) => G.input(_);
-const _9rxqcj = function _4(rewind,Inputs,rewindToTime,md){return(
-rewind
-  ? Inputs.button(`rewind to ${new Date(rewind).toISOString()}`, {
-      reduce: () => rewindToTime(rewind)
-    })
-  : md`⚠️ pick a time to rewind`
+const _ta70mv = function _3(selectedChanges,Inputs,revertVariables,md){return(
+selectedChanges.length ? Inputs.button('revert variables', { reduce: () => revertVariables(selectedChanges) }) : md`⚠️ select some variables to revert individual cells`
 )};
-const _x81t46 = function _selectedChanges(Inputs,history,html){return(
-Inputs.table(history, {
-  columns: ["t", "op", "source", "_name", "_inputs", "_definition"],
-  format: {
-    t: (t) => new Date(t).toISOString(),
-    _definition: (d) => d.toString(),
-    _inputs: (i) =>
-      html`<details><summary>${i.length}</summary>${i.map(
-        (i) => html`${i}<br>`
-      )}`,
-    source: (s) =>
-      ({
-        runtime: "📓",
-        git: "💾"
-      }[s]),
-    op: (t) =>
-      ({
-        upd: "✍️",
-        del: "␡",
-        new: "🆕",
-        init: "🏁"
-      }[t])
-  },
-  layout: "auto",
-  sort: "t",
-  reverse: true,
-  required: false
-})
-)};
-const _1a64yt8 = (G, _) => G.input(_);
-const _1eayu9o = function _6(selectedChanges,Inputs,revertVariables,md){return(
-selectedChanges.length
-  ? Inputs.button("revert variables", {
-      reduce: () => revertVariables(selectedChanges)
-    })
-  : md`⚠️ select some variables to revert individual cells`
-)};
-const _14zrzgj = function _7(md){return(
+const _11ax55a = function _4(md){return(
 md`## History Data Model
 
 The primary data is history with an array of history entries. Each has the following fields.
@@ -9683,11 +10709,7 @@ The primary data is history with an array of history entries. Each has the follo
 ~~~
 `
 )};
-const _20mogr = function _history(Inputs){return(
-Inputs.input([])
-)};
-const _bmiya2 = (G, _) => G.input(_);
-const _18jzahh = function _9(md){return(
+const _yk1snt = function _5(md){return(
 md`## Isomorphic Git
 
 Changes are saved to a IndexDB filesystem (lightning-fs) in a git repository (ismorphic-git).
@@ -9721,7 +10743,7 @@ We avoid "checkouts" and other staging concepts because the filesystem is shared
 Two tabs will work on different branches, but they share a IndexDB filesystem, therefore each other's histories are visible.
 `
 )};
-const _7vt8ig = function _10(md){return(
+const _if05zb = function _6(md){return(
 md`## Replay and Save Algorithm
 
 On page refresh, the notebook will load in a state that does not have the latest changes, so we need to replay to catch up.
@@ -9737,486 +10759,482 @@ We also want to capture any future changes and save them for git. We have to be 
 4. *add a listener for *new changes* made to the runtime
    - on change, commit to git, if it did not come from git`
 )};
-const _ks64y8 = function _11(md){return(
+const _fo0ea9 = function _7(md){return(
 md`## Persistent Variable IDs
 
 Variables \`definitions\` are tagged with a persistent id (pid) so we can track what change applies to what variable. This does not work on Observablehq.com, which has a first party history feature anyway. This work only makes sense in the context of [Lopecode](https://github.com/tomlarkworthy/lopecode), if you want to try it out, you can convert his notebook to Lopecode <a href="https://observablehq.com/@tomlarkworthy/jumpgate?source=https://observablehq.com/d/50857b98f55745c3&export_state=%7B%22hash%22%3A%22%23view%3Dd%2F50857b98f55745c3%22%2C%22headless%22%3Atrue%2C%22title%22%3A%22d%2F50857b98f55745c3%22%7D&git_url=https%3A%2F%2Fgithub.com%2Ftomlarkworthy%2Flopecode&load_source=true&commit=false" target="_blank"> with Jumpgate</a>`
 )};
-const _4xwmln = function _12(md){return(
+const _5nkgqg = function _8(md){return(
 md`## Git Replay
 
 `
 )};
-const _a8y5z4 = async function _git_commits(listCommits,config){return(
-(await listCommits(config)).map((v) => ({
-  ...v,
-  summary: JSON.parse(v.commit.message)
+const _mohljl = async function _git_commits(listCommits,config){return(
+(await listCommits(config)).map(v => ({
+    ...v,
+    summary: JSON.parse(v.commit.message)
 }))
 )};
-const _2zxk4p = function _relevant_git_commits(git_commits)
+const _1wwku9q = function _relevant_git_commits(git_commits)
 {
-  const commits = Array.isArray(git_commits) ? git_commits : [];
-  const seen = new Set();
-  const keptNewestFirst = [];
-
-  const coercePaths = (summary) => {
-    const out = [];
-    const push = (v) => {
-      if (v == null) return;
-      if (Array.isArray(v)) for (const x of v) push(x);
-      else if (typeof v === "string") out.push(v);
-    };
-
-    if (Array.isArray(summary)) {
-      push(summary);
-      return out;
-    }
-    if (summary && typeof summary === "object") {
-      push(summary.new);
-      push(summary.upd);
-      push(summary.del);
-      return out;
-    }
-    if (typeof summary === "string") {
-      try {
-        return coercePaths(JSON.parse(summary));
-      } catch {
+    const commits = Array.isArray(git_commits) ? git_commits : [];
+    const seen = new Set();
+    const keptNewestFirst = [];
+    const coercePaths = summary => {
+        const out = [];
+        const push = v => {
+            if (v == null)
+                return;
+            if (Array.isArray(v))
+                for (const x of v)
+                    push(x);
+            else if (typeof v === 'string')
+                out.push(v);
+        };
+        if (Array.isArray(summary)) {
+            push(summary);
+            return out;
+        }
+        if (summary && typeof summary === 'object') {
+            push(summary.new);
+            push(summary.upd);
+            push(summary.del);
+            return out;
+        }
+        if (typeof summary === 'string') {
+            try {
+                return coercePaths(JSON.parse(summary));
+            } catch {
+                return out;
+            }
+        }
         return out;
-      }
+    };
+    for (const h of commits) {
+        const paths = coercePaths(h?.summary ?? h?.commit?.message).filter(p => typeof p === 'string');
+        if (paths.length === 0)
+            continue;
+        let useful = false;
+        for (const p of paths) {
+            if (!seen.has(p)) {
+                useful = true;
+                break;
+            }
+        }
+        if (!useful)
+            continue;
+        keptNewestFirst.push({
+            ...h,
+            _paths: paths
+        });
+        for (const p of paths)
+            seen.add(p);
     }
-    return out;
-  };
-
-  for (const h of commits) {
-    const paths = coercePaths(h?.summary ?? h?.commit?.message).filter(
-      (p) => typeof p === "string"
-    );
-    if (paths.length === 0) continue;
-
-    let useful = false;
-    for (const p of paths) {
-      if (!seen.has(p)) {
-        useful = true;
-        break;
-      }
-    }
-    if (!useful) continue;
-
-    keptNewestFirst.push({ ...h, _paths: paths });
-    for (const p of paths) seen.add(p);
-  }
-
-  return keptNewestFirst;
+    return keptNewestFirst;
 };
-const _k9wqu2 = function _notebookCreationTime(git_commits)
+const _1gt738 = function _notebookCreationTime(git_commits)
 {
-  const timesSec = (git_commits ?? [])
-    .map(
-      (h) =>
-        h?.commit?.committer?.timestamp ?? h?.commit?.author?.timestamp ?? null
-    )
-    .filter((t) => t != null);
-
-  if (timesSec.length) return Math.min(...timesSec) * 1000 - 1000;
-  return Date.now() - 1000;
+    const timesSec = (git_commits ?? []).map(h => h?.commit?.committer?.timestamp ?? h?.commit?.author?.timestamp ?? null).filter(t => t != null);
+    if (timesSec.length)
+        return Math.min(...timesSec) * 1000 - 1000;
+    return Date.now() - 1000;
 };
-const _3hs18u = function _parseGitMessage(){return(
+const _kd4rgi = function _parseGitMessage(){return(
 function parseGitMessage(message) {
-  let payload = message;
-  if (typeof payload === "string") payload = JSON.parse(payload);
-
-  const parseGitPath = (path) => {
-    if (typeof path !== "string")
-      throw new Error("parseGitMessage: path must be a string");
-    const normalized = path.startsWith("/") ? path : `/${path}`;
-    const parts = normalized.split("/").filter(Boolean);
-    if (parts.length < 4)
-      throw new Error(
-        `parseGitMessage: path too short to contain notebook/module/pid: ${path}`
-      );
-    const notebook = `/${parts[0]}/${parts[1]}`;
-    const filename = parts[parts.length - 1];
-    const module = parts.slice(2, -1).join("/");
-    const m = filename.match(/^(.*?)(?:\.([^.]+))?$/);
-    const pid = m?.[1] ?? filename;
-    const ext = m?.[2] ?? "";
-    return { path, notebook, module, pid, ext, filename };
-  };
-
-  if (Array.isArray(payload)) {
-    return payload.map((p) => ({ ...parseGitPath(p), op: "upd" }));
-  }
-
-  if (payload && typeof payload === "object") {
-    const out = [];
-    const pushAll = (op, arr) => {
-      if (arr == null) return;
-      const list = Array.isArray(arr) ? arr : [arr];
-      for (const p of list) out.push({ ...parseGitPath(p), op });
+    let payload = message;
+    if (typeof payload === 'string')
+        payload = JSON.parse(payload);
+    const parseGitPath = path => {
+        if (typeof path !== 'string')
+            throw new Error('parseGitMessage: path must be a string');
+        const normalized = path.startsWith('/') ? path : `/${ path }`;
+        const parts = normalized.split('/').filter(Boolean);
+        if (parts.length < 4)
+            throw new Error(`parseGitMessage: path too short to contain notebook/module/pid: ${ path }`);
+        const notebook = `/${ parts[0] }/${ parts[1] }`;
+        const filename = parts[parts.length - 1];
+        const module = parts.slice(2, -1).join('/');
+        const m = filename.match(/^(.*?)(?:\.([^.]+))?$/);
+        const pid = m?.[1] ?? filename;
+        const ext = m?.[2] ?? '';
+        return {
+            path,
+            notebook,
+            module,
+            pid,
+            ext,
+            filename
+        };
     };
-    pushAll("new", payload.new);
-    pushAll("upd", payload.upd);
-    pushAll("del", payload.del);
-    return out;
-  }
-
-  throw new Error(
-    "parseGitMessage: unsupported commit message shape (expected array or {new,upd,del})"
-  );
+    if (Array.isArray(payload)) {
+        return payload.map(p => ({
+            ...parseGitPath(p),
+            op: 'upd'
+        }));
+    }
+    if (payload && typeof payload === 'object') {
+        const out = [];
+        const pushAll = (op, arr) => {
+            if (arr == null)
+                return;
+            const list = Array.isArray(arr) ? arr : [arr];
+            for (const p of list)
+                out.push({
+                    ...parseGitPath(p),
+                    op
+                });
+        };
+        pushAll('new', payload.new);
+        pushAll('upd', payload.upd);
+        pushAll('del', payload.del);
+        return out;
+    }
+    throw new Error('parseGitMessage: unsupported commit message shape (expected array or {new,upd,del})');
 }
 )};
-const _n91s4i = function _GitEntry(ensure_repo,git,fs){return(
+const _2qhh6w = function _GitEntry(ensure_repo,git,fs){return(
 class GitEntry {
-  constructor({
-    repo,
-    branch,
-    oid,
-    pid,
-    module,
-    notebook,
-    op = "upd",
-    source = "git",
-    t = null
-  } = {}) {
-    if (!repo) throw new Error("GitEntry: repo is required");
-    if (!branch) throw new Error("GitEntry: branch is required");
-    if (!oid) throw new Error("GitEntry: oid is required");
-    if (!pid) throw new Error("GitEntry: pid is required");
-    if (!module) throw new Error("GitEntry: module is required");
-    this.repo = repo;
-    this.branch = branch;
-    this.oid = oid;
-    this.pid = pid;
-    this.module = module;
-    this.notebook = notebook;
-    this.op = op;
-    this.source = source;
-    this.t = t;
-    this.__loaded = null;
-    this.__loadPromise = null;
-  }
-  async __readTextAtCommit(filepath) {
-    await ensure_repo({ repo: this.repo });
-    try {
-      const { object } = await git.readObject({
-        fs,
-        dir: this.repo,
-        oid: this.oid,
-        filepath
-      });
-      if (typeof object === "string") return object;
-      if (object == null) return "";
-      if (object instanceof Uint8Array)
-        return new TextDecoder("utf-8").decode(object);
-      if (ArrayBuffer.isView(object))
-        return new TextDecoder("utf-8").decode(object);
-      if (object instanceof ArrayBuffer)
-        return new TextDecoder("utf-8").decode(new Uint8Array(object));
-      return String(object);
-    } catch (err) {
-      const msg = err?.message || "";
-      const code = err?.code || err?.name || "";
-      if (
-        code === "NotFoundError" ||
-        code === "ResolveRefError" ||
-        msg.includes("ENOENT") ||
-        msg.includes("NotFoundError")
-      )
-        return "";
-      throw err;
+    constructor({repo, branch, oid, pid, module, notebook, op = 'upd', source = 'git', t = null} = {}) {
+        if (!repo)
+            throw new Error('GitEntry: repo is required');
+        if (!branch)
+            throw new Error('GitEntry: branch is required');
+        if (!oid)
+            throw new Error('GitEntry: oid is required');
+        if (!pid)
+            throw new Error('GitEntry: pid is required');
+        if (!module)
+            throw new Error('GitEntry: module is required');
+        this.repo = repo;
+        this.branch = branch;
+        this.oid = oid;
+        this.pid = pid;
+        this.module = module;
+        this.notebook = notebook;
+        this.op = op;
+        this.source = source;
+        this.t = t;
+        this.__loaded = null;
+        this.__loadPromise = null;
     }
-  }
-  async __load() {
-    const base = `${this.module}/${this.pid}`;
-    const [jsSrc, jsonSrc] = await Promise.all([
-      this.__readTextAtCommit(`${base}.js`),
-      this.__readTextAtCommit(`${base}.json`)
-    ]);
-    let meta = {};
-    try {
-      meta = jsonSrc ? JSON.parse(jsonSrc) : {};
-    } catch {
-      meta = {};
+    async __readTextAtCommit(filepath) {
+        await ensure_repo({ repo: this.repo });
+        try {
+            const {object} = await git.readObject({
+                fs,
+                dir: this.repo,
+                oid: this.oid,
+                filepath
+            });
+            if (typeof object === 'string')
+                return object;
+            if (object == null)
+                return '';
+            if (object instanceof Uint8Array)
+                return new TextDecoder('utf-8').decode(object);
+            if (ArrayBuffer.isView(object))
+                return new TextDecoder('utf-8').decode(object);
+            if (object instanceof ArrayBuffer)
+                return new TextDecoder('utf-8').decode(new Uint8Array(object));
+            return String(object);
+        } catch (err) {
+            const msg = err?.message || '';
+            const code = err?.code || err?.name || '';
+            if (code === 'NotFoundError' || code === 'ResolveRefError' || msg.includes('ENOENT') || msg.includes('NotFoundError'))
+                return '';
+            throw err;
+        }
     }
-    return {
-      _name: meta?.name ?? null,
-      _inputs: Array.isArray(meta?.inputs) ? meta.inputs : [],
-      _definition: jsSrc || "",
-      _js: jsSrc,
-      _json: jsonSrc
-    };
-  }
-  _ensureLoaded() {
-    if (this.__loaded) return Promise.resolve(this.__loaded);
-    if (!this.__loadPromise)
-      this.__loadPromise = this.__load().then((d) => (this.__loaded = d));
-    return this.__loadPromise;
-  }
-  get _name() {
-    return this._ensureLoaded().then((d) => d._name);
-  }
-  get _inputs() {
-    return this._ensureLoaded().then((d) => d._inputs);
-  }
-  get _definition() {
-    return this._ensureLoaded().then((d) => d._definition);
-  }
-  materialize() {
-    return this._ensureLoaded().then((d) => ({
-      source: this.source,
-      op: this.op,
-      t: this.t,
-      pid: this.pid,
-      module: this.module,
-      notebook: this.notebook,
-      oid: this.oid,
-      repo: this.repo,
-      branch: this.branch,
-      _name: d._name,
-      _inputs: d._inputs,
-      _definition: d._definition
-    }));
-  }
+    async __load() {
+        const base = `${ this.module }/${ this.pid }`;
+        const [jsSrc, jsonSrc] = await Promise.all([
+            this.__readTextAtCommit(`${ base }.js`),
+            this.__readTextAtCommit(`${ base }.json`)
+        ]);
+        let meta = {};
+        try {
+            meta = jsonSrc ? JSON.parse(jsonSrc) : {};
+        } catch {
+            meta = {};
+        }
+        return {
+            _name: meta?.name ?? null,
+            _inputs: Array.isArray(meta?.inputs) ? meta.inputs : [],
+            _definition: jsSrc || '',
+            _js: jsSrc,
+            _json: jsonSrc
+        };
+    }
+    _ensureLoaded() {
+        if (this.__loaded)
+            return Promise.resolve(this.__loaded);
+        if (!this.__loadPromise)
+            this.__loadPromise = this.__load().then(d => this.__loaded = d);
+        return this.__loadPromise;
+    }
+    get _name() {
+        return this._ensureLoaded().then(d => d._name);
+    }
+    get _inputs() {
+        return this._ensureLoaded().then(d => d._inputs);
+    }
+    get _definition() {
+        return this._ensureLoaded().then(d => d._definition);
+    }
+    materialize() {
+        return this._ensureLoaded().then(d => ({
+            source: this.source,
+            op: this.op,
+            t: this.t,
+            pid: this.pid,
+            module: this.module,
+            notebook: this.notebook,
+            oid: this.oid,
+            repo: this.repo,
+            branch: this.branch,
+            _name: d._name,
+            _inputs: d._inputs,
+            _definition: d._definition
+        }));
+    }
 }
 )};
-const _hjh7k7 = function _git_history(git_commits,parseGitMessage,GitEntry,config)
+const _177arhl = function _git_history(git_commits,parseGitMessage,GitEntry,config)
 {
-  const entries = [];
-  for (const h of git_commits) {
-    const parsed = parseGitMessage(h.commit.message);
-    const byPid = new Map();
-    for (const p of parsed) byPid.set(p.pid, p);
-    const tsSec =
-      h.commit?.committer?.timestamp ?? h.commit?.author?.timestamp ?? null;
-    const ts = tsSec == null ? null : tsSec * 1000;
-    for (const p of byPid.values()) {
-      entries.push(
-        new GitEntry({
-          source: "git",
-          op: p.op,
-          repo: config.repo,
-          branch: config.branch,
-          oid: h.oid,
-          pid: p.pid,
-          module: p.module,
-          notebook: p.notebook,
-          t: ts
-        })
-      );
+    const entries = [];
+    for (const h of git_commits) {
+        const parsed = parseGitMessage(h.commit.message);
+        const byPid = new Map();
+        for (const p of parsed)
+            byPid.set(p.pid, p);
+        const tsSec = h.commit?.committer?.timestamp ?? h.commit?.author?.timestamp ?? null;
+        const ts = tsSec == null ? null : tsSec * 1000;
+        for (const p of byPid.values()) {
+            entries.push(new GitEntry({
+                source: 'git',
+                op: p.op,
+                repo: config.repo,
+                branch: config.branch,
+                oid: h.oid,
+                pid: p.pid,
+                module: p.module,
+                notebook: p.notebook,
+                t: ts
+            }));
+        }
     }
-  }
-  return entries;
+    return entries;
 };
-const _rd1nhl = function _relevant_git_history(relevant_git_commits,parseGitMessage,GitEntry,config)
+const _n6n063 = function _relevant_git_history(relevant_git_commits,parseGitMessage,GitEntry,config)
 {
-  const entries = [];
-  for (const h of relevant_git_commits) {
-    const parsed = parseGitMessage(h.commit.message);
-    const byPid = new Map();
-    for (const p of parsed) byPid.set(p.pid, p);
-    const tsSec =
-      h.commit?.committer?.timestamp ?? h.commit?.author?.timestamp ?? null;
-    const ts = tsSec == null ? null : tsSec * 1000;
-    for (const p of byPid.values()) {
-      entries.push(
-        new GitEntry({
-          source: "git",
-          op: p.op,
-          repo: config.repo,
-          branch: config.branch,
-          oid: h.oid,
-          pid: p.pid,
-          module: p.module,
-          notebook: p.notebook,
-          t: ts
-        })
-      );
+    const entries = [];
+    for (const h of relevant_git_commits) {
+        const parsed = parseGitMessage(h.commit.message);
+        const byPid = new Map();
+        for (const p of parsed)
+            byPid.set(p.pid, p);
+        const tsSec = h.commit?.committer?.timestamp ?? h.commit?.author?.timestamp ?? null;
+        const ts = tsSec == null ? null : tsSec * 1000;
+        for (const p of byPid.values()) {
+            entries.push(new GitEntry({
+                source: 'git',
+                op: p.op,
+                repo: config.repo,
+                branch: config.branch,
+                oid: h.oid,
+                pid: p.pid,
+                module: p.module,
+                notebook: p.notebook,
+                t: ts
+            }));
+        }
     }
-  }
-  return entries;
+    return entries;
 };
-const _195a7nq = function _git_history_materialized(git_history){return(
-Promise.all(git_history.map((e) => e.materialize()))
+const _4rcrzb = function _git_history_materialized(git_history){return(
+Promise.all(git_history.map(e => e.materialize()))
 )};
 const _yngfrp = function _replay_pid_map(){return(
 new Map()
 )};
-const _1hnuqrm = function _replayGitEntries(modules,getVariableByPersistentId,runtime,replay_pid_map,GitEntry,realize,tag){return(
-async function replayGitEntries(
-  gitEntries,
-  { defaultModule = "main" } = {}
-) {
-  const entries = Array.isArray(gitEntries) ? gitEntries : [];
-  const moduleByName = new Map();
-  if (modules instanceof Map)
-    for (const [m, meta] of modules)
-      if (meta?.name) moduleByName.set(meta.name, m);
-
-  const defaultRuntimeModule =
-    moduleByName.get(defaultModule) ??
-    moduleByName.get("main") ??
-    (modules instanceof Map ? modules.keys().next().value : null) ??
-    null;
-
-  const ensureVariable = (pid, moduleName) => {
-    const existing =
-      getVariableByPersistentId(pid, runtime) ??
-      replay_pid_map.get(pid) ??
-      null;
-
-    if (existing) return { variable: existing, created: false, module: null };
-
-    const mod = moduleByName.get(moduleName) ?? defaultRuntimeModule;
-    if (!mod)
-      return {
-        variable: null,
-        created: false,
-        module: null,
-        reason: "module not found"
-      };
-
-    const v = mod.variable();
-    replay_pid_map.set(pid, v);
-    return { variable: v, created: true, module: mod };
-  };
-
-  const results = [];
-  for (const e0 of entries) {
-    const e = e0 instanceof GitEntry ? e0 : null;
-    if (!e) {
-      results.push({ ok: false, reason: "not a GitEntry", entry: e0 });
-      continue;
-    }
-
-    const pid = e.pid ?? null;
-    const op = e.op ?? "upd";
-    const moduleName = e.module ?? defaultModule;
-
-    if (!pid) {
-      results.push({ ok: false, op, reason: "missing pid", entry: e });
-      continue;
-    }
-
-    if (op === "del") {
-      const v =
-        getVariableByPersistentId(pid, runtime) ??
-        replay_pid_map.get(pid) ??
-        null;
-
-      if (v) {
-        try {
-          v.delete?.();
-          replay_pid_map.delete(pid);
-          results.push({ ok: true, pid, op, action: "delete", had: true });
-        } catch (err) {
-          results.push({
-            ok: false,
-            pid,
-            op,
-            action: "delete",
-            had: true,
-            reason: String(err?.message ?? err)
-          });
-        }
-      } else {
-        results.push({ ok: true, pid, op, action: "delete", had: false });
-      }
-      continue;
-    }
-
-    const {
-      variable,
-      created,
-      reason: createReason
-    } = ensureVariable(pid, moduleName);
-    if (!variable) {
-      results.push({
-        ok: false,
-        pid,
-        op,
-        reason: createReason ?? "could not create/locate variable",
-        module: moduleName
-      });
-      continue;
-    }
-
-    let mat;
-    try {
-      mat = await e.materialize();
-    } catch (err) {
-      results.push({
-        ok: false,
-        pid,
-        op,
-        reason: "materialize failed: " + String(err?.message ?? err),
-        module: moduleName
-      });
-      continue;
-    }
-
-    let defRaw = null;
-    try {
-      defRaw = (await realize([mat?._definition ?? ""], runtime))[0] ?? null;
-    } catch {
-      defRaw = null;
-    }
-
-    if (!defRaw) {
-      results.push({
-        ok: false,
-        pid,
-        op,
-        reason: "could not realize definition",
-        module: moduleName
-      });
-      continue;
-    }
-
-    const prov = {
-      source: e.source ?? "git",
-      repo: e.repo ?? null,
-      branch: e.branch ?? null,
-      oid: e.oid ?? null,
-      t: e.t ?? mat?.t ?? Date.now(),
-      pid
+const _b2d64x = function _replayGitEntries(modules,getVariableByPersistentId,runtime,replay_pid_map,GitEntry,realize,tag){return(
+async function replayGitEntries(gitEntries, {
+    defaultModule = 'main'
+} = {}) {
+    const entries = Array.isArray(gitEntries) ? gitEntries : [];
+    const moduleByName = new Map();
+    if (modules instanceof Map)
+        for (const [m, meta] of modules)
+            if (meta?.name)
+                moduleByName.set(meta.name, m);
+    const defaultRuntimeModule = moduleByName.get(defaultModule) ?? moduleByName.get('main') ?? (modules instanceof Map ? modules.keys().next().value : null) ?? null;
+    const ensureVariable = (pid, moduleName) => {
+        const existing = getVariableByPersistentId(pid, runtime) ?? replay_pid_map.get(pid) ?? null;
+        if (existing)
+            return {
+                variable: existing,
+                created: false,
+                module: null
+            };
+        const mod = moduleByName.get(moduleName) ?? defaultRuntimeModule;
+        if (!mod)
+            return {
+                variable: null,
+                created: false,
+                module: null,
+                reason: 'module not found'
+            };
+        const v = mod.variable();
+        replay_pid_map.set(pid, v);
+        return {
+            variable: v,
+            created: true,
+            module: mod
+        };
     };
-
-    const def = tag(defRaw, prov);
-    const name =
-      (typeof mat?._name === "string" && mat._name.length ? mat._name : null) ??
-      pid;
-    const inputs = Array.isArray(mat?._inputs) ? mat._inputs : [];
-
-    try {
-      variable.define(name, inputs, def);
-      results.push({
-        ok: true,
-        pid,
-        op,
-        action: "define",
-        name,
-        inputs,
-        module: moduleName,
-        created
-      });
-    } catch (err) {
-      results.push({
-        ok: false,
-        pid,
-        op,
-        action: "define",
-        name,
-        inputs,
-        module: moduleName,
-        created,
-        reason: String(err?.message ?? err)
-      });
+    const results = [];
+    for (const e0 of entries) {
+        const e = e0 instanceof GitEntry ? e0 : null;
+        if (!e) {
+            results.push({
+                ok: false,
+                reason: 'not a GitEntry',
+                entry: e0
+            });
+            continue;
+        }
+        const pid = e.pid ?? null;
+        const op = e.op ?? 'upd';
+        const moduleName = e.module ?? defaultModule;
+        if (!pid) {
+            results.push({
+                ok: false,
+                op,
+                reason: 'missing pid',
+                entry: e
+            });
+            continue;
+        }
+        if (op === 'del') {
+            const v = getVariableByPersistentId(pid, runtime) ?? replay_pid_map.get(pid) ?? null;
+            if (v) {
+                try {
+                    v.delete?.();
+                    replay_pid_map.delete(pid);
+                    results.push({
+                        ok: true,
+                        pid,
+                        op,
+                        action: 'delete',
+                        had: true
+                    });
+                } catch (err) {
+                    results.push({
+                        ok: false,
+                        pid,
+                        op,
+                        action: 'delete',
+                        had: true,
+                        reason: String(err?.message ?? err)
+                    });
+                }
+            } else {
+                results.push({
+                    ok: true,
+                    pid,
+                    op,
+                    action: 'delete',
+                    had: false
+                });
+            }
+            continue;
+        }
+        const {
+            variable,
+            created,
+            reason: createReason
+        } = ensureVariable(pid, moduleName);
+        if (!variable) {
+            results.push({
+                ok: false,
+                pid,
+                op,
+                reason: createReason ?? 'could not create/locate variable',
+                module: moduleName
+            });
+            continue;
+        }
+        let mat;
+        try {
+            mat = await e.materialize();
+        } catch (err) {
+            results.push({
+                ok: false,
+                pid,
+                op,
+                reason: 'materialize failed: ' + String(err?.message ?? err),
+                module: moduleName
+            });
+            continue;
+        }
+        let defRaw = null;
+        try {
+            defRaw = (await realize([mat?._definition ?? ''], runtime))[0] ?? null;
+        } catch {
+            defRaw = null;
+        }
+        if (!defRaw) {
+            results.push({
+                ok: false,
+                pid,
+                op,
+                reason: 'could not realize definition',
+                module: moduleName
+            });
+            continue;
+        }
+        const prov = {
+            source: e.source ?? 'git',
+            repo: e.repo ?? null,
+            branch: e.branch ?? null,
+            oid: e.oid ?? null,
+            t: e.t ?? mat?.t ?? Date.now(),
+            pid
+        };
+        const def = tag(defRaw, prov);
+        const name = ((typeof mat?._name === 'string' && mat._name.length) ? mat._name : null) ?? pid;
+        const inputs = Array.isArray(mat?._inputs) ? mat._inputs : [];
+        try {
+            variable.define(name, inputs, def);
+            results.push({
+                ok: true,
+                pid,
+                op,
+                action: 'define',
+                name,
+                inputs,
+                module: moduleName,
+                created
+            });
+        } catch (err) {
+            results.push({
+                ok: false,
+                pid,
+                op,
+                action: 'define',
+                name,
+                inputs,
+                module: moduleName,
+                created,
+                reason: String(err?.message ?? err)
+            });
+        }
     }
-  }
-  return results;
+    return results;
 }
 )};
-const _9748ey = function _replayGitCommits() {return ((config, parseGitMessage, GitEntry, replayGitEntries, moduleBaseHash) => {
+const _1h8l7wf = function _replayGitCommits(){return(
+(config, parseGitMessage, GitEntry, replayGitEntries, moduleBaseHash) => {
     return async function replayGitCommits(commits, {repo = config?.repo, branch = config?.branch, order = 'oldest-first'} = {}) {
         const list = Array.isArray(commits) ? commits : [];
         const ordered = order === 'newest-first' ? list.slice() : order === 'oldest-first' ? list.slice().reverse() : list.slice();
@@ -10268,1088 +11286,1099 @@ const _9748ey = function _replayGitCommits() {return ((config, parseGitMessage, 
         }
         return replayGitEntries(entries);
     };
-});};
-const _axol8 = function _replay_git(isOnObservableCom,modules,replayGitCommits,relevant_git_commits)
+}
+)};
+const _frdbmi = function _replay_git(isOnObservableCom,modules,replayGitCommits,relevant_git_commits)
 {
-  if (isOnObservableCom()) return []; // doesn't work on Observablehq
-  modules;
-  return replayGitCommits(relevant_git_commits, { order: "oldest-first" });
+    if (isOnObservableCom())
+        return [];
+    // doesn't work on Observablehq
+    modules;
+    return replayGitCommits(relevant_git_commits, { order: 'oldest-first' });
 };
-const _1tptp40 = function _25(md){return(
+const _1rm7oy4 = function _21(md){return(
 md`## IndexDB State Explorer`
 )};
-const _145kx9v = function _26(Inputs,exportToZip,fs,config,getCompactISODate){return(
-Inputs.button("download git zip", {
-  reduce: async () => {
-    const zip = await exportToZip({ fs, dir: config.repo });
-    const url = URL.createObjectURL(zip);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = `history_${getCompactISODate()}.zip`;
-    a.click();
-    URL.revokeObjectURL(url);
-  }
+const _krsfjh = function _22(Inputs,exportToZip,fs,config,getCompactISODate){return(
+Inputs.button('download git zip', {
+    reduce: async () => {
+        const zip = await exportToZip({
+            fs,
+            dir: config.repo
+        });
+        const url = URL.createObjectURL(zip);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `history_${ getCompactISODate() }.zip`;
+        a.click();
+        URL.revokeObjectURL(url);
+    }
 })
 )};
-const _1x4vn9a = function _fs(Inputs,FS){return(
-Inputs.button("wipe filesystem", {
-  reduce: () =>
-    new FS("lopecode_history", {
-      wipe: true
-    }).promises,
-  value: new FS("lopecode_history", {
-    wipe: false
-  }).promises
-})
-)};
-const _1dt24ln = (G, _) => G.input(_);
 const _1ax2z4b = function _repos(listRepos){return(
 listRepos()
 )};
-const _u259bo = function _selected_repo(Inputs,repos,config){return(
-Inputs.select(repos, {
-  label: "select repo",
-  value: config.repo
-})
-)};
-const _9lv1oo = (G, _) => G.input(_);
 const _1lmwwtp = function _branches(listBranches,selected_repo){return(
 listBranches({ repo: selected_repo })
 )};
-const _mu1lyv = function _selected_branch(Inputs,branches,selected_repo,config){return(
-Inputs.select(branches, {
-  label: "select branch",
-  value: selected_repo == config.repo ? config.branch : undefined
+const _yvu9cl = function _selected_files(listFiles,selected_repo,selected_branch){return(
+listFiles({
+    repo: selected_repo,
+    branch: selected_branch
 })
 )};
-const _1u33aug = (G, _) => G.input(_);
-const _14evvq7 = function _selected_files(listFiles,selected_repo,selected_branch){return(
-listFiles({ repo: selected_repo, branch: selected_branch })
+const _29j25n = function _26(Inputs,selected_files){return(
+Inputs.table(selected_files.map(path => ({ path })))
 )};
-const _15hte9q = function _33(Inputs,selected_files){return(
-Inputs.table(selected_files.map((path) => ({ path })))
-)};
-const _1dlj40t = function _selected_commits(listCommits,selected_repo,selected_branch){return(
-listCommits({ repo: selected_repo, branch: selected_branch })
-)};
-const _1qadth7 = function _35(Inputs,selected_commits){return(
-Inputs.table(selected_commits, {
-  format: {
-    commit: (commit) => JSON.stringify(commit, null, 2)
-  }
+const _5xw5rr = function _selected_commits(listCommits,selected_repo,selected_branch){return(
+listCommits({
+    repo: selected_repo,
+    branch: selected_branch
 })
 )};
-const _1h1k0un = function _exportFsToZip(JSZip){return(
+const _1kqllm6 = function _28(Inputs,selected_commits){return(
+Inputs.table(selected_commits, { format: { commit: commit => JSON.stringify(commit, null, 2) } })
+)};
+const _1aj637r = function _exportFsToZip(JSZip){return(
 async function exportFsToZip({fs, dir} = {}) {
-  if (!fs) throw new Error("exportFsToZip: fs is required");
-  if (!dir) throw new Error("exportFsToZip: dir is required");
-  if (!JSZip) throw new Error("exportFsToZip: JSZip is not available");
-
-  const zip = new JSZip();
-
-  async function walk(currentPath, relPath = "") {
-    const names = await fs.readdir(currentPath);
-    for (const name of names) {
-      if (name === "." || name === "..") continue;
-
-      const fullPath = (currentPath.endsWith("/") ? currentPath : currentPath + "/") + name;
-      const childRelPath = relPath ? relPath + "/" + name : name;
-
-      const stat = await fs.stat(fullPath);
-      if (stat.type === "file") {
-        const data = await fs.readFile(fullPath);
-        zip.file(childRelPath, data);
-      } else if (stat.type === "dir") {
-        await walk(fullPath, childRelPath);
-      }
+    if (!fs)
+        throw new Error('exportFsToZip: fs is required');
+    if (!dir)
+        throw new Error('exportFsToZip: dir is required');
+    if (!JSZip)
+        throw new Error('exportFsToZip: JSZip is not available');
+    const zip = new JSZip();
+    async function walk(currentPath, relPath = '') {
+        const names = await fs.readdir(currentPath);
+        for (const name of names) {
+            if (name === '.' || name === '..')
+                continue;
+            const fullPath = (currentPath.endsWith('/') ? currentPath : currentPath + '/') + name;
+            const childRelPath = relPath ? relPath + '/' + name : name;
+            const stat = await fs.stat(fullPath);
+            if (stat.type === 'file') {
+                const data = await fs.readFile(fullPath);
+                zip.file(childRelPath, data);
+            } else if (stat.type === 'dir') {
+                await walk(fullPath, childRelPath);
+            }
+        }
     }
-  }
-
-  await walk(dir, "");
-  return zip.generateAsync({type: "blob"});
+    await walk(dir, '');
+    return zip.generateAsync({ type: 'blob' });
 }
 )};
-const _1kamd3r = function _37(md){return(
+const _z3yxk8 = function _30(md){return(
 md`### Git utils`
 )};
 const _4q2hvf = function _known_dirs(fs){return(
 fs && new Set()
 )};
-const _gf2cfd = function _ensure_dir(known_dirs,fs){return(
-async function ensure_dir({ dir }) {
-  if (known_dirs.has(dir)) return;
-  if (!dir || dir === "/") return;
-  const lastSlash = dir.lastIndexOf("/");
-  const parent = lastSlash > 0 ? dir.slice(0, lastSlash) : "/";
-  if (parent && parent !== dir) {
-    await ensure_dir({ dir: parent });
-  }
-  try {
-    await fs.mkdir(dir);
-  } catch (err) {
-    if (!(err && err.message === "EEXIST")) {
-      throw err;
+const _1yebjl5 = function _ensure_dir(known_dirs,fs){return(
+async function ensure_dir({dir}) {
+    if (known_dirs.has(dir))
+        return;
+    if (!dir || dir === '/')
+        return;
+    const lastSlash = dir.lastIndexOf('/');
+    const parent = lastSlash > 0 ? dir.slice(0, lastSlash) : '/';
+    if (parent && parent !== dir) {
+        await ensure_dir({ dir: parent });
     }
-  }
-  known_dirs.add(dir);
+    try {
+        await fs.mkdir(dir);
+    } catch (err) {
+        if (!(err && err.message === 'EEXIST')) {
+            throw err;
+        }
+    }
+    known_dirs.add(dir);
 }
 )};
 const _1ccskir = function _known_repos(fs){return(
 fs && new Set()
 )};
-const _1x25x9p = function _ensure_repo(known_repos,ensure_dir,git,fs){return(
-async ({ repo, defaultBranch = "default" }) => {
-  if (known_repos.has(repo)) return;
-  await ensure_dir({ dir: repo });
-  await git.init({
-    fs,
-    dir: repo,
-    bare: false, // We should switch to this but we need to set gitdir everywhere
-    defaultBranch
-  });
-  fs.flush();
-  known_repos.add(repo);
+const _8gl5oz = function _ensure_repo(known_repos,ensure_dir,git,fs)
+{
+    return async ({repo, defaultBranch = 'default'}) => {
+        if (known_repos.has(repo))
+            return;
+        await ensure_dir({ dir: repo });
+        await git.init({
+            fs,
+            dir: repo,
+            bare: false,
+            // We should switch to this but we need to set gitdir everywhere
+            defaultBranch
+        });
+        fs.flush();
+        known_repos.add(repo);
+    };
+};
+const _3nw6gd = function _ensure_branch(ensure_repo,listBranches,git,fs){return(
+async ({repo, branch, create = true} = {}) => {
+    if (!repo)
+        throw new Error('ensure_branch: repo is required');
+    if (!branch)
+        throw new Error('ensure_branch: branch is required');
+    await ensure_repo({
+        repo,
+        defaultBranch: branch
+    });
+    const branches = await listBranches({ repo });
+    const hasBranch = branches.includes(branch);
+    if (!hasBranch && create) {
+        try {
+            await git.branch({
+                fs,
+                dir: repo,
+                ref: 'refs/heads/' + branch,
+                checkout: false
+            });
+        } catch (err) {
+            if (err.toString().includes('it already exists'))
+                return true;
+            throw err;
+        }
+        return true;
+    }
+    if (!hasBranch)
+        return false;
+    return true;
 }
 )};
-const _vttaz9 = function _ensure_branch(ensure_repo,listBranches,git,fs){return(
-async ({ repo, branch, create = true } = {}) => {
-  if (!repo) throw new Error("ensure_branch: repo is required");
-  if (!branch) throw new Error("ensure_branch: branch is required");
-
-  await ensure_repo({ repo, defaultBranch: branch });
-
-  const branches = await listBranches({ repo });
-  const hasBranch = branches.includes(branch);
-
-  if (!hasBranch && create) {
+const _1dn3olo = async function _git_repo_layout(config,fs)
+{
+    const repo = config?.repo ?? null;
+    if (!repo)
+        return {
+            ok: false,
+            reason: 'missing config.repo'
+        };
+    const stat = async path => {
+        try {
+            const s = await fs.stat(path);
+            return {
+                ok: true,
+                type: s?.type ?? null,
+                size: s?.size ?? null
+            };
+        } catch (e) {
+            return {
+                ok: false,
+                error: String(e?.message ?? e),
+                code: e?.code ?? e?.name ?? null
+            };
+        }
+    };
+    const readText = async path => {
+        try {
+            const b = await fs.readFile(path);
+            if (typeof b === 'string')
+                return {
+                    ok: true,
+                    text: b
+                };
+            if (b instanceof Uint8Array)
+                return {
+                    ok: true,
+                    text: new TextDecoder('utf-8').decode(b)
+                };
+            if (ArrayBuffer.isView(b))
+                return {
+                    ok: true,
+                    text: new TextDecoder('utf-8').decode(b)
+                };
+            return {
+                ok: true,
+                text: String(b)
+            };
+        } catch (e) {
+            return {
+                ok: false,
+                error: String(e?.message ?? e),
+                code: e?.code ?? e?.name ?? null
+            };
+        }
+    };
+    return {
+        repo,
+        nonbare: {
+            head: await readText(`${ repo }/.git/HEAD`),
+            objects: await stat(`${ repo }/.git/objects`),
+            refs_heads: await stat(`${ repo }/.git/refs/heads`)
+        }
+    };
+};
+const _4nrbhc = function _setFileAndCommit(setFilesAndCommit){return(
+async function setFileAndCommit({repo, branch, path, content}) {
+    return await setFilesAndCommit({
+        repo,
+        branch,
+        data: new Map([[
+                path,
+                content
+            ]])
+    });
+}
+)};
+const _femrmt = function _setFilesAndCommit(ensure_branch,git,fs,ensure_dir){return(
+async function setFilesAndCommit({repo, branch, data}) {
+    await ensure_branch({
+        repo,
+        branch
+    });
+    let headOid = null;
     try {
-      await git.branch({
+        headOid = await git.resolveRef({
+            fs,
+            dir: repo,
+            ref: branch
+        });
+    } catch {
+        headOid = null;
+    }
+    const existsAtHead = async filepath => {
+        if (!headOid)
+            return false;
+        try {
+            await git.readObject({
+                fs,
+                dir: repo,
+                oid: headOid,
+                filepath
+            });
+            return true;
+        } catch (err) {
+            const msg = err?.message || '';
+            const code = err?.code || err?.name || '';
+            if (code === 'NotFoundError' || code === 'ResolveRefError' || msg.includes('ENOENT') || msg.includes('NotFoundError'))
+                return false;
+            return false;
+        }
+    };
+    const summary = {
+        new: [],
+        upd: [],
+        del: []
+    };
+    let hasFiles = false;
+    for (const [path, content] of data) {
+        hasFiles = true;
+        const full_path = `${ repo }/${ path }`;
+        const lastSlash = full_path.lastIndexOf('/');
+        const dir = lastSlash === -1 ? repo : full_path.slice(0, lastSlash);
+        await ensure_dir({ dir });
+        const isUpd = await existsAtHead(path);
+        (isUpd ? summary.upd : summary.new).push(full_path);
+        await fs.writeFile(full_path, content);
+        await git.add({
+            fs,
+            dir: repo,
+            filepath: path
+        });
+    }
+    if (!hasFiles)
+        return;
+    await git.commit({
         fs,
         dir: repo,
-        ref: "refs/heads/" + branch,
-        checkout: false
-      });
-    } catch (err) {
-      if (err.toString().includes("it already exists")) return true;
-      throw err;
-    }
-    return true;
-  }
-
-  if (!hasBranch) return false;
-  return true;
-}
-)};
-const _as5npg = async function _git_repo_layout(config,fs)
-{
-  const repo = config?.repo ?? null;
-  if (!repo) return { ok: false, reason: "missing config.repo" };
-
-  const stat = async (path) => {
-    try {
-      const s = await fs.stat(path);
-      return { ok: true, type: s?.type ?? null, size: s?.size ?? null };
-    } catch (e) {
-      return {
-        ok: false,
-        error: String(e?.message ?? e),
-        code: e?.code ?? e?.name ?? null
-      };
-    }
-  };
-
-  const readText = async (path) => {
-    try {
-      const b = await fs.readFile(path);
-      if (typeof b === "string") return { ok: true, text: b };
-      if (b instanceof Uint8Array)
-        return { ok: true, text: new TextDecoder("utf-8").decode(b) };
-      if (ArrayBuffer.isView(b))
-        return { ok: true, text: new TextDecoder("utf-8").decode(b) };
-      return { ok: true, text: String(b) };
-    } catch (e) {
-      return {
-        ok: false,
-        error: String(e?.message ?? e),
-        code: e?.code ?? e?.name ?? null
-      };
-    }
-  };
-
-  return {
-    repo,
-    nonbare: {
-      head: await readText(`${repo}/.git/HEAD`),
-      objects: await stat(`${repo}/.git/objects`),
-      refs_heads: await stat(`${repo}/.git/refs/heads`)
-    }
-  };
-};
-const _1831q7g = function _setFileAndCommit(setFilesAndCommit){return(
-async function setFileAndCommit({
-  repo,
-  branch,
-  path,
-  content
-}) {
-  return await setFilesAndCommit({
-    repo,
-    branch,
-    data: new Map([[path, content]])
-  });
-}
-)};
-const _1ke7zw = function _setFilesAndCommit(ensure_branch,git,fs,ensure_dir){return(
-async function setFilesAndCommit({ repo, branch, data }) {
-  await ensure_branch({ repo, branch });
-
-  let headOid = null;
-  try {
-    headOid = await git.resolveRef({ fs, dir: repo, ref: branch });
-  } catch {
-    headOid = null;
-  }
-
-  const existsAtHead = async (filepath) => {
-    if (!headOid) return false;
-    try {
-      await git.readObject({ fs, dir: repo, oid: headOid, filepath });
-      return true;
-    } catch (err) {
-      const msg = err?.message || "";
-      const code = err?.code || err?.name || "";
-      if (code === "NotFoundError" || code === "ResolveRefError" || msg.includes("ENOENT") || msg.includes("NotFoundError")) return false;
-      return false;
-    }
-  };
-
-  const summary = { new: [], upd: [], del: [] };
-  let hasFiles = false;
-
-  for (const [path, content] of data) {
-    hasFiles = true;
-    const full_path = `${repo}/${path}`;
-    const lastSlash = full_path.lastIndexOf("/");
-    const dir = lastSlash === -1 ? repo : full_path.slice(0, lastSlash);
-    await ensure_dir({ dir });
-
-    const isUpd = await existsAtHead(path);
-    (isUpd ? summary.upd : summary.new).push(full_path);
-
-    await fs.writeFile(full_path, content);
-    await git.add({ fs, dir: repo, filepath: path });
-  }
-
-  if (!hasFiles) return;
-
-  await git.commit({
-    fs,
-    dir: repo,
-    author: { name: "-" },
-    message: JSON.stringify(summary)
-  });
-}
-)};
-const _121eabg = function _listRepos(fs){return(
-async function listRepos({ root = "/", maxDepth = 4 } = {}) {
-  const norm = (p) => (p === "/" ? "/" : p.replace(/\/+$/, ""));
-  root = norm(root);
-
-  const repos = new Set();
-  const visited = new Set();
-  const q = [{ path: root, depth: 0 }];
-
-  const safeReaddir = async (p) => {
-    try {
-      return await fs.readdir(p);
-    } catch (e) {
-      return null;
-    }
-  };
-
-  const safeStat = async (p) => {
-    try {
-      return await fs.stat(p);
-    } catch (e) {
-      return null;
-    }
-  };
-
-  while (q.length) {
-    const { path, depth } = q.shift();
-    const key = `${depth}:${path}`;
-    if (visited.has(key)) continue;
-    visited.add(key);
-
-    const stat = await safeStat(path);
-    if (!stat || stat.type !== "dir") continue;
-
-    const names = await safeReaddir(path);
-    if (!names) continue;
-
-    if (names.includes(".git")) repos.add(path);
-
-    if (depth >= maxDepth) continue;
-
-    for (const name of names) {
-      if (name === "." || name === "..") continue;
-      const child = path === "/" ? `/${name}` : `${path}/${name}`;
-      const cstat = await safeStat(child);
-      if (cstat && cstat.type === "dir")
-        q.push({ path: child, depth: depth + 1 });
-    }
-  }
-
-  return Array.from(repos).sort();
-}
-)};
-const _3e3c2g = function _listBranches(ensure_repo,git,fs){return(
-async function listBranches({ repo } = {}) {
-  if (!repo) throw new Error("repo is required");
-  await ensure_repo({ repo });
-  try {
-    return await git.listBranches({ fs, dir: repo });
-  } catch (e) {
-    return [];
-  }
-}
-)};
-const _1685ilj = function _listFiles(ensure_branch,git,fs){return(
-async function listFiles({ repo, branch, ref } = {}) {
-  if (!repo) throw new Error("repo is required");
-  if (!branch) throw new Error("branch is required");
-  try {
-    await ensure_branch({ repo, branch, create: true });
-    return await git.listFiles({
-      fs,
-      dir: repo,
-      ref: ref ?? branch
+        author: { name: '-' },
+        message: JSON.stringify(summary)
     });
-  } catch (err) {
-    console.error(err);
-    debugger;
-    return [];
-  }
 }
 )};
-const _1a64td9 = function _listCommits(ensure_branch,git,fs){return(
-async function listCommits({ repo, branch, depth } = {}) {
-  if (!repo) throw new Error("repo is required");
-  if (!branch) throw new Error("branch is required");
-  const hasBranch = await ensure_branch({ repo, branch, create: false });
-  if (!hasBranch) return [];
-  return git.log({
-    fs,
-    dir: repo,
-    ref: branch,
-    depth
-  });
+const _6dncmw = function _listRepos(fs){return(
+async function listRepos({root = '/', maxDepth = 4} = {}) {
+    const norm = p => p === '/' ? '/' : p.replace(/\/+$/, '');
+    root = norm(root);
+    const repos = new Set();
+    const visited = new Set();
+    const q = [{
+            path: root,
+            depth: 0
+        }];
+    const safeReaddir = async p => {
+        try {
+            return await fs.readdir(p);
+        } catch (e) {
+            return null;
+        }
+    };
+    const safeStat = async p => {
+        try {
+            return await fs.stat(p);
+        } catch (e) {
+            return null;
+        }
+    };
+    while (q.length) {
+        const {path, depth} = q.shift();
+        const key = `${ depth }:${ path }`;
+        if (visited.has(key))
+            continue;
+        visited.add(key);
+        const stat = await safeStat(path);
+        if (!stat || stat.type !== 'dir')
+            continue;
+        const names = await safeReaddir(path);
+        if (!names)
+            continue;
+        if (names.includes('.git'))
+            repos.add(path);
+        if (depth >= maxDepth)
+            continue;
+        for (const name of names) {
+            if (name === '.' || name === '..')
+                continue;
+            const child = path === '/' ? `/${ name }` : `${ path }/${ name }`;
+            const cstat = await safeStat(child);
+            if (cstat && cstat.type === 'dir')
+                q.push({
+                    path: child,
+                    depth: depth + 1
+                });
+        }
+    }
+    return Array.from(repos).sort();
 }
 )};
-const _1f0bz98 = function _getCommitChanges(git,fs){return(
-async function getCommitChanges({ repo, oid } = {}) {
-  if (!repo) throw new Error("repo is required");
-  if (!oid) throw new Error("oid is required");
-
-  const { commit } = await git.readCommit({ fs, dir: repo, oid });
-  const parentOid = commit.parent && commit.parent[0] ? commit.parent[0] : null;
-
-  const filesAt = async (ref) => {
-    if (!ref) return new Map();
-    const filepaths = await git.listFiles({ fs, dir: repo, ref });
-    const entries = await Promise.all(
-      filepaths.map(async (filepath) => {
-        const { oid: blobOid } = await git.readObject({
-          fs,
-          dir: repo,
-          oid: ref,
-          filepath
+const _1idfiqe = function _listBranches(ensure_repo,git,fs){return(
+async function listBranches({repo} = {}) {
+    if (!repo)
+        throw new Error('repo is required');
+    await ensure_repo({ repo });
+    try {
+        return await git.listBranches({
+            fs,
+            dir: repo
         });
-        return [filepath, blobOid];
-      })
-    );
-    return new Map(entries);
-  };
-
-  const [currFiles, parentFiles] = await Promise.all([
-    filesAt(oid),
-    filesAt(parentOid)
-  ]);
-
-  const added = [];
-  const modified = [];
-  const removed = [];
-
-  for (const [filepath, blobOid] of currFiles) {
-    if (!parentFiles.has(filepath)) {
-      added.push(filepath);
-    } else if (parentFiles.get(filepath) !== blobOid) {
-      modified.push(filepath);
+    } catch (e) {
+        return [];
     }
-  }
-
-  for (const filepath of parentFiles.keys()) {
-    if (!currFiles.has(filepath)) {
-      removed.push(filepath);
-    }
-  }
-
-  return {
-    oid,
-    parentOid,
-    added,
-    modified,
-    removed
-  };
 }
 )};
-const _19ky3g9 = function _getCompactISODate(){return(
+const _1lvo029 = function _listFiles(ensure_branch,git,fs){return(
+async function listFiles({repo, branch, ref} = {}) {
+    if (!repo)
+        throw new Error('repo is required');
+    if (!branch)
+        throw new Error('branch is required');
+    try {
+        await ensure_branch({
+            repo,
+            branch,
+            create: true
+        });
+        return await git.listFiles({
+            fs,
+            dir: repo,
+            ref: ref ?? branch
+        });
+    } catch (err) {
+        console.error(err);
+        debugger;
+        return [];
+    }
+}
+)};
+const _tjjpfp = function _listCommits(ensure_branch,git,fs){return(
+async function listCommits({repo, branch, depth} = {}) {
+    if (!repo)
+        throw new Error('repo is required');
+    if (!branch)
+        throw new Error('branch is required');
+    const hasBranch = await ensure_branch({
+        repo,
+        branch,
+        create: false
+    });
+    if (!hasBranch)
+        return [];
+    return git.log({
+        fs,
+        dir: repo,
+        ref: branch,
+        depth
+    });
+}
+)};
+const _1szf3ci = function _getCommitChanges(git,fs){return(
+async function getCommitChanges({repo, oid} = {}) {
+    if (!repo)
+        throw new Error('repo is required');
+    if (!oid)
+        throw new Error('oid is required');
+    const {commit} = await git.readCommit({
+        fs,
+        dir: repo,
+        oid
+    });
+    const parentOid = commit.parent && commit.parent[0] ? commit.parent[0] : null;
+    const filesAt = async ref => {
+        if (!ref)
+            return new Map();
+        const filepaths = await git.listFiles({
+            fs,
+            dir: repo,
+            ref
+        });
+        const entries = await Promise.all(filepaths.map(async filepath => {
+            const {oid: blobOid} = await git.readObject({
+                fs,
+                dir: repo,
+                oid: ref,
+                filepath
+            });
+            return [
+                filepath,
+                blobOid
+            ];
+        }));
+        return new Map(entries);
+    };
+    const [currFiles, parentFiles] = await Promise.all([
+        filesAt(oid),
+        filesAt(parentOid)
+    ]);
+    const added = [];
+    const modified = [];
+    const removed = [];
+    for (const [filepath, blobOid] of currFiles) {
+        if (!parentFiles.has(filepath)) {
+            added.push(filepath);
+        } else if (parentFiles.get(filepath) !== blobOid) {
+            modified.push(filepath);
+        }
+    }
+    for (const filepath of parentFiles.keys()) {
+        if (!currFiles.has(filepath)) {
+            removed.push(filepath);
+        }
+    }
+    return {
+        oid,
+        parentOid,
+        added,
+        modified,
+        removed
+    };
+}
+)};
+const _t237wb = function _getCompactISODate(){return(
 function getCompactISODate() {
-  const date = new Date();
-
-  const year = date.getUTCFullYear();
-  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
-  const day = String(date.getUTCDate()).padStart(2, "0");
-  const hours = String(date.getUTCHours()).padStart(2, "0");
-  const minutes = String(date.getUTCMinutes()).padStart(2, "0");
-  const seconds = String(date.getUTCSeconds()).padStart(2, "0");
-
-  return `${year}${month}${day}T${hours}${minutes}${seconds}Z`;
+    const date = new Date();
+    const year = date.getUTCFullYear();
+    const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+    const day = String(date.getUTCDate()).padStart(2, '0');
+    const hours = String(date.getUTCHours()).padStart(2, '0');
+    const minutes = String(date.getUTCMinutes()).padStart(2, '0');
+    const seconds = String(date.getUTCSeconds()).padStart(2, '0');
+    return `${ year }${ month }${ day }T${ hours }${ minutes }${ seconds }Z`;
 }
 )};
-const _i5o28z = function _exportToZip(JSZip){return(
-async function exportToZip({ fs, dir }) {
-  const zip = new JSZip();
-  async function walk(currentPath, relPath = "") {
-    const names = await fs.readdir(currentPath);
-    for (const name of names) {
-      if (name === "." || name === "..") continue;
-      const fullPath =
-        (currentPath.endsWith("/") ? currentPath : currentPath + "/") + name;
-      const childRelPath = relPath ? relPath + "/" + name : name;
-      const stat = await fs.stat(fullPath);
-      if (stat.type === "file") {
-        const data = await fs.readFile(fullPath);
-        zip.file(childRelPath, data);
-      } else if (stat.type === "dir") {
-        await walk(fullPath, childRelPath);
-      }
+const _8ou4wx = function _exportToZip(JSZip){return(
+async function exportToZip({fs, dir}) {
+    const zip = new JSZip();
+    async function walk(currentPath, relPath = '') {
+        const names = await fs.readdir(currentPath);
+        for (const name of names) {
+            if (name === '.' || name === '..')
+                continue;
+            const fullPath = (currentPath.endsWith('/') ? currentPath : currentPath + '/') + name;
+            const childRelPath = relPath ? relPath + '/' + name : name;
+            const stat = await fs.stat(fullPath);
+            if (stat.type === 'file') {
+                const data = await fs.readFile(fullPath);
+                zip.file(childRelPath, data);
+            } else if (stat.type === 'dir') {
+                await walk(fullPath, childRelPath);
+            }
+        }
     }
-  }
-  await walk(dir, "");
-  return zip.generateAsync({ type: "blob" });
+    await walk(dir, '');
+    return zip.generateAsync({ type: 'blob' });
 }
 )};
-const _exnpt6 = function _53(md){return(
+const _1q9qys8 = function _46(md){return(
 md`### Provenance Utils`
 )};
-const _140zfwr = function _tag(){return(
+const _1jkr4mu = function _tag(){return(
 function tag(def, provenance) {
-  if (def == null) return def;
-  const p =
-    provenance && typeof provenance === "object"
-      ? { ...provenance }
-      : { value: provenance };
-  try {
-    if (
-      typeof def === "function" ||
-      (typeof def === "object" && def !== null)
-    ) {
-      Object.defineProperty(def, "__provenance", {
-        value: p,
-        configurable: true
-      });
-      return def;
+    if (def == null)
+        return def;
+    const p = provenance && typeof provenance === 'object' ? { ...provenance } : { value: provenance };
+    try {
+        if (typeof def === 'function' || typeof def === 'object' && def !== null) {
+            Object.defineProperty(def, '__provenance', {
+                value: p,
+                configurable: true
+            });
+            return def;
+        }
+    } catch {
     }
-  } catch {}
-  return def;
+    return def;
 }
 )};
-const _icsevy = function _read(){return(
+const _1qh1oaw = function _read(){return(
 function read(def) {
-  if (def == null) return null;
-  try {
-    return def.__provenance ?? null;
-  } catch {
-    return null;
-  }
+    if (def == null)
+        return null;
+    try {
+        return def.__provenance ?? null;
+    } catch {
+        return null;
+    }
 }
 )};
-const _n6xuup = function _56(md){return(
+const _1l4hr6l = function _49(md){return(
 md`## History API Functions`
 )};
-const _1l5m90g = function _revertVariables(getVariableByPersistentId,runtime,realize){return(
-async (entries) => {
-  const out = [];
-  for (const e of entries ?? []) {
-    const pid = e?.pid ?? null;
-    if (!pid) continue;
-
-    const variable = getVariableByPersistentId(pid, runtime) || null;
-    if (!variable) {
-      out.push({ pid, ok: false, reason: "no runtime variable" });
-      continue;
-    }
-
-    const prev = e?.previous ?? null;
-
-    if (!prev) {
-      if (e?.op === "new") {
-        try {
-          variable.delete?.();
-          out.push({ pid, ok: true, action: "delete" });
-        } catch (err) {
-          out.push({
-            pid,
-            ok: false,
-            action: "delete",
-            reason: String(err?.message ?? err)
-          });
+const _1lftkrn = function _revertVariables(getVariableByPersistentId,runtime,realize){return(
+async entries => {
+    const out = [];
+    for (const e of entries ?? []) {
+        const pid = e?.pid ?? null;
+        if (!pid)
+            continue;
+        const variable = getVariableByPersistentId(pid, runtime) || null;
+        if (!variable) {
+            out.push({
+                pid,
+                ok: false,
+                reason: 'no runtime variable'
+            });
+            continue;
         }
-      } else {
-        out.push({ pid, ok: false, reason: "no previous snapshot" });
-      }
-      continue;
+        const prev = e?.previous ?? null;
+        if (!prev) {
+            if (e?.op === 'new') {
+                try {
+                    variable.delete?.();
+                    out.push({
+                        pid,
+                        ok: true,
+                        action: 'delete'
+                    });
+                } catch (err) {
+                    out.push({
+                        pid,
+                        ok: false,
+                        action: 'delete',
+                        reason: String(err?.message ?? err)
+                    });
+                }
+            } else {
+                out.push({
+                    pid,
+                    ok: false,
+                    reason: 'no previous snapshot'
+                });
+            }
+            continue;
+        }
+        const def = (await realize([prev._definition ?? ''], runtime))[0];
+        if (!def) {
+            out.push({
+                pid,
+                ok: false,
+                reason: 'could not realize previous definition'
+            });
+            continue;
+        }
+        const name = ((typeof prev._name === 'string' && prev._name.length) ? prev._name : null) ?? ((typeof variable._name === 'string' && variable._name.length) ? variable._name : null) ?? pid;
+        try {
+            variable.define(name, Array.isArray(prev._inputs) ? prev._inputs : [], def);
+            out.push({
+                pid,
+                ok: true,
+                action: 'define'
+            });
+        } catch (err) {
+            out.push({
+                pid,
+                ok: false,
+                action: 'define',
+                reason: String(err?.message ?? err)
+            });
+        }
     }
-
-    const def = (await realize([prev._definition ?? ""], runtime))[0];
-    if (!def) {
-      out.push({
-        pid,
-        ok: false,
-        reason: "could not realize previous definition"
-      });
-      continue;
-    }
-
-    const name =
-      (typeof prev._name === "string" && prev._name.length
-        ? prev._name
-        : null) ??
-      (typeof variable._name === "string" && variable._name.length
-        ? variable._name
-        : null) ??
-      pid;
-
-    try {
-      variable.define(
-        name,
-        Array.isArray(prev._inputs) ? prev._inputs : [],
-        def
-      );
-      out.push({ pid, ok: true, action: "define" });
-    } catch (err) {
-      out.push({
-        pid,
-        ok: false,
-        action: "define",
-        reason: String(err?.message ?? err)
-      });
-    }
-  }
-  return out;
+    return out;
 }
 )};
-const _i49sc4 = function _rewindToTime(history,revertVariables){return(
+const _krzgpe = function _rewindToTime(history,revertVariables){return(
 function (time) {
-  const byPid = new Map();
-  for (const entry of history) {
-    if (entry?.t > time) {
-      const pid = entry?.pid;
-      if (pid && !byPid.has(pid)) byPid.set(pid, entry);
+    const byPid = new Map();
+    for (const entry of history) {
+        if (entry?.t > time) {
+            const pid = entry?.pid;
+            if (pid && !byPid.has(pid))
+                byPid.set(pid, entry);
+        }
     }
-  }
-  revertVariables(Array.from(byPid.values()));
+    revertVariables(Array.from(byPid.values()));
 }
 )};
-const _s8r7nk = function _59(md){return(
+const _1rfq6xd = function _52(md){return(
 md`## State`
 )};
-const _bjgii1 = async function _config(notebook_title,ensure_branch)
+const _10ihggp = async function _config(notebook_title,ensure_branch)
 {
-  const url = new URL(document.baseURI);
-  const config = {
-    repo: "/" + notebook_title,
-    branch: (url.origin + url.pathname).replace(/[.:/]/g, "_")
-  };
-  await ensure_branch(config);
-  return config;
+    const url = new URL(document.baseURI);
+    const config = {
+        repo: '/' + notebook_title,
+        branch: (url.origin + url.pathname).replace(/[.:/]/g, '_')
+    };
+    await ensure_branch(config);
+    return config;
 };
-const _1lp66j8 = function _initial_state(Inputs){return(
-Inputs.input(new Map())
-)};
-const _8pswzc = (G, _) => G.input(_);
-const _1kbsmg2 = function _module_load_time(Inputs){return(
-Inputs.input(new Map())
-)};
-const _1g6l5w7 = (G, _) => G.input(_);
-const _no07ya = function _historyUtils(){return(
+const _1uqj96c = function _historyUtils(){return(
 {
-  snapshotVariable(v) {
-    if (!v) return null;
-    const name = typeof v._name === "string" && v._name.length ? v._name : null;
-    const inputsRaw = Array.isArray(v._inputs) ? v._inputs : [];
-    const inputs = inputsRaw
-      .map((i) => (typeof i === "string" ? i : i?._name))
-      .filter((x) => x != null);
-    const def = v._definition;
-    const _definition =
-      typeof def === "function"
-        ? def.toString()
-        : def == null
-        ? ""
-        : String(def);
-    return { _name: name, _inputs: inputs, _definition };
-  },
-  insertByTime(arr, entry) {
-    const t = entry?.t ?? 0;
-    let lo = 0,
-      hi = arr.length;
-    while (lo < hi) {
-      const mid = (lo + hi) >> 1;
-      const mt = arr[mid]?.t ?? 0;
-      if (mt <= t) lo = mid + 1;
-      else hi = mid;
+    snapshotVariable(v) {
+        if (!v)
+            return null;
+        const name = typeof v._name === 'string' && v._name.length ? v._name : null;
+        const inputsRaw = Array.isArray(v._inputs) ? v._inputs : [];
+        const inputs = inputsRaw.map(i => typeof i === 'string' ? i : i?._name).filter(x => x != null);
+        const def = v._definition;
+        const _definition = typeof def === 'function' ? def.toString() : def == null ? '' : String(def);
+        return {
+            _name: name,
+            _inputs: inputs,
+            _definition
+        };
+    },
+    insertByTime(arr, entry) {
+        const t = entry?.t ?? 0;
+        let lo = 0, hi = arr.length;
+        while (lo < hi) {
+            const mid = lo + hi >> 1;
+            const mt = arr[mid]?.t ?? 0;
+            if (mt <= t)
+                lo = mid + 1;
+            else
+                hi = mid;
+        }
+        arr.splice(lo, 0, entry);
+        return lo;
     }
-    arr.splice(lo, 0, entry);
-    return lo;
-  }
 }
 )};
-const _1kdskqz = function _change_listener(runtime,$0,persistentId,historyUtils,$1,read,onCodeChange,identity,modules,$2,Event,invalidation)
+const _142fbfa = function _change_listener(runtime,$0,persistentId,historyUtils,$1,read,onCodeChange,identity,modules,$2,Event,invalidation)
 {
-  // scan the runtime for things that were loaded before we attached the hook
-  if (!this) {
-    const t = Date.now();
-    [...runtime._variables].forEach((variable) => {
-      $0.value.set(
-        persistentId(variable),
-        historyUtils.snapshotVariable(variable)
-      );
-      $1.value.set(variable._module, t);
+    // scan the runtime for things that were loaded before we attached the hook
+    if (!this) {
+        const t = Date.now();
+        [...runtime._variables].forEach(variable => {
+            $0.value.set(persistentId(variable), historyUtils.snapshotVariable(variable));
+            $1.value.set(variable._module, t);
+        });
+    }
+    const inferProvenance = (v, previous) => {
+        const currDef = v?._definition ?? null;
+        const prevDef = previous?.variable?._definition ?? previous?._definition ?? null;
+        return read(currDef) ?? read(prevDef) ?? null;
+    };
+    const stop = onCodeChange(({variable, previous, t}) => {
+        let v = variable || previous.variable;
+        // lazyImport
+        // Suprised the do not referentially match
+        if (v._definition.toString() === identity.toString())
+            return;
+        if (typeof v?._name == 'string' && v._name.startsWith('dynamic '))
+            return;
+        if (typeof previous?._name == 'string' && previous._name.startsWith('dynamic '))
+            return;
+        const pid = persistentId(v);
+        const module = v._module;
+        const moduleName = modules.get(module)?.name || 'unknown';
+        const prov = inferProvenance(variable, previous);
+        const source = prov?.source ?? 'runtime';
+        if (variable && !previous) {
+            // new variable
+            // record it as a base state
+            $0.value.set(pid, historyUtils.snapshotVariable(variable));
+            if ((!$1.value.get(variable._module) || t < $1.value.get(variable._module) + 1000) && source == 'runtime') {
+                // its a new module loading
+                $1.value.set(module, t);
+                return;
+            }
+        }
+        if (variable) {
+            // its a user defined variable
+            historyUtils.insertByTime($2.value, {
+                t,
+                op: previous ? 'upd' : 'new',
+                source,
+                pid,
+                module: moduleName,
+                provenance: prov,
+                ...historyUtils.snapshotVariable(variable)
+            });
+        } else {
+            historyUtils.insertByTime($2.value, {
+                t,
+                op: 'del',
+                source,
+                pid,
+                module: moduleName,
+                provenance: prov,
+                _name: previous._name
+            });
+        }
+        $2.dispatchEvent(new Event('input'));
     });
-  }
-  const inferProvenance = (v, previous) => {
-    const currDef = v?._definition ?? null;
-    const prevDef =
-      previous?.variable?._definition ?? previous?._definition ?? null;
-    return read(currDef) ?? read(prevDef) ?? null;
-  };
-
-  const stop = onCodeChange(({ variable, previous, t }) => {
-    let v = variable || previous.variable;
-
-    // lazyImport
-    // Suprised the do not referentially match
-    if (v._definition.toString() === identity.toString()) return;
-    if (typeof v?._name == "string" && v._name.startsWith("dynamic ")) return;
-    if (
-      typeof previous?._name == "string" &&
-      previous._name.startsWith("dynamic ")
-    )
-      return;
-
-    const pid = persistentId(v);
-    const module = v._module;
-    const moduleName = modules.get(module)?.name || "unknown";
-    const prov = inferProvenance(variable, previous);
-    const source = prov?.source ?? "runtime";
-
-    if (variable && !previous) {
-      // new variable
-      // record it as a base state
-      $0.value.set(
-        pid,
-        historyUtils.snapshotVariable(variable)
-      );
-
-      if (
-        (!$1.value.get(variable._module) ||
-          t < $1.value.get(variable._module) + 1000) &&
-        source == "runtime"
-      ) {
-        // its a new module loading
-        $1.value.set(module, t);
-        return;
-      }
-    }
-    if (variable) {
-      // its a user defined variable
-      historyUtils.insertByTime($2.value, {
-        t,
-        op: previous ? "upd" : "new",
-        source,
-        pid,
-        module: moduleName,
-        provenance: prov,
-        ...historyUtils.snapshotVariable(variable)
-      });
-    } else {
-      historyUtils.insertByTime($2.value, {
-        t,
-        op: "del",
-        source,
-        pid,
-        module: moduleName,
-        provenance: prov,
-        _name: previous._name
-      });
-    }
-
-    $2.dispatchEvent(new Event("input"));
-  });
-
-  invalidation.then(stop);
-  return "initialized";
+    invalidation.then(stop);
+    return 'initialized';
 };
-const _x41am1 = function _65(Inputs,history){return(
-Inputs.table(history, { sort: "t", reverse: true })
+const _1behp0h = function _56(Inputs,history){return(
+Inputs.table(history, {
+    sort: 't',
+    reverse: true
+})
 )};
-const _1s7m7g8 = function _66(md){return(
+const _ztvqq8 = function _57(md){return(
 md`## Commit History`
 )};
 const _1klmxot = function _commit_watermarks(){return(
 new Map()
 )};
-const _1bwderc = function _commitRuntimeHistorySince(commit_watermarks,commit_changes){return(
-async function commitRuntimeHistorySince({
-  repo,
-  branch,
-  history,
-  watermarkKey = `${repo}:${branch}`
-} = {}) {
-  const prev = commit_watermarks.get(watermarkKey) ?? 0;
-  const entries = Array.isArray(history) ? history : [];
-  const allowedOps = new Set(["new", "upd", "del"]);
-
-  const pending = entries
-    .filter((e) => (e?.t ?? 0) > prev)
-    .filter((e) => e?.source !== "git")
-    .filter((e) => allowedOps.has(e?.op))
-    .sort((a, b) => (a?.t ?? 0) - (b?.t ?? 0));
-
-  let maxT = prev;
-  const results = [];
-
-  for (const change of pending) {
-    try {
-      const r = await commit_changes({ repo, branch, change });
-      results.push(r);
-      if ((change?.t ?? 0) > maxT) maxT = change.t;
-    } catch (err) {
-      const failure = {
-        ok: false,
-        error: String(err?.message ?? err),
-        change: {
-          t: change?.t ?? null,
-          op: change?.op ?? null,
-          pid: change?.pid ?? null,
-          module: change?.module ?? null,
-          source: change?.source ?? null,
-          _name: change?._name ?? null
+const _1p3t9pb = function _commitRuntimeHistorySince(commit_watermarks,commit_changes){return(
+async function commitRuntimeHistorySince({repo, branch, history, watermarkKey = `${ repo }:${ branch }`} = {}) {
+    const prev = commit_watermarks.get(watermarkKey) ?? 0;
+    const entries = Array.isArray(history) ? history : [];
+    const allowedOps = new Set([
+        'new',
+        'upd',
+        'del'
+    ]);
+    const pending = entries.filter(e => (e?.t ?? 0) > prev).filter(e => e?.source !== 'git').filter(e => allowedOps.has(e?.op)).sort((a, b) => (a?.t ?? 0) - (b?.t ?? 0));
+    let maxT = prev;
+    const results = [];
+    for (const change of pending) {
+        try {
+            const r = await commit_changes({
+                repo,
+                branch,
+                change
+            });
+            results.push(r);
+            if ((change?.t ?? 0) > maxT)
+                maxT = change.t;
+        } catch (err) {
+            const failure = {
+                ok: false,
+                error: String(err?.message ?? err),
+                change: {
+                    t: change?.t ?? null,
+                    op: change?.op ?? null,
+                    pid: change?.pid ?? null,
+                    module: change?.module ?? null,
+                    source: change?.source ?? null,
+                    _name: change?._name ?? null
+                }
+            };
+            results.push(failure);
+            return {
+                ok: false,
+                watermarkKey,
+                previous: prev,
+                current: prev,
+                attempted: pending.length,
+                committed: results.filter(d => d?.ok).length,
+                results
+            };
         }
-      };
-      results.push(failure);
-      return {
-        ok: false,
+    }
+    commit_watermarks.set(watermarkKey, maxT);
+    return {
+        ok: true,
         watermarkKey,
         previous: prev,
-        current: prev,
+        current: maxT,
         attempted: pending.length,
-        committed: results.filter((d) => d?.ok).length,
+        committed: results.filter(d => d?.ok).length,
         results
-      };
-    }
-  }
-
-  commit_watermarks.set(watermarkKey, maxT);
-
-  return {
-    ok: true,
-    watermarkKey,
-    previous: prev,
-    current: maxT,
-    attempted: pending.length,
-    committed: results.filter((d) => d?.ok).length,
-    results
-  };
+    };
 }
 )};
-const _v9uu47 = function _commit_changes() {return ((ensure_branch, git, fs, moduleBaseHash) => {
-    return async ({repo, branch, change} = {}) => {
-        if (!repo)
-            throw new Error('commit_changes_direct: repo is required');
-        if (!branch)
-            throw new Error('commit_changes_direct: branch is required');
-        if (!change)
-            throw new Error('commit_changes_direct: change is required');
-        const pid0 = change?.pid;
-        if (pid0 == null)
-            throw new Error('commit_changes_direct: change.pid is required');
-        const pid = typeof pid0 === 'string' ? pid0 : String(pid0);
-        const module_name = change?.module ?? 'main';
-        let op = change?.op ?? 'upd';
-        op = op === 'new' || op === 'upd' || op === 'del' ? op : 'upd';
-        await ensure_branch({
-            repo,
-            branch
-        });
-        const branchRef = `refs/heads/${ branch }`;
-        const resolveHeadOid = async () => {
-            try {
-                return await git.resolveRef({
-                    fs,
-                    dir: repo,
-                    ref: branchRef
-                });
-            } catch {
-                return null;
-            }
-        };
-        const readCommitTreeOid = async commitOid => {
-            if (!commitOid)
-                return null;
-            const {commit} = await git.readCommit({
-                fs,
-                dir: repo,
-                oid: commitOid
+const _1klrowp = function _commit_changes()
+{
+    return (ensure_branch, git, fs, moduleBaseHash) => {
+        return async ({repo, branch, change} = {}) => {
+            if (!repo)
+                throw new Error('commit_changes_direct: repo is required');
+            if (!branch)
+                throw new Error('commit_changes_direct: branch is required');
+            if (!change)
+                throw new Error('commit_changes_direct: change is required');
+            const pid0 = change?.pid;
+            if (pid0 == null)
+                throw new Error('commit_changes_direct: change.pid is required');
+            const pid = typeof pid0 === 'string' ? pid0 : String(pid0);
+            const module_name = change?.module ?? 'main';
+            let op = change?.op ?? 'upd';
+            op = op === 'new' || op === 'upd' || op === 'del' ? op : 'upd';
+            await ensure_branch({
+                repo,
+                branch
             });
-            return commit?.tree ?? null;
-        };
-        const readTreeCached = async (treeOid, cache) => {
-            if (!treeOid)
-                return [];
-            if (cache.has(treeOid))
-                return cache.get(treeOid);
-            const {tree} = await git.readTree({
-                fs,
-                dir: repo,
-                oid: treeOid
-            });
-            cache.set(treeOid, tree);
-            return tree;
-        };
-        const existsAtTree = async (rootTreeOid, filepath, treeCache) => {
-            if (!rootTreeOid)
-                return false;
-            const parts = String(filepath).split('/').filter(Boolean);
-            let treeOid = rootTreeOid;
-            for (let i = 0; i < parts.length; i++) {
-                const seg = parts[i];
-                const entries = await readTreeCached(treeOid, treeCache);
-                const ent = entries.find(e => e.path === seg);
-                if (!ent)
-                    return false;
-                if (i === parts.length - 1)
-                    return !!ent.oid;
-                if (ent.type !== 'tree')
-                    return false;
-                treeOid = ent.oid;
-            }
-            return false;
-        };
-        const Node = () => ({
-            files: new Map(),
-            dirs: new Map()
-        });
-        const addUpdate = (node, segments, update) => {
-            if (!segments.length)
-                return;
-            const [head, ...rest] = segments;
-            if (!head)
-                return;
-            if (!rest.length) {
-                node.files.set(head, update);
-                return;
-            }
-            let child = node.dirs.get(head);
-            if (!child)
-                node.dirs.set(head, child = Node());
-            addUpdate(child, rest, update);
-        };
-        const applyDir = async (treeOid, node, treeCache) => {
-            const entries = new Map();
-            if (treeOid) {
-                const tree = await readTreeCached(treeOid, treeCache);
-                for (const e of tree)
-                    entries.set(e.path, { ...e });
-            }
-            for (const [name, up] of node.files) {
-                if (up?.op === 'del') {
-                    entries.delete(name);
-                } else if (up?.op === 'put') {
-                    entries.set(name, {
-                        mode: up.mode ?? '100644',
-                        path: name,
-                        oid: up.oid,
-                        type: 'blob'
+            const branchRef = `refs/heads/${ branch }`;
+            const resolveHeadOid = async () => {
+                try {
+                    return await git.resolveRef({
+                        fs,
+                        dir: repo,
+                        ref: branchRef
                     });
-                } else {
-                    throw new Error(`commit_changes_direct: unknown file update op for ${ name }`);
+                } catch {
+                    return null;
                 }
-            }
-            for (const [name, childNode] of node.dirs) {
-                const existing = entries.get(name);
-                const childTreeOid = existing && existing.type === 'tree' ? existing.oid : null;
-                const newChildOid = await applyDir(childTreeOid, childNode, treeCache);
-                if (!newChildOid)
-                    entries.delete(name);
-                else
-                    entries.set(name, {
-                        mode: '040000',
-                        path: name,
-                        oid: newChildOid,
-                        type: 'tree'
-                    });
-            }
-            if (entries.size === 0)
-                return null;
-            const tree = Array.from(entries.values()).map(e => ({
-                mode: e.mode,
-                path: e.path,
-                oid: e.oid,
-                type: e.type
-            })).sort((a, b) => a.path < b.path ? -1 : a.path > b.path ? 1 : 0);
-            return git.writeTree({
-                fs,
-                dir: repo,
-                tree
-            });
-        };
-        const headOid = await resolveHeadOid();
-        const headTreeOid = await readCommitTreeOid(headOid);
-        const base = `${ module_name }/${ pid }`;
-        const codePath = `${ base }.js`;
-        const metaPath = `${ base }.json`;
-        const fullCodePath = `${ repo }/${ codePath }`;
-        const fullMetaPath = `${ repo }/${ metaPath }`;
-        const root = Node();
-        if (op === 'del') {
-            addUpdate(root, codePath.split('/').filter(Boolean), { op: 'del' });
-            addUpdate(root, metaPath.split('/').filter(Boolean), { op: 'del' });
-        } else {
-            const enc = new TextEncoder();
-            const content = String(change?._definition ?? '');
-            const metadata = JSON.stringify({
-                name: change?._name ?? null,
-                inputs: Array.isArray(change?._inputs) ? change._inputs : []
-            });
-            const [codeBlobOid, metaBlobOid] = await Promise.all([
-                git.writeBlob({
+            };
+            const readCommitTreeOid = async commitOid => {
+                if (!commitOid)
+                    return null;
+                const {commit} = await git.readCommit({
                     fs,
                     dir: repo,
-                    blob: enc.encode(content)
-                }),
-                git.writeBlob({
+                    oid: commitOid
+                });
+                return commit?.tree ?? null;
+            };
+            const readTreeCached = async (treeOid, cache) => {
+                if (!treeOid)
+                    return [];
+                if (cache.has(treeOid))
+                    return cache.get(treeOid);
+                const {tree} = await git.readTree({
                     fs,
                     dir: repo,
-                    blob: enc.encode(metadata)
-                })
-            ]);
-            addUpdate(root, codePath.split('/').filter(Boolean), {
-                op: 'put',
-                oid: codeBlobOid,
-                mode: '100644'
+                    oid: treeOid
+                });
+                cache.set(treeOid, tree);
+                return tree;
+            };
+            const existsAtTree = async (rootTreeOid, filepath, treeCache) => {
+                if (!rootTreeOid)
+                    return false;
+                const parts = String(filepath).split('/').filter(Boolean);
+                let treeOid = rootTreeOid;
+                for (let i = 0; i < parts.length; i++) {
+                    const seg = parts[i];
+                    const entries = await readTreeCached(treeOid, treeCache);
+                    const ent = entries.find(e => e.path === seg);
+                    if (!ent)
+                        return false;
+                    if (i === parts.length - 1)
+                        return !!ent.oid;
+                    if (ent.type !== 'tree')
+                        return false;
+                    treeOid = ent.oid;
+                }
+                return false;
+            };
+            const Node = () => ({
+                files: new Map(),
+                dirs: new Map()
             });
-            addUpdate(root, metaPath.split('/').filter(Boolean), {
-                op: 'put',
-                oid: metaBlobOid,
-                mode: '100644'
-            });
-        }
-        const treeCache = new Map();
-        let newRootTreeOid = await applyDir(headTreeOid, root, treeCache);
-        if (!newRootTreeOid)
-            newRootTreeOid = await git.writeTree({
+            const addUpdate = (node, segments, update) => {
+                if (!segments.length)
+                    return;
+                const [head, ...rest] = segments;
+                if (!head)
+                    return;
+                if (!rest.length) {
+                    node.files.set(head, update);
+                    return;
+                }
+                let child = node.dirs.get(head);
+                if (!child)
+                    node.dirs.set(head, child = Node());
+                addUpdate(child, rest, update);
+            };
+            const applyDir = async (treeOid, node, treeCache) => {
+                const entries = new Map();
+                if (treeOid) {
+                    const tree = await readTreeCached(treeOid, treeCache);
+                    for (const e of tree)
+                        entries.set(e.path, { ...e });
+                }
+                for (const [name, up] of node.files) {
+                    if (up?.op === 'del') {
+                        entries.delete(name);
+                    } else if (up?.op === 'put') {
+                        entries.set(name, {
+                            mode: up.mode ?? '100644',
+                            path: name,
+                            oid: up.oid,
+                            type: 'blob'
+                        });
+                    } else {
+                        throw new Error(`commit_changes_direct: unknown file update op for ${ name }`);
+                    }
+                }
+                for (const [name, childNode] of node.dirs) {
+                    const existing = entries.get(name);
+                    const childTreeOid = existing && existing.type === 'tree' ? existing.oid : null;
+                    const newChildOid = await applyDir(childTreeOid, childNode, treeCache);
+                    if (!newChildOid)
+                        entries.delete(name);
+                    else
+                        entries.set(name, {
+                            mode: '040000',
+                            path: name,
+                            oid: newChildOid,
+                            type: 'tree'
+                        });
+                }
+                if (entries.size === 0)
+                    return null;
+                const tree = Array.from(entries.values()).map(e => ({
+                    mode: e.mode,
+                    path: e.path,
+                    oid: e.oid,
+                    type: e.type
+                })).sort((a, b) => a.path < b.path ? -1 : a.path > b.path ? 1 : 0);
+                return git.writeTree({
+                    fs,
+                    dir: repo,
+                    tree
+                });
+            };
+            const headOid = await resolveHeadOid();
+            const headTreeOid = await readCommitTreeOid(headOid);
+            const base = `${ module_name }/${ pid }`;
+            const codePath = `${ base }.js`;
+            const metaPath = `${ base }.json`;
+            const fullCodePath = `${ repo }/${ codePath }`;
+            const fullMetaPath = `${ repo }/${ metaPath }`;
+            const root = Node();
+            if (op === 'del') {
+                addUpdate(root, codePath.split('/').filter(Boolean), { op: 'del' });
+                addUpdate(root, metaPath.split('/').filter(Boolean), { op: 'del' });
+            } else {
+                const enc = new TextEncoder();
+                const content = String(change?._definition ?? '');
+                const metadata = JSON.stringify({
+                    name: change?._name ?? null,
+                    inputs: Array.isArray(change?._inputs) ? change._inputs : []
+                });
+                const [codeBlobOid, metaBlobOid] = await Promise.all([
+                    git.writeBlob({
+                        fs,
+                        dir: repo,
+                        blob: enc.encode(content)
+                    }),
+                    git.writeBlob({
+                        fs,
+                        dir: repo,
+                        blob: enc.encode(metadata)
+                    })
+                ]);
+                addUpdate(root, codePath.split('/').filter(Boolean), {
+                    op: 'put',
+                    oid: codeBlobOid,
+                    mode: '100644'
+                });
+                addUpdate(root, metaPath.split('/').filter(Boolean), {
+                    op: 'put',
+                    oid: metaBlobOid,
+                    mode: '100644'
+                });
+            }
+            const treeCache = new Map();
+            let newRootTreeOid = await applyDir(headTreeOid, root, treeCache);
+            if (!newRootTreeOid)
+                newRootTreeOid = await git.writeTree({
+                    fs,
+                    dir: repo,
+                    tree: []
+                });
+            const existedCode = await existsAtTree(headTreeOid, codePath, treeCache);
+            const existedMeta = await existsAtTree(headTreeOid, metaPath, treeCache);
+            const existedAny = existedCode || existedMeta;
+            const summary = {
+                new: [],
+                upd: [],
+                del: []
+            };
+            if (op === 'del') {
+                if (existedCode)
+                    summary.del.push(fullCodePath);
+                if (existedMeta)
+                    summary.del.push(fullMetaPath);
+            } else {
+                (existedAny ? summary.upd : summary.new).push(fullCodePath, fullMetaPath);
+            }
+            // Add base hash for the affected module
+            const baseHash = moduleBaseHash(module_name);
+            if (baseHash) {
+                summary.baseHashes = { [module_name]: baseHash };
+            }
+            const now = Date.now();
+            const author = {
+                name: '-',
+                email: '-',
+                timestamp: Math.floor(now / 1000),
+                timezoneOffset: new Date().getTimezoneOffset()
+            };
+            const commit = {
+                tree: newRootTreeOid,
+                parent: headOid ? [headOid] : [],
+                author,
+                committer: author,
+                message: JSON.stringify(summary)
+            };
+            const newCommitOid = await git.writeCommit({
                 fs,
                 dir: repo,
-                tree: []
+                commit
             });
-        const existedCode = await existsAtTree(headTreeOid, codePath, treeCache);
-        const existedMeta = await existsAtTree(headTreeOid, metaPath, treeCache);
-        const existedAny = existedCode || existedMeta;
-        const summary = {
-            new: [],
-            upd: [],
-            del: []
-        };
-        if (op === 'del') {
-            if (existedCode)
-                summary.del.push(fullCodePath);
-            if (existedMeta)
-                summary.del.push(fullMetaPath);
-        } else {
-            (existedAny ? summary.upd : summary.new).push(fullCodePath, fullMetaPath);
-        }
-        // Add base hash for the affected module
-        const baseHash = moduleBaseHash(module_name);
-        if (baseHash) {
-            summary.baseHashes = { [module_name]: baseHash };
-        }
-        const now = Date.now();
-        const author = {
-            name: '-',
-            email: '-',
-            timestamp: Math.floor(now / 1000),
-            timezoneOffset: new Date().getTimezoneOffset()
-        };
-        const commit = {
-            tree: newRootTreeOid,
-            parent: headOid ? [headOid] : [],
-            author,
-            committer: author,
-            message: JSON.stringify(summary)
-        };
-        const newCommitOid = await git.writeCommit({
-            fs,
-            dir: repo,
-            commit
-        });
-        await git.writeRef({
-            fs,
-            dir: repo,
-            ref: branchRef,
-            value: newCommitOid,
-            force: true
-        });
-        return {
-            ok: true,
-            op,
-            pid,
-            module: module_name,
-            headOid,
-            newCommitOid,
-            ref: branchRef,
-            summary
+            await git.writeRef({
+                fs,
+                dir: repo,
+                ref: branchRef,
+                value: newCommitOid,
+                force: true
+            });
+            return {
+                ok: true,
+                op,
+                pid,
+                module: module_name,
+                headOid,
+                newCommitOid,
+                ref: branchRef,
+                summary
+            };
         };
     };
-});};
-const _1ocduj = function _commit_history(commitRuntimeHistorySince,config,history){return(
-commitRuntimeHistorySince({ ...config, history })
+};
+const _va7229 = function _commit_history(commitRuntimeHistorySince,config,history){return(
+commitRuntimeHistorySince({
+    ...config,
+    history
+})
 )};
-const _1xml7l2 = function _71(md){return(
+const _ir0qsi = function _62(md){return(
 md`## Utils`
 )};
-const _1tpet0t = function _historyModule(thisModule){return(
-thisModule()
-)};
-const _1ryokzy = (G, _) => G.input(_);
-const _1cefd8c = async function _identity(lookupVariable,historyModule){return(
-(await lookupVariable("lookupVariable", historyModule))._definition
+const _1j8ga5m = async function _identity(lookupVariable,historyModule){return(
+(await lookupVariable('lookupVariable', historyModule))._definition
 )};
 const _1lfjhgx = function _modules(moduleMap){return(
 moduleMap()
 )};
-const _1k3d7zr = function _timeline(history)
+const _1ostthv = function _timeline(history)
 {
-  const first = history.at(0)?.t ?? 0;
-  const last = history.at(-1)?.t ?? 0;
-  const factor = Math.max(last - first, 1) / 1024;
-  return Array.from({ length: 1024 }).map((_, i) =>
-    Math.floor(first + i * factor)
-  );
+    const first = history.at(0)?.t ?? 0;
+    const last = history.at(-1)?.t ?? 0;
+    const factor = Math.max(last - first, 1) / 1024;
+    return Array.from({ length: 1024 }).map((_, i) => Math.floor(first + i * factor));
 };
-const _14jbeee = function _moduleBaseHash() {
+const _36jocw = function _moduleBaseHash()
+{
     const hash = s => {
         s = String(s);
         let h = 2166136261;
@@ -11364,6 +12393,127 @@ const _14jbeee = function _moduleBaseHash() {
         return hash(script.textContent);
     };
 };
+const _1lydoz3 = function _temporal(Inputs){return(
+Inputs.select([
+    'temporal',
+    'discrete'
+], {
+    label: 'y-axis',
+    value: 'discrete'
+})
+)};
+const _d0qi2e = (G, _) => G.input(_);
+const _1enjs3i = function _rewind(Plot,width,temporal,d3,history,timeline){return(
+Plot.plot({
+    marginLeft: 200,
+    width,
+    y: {
+        type: temporal == 'temporal' ? 'time' : 'point',
+        reverse: true,
+        tickFormat: f => new Date(f)
+    },
+    marks: [
+        Plot.ruleY([d3.max(history, d => d.t)], { stroke: 'green' }),
+        Plot.ruleX(history, {
+            x: h => h.pid,
+            strokeDasharray: [
+                1,
+                10
+            ]
+        }),
+        Plot.dot(history, {
+            x: h => h.pid,
+            y: 't',
+            symbol: 'op',
+            stroke: h => h.pid,
+            channels: {
+                name: '_name',
+                definition: '_definition'
+            },
+            tip: {
+                format: {
+                    y: false,
+                    symbol: true,
+                    stroke: false,
+                    x: false,
+                    name: true
+                }
+            }
+        }),
+        Plot.ruleY(temporal == 'temporal' ? timeline : history.map(e => e.t), Plot.pointerY({ stroke: 'red' }))
+    ]
+})
+)};
+const _apj797 = (G, _) => G.input(_);
+const _138eq5p = function _selectedChanges(Inputs,history,html){return(
+Inputs.table(history, {
+    columns: [
+        't',
+        'op',
+        'source',
+        '_name',
+        '_inputs',
+        '_definition'
+    ],
+    format: {
+        t: t => new Date(t).toISOString(),
+        _definition: d => d.toString(),
+        _inputs: i => html`<details><summary>${ i.length }</summary>${ i.map(i => html`${ i }<br>`) }`,
+        source: s => ({
+            runtime: '\uD83D\uDCD3',
+            git: '\uD83D\uDCBE'
+        }[s]),
+        op: t => ({
+            upd: '\u270D️',
+            del: '\u2421',
+            new: '\uD83C\uDD95',
+            init: '\uD83C\uDFC1'
+        }[t])
+    },
+    layout: 'auto',
+    sort: 't',
+    reverse: true,
+    required: false
+})
+)};
+const _1a64yt8 = (G, _) => G.input(_);
+const _20mogr = function _history(Inputs){return(
+Inputs.input([])
+)};
+const _bmiya2 = (G, _) => G.input(_);
+const _1ve4ius = function _fs(Inputs,FS){return(
+Inputs.button('wipe filesystem', {
+    reduce: () => new FS('lopecode_history', { wipe: true }).promises,
+    value: new FS('lopecode_history', { wipe: false }).promises
+})
+)};
+const _1dt24ln = (G, _) => G.input(_);
+const _1uk8yq0 = function _selected_repo(Inputs,repos,config){return(
+Inputs.select(repos, {
+    label: 'select repo',
+    value: config.repo
+})
+)};
+const _9lv1oo = (G, _) => G.input(_);
+const _1j6kx3r = function _selected_branch(Inputs,branches,selected_repo,config){return(
+Inputs.select(branches, {
+    label: 'select branch',
+    value: selected_repo == config.repo ? config.branch : undefined
+})
+)};
+const _1u33aug = (G, _) => G.input(_);
+const _1lp66j8 = function _initial_state(Inputs){return(
+Inputs.input(new Map())
+)};
+const _8pswzc = (G, _) => G.input(_);
+const _1kbsmg2 = function _module_load_time(Inputs){return(
+Inputs.input(new Map())
+)};
+const _1g6l5w7 = (G, _) => G.input(_);
+const _1tpet0t = function _historyModule(thisModule){return(
+thisModule()
+)};
+const _1ryokzy = (G, _) => G.input(_);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -11378,90 +12528,91 @@ export default function define(runtime, observer) {
   main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
   main.define("module @tomlarkworthy/exporter-3", async () => runtime.module((await import("/@tomlarkworthy/exporter-3.js?v=4")).default));  
   $def("_1f8tza", null, ["md"], _1f8tza);  
-  $def("_e1f5vn", "viewof temporal", ["Inputs"], _e1f5vn);  
+  $def("_lprfj9", null, ["rewind","Inputs","rewindToTime","md"], _lprfj9);  
+  $def("_ta70mv", null, ["selectedChanges","Inputs","revertVariables","md"], _ta70mv);  
+  $def("_11ax55a", null, ["md"], _11ax55a);  
+  $def("_yk1snt", null, ["md"], _yk1snt);  
+  $def("_if05zb", null, ["md"], _if05zb);  
+  $def("_fo0ea9", null, ["md"], _fo0ea9);  
+  $def("_5nkgqg", null, ["md"], _5nkgqg);  
+  $def("_mohljl", "git_commits", ["listCommits","config"], _mohljl);  
+  $def("_1wwku9q", "relevant_git_commits", ["git_commits"], _1wwku9q);  
+  $def("_1gt738", "notebookCreationTime", ["git_commits"], _1gt738);  
+  $def("_kd4rgi", "parseGitMessage", [], _kd4rgi);  
+  $def("_2qhh6w", "GitEntry", ["ensure_repo","git","fs"], _2qhh6w);  
+  $def("_177arhl", "git_history", ["git_commits","parseGitMessage","GitEntry","config"], _177arhl);  
+  $def("_n6n063", "relevant_git_history", ["relevant_git_commits","parseGitMessage","GitEntry","config"], _n6n063);  
+  $def("_4rcrzb", "git_history_materialized", ["git_history"], _4rcrzb);  
+  $def("_yngfrp", "replay_pid_map", [], _yngfrp);  
+  $def("_b2d64x", "replayGitEntries", ["modules","getVariableByPersistentId","runtime","replay_pid_map","GitEntry","realize","tag"], _b2d64x);  
+  $def("_1h8l7wf", "replayGitCommits", [], _1h8l7wf);  
+  $def("_frdbmi", "replay_git", ["isOnObservableCom","modules","replayGitCommits","relevant_git_commits"], _frdbmi);  
+  $def("_1rm7oy4", null, ["md"], _1rm7oy4);  
+  $def("_krsfjh", null, ["Inputs","exportToZip","fs","config","getCompactISODate"], _krsfjh);  
+  $def("_1ax2z4b", "repos", ["listRepos"], _1ax2z4b);  
+  $def("_1lmwwtp", "branches", ["listBranches","selected_repo"], _1lmwwtp);  
+  $def("_yvu9cl", "selected_files", ["listFiles","selected_repo","selected_branch"], _yvu9cl);  
+  $def("_29j25n", null, ["Inputs","selected_files"], _29j25n);  
+  $def("_5xw5rr", "selected_commits", ["listCommits","selected_repo","selected_branch"], _5xw5rr);  
+  $def("_1kqllm6", null, ["Inputs","selected_commits"], _1kqllm6);  
+  $def("_1aj637r", "exportFsToZip", ["JSZip"], _1aj637r);  
+  $def("_z3yxk8", null, ["md"], _z3yxk8);  
+  $def("_4q2hvf", "known_dirs", ["fs"], _4q2hvf);  
+  $def("_1yebjl5", "ensure_dir", ["known_dirs","fs"], _1yebjl5);  
+  $def("_1ccskir", "known_repos", ["fs"], _1ccskir);  
+  $def("_8gl5oz", "ensure_repo", ["known_repos","ensure_dir","git","fs"], _8gl5oz);  
+  $def("_3nw6gd", "ensure_branch", ["ensure_repo","listBranches","git","fs"], _3nw6gd);  
+  $def("_1dn3olo", "git_repo_layout", ["config","fs"], _1dn3olo);  
+  $def("_4nrbhc", "setFileAndCommit", ["setFilesAndCommit"], _4nrbhc);  
+  $def("_femrmt", "setFilesAndCommit", ["ensure_branch","git","fs","ensure_dir"], _femrmt);  
+  $def("_6dncmw", "listRepos", ["fs"], _6dncmw);  
+  $def("_1idfiqe", "listBranches", ["ensure_repo","git","fs"], _1idfiqe);  
+  $def("_1lvo029", "listFiles", ["ensure_branch","git","fs"], _1lvo029);  
+  $def("_tjjpfp", "listCommits", ["ensure_branch","git","fs"], _tjjpfp);  
+  $def("_1szf3ci", "getCommitChanges", ["git","fs"], _1szf3ci);  
+  $def("_t237wb", "getCompactISODate", [], _t237wb);  
+  $def("_8ou4wx", "exportToZip", ["JSZip"], _8ou4wx);  
+  $def("_1q9qys8", null, ["md"], _1q9qys8);  
+  $def("_1jkr4mu", "tag", [], _1jkr4mu);  
+  $def("_1qh1oaw", "read", [], _1qh1oaw);  
+  $def("_1l4hr6l", null, ["md"], _1l4hr6l);  
+  $def("_1lftkrn", "revertVariables", ["getVariableByPersistentId","runtime","realize"], _1lftkrn);  
+  $def("_krzgpe", "rewindToTime", ["history","revertVariables"], _krzgpe);  
+  $def("_1rfq6xd", null, ["md"], _1rfq6xd);  
+  $def("_10ihggp", "config", ["notebook_title","ensure_branch"], _10ihggp);  
+  $def("_1uqj96c", "historyUtils", [], _1uqj96c);  
+  $def("_142fbfa", "change_listener", ["runtime","viewof initial_state","persistentId","historyUtils","viewof module_load_time","read","onCodeChange","identity","modules","viewof history","Event","invalidation"], _142fbfa);  
+  $def("_1behp0h", null, ["Inputs","history"], _1behp0h);  
+  $def("_ztvqq8", null, ["md"], _ztvqq8);  
+  $def("_1klmxot", "commit_watermarks", [], _1klmxot);  
+  $def("_1p3t9pb", "commitRuntimeHistorySince", ["commit_watermarks","commit_changes"], _1p3t9pb);  
+  $def("_1klrowp", "commit_changes", [], _1klrowp);  
+  $def("_va7229", "commit_history", ["commitRuntimeHistorySince","config","history"], _va7229);  
+  $def("_ir0qsi", null, ["md"], _ir0qsi);  
+  $def("_1j8ga5m", "identity", ["lookupVariable","historyModule"], _1j8ga5m);  
+  $def("_1lfjhgx", "modules", ["moduleMap"], _1lfjhgx);  
+  $def("_1ostthv", "timeline", ["history"], _1ostthv);  
+  $def("_36jocw", "moduleBaseHash", [], _36jocw);  
+  $def("_1lydoz3", "viewof temporal", ["Inputs"], _1lydoz3);  
   $def("_d0qi2e", "temporal", ["Generators","viewof temporal"], _d0qi2e);  
-  $def("_11s75oi", "viewof rewind", ["Plot","width","temporal","d3","history","timeline"], _11s75oi);  
+  $def("_1enjs3i", "viewof rewind", ["Plot","width","temporal","d3","history","timeline"], _1enjs3i);  
   $def("_apj797", "rewind", ["Generators","viewof rewind"], _apj797);  
-  $def("_9rxqcj", null, ["rewind","Inputs","rewindToTime","md"], _9rxqcj);  
-  $def("_x81t46", "viewof selectedChanges", ["Inputs","history","html"], _x81t46);  
+  $def("_138eq5p", "viewof selectedChanges", ["Inputs","history","html"], _138eq5p);  
   $def("_1a64yt8", "selectedChanges", ["Generators","viewof selectedChanges"], _1a64yt8);  
-  $def("_1eayu9o", null, ["selectedChanges","Inputs","revertVariables","md"], _1eayu9o);  
-  $def("_14zrzgj", null, ["md"], _14zrzgj);  
   $def("_20mogr", "viewof history", ["Inputs"], _20mogr);  
   $def("_bmiya2", "history", ["Generators","viewof history"], _bmiya2);  
-  $def("_18jzahh", null, ["md"], _18jzahh);  
-  $def("_7vt8ig", null, ["md"], _7vt8ig);  
-  $def("_ks64y8", null, ["md"], _ks64y8);  
-  $def("_4xwmln", null, ["md"], _4xwmln);  
-  $def("_a8y5z4", "git_commits", ["listCommits","config"], _a8y5z4);  
-  $def("_2zxk4p", "relevant_git_commits", ["git_commits"], _2zxk4p);  
-  $def("_k9wqu2", "notebookCreationTime", ["git_commits"], _k9wqu2);  
-  $def("_3hs18u", "parseGitMessage", [], _3hs18u);  
-  $def("_n91s4i", "GitEntry", ["ensure_repo","git","fs"], _n91s4i);  
-  $def("_hjh7k7", "git_history", ["git_commits","parseGitMessage","GitEntry","config"], _hjh7k7);  
-  $def("_rd1nhl", "relevant_git_history", ["relevant_git_commits","parseGitMessage","GitEntry","config"], _rd1nhl);  
-  $def("_195a7nq", "git_history_materialized", ["git_history"], _195a7nq);  
-  $def("_yngfrp", "replay_pid_map", [], _yngfrp);  
-  $def("_1hnuqrm", "replayGitEntries", ["modules","getVariableByPersistentId","runtime","replay_pid_map","GitEntry","realize","tag"], _1hnuqrm);  
-  $def("_9748ey", "replayGitCommits", [], _9748ey);  
-  $def("_axol8", "replay_git", ["isOnObservableCom","modules","replayGitCommits","relevant_git_commits"], _axol8);  
-  $def("_1tptp40", null, ["md"], _1tptp40);  
-  $def("_145kx9v", null, ["Inputs","exportToZip","fs","config","getCompactISODate"], _145kx9v);  
-  $def("_1x4vn9a", "viewof fs", ["Inputs","FS"], _1x4vn9a);  
+  $def("_1ve4ius", "viewof fs", ["Inputs","FS"], _1ve4ius);  
   $def("_1dt24ln", "fs", ["Generators","viewof fs"], _1dt24ln);  
-  $def("_1ax2z4b", "repos", ["listRepos"], _1ax2z4b);  
-  $def("_u259bo", "viewof selected_repo", ["Inputs","repos","config"], _u259bo);  
+  $def("_1uk8yq0", "viewof selected_repo", ["Inputs","repos","config"], _1uk8yq0);  
   $def("_9lv1oo", "selected_repo", ["Generators","viewof selected_repo"], _9lv1oo);  
-  $def("_1lmwwtp", "branches", ["listBranches","selected_repo"], _1lmwwtp);  
-  $def("_mu1lyv", "viewof selected_branch", ["Inputs","branches","selected_repo","config"], _mu1lyv);  
+  $def("_1j6kx3r", "viewof selected_branch", ["Inputs","branches","selected_repo","config"], _1j6kx3r);  
   $def("_1u33aug", "selected_branch", ["Generators","viewof selected_branch"], _1u33aug);  
-  $def("_14evvq7", "selected_files", ["listFiles","selected_repo","selected_branch"], _14evvq7);  
-  $def("_15hte9q", null, ["Inputs","selected_files"], _15hte9q);  
-  $def("_1dlj40t", "selected_commits", ["listCommits","selected_repo","selected_branch"], _1dlj40t);  
-  $def("_1qadth7", null, ["Inputs","selected_commits"], _1qadth7);  
-  $def("_1h1k0un", "exportFsToZip", ["JSZip"], _1h1k0un);  
-  $def("_1kamd3r", null, ["md"], _1kamd3r);  
-  $def("_4q2hvf", "known_dirs", ["fs"], _4q2hvf);  
-  $def("_gf2cfd", "ensure_dir", ["known_dirs","fs"], _gf2cfd);  
-  $def("_1ccskir", "known_repos", ["fs"], _1ccskir);  
-  $def("_1x25x9p", "ensure_repo", ["known_repos","ensure_dir","git","fs"], _1x25x9p);  
-  $def("_vttaz9", "ensure_branch", ["ensure_repo","listBranches","git","fs"], _vttaz9);  
-  $def("_as5npg", "git_repo_layout", ["config","fs"], _as5npg);  
-  $def("_1831q7g", "setFileAndCommit", ["setFilesAndCommit"], _1831q7g);  
-  $def("_1ke7zw", "setFilesAndCommit", ["ensure_branch","git","fs","ensure_dir"], _1ke7zw);  
-  $def("_121eabg", "listRepos", ["fs"], _121eabg);  
-  $def("_3e3c2g", "listBranches", ["ensure_repo","git","fs"], _3e3c2g);  
-  $def("_1685ilj", "listFiles", ["ensure_branch","git","fs"], _1685ilj);  
-  $def("_1a64td9", "listCommits", ["ensure_branch","git","fs"], _1a64td9);  
-  $def("_1f0bz98", "getCommitChanges", ["git","fs"], _1f0bz98);  
-  $def("_19ky3g9", "getCompactISODate", [], _19ky3g9);  
-  $def("_i5o28z", "exportToZip", ["JSZip"], _i5o28z);  
-  $def("_exnpt6", null, ["md"], _exnpt6);  
-  $def("_140zfwr", "tag", [], _140zfwr);  
-  $def("_icsevy", "read", [], _icsevy);  
-  $def("_n6xuup", null, ["md"], _n6xuup);  
-  $def("_1l5m90g", "revertVariables", ["getVariableByPersistentId","runtime","realize"], _1l5m90g);  
-  $def("_i49sc4", "rewindToTime", ["history","revertVariables"], _i49sc4);  
-  $def("_s8r7nk", null, ["md"], _s8r7nk);  
-  $def("_bjgii1", "config", ["notebook_title","ensure_branch"], _bjgii1);  
   $def("_1lp66j8", "viewof initial_state", ["Inputs"], _1lp66j8);  
   $def("_8pswzc", "initial_state", ["Generators","viewof initial_state"], _8pswzc);  
   $def("_1kbsmg2", "viewof module_load_time", ["Inputs"], _1kbsmg2);  
   $def("_1g6l5w7", "module_load_time", ["Generators","viewof module_load_time"], _1g6l5w7);  
-  $def("_no07ya", "historyUtils", [], _no07ya);  
-  $def("_1kdskqz", "change_listener", ["runtime","viewof initial_state","persistentId","historyUtils","viewof module_load_time","read","onCodeChange","identity","modules","viewof history","Event","invalidation"], _1kdskqz);  
-  $def("_x41am1", null, ["Inputs","history"], _x41am1);  
-  $def("_1s7m7g8", null, ["md"], _1s7m7g8);  
-  $def("_1klmxot", "commit_watermarks", [], _1klmxot);  
-  $def("_1bwderc", "commitRuntimeHistorySince", ["commit_watermarks","commit_changes"], _1bwderc);  
-  $def("_v9uu47", "commit_changes", [], _v9uu47);  
-  $def("_1ocduj", "commit_history", ["commitRuntimeHistorySince","config","history"], _1ocduj);  
-  $def("_1xml7l2", null, ["md"], _1xml7l2);  
   $def("_1tpet0t", "viewof historyModule", ["thisModule"], _1tpet0t);  
   $def("_1ryokzy", "historyModule", ["Generators","viewof historyModule"], _1ryokzy);  
-  $def("_1cefd8c", "identity", ["lookupVariable","historyModule"], _1cefd8c);  
-  $def("_1lfjhgx", "modules", ["moduleMap"], _1lfjhgx);  
-  $def("_1k3d7zr", "timeline", ["history"], _1k3d7zr);  
   main.define("thisModule", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("thisModule", _));  
   main.define("lookupVariable", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("lookupVariable", _));  
   main.define("onCodeChange", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("onCodeChange", _));  
@@ -11475,11 +12626,9 @@ export default function define(runtime, observer) {
   main.define("http", ["module @tomlarkworthy/isomorphic-git-1-30-1", "@variable"], (_, v) => v.import("http", _));  
   main.define("JSZip", ["module @tomlarkworthy/jszip-3-10-1", "@variable"], (_, v) => v.import("JSZip", _));  
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
-  main.define("notebook_title", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("notebook_title", _));  
-  $def("_14jbeee", "moduleBaseHash", [], _14jbeee);
+  main.define("notebook_title", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("notebook_title", _));
   return main;
-}
-</script>
+}</script>
 
 <script id="@tomlarkworthy/local-storage-view" 
   type="text/plain"
@@ -14554,6 +15703,78 @@ export default function define(runtime, observer) {
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));
   return main;
 }</script>
+<script id="@tomlarkworthy/observable-runtime/runtime.js.gz" 
+  type="text/plain"
+  data-encoding="base64"
+  data-mime="application/gzip"
+>
+H4sICP/9J2cCA3J1bnRpbWUuanMA7L1dbxxJsij2rl9R6tU5qhKbRVLSzoyaw+FSFDXDcyhSS1IzO0vxkMXuIlmj7q7eqmpSXKqBfTVgwIBfjAvY8JOP/4HhZxvwD9k/YP8Ex1d+VnWzqdXcPXfvXeyIXfkRmRkZGRkZGRF5Ph52qywfBr2sHCVV9zIc5r20HVQ3I/i3l1ZJ1o+C2weB/A7W1I9Pn4LbySpkXCVF0Mu740E6rCAb68f59TAtXkliO0ivOE8Vi3vpeTLuVz9m6XW8OS6rfLCFRRBcdh6E2Hp+rqqtrQWtc+lnizsTaJDD9Jp/h9zlW+5eR7o5iRDmJEj7ZerV1J3pFmlSpdSBsEV/WlRLisbZMKu2rCbOEwAmf5yCHoqoZfiPMKLwy4CoPNSdPHiwtBQc7r3aCy6ralR2lpaq66yq0iLu5oOlwVkOuOl+WCqrpBqXS18vP/362dfLX/125enK18+ffvP8mwcKMUFWJkWR3IRXSX+cMpaKtBoXw2AD0+Os3LDyqdcBTiJ9B9kQmhh2Eevbw+obKjq7zMpXcxR69vSuQu+yOZqjQpv9ZDBKe/OUvbtvWOruzr3u58m8xb56TsXUnO7mw0VoI71Ii+BDelNC+YAmqITlEF/EwdFKO3jaDpbj33aCFoFsHcf2dGbDXvoxhLrOZMI3rQjMCD4Fy1GwELRa1KqpOyxHabfaTQZpOIR/GEA3hx4HwwbK76cDon2g0CGT/jDu9pOyRAhQvpWflWlxlZz108s/LS52034fwba4ZJV+rDZzGCqtqtNHt5g3wZ+rpttD6iF3obwBuu4f5gdVkQ0voOABJcSjIq9yXGJxJXmrhErOLqHbsJQqGEdadNOgyoOSCpWrQXUJyBgAHwnO0iD9OOpn3azq3+CQr9KiSnsWYs/zYpBUDDPkrjgIdnsXd5O+LmaN4fYirfauh2+LfAQN3EgX24EeQye4vUxKq0gncL8frUwQSXtnv8BUrSqwauSHycVEY2ZVtfp6b//l9qtXW7uQhczXQWgJlLgWNPZr1SaOEphzmFOz7cAnL7+PPH67tEtqVXKRn0u+A4iTjqzxHJsVJBVi6n4x7lZ5EfzzPwf11JjI11RsMbo8eqfVk58/WqkPqypuhO0zqnjtrqnuQblj5uC47QjrpD92L1YDZNIpVAfiCQ7S7rjIqputooAOUmUZM1Xk/aaLvD4Is4thXqRqz5JiehZ5g9A0dfDzm5d7OwfQuyPIuJVpBe7wu9+dnGy/efPucOPlztbJ9u6rrT9svTo5+d3vWu0AEQRFtpFZpD1IGOS97DxLiw6MHYY6ac+C9a9bP/uQ/jW9uT+cne2DQxfMTlZW8EUsLysv54LyZuOtC+RNMmpJHULglHp7+6+29tU4qKDU3yt6aYGjoUR3RJw2KtLz7COn4GzM7N/+1iY05XZxP+3mRW+eXh5sHdZ7eJBWkuBiitPKtNIpd/bu4HBj81/dzh1USfdDwyw8OHY4wmAwrpC504YBK8NfOv1U8xjkSUym8XnWBzklDFWHgkkUrH2HK+uIE45po8IWI7PGHgqguJ8OL6rLSBYF9Mcs0iFvO6rkOeyEYYmwH5axmkQByRV4FoM1YRRYP2YgKDsSFQF7qcMz4Cg/ZjiR0xmFO6tDZQ54EgAq2+kPz9uUGpypGhGecGt1vYObqAxpXcbGw4EpbU14g6WEyWlb6klD6tNMuO4+DPAhN63r0Bd9TByu5TOs4bjf93gV7n9v1V63d9729p1XadktshHwzrK+yTHv1bV507KAhbcotdfEma2PIJ700p5m8idM57Lpcp+RVK0ZU0KxbFCrUgJ2LZDfs7Tfgy17CPJLO2AKRArlsrZ8BwSkMNJcoL5xRXpGoS2UhQBG+OhWCpbZn9NJdLoqRbgn2F1YUCCQQdlHK5ypTi64AyVXedaDZuFkAEeJDBYsTFA3zUDECVLcjGh70hKI0z4ugjBqTWuRJ0g3ao5MzeMFrvU3IwRgzI0QKPvFEYLtfyZC9JqXMcmI9Gh8AWZiBspcTw/Vb5aOENyq1V6IQnuNSyNBR14XtlWhGLgEt61+MC9U29U6cBJgJ6e1KZhIz6xFNNRMzuu0yRAsrqtxbA9kJJLRgbIWu3FK0uTqcjrZngELF9ZaV6N2ZNBmvBJ3qWkC5q7u9OWBPkvheWmu4xT+mnWiSoW1tZQCxJzapHIyGqXD3uZl1u+FteNdpDQNsmPhxuNXmtbJpMXVkzgbDtPih8M3O0hI35ZXF8F11qsu174JLtPs4rKCHzSEtcfecTCBbeLxd9TXb2EdXga9tcdvngdf7ywHK5ff/PkxoLPfX3sMUnMBTW7m/bx4HCxhhW+XoJnvTrn9Gb09BBa9m/fSENYYTBfQtCZPIOTgCEm5Fdy2JqdqMEmvR5oWFENTGFfYGuTjMh2PQBpSG4toYWy1UFxW+Qg3seQioSJCEEU66idd2MIBrW21IcFI+smotHYk3CjdTYmnhjd7TVX8wyY55FMh7kwZZC+vBg9D3JV00Ri/wiiKe/kwxZ08C74NnkK5hYVsKplgnZiPNJpuSQKjDIQUOUejzyIbxPUMwqbut1TBsrrpsyasn9xg4bN+DvKpyp6LAILgr3/5dxDli/TU9OD+s33HfAs6YaJBmnmZwvSkFj7bnAvDrqi3KDdeZdDiAexBcNjVQD5nWldeONP6xfoykb/EXgwFUO0iHeRXKWN+TnBaX8xLotXPk55Sm04Mwd1FUHpi7QV9TOt5QiRmKWYAlHPuf+LIS+FASWmEdaZpPOC3+Vx+HIBcMjCS3A1OgWiDAMBr/AQopoLmqlTyib8XUHvN/aEdLSyVkGT1h9UP0JHSSFB2R6AmdSScqwcIpLkHsqt+uT40NSJbPE+d1Ywm+DZpGylbBJ9VIvGhQ+FIkJlWjxq6t/ukZidrW8oeKg/cOGr7bIdUp5oaBYkWClB36jdIrNHRuuKCJGWZNISJs7tniMfuINardRESZ3RQTtQ4SUq3J2humjHVvOE6NQ2nOvPVOufle73k3BZlzqAELe7ZtEBksEKMzx2cIQqUOVexkKKJlVnDy1ZEkxHDeRG+AKlaudDcLxL7HO1knQimHly1jD2jS96E2+rH6TM+x1zP0fS9Jlt17N6z/cCoWACV9aO6JcNo6RwXDv94uLbmn/abhqQzRbqfPqGa9c2eUztXGExN632vlTzfxM69lP/b9E7jI3dNsL+huzM9eyZnrUj7OsHvtXWjyp2A3g5mnPt62RWDdU6JWGku0ZqPjYxzrDOXeH3XCVMrQWjQuoZ3d4cHOFWQj2V39VrLby2Q2KxON5xXQ5mEMeyw59kw7U37SUw9si4PEeJqwxQ1TbHGwX9pE6Z/T5+cR7cw0smvMy9zIbxZTv4MRM+Pp/kHGtw5UGL79wS69t0XxJ8nWv8Xg7h5RniZlAdpP5WzNnTcHl6ZolnMNQjX+TVKb6akDTSUS69+zPcCpLBMhhcpXt9QXoiZALJKoGvUe2xJWEbw6ZO+2ejHybB7mRdYJs6wZ+d7BQp3MLYEDXCog06Fc8BPObM8XkRHjaYWdVVQeZn0+/n1P/AVxd/hguI/7vXE3+Fy4u9xNfGrXUw85ouJx8F68PjxF7yYqF1JWFcR3iVE/fLhb70wcNSuwhBcnevcNwh3S3gCv2Wu2u1LhLmvEZSicG7FHWAjsrv4ObpY7K2zfyCkyNgGzKWxnUtHHzkqSk+3+Otc7nRVF/6Bbne+Dp7vrATf/Lj897jd+Uwym4fI7n8JVLNKmHYHpJVVv/pNECtUv0Pb0LlXMWCt5S7je94k3aelv/7l31v2VP761wNf4nJg3quB2RcD91TJe2dnS985pfE77gS+WPMz1MA1JfAykO/iSvvztcFE0StA0gBqIYBke362BqPqBrMXMXsRslcbRjBNcRxw97IVhdV7tzX1auRz8aCvSqZjon5b8lkoapxm527Fw5WDLaPu/IzGf+3bmL/rXUzYqLadfvkyRVN7pyL811WD/52V4Hci0dd63x+LStD/Qtrmz9Y18xJxFEJfzrYIYU/T+PLhawV3VS6HRy/6Ffzf/1Pw6Dad2E4ctS126uAbtbDnRXIxaPS9Up5ir6VEWNfGqsr31cjeW88KwyD+NEd7DUrWxmpNu6it91KVZqlcpyhc74vTmf2jJkzv7ocCS1P6xZEQ9qAp8rjrnyXdD4wA2iIox1btvIJv4CmUzN6BmBIuYIK+x8qAAHapqpb/A/E5VG14boewQlQO14OFohIMrV7m4wLFeiyBssa7w80fMMmm50E2HFepV+oNJzp0n8LfnlfugBNdeP1+1lj4jZXj6FnhnMV4/TlNCmCkVp3XcHrBVDhiTBYf3Y6Snpv/BtbJZYhOZ+i+1lyGEB5R9iPmlIyXT5/04OGn6jKlWkNYD04PFVCqR4A6Kkkg2NCDWbB0RUlzKwa18rFpyGS0g2fR5BR546myprK+Jn/UH8gu6+QraL6BP46PFCaAiLeM7WpELmJqO/gKGnzAJrFU7LvgBfwPSy6okrWCdvJzT1HNebL46OjvdAVIgvImpzGUPKiSogqpFGxky62oaVQ4zTLxDihnyba2hwA369EqFDjoMEwaUMsFkJ2pGj0A/b0SSzZ4ubLXVokeL0gHTgPsxaaObtKFIr2Aw7vVh31KmKsTXLShFy7QWrtLT4K07GfDarGXlbhDB8N8Ee8ziry/CHXTj8GTJXGT2N36aWd7F32r3mwfQvfglF+/UKJmQnaEtC4dlEExKyIMv5QCxNzYf1lkGXSzZDxcJmVwnl6jlrrsJiNYrGKwmfaAblD/k4+x438a57AOtWTZzcdDsjiTriwdtd4Pj5cuouBb2HP9zNNP7x/dQqaRPu+tD7VVaXPrNlU7uOX/KK6AcyvTLKmClMEKxkytLI24Va/jCh3/crC3G3PZ7PxG8GRpNh0lpVLR8lCAmmg34ToxTFUGfX2v8YRYojJyrgRO4lIWOgYpevHno5ddzXMr6c4GJH/2ZPh1/w5z0TptwfZWgRTcTyqcDcYeLNtuGi63XexF8S95NmR8e8OimYBzxuePStBTwJqHUr1NXEUAzZnNRbc/xnyZG/eNCA4uYfU/unVhTkwbBNzPB5KhI0LZIge001UD/k50i29Dq9axeRS4gX9RcOclgNHSAs61krbOIMnHMnCpceIvOABRX2/3YFGfwaC+FHtqXhCnTTMEpzxZ/aRun+KZEsjUP7jX0hFGhjEKTltf7Mbl3nj9Mli9L5O5F7M33HllGQRCQhUIZYqrK+bz2+Vo8te//LuXsfj8Bcun1sYx9czeMD12+AOGq1bR0tH796fvPy4vL8I/L+C/M/ix8uKY9++2BWzzMimiaS1hZti9VPIvil9dODXicRwSY/xnE743qnCZT+0gaaAnKhbSN6ZJmQbLH7/pqK623r8/E6KSvBd2XuXmndl5V25e1847d/N6dl7RUmpiSaNRgAj/cQWleCjxcRmXACZr8TFc+SrS/m26wlNVYXZ5KEEFAEMucn2ZSoUZQNwOlX75Gmg7DcIijdOPaVfNN6zHhWEtOAdWVF14hBrq19JUg0TMFqaHP7/dOtk4+Hl3E+NRKFf6VlLeDLvB//M/tiZ+sZPvt3a39jcO9/YbKzxxamzubBwcOOVo2TllXr/b3Tzc3tt1inktN7dJrTV4GatBh+e27Ey4oeA/aGyENgAaUSzjn/NdlKLbcz+0xXk9qoVN1q0NRIFqG7ZZcYw2qFsNzoAxfVj163yPe2cCQGdVNjhoAHMXhOa6EsFJF136N5qd92dLwO3KKoRNe92ex447YRYs2gHg/LHBqrl2MMrLMjvr3xD+ezHnUl6APNeKEUXnGNOI57Yuykk1oTx/LYmOEDlN0+0DSEaaGuikkwQlTDEsoKS44M2Bi5/nebD2Hf9m2tUpZBUzIHyE6x3KfF8+idbD99cLEfxa+26Jl6JlIjOzuyGu/sHRyjHuodE9Oj9K8D7+MsVbtZ4eQSlDCGETiewRqIRpA3gfwh8cBaTCrzb8h0PCHPgV3W9UNJ51a3BmvxHYuLfQnTQPGxlh2Dx6PWxDOB0eEwYlENJuB8kwH96ghAlCYAbb0k0NJRp92IaFH3Nr4GXI1E+p5ua6lachWRsuEI7fI93wL8A04fk/6CQc5IO0ukTtQUqh0frZhxQ4BPO7Me9P3XxA2A6AIQrzYJ0N4X/2GkC0mXYbLiDcCjCzMM0qTJXh4F/sTkWrhZU06rZ1h1WPLqxv8lXnDpmXfo5wqqrP6vaH9OYavf+d8q5sSrs8b5L3tM+4KKNGuVPihdiBsdTm6QTAqu3ESlnpKbWmWNTKNiRafB2JSW3Itm8Kb3tned5PAX0dK007IcAWeCtmEQtrGF9Ntit1EqTSw/HgLC2somvqL+xKy7jrrwRLksRa3tbiMq4iATwN7ll2kQ2rBrhQY9hcRa467SrO7amoIJuqnptd/1Zbd3uykMwErz+3YT7uWHUdxeSsKdSQtChh2zIYTKJBFUydmmG2r1KjbOGnjxMbgn81ZAC1UEPdansIE612I8L8nulAXjZUAHOW9Xrp0ALdOtKpx/XOahpt0Brbqg/G+JGYM7MK+phQr9omDfKoNiZHW11r3gdMCnaEC4xdBaW8AIlifEYxKft5Lykv1Z+zfn62NEjKKi2WspK1+L+Uv9l5+tUU6K/23mx97KYjpCu386Sxr/XdVvc3dF3TjnIhYApD017XPg+tez2T0KhGnjZn8f3mLdl34hhk/tpqi+Fn7gjDWaqfR7eIdtbn+DfgmnlOVSHYlpB7/R7HINhNr62LBs7hLqCKT3tthDVfbRo6dFpBsSolvd7U8mp/wmZY2CXnDembCWYAENuqIFVyQhdQro5eoPernb3NDTynnLzZONz8ASW19+UCiF+9hQ789z56tDTA8It0KNnmHoFco+/l+ZxHsXQdiyZOqC5RXMe7aabuViaXZJitlIcgT5XxyZC1JPiHkymY7AwEGRdjJBbkwa7F+S2BxI0XG2CYJx5QDgfhI57XZ9RcpWGiivFwiHuD8Xke99FWOO05+8mdvRNTMMxQF24YQpLv+8zE435bS0MPVQJpMVLFXzwxQ6L68sDOs0ICYAQqPu+rnPoUnKWkvtYcKMCG/VoGM/OWm7o+tAY2sgRvPY57rBXFyuabbTV7NUMmhwxwbmoYQ6RbN6PTytlbm+ipuIgOPmKmz6nGKXbMEq+edRugylo8Qea7BlczfNvjw8Cwua8xAjZoFVlG8ZYTjqPdGo96cvOt9Ia4DcIaIDzOuwbuN2fzr1FnMpsnYX58UyDweS8M8UpsxlFFUa5/kTLv3eIdN2763MLTQLJ4pM+/LvNHnVEUOTh1IGdXuk1v7pVEc0s/OmyTMDFWgHrjiEHeR+97ff4XZpAWZkeVk43OYQMlkb8tClK5ZhL+NE6LG3Z7gM3GgF61Lu8NUJG3a3uUKYNBmM9zOCvZVM2yv+q/H0ASwOjBmtbmkmiIZuSoDBs0h4TeJ7glhzOFEVSXaXCRXaVDFZy7DEqtk6guE5DSLvMxcJSzNIBlAOJglVMlEEcR3tkNfWWqj+2gSCChwLpDqIRgJDPtxcEhbgS9tJ+dkRlp/wYONt3+uJeWCMy3vEMtYhfaHcmOHCTGbO+vf/mfgWzKvH+Vln/9y/8ShOgmV6UlTkCKwFRJ1GD1gus0uEYvCLRRdTqM48F5uUyuUmivly6m5+eQU8bBRr/M2wgKvX8ErUalj6hKhvYxSYq0g7NxRTAhO+W0h3YYaXtDti6Q6ucuAdgYOh0XorrsgP2xXrkWjNkY8Gzt7VAcbNb1b+29tr5+/27vcAu+nz3nb7kkh5SVZU7Z3zp8t48XByvPbOUDH1M2JXA4Emt/PBiWzhCRnPXZuIXBklsqjCtf5lCVeJCMQr0i+GiReQvDuwpkHgfMqBP0jhBUhh/HiLn3rfctvnxSJgdt1stNfOusLr2nUBsBSDhGEyaHsbWpw11tWNQFHpH8ESg7bswFCSVrBzaIiQqHv5kPRuMqDcbDDNiRKkNG6hijGY2rYR10YYcpbuwo+MPztNjkwthCad8fYir6bSodknCOkBhYW9tQcEtrwdExuwsBlBjWz1YCnNoemxoY2X+bFrCPVq6yOzWZuiPuYV2IYDQuL0Nd5Ih/HePFJ/1qECImjluTwKkZ8zWY8pEW0VYWAWHKrTKcIJVbiQEted8yDDgyI12z5wqnLKoi6NPBVEfvDZR40zzN0HGmmWNrEakau6/NHBuNHFsLqpxXzCQ9n2qUaJkkIkqmG+UqGpltktv2jEybDXINrHub41rWyDh0x2JS3wNbCG4218UJ19idbrE7rZgx2pUmF4LQs41tHap62i6XeJVKtUxznXTL8hbTY1PetbDFzD+aEX/xhi3Ylh0yk8e9G7GAtXwO3Cuv0DAW5IMBOpoYUizS1zSNYpkuernWEbB2gKkrIPz3w/fFcUuT1astMu/a2qfXZaScbzdBZ2zNIooyDSsKHHGuGBNzNeL1mk+3iSMCWKqxD79VrWa+ryVGhBIZNkXfUtZxMTMcmDKlJEq7gHV/s6Ii52hd7+9MyIM9323k5Aa6+gVzenTs2BphQX1d5WLIHq+NJcHJ0XEbFQD5uILdixI1g0fRASsKX23rjG0OfYh31uwTTcYbSRcnlvzZdMlhrSRa3wV8r6BLVU6JKv+QDo01HL35sYs2tsv1YsA0UK8J0i7ItyAfrVv1MB4LqTxW76q2s/7ANhEekeBZFUmG8UCRjrHTsT5LEE4swtwlYqDTighhUbC4uLs6TwWW0aQ8b87atgh7GrpECdjQBAnDXXWy+jrLGnwbxyegaYTvhmz1LObNsda1FCja/AL1toGEbch+93/hrpMA2qDi2F5YgL1wF4Vdv+Z2RAoPFl2Biv38hYVtG7ZRctB1MvqLQ/53gOZI6AJPR6aUidrRVaRrN76wEHmzxHiaAqTrTNCtXbgRLdsecBiMrcdXTjhYi23afuEdi3mJuZputehW+n2rZYlOZv5ewwqjcDkWNwV5zqFSMxc4E/YcTcUOIffviyELLlKJ3hAiOvTD5pSuzsImcvAmhO2LLJiUavWfUYhhXECxaw5riKrtgd7VCkZbkRSyoRStUyZtgGnrYYnNimTuTEwlpXdomZiqUJwF6ipSZlgE3V6P53SOZMDnvJ8MZeZEteHji/YRAmvtMQ/m2ECKlKWyl3nvhk4n5vDjHpKoBec46JwoXFHfLSjHBItInXtWsi9FaOpkYVkzs8RuxJBacGbfy65xCLzbyyZrUKh23foJzdl6j5xBmS7XOneMZ/wudGIWVm1r+2mjmD4Zf9tIZvVrjm6RoGFOsA2koYrNCc0mIQPrTjxPg8iE5KjtbccqhTB6OEKTYidovGRHZ0lzGnMeHMQ6SgpmQ0HLyoKOPywLs9rHcH1h+sj2STqud0IPzHlRh4S8Dv9pmxScjY752X5gYq2qo5adhlPesX7beQzK/PbyrCw7h9DdsT+0toSE9JLU6HSOQEXPqk5+i31Gabe8iqn/q07OPsutOnefOBfb9tow31caaGWAVi7QygVaeUA1BSXjKkdborobPUJpDEaAGQ1vscUgYA7wGMoycDsYWHeA9vNsYggiUXvU1mhMM1q4TbVMYbNHNxUmWdAqzYLx1OJwXLcKw5dX9CGf6HkMUGJB2XKYrmOOV2ugVDewhvEWYenfwqPFheP3vdunk2gd/jyfhIv0JX+i9Wg9PKSfHU6XP+9j+PuM8//4SQPp6FqPliJXcj7PPlZ/Jk+wh4Oj58f0a3D09XHkWiCZBblIC3LJujRZOlyClKDl3k/aPtj2rdnEjN3dji1isE0RJv7Lgkqx2GCh0nsG/18EQl/KynKclkvPfyu3+jxMq0utp8srLxaXV+D/h8vLneVlGNBFWol+CIVwv+jXzUXt5dBLUdGfDrs3ovWFE2xJBqqDJBs6qjHFaOkCIKTwWmtWKYsLq3c1f/foVsBNltARuLpUTjkTzUHEd+8Z6Qp0X1q9Z6ip/jp+ES/jj15WVoCoeJAN419KnDcJRTqEs27p1f2dfT23xEUQyHK8smKB44wayFE/r2YCxAIM7qt45SsNDpPj8aBXA3hRJKPLq+zPM4GqQgz4abyi4aqcGtzL7OKyj+HQZgLWpbAuwHwaLzMOTIYP+AOQ0MeZQKmERqnpK6XX4LH5lQeQE7Hm83jl6/gpAeHE+kirvlcbUrj5Z1brkFir+kv552zkVaY0rAWVl636lF6DMEiKD2nPA8GJugtP8Ren1eqXf/I7DykyGSvxNxZBQvridVIOnOpX6UXi1cckrPTb+KkQytk46/eWML3WPCb2Mwow4cNYxHQG9BV3w8ChvKnANkbZNHiLyShjmMuNMDG/Bpd8Ap57IJNR0r2E8pjHdCKTtYEpcVoCk/ttM6gXd4B6oTq3kJYDr+7Kyh2VkYk018bL69yvzak8gG/ib/RsS0ZtAFU+yn8p86EHRyUvdvsZvvrN5GtRj1egBjf92E37v/i8UlK5e88scJJRXw4pSIFZ75GPJUln7D6Nn2pAklHnCmly3seHX3zGwOm8PF7EzzQgyXCA9MbdD70zn1dx6hL/oSXF0J4+d+dND6lKStlpKVYwJ8P0jFPqHp75FTMYPXoKKZKHJxi9znOyDVE5+Kn5l/NQsVXIzdCbGoyjopc+99lbKQzXO787+rel3x0vvF+K1vlXhIkh/Iaf7HuxFMZPIhSYzHKlzVegoC1grP4JF4/eXy/GC1DZqpB+rNKhqYJAY2zhySdoF4uJFeF++qdxVqRkbcGVeiXbXtTMCgdpWSYXxtlgDEPVidq6xAZoufDJ46pO7pDCIT1wVePbGmWhwZ4de4jEVDw4W7hlDxSrvHXPxeVBtLy1XsClxKOVYz4cCXZV8tNjdWarLlXas2Mt51j2qCRAvS7yQZgXaD6PFkVKNOz2cJXgEfgKhppWS8PRYKnF0hgp+Vvj4egDmbqpYsRk8WieFrwNZcPWsRV2aOn90iNxdOP2ogaLGekJSMcfSqMwL/u4R3u3NdhAiGvGuYQ2wdwoOmVmVBns86AkbKxoPWXt2AtZxxbPVsixZ8fAKUVV/gRSdNiKl1qRL/mzru9pVFMyWvRtHejxKM8AOia2DMzCacN9t4MJmco3MKQQunRhIlIyNsZFXwJaE3YnGDIWS6mY0vIlhITxcn7nJ5KndKs1WYJN6AMsmRhZvHQM0YroFKyWFDES2rRfMOZ54uySs9uq0nmKRzesEFeX6TCE4Yyg3ylGx3IMCFRGnH+wScdeliHQJcWIqfIADZQDu79u4A0NrUh7UB2tlPgMR50ElmhKYN/s3tsZPAw/DIIuge2GWo3oqsewoq+C8Rzk1DGHD0VnSenYRtOjxhYV6nUlDIvzx2dMxZKtXpE2swOc/f31QicC7vp+aSljkmTLQG2+I8HfVIWj+Ph2uf10MrU8zMu7/R2r35Y2rJ93KQQFkBSNKL4s0nOLWKjbYkYBx0lo7X0ZnxwvWQ1R+vvy0ZLT+DSaQAtqkBhpFC03agRRubrJtdi3ZTZMfVLryhwt9WLiV6VrZfV6AqIiBDwUBMh348S5oWRkgSTXSVY5q9zvLcObMtFWyBe3Y7xeYy2zZGmJnaslHlnsggyrqMQoTYtXTVX9DKe6rcoglst5dIznqDoea7QK4AxbxVH/iVLY6jRg9XnQkogDW1Kjxtm1WWWdLS7pFFutcMfsCS05vMBukrCoGqSP5uZoKswuCF8tuixHpHBXJlbkLloQaFHAv2jjt4WAyFHINJRyBJkuHkZsYVVlSMWXtOTV136KMS2uxM5s1du9qMjGGTQyrlLaCCweJ3sy7mEPnR1ZEAcZ1jaU98Z9UvVi9xo3IioRSQGzFamKOB4QhAdZmYZq4G2xQI/sHUmkbXr5bpYrExUwOw9/x/mQdqe1IHSAwhItbsgvkNm+EtBH+SiMQh+ZtC1FrlcaP0aPbC8iOGRn2MARxWCKx91yoUgfxWDe3I7VxsCG4PVBTG3W25xN6/dtm7dJ9x5ZssoCMzRZBOoJHXZTpTMa/tCPsqqJu0yTnmNdzfCm7d3U9dUGWcydI3vLtvZSxJeQWawmWy0ze7PXIpGzRqKp7W70MxBcEvw3rV2bWUvaESg8OYv6h8GlXSjq/IEsjXOOiKOr7d26XPDWLtVqXLxGrDBOg0aCqmFj+m2sjM15JkJJVDpmgQkXpHu5rmcB/UfpWM2upLpW2+Zoaj4GKTBh935OlwldV3/JiQlnhiPSRK1a+TJeKsEjt01apZR7hKNehEyJpc2cc7Lq9kKGD+hEZBd2j0w45YPa+yKWXoARM2gHHyL/PDQ4+nBs7ofFtJjXmaod5lCxHdwCT+7gk4lon0awJpFnCJITsABhNp18zKWGiw2Bqd+U0JSgjOyJ0OWuRGQR51mqElWEVTa0iMiSo9n3/IG3ipGo04+jHAS5Fl196FThbZ6VI6FESNoWsdCXDvUUN/Y0cnh7l3q1Uyy+YRGpWtJHF6a2EtHXZVjpmV3J7YJX2V699mEYFs3RMb4JJItXb1JoDoL6JiYUF7bGLp5ytTDynXNOFURq4tWClNqcb6XExGHFU1aw275iuopum2a2xqOd2V3X/evUpxlypZcdlxfp3YMZh4ti0x2ZEtx/+jch++vbZf3zJTcWS48cvmh6YBq4D6ak8l099kNAC0nVI0DfMTAKCk1lnFGweTCvlzgZ9IQoHijX0g2KyUrepSBNnAHXAI5ZULiAYFyyC1Ma7GRnRVLc/PUv/6nUbDUWJWO3V9N4mculMfzosnc33Y+S+guaRyFTEPRKArKsGeZsFjoIlpIvApDawhVLmgZiUpfBC08A9zZI62Dtge00S/HUiKdnOPj9TlZ5nZR4/tkwA3aKqu9jfZqxCelI0TveJylZJora/s7m5LMqHSS/Y8eqH5oKb0k9kL7O+mjsgbZtQHVwPMIacDjClMmp0Aergbnzr5IqQSlhk+4dagrg3pnatJq2J6DEEImpren7pHfWCVgJ1wl6ZxNH9ABhswL5rivqGgAxBM43LrqeX+oRdA2dws7P02IK9lzMy9QB9nzpUMDzokTpOTp2JVKUtpswEUpGrJJD7o8JpcODIJfHkP5tozokGfgCJPee4yWRp33vrB24FRpAot3VLKghgyWITX2IjpZJ6aDESwMeuF8fj7+N0OU0ymY4tSZOt/7wdmdjezf4/but/Z8D+L0bPLqlvMmpMxqjtOUjHVoCjQq8r7zVvridaa64k3ZwZIXOffQ01LZrZG35Hdmf9eD4nvWdsLhU6dhDZ48eWj9LD7GZMrwt4Qg7SCbEGj2k2kM92NrZ2jwMdt/t7Gy/DrlSO3iMmoPHUbBxEKgk2tVe7++9CUboQZmc0OuDJ31YeCA8/fTD1v6WijzymLIeP5I+OKZuqL4ONnZfBSovWD+dUAI1sLt3GOxs/+tW8BgYAlDryT89Dvb2X23tBy9/droC81CDToLHESdPQ4+yR7xVwKivLppYW4Rn0aneu6ew/HgjwXKnjtpwKlkJrlkYk1Bcw7yiiDsNqM2G53m4PhWLbcRcZLDTzXqNSCFghBn6pYoc24oPIjzRCNbHWklgdfFS7mC8Y8LaabTaaHoZ3tpjlCFOSMS2szoBTzKZulFAqTb6dxEfOqR8AQC1sb1O8FDDmjK9oWsV1zAh6vVSFEZ0eKoH6sA3Zbp4doQkOTpPI8mfmjijDZCeTJ3kCGZOAvocR3NPTGvXdRzXAQ/EjHbCLkLlNE5FPUBeJRsZlrWYkl0S9R9Q8shOw5s82xq5i/PrVMIawtq6sCPhht5uAH6W925abUM+hQ/ozpZ6VkvFUfeYGpvCKGEWw+kMMY5j83WYXIhsytu/Pm8Z8lPlJBQsFAIIjVvZkZQQTr6O8Ue44LG+Ym4+HDdt3OYCmkwPEgxG0GqLYxzNZovJtfWA/F8ty77r6+uY8+K8uFjCFYdwnsWX1aBvSane2iTY08O/4Q4isd/0kCWYmFVqe/fQCRAH31vfb+07aYfbuz/75Q7ebMAG5SW+2Xq1/e6Nn/py+3s/6d3uwfb3u1uvAsgLGrrw1E/4pjaSDMT9i7RwBnO49QcX1ObO3staTSdKPpfb39rYcSq+2nv3cmerISl4u7+1uX2wvbfrZL7e2dtwm95992Zrf3uzYQYopp7d+sumXrLY55R7tXHodQkSDrffbE0doo7to3wSheTxFPbKfleIHNXZxMyJWOfCpWCe/P8fN/aBJr7/tLtxuP3jVhRE65s/bOxvbB5u7X+C7N1PUODTLvwTYXr0PlRRc4lO13UXLa0cQX8F2AXS+iToa6goCLQqtnKMZNGqvz2Ggrcj6bvHYM7xtSV8wV0X4MU/WypZDgH76gYc3/yp5b7s52cAlTP41eaXNLXhXMA3TAXxX38HlP8NO7FLJ53KTedFOgTUxX/73AgHF5hvc+rpnbGhS/3AoC738eCjWemxuVK61W63HPx0wkpSKG5dO7EAINFRLQFb+O05HKe2hjAlKbmUsAwj8QAyEluU281Rdqzer5Or02anWevcyjuwTSdm59Lx8Ubo/IIXC0U6NGYxNe000s7TSJfEq2muS38CS6Ixg5fWpl9DaVUUNsmAHtrCUWRrgke4cqlQpCAfjY5VR+CnjuCq+jgdVheVzmbUAs65ZunaGgAp4MfEp12/HjdlWoQi6/Ug43BRdiW4G5wIzhwwRpaG9XZmCda7yS6sgiT4NsAFt7hCH9/Rh/xeo49l+CCXBkcfTX1Sxj3k+TTAMGu4IFRfTCzWQULBY/Gn4NH2qWA3LKpu04l+4lQg/KhM/x3NvqIOZdlU+mYGympJWgilgmMt40rRLEkblMpCUl2I8CVlq2inXlQmk8K+2rcJAALfWFRkYCX/aNtWrdrRLAVb9l2gdWFghyZresDXx8m00SrsmLHWh+mVmT3I+w7Etgr86GsK0UJA2i1rAbA4+YgD28b8kGdeHPOdnNbW2qcPlAnlBMKVMeYRHg+pMp4p7FVLewexWNWDWPUo8i9ZNtjemHQY9pLGuORiuUyHlpLjMiXBaZWTpTVvWad6D/KeMSODD2u4sVPNU0wrT5immFhXyVhFeNogk+uA4HCvJI7VuIT+JRSJatz9gEGocKUjRIyuVsFJit5the2mW1l7bxScpd0EKlNQqmSI6ETB6TovPqjw+UUyvEC6RGBO+2IDAu2S0TKQ8NdoAI6u2slZfpXG9gGArMRjNhnnI0DeLZegwtIv5RLprdJyieCe9PJBTLPhHQ5wqiC/NlFKbffAOCz98z9z+E0b/RepBCT0rgSaytJUJTdTiooxJWs9JI0pjroIUotdIuZH31GEiWoXhGZEB1SYdUCuJEeocGCRsKBq08uiXHsKfKtESAAa3JfYkJdyydKnrZHSMf3EcxkXYc0J19SaEqkt35zr6lYkorQFw44v1eAGxgTD1MNxir95cf4iWX7x/JsXX62cf5W+eH6+kp7/Nn1+/mxl+ezr5a97T58mz7orK0hXZdFdSkGYjqvyNzsrz5cX4Z+VBvxPP29SJ7d7zrHzKUVV3h5Wdx/XnlHR1yD/Vibxa0p8lXazQdK/8+j0nEq/zIZJcWNSV37LkLOPae8g+3Nq5c86X3Gtd9X5N3ceGL/idvPc76KKuW6V/YZHBNKFSXtBaYfZwEpbWdaJwIEGIw8yBdm0wK4wpnUEVk78yh25FZ9VwaETiAOI5+GArl6sZMbtuyEzbxsE68UcGCtq2lGt3rcyeD7fJKMZx0r//OadXvCARKQYunIgnVOyAd6phqePbrs9tMYTbxxztUU6UV5CG71khHbDuPXp9WRfBdCq+l13MO5lF8oRhB1jOMLb6KYg17mny09Xgs0373BWEx51wn39vsjHIyjM2xVeghXZ2ZhF2mEPdyI6aPMxD1POiDbJTbps864CWwT+zcfU6iDvZecZm+CiwisNRmkxwBfmeijiX2UU6xEDQOJ2yIFtUA+OgaGyircgqDRIAevcr5XY61oZmMMwvd40GJNpIMawJKi0Y0GWGj+IFlk3pZCLEsc5wGuHgKN36maHPa9PGACvnwCBF7H05Wm9L9CmhRTVFxgqTEj6K3UnkIGqIwphW+BBvSWYEqJR9NBIiwwEfYN7mjOqbA1Dje9ZHOymmQTaTFl1nbPkYvp/mfd7FHXUFKIpyaqSfIcJaF6U0qEB7L1nKdISBfkEST1H53aoDX0a5FUaMLIqjOBZZFeK4gkxZX5eXQNBCCwhtAAvwJDMoGqG9FcggQ2Z1MrSGtDhD9sHwcHe68OfNva3Avj9dn/vx+1XqMr7GTK3gs29tz/vb3//w2Hww97Oq639A7pL2tzbPdzffvnucA8SWhsHULNFSxLyNnZ/Drb+8HZ/6+Ag2NsPtt+83dkGeNDA/sbu4fbWQTvY3t3cefdqe/f7dgAw5FIKg8O8Cg732tguAqvXDPZeB2+29jd/gM+Nl9s724c/U5Ovtw93sbnX0N5G8HZj/3B7893Oxn7w9t3+270Dgobje7V9sLmzsf1m61UMfYB2g60ft3YPg4MfNnZ2GoeLI3AG+5KA7WxvoPKQ2oPhvtre39o8xHGZX5uARejlTjs4eLu1uY0/tv6wBUPa2P+5DWCJBe3tHmz9/h2Ug/zg1cabje9hkOEd6IEp2ny3v/UGe773GuEcvHt5cLh9+O5wK/h+b+8V4f1ga//H7c2tg9VgZ++AMPfuYKsNjRxuYPMIBdAG2fD75buDbUQgYX33cGt//91bjCccARZ+AhQBDjag9itC9t4ujRmwtbf/M8JFZNBctPHOBtJh0ndleIeoQwQUAAI3D+2S0Crg89AabLC79f3O9vdbu5tbmLuHgH7aPtiKePa2D7DMNjf+0wa0/A6HT7MGfeOfFjG3aW6D7dfBxqsft7HzXBihAU0cbAv9QOrBu80fBPsxW5mM+P5f+7q9gs3j1cv/HMYN7vU97OJpMph1xw7/DlPerJwrUWgkljxlyMvmM0kPw1Scoa2yxO1Ho2fr+M2trBuDzWU3TChZXmPMX9F6caOmH/gaD53DqdeO/xW2rWtoGHEJPC801zpT45p7AKwmCYLbnn4GQ5z+lCcAgogx4JYbhYmKxb182PTcgbqMpuDrDFGHqPfNvgVmrYvdfl5aNtXcBlWyvTKcc0ogV8mdxtMT95jPhurWj0nnCY6S4vdEvnG7pTCR0FUP7ZHb+UFwg0eXwGpHnRXt52vnxLE9JYg1WCFJv+/26C6cGQiyZpqWzEyDFNJbN9gONK6z1VrN0or9hdosufG2lOCwzXPR2MyBQaulAcPZx8JWgCWJrIHt+NG93Jj9qpA28ZAm+ds1GeCiTYiaahr0t+NKlmkNE3WGI3cMSH2isZvMpiOtfB7SBQ3H2FG8ap11xxJg6WhZOTzVqM1pgEGG0arr4Wlus+2rZ3o3rMkyy7rjbriIpmp6Fr7gpTZaGFMAyCbr+9OWOMi1Tj0K8KyZ3KkXFWCjiQ0IBMEhCj8HnnEKV7LMU2x7FG1PMt1eqMFOSO1w6u6n3p1XWwebIJptocUMJgsqWLHkm8/YFg6hXGud8A2RfBhzmI5W9ahhWKbLncCurBi6Uh+xrEB6FgusZtFGhaR+sSZ4d6+lirh6JAuI7QxDuHQNIc/lBpGNuCly7Xl20YBSipYg3JYuSrjPofvCAtRlPK/HcPivtCbjMKe75jX33sla0dIo0DR/yEVlx0qKhX00AO6QQngy8Z0V6z16mV3AYR1q5WM2JvtCHXLhNvVHX6qS8SlDEOTVrUylHyIcpnIPKlMVETnKk6ZHTI2cdez5ddErVbULZbTU3aiqpHs54IfnUT9zhioCtNWtba5QE2RSrEQXyHZ79jZrvBYcRbQUtFtJjHp+SmNW/fmadNXLzW0mFGKANVfl9Iah/vzDtK5GTKNTYVul52sCVX5Jy+iLZESYGiwEOT0wZw9FbY2QT/uDlEAWqUwDTOHaVGG1yBfo7pwWbkxacmU3Xxi/C9szQDViB8m1jh0yQZ+BHcy/GzszaJ8B1LvZMN6a3aby4+QG0WyTf+mNxxFZ2a6jbjZuny3xLHmHsZpdfA4jNVZ7ipGap4m1ESJbTjNaLMsSDmfBCMVCGIUh1NYN8OEE5sBbjE4rcnefM7kUtKE4hjQ2I1UdAyntIkO7UOyuFKSa3F/PksYxsrdncgZQjJjgQ4Qk8lBWQRM4WgK95UBrl5Ab85Sg8vgtzgds2PEPh4dvnUcXG87puhfOOd1Ix/ptduzUADbJQ8soUNmMoXnGUre80jZjVjKAXyzxLA67am+RL4dbnXpk3tq5iwlj8+BH9F15m8BMWoixl4QtANnnVQ5AY+eYJWpWRhTT2VntfnKCdjY9uprePifnFKDvIKmqdDCie1vuZAC9lING2iPHWTGOK81Fh4CRB8wQwckF9K8tHkyA2QDPNBU9dQTnByVxJqUysIs9VkugYvX+aRgBxvg5pbC1Sc824W29GOm1amzYvfGgYbwb4iruwWBCMw9qGTqv6LkctEGRYL84YIoyWaCxrVw+LFFQls6ctIDv/vzKxKB9wt1LJQl68j4mSeORinii++Bh12MxHl+YxnEc7M7GBN8yAyq2327KUZhba3uz7KNjFkIaUWIjxZ5zwceIgsdVd2Jk2nD4COV04nRzf2vjcCv4cXvrp+CxnB0fo5eKZ2HPTZ/AaWsYPma3MI6Z8Tg6tSA2dr+2jY6HH4b59ZD3ej5GCUjF9PSGyjZF7ml+ltao6f5x3gVnbXpzqTsf2BikI/IsFKLu4QT49gnGIg7X28HGzs7Jjxt4t7G/drj/bosQadv5NGpNzaSvTh2qJxXa27x4rDTs85+xX81aMNy8NGefpdsPZq0Nb1UoJ9svQQCuBO/hxTYyVjbXP12mQzQd4hfrql4/O1NmQbRxDHvAZIfBeHRRJL3U2FPlqlTw2zaDAyBYEs2FA/QBVtbEYjQV4quRGBOrfyNXyDVERnqe+Pylpsi6WzcGquJqxUVj+hL+FboNO9ywYZO6i5Bm0yCeDrxaxIMbye/zh4U7VUiAP3cY9nGg2XxBqUvs2ILKTb7ZjkEkRdeMwexWw55VV9zLS3oA8yXlifppcDUy4hsulDdUlCLWNbYjMZPZ9AFqxxQHE1pvW0B+yosPaTEnEAkyyMCoIsXinDDbl8cM08u/oZvp5ZfrJcKqd/KB4iQqNPHFhRYWBPmbkJP30x3Kch4/u+USbZm1tlSfNNGKq1zThqFyu+grrHSyQ2OWJf6UljXh6FtLVYPH7hMW94rxGTKs2GDYapDUhBZSNnB00i9uuy1NUCWtFGP1FMjrVWrDZyqwcdk7883hZFK10WT5pz45UJH6s1zCOANXWXrt2LVZCtd5HKka/Jd+ePf9Vs2nySlnmYRhnLDKdeSpexfVPJBsj6KZ3kNNHluN3llNblzvGku+a4L5zq0/2xPr5d7eztbGbh0Zdfu4ulsTujQdHG68educGvy0ffhDgJ/BH/d2685PvqVcS6QkdzTvtl/N9gzDR8N89yydRkYPP+op0+mWN5Z3LOFIjOLe5Ho1RVNQOdVATgLObF6mGHh1LXi6TNoFeY5Bm5CjKNHFMnjMTROgbtrmaP38lGJUXdxzguo6D/rpVdqn20jPqzE4vMTndgejPnTXy0Q4lEMuMUE+7PMjwxJLGmOYVwms+l6AZ/A+3gH0ySK9Hwdv8AWmpHeFWuneAzaQtECXBrACR8cPlpqsBD5RtfFyGsYnQ0J4JWUoQSs5ywt5YdjqobpWm9bNgI3HqX/4nHKRDEvKZ/stCjhCSEswZEPQTUE0y4uARAX+omevyWZthP44BbI4hKYdieiKF2U6stmzR4rptYHGwWu0EtMNoM0gA+yxnRuJuSqijNT3rs54Tr08vtdDM8HLnMYLQ2epBmbLNjP3wlUo/4q8d6fBuePfQNThWZB/+iRk75bUs9RscD6lwlTgNXt2C71epQiWpuo8jpAv3thLm96vs8F4WPZBOfbxBOjkhDuKesF8+Ne//CcVcBpkbCSctADcB5dpf0RvJUaz3SDkUfCEOtWTK4+QjA7wee6LfrooL/qy6N1GAsvIcSGrKOROMuRacbDN1pB9VJ4VxNnalJDqpc6tciNkoXlGVIiMCfWjwwpZAXakE4j5IwX/UBcwbKyIDzZlVyl9IdMua4RmOQw0UFfY4FcQGbIIs/L3ZLdAyr6DtBI7GNv/ILLpwi+vrprVC93y1pZVgxCwya+9l6x+L1U/phV7q8d9V0m83FSFIl0sK1Fy6dljtqnje3okXs1lmzeA0lgIe4/Iq4JcoJenpVJFYheIswxvzFypnSXUbi3qoXY2dToH4U9tPggQT67YgYh4L/FRbapMFST4g7RXBuiRwD5LGBYcGirTlBy1xpXYMVGLl3DYY8ZHj5oJQ5a3ynBzS8pyjGpa1ZrNrel5T2oCLwcv80F+kQ7zcUkWxPgm/HWqV6S8GwrknA6hYbJAzkrHe6duQe48e6KOjGJJvqhMbUmp+pv/63+3fC5mkZMbaO5NUtGLJ6EIAWILY0eLJtshNOHDVzdAQMiCb4PharCwkLm3K1fKue0oOzbX+VfEv5SbpWJ0zADF/l+LLdrx0XJ6G6IdIHp5ceEfknJLz+y/wsSGyuJGE+47spij6V3EoPJ5PgLmR6brydAiJ6RY3M2D5By5E5yFelRREWQ+JLpwCSkIrxFWUqpbdSKua1K9q91S2XZnf1YBydS9MS0DwARWUqIG1z1Lmef1qKmboMRnZQuXK19CqwNcRVj9YUS0Q35plrcrEquM0V6a8hJUgIugiTgshjkTz9aDZTzpJygSSpayxxE/RndSXXfARn7KnLRsYNDexbwqJxxavmP0PbwBZs3sVpy16g5h07iz8waiat5tWRcBelRGPdyqGEGtfTc1fmJU64bdz1BtI1bj2vdNxxlg97R6aMZaEQ5eYxW5e89H14i0JNameTkAtHbXMIvTGPgvScUNkoB4SZaXRNEkxQNZj9DrsKeYOZIO0T2LhnpvljFzx2KPk22bvW7qHt6wm6mNbr5dc+qOeZ9NkfeioRFwyM/GQqG81icHC0BiO5CjLPygA37E5wAjAdHUxlOYe3049+bvFIchJD4b1VkxMn7sgPoNTEi36TyMnQ7LcUEurumwm49R7AxWFqzBf5GtxH+YFlvOLoZ4CKQ9hpyjnOBPorM1kU2vVp0o49Ost7QexzFCp8O5KE86XrLSSfjpsgRrxVmf0/GOE9hR+1LwDHabD46/uHtJGdSmzLLaNWYu/DZw5Vzk1ytyNW+OFUO3dmW7xN+0Nnxxfeoq/DXoGkbBBoV3kzH18+9EwTyQK//t2IZBBdaQmmcNM/19qM44p5y/rQ5sq5ttxT6bSqx8dWeRZ09nFzFX6LOLbPaTgRrFzJJ39QnL3NUpcjWeq9BXz6mQvYWo07qohIKzG1sNs6rySa9hlVF6oVIFslVw1pQkCvss0FGoDZ3ljg0vlTDyA94rtQOxHBMvUC20iN2PxDGyLr9InYO79AHliR2Dguw9l1JT6mhrRhXnBbEEFPh7tlYXKIPkA6ccitostHssMNyu1xr1TDalvROOxdeACTsUn7pznep9Q5aSXEp539TKKpO8Wlm6mRL8okm/dKVpIjy+7N3phA1Pm7sINdN28Kf+7EmzQt41Yla/vcBeCRJo7ifyFgXp5Br2JHyOjjTDFK0CW02d4ZdItnhkKnN96FKnYbzKFmVoGl/Ecl8VKJuxxoi2cKZHUZvNpq5TgAMsk9aAHLNIqELZmGuzWUeiTZTj4CAbyrmbNVxqFG1guLTOivQcDncUxuw66/fpGJ8GF0lxllyQXqDPD0Zd4wU6tHhDe9gQ37UY4k1eLy3hANiLg92czMmVpy6LxALOSHZtNPTCO1vWlcDYK+3US0gF7D204vYRWjcxh4J9HVi2AvXnWX6Cwb1JRs4VYujQgFn41jKwTumS4B7V5yd83mPN3aJ5nMUxVqa2VSlovGlB4wFHLAbE4QY7JZXiE5DH0M3HMj9CWk0KNI/oAM0RdnkR4OH9IdLxMGWv51E+GhtVPOEPlx2MEjU5/RtlgOfekcrCauCDQa1b2jBYxfIP1LkdaYw8sNV2T+KFR/XajE69XKMalXaiBi8+6z7Wfue4gaHrzjFZeTuHQyZzugE4FqQy8LttSPWZlytAmvG8utuw1K1c1SvXzQ+9OvaDbU2VPi5y1MxntZqcHka+18jS+zgkC5FPYrQWaYM5qem+nWau3p3N0yGuBgs2ualC2rGt2DzEi9XH5EEw1bcC1940Z4S5uzhlQ8b1WzvJK+g24VohpRRsJZOSLxQ76jl2QjpaoXlStbYD/keh8nkJek7anYdk/msg5ukCYK0fvAskdfrXcpFHy7/SQmkiXk/eczopZ2rfPnSmtZp+CclbeGyj9kCi+blGbITGMrzlp3I6XHmiIoPOsnjz46U643+gDhdt87zOXatMOggCA6bzQsaw+1600pYI+a0HzrnV8VbJz82IxFOmHsXLawUp0IGoLV6p4bhI4awCMsDS7/BB4/W19/GnR9FSO2iBkCTavREczdQFDlO0MshkDZIH6H38/nrhEYNYNTCoon4gsSkqa+OpCh1/PdHevMp73yPPA+UOQcKz9+aGrNpSXacMe8Zook0HBhT/Yzc4oazpKXfyrjKF4KJSqEAJXBnMbbipoeMKLoaU6HyJp+Kk3/GhxJwuxxwbTxxOlx+O8ivRtxZ6kWm37LDuDYNrNgionfW63fGABNHfu9bxdVAYsMLDnsQyt6c+MsakDxyb+Mmszt7VTbvsvfvhubkDQe3hjf51hmYB50m/f5Z0PwRi5wL0lZET/FTTn0Z6qluDeJ7pplxTZ1etzqHtdYciPGI7ilvhudE7WLI5kLKCQregtOpi92qrS4Do23FjmyROwI4pEpwFoJstc/mQDjmEp1n6dK6maBmlRUI9hqNjR9TNfzwW8qRGfxyoIYU/ZWXC1ZLh+BpGc8KQWsi146FrGy311FPOsjHZ0ExZuRJSkS0kiDMFWLCC4EqyenRSvQcjyToShdOwFZDCeAlMjZvhVm0Kn0G2s/6gg0XGx3fBym/phlq61By+hkOacJFVyyVlOkJt55WmCLZ+BA9pngJ4qFDI9RAeLpZNzFm/f83hZbzJsJy/avWJaJ88eRA80ZeObN0m6s+hBFErBsHREao+ymMrGsVxQPfspBMpbfsShIfLfQxys8Sgx9XHtUgdg2DpM0XdvbFgPEvFDB8Vqml1naZszIgQDThYt0+WrMcW59FNWgIZx4EA3NjhToXncF79sTQ3uwNSJ209mWWAzSb5bYq/Rr5CFZpAl2SLSO/Noy226Zm+/sDyLK9FzWpLHWCIAruZEL90DKJGdQh01ME4KXZM6uUp8G1rCrkyV3ZeAi2VN07kbodi1ukHhi1sk+hVrjtBNFggntiB3DlJ3lrx43h4I1r3B0Sw+YNgOlKIPDWn3g/kB++lsONbrQuuo8+AUIQqOUGPLJOqykaTU5h5ryw/iScRWEAsxFfzWk9aq5b4f0H8k1o/Uq/RPDLPxJDH16NbYi4VnyQMSbRVe9D4MYA4nmbtw/Sm1VfWZRdHdIezdpjhaN8PMU4bjgR+8jM6p9bOqsr/hEsbw/LfhAyagu+zwKq6pE54Tf1Bup+jN23VE/2SUlNn9opeWrxEOaCoZvTD6AVi8XeXlyBL3KPNkw1ubl4kXVxSlp6VlmsM/OihZRfFibQIH+orQnv3eWiN2X+G9aFLxdGMyAGO02UQzFye+M5a1s3QZE1MzVCzvZ92UwoF+fjJ47jV7HJp5mE68usTYMESAu546/No+bgtHmrAEToY/3GzNbHdWWnurG+ZxQe1TqqN1e3q69cHW7h+rOmAyVmeBPt7Px34/TdVNXiA8XrrcPOHYHfrDwjH9kmuTfu6SVtUZKGbxKW+kr6wokJgF4K93Z2fT9sP7OHWpXsn7sDnkVzz2CgWpEbPfccyubPjdm/v7Nhp0DBdE3eSvAD6mOMe+23G6PFEP5q+ejfOvgyhSCFsFUVXDBwlhgUJvWgKfRdCY1rTz87q1+hiZdoJA5bxUtGFNb0juOUifLw2roERYfgOIMrSzALRXFC5VtqmIlCwFtpC3UXalaP6Izpm6oBjyjQ5rs4szdHjx6WEUJNEHYxMJI7FYOUY+wuAVhvaUBxFSwmaZ0x89k4dsIiqYb/GN0ilOtD3OyhbbOJ7mpFFbPU+WHvcLcdJIVFm2Cub+4CzqEqoYX6LT33URKptuXCT0gEXNlqadxTz2AhOnPqThJoITq9OSWI+HeKPMjjF970kCQO+8ufYA4LyOr5qysBKuUhNtWt2kPTx4HQTKL1IqbYT8p+Lp4yQnjNRV468uK5a7vfwquXu73sMQ8OiXaG+aTd74mkTLk/JPryyDLFsJrN9wBipbV5M9a6SfeiDnQVV4foOyDWDr6kEwbKUmbRWg8aFQ9i71DFtYp7aYstRC73jYYjw59hEHRG/s1VjaHbU6lK5bkMx63qWtSu4kPDxjKhE7SZqp9cdRj/3XE+bbTURXcfOzp4KepS0Pgk1wzuZ4emA9AundwKbNI6xn31Ia+NdOY6mDdgmEy9o1BdGXvqnqYNeuwfq0qlQvv1ufjAX1VQw94DSnw7l2/v0ZfqYvlu7T29m4GYuOA1moffmE9MI0yLGuWjRYjc7FD7fZjb3Is3pvtSZ4bQOX90NQh9bFqaEEKdUxgV8BwAPzfdE8USPH/EiOCgN7yU5Nlyxo7aa/rWi1gxxQyN0unBhOQXw1tyqn5u1WkKFd7bU4k40M0hlTaMquarTYS45q9UyUqDm+AeiJhfpQI2dDHPW/VF5aCptqZEEajIpNmpMS02ajyhO46i0NzEqH+lqlt0sjc1CdrvlqgrMeEfzDdjchdbZuvsyEIWaofS2Cp53+k+PbiWNW5v806l+wGeTXhtruAcY5OhiQOcx5V2nLYs4uGwb36uL5IqFnZt6jg+mZYktFevv5oXOw3kPQ3oPD0M+wsnvzM06o6fyoujOrpd0f6jeHLOe7QvygsLGUzQae2hJxU6AaKfdixse/Hs1rf/uwNDibOpTf8v37zl6787uOjmBVQ1dN1Xv1ffv7L5/29D319KA+IijvTxZTCI7IHaVVTdiOZOVP2LCLgcAWLONb2wfZZHM2Q0CFcMPuUaclUBg+vbBgbnNIQlcoLqa5Brf23lAchC8u7qpPaCcui/ZWeOuyibOhFubfDfurKwidjh1xT7fqlmzHaciiIMZg1cv3M0EZL366lWXp9fs2k1e0F6tPXliffa4RT+i78S0HseHRg7dDSN4qIrb5Its6yJVXrgFHsk1+Rqq1qsJT6XohUb9cww90IboRz6m5nTOP6wFb3ESp/jxyJJ0aNEWMzz/Hrc4E5BT3PMe8spzriPGuF5IbnlePKuOxMQhQZrLy/qzK1D4k+bS7EVi9Z3fQJvSdSE/yxaNng5rLk3EZxcWYmouzfToFKcIJ50Zr4TZxGfLJxvdbjrCt45Ie2HfT6KrysGecBtUlOzk3YSsaNMDceLzHtwiI3UhdgxLc3K4dXAIlL70b2F4tLhw/L53+3QSrcOf55Nwkb7kTxR9CuHHSht+vl/yfj5tP4cC4dFhwBA6XFP+vI/h7zMAG62Hf/ykm+lIY9H6o6VVSzDp5mnRTQ9zil8k4TfmCWPUvAym8l3cpVSqUhbzt36p0BaomheD/6qp61lbeyUG0gfOw7ExpuBD2fkO+lWz/s7XuNjVKD4HSJUt5zFYTHFefvVqkEDpVqEkp46yYLAPXFORqBBRw+ID0wSlW8+YC69oQmsjS5q6cd2n0dpOPp0gcGOzZ0U/ubygHW5VKxwQX+0PKLDCGWlYLfayErXMi/CB/heLJOdavXFey65xQIpxRPr6CuR3cXBl4QjXBHnkYPgGDBFAVgPAvwrlTurwXt8+aqqQNANz7uJAmW5+1Nm4AhzW5sOhgUmNuTtXjM1SiE8CkfP87urM9Sljj5yg42hD4Zqn1NeswxdkqKvzsAJCkIZkGraWnN8XzZ4lkJapvG71iV76bsCjvZU17FcN22N9mwoaUHqHouH03ZCuo9D9itg4nenEXLqybaQ9I1cVbaBmuGJsBuw49njIvuULIzeD7p1nxnHQ6l5tokXryOlA++5gDOvafMNa1e6llHSwrReqPJzheb82FCPmrA/WbiwNKoU2S9J/efowVZaA/MwA4AGvztGib/i4UrcgdLT+mJViGjhIgcuUzGUwGkKhrlQq8YyTqA1sYJuqFq+TUgemKVCWVfFACg4448Fr07PSFNqVSKIkWGTkxsIM+ceZzitLS7qgMVf8SvKRPjkqmf4NCgtlkz+lRUrZcDSuppGRQT8SVI0irSir1C1jCST9Mc/8sLQixj8mQUx/9KUGGw8RtKj+HrwNiRVGzVUCucdCByxTRTMlwOx41CMXRpk7lAfHGAlUWTkF+h0dueaWZbG2xgjT97J6vciIWSvIFuH41ieeafBdzdRhn7BKtmF5fDT1MKANJZFJE6EJHwjQ0UMcJxF+50ZAfBcsrqh+HKnUY3nIxk8W5NmssXSdbmjOetw+Eia+/9XjamhDJ9zC0jGS54VQiZoA0sGkmnaTLhwBScsCVIwkoqhrPOynpUQduCSFHnqljpFBKjj+HLfVS+p/W99tTiPrQzhnTWHbv0EXg+nriLirb/oW+U4jvmFa+ZLAzrCe49UzlCUTa4u54waPKi7bw7L2E5PIBrfkJSErBBIU5AofnHcUapZzXl/Jhu6D/8bakSq1ztS6vh58aAe9ow/H6l21yInK4gVBQk8n5H4meqJ1jw3kkiBzXxykg7xQvvehHaFJYsvBikOv6UsVnwmjO8EOTRFZcqOFQLNhIkRt2xpz2O53JXFc5wXPc45Ql7C2FSioynMdTZKCfFM4KHaSJhdVjOGHMerFywUhnlsKkV4uI7CGmNvjw9YsvfoMj3jbihWFDJv5Wny5zt0Nv+6h9cbMbWL1gbXEqErsbhOa+0mmNuT2GDq/SGxxh1fyRLESF/B14146Ig232hJNGCK1mecFHnWSvu3w0lYgyxxnhOzhlI8Nv4QsiObAYQhGvRJCXAsdyDm+qJwmNLwqHcX2a2jcZe2jqF54rA3T2fXEB9JeZog4HveWmjkFqwE3pNQY9xPGkfZ5h1/YgMZg2xq/ASUh9Bw85CwxqPrCP4If4Kh9RRpwcvx/XPEb5BTb1QBUjhUVbJTnvG8qQGwMPB5WWd/CNT+gbdE7vkKtwfHqBxZ9lnYT9D2yCuJVjLqaI5cNvIgy41e0YA+W8MW807VdCDbw9W/9MLaiOliSFkDqqVckNjePM7YBnnEQ3lBegm3We52GX9Sl+OO91akPraquqjs31TPkVqcEVux+UEg81W+XU381l4mdSEPcpFKrOA+FTn+SlinekCfflt1SD9rMbCbeQyi6He8kX3+QxFlERwTz2G26qYQIM01Z7UC5CqpuTGa+zuXAkKHVIDS+y+UJXwY/ys6X+bAldNql1Gk00mGmOb6FT5J4VBjzoyMYkUNOlrIq4XyDAdroElDJp+rMUeNjsgiZBajYhqo5cQ2xY25hk4r1OBuDg7KGsCzQgzd4ZtLAhUnQorUEbO84BniaLsTJYhJHcph7+oa/djdlMzrKjifKrU9vSEda+G2oRunHjtG6HDA84z/vkMHcyHV3PFJPdPMMTo6VbwfUt30ctf9UzYBA9gtrp7A1Ls3GPoBztl0IKXiwHB8tI77It2yrqV2P5NrkWPEHy9PJufjhk1/zPcyq5/poZpFxxdK4AAp74vZxbL+k1GhsJTo/GaM6sHOg5JkjHf6dh/rw/mM1Zlv1jlNvm7o9VQfY9M4VBeFZE43tqhIM6I3M0sT8s+3fm0fIB4xgQY+NjqYIffaTiLPBudBcbaO9f8xA3jC9F/Lm7c/Dhv7M6EX3S3TCQpv0R/SnLppsHarOMSacnm5+vv4P/14DePilRoC2YrURwEYjh6ODVG4nSlbQkLylXIHpJnF9ThrBzesyKe+9yof/2Xr48LO76HRw/qXLFw7zNfF5bTy8TxtoM/orsIRv78MQ+tWvw5e+vRdbuvh1MPHd/frw62Diuzkxcaddvv28IJ1d69czxkPJlhjrXivk7o1n6dL2P47x/Br5b9bzLrxmajNvROMydDauGZmh2ZiXZPyKFNKUkjqqodHWTgNK0Iz/KiU9tSWJU09DsVojXSr1MkwU1iHD5SkTdWvAHs9V7jo4c7Nk8sk+VfxHGxgsw6g4RGzyMVxmv2l+NDBH1VJuFd0enqP25sarUeX6GoFgYxR69EvJYb2qKpEfN9PBSa39tt+AHing7i0G3y6uUvsCiCIWmGdhY2X1Ch0/mHJJUFeUec6htlugFXLc2jkotaZKtq9fSlYgl/IUa2ntA/q0NLUH4mTNe57VFrtTR9FdFwmWSrpRKT1Xw0dd1Cd3j48j63HsSR15onhvcgP/m7XtzZPg3/5YCPd53R1q9TL2nu9V9rt0i0Nn2NByVSftYkdD4ldVxVwlsp71rflrGnI0o3BI1Hz8Bx+NiX87UzdXdwknsV4YZH19Ka7gzqyCorajZowZfXmslfL8oymKWM26C6+r+DrDv7NyXlxl3fhacDvxrOiBZgP9qoC7DlSscroWlVAI9hzZ0UrW5E7lSJU5VmWoZZMsAHnLKpLrlmUsNtVezbt9E6AeOijALFbdxKDeoWuCT50RU6tOsNyWkFBkLqS/2ZpFf6LorD/45KE/6XZHf/HY9ScbV5lPMg4xYHkLhm8dvBOvPpMxu7zznUUPxImzFPXPA3paqXwY/H//63//f/y//+f/QE9yyYs4Q3m2hl5gYHXOX/+7/+3F8j9RUCOyBtCXWwRXVaDHdnKMyiQ3U0V6nnNklVLbC+iqfQxmS8FtaaMc5LiJyNs0uF9ygAGVosJXq+t9jF2hrdwQBdpMiz7EhIh+k80S/RL7NPrNFjj0U0xvuAjb3PDmyuF4xeiGBqXPiigsZfSkj3r0LB9kgNMeP5ZCWH744FjHP1ZxY0t8OegJVHjC7wvJ4xlKia7fz5AHVhwjnI1+n55UMRF8GCcEyJzaIm8xonjpxf3BC4+rPOsBfSflJXIdLJSJFwhUrUeSR5W9rfSjdzqsR27weTm0KEnLeuwhjOYMA3RAGCAo69Zqc6OyT0NuldNzFnCM3LsevuXSNzE+XMcKWmjCe0YcbSuG2Z/GdtfaCs+8FjgU82iUJoVVEdEZJ71eiDAb9O9NIQKsAKRY3X+zpcGCyUSXsWZWB4S0/Nu1HvnYXJqWCUYAO8j+jDxyZXnZz/FlSpAbTZWomVl7kp7OI8aHcZh9VrjqG8WQTxC3Ezl3jIqbE8c+Xq0ZD9ZfN3BN/MyWoaz3fKs+jjbdYNi7sKCGENcuhLByk/NCZNdKjGG5dviaofK029PW7rMrWs4WTv0zywDegWA5uStLSZvwLRBDy5zfjHmK94zTeGYb9rvaTwxHTozUeoMGiIC56JTeZkNNSnYzR2R5paUqX1971WCL7U7fQzHx9Qln9sRbeaXlf2GeSQ3REPATmfmZiLUKS1NwfWa7WnivqKh3KF3PnL912hbmmjfTC89ktaG2TbJ29DcUJXBn59D0+XBRPUKEv/m6mqZZ365dELMgBoLcg8QDjMbWL7U5FcsUq2KeOIStcYxXKghmkKaV2GJ10WKtINNqO9SjxErJzn1oFNkCBAfYV+zy1Ef7knGQDRVj06frlXbg00zwJFiOXziiKa8+QZIaZyhSslyO6YNmELikjmoi3fS6n9mxjLEjNF8KPTr1qmtpRAspzuWjXCoLQD7ZAMC2ZZnYoX9VimUIqy51J76YrE4hGB2+j1fA+Ao30P4Hs2cV4y5eV11LhiJz2cwZs2/1nhxibNi2XgonnUDdYyoAOlRTeQmEQeerjs8lTGl6QJ1Klva5UQ6CJpaQkV06toPGxBs2QZJrdBWR1NkiS7aMfOC87GreWqsb8tMDjmYofOdvmeB7+eYignqB8WtaLceCXwcX9h1F6DQpXZEdtqZtPMCG6IrzHKiqh5pGOvSeOkRP3cE9GPt2gue2nxSWuQXXtDr9WBVJF7KwgBvJ1TUt9wreFsnwAhB9mSYgn5FR+e3E+G0fHXVBkinQ6f+oC6u1WDnGo98oKcp0H2uGUp/AWcZnDG+fYl4LbIw9haXiExSMj4rlhYVjC3nYnB1UEAXro9ZvWsfu25boCNpdXoW/38KPFfixsOC96CR7mOmCHE33zkOdRka3mykIs8NgIViJImcaVV+0y6PxkFyguNGkYGQT+FAFFby+xGizIWuU8PZFIq1rGjqRIE5cAuVdPY8TibatBi+vGC5HMYypm1ShJe6yqoujCIlGZlyxqZ+pWqwEizBvNDYHf+jGWQD+CsRfAfgrfPxxoPKQgR4VBOfYvF7EUmnIXuq3MEGGfRTY3EQbZMjzRwyPpx7IGDUdhe4XLxksgyj7ka+/7PMMWczJnHfVnHdNn+vzruaagOpp7vI0N92i6zBcUIF4Q3lEpY/17YS9Q1PEDEZObI4UPKfqqoKvPgu8m8Ct8jXfK5S0bJTYbxg8A3MPMGoQaBVrmRrzpwniIRcRbD+CWEqZhB0RaKbf78MpcrWtH2NpUIwRtaMRcEw4k/dec3ItAjWX4cjGevnIt8SlVe5kdpavtJS8rHt5CKyr1orKaPCfMrUrpybdVmDSxJ9eEp4hw2oOP3HFqGYI1GrTSC8By0U/G34wgzVJ9KQfVLX2kNNHt14pjGBG/Tq19yZIaHg4RvfbEhQkzSYjDz22Ls1FrKWxD3qMMAln2vKO1hbv14HzMFZep9VWN2IkLbVxOdEv2U9M6QUVWo+DYqr0mGx84DBwtLH4x+Mn73tPOvrXo6VoSuDaN0kfKRMfhcJOmWbsaLW4j2FYUtzL8C/vZ7hgTIcxWB3ucDjd0nOKX3csoobpZznqZ1UII2b7LeTKyGP2lT2pbaMvIV/VNipfvJVyKFfvvVey1KMbS9uqla+Ygj+nRb7IDvOSSaaQ9MIwLETY3UkZ0AmWg8XvgtYGzMkK/XoJv57+ln7+EX9+xflY4OnX/Ptly/Ih0rtb1wgDZVfHRAQGjH96uXYd086AtEltAmvYzHtp+NVz4KTAfP8JmwTO8fQrPP9AefYikT0z7KpTwXk/h0mF70UMqbdE5R2Xh24Twiy0ED6U4XjCXgXa0LeOp9bGSguHfwTzg1TRevmUv2GGMIoSoGhlmVOeftUOXhxbOKrNe+goCY9QhQ//FbiNlJq4Q6bpKASqhqNupGSfLoXNVbcV3eiBswXaQXW7OqRuBvugUtzgqiIUjmCDxb7qcoDLjPH5BCHHXZmcjQoDWC8GXz13CLaLxyQsbzvy4TggfaEs/BymYO+liyId5FV6cp7imM0DHSJg+FHnuZj8xsc7xkU/NN5hD1WFGI82Mzws8TUTAoAytX4FRARrtWEILJepyVPvnsawfgPzN/q6SR/cdyDv47/U1k6eURPae+UVYbsNLKSPpn1o1H+bSAQR0q60tf8H+1RaAr8MkXc8azYwxXYsYTFmDS26pRGWKt5XLXkKRrx04ORVXr2l/QKdGzv6Uz0Jo8t13XLq09CAdBqbScZVzqILv2jjng3VzSB10t6u1UGpcaab9MXqhTPR0vrHctOAQim+nQV9E4tRfVzfOCvpyIXP1tSO7Ewi/oNUTQf3Gzm2t7AK7rUidDME/2w9saRrBZ2kEOsB5ZmtqEpWSxoOnoGmNTnRz5qe9fOz0HvUQxa5wx6wwSiKubgLIjGK2ntAcmq5AJmU54ZkKN+A4Afo5gZh3qszIPjRnfvgJu/duCDw3T1POaIiT0GOzCHGRnM1ARoP81SH9TytfjZIQP7Dax5PNwOcWzMPUl0QK3dWIPLOt/zuYRiK3wWIQykSY4NPYibsdpuadFwxMPnd/k4IbQDHy7v0TGqMcsC7/e0oZjchjmkkJfs5v6ymMp0I7XC0zctyj2shoxnmw5tBPi5bvkmZy8AzeuJxZOIQZnE+pL1oLeCjoIwStlu7iHqcQ5VBmOHdGxuhVTY2C15ZoAQBqFj19Gl6KcGOcqvetVoLntus3/gaSAEvDO/zBgM+esCsrTfUYz3vMrkxXhUeFeiNWaSvWKTlt+mexwohuKPVCf64bj1CjcUU/5u1IKrZqNHo8MVn9zcboL0txpfu9oaTR7fU4Remw4D0e3VZv8G2/Xbzjk6vrHzZXq+s/NrdVqaVs58I5LfvhLCQguVnzbZSuKM8bejypaaHhjEc4zBsYJgu6f85G4We486/HPwxG7XFpGM+yv2lBDgO4dJCdDab4zqng3Y2iu4lPedHbVDTMb0AiL0LuQ9+nz8O+mbfXvNehRz0/ceyiG282ntDUlMRxSSc4PRJgBaLIfOeZskcbsOXFbTsQad62CN+ChOLtPz+9suPPpK3PsLp618O7ofmFCv9Ut4f0epWRMZKtMgdiHVWFGM/Cfke3rW05j5tyM/59e4Q4mj/aZbkYBWkNSlv9W4h7wRgWqIXfPkMnTbWRgmCrwwgn54OaNXvAHZzd5SiqiZgtZVMI26+rbBh+hBl/hyVk7ttal14fc8XreGa3jitexhbAFDlpt61zOh8LUiRBuYqSFs4E2RMQ/l1vfMtTb9+85R7rTWZHpW6aGqknCkhxxpqczvOW61yc3erDXg6XiVj2jNh/1Gl9tVxGngdGL5VI/eE0+c6rJxYRCz1JvpZ2Yw05qm6+LCjVEhZyi8jpVhX1PLQyeb7vLiXWY8RQXo4SswTPHJRoqJiyq2aLubQFgf14KKfPkklAl8nsPMagSE4TWCNGwE/NsFgffbjlZqP/wgoh+VIry3SmHueuOrkPmwKw9xMPwk2sCrNoziOmv6SqeHDIL/vCXK7XDpxV+A7muOoKVNMBcIWlmjNf7p0K1NBsVOc40DpVsYSrTnOkPhGL+/b9d264R63mwyvkjK8znrVJV7fZheXQgFXSSG5aACmTkWMwS1+xTJscQFRkdPvmEBBFfprpTNsulDFH5Yeiwv45sxD7PPTnts1OJ+NMnORBR+Ga9MHyJJXWTd9m31M+/so56x+qaEET7CF6QOq5ZfVDZwyXBiwkY4+tnSfeJB4f8BVLlJ6exYnq/XUvJNHl0klhiDFETMObPxxCReBvfyaDo/KclruoVsYXaPqpz1Ybv3kLMWl0jpIrtSbZfLO3Aw8JfaFyBkKYzHHUd+8zPq9cFq1s3FVYVx8qnxGBElDJUse6gmFv49Vv+UylK6na1phDJCgg9lrOU1pAwp+eHRjmA1I0n1dGO6FXKBIr/IPhguESXxZpOcqwHuMB4Er3OqKDDqdhi3MVUx9as8xS6JU9uxQ83TPm8AxvQuC9wdEFw0mvaL6SmJx6ppHOpHGpXeW4plMhXHX3ZA3eMoEYxI09g/nFiT3v/7l30X7YMcM8XYzeSy1fs9rP17JcUAidd1qHk3wG34lE6m1HjwQyGrgxHobmxbzU8T7xaSCOe4ucvC18oEThQSkwbywLFhnzJW52qWJiOnft5f01NYMRCviNNhunHIiWvUGGS1LXO0kn4ySLgkp2EegzstO0LqsqlFnaen6+jq+fhbnxcXSyosX3yzhJQz982aHLNzLq4vGwk+Xl5eXIJMKfcRD1TSYL5YomwviTfGMgpjNBafA+8ObHe6nHpYqPiyn95Oyl1oPJnZg4lR4BAuwiVp4pdmHRkA42UdhCSxktUmjxxkx3dbtndNdattcalNcOTS9o+d6QweKMbDOooitkKlzrUixSqtUpg1NsDfSX2WuQVPqGbhLW7NC2GoBevFsDGJpNlQW9OtTWO/uQWjaO+IGjkVqf6Du+aewXy2/EUexMEw3gzgoMfX3sR8Y3EOJu5COTEQDOIIKx4aPNU0ElJgxD9glu0zmmfvcif1ITRVG1NEMfQoeaXjC0+4/bWSr29RaaMN1r36kuO9yMBpXj1asYC04OyoI27TdlfJbzjWXsUficJOWMb4lO1CeZ+yB9g/Qg0E2hONk8rFNccyM0JUUF9QH91G3CIsGZOWKh9Ch83T3/QZA3WUQ1r+Or+8CJFlluWXzry67QmWTj6YsjgUv0umPLtdKhjdojSu5C/jX1BHUtQgzrdnYYx9UFYFBTyAnz0AAF2AMsJWecZ6BRboF5272mmHIbS0O2TY53BbftcxoiwsokYa/Yu25x5/u1mnZN4mTrS3zcRV5vti2sqCiHn6uLoC2ppw3IHNqt2HZztz9ghb+4YCDVxfuGmxdZen1y/wjlCILjXbgdOB4Si0q1JLCU8owhJYeiz38qwt37IhTGHzdiMobMVpS7aLZi2IbIkF0xfB92d49x1nP0rtZmoLtXtjaW2yh4YxtSozUjqTOW2nQWmyhfg99CdDHw+0wgMh6SqEHx0gKb5SRQwZ9i0CnrsVOf/PoNuvhM5n6gkxUhwB0u2dRdJXrt1w0HTsDQHVZiH037QCkCEGtMjJe7b3BBxae/Obk5O27/a2TkydL2js8Tf+ckv38yQm1eXLCZrltfTrryN+2OWE97XXMzzaZJbG019G/MFW4dkf9aCs20VG8G1OIVXQULyX5jRaDeuJYS3S0HvAL2+0IieA3zGsH/3mAS8pMCesPLGOYhutQjdLatahhEgWZMMvkoTponxKUvgl/m+tHe460MlUKiT5zNZh4ddW9JLftZOKfjdLyn+LxKAbir5l/iNEe6oE0DRPJ/R9hlHizhqzAHyh2D3tUftaaVT7T/NddLbRWij5dbnhrBR2RXLaC3MTTk2TlKCcRT2lKOCU1Bos9dJS2zneWsl/Kstyqj8lqTmpGpqo4OuzSexSmih9Smi08D24GZ3k/RuMojCR33KExiX86oYBv/amL68Et/hXlKdpFSc/xu60yxXxLYgW2Ld2hAuZWkz6H6oFAuw2pTuPUtaWABWQSad92NeAnEiUnVENrk5O6EQXUpUQmQc4XVxBDYuj5UF/ZBKp+PGQVZ4zt2lbn5OUl9uIywwsLHGPVqApusrTfC+xS9pWyTS/5GYVtCSUCMLrlGsvWKuk7lKJ9aNWHrDOjQFMUsRYYgGH3ErcNds0gNaemMt7BjTH+/ejPrURqcU/BYxmWt8RER3er4NCiSLj6Ur5lmZi3rKJCURTJc5DCqkOfQ3xihcleddsnf7xy0RpgQkL40Z5LfRuo+NVHMkeg39aBQ45jajqMPs22WYeMj/VWhw2K+IaF02HgFrpCZ/Lb+nJa9VScNm13L4u7n9DKMSM5iaKJ7tz8LKFxIdor1V/odcJSy715pQ/Z+WDScGYNrXgoyiNF1oreaoSwrS1L9KD8Nz8XIG3XC0eni+e60y5QIW1hQi9uBdzCJLgHHuSSXm8LG8J3RlPYzFj719aALOWCecjOMnW023Cv5pzdlBtjPfId7fEO60sD7iCc97nMidR9pYvPpp2mN4vswyozt42y/l6cvBDUVNh//o0e3zuD45RXnNLdN5hQDvCLDYDJZhjsYF0S6Po16NhfR8vHNhgWmhdVTQPRcmiT8708v7E3kkdScqR099VabW9UH2yDp6NDmXPNhdx12JNRjs8GmftKUB2LLbojaE3HX4sJsNU8DFGi1IbwJBgkIzh3WlstUEuJ7i5feL/lbVRDn7Lt1nH8p3E6bt5SaxsmFfWiajRuouhD/V/5Fkpu5HoDJczFkrY6fU/lcuVldl6JYWV9fxWK+1s2UG6GVYgWzvx90+3NP+L2+YS1BChAFBUqW/ORrXKlZNZJwg9SQkEJTshH/E1KyxBVfr5yNgq+DZ6yeJKz3lMaYaDLbdTcdtANOnim9KVK+Ul6W2IFbfKXtqMZ0u9umvVDhrzIINHXiroeBZ/YDUk4CKx9aGLoMgruxQI08iRQjU7qGyE6GGnWZd3+P8zK17hg8GYA0JGRPzU2s8w/KEgb9sN2df2iZwvhaBwvs+5UOsdxAmMegFxQf5+NrViarkqR8F+ipcoR1zpuc9B5YB9kV/lLcpWU3SIbVS3xoWaI3JRoB37idtG6z9JYWodhLt0WUueRcVoMWBlkQ/TennGpriBb5//vUQRCfH6eEsB0rmP9brOZVoXqAf7rK+TadNU66vAuiF8il3bUD0wjPiNcyVfgtR8EihI76gemMT468tdXPqSDUR+RVKRDfhe8QJ154UjIWmzkgCClLRqXSkMqeUfK75Nu5RJ8hhy3wTb9NjlFnlfCq03iMO+hDQj8W5rE66T/gdElRoxQoh380g4G7eCDLAvzFhfGD0hx1vkRObRbGZfYwW4+II5DkeD7STe9zPsYqCE2roe4PoWJ+AyKnRGHqygdmBU0YvakCx9lTvQpyrZczVFZbltUEnaOFhY+SJQJy4hSsIp3yN8+XFzMO6hk/kCK8MXvWl5Eo3qgKQTmxP+h8f3CrHQgremh/QJDG+DQfnFDBuFESNmjX479eEGUO2N0JrJbznamfM3nFvCQIFThXTS8ks/XRXJBV0POqyzzo8uPNKXo0LklwmE58BvC/Dvk60I3PUFADpyGWFcNYGrNGYg2iSgYJletP0WDE70q9mlp6wXBFC9N87KXhR2ZlfQTrDr1fBIUIBdsvmajt4RoBak11bCeeNv5gPGJzZTTwnYCd5g31niV1+f+EJjtT5RHhNQmMuMQE/HBD3s/nWzuvXmztXvYZlbC0puBypslA6f9kS6snKUhVC5luuOiwGs8Z/I4alfeWeLIVlgjxn9+bIizRYM8WnDLiGnA0wiJ3CWMiTehmhOJA/QHj+dYi29NGsuO611A40oZRyzTxfTN6y07Zj47IwChooTtspEOdGSsv/w7vdaDrWGAviRAdotP3GFz68GrFI2xKXCW1m5LZuzCUDMfnMs6XwfKZUKjN88llaOAJdowwYGChxB54AqHty6O8yAjxbaoT6ue+oAIck0EQL6kbFaMMNIogeKX0rct4FMWtnWowuatIIhQTZHspyiX2WwGq0UyBx60VS17S3ShakCmwmqn9nZjczhWJWbcqasifA5TX3E2BJnnh8M3O3oft8Lh+be/7H5FC0kDEKJoSxyYB5P2lBvTqYYFo4QOhySdeJaU/TQ5h1N2KNZ1tvy5ow0CJTOUwo8sdzDjW78Tn5C9q2soT0FLpuOMjMz+/9qetbmN48jv+hUw6yoFlEFosQtgATGO4sTJlaos22X7krqSVco+ScQggAAgaVpm1f2N+3v3S65fM9MzuwuCkqIPNrEz0/Pq7unp6YcQCv4NgMkelSBRpJ8zVSiPzd6g7FCag8PHlsNz+T4q9vsz4+ZoxqpHhhGdPDTCLsNHma99Ld116S+cFft5va4zkApLtVhsh253j8tDo2+DizawdgtKmvBpu45j3S5wubw90655SFEaI3kIfRMU8P0KpN3vyCAKLhNwe2iEbmQrBCI/Akb5L38gldtm9+Vq1T/b7iqq8YYcEd6eBaGSsMgwBe8I4zXglbtaXl6t0Jqie/GuGgIPQRZLGVcvX22Kn5uykTKTXjsfQf3vajWyw/gTAhFQF42a9F2fCjRzVPlScK4zvmTgXeXqX+fn1+U5LNFZA85D8BsXC8ZwWR2+hk25Qadl7oigf8MxwZrD5vk0gLdJWsdXnHVX5yvpfP+cI8T8c69D2Ll/vD1yG/5DS0/WDJDAYFyzU6YT3KdPHixKqdwTRipv9CTYZOp3j1gwYVddogZ/17UVaEvPJS34EWb/O77vXLdzhXF/h7TLj2CQ399DazosdWZb6XcYMh69LY8cNR67eVCJFlqjjFxXu+tsWbYdPtcksPrHj1RvHD/XGFrVqX3f7yuQNJeH+6+r2wpNl1ebzR7DT8DyYRzNs3V1c9hlqzPPUq0xqDCW3alstsliyTSCrgJoqTUYLcuhCXG0y+5GlHqg/4NwYHvhHfjPS4/KTRfNV7nXNwdn1uA06vyEgPVPiet5aXQ2L5RfF7/qkdKVgpHLu54oXofPVHDP90B/Rl8qzwB7/EJcQj+n4XPs4OGI4S00Awo85wWxloanPtV5+tb15k42WK4xJFt5qkl88hpRvaZSsqxWcMMqbzg/hDHuPdVwx/rXVYcfl9fV5ubQb6E1/9nYOGX2TKehau3AkFRMIU8VJf2sMQQA5dpzkq20eGy0pgPAFkAikE9dxj4EQ0vS40R+vXNcYOUD2edSPO6bro9nyzWnaMSm2nXSNvolrflfS+PDBqNacFZ45BY2jq5bXGsvRQCVkaqdEvp54A9YG80TAsPVO2S/XE1tODl28GytDz0FqrTQLwU6qqhp1QYY+RVjIyBARRnOiF9AOBwcoO08AXnZYVhg2zb3utlRYGG3BOHmGDbTzJXC342LDPJ7zx1aohNcAMniqAz8A5W/uHkv+H9k/wWDfkH/JUUsjPAF/TdQwmrH72Evz4xZl0QL/+nu8xeD3356/tNzEytcgq0aOiYPNFP9zejt+2gYP3TWFjNY15myuTUWsbBFNAy6ztjrE/maiFj822896Oun/ejd2+eqG/r+0/4/nntdN8lptaousxUN/UyjMxlP7188f36z3v58CffKa5KSeIr2SswW2I/fiI+eiI+baouhduO07Lois4jyxLvvicMgjKE5ZXcu/CD80IhEF8Y+e+J9hIXmv+NCbBBJvrYbaUqR2H6qV/XeSXfgplFu69XXi8jxTF8wfoZp/qKjcehS+92vxTd4/na9XMsdntkZKxsw8mV4M9SeF7zoBMFmCMRnlB5/EM0bhffyLYtsSRDdqtXe5yNu5GbCJB8eEweHPVbS6jhaDSH+UQmRpAhPiY3dC0y1IBe2jC46eqne49MbMOHXcNP1Y8RZDcYv3TL/7apN3H9zC4fFCqa7XXZEd7kFngZ1kLMtD5X760to4UIeGmTTShcvYiJ0YO9yfeo0QGzy9Og/1YjN+HiLzOlCiG3Ke7gkYoyhv1sXEg/L9nBlKRUOETSNPiEI/Qp2RzIvO6eYvq27uRfD+A7uwiBxNMzfzngEZ0MzlG6jNqP3Z0httm1dwLSFm+gWl/ku2927WB0SyqXrQmIXTBoaDrvzw4HS5hOu0l87V+3x245LNSR5F/xwJ+YK0wh5w3xMrlqmlvwUmw8QxGQT0OXIav9/zC4vMbWUUS2vyNpgtReebLs0SH25y7ZXt8tfG0z06rAK68KnlmrXth7+zV+vS/NNaTMlxxm6p3AZ/Dk0LMF802fAUL2I8dNVCVNb0W6Z1FBQaCQQrREjQeSP+svznYNx7sN4F050tSmz/VVjrtm/gorARZYZbO1ZtoWdq84pltjZi14YR+5h0M92qNTceJGjTBrlmy3sQkmx9DSgPy6oVwp5Fo6wJVLdadDKJARVJo2JfnVT/PzVnziMmamuv3GtV2gGsQ/BkXHEvqFi5cpsATUajfjnUMIG8i8y0fy27utoMrB0MqavTUfh64JgHGtYLNoFWiCu9N2qSQDb1ebQWIB370gFberKT0+6COCYMoLzwo+sOOSstlvAwIxSwt3sKwnYEIgq9D4P8hIB46ByBhb/CibUFnfOb+CXCbltthsM8hIuhfneWI5bS+LqpHXU+QMnGSuhK7j0PpUuOUPYudc6y7a2y5bQUvbSsT/A7acYOXiwsjt526KuyOr3eVIUdb1I6zIuF0mZpcmkSmfzeJHHeTSbAT6VWVbMsnENf1VFBP+bVXkxmSRxOi7qYhwtynhRzaOyjMfpZDavizzO6npczfK6Los0qZPprCgm87rKZ9MUfiXpvJplOfybJfnibDDCkKhkT1X6tnvZanuV5U6b9Qlmm07LaVzNimScRPm4yKp5UpTZfJFE02qc5tOoTpIqncRRVcfRdDpPs3EyrebTWZwXsERxNYEG9aTO4jqflvWsrOvZrF4U03K8SCdRXsGaZPUE/pzF81kV05wn+WRR18VsPi2PzLbIdvtPONNoMq+KpKxhvvPxOCpgM2HAWTJLYKfmeTEdz+o6T+NJGifjOsnyeBpF0yiZpeO0nhaTIk7ibFrVRZrnMIMiSqIkHU+nBbTJx7At82mWJCVMMl/UY/hzNl7MoBJgRl5N6tmxmS4P93f4aPAp0XgxT9IKZhWP66IYz2CDx2VexHU1L8ZZXEV5MomTDPapWszyaVHBZKo4K+IqjrJ4EZXpPE/H2aTOozlMKJtl0ThK03QGaAHLNM9qgJjPqyyN6klRzGaA0Fk5m5dlHc3qNDsy3XKZXW/W5aec7TxdTGAX6mkZzWB2QJyTPJ/X8XgWl/lkUiVVHdVpsgAsH9fzWZrl0zxLx/M8jqfZLIkW4wzwe5ZO6yivq7RexNAuWqQ50HCepCkgfRwlWVplsGyzKazUOJuX0aIG0Gk8jY/Mtl5l7gD4BFPNZnlULiYZIOU8ntflOEnS2TRbJBPYB6C5WRnDTlVxDftbJsl0ESeLBSD0OB9PxnFU8nbnk3o8i8opcKt5WczitMbtLQEo0HwalTGSQzSuJsUcSH2aT2DRpkkSRdGRqYJgfrOnlNifkkPN6nGSTsbjeJ5MoqKYw17PiyiL8rTOpllc1oDoUT1Np9MJDC9NJxmgZbXIqnQ+rWvEZdj0qADkhHlNFskCULdaFOO0AhY3r9IKWF0Z58k8n0/mQADAw7MIuEMG/42m9ZH54uWQwoZ/UsIdl4sI+AWgWAk7OFnMkqqA8c7hzKjzMkUWlJfFJJrk9XQ8zot0sQCKi7JxXs3m+RTotFok0xqwNAbmFVVlBEg6LbI5cPekiPPFJKnncV7PgTKAUWeztJgDQuRT+BARKnNQN8kkvLq/3i6z9aedYpHFk+kExgocsiyqaLEoAWer+aKqprBxMRyhsLlw0AC7LeCsgLOlKuHwKeYJNCnnUQ2rBCtUT+DEqvJoUoyhMZw3aTxPy3G6ADZHFefArMY1nFz1JAGiGCOGFEe2dFutL2+Wn3S2cEiU+TiOkwoYTI1nSpTOEVFBAChmRZXnJex4MZ6OywS4bjKG/YjiNAHWBEdunOVRhfsIDD2FH4siTctZVS8W1bSewgrCiZUn07Is5ot5Ni4WiwIIHc7zLEkB0+fRMU68Xf76a/YJp1rMpsk4mmf5OJ1Fc0A4QKskgUOijpPJBPB3ms7Hs/k4jeK8nGWwrdPZIs2SejHOAZfhFJnDITyZLYBCkyxOi5RoOgKWniSTMi+BeCeTBezuBJhYlM1zQGg8qMq4ho2eHpnqXZWh5dgnnOxskWQwjBhYRwKUU0eTGLEviqoIpDwQpGY1CEslsCXgyfV8AcwX5Ej4nSSLYlbmaVHAHqYT3PWkjicV/AZqBvEhKxbZGBjTOJrA/6tpXERRBotapVA6jmI4xopxF2MyEjUnoOb82eTxYwIOSbS1vUm1fbPvVb+gx0gJJzNcOzD/5S7jxJxX2drAyyu0RWWLt5LiNFnlzKj34xVl6Fxh0gu+L9+PlK09mZXy9caAUz1QgmsEfr0pb1YVeyuwSd9X374eWl2IaDocXLmoyaMOqXjYPI11Z3K9Mq/I4W1O4jSPvJGFqSCG5gm+Xl7e+Bkf6ZXZXvAe6WVo3gQx+sZBPn6vr4NP6fnZw8CbJMbHVqPBn8ErlFIuae20H84YfRgxWCvWkk+V/JRGpOgUWPeDMJ+WiX31xgWceuv1wwX99/IM78dabcvD8VbF8f0e40ZeV/TIZKPJ8q8wjCxg+j67rMTL1Q8nK2U6dK+JDCWxlOSxXfen4saYKJa6+EwvtbVXWO6vurKViSozSGlHRsztvnxhTQHm123EL0X7/YNxvzOPw4SdvwTu0yVmo4et8+sGteArvvX16XWnBaj2V6Q6obWrXUVYwCDC1IVUAQSj+G5mua99O4L1ZkMh8C3IH//7u7+8++bb719/iY93Y4qblkG13XW2Ql32EtFJ1331+ruvX/351Y9QO6ba/DxS9miCkv9KN/jqv7DBlz/+BVokYYvyhqPZU6ozsgHarM3Q1pt3ornHpzD2+uufrTfn5uuZR6J/k8GSg+dQmOHQKP93QQpZCe3MZYOe6kh1e6qJjW3QMLHZhVQqtjXv3HRdG7Pc71SyrY7WZtlc49Pb7J/QCC3wLneV6ueb7JtmZVKIYn5q8knnlPbXwAwoUTQrHA081mMaaOj81NUzGZV4c0Ts7arP++3q8m9TyhmYLRxyh2iHwzk41RAlBW1X/S0fn65+aN3hLJq6QAA5FFf8OUQfzlnjMLJ96ckNASQIg0Dsvw3YdVuBMHK73C/h40vT2T/J1LcF7UwR584wo9tfZSUqxU11RNsf6Fvf0phQlmnCvoymAYWYlxJjU3Yq/tlcIaZF1Kjpnqa6SNVwBsctmXDf4Ts5oGjLUkhJ84xtChQ01Hf1zapGw42yBZgtOx0cb0UrNFP0FGBGlGvCEqX5iaB4aVsAccET4KAJWiscLDgZDrtbtMDhgpPgBJLeEfRWBwd/eTli4nD2Q+KspmxLMDmgDp9vJEIBYSCInMIJBCVfoDsj3uo0guQ+bE8771A2xx46OtOO9JHBOjiDtwOb3UF5aMuiZXSZ65vf1lSIiUc47OjdjiW30Tu47hzuyULeNrnwWggvpSrEUzo6Lqt/U8fG1PFI35YF9XXak2ZxR3OKGdTelIo6mllW68/ZiIMiIVqZkMJcs03QF18EPQxCibGzurKtdUZnWg7vUypis4iUIMUEOpOW/xj2/AqDsEfl9cqXCxC9qWRkbg5dnXu1Ovo5fdzF5mZV0tDzytzzOob/0IWWRmJqRudsCuxtY7IrKKsH1Lmr+M6+gSX6x/HemYCZ5pfyhqtI2Ytj0wwaoaLZqGxirr3EvrZpBZbyaOw53OYgmvyszVAIXtwBj0G0JNSR4KVkBodmUWeD9u7YY9uW6OEdGZWX+NpbvFfX2xWH3CVpXeUZskad9L8XYjLI+zx04ab2quabtz0KQMAAzYZwig97jhKnkZdfiTOjViiMxK/KXrj7ptrjI8xa28U2AiSORGp7SbbLXOXlSymy7FRDOIqEuI6PIKLYnhYbDlHtdURfhz1h341i+U4GfFwiVwbjChacE7LKNrhzS0U+yVRFDdfDVC7w0Nj9cBWMg4M6Dp71tOgNJJ0VKHA7IbyPYWkAY+6tYZPEvFgNXpqYRj5y4P1m0LPHnIEUnmNCKC311EHLw/sKzfKv3KD+73/+d88kwNZmL3toZI8Kxi1lYLA3+P1nz1yIds5aTwtBP3/7jXdaYZepYRgP+qkQQx9yQiQxzySmYAFhpDU7SH1/2e6q2+XmZg+3l6sM1jSjMb/UnIWAmHN+zxGnKNHDGvWwpTg626VxM/O7euliCdCM1Ep7Bw+7n8NEmugrZNTdxI7TtpXfQ/+nOHLAZbMLQNM7kgtw7vyXQfI3/k8b6p+TPWKQQ9oV9EixWHW0R4ttkrgDcW3YC79qq9amtEagBxpL/cUnNw67jII5g5aIHn2zFQ4N1fIPiJgEGwnBNkBanxAjiPAPREv7rCby4VqfNYcqy3kwHvC+TswNMBwdG1Ty0DTy2w1y+hyfPbAuRlPTmj1sADwD3TuoIwtVGKHVx3m8Trt/NrtH6jMpBN67sAgUJu0OJB2gYowka8fDo0DdUMvsHJk1O6KEcAOJ5SRRmZjm7xXnkgBtd716+UtVfqYgG7P6Vqy5CIeg6ZJlU0e3/u82wv30pMuXAk27bWP2jrJwCYeNL+373Eq93L8i5Nb6ij20VDuFzlW4jdDpOfCVuWgLy9F1OjTaellILCFWoS7NHEDQMDyEmlxI+E8XUTuWs9kdofCn8A0birPBQEzGI9rcdlJrkX66bj/DFg7hS0rd/KmF4T/GIY1Gw5zqu8qTYzS557vNz9W6OS1HnD4lDpvkbaiXH37vsKt7YO/QaYOH+Kj10UTNqP9WJIO28/iJJ6mmMaau9pV36J6tfdQ5ijEt/KPBeB5BleYiK1Rp4dZNdZclg6Eni3mrIBxaZYJqKfUwv4UY2nhqF4G0gP8ADOwE8ilRjVVFwflhlsTuhRtV/w2/dhGEt0/ATT4yTjwnOlqE6BzW6DwsjtKBd2Soq41DlQdzw6uZEnaV0eJYQrnDeHnuqlKhRJKRat69XmF4pV6fgFQM0Gu+rvCVR7WkeLTI6hyIUmJpi0qLWuCp9EwMS6CBsUBBk5S7CjOj9DJy7Kehg7y0yyjG4WjwTJ+Q8rzCcVw+/9z7yCnw2rbLLqQt5de+ynP4bCZqCLTzkq/dpj1mGu5OUvX7XjKQWqF2iCFdnKoI8tU9vTfhVU6KGepg8HZoH/i79SQkgQeWCkfHwI+QbyjYGFz7OwDLQ1TfrYscQPIgOJIKg177934XYPsopW0sWuDbeo0eAgjDnidMH1F7V6U2gWjp01RrdOm3b/bIWijbnaU0Zz5gPqHtQFDbEhzzedNCf25pRa+ryxXghu7FfvRtFF4Topm7NAaD5gR0FAaUl+MkewMB4B6+5IN9s0XW5z9hv862ptT02qggHr+93puzP9qFGjbX00YxfeOvzrB9MVV1tTDDtjW0VUejkZed7617j6aQuY885j/+KMxb0XgSbryVMm948kupOS1aAD35rbQVzpOh7Ja3bVDw8we/twqUJ7y22kC8DSAdRm2dMBh3WsBwwcmQBM0agOT7h7whB1utdPTCPKy0GdwcbTSJ28Epz0r6Yc7F0jlyafzIpypzsAk1iav7rfZyD+LraVzth0vQFOzZEE2Jah/ao0gYH9Mjgzi5R4N3/Q6DM2US0D2CNnO11sBbimQUdlGyon8zbjlLOd8yyXrTm/7tglBoJmuPgB34AlWY09p4+lMMAUtKPFd5bjPn561xUId7+hpEKwfk1ihFlRe9d0OQXk6BT+as5iagdBDepSCvaqSY5WEv0rqcGKjkh8lll9lyPerYR9O769ezCpAoaq3Ctls4b9ncK7fYp9E8TJptJX09ZlvQvkzNgV602q62MwM8cvrLtVjR8x+vlfSvLVmNZKKi4DMcfT1VhYDzy2ov2UX4gvSf0B2a2xtzHh4AP9mhTzmaK/JTHd8tTAxdCUm3uj+vrreHewbmVAEjsnh0+rY7kIXR1oBGUPYwIsCO7fz3FYyt7G3RCjuvVpu7kU63wX7tOn0AE/IBGE51oBCfW6JiqeIMLriG3SP+KRthGtP6sdTJ7RV2mw9G0BrotiMRtFC9SX9wIQ5mbwczlMrSkhefE5S84RLTi9EayObRPdKbUGMS9v5N+EGUd0k7qd9IoBleVyuRTPaw4IcN1eVdLo1ThMs0Q98xRgmtu+X7FFuaqzBGIloIkvqhBN9TS757Pkg+ZluXH/nZReSM0iPRV5Au2ASVfz+Y9D84FjlpTPJ0QklloIA33Bc96dMjFm+VKNFF1dsgawak9TjVHmbGsbtX92h6wVoBWRlka9la0HuHnvN7zgWwlkU9J4LoL0fVaOi+cjxrj2SMbE66YtFOOEtUD9r1zf7giAXqbzZD3E72oJFpUkgbfD/P6hp+NgHaWiNy12EqDsZdkAQDJwP2JobnWMDQZA0EKVB7ckXq+SW/7uEhuN3syX6WMCQADrgGYAGXq5LhEdVf8OsXnQd3FfeOPjocJgLECV5/yh5F0tWQosn5SCgrC6ssJGOQUNURg0B7LXO15fR3UV84yqI5FAK7A3sYs1aYZ+i9Rhi1i7yrUp4cRl4RMzAcrDx+oKvXci1Pc4iPuyUs0LqX37sde+Zi/hLFXXMmpddGu+OGKjrN6K3R8vqvkX5Lw7QGQt1+aUP558jnryw+DBmTkXbMKWNMx1Du3977AoBbxn2weyH3Y5N45I7d28hV/6Y303DoYDO5GXfxN6fjsIy7Kfj5R4Ztg24x3he5O3zWfIbxdpWYxE6ToOrDn8cTkU3siAjEK/ErCgFalLhobWaRSEFpIo8slvBer6pTLQ6Dw9dIKWgAoz+ECSpwYuvN+jyYnPTpWfa1T47sgK0sJnrK7oXtwmwTXI9ItfXa0jQj44ynDqna7hJDlxOVrxSevNrT7Y8ZKyuNvNMCGmlEsxQVXIvn7i2htZwLALgHWXtNsI+OnqBv27Rws0bX3mndDsbvzkDQd5yeTY8ZQLhcbfJs5RNuu9zuZUNtWxbf3WwQZkdxcXe/8OPuvg9sQtw7im87a5XwwSWg5SnmkX2TzKptSNyYYysWy7r3zXisQjvACPcY1BZG1aO3dstsfwWUzrne8YqIMIgWf9X+8OV6eU0q0L/urAmsNgBtrfaMgsAyHBjwq+vrqlzSK2rYXJdSq5pCfamwxMNe5Gmm5LrfV4pnJFCJyjbsMfph9DmKEifoqK9l0tJgLm9Af3Cyqxy9Eza8q4xyV56ZOsu3FFkMr78nOZFZL7TTfL+Qm55WU6SDThW7lbw7ZyJpBpWHjyRXbO+woaWUD6acN8oV8+8HL8q2vedp4YMoGfbTFfJGHfUyMXxu4BM0boSBw4oepz/pQg7ByKZvlt3pxiuHKjvdCaoT2IdC+mGj/dICaFj4ZIjfaDe7AOA3GAz6VF0/o1YTlhScDCj0qTRwjCblRDC1H3DRwQsjMX6Aqj2YWl+zfeeD+kXDK1NZhRtKVHnGjdG3sau2BubO6+N2pFxUjZbx1j2pf4Gesm2Rd/1F7Jt3HM8DebN1spgTXK3FeMeRrS9q1uJ9eXAnuvsWeFR4Wj7t76Ed2Xi8VmZ7sAgSmESz4MVjs7zHvO43evLG5F73Wzr0+9jbPqzpgK8PFc7kq9V55IG2uHVZlOhhBtu2i44V9fFtP89MrhoGqs4rVovZShcBmlb9DjyxxU0nD4fgcCHpN5Heg48sqT843gnX6QyPjdKJF4w+IKCXDidRhNG9f0NB8NveMpqMru+Q3+WKHgZy+D78YH6rJbdLoL5daLMetFFGa+Fsfd/bZjc4h0sXHoXSv16T4eG10e+75d2TnlH0ZqhlYtml1wd0xxmC7L3e3MB52mgJghXG2qiyazebkdCJRhjflasxE5tC21MmGARD9YGqPLAFhld5rwp4l6x2/cTTKf6Z20qKO/JRZ0OHDT+EKFVcsdrsb3akriIBz5+YmGgDLq3uz623u7slkjYQpJ8N++rJmEvddHPOJuydzXNM4ChZbamlU366hwKDrzt5eGpyeBWEvP1K2+mdJB4R9qfViXNoYzPqL7Q1jHzsBzcoTuptWvxB9W2/hkxd22cF0NSt1wH9/XGgerbhIfcQrIeem/2b8Mje8Jv41I47NAvyu29u8/74pmoHlCdsq68XfWQlOBYG5Z9slIZmmo+gRXBFbu1FBAiP65lnzXCPRdBolX3MkeZjSrGqsp0vB6EFp/3c3DM7NLVTHdvzFHrqWjlYimJHQfdtBgMUbjcCAHk4qRJr1spS2H714nG4wsTupM9db9x4mXoHo2f+sj463hBV3D6BKOZlweN893TaNzUjz0wuL5eW2S2wGz2+0Wy2m9Xmcgl8u7fZldWOhyz5jpSGTfrDwD5NtLXiQ2Mo3RsAh/mBgA5ORz8zHXbFuc6Waw856JQtlrviZpWhbQPmG0ILRYwBhMfrR27HOwPa1Ru0qJ/ekSqs70yEGhYQZwaQ0u2fDfz0iY+hbVlptD1tATVmIHMIdll8WAhrXLwws02tTO38/HFc7cbUB2X28He0VObkxvgA60lIy1qb8Yvop6QffFLJyNcU3ew2CE7EpNOkIvZk43e7PT6lO9DP6B2CJFPsAChGxBJ+JQb8opec7NC7Q7fX1UokHunYiBnQNUJql8ma10wSkxi2XUoUVLddd0wSzbCGyltM7SV3MYXr0jL1ey+t3bZDRdlEeKWjcy70ckSGwkvjxZsfu6lI4dDSMwlxhgZyS4ZKDWlIftKZp/pStylSc3UZhhuOH0zr88+byNxpid0Ooo0eOkCwjcsj+l9BvRGp5j0RgiN7DDqnKPJUV/CPU3K5tYlnflKgh+7+D2gwQcFHtJFuaHSEKCtpmkUX/cq0hNrfaiswpZP+3e80hzSVWr+O3plk3/TixEGqoLfP8PPQzEXUISYTk/0py+9u9kbRQFmjZZm0TgVWtW0C/f4bjMhzzxF2+m4Y9HW03LtGaGQPM+kbpvOFaIhVppoLr9uRSTyjsonrJddUb80GR3CbBqJcQ4/9ga8Wkt7+SUWDBl156ZM8+ZYnNQhzPLVlKAzi4jVacOeqrqzGoKeWRWFwHw6ANc/Q7ei93s4gT6ahq5aUd92xUhpCThBBKLzEdNAPopZfrLwonCEpDifyjBTsa6jUsDpAzbi0Xw2cOF9nvy7hOmzjblJUWOWBYB+82IDEq1c7/8cSzWbIWg3froWaAlcGvgBovYeyYdhU+zWcjwdxdF3f2xgf4kiEhqjX6OK9p5S9q3tnTOX2vMEY4Vvj2BGNhkgfL70EUbdHX8DlhVAy6LJq0SZM1PhmkewPKgFn88GcHXF4JzHD1DOXn1fEm6rjCkQ2gfJ6u/HX0jPrE/Vj81BtIARZW8jfg44gUi45z3aFMYgz7fGOkpm349aIxXLJFSHbyCmLrEQC5GkDosj+sJCyFgHFCIsm1JBYXyzfagmb4gK1On+88PIy28bUp4ekx09I7RGo4v/42ZD9UTivkmAMyLZ054MPH4qez1OO2A+ZjvN4eGQAJwD33B8bso2iEzF/J0IJJLqAnyBBYCAcdz8QZ0YAv1tWt2wbTensTB7hjGK1kPIYaEns+67UDUPuF57JtfKL1GZ/WK2oQMq/zkQnaxzgia+Rl6R2qUTdL04Ir1rFFa81MDxjp2d1ic6UUY3KPLqv7j/TNG9YR8sR/CFEbxq3RER2tOdhGL4DHEdeYaFKB4l7H1pghB6MamLm6ixjH/a8/MY+PsmhSKjin+uyQO41zT9KTarHi6AwdFoULeOT4uXpNerYDp7ARcfIgngZoehfaSfmTjH82Ira/faS49noWZ2BEY0sLba+f7PxUeipAmiEE2Mbx4SeWErTV+NkLFT9vaFZrEBhtXn2GOLcJ9ELXOz9TVFU+z1sD7k+b35WZLPfVsWyRpN48wLBlvO8yPDZCAxHx4U6I2EQG/XKJPxBkeYeJJq1fxQb6XCzVs6s78P3zSMShAXPoWf0+g4MRfXfY79CDg8KF1WK23UVPJG1S+IMUI/2QiuHPn6LBHDTJX1o1qpVH8IMe19cVfRKG/RLttAMbnuDo24ZSU8YNRAiW5BbGJkxgWJLKrJKX2/E5luPXS4O+lQ4ZdS8Bx5auJdb377fCbCmvMGuPpKp9zwS9Zldj/R67kJDuG8uWfpWZE0G1RO0/WvQouZtY55t7LpnA0P4Oo4Gl/2kfNaftwoMbebenFALvw2J5Mv6QFkyNA7KOuxRC80gAEf2KA+DfCIb0/MXfigShUZ/FMHb8I3ka1ZyjkJ1bce2Pu0QdPipfLuOaaafFLrNJCNu9TYzy/p3JddxHK9KS3YtlD/U95EeZUIFXu0LatUejX9AyMFthzMr9J1gYwDLMpDLjJz+o5NYP4pUuwn1OP1dtEtCXeJA+DChLH0/rRaj166SOP4C2W9DvkAnJFbGwiskpMWj4tMRYu4IIEHiaiAhdSU7due2tDuqRGp5jrcBKlqUmp+F/q9aO85hLU02IAPYKU4agX/6DfINdfT8GQ9NU0Hhtwn5c9roWEtpmgTcQgXtHvb0WI7r8D2D4WZUWv6OrzlsGEqNMWoNyAHve6/WKCUSm7CmyN8bN0UvcQ1s3v8D4xGaW9cpAgA=
+</script>
+<script id="@tomlarkworthy/observable-runtime" 
+  type="text/plain"
+  data-mime="application/javascript"
+>
+const _kvrivm = function _1(md){return(
+md`# Observable Runtime (v5)
+
+\`\`\`js
+import {Runtime, Inspector, Library, RuntimeError} from "@tomlarkworthy/observable-runtime"
+\`\`\``
+)};
+const _a188e4 = function _Runtime(observable){return(
+observable.Runtime
+)};
+const _nz6rsh = function _Inspector(observable){return(
+observable.Inspector
+)};
+const _1s7i28f = function _Library(observable){return(
+observable.Library
+)};
+const _1iyzb44 = function _RuntimeError(observable){return(
+observable.RuntimeError
+)};
+const _b2ba5g = async function _observable(unzip,FileAttachment)
+{
+  const blob = await unzip(FileAttachment("runtime.js.gz"));
+
+  const objectURL = URL.createObjectURL(
+    new Blob([blob], { type: "application/javascript" })
+  );
+  try {
+    return await importShim(objectURL, 'https://api.observablehq.com/@tomlarkworthy/observable-runtime.js?v=4');
+  } finally {
+    URL.revokeObjectURL(objectURL);
+  }
+};
+const _17n6uge = function _unzip(Response,DecompressionStream){return(
+async (attachment) =>
+  await new Response(
+    (await attachment.stream()).pipeThrough(new DecompressionStream("gzip"))
+  ).blob()
+)};
+
+export default function define(runtime, observer) {
+  const main = runtime.module();
+  const $def = (pid, name, deps, fn) => {
+    main.variable(observer(name)).define(name, deps, fn).pid = pid;
+  };
+  const fileAttachments = new Map(["runtime.js.gz"].map((name) => {
+    const module_name = "@tomlarkworthy/observable-runtime";
+    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
+    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
+    return [name, {url: blob_url, mimeType: mime}]
+  }));
+  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  $def("_kvrivm", null, ["md"], _kvrivm);  
+  $def("_a188e4", "Runtime", ["observable"], _a188e4);  
+  $def("_nz6rsh", "Inspector", ["observable"], _nz6rsh);  
+  $def("_1s7i28f", "Library", ["observable"], _1s7i28f);  
+  $def("_1iyzb44", "RuntimeError", ["observable"], _1iyzb44);  
+  $def("_b2ba5g", "observable", ["unzip","FileAttachment"], _b2ba5g);  
+  $def("_17n6uge", "unzip", ["Response","DecompressionStream"], _17n6uge);
+  return main;
+}</script>
 
 <script id="@tomlarkworthy/observable-runtime-v6" 
   type="text/plain"
@@ -14623,7 +15844,7 @@ H4sICB8jLWcCA2Fjb3JuLXdhbGtAOC4zLjIuanMApVlbU+O4En6fX2E4VZQza5wAs8yC8XK47FZRNbcC
 >
 H4sICOAiLWcCA3BhcnNlckA2LjEuMC5qcwDtOmtz20aS3/MrIF6KAWIIFKX4ETCwYstKnW4V2yfJSW2ptKsh0KQmAgF6MJTEpfDfr3sewICknNzdbu1+2CqVOK/u6el3z2Dw7bdfed96bxdFlkPmjZfeb9U7yPmd8BYVL6beWZnni7l3tx+9/D4aeqzIvAsQFQjv7nk0/D7ajwj+g+BTXrDcm/AcYm9QzGeDH8sxLrtj4xxuPg/mjIB+fBENo71BJdIBLzJ4iH6rEJwwvCu99x8ucFPwzs9OvHsub7xsWbAZT1meL70pFCCYRBppi2rH+7kU4PFiUooZk7wsYu9GynkVDwb39/eIN1OniNJyNlAn2a0E3yW0uwbtrkKEew++4rN5KeTqorw9KgsJD9JjlQehLG8vlnOoqCfDj+oE1BbhFOQpL+AEt6eBop6IctZTx2ZpKYofX0XDYXQweAbVrDcy6GfsFmh1FbIihUqWChkPK5zP1Qxbx7N7z/JbRHYQ7Rtcd0x4ZVLAvXcO0r/svRGCLXuh/n27mExAYI/JckyDi4yX5kjYfZur0bdlmQMrqMWnJwXNjGXJ8CfFcYEjJLbc9i/4DMoFrUrLokJQaonlXJbYOFrgOWbHd6DQvGOS/cLhXjdpYQZpmcGnsxO3fVQiQwoNksEdT+Ejf4D8jORIQ2W6mOlZKFrwpu2CHwtR0oGhStmcNgRN+QRkeoO/P3FFL/2c8kqa5hmwTPHpp7xk8mDfMlF1X3zXdBdFSqqFzf9UEBW2TmZsCvaXDkztYsILLpeqKYcvLALstMix88ppE5W8+ongQDXfs/f4+1/nH+jnZzZX/yUdQs+8X8zGiuiC3fEpSpjaH8a/QUrHUval6LcdLdk5CGUiqHHY+4gI999RA/WMV6BbD0TSGSumYNl5BqhHyHB3INcbncH0+IGISwln/qbg2v5+EmxG+AR8XqByb4yjuuL/CqSjX9hrtetcCjRTaixn4zJXjUKyB0vCBSrxO6VCtndc2J684SQbsla7/BN3JUG9VhTUe9XpHOVsNofMjqE7BBQpZKrdKBcqX4P+7BT//wrsVouKWvqIv8L4vExvdbsUt4rAe3R35X3vKgjTpPJXJ8oj+MGqDslekKECqgq55aPXCUWwEj5EPMN27yRDTecTjmiCOvx5Icmh/mGAOhhNjBZ7cx9wHciFKBrVbhH1kiSBSCIHHx+baeR3zoSSY2ce+VTe/w4OVKwpyr4dqxtKcocSdErp7blEd6FsvkNFic7oyakPkyentk7Q8VsSFn8nZrQYb0gUwYqcpPREsqLZuOFCOC6zZXwJEf1e1WGhfDjqTohUGGOr4qpOYKSp8pgvwtURBr+WrBiS13qDFUVFgFiETEyVt6xiTsB84rsasJMkwpxDRBj2AAfk42MVqfD7YeKL4Ie9QO9IsEOc51EOxVTePD7u+L1TdE8CjRUPzC/3rhSufn/wl8tveleDSKKl+2pcsPsAeXUBGMuQ+dvB9mwXmiNVZrMgkDeoU552aBHDyWnhqzjXegH/+uuVrD1yMVxQXPYosmPszPV2XqV8iGd5ch2EqwJdRAxoB4pvl+wq4WGZuOdiirpDFqFTWkDMos8LVvGK6FQjmEOUt5Ch5a4qyYTEFeo3hCLDNv6vR0V0wyq/DA6LCHMDbETzRXXjp0FcRBUNhJfpFZpjmAZh0erMBHVmJdk0Rhtm9yjNKYZolldxEUZRhNqwqoNVDtLjJJxikec7iez3UXV5soyUm0cMlTmcx5KxGZQ0OPUZOoQiCO+pEYQ8wq0Shr+4WbKzI2rIMd/iSeaiMuo39XkIGhgbCFyj9leVl3noefHMmAZpVRSLFGMRwiLFqP/VAkOO3xXjCtIZ+wXjJ+nw8KAmfGp1DRQMztNyDq09evt91JVnz8ipRx/+apkVKsxRB6KGBy51x4FWgOlCoFHZyWiSs2nV7+/uPoG1xVPrUEq+R1u0wTtEVVkDRklE7J5xFIlvpli1LNJkZy8wiNeQaeRvCMb/MuYvIjQINLY/c8gzh31fRGfy6FKso7RYNE4ToFqkCrxA0ftBCFE1h1Q5mErv5MCcN1O4Uk2SdRFJ0V8p/bakNLh4QapCruCLuAwy9By42uS0C5b7PZUyK6LKhUgh6e6pPcJhi5m86RvMWf0gVoMY3hVKyCy9lMtVN+/Rb6DIepoS1/d3WOSSaHw/JJdXobA5+ojMt0BujzAP850z+DIaC5bCaTDa0cOsGTsLRmjiaPEBQg5H2kwna9BY2syYoZlN0CouBOM5nvaIJlpUwVhgcmJchGGycmDqiMGoiu4wB0ksDS5vaaKcIHeraKYzj2RHL+/3t603ixSArnogc6VKgcmyOb2B9PZTgX4c00HkfgvhLjgtMdJtzq3ty6pecIirclr9xzdUy7ftpieC2GJs93cX/8Lyc1W7WYiwh8LGwwsVDcygCruB4RdKqGqWmzBy3cZr75uvVy5Y/Y13Q3VhjhLMlt4YoPAypYqQXdM+LMu6+6AdqMizrsmV1eRGYXtBUBvjhrprGmtmryZ/Zssx/AmW96XInPTTqkjY6yayPcwGfh/Y6guWOuuJLSFw3JNDW63YdgR5jia35uiSvbDrN4fhpuMzY+QaUomWaVSqDSzD7zBTVLxTu9gUW7NEGFE6CiOUH8sSEer8LsHcINIEuNTgYEvFOlnWvTVxaJszInKs/zGkCet2dEaZ+VhTKEhezBcybK09UJ6oSlSGcoEZTYF78ISSipCpn5ErdIfJoevDtSH0+y4aNU2ZJckKitNDvuHK/XW3Q8bVgEE56fedfgUzjoHC2ZeUG0esuuGqSmdn/X6jRe3g46O/dlAHuUZVdDw/Lti2Xm0Nn3FjlvxzTWHTp60R3I0N8DkIOofQoaYjGFV5YRj03UGHJMxUVcKZMKcIcqhSpYJO7HtHlBtum0NJMGzyLLARnGSblrnawNpSS3c56Si+UXIeMqP1F+X8FO4g3+qjzGrMbGpZvlG5J3Gya8Bb+NtUc4cQa5+zBbx2DB6s0cmEDP/xEUZ+qZy+Vi8qhZrCrNcocDcKyO3+X1rPzzHFNrHq2uzuRK+2fG1NAoxuuxahx4wC6Y3BbvypsQDvVmskEQCGgGubH25uXa8HwK6LdMCcNV9mPLIxNox2DBOMh9eEa30kKbXeZC3HRAU67DnnwkrFKyeecoa92J2RZDjWmT5hlSr/t4kXr5yUA4I23dvIqLbmzPzJTKjj47FGqGuNeaY8OjLuuoc6TX8+JK8fIqr9iQAs+1RJtmxKsqxTkmGJBbYgU22HV+gRWHr734tSQuM6xJs8L+8xY9sZ1nQvyVluTtzUKpezKzf6GOm4sWJDHDbhV4456fVssSq28M29GMAs2uTOLdvs9cJxrq53/BWvLth0ClmMZ6Yin3JsYQr45LK4GjXk2DgzCroeJytzTKfe6kw87FDgZFIbvnHd4ZpcO7Sba9j/De2N2hRYpvO8yUuMAq1rigg3Lls2gsB2ZyqUX0c1a64hHlC+EBPvNL/mZfVDm0OYG5pm6tmzoMJKLjWs0WvSGyaOkK43JtLjOrIQhoXL9/vx01h3h02pj/MjU6oQ2MGLmC6k9g9sOfvkRs+GQWul2LcASrWMy200kheoiDyzvAs6QQRxJfsuy3R0XdMSTSVmzbUL3AVY28ZJyaIq5yn46x5MMczcsYz/33cs+/++Y/mXv2N5KpX5B1QzTV2yPc8DrZmOmf0D6xd0ej3X+Ux18pCUyoY1oYG6xt64eVHpAs0rcw4gaq/O7UR7m3S4MRLN2NynEArtdUIQY5hR9ytSLFcdjJbC/+O9ftW80soACyzcpjly2UWp74zBBoCdHUyL9RWCDJ58X2iBDvU1gEkxzYUzhM0bsZ64CoLOvTN6fNIENkMZleKYoTv3ZfIa8YSUWqiEpd+nTanlwGaaDhMCdPqmPb378BDfKESOQzdvlR+ZRM0sejFuL1BRhOTgkABEAm0QdGDVw5wDCjqIdgHRo22D/ai3WfZinNVpCK5xV5xBJU1Y1ots7r62TtcENNGQQqtzmDgrM5iwRS5j/Z5BUtBvFz3KoNNyWvC/YfY51wg8pU1e75nho2MX6hrmxqc7BX0d1U4ttQgoOxImwVcPP+2zJb37BCuK6CaFsuF2f1S8TvZGu7uFMrdulYJ6t/Alpk2B8yRUqhHMy+3YenlLrhBXmFLQF8m1rki8r1coFYUONUgXFVhTbC8D1jCYAmY7ihqp2qmUgYhg2zH+0FtSC0OVVlFKj+n0t+e+GjGdyJFk3HzJFgYQ/J4dqIFfmOB0nkZtSDLGkqk8kYFiNMlaGbHD/qfY1UpU882C/KFntFaRsQzyFCEM23eGTK8pArsvaJuWuHaO1jCDBzyNtC5tqwPYgG39wTbo1oxNsLwreUaiaE1605jXlzqG7chzrOX50Nqyzew4PcJa6TmhKFYQyWtjg+r2bIu1DZW19fs0T4qp7M7vIZ91LLvlRXY41yYX58b0lAWo5giirN1zw0vSgz8aQFCHW56ov0QhuP4A1imEgCjCgGEIwdZI+yGMAyHpfLthPAnV1c/fYWPY3f3SxrXeKG6jMkWwbowKjxjaIq5bVLC2UIU6FR90M6RT2AxDOezmYjyehWtX5c3Ie7SJao5FgDOl3nQ7emI0PF6GrSOIl+261vqcp/1xuBFdcOzTPKOSsV3WTUrWVTrsfheBCLrfUMRjRQWr1cVxnTLlukziRXbu5BcUv9WYvT6GCA9fsSk8S649/+uViHKMNXVMrbTMF7OiDq7p/aGkbKyF1AEsEWGGzkGCp+dq7ahAv0F3Ei9MlZqHicZG71ufq3Ktfn9LgrjTTRB1Skff+b2REg1HeaaE9EV9BtYOqvdD5DQbowc5ynm77l1nUL8zQorkmflz1VHjGEJQ1KmipIPj/cZE71+L9+scsinsJk/aGcuFdmTb+c1sK099xONEf+Tl9xSVyL7zZmRWZuZ9KjxpBq0a4OBtM0gRqud84HRH7FQeGJPv4xFJv40xnGIMXexifY4ZGBXT3ZJ5WAdNVluZq4tjFb69c7qJ4N3HCCU4umo4dp4l6PsW+wLRXMJ2BlUh5QzRnsk5XYlJXiygrpJbrCF4O9DduSkNHx/dUXVtQJhOWkDnKuV2jX74HDR3TYoK997lZG0xSSiwWEebjOj3OX0D8wPYL3ls6NSoTSStW4W3A/CgPovN6MtXKgz1B7bhkvr23sQZn9B4c/cY3qkuwO1JFqbUpk9l65FG6pkk3FPR56vB4D88/XUA6uKcF9NPZ6fJoJoNMjaewKv0OYwnr9hzdrB3MMmeP987eAUwefny1ffsJUvHL4bfPX+ZpbA3hvH4VXbwcnLA9sfP0zGkVFH+D3KMR1ZDLQAA
 </script>
-<script id="@tomlarkworthy/observablejs-toolchain"
+<script id="@tomlarkworthy/observablejs-toolchain" 
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -17700,8 +18921,7 @@ export default function define(runtime, observer) {
   main.define("Library", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Library", _));  
   main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));
   return main;
-}
-</script>
+}</script>
 
 <script id="@tomlarkworthy/reversible-attachment" 
   type="text/plain"

--- a/notebooks/@tomlarkworthy_editor-5.json
+++ b/notebooks/@tomlarkworthy_editor-5.json
@@ -68,10 +68,10 @@
       ]
     },
     "@tomlarkworthy/claude-code-pairing": {
-      "hash": "eb261fa59eff8c39dcce028c2992e8c4",
+      "hash": "e3d2efd40f14f02510af61a5df5b451c",
       "dependsOn": [
         "@tomlarkworthy/module-map",
-        "@tomlarkworthy/exporter-2",
+        "@tomlarkworthy/exporter-3",
         "@tomlarkworthy/observablejs-toolchain",
         "@tomlarkworthy/local-change-history",
         "@tomlarkworthy/runtime-sdk",
@@ -112,7 +112,7 @@
       ]
     },
     "@tomlarkworthy/editor-5": {
-      "hash": "c87ba2e3220fa0f518c060503c1f2986",
+      "hash": "d84ef7e2a1df180d1e1acfaaec951a1f",
       "files": [
         "cell_options.json"
       ],
@@ -145,7 +145,7 @@
       ]
     },
     "@tomlarkworthy/exporter-3": {
-      "hash": "fa9e0682efff3d0869b591b84790c0d7",
+      "hash": "12548ff77d201dd107f24d26dd2165e6",
       "dependsOn": [
         "@tomlarkworthy/observable-runtime-v6",
         "@tomlarkworthy/flow-queue",
@@ -161,17 +161,33 @@
         "@tomlarkworthy/themes"
       ],
       "dependedBy": [
+        "@tomlarkworthy/claude-code-pairing",
+        "@tomlarkworthy/file-sync",
         "@tomlarkworthy/local-change-history",
         "@tomlarkworthy/lopepage"
       ]
     },
+    "@tomlarkworthy/file-sync": {
+      "hash": "e379596265cd3030c6f98d97aa807b75",
+      "dependsOn": [
+        "@tomlarkworthy/module-map",
+        "@tomlarkworthy/exporter-3",
+        "@tomlarkworthy/runtime-sdk",
+        "@tomlarkworthy/local-change-history",
+        "@tomlarkworthy/fileattachments"
+      ],
+      "dependedBy": [
+        "@tomlarkworthy/claude-code-pairing"
+      ]
+    },
     "@tomlarkworthy/fileattachments": {
-      "hash": "fc07a6c8b39d5fa8495e9b9c8c75edf9",
+      "hash": "fba8f936fac563f937051341f9c4aaf4",
       "dependsOn": [
         "@tomlarkworthy/runtime-sdk"
       ],
       "dependedBy": [
         "@tomlarkworthy/editor-5",
+        "@tomlarkworthy/file-sync",
         "@tomlarkworthy/module-selection"
       ]
     },
@@ -262,7 +278,7 @@
       ]
     },
     "@tomlarkworthy/local-change-history": {
-      "hash": "9b6f7a7ec81fd30dcf36221c88767c5f",
+      "hash": "4be33bfdca2870137e4daf135bb96919",
       "dependsOn": [
         "@tomlarkworthy/runtime-sdk",
         "@tomlarkworthy/lightning-fs-4-6-0",
@@ -273,6 +289,7 @@
       ],
       "dependedBy": [
         "@tomlarkworthy/claude-code-pairing",
+        "@tomlarkworthy/file-sync",
         "@tomlarkworthy/lopepage"
       ]
     },
@@ -329,6 +346,7 @@
         "@tomlarkworthy/claude-code-pairing",
         "@tomlarkworthy/editor-5",
         "@tomlarkworthy/exporter-3",
+        "@tomlarkworthy/file-sync",
         "@tomlarkworthy/local-change-history",
         "@tomlarkworthy/module-selection",
         "@tomlarkworthy/spectral-layout",
@@ -350,6 +368,15 @@
         "@tomlarkworthy/lopepage"
       ]
     },
+    "@tomlarkworthy/observable-runtime": {
+      "hash": "015af244c77d1c0a73fb2aad51c8da83",
+      "files": [
+        "runtime.js.gz"
+      ],
+      "dependedBy": [
+        "@tomlarkworthy/observablejs-toolchain"
+      ]
+    },
     "@tomlarkworthy/observable-runtime-v6": {
       "hash": "060835989c27d5cd2f82d358975a0328",
       "dependedBy": [
@@ -357,7 +384,7 @@
       ]
     },
     "@tomlarkworthy/observablejs-toolchain": {
-      "hash": "810bcb2969379425aaeab9ee806876e6",
+      "hash": "4fef8e87ae193330ccb6af2ac955aa86",
       "files": [
         "acorn-walk-8.3.2.js.gz",
         "parser-6.1.0.js.gz"
@@ -367,7 +394,8 @@
         "@tomlarkworthy/cell-map",
         "@tomlarkworthy/escodegen",
         "@tomlarkworthy/acorn-8-11-3",
-        "@tomlarkworthy/jest-expect-standalone"
+        "@tomlarkworthy/jest-expect-standalone",
+        "@tomlarkworthy/observable-runtime"
       ],
       "dependedBy": [
         "@tomlarkworthy/cell-map",
@@ -399,6 +427,7 @@
         "@tomlarkworthy/dataflow-templating",
         "@tomlarkworthy/editor-5",
         "@tomlarkworthy/exporter-3",
+        "@tomlarkworthy/file-sync",
         "@tomlarkworthy/fileattachments",
         "@tomlarkworthy/import-notebook",
         "@tomlarkworthy/local-change-history",

--- a/notebooks/@tomlarkworthy_exporter-2.html
+++ b/notebooks/@tomlarkworthy_exporter-2.html
@@ -4690,7 +4690,7 @@ export default function define(runtime, observer) {
 >
 e30K
 </script>
-<script id="@tomlarkworthy/editor-5" 
+<script id="@tomlarkworthy/editor-5"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -4737,7 +4737,6 @@ md`## TODO
 const _1ociws4 = function _6(md){return(
 md`## Sync editors`
 )};
-const _1vq49kx = (_, v) => v.import("syncers", _);
 const _hdieof = function _editors(){return(
 new Map()
 )};
@@ -4815,12 +4814,12 @@ Inputs.toggle({
   value: !isOnObservableCom()
 })
 )};
+const _1oaz8r1 = (G, _) => G.input(_);
 const _16ks4jz = function _12(md){return(
 md`## \`cellEditor\` component
 
 Using Dataflow templating to create reusable Hotbar Component builder`
 )};
-const _1deps8p = (_, v) => v.import("cloneDataflow", _);
 const _199ztvl = function _hotbarTemplate(lookupVariable,editorModule){return(
 lookupVariable(
   [
@@ -5057,6 +5056,7 @@ md`## Hotbar Prototype`
 const _1o2h65s = function _editedCell(Inputs){return(
 Inputs.input(null)
 )};
+const _7g3h7h = (G, _) => G.input(_);
 const _1urs1md = function _findCell($0,modules){return(
 (variable, dom = undefined) => {
   if (variable) {
@@ -5216,9 +5216,11 @@ Inputs.toggle({
   value: true
 })
 )};
+const _1h8337z = (G, _) => G.input(_);
 const _tct2nf = function _edit(Inputs){return(
 Inputs.toggle({ label: "edit" })
 )};
+const _7izj7k = (G, _) => G.input(_);
 const _1fwb5jc = function _toolbar(htl,reversibleAttach,combine,$0,$1,$2,$3,$4,$5,$6,$7){return(
 htl.html`<div
     class="toolbar"
@@ -5246,11 +5248,13 @@ Inputs.button("➕", {
   }
 })
 )};
+const _1aii9ps = (G, _) => G.input(_);
 const _1bn860e = function _remove(Inputs,deleteCell,$0){return(
 Inputs.button("🗑️", {
   reduce: () => deleteCell({ cell: $0.value })
 })
 )};
+const _1ad0xr8 = (G, _) => G.input(_);
 const _tw1j7n = function _apply(Inputs,compile_and_update,states,editedCell)
 {
   const button = Inputs.button("▶️", {
@@ -5269,11 +5273,13 @@ const _tw1j7n = function _apply(Inputs,compile_and_update,states,editedCell)
   button.onmousedown = (e) => e.preventDefault();
   return button;
 };
+const _1cjyuqm = (G, _) => G.input(_);
 const _14rfku9 = function _up(Inputs,moveCell,$0){return(
 Inputs.button("⬆", {
   reduce: () => moveCell($0.value, -1)
 })
 )};
+const _frzs5d = (G, _) => G.input(_);
 const _9pymuj = function _paste(Inputs,readObservableClipboardCells,pasteObservableCellsIntoModule,editedCell){return(
 Inputs.button("📋", {
   reduce: async () => {
@@ -5282,11 +5288,13 @@ Inputs.button("📋", {
   }
 })
 )};
+const _1whsszt = (G, _) => G.input(_);
 const _corxwl = function _down(Inputs,moveCell,$0){return(
 Inputs.button("⬇", {
   reduce: () => moveCell($0.value, 1)
 })
 )};
+const _1to28po = (G, _) => G.input(_);
 const _gia2ci = function _copy(Inputs,html,$0,decompile,$1,getOption,cellsToClipboard){return(
 Inputs.button(
   html`<span style="font-size: .875em; margin-right: .125em; position: relative; top: -.25em; left: -.125em">
@@ -5328,6 +5336,7 @@ Inputs.button(
   }
 )
 )};
+const _fw41wt = (G, _) => G.input(_);
 const _srtw8o = function _module(editedCell){return(
 editedCell.module.module
 )};
@@ -5382,6 +5391,7 @@ md`## API handler`
 const _d7ouqx = function _command(flowQueue){return(
 flowQueue()
 )};
+const _118qt2v = (G, _) => G.input(_);
 const _19l2nem = function _54(command){return(
 command
 )};
@@ -5654,10 +5664,10 @@ const _rtf009 = function _select(editedCell,Inputs,getOption,setOption){return(
   return el;
 })()
 )};
+const _14mwbuc = (G, _) => G.input(_);
 const _l4sbcd = function _70(md){return(
 md`## Pinning`
 )};
-const _1sxszb9 = (_, v) => v.import("getFileAttachment", _);
 const _ezl7wk = function _72(FileAttachment){return(
 FileAttachment("cell_options.json")
 )};
@@ -5667,6 +5677,7 @@ getFileAttachment("cell_options.json", editorModule)
 const _760ozq = async function _options(Inputs,optionsFile){return(
 Inputs.input(await optionsFile.json())
 )};
+const _4rh26k = (G, _) => G.input(_);
 const _1lqy7cs = function _setOption(findCell,_,$0,Event){return(
 (variable, option, value) => {
   const cell = findCell(variable);
@@ -5846,6 +5857,7 @@ const _1j3c2uf = function _decompiled(editedCell,decompile)
 const _w5q3yf = function _editorModule(thisModule){return(
 thisModule()
 )};
+const _18kaj2p = (G, _) => G.input(_);
 const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_options)
 {
   //editedCell;
@@ -5857,43 +5869,47 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1ju14cq = function _compile_and_update(compile,runtime,repositionSetElement){return(
-(source, variables = [], cell) => {
-    try {
-        debugger;
-        let reposition = false, insertionIndex = -1;
-        const newVariables = compile(source);
-        if (!variables || variables.length !== newVariables.length) {
-            reposition = true;
-            variables.forEach(v => v.delete());
-            variables.length = 0;
-            for (let i = 0; i < newVariables.length; i++) {
-                const newVariable = cell.module.module.variable({});
-                variables.push(newVariable);
+const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+{
+    return (source, variables = [], cell) => {
+        try {
+            debugger;
+            let reposition = false, insertionIndex = -1;
+            const newVariables = compile(source);
+            if (!variables || variables.length !== newVariables.length) {
+                reposition = true;
+                variables.forEach(v => v.delete());
+                variables.length = 0;
+                for (let i = 0; i < newVariables.length; i++) {
+                    const newVariable = cell.module.module.variable({});
+                    // Assign a random pid up-front so blank/identical new cells don't
+                    // collide via persistentId's contentHash. See lopecode#144.
+                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+                    variables.push(newVariable);
+                }
             }
-        }
-        if (reposition) {
-            insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-        }
-        newVariables.forEach((v, i) => {
-            const variable = variables[i];
-            let _fn;
-            eval('_fn = ' + v._definition);
-            if (v._name) {
-                variable.define(v._name, v._inputs, _fn);
-            } else {
-                variable.define(v._inputs, _fn);
+            if (reposition) {
+                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
-            if (reposition)
-                repositionSetElement(runtime._variables, variable, insertionIndex + i);
-        });
-        return variables;
-    } catch (e) {
-        console.error(e);
-        debugger;
-    }
-}
-)};
+            newVariables.forEach((v, i) => {
+                const variable = variables[i];
+                let _fn;
+                eval('_fn = ' + v._definition);
+                if (v._name) {
+                    variable.define(v._name, v._inputs, _fn);
+                } else {
+                    variable.define(v._inputs, _fn);
+                }
+                if (reposition)
+                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
+            });
+            return variables;
+        } catch (e) {
+            console.error(e);
+            debugger;
+        }
+    };
+};
 const _1jqs8in = function _91(md){return(
 md`### Remove Cells`
 )};
@@ -5912,6 +5928,7 @@ Inputs.radio(editedCell.variables, {
   value: editedCell.variables[0]
 })
 )};
+const _11gvkq4 = (G, _) => G.input(_);
 const _r5nvms = function _name(variable){return(
 variable._name
 )};
@@ -5925,6 +5942,7 @@ Inputs.textarea({
   rows: 10
 })
 )};
+const _b4rsn5 = (G, _) => G.input(_);
 const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
@@ -5938,22 +5956,12 @@ Inputs.button("update variable", {
 const _1q557s = function _99(md){return(
 md`### Editor Libraries`
 )};
-const _192vvs7 = (_, v) => v.import("descendants", _);
-const _3va6tf = (_, v) => v.import("EditorState", _);
-const _lmqjiv = (_, v) => v.import("decompile", _);
 const _1d94dks = function _javascriptPlugin(codemirror){return(
 codemirror
 )};
 const _ar9tao = function _104(md){return(
 md`### Libraries`
 )};
-const _viogn = (_, v) => v.import("reversibleAttach", _);
-const _nxg8mr = (_, v) => v.import("moduleMap", _);
-const _14a94d = (_, v) => v.import("flowQueue", _);
-const _gurtwb = (_, v) => v.import("viewof liveCellMap", _);
-const _19ebgtz = (_, v) => v.import("hash", _);
-const _n2vgkz = (_, v) => v.import("extractNotebookAndCell", _);
-const _1qucevb = (_, v) => v.import("cellsToClipboard", _);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -5967,22 +5975,34 @@ export default function define(runtime, observer) {
     return [name, {url: blob_url, mimeType: mime}]
   }));
   main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
+  main.define("module @tomlarkworthy/dataflow-templating", async () => runtime.module((await import("/@tomlarkworthy/dataflow-templating.js?v=4")).default));  
+  main.define("module @tomlarkworthy/fileattachments", async () => runtime.module((await import("/@tomlarkworthy/fileattachments.js?v=4")).default));  
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/codemirror-6-v2", async () => runtime.module((await import("/@tomlarkworthy/codemirror-6-v2.js?v=4")).default));  
+  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
+  main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
+  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
+  main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
+  main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
+  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
+  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
+  main.define("module @tomlarkworthy/cells-to-clipboard", async () => runtime.module((await import("/@tomlarkworthy/cells-to-clipboard.js?v=4")).default));  
   $def("_1tdjp0a", "title", ["md"], _1tdjp0a);  
   $def("_dm53bx", null, ["md"], _dm53bx);  
   $def("_61oxjf", "title_variable", ["lookupVariable","editorModule"], _61oxjf);  
   $def("_15uilf0", null, ["cellEditor","title_variable"], _15uilf0);  
   $def("_3x695f", null, ["md"], _3x695f);  
   $def("_1ociws4", null, ["md"], _1ociws4);  
-  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
   $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
-  main.variable(observer("attachContextManu")).define("attachContextManu", ["Generators", "viewof attachContextManu"], (G, _) => G.input(_));  
+  $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
   $def("_16ks4jz", null, ["md"], _16ks4jz);  
-  main.define("module @tomlarkworthy/dataflow-templating", async () => runtime.module((await import("/@tomlarkworthy/dataflow-templating.js?v=4")).default));  
   main.define("cloneDataflow", ["module @tomlarkworthy/dataflow-templating", "@variable"], (_, v) => v.import("cloneDataflow", _));  
   main.define("lookupVariable", ["module @tomlarkworthy/dataflow-templating", "@variable"], (_, v) => v.import("lookupVariable", _));  
   $def("_199ztvl", "hotbarTemplate", ["lookupVariable","editorModule"], _199ztvl);  
@@ -5993,7 +6013,7 @@ export default function define(runtime, observer) {
   $def("_110gwi7", "editorTemplate", ["lookupVariable","editorModule"], _110gwi7);  
   $def("_16rqzgl", null, ["md"], _16rqzgl);  
   $def("_1o2h65s", "viewof editedCell", ["Inputs"], _1o2h65s);  
-  main.variable(observer("editedCell")).define("editedCell", ["Generators", "viewof editedCell"], (G, _) => G.input(_));  
+  $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
   $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
@@ -6008,24 +6028,24 @@ export default function define(runtime, observer) {
   $def("_mrrmx3", null, ["md"], _mrrmx3);  
   $def("_14b1byw", null, ["md"], _14b1byw);  
   $def("_1j1loxx", "viewof combine", ["Inputs"], _1j1loxx);  
-  main.variable(observer("combine")).define("combine", ["Generators", "viewof combine"], (G, _) => G.input(_));  
+  $def("_1h8337z", "combine", ["Generators","viewof combine"], _1h8337z);  
   $def("_tct2nf", "viewof edit", ["Inputs"], _tct2nf);  
-  main.variable(observer("edit")).define("edit", ["Generators", "viewof edit"], (G, _) => G.input(_));  
+  $def("_7izj7k", "edit", ["Generators","viewof edit"], _7izj7k);  
   $def("_1fwb5jc", "toolbar", ["htl","reversibleAttach","combine","viewof select","viewof up","viewof down","viewof remove","viewof addCells","viewof apply","viewof copy","viewof paste"], _1fwb5jc);  
   $def("_yej3hb", "viewof addCells", ["Inputs","createCell","viewof editedCell"], _yej3hb);  
-  main.variable(observer("addCells")).define("addCells", ["Generators", "viewof addCells"], (G, _) => G.input(_));  
+  $def("_1aii9ps", "addCells", ["Generators","viewof addCells"], _1aii9ps);  
   $def("_1bn860e", "viewof remove", ["Inputs","deleteCell","viewof editedCell"], _1bn860e);  
-  main.variable(observer("remove")).define("remove", ["Generators", "viewof remove"], (G, _) => G.input(_));  
+  $def("_1ad0xr8", "remove", ["Generators","viewof remove"], _1ad0xr8);  
   $def("_tw1j7n", "viewof apply", ["Inputs","compile_and_update","states","editedCell"], _tw1j7n);  
-  main.variable(observer("apply")).define("apply", ["Generators", "viewof apply"], (G, _) => G.input(_));  
+  $def("_1cjyuqm", "apply", ["Generators","viewof apply"], _1cjyuqm);  
   $def("_14rfku9", "viewof up", ["Inputs","moveCell","viewof editedCell"], _14rfku9);  
-  main.variable(observer("up")).define("up", ["Generators", "viewof up"], (G, _) => G.input(_));  
+  $def("_frzs5d", "up", ["Generators","viewof up"], _frzs5d);  
   $def("_9pymuj", "viewof paste", ["Inputs","readObservableClipboardCells","pasteObservableCellsIntoModule","editedCell"], _9pymuj);  
-  main.variable(observer("paste")).define("paste", ["Generators", "viewof paste"], (G, _) => G.input(_));  
+  $def("_1whsszt", "paste", ["Generators","viewof paste"], _1whsszt);  
   $def("_corxwl", "viewof down", ["Inputs","moveCell","viewof editedCell"], _corxwl);  
-  main.variable(observer("down")).define("down", ["Generators", "viewof down"], (G, _) => G.input(_));  
+  $def("_1to28po", "down", ["Generators","viewof down"], _1to28po);  
   $def("_gia2ci", "viewof copy", ["Inputs","html","viewof editedCell","decompile","viewof liveCellMap","getOption","cellsToClipboard"], _gia2ci);  
-  main.variable(observer("copy")).define("copy", ["Generators", "viewof copy"], (G, _) => G.input(_));  
+  $def("_fw41wt", "copy", ["Generators","viewof copy"], _fw41wt);  
   $def("_srtw8o", "module", ["editedCell"], _srtw8o);  
   $def("_rv7t7x", "code_editor_view", ["EditorView"], _rv7t7x);  
   $def("_xvo1n6", "code_editor", ["code_editor_view"], _xvo1n6);  
@@ -6035,7 +6055,7 @@ export default function define(runtime, observer) {
   $def("_d9nzys", "deleteCell", ["viewof command"], _d9nzys);  
   $def("_c1u9w8", null, ["md"], _c1u9w8);  
   $def("_d7ouqx", "viewof command", ["flowQueue"], _d7ouqx);  
-  main.variable(observer("command")).define("command", ["Generators", "viewof command"], (G, _) => G.input(_));  
+  $def("_118qt2v", "command", ["Generators","viewof command"], _118qt2v);  
   $def("_19l2nem", null, ["command"], _19l2nem);  
   $def("_1f6v167", "findCellByVariable", [], _1f6v167);  
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
@@ -6052,9 +6072,8 @@ export default function define(runtime, observer) {
   $def("_dvne2z", "replaceCodeMirrorDoc", [], _dvne2z);  
   $def("_1fpqfm0", null, ["md"], _1fpqfm0);  
   $def("_rtf009", "viewof select", ["editedCell","Inputs","getOption","setOption"], _rtf009);  
-  main.variable(observer("select")).define("select", ["Generators", "viewof select"], (G, _) => G.input(_));  
+  $def("_14mwbuc", "select", ["Generators","viewof select"], _14mwbuc);  
   $def("_l4sbcd", null, ["md"], _l4sbcd);  
-  main.define("module @tomlarkworthy/fileattachments", async () => runtime.module((await import("/@tomlarkworthy/fileattachments.js?v=4")).default));  
   main.define("getFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachment", _));  
   main.define("setFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("setFileAttachment", _));  
   main.define("removeFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("removeFileAttachment", _));  
@@ -6063,7 +6082,7 @@ export default function define(runtime, observer) {
   $def("_ezl7wk", null, ["FileAttachment"], _ezl7wk);  
   $def("_kygz54", "optionsFile", ["getFileAttachment","editorModule"], _kygz54);  
   $def("_760ozq", "viewof options", ["Inputs","optionsFile"], _760ozq);  
-  main.variable(observer("options")).define("options", ["Generators", "viewof options"], (G, _) => G.input(_));  
+  $def("_4rh26k", "options", ["Generators","viewof options"], _4rh26k);  
   $def("_1lqy7cs", "setOption", ["findCell","_","viewof options","Event"], _1lqy7cs);  
   $def("_1oxe5ee", "getOption", ["findCell","_","viewof options"], _1oxe5ee);  
   $def("_kwq69p", "save_options", ["setFileAttachment","jsonFileAttachment","options","editorModule"], _kwq69p);  
@@ -6077,22 +6096,21 @@ export default function define(runtime, observer) {
   $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
   $def("_1j3c2uf", "decompiled", ["editedCell","decompile"], _1j3c2uf);  
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
-  main.variable(observer("editorModule")).define("editorModule", ["Generators", "viewof editorModule"], (G, _) => G.input(_));  
+  $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1ju14cq", "compile_and_update", ["compile","runtime","repositionSetElement"], _1ju14cq);  
+  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
   $def("_rwez9", "viewof variable", ["Inputs","editedCell"], _rwez9);  
-  main.variable(observer("variable")).define("variable", ["Generators", "viewof variable"], (G, _) => G.input(_));  
+  $def("_11gvkq4", "variable", ["Generators","viewof variable"], _11gvkq4);  
   $def("_r5nvms", "name", ["variable"], _r5nvms);  
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
-  main.variable(observer("definition")).define("definition", ["Generators", "viewof definition"], (G, _) => G.input(_));  
+  $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
   $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
   $def("_1q557s", null, ["md"], _1q557s);  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -6103,12 +6121,10 @@ export default function define(runtime, observer) {
   main.define("isnode", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("isnode", _));  
   main.define("repositionSetElement", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("repositionSetElement", _));  
   main.define("onCodeChange", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("onCodeChange", _));  
-  main.define("module @tomlarkworthy/codemirror-6-v2", async () => runtime.module((await import("/@tomlarkworthy/codemirror-6-v2.js?v=4")).default));  
   main.define("EditorState", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("EditorState", _));  
   main.define("EditorView", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("EditorView", _));  
   main.define("codemirror", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("codemirror", _));  
   main.define("myDefaultTheme", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("myDefaultTheme", _));  
-  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
   main.define("decompile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("decompile", _));  
   main.define("compile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("compile", _));  
   main.define("cellMap", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("cellMap", _));  
@@ -6117,27 +6133,21 @@ export default function define(runtime, observer) {
   main.define("parser", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("parser", _));  
   $def("_1d94dks", "javascriptPlugin", ["codemirror"], _1d94dks);  
   $def("_ar9tao", null, ["md"], _ar9tao);  
-  main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
   main.define("reversibleAttach", ["module @tomlarkworthy/reversible-attachment", "@variable"], (_, v) => v.import("reversibleAttach", _));  
-  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
   main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
-  main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
   main.define("flowQueue", ["module @tomlarkworthy/flow-queue", "@variable"], (_, v) => v.import("flowQueue", _));  
-  main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
   main.define("viewof liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("viewof liveCellMap", _));  
   main.define("liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("liveCellMap", _));  
-  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
   main.define("hash", ["module d/57d79353bac56631@44", "@variable"], (_, v) => v.import("hash", _));  
-  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
   main.define("extractNotebookAndCell", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("extractNotebookAndCell", _));  
   main.define("navHref", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("navHref", _));  
-  main.define("module @tomlarkworthy/cells-to-clipboard", async () => runtime.module((await import("/@tomlarkworthy/cells-to-clipboard.js?v=4")).default));  
   main.define("cellsToClipboard", ["module @tomlarkworthy/cells-to-clipboard", "@variable"], (_, v) => v.import("cellsToClipboard", _));
   return main;
-}</script>
+}
+</script>
 <script id="@tomlarkworthy/escodegen/escodegen.browser.min.js.gz" 
   type="text/plain"
   data-encoding="base64"

--- a/notebooks/@tomlarkworthy_exporter-3.html
+++ b/notebooks/@tomlarkworthy_exporter-3.html
@@ -4667,7 +4667,7 @@ export default function define(runtime, observer) {
 >
 e30K
 </script>
-<script id="@tomlarkworthy/editor-5" 
+<script id="@tomlarkworthy/editor-5"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -5846,43 +5846,47 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1ju14cq = function _compile_and_update(compile,runtime,repositionSetElement){return(
-(source, variables = [], cell) => {
-    try {
-        debugger;
-        let reposition = false, insertionIndex = -1;
-        const newVariables = compile(source);
-        if (!variables || variables.length !== newVariables.length) {
-            reposition = true;
-            variables.forEach(v => v.delete());
-            variables.length = 0;
-            for (let i = 0; i < newVariables.length; i++) {
-                const newVariable = cell.module.module.variable({});
-                variables.push(newVariable);
+const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+{
+    return (source, variables = [], cell) => {
+        try {
+            debugger;
+            let reposition = false, insertionIndex = -1;
+            const newVariables = compile(source);
+            if (!variables || variables.length !== newVariables.length) {
+                reposition = true;
+                variables.forEach(v => v.delete());
+                variables.length = 0;
+                for (let i = 0; i < newVariables.length; i++) {
+                    const newVariable = cell.module.module.variable({});
+                    // Assign a random pid up-front so blank/identical new cells don't
+                    // collide via persistentId's contentHash. See lopecode#144.
+                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+                    variables.push(newVariable);
+                }
             }
-        }
-        if (reposition) {
-            insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-        }
-        newVariables.forEach((v, i) => {
-            const variable = variables[i];
-            let _fn;
-            eval('_fn = ' + v._definition);
-            if (v._name) {
-                variable.define(v._name, v._inputs, _fn);
-            } else {
-                variable.define(v._inputs, _fn);
+            if (reposition) {
+                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
-            if (reposition)
-                repositionSetElement(runtime._variables, variable, insertionIndex + i);
-        });
-        return variables;
-    } catch (e) {
-        console.error(e);
-        debugger;
-    }
-}
-)};
+            newVariables.forEach((v, i) => {
+                const variable = variables[i];
+                let _fn;
+                eval('_fn = ' + v._definition);
+                if (v._name) {
+                    variable.define(v._name, v._inputs, _fn);
+                } else {
+                    variable.define(v._inputs, _fn);
+                }
+                if (reposition)
+                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
+            });
+            return variables;
+        } catch (e) {
+            console.error(e);
+            debugger;
+        }
+    };
+};
 const _1jqs8in = function _91(md){return(
 md`### Remove Cells`
 )};
@@ -6072,7 +6076,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1ju14cq", "compile_and_update", ["compile","runtime","repositionSetElement"], _1ju14cq);  
+  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -6119,7 +6123,8 @@ export default function define(runtime, observer) {
   main.define("navHref", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("navHref", _));  
   main.define("cellsToClipboard", ["module @tomlarkworthy/cells-to-clipboard", "@variable"], (_, v) => v.import("cellsToClipboard", _));
   return main;
-}</script>
+}
+</script>
 <script id="@tomlarkworthy/escodegen/escodegen.browser.min.js.gz" 
   type="text/plain"
   data-encoding="base64"

--- a/notebooks/@tomlarkworthy_fileattachments.html
+++ b/notebooks/@tomlarkworthy_fileattachments.html
@@ -4667,7 +4667,7 @@ export default function define(runtime, observer) {
 >
 e30K
 </script>
-<script id="@tomlarkworthy/editor-5" 
+<script id="@tomlarkworthy/editor-5"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -5846,43 +5846,47 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1ju14cq = function _compile_and_update(compile,runtime,repositionSetElement){return(
-(source, variables = [], cell) => {
-    try {
-        debugger;
-        let reposition = false, insertionIndex = -1;
-        const newVariables = compile(source);
-        if (!variables || variables.length !== newVariables.length) {
-            reposition = true;
-            variables.forEach(v => v.delete());
-            variables.length = 0;
-            for (let i = 0; i < newVariables.length; i++) {
-                const newVariable = cell.module.module.variable({});
-                variables.push(newVariable);
+const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+{
+    return (source, variables = [], cell) => {
+        try {
+            debugger;
+            let reposition = false, insertionIndex = -1;
+            const newVariables = compile(source);
+            if (!variables || variables.length !== newVariables.length) {
+                reposition = true;
+                variables.forEach(v => v.delete());
+                variables.length = 0;
+                for (let i = 0; i < newVariables.length; i++) {
+                    const newVariable = cell.module.module.variable({});
+                    // Assign a random pid up-front so blank/identical new cells don't
+                    // collide via persistentId's contentHash. See lopecode#144.
+                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+                    variables.push(newVariable);
+                }
             }
-        }
-        if (reposition) {
-            insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-        }
-        newVariables.forEach((v, i) => {
-            const variable = variables[i];
-            let _fn;
-            eval('_fn = ' + v._definition);
-            if (v._name) {
-                variable.define(v._name, v._inputs, _fn);
-            } else {
-                variable.define(v._inputs, _fn);
+            if (reposition) {
+                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
-            if (reposition)
-                repositionSetElement(runtime._variables, variable, insertionIndex + i);
-        });
-        return variables;
-    } catch (e) {
-        console.error(e);
-        debugger;
-    }
-}
-)};
+            newVariables.forEach((v, i) => {
+                const variable = variables[i];
+                let _fn;
+                eval('_fn = ' + v._definition);
+                if (v._name) {
+                    variable.define(v._name, v._inputs, _fn);
+                } else {
+                    variable.define(v._inputs, _fn);
+                }
+                if (reposition)
+                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
+            });
+            return variables;
+        } catch (e) {
+            console.error(e);
+            debugger;
+        }
+    };
+};
 const _1jqs8in = function _91(md){return(
 md`### Remove Cells`
 )};
@@ -6072,7 +6076,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1ju14cq", "compile_and_update", ["compile","runtime","repositionSetElement"], _1ju14cq);  
+  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -6119,7 +6123,8 @@ export default function define(runtime, observer) {
   main.define("navHref", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("navHref", _));  
   main.define("cellsToClipboard", ["module @tomlarkworthy/cells-to-clipboard", "@variable"], (_, v) => v.import("cellsToClipboard", _));
   return main;
-}</script>
+}
+</script>
 <script id="@tomlarkworthy/escodegen/escodegen.browser.min.js.gz" 
   type="text/plain"
   data-encoding="base64"

--- a/notebooks/@tomlarkworthy_flow-queue.html
+++ b/notebooks/@tomlarkworthy_flow-queue.html
@@ -4690,7 +4690,7 @@ export default function define(runtime, observer) {
 >
 e30K
 </script>
-<script id="@tomlarkworthy/editor-5" 
+<script id="@tomlarkworthy/editor-5"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -4737,7 +4737,6 @@ md`## TODO
 const _1ociws4 = function _6(md){return(
 md`## Sync editors`
 )};
-const _1vq49kx = (_, v) => v.import("syncers", _);
 const _hdieof = function _editors(){return(
 new Map()
 )};
@@ -4815,12 +4814,12 @@ Inputs.toggle({
   value: !isOnObservableCom()
 })
 )};
+const _1oaz8r1 = (G, _) => G.input(_);
 const _16ks4jz = function _12(md){return(
 md`## \`cellEditor\` component
 
 Using Dataflow templating to create reusable Hotbar Component builder`
 )};
-const _1deps8p = (_, v) => v.import("cloneDataflow", _);
 const _199ztvl = function _hotbarTemplate(lookupVariable,editorModule){return(
 lookupVariable(
   [
@@ -5057,6 +5056,7 @@ md`## Hotbar Prototype`
 const _1o2h65s = function _editedCell(Inputs){return(
 Inputs.input(null)
 )};
+const _7g3h7h = (G, _) => G.input(_);
 const _1urs1md = function _findCell($0,modules){return(
 (variable, dom = undefined) => {
   if (variable) {
@@ -5216,9 +5216,11 @@ Inputs.toggle({
   value: true
 })
 )};
+const _1h8337z = (G, _) => G.input(_);
 const _tct2nf = function _edit(Inputs){return(
 Inputs.toggle({ label: "edit" })
 )};
+const _7izj7k = (G, _) => G.input(_);
 const _1fwb5jc = function _toolbar(htl,reversibleAttach,combine,$0,$1,$2,$3,$4,$5,$6,$7){return(
 htl.html`<div
     class="toolbar"
@@ -5246,11 +5248,13 @@ Inputs.button("➕", {
   }
 })
 )};
+const _1aii9ps = (G, _) => G.input(_);
 const _1bn860e = function _remove(Inputs,deleteCell,$0){return(
 Inputs.button("🗑️", {
   reduce: () => deleteCell({ cell: $0.value })
 })
 )};
+const _1ad0xr8 = (G, _) => G.input(_);
 const _tw1j7n = function _apply(Inputs,compile_and_update,states,editedCell)
 {
   const button = Inputs.button("▶️", {
@@ -5269,11 +5273,13 @@ const _tw1j7n = function _apply(Inputs,compile_and_update,states,editedCell)
   button.onmousedown = (e) => e.preventDefault();
   return button;
 };
+const _1cjyuqm = (G, _) => G.input(_);
 const _14rfku9 = function _up(Inputs,moveCell,$0){return(
 Inputs.button("⬆", {
   reduce: () => moveCell($0.value, -1)
 })
 )};
+const _frzs5d = (G, _) => G.input(_);
 const _9pymuj = function _paste(Inputs,readObservableClipboardCells,pasteObservableCellsIntoModule,editedCell){return(
 Inputs.button("📋", {
   reduce: async () => {
@@ -5282,11 +5288,13 @@ Inputs.button("📋", {
   }
 })
 )};
+const _1whsszt = (G, _) => G.input(_);
 const _corxwl = function _down(Inputs,moveCell,$0){return(
 Inputs.button("⬇", {
   reduce: () => moveCell($0.value, 1)
 })
 )};
+const _1to28po = (G, _) => G.input(_);
 const _gia2ci = function _copy(Inputs,html,$0,decompile,$1,getOption,cellsToClipboard){return(
 Inputs.button(
   html`<span style="font-size: .875em; margin-right: .125em; position: relative; top: -.25em; left: -.125em">
@@ -5328,6 +5336,7 @@ Inputs.button(
   }
 )
 )};
+const _fw41wt = (G, _) => G.input(_);
 const _srtw8o = function _module(editedCell){return(
 editedCell.module.module
 )};
@@ -5382,6 +5391,7 @@ md`## API handler`
 const _d7ouqx = function _command(flowQueue){return(
 flowQueue()
 )};
+const _118qt2v = (G, _) => G.input(_);
 const _19l2nem = function _54(command){return(
 command
 )};
@@ -5654,10 +5664,10 @@ const _rtf009 = function _select(editedCell,Inputs,getOption,setOption){return(
   return el;
 })()
 )};
+const _14mwbuc = (G, _) => G.input(_);
 const _l4sbcd = function _70(md){return(
 md`## Pinning`
 )};
-const _1sxszb9 = (_, v) => v.import("getFileAttachment", _);
 const _ezl7wk = function _72(FileAttachment){return(
 FileAttachment("cell_options.json")
 )};
@@ -5667,6 +5677,7 @@ getFileAttachment("cell_options.json", editorModule)
 const _760ozq = async function _options(Inputs,optionsFile){return(
 Inputs.input(await optionsFile.json())
 )};
+const _4rh26k = (G, _) => G.input(_);
 const _1lqy7cs = function _setOption(findCell,_,$0,Event){return(
 (variable, option, value) => {
   const cell = findCell(variable);
@@ -5846,6 +5857,7 @@ const _1j3c2uf = function _decompiled(editedCell,decompile)
 const _w5q3yf = function _editorModule(thisModule){return(
 thisModule()
 )};
+const _18kaj2p = (G, _) => G.input(_);
 const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_options)
 {
   //editedCell;
@@ -5857,43 +5869,47 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1ju14cq = function _compile_and_update(compile,runtime,repositionSetElement){return(
-(source, variables = [], cell) => {
-    try {
-        debugger;
-        let reposition = false, insertionIndex = -1;
-        const newVariables = compile(source);
-        if (!variables || variables.length !== newVariables.length) {
-            reposition = true;
-            variables.forEach(v => v.delete());
-            variables.length = 0;
-            for (let i = 0; i < newVariables.length; i++) {
-                const newVariable = cell.module.module.variable({});
-                variables.push(newVariable);
+const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+{
+    return (source, variables = [], cell) => {
+        try {
+            debugger;
+            let reposition = false, insertionIndex = -1;
+            const newVariables = compile(source);
+            if (!variables || variables.length !== newVariables.length) {
+                reposition = true;
+                variables.forEach(v => v.delete());
+                variables.length = 0;
+                for (let i = 0; i < newVariables.length; i++) {
+                    const newVariable = cell.module.module.variable({});
+                    // Assign a random pid up-front so blank/identical new cells don't
+                    // collide via persistentId's contentHash. See lopecode#144.
+                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+                    variables.push(newVariable);
+                }
             }
-        }
-        if (reposition) {
-            insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-        }
-        newVariables.forEach((v, i) => {
-            const variable = variables[i];
-            let _fn;
-            eval('_fn = ' + v._definition);
-            if (v._name) {
-                variable.define(v._name, v._inputs, _fn);
-            } else {
-                variable.define(v._inputs, _fn);
+            if (reposition) {
+                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
-            if (reposition)
-                repositionSetElement(runtime._variables, variable, insertionIndex + i);
-        });
-        return variables;
-    } catch (e) {
-        console.error(e);
-        debugger;
-    }
-}
-)};
+            newVariables.forEach((v, i) => {
+                const variable = variables[i];
+                let _fn;
+                eval('_fn = ' + v._definition);
+                if (v._name) {
+                    variable.define(v._name, v._inputs, _fn);
+                } else {
+                    variable.define(v._inputs, _fn);
+                }
+                if (reposition)
+                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
+            });
+            return variables;
+        } catch (e) {
+            console.error(e);
+            debugger;
+        }
+    };
+};
 const _1jqs8in = function _91(md){return(
 md`### Remove Cells`
 )};
@@ -5912,6 +5928,7 @@ Inputs.radio(editedCell.variables, {
   value: editedCell.variables[0]
 })
 )};
+const _11gvkq4 = (G, _) => G.input(_);
 const _r5nvms = function _name(variable){return(
 variable._name
 )};
@@ -5925,6 +5942,7 @@ Inputs.textarea({
   rows: 10
 })
 )};
+const _b4rsn5 = (G, _) => G.input(_);
 const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
@@ -5938,22 +5956,12 @@ Inputs.button("update variable", {
 const _1q557s = function _99(md){return(
 md`### Editor Libraries`
 )};
-const _192vvs7 = (_, v) => v.import("descendants", _);
-const _3va6tf = (_, v) => v.import("EditorState", _);
-const _lmqjiv = (_, v) => v.import("decompile", _);
 const _1d94dks = function _javascriptPlugin(codemirror){return(
 codemirror
 )};
 const _ar9tao = function _104(md){return(
 md`### Libraries`
 )};
-const _viogn = (_, v) => v.import("reversibleAttach", _);
-const _nxg8mr = (_, v) => v.import("moduleMap", _);
-const _14a94d = (_, v) => v.import("flowQueue", _);
-const _gurtwb = (_, v) => v.import("viewof liveCellMap", _);
-const _19ebgtz = (_, v) => v.import("hash", _);
-const _n2vgkz = (_, v) => v.import("extractNotebookAndCell", _);
-const _1qucevb = (_, v) => v.import("cellsToClipboard", _);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -5967,22 +5975,34 @@ export default function define(runtime, observer) {
     return [name, {url: blob_url, mimeType: mime}]
   }));
   main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
+  main.define("module @tomlarkworthy/dataflow-templating", async () => runtime.module((await import("/@tomlarkworthy/dataflow-templating.js?v=4")).default));  
+  main.define("module @tomlarkworthy/fileattachments", async () => runtime.module((await import("/@tomlarkworthy/fileattachments.js?v=4")).default));  
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/codemirror-6-v2", async () => runtime.module((await import("/@tomlarkworthy/codemirror-6-v2.js?v=4")).default));  
+  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
+  main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
+  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
+  main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
+  main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
+  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
+  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
+  main.define("module @tomlarkworthy/cells-to-clipboard", async () => runtime.module((await import("/@tomlarkworthy/cells-to-clipboard.js?v=4")).default));  
   $def("_1tdjp0a", "title", ["md"], _1tdjp0a);  
   $def("_dm53bx", null, ["md"], _dm53bx);  
   $def("_61oxjf", "title_variable", ["lookupVariable","editorModule"], _61oxjf);  
   $def("_15uilf0", null, ["cellEditor","title_variable"], _15uilf0);  
   $def("_3x695f", null, ["md"], _3x695f);  
   $def("_1ociws4", null, ["md"], _1ociws4);  
-  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
   $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
-  main.variable(observer("attachContextManu")).define("attachContextManu", ["Generators", "viewof attachContextManu"], (G, _) => G.input(_));  
+  $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
   $def("_16ks4jz", null, ["md"], _16ks4jz);  
-  main.define("module @tomlarkworthy/dataflow-templating", async () => runtime.module((await import("/@tomlarkworthy/dataflow-templating.js?v=4")).default));  
   main.define("cloneDataflow", ["module @tomlarkworthy/dataflow-templating", "@variable"], (_, v) => v.import("cloneDataflow", _));  
   main.define("lookupVariable", ["module @tomlarkworthy/dataflow-templating", "@variable"], (_, v) => v.import("lookupVariable", _));  
   $def("_199ztvl", "hotbarTemplate", ["lookupVariable","editorModule"], _199ztvl);  
@@ -5993,7 +6013,7 @@ export default function define(runtime, observer) {
   $def("_110gwi7", "editorTemplate", ["lookupVariable","editorModule"], _110gwi7);  
   $def("_16rqzgl", null, ["md"], _16rqzgl);  
   $def("_1o2h65s", "viewof editedCell", ["Inputs"], _1o2h65s);  
-  main.variable(observer("editedCell")).define("editedCell", ["Generators", "viewof editedCell"], (G, _) => G.input(_));  
+  $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
   $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
@@ -6008,24 +6028,24 @@ export default function define(runtime, observer) {
   $def("_mrrmx3", null, ["md"], _mrrmx3);  
   $def("_14b1byw", null, ["md"], _14b1byw);  
   $def("_1j1loxx", "viewof combine", ["Inputs"], _1j1loxx);  
-  main.variable(observer("combine")).define("combine", ["Generators", "viewof combine"], (G, _) => G.input(_));  
+  $def("_1h8337z", "combine", ["Generators","viewof combine"], _1h8337z);  
   $def("_tct2nf", "viewof edit", ["Inputs"], _tct2nf);  
-  main.variable(observer("edit")).define("edit", ["Generators", "viewof edit"], (G, _) => G.input(_));  
+  $def("_7izj7k", "edit", ["Generators","viewof edit"], _7izj7k);  
   $def("_1fwb5jc", "toolbar", ["htl","reversibleAttach","combine","viewof select","viewof up","viewof down","viewof remove","viewof addCells","viewof apply","viewof copy","viewof paste"], _1fwb5jc);  
   $def("_yej3hb", "viewof addCells", ["Inputs","createCell","viewof editedCell"], _yej3hb);  
-  main.variable(observer("addCells")).define("addCells", ["Generators", "viewof addCells"], (G, _) => G.input(_));  
+  $def("_1aii9ps", "addCells", ["Generators","viewof addCells"], _1aii9ps);  
   $def("_1bn860e", "viewof remove", ["Inputs","deleteCell","viewof editedCell"], _1bn860e);  
-  main.variable(observer("remove")).define("remove", ["Generators", "viewof remove"], (G, _) => G.input(_));  
+  $def("_1ad0xr8", "remove", ["Generators","viewof remove"], _1ad0xr8);  
   $def("_tw1j7n", "viewof apply", ["Inputs","compile_and_update","states","editedCell"], _tw1j7n);  
-  main.variable(observer("apply")).define("apply", ["Generators", "viewof apply"], (G, _) => G.input(_));  
+  $def("_1cjyuqm", "apply", ["Generators","viewof apply"], _1cjyuqm);  
   $def("_14rfku9", "viewof up", ["Inputs","moveCell","viewof editedCell"], _14rfku9);  
-  main.variable(observer("up")).define("up", ["Generators", "viewof up"], (G, _) => G.input(_));  
+  $def("_frzs5d", "up", ["Generators","viewof up"], _frzs5d);  
   $def("_9pymuj", "viewof paste", ["Inputs","readObservableClipboardCells","pasteObservableCellsIntoModule","editedCell"], _9pymuj);  
-  main.variable(observer("paste")).define("paste", ["Generators", "viewof paste"], (G, _) => G.input(_));  
+  $def("_1whsszt", "paste", ["Generators","viewof paste"], _1whsszt);  
   $def("_corxwl", "viewof down", ["Inputs","moveCell","viewof editedCell"], _corxwl);  
-  main.variable(observer("down")).define("down", ["Generators", "viewof down"], (G, _) => G.input(_));  
+  $def("_1to28po", "down", ["Generators","viewof down"], _1to28po);  
   $def("_gia2ci", "viewof copy", ["Inputs","html","viewof editedCell","decompile","viewof liveCellMap","getOption","cellsToClipboard"], _gia2ci);  
-  main.variable(observer("copy")).define("copy", ["Generators", "viewof copy"], (G, _) => G.input(_));  
+  $def("_fw41wt", "copy", ["Generators","viewof copy"], _fw41wt);  
   $def("_srtw8o", "module", ["editedCell"], _srtw8o);  
   $def("_rv7t7x", "code_editor_view", ["EditorView"], _rv7t7x);  
   $def("_xvo1n6", "code_editor", ["code_editor_view"], _xvo1n6);  
@@ -6035,7 +6055,7 @@ export default function define(runtime, observer) {
   $def("_d9nzys", "deleteCell", ["viewof command"], _d9nzys);  
   $def("_c1u9w8", null, ["md"], _c1u9w8);  
   $def("_d7ouqx", "viewof command", ["flowQueue"], _d7ouqx);  
-  main.variable(observer("command")).define("command", ["Generators", "viewof command"], (G, _) => G.input(_));  
+  $def("_118qt2v", "command", ["Generators","viewof command"], _118qt2v);  
   $def("_19l2nem", null, ["command"], _19l2nem);  
   $def("_1f6v167", "findCellByVariable", [], _1f6v167);  
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
@@ -6052,9 +6072,8 @@ export default function define(runtime, observer) {
   $def("_dvne2z", "replaceCodeMirrorDoc", [], _dvne2z);  
   $def("_1fpqfm0", null, ["md"], _1fpqfm0);  
   $def("_rtf009", "viewof select", ["editedCell","Inputs","getOption","setOption"], _rtf009);  
-  main.variable(observer("select")).define("select", ["Generators", "viewof select"], (G, _) => G.input(_));  
+  $def("_14mwbuc", "select", ["Generators","viewof select"], _14mwbuc);  
   $def("_l4sbcd", null, ["md"], _l4sbcd);  
-  main.define("module @tomlarkworthy/fileattachments", async () => runtime.module((await import("/@tomlarkworthy/fileattachments.js?v=4")).default));  
   main.define("getFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachment", _));  
   main.define("setFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("setFileAttachment", _));  
   main.define("removeFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("removeFileAttachment", _));  
@@ -6063,7 +6082,7 @@ export default function define(runtime, observer) {
   $def("_ezl7wk", null, ["FileAttachment"], _ezl7wk);  
   $def("_kygz54", "optionsFile", ["getFileAttachment","editorModule"], _kygz54);  
   $def("_760ozq", "viewof options", ["Inputs","optionsFile"], _760ozq);  
-  main.variable(observer("options")).define("options", ["Generators", "viewof options"], (G, _) => G.input(_));  
+  $def("_4rh26k", "options", ["Generators","viewof options"], _4rh26k);  
   $def("_1lqy7cs", "setOption", ["findCell","_","viewof options","Event"], _1lqy7cs);  
   $def("_1oxe5ee", "getOption", ["findCell","_","viewof options"], _1oxe5ee);  
   $def("_kwq69p", "save_options", ["setFileAttachment","jsonFileAttachment","options","editorModule"], _kwq69p);  
@@ -6077,22 +6096,21 @@ export default function define(runtime, observer) {
   $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
   $def("_1j3c2uf", "decompiled", ["editedCell","decompile"], _1j3c2uf);  
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
-  main.variable(observer("editorModule")).define("editorModule", ["Generators", "viewof editorModule"], (G, _) => G.input(_));  
+  $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1ju14cq", "compile_and_update", ["compile","runtime","repositionSetElement"], _1ju14cq);  
+  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
   $def("_rwez9", "viewof variable", ["Inputs","editedCell"], _rwez9);  
-  main.variable(observer("variable")).define("variable", ["Generators", "viewof variable"], (G, _) => G.input(_));  
+  $def("_11gvkq4", "variable", ["Generators","viewof variable"], _11gvkq4);  
   $def("_r5nvms", "name", ["variable"], _r5nvms);  
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
-  main.variable(observer("definition")).define("definition", ["Generators", "viewof definition"], (G, _) => G.input(_));  
+  $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
   $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
   $def("_1q557s", null, ["md"], _1q557s);  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -6103,12 +6121,10 @@ export default function define(runtime, observer) {
   main.define("isnode", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("isnode", _));  
   main.define("repositionSetElement", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("repositionSetElement", _));  
   main.define("onCodeChange", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("onCodeChange", _));  
-  main.define("module @tomlarkworthy/codemirror-6-v2", async () => runtime.module((await import("/@tomlarkworthy/codemirror-6-v2.js?v=4")).default));  
   main.define("EditorState", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("EditorState", _));  
   main.define("EditorView", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("EditorView", _));  
   main.define("codemirror", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("codemirror", _));  
   main.define("myDefaultTheme", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("myDefaultTheme", _));  
-  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
   main.define("decompile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("decompile", _));  
   main.define("compile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("compile", _));  
   main.define("cellMap", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("cellMap", _));  
@@ -6117,27 +6133,21 @@ export default function define(runtime, observer) {
   main.define("parser", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("parser", _));  
   $def("_1d94dks", "javascriptPlugin", ["codemirror"], _1d94dks);  
   $def("_ar9tao", null, ["md"], _ar9tao);  
-  main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
   main.define("reversibleAttach", ["module @tomlarkworthy/reversible-attachment", "@variable"], (_, v) => v.import("reversibleAttach", _));  
-  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
   main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
-  main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
   main.define("flowQueue", ["module @tomlarkworthy/flow-queue", "@variable"], (_, v) => v.import("flowQueue", _));  
-  main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
   main.define("viewof liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("viewof liveCellMap", _));  
   main.define("liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("liveCellMap", _));  
-  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
   main.define("hash", ["module d/57d79353bac56631@44", "@variable"], (_, v) => v.import("hash", _));  
-  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
   main.define("extractNotebookAndCell", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("extractNotebookAndCell", _));  
   main.define("navHref", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("navHref", _));  
-  main.define("module @tomlarkworthy/cells-to-clipboard", async () => runtime.module((await import("/@tomlarkworthy/cells-to-clipboard.js?v=4")).default));  
   main.define("cellsToClipboard", ["module @tomlarkworthy/cells-to-clipboard", "@variable"], (_, v) => v.import("cellsToClipboard", _));
   return main;
-}</script>
+}
+</script>
 <script id="@tomlarkworthy/escodegen/escodegen.browser.min.js.gz" 
   type="text/plain"
   data-encoding="base64"

--- a/notebooks/@tomlarkworthy_global-search.html
+++ b/notebooks/@tomlarkworthy_global-search.html
@@ -3970,12 +3970,12 @@ e30K
   type="text/plain"
   data-mime="application/javascript"
 >
-const _1yqq2tb = function _title(md){return(
+const _1tdjp0a = function _title(md){return(
 md`# Editor: Reactive Userspace Cell Mutator (v5)
 
 [YouTube explainer](https://www.youtube.com/shorts/6FjeJRBC2iw)
 
-A cell that edits the source of other cells. It is implemented in userspace as a normal cell, so it follows exported notebooks, so exported notebooks become editable! It pairs particularly well with the [single file export](https://observablehq.com/@tomlarkworthy/exporter-2), because edits are also exported, so you can permanently save your works in a format that continues to be editable and exportable indefinitely. It works offline too!
+A cell that edits the source of other cells. It is implemented in userspace as a normal cell, so it follows exported notebooks, so exported notebooks become editable! It pairs particularly well with the [single file export](https://observablehq.com/@tomlarkworthy/exporter-3), because edits are also exported, so you can permanently save your works in a format that continues to be editable and exportable indefinitely. It works offline too!
 
 
 The editor is able to edit _any_ cell in the runtime, including those in dependancies. Import \`auto_attach\` and run that cell. You can also instanciate an editor component on any variable reference.
@@ -4013,7 +4013,6 @@ md`## TODO
 const _1ociws4 = function _6(md){return(
 md`## Sync editors`
 )};
-const _1vq49kx = (_, v) => v.import("syncers", _);
 const _hdieof = function _editors(){return(
 new Map()
 )};
@@ -4091,12 +4090,12 @@ Inputs.toggle({
   value: !isOnObservableCom()
 })
 )};
+const _1oaz8r1 = (G, _) => G.input(_);
 const _16ks4jz = function _12(md){return(
 md`## \`cellEditor\` component
 
 Using Dataflow templating to create reusable Hotbar Component builder`
 )};
-const _1deps8p = (_, v) => v.import("cloneDataflow", _);
 const _199ztvl = function _hotbarTemplate(lookupVariable,editorModule){return(
 lookupVariable(
   [
@@ -4333,6 +4332,7 @@ md`## Hotbar Prototype`
 const _1o2h65s = function _editedCell(Inputs){return(
 Inputs.input(null)
 )};
+const _7g3h7h = (G, _) => G.input(_);
 const _1urs1md = function _findCell($0,modules){return(
 (variable, dom = undefined) => {
   if (variable) {
@@ -4479,14 +4479,11 @@ const _1nfia2p = function _variableLink(identity,navHref,modules)
 const _gycral = function _32(md){return(
 md`Save edits by exporting to a single file`
 )};
-const _oxwwla = function _33(exporter){return(
-exporter()
-)};
-const _cifk0w = function _34(md){return(
+const _mrrmx3 = function _33(md){return(
 md`### Known Issues
 - If you create a new cell, it is invisible, it will appear after exporting.`
 )};
-const _px06sj = function _35(md){return(
+const _14b1byw = function _34(md){return(
 md`### Editor UI Components`
 )};
 const _1j1loxx = function _combine(Inputs){return(
@@ -4495,9 +4492,11 @@ Inputs.toggle({
   value: true
 })
 )};
+const _1h8337z = (G, _) => G.input(_);
 const _tct2nf = function _edit(Inputs){return(
 Inputs.toggle({ label: "edit" })
 )};
+const _7izj7k = (G, _) => G.input(_);
 const _1fwb5jc = function _toolbar(htl,reversibleAttach,combine,$0,$1,$2,$3,$4,$5,$6,$7){return(
 htl.html`<div
     class="toolbar"
@@ -4525,11 +4524,13 @@ Inputs.button("➕", {
   }
 })
 )};
+const _1aii9ps = (G, _) => G.input(_);
 const _1bn860e = function _remove(Inputs,deleteCell,$0){return(
 Inputs.button("🗑️", {
   reduce: () => deleteCell({ cell: $0.value })
 })
 )};
+const _1ad0xr8 = (G, _) => G.input(_);
 const _tw1j7n = function _apply(Inputs,compile_and_update,states,editedCell)
 {
   const button = Inputs.button("▶️", {
@@ -4548,11 +4549,13 @@ const _tw1j7n = function _apply(Inputs,compile_and_update,states,editedCell)
   button.onmousedown = (e) => e.preventDefault();
   return button;
 };
+const _1cjyuqm = (G, _) => G.input(_);
 const _14rfku9 = function _up(Inputs,moveCell,$0){return(
 Inputs.button("⬆", {
   reduce: () => moveCell($0.value, -1)
 })
 )};
+const _frzs5d = (G, _) => G.input(_);
 const _9pymuj = function _paste(Inputs,readObservableClipboardCells,pasteObservableCellsIntoModule,editedCell){return(
 Inputs.button("📋", {
   reduce: async () => {
@@ -4561,11 +4564,13 @@ Inputs.button("📋", {
   }
 })
 )};
+const _1whsszt = (G, _) => G.input(_);
 const _corxwl = function _down(Inputs,moveCell,$0){return(
 Inputs.button("⬇", {
   reduce: () => moveCell($0.value, 1)
 })
 )};
+const _1to28po = (G, _) => G.input(_);
 const _gia2ci = function _copy(Inputs,html,$0,decompile,$1,getOption,cellsToClipboard){return(
 Inputs.button(
   html`<span style="font-size: .875em; margin-right: .125em; position: relative; top: -.25em; left: -.125em">
@@ -4607,6 +4612,7 @@ Inputs.button(
   }
 )
 )};
+const _fw41wt = (G, _) => G.input(_);
 const _srtw8o = function _module(editedCell){return(
 editedCell.module.module
 )};
@@ -4623,7 +4629,7 @@ const _xvo1n6 = function _code_editor(code_editor_view)
   });
   return code_editor_view.dom;
 };
-const _1h6etoc = function _49(md){return(
+const _1eznltv = function _48(md){return(
 md`## API`
 )};
 const _470wv4 = function _moveCell($0){return(
@@ -4655,13 +4661,14 @@ async ({cell}) =>
     }
   })
 )};
-const _xeocn3 = function _53(md){return(
+const _c1u9w8 = function _52(md){return(
 md`## API handler`
 )};
 const _d7ouqx = function _command(flowQueue){return(
 flowQueue()
 )};
-const _1a7fx5d = function _55(command){return(
+const _118qt2v = (G, _) => G.input(_);
+const _19l2nem = function _54(command){return(
 command
 )};
 const _1f6v167 = function _findCellByVariable(){return(
@@ -4749,7 +4756,7 @@ const _geoudp = async function _command_processor(command,$0,compile_and_update,
     $2.resolve(result);
   }
 };
-const _o2b3f7 = function _61(md){return(
+const _1jadxoe = function _60(md){return(
 md`### UI Action`
 )};
 const _m873d1 = function _states(){return(
@@ -4811,7 +4818,7 @@ const _65mlp5 = function _divToCell(){return(
   }
 }
 )};
-const _1yoywvn = function _66(md){return(
+const _1jt3c14 = function _65(md){return(
 md`## Reacting to runtime changes
 
 Other editors might change the definition underfoot, so we need to reload the code mirror state`
@@ -4912,7 +4919,7 @@ const _dvne2z = function _replaceCodeMirrorDoc(){return(
   return true;
 }
 )};
-const _ori9ox = function _69(md){return(
+const _1fpqfm0 = function _68(md){return(
 md`### Selection`
 )};
 const _rtf009 = function _select(editedCell,Inputs,getOption,setOption){return(
@@ -4933,11 +4940,11 @@ const _rtf009 = function _select(editedCell,Inputs,getOption,setOption){return(
   return el;
 })()
 )};
-const _1he1wje = function _71(md){return(
+const _14mwbuc = (G, _) => G.input(_);
+const _l4sbcd = function _70(md){return(
 md`## Pinning`
 )};
-const _1sxszb9 = (_, v) => v.import("getFileAttachment", _);
-const _15ef4d1 = function _73(FileAttachment){return(
+const _ezl7wk = function _72(FileAttachment){return(
 FileAttachment("cell_options.json")
 )};
 const _kygz54 = function _optionsFile(getFileAttachment,editorModule){return(
@@ -4946,6 +4953,7 @@ getFileAttachment("cell_options.json", editorModule)
 const _760ozq = async function _options(Inputs,optionsFile){return(
 Inputs.input(await optionsFile.json())
 )};
+const _4rh26k = (G, _) => G.input(_);
 const _1lqy7cs = function _setOption(findCell,_,$0,Event){return(
 (variable, option, value) => {
   const cell = findCell(variable);
@@ -4972,7 +4980,7 @@ setFileAttachment(
   editorModule
 )
 )};
-const _1wls4er = function _79(md){return(
+const _4a056s = function _78(md){return(
 md`## Pasting`
 )};
 const _dbvt0t = function _escapeTemplateLiteral(){return(
@@ -5111,7 +5119,7 @@ async ({ cells, editedCell }) => {
   return { total: normalized.length, matched: matched.length, replacedCurrent, inserted };
 }
 )};
-const _rkhvti = function _85(md){return(
+const _nnkymf = function _84(md){return(
 md`## Decompiler`
 )};
 const _kdc1xp = function _modules(moduleMap,runtime){return(
@@ -5125,6 +5133,7 @@ const _1j3c2uf = function _decompiled(editedCell,decompile)
 const _w5q3yf = function _editorModule(thisModule){return(
 thisModule()
 )};
+const _18kaj2p = (G, _) => G.input(_);
 const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_options)
 {
   //editedCell;
@@ -5133,47 +5142,51 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
   save_options;
   return "editor_jobs";
 };
-const _wjug40 = function _90(md){return(
+const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1ju14cq = function _compile_and_update(compile,runtime,repositionSetElement){return(
-(source, variables = [], cell) => {
-    try {
-        debugger;
-        let reposition = false, insertionIndex = -1;
-        const newVariables = compile(source);
-        if (!variables || variables.length !== newVariables.length) {
-            reposition = true;
-            variables.forEach(v => v.delete());
-            variables.length = 0;
-            for (let i = 0; i < newVariables.length; i++) {
-                const newVariable = cell.module.module.variable({});
-                variables.push(newVariable);
+const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+{
+    return (source, variables = [], cell) => {
+        try {
+            debugger;
+            let reposition = false, insertionIndex = -1;
+            const newVariables = compile(source);
+            if (!variables || variables.length !== newVariables.length) {
+                reposition = true;
+                variables.forEach(v => v.delete());
+                variables.length = 0;
+                for (let i = 0; i < newVariables.length; i++) {
+                    const newVariable = cell.module.module.variable({});
+                    // Assign a random pid up-front so blank/identical new cells don't
+                    // collide via persistentId's contentHash. See lopecode#144.
+                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+                    variables.push(newVariable);
+                }
             }
-        }
-        if (reposition) {
-            insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-        }
-        newVariables.forEach((v, i) => {
-            const variable = variables[i];
-            let _fn;
-            eval('_fn = ' + v._definition);
-            if (v._name) {
-                variable.define(v._name, v._inputs, _fn);
-            } else {
-                variable.define(v._inputs, _fn);
+            if (reposition) {
+                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
-            if (reposition)
-                repositionSetElement(runtime._variables, variable, insertionIndex + i);
-        });
-        return variables;
-    } catch (e) {
-        console.error(e);
-        debugger;
-    }
-}
-)};
-const _ksln5y = function _92(md){return(
+            newVariables.forEach((v, i) => {
+                const variable = variables[i];
+                let _fn;
+                eval('_fn = ' + v._definition);
+                if (v._name) {
+                    variable.define(v._name, v._inputs, _fn);
+                } else {
+                    variable.define(v._inputs, _fn);
+                }
+                if (reposition)
+                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
+            });
+            return variables;
+        } catch (e) {
+            console.error(e);
+            debugger;
+        }
+    };
+};
+const _1jqs8in = function _91(md){return(
 md`### Remove Cells`
 )};
 const _mhcibs = function _remove_variables(){return(
@@ -5181,7 +5194,7 @@ const _mhcibs = function _remove_variables(){return(
   variables.forEach((v) => v.delete());
 }
 )};
-const _1qcfq34 = function _94(md){return(
+const _1n8o4pt = function _93(md){return(
 md`### Runtime Representation`
 )};
 const _rwez9 = function _variable(Inputs,editedCell){return(
@@ -5191,6 +5204,7 @@ Inputs.radio(editedCell.variables, {
   value: editedCell.variables[0]
 })
 )};
+const _11gvkq4 = (G, _) => G.input(_);
 const _r5nvms = function _name(variable){return(
 variable._name
 )};
@@ -5204,7 +5218,8 @@ Inputs.textarea({
   rows: 10
 })
 )};
-const _71x0y8 = function _99(Inputs,definition,variable,inputs){return(
+const _b4rsn5 = (G, _) => G.input(_);
+const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
   reduce: () => {
@@ -5214,26 +5229,15 @@ Inputs.button("update variable", {
   }
 })
 )};
-const _7dmbbr = function _100(md){return(
+const _1q557s = function _99(md){return(
 md`### Editor Libraries`
 )};
-const _192vvs7 = (_, v) => v.import("descendants", _);
-const _3va6tf = (_, v) => v.import("EditorState", _);
-const _lmqjiv = (_, v) => v.import("decompile", _);
 const _1d94dks = function _javascriptPlugin(codemirror){return(
 codemirror
 )};
-const _1xaw0at = function _105(md){return(
+const _ar9tao = function _104(md){return(
 md`### Libraries`
 )};
-const _viogn = (_, v) => v.import("reversibleAttach", _);
-const _10vtplb = (_, v) => v.import("exporter", _);
-const _nxg8mr = (_, v) => v.import("moduleMap", _);
-const _14a94d = (_, v) => v.import("flowQueue", _);
-const _gurtwb = (_, v) => v.import("viewof liveCellMap", _);
-const _19ebgtz = (_, v) => v.import("hash", _);
-const _n2vgkz = (_, v) => v.import("extractNotebookAndCell", _);
-const _1qucevb = (_, v) => v.import("cellsToClipboard", _);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -5247,22 +5251,34 @@ export default function define(runtime, observer) {
     return [name, {url: blob_url, mimeType: mime}]
   }));
   main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
-  $def("_1yqq2tb", "title", ["md"], _1yqq2tb);  
+
+  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
+  main.define("module @tomlarkworthy/dataflow-templating", async () => runtime.module((await import("/@tomlarkworthy/dataflow-templating.js?v=4")).default));  
+  main.define("module @tomlarkworthy/fileattachments", async () => runtime.module((await import("/@tomlarkworthy/fileattachments.js?v=4")).default));  
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/codemirror-6-v2", async () => runtime.module((await import("/@tomlarkworthy/codemirror-6-v2.js?v=4")).default));  
+  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
+  main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
+  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
+  main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
+  main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
+  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
+  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
+  main.define("module @tomlarkworthy/cells-to-clipboard", async () => runtime.module((await import("/@tomlarkworthy/cells-to-clipboard.js?v=4")).default));  
+  $def("_1tdjp0a", "title", ["md"], _1tdjp0a);  
   $def("_dm53bx", null, ["md"], _dm53bx);  
   $def("_61oxjf", "title_variable", ["lookupVariable","editorModule"], _61oxjf);  
   $def("_15uilf0", null, ["cellEditor","title_variable"], _15uilf0);  
   $def("_3x695f", null, ["md"], _3x695f);  
   $def("_1ociws4", null, ["md"], _1ociws4);  
-  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
   $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
-  main.variable(observer("attachContextManu")).define("attachContextManu", ["Generators", "viewof attachContextManu"], (G, _) => G.input(_));  
+  $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
   $def("_16ks4jz", null, ["md"], _16ks4jz);  
-  main.define("module @tomlarkworthy/dataflow-templating", async () => runtime.module((await import("/@tomlarkworthy/dataflow-templating.js?v=4")).default));  
   main.define("cloneDataflow", ["module @tomlarkworthy/dataflow-templating", "@variable"], (_, v) => v.import("cloneDataflow", _));  
   main.define("lookupVariable", ["module @tomlarkworthy/dataflow-templating", "@variable"], (_, v) => v.import("lookupVariable", _));  
   $def("_199ztvl", "hotbarTemplate", ["lookupVariable","editorModule"], _199ztvl);  
@@ -5273,7 +5289,7 @@ export default function define(runtime, observer) {
   $def("_110gwi7", "editorTemplate", ["lookupVariable","editorModule"], _110gwi7);  
   $def("_16rqzgl", null, ["md"], _16rqzgl);  
   $def("_1o2h65s", "viewof editedCell", ["Inputs"], _1o2h65s);  
-  main.variable(observer("editedCell")).define("editedCell", ["Generators", "viewof editedCell"], (G, _) => G.input(_));  
+  $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
   $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
@@ -5285,95 +5301,92 @@ export default function define(runtime, observer) {
   $def("_1opggh8", "identity", ["lookupVariable","editorModule"], _1opggh8);  
   $def("_1nfia2p", "variableLink", ["identity","navHref","modules"], _1nfia2p);  
   $def("_gycral", null, ["md"], _gycral);  
-  $def("_oxwwla", null, ["exporter"], _oxwwla);  
-  $def("_cifk0w", null, ["md"], _cifk0w);  
-  $def("_px06sj", null, ["md"], _px06sj);  
+  $def("_mrrmx3", null, ["md"], _mrrmx3);  
+  $def("_14b1byw", null, ["md"], _14b1byw);  
   $def("_1j1loxx", "viewof combine", ["Inputs"], _1j1loxx);  
-  main.variable(observer("combine")).define("combine", ["Generators", "viewof combine"], (G, _) => G.input(_));  
+  $def("_1h8337z", "combine", ["Generators","viewof combine"], _1h8337z);  
   $def("_tct2nf", "viewof edit", ["Inputs"], _tct2nf);  
-  main.variable(observer("edit")).define("edit", ["Generators", "viewof edit"], (G, _) => G.input(_));  
+  $def("_7izj7k", "edit", ["Generators","viewof edit"], _7izj7k);  
   $def("_1fwb5jc", "toolbar", ["htl","reversibleAttach","combine","viewof select","viewof up","viewof down","viewof remove","viewof addCells","viewof apply","viewof copy","viewof paste"], _1fwb5jc);  
   $def("_yej3hb", "viewof addCells", ["Inputs","createCell","viewof editedCell"], _yej3hb);  
-  main.variable(observer("addCells")).define("addCells", ["Generators", "viewof addCells"], (G, _) => G.input(_));  
+  $def("_1aii9ps", "addCells", ["Generators","viewof addCells"], _1aii9ps);  
   $def("_1bn860e", "viewof remove", ["Inputs","deleteCell","viewof editedCell"], _1bn860e);  
-  main.variable(observer("remove")).define("remove", ["Generators", "viewof remove"], (G, _) => G.input(_));  
+  $def("_1ad0xr8", "remove", ["Generators","viewof remove"], _1ad0xr8);  
   $def("_tw1j7n", "viewof apply", ["Inputs","compile_and_update","states","editedCell"], _tw1j7n);  
-  main.variable(observer("apply")).define("apply", ["Generators", "viewof apply"], (G, _) => G.input(_));  
+  $def("_1cjyuqm", "apply", ["Generators","viewof apply"], _1cjyuqm);  
   $def("_14rfku9", "viewof up", ["Inputs","moveCell","viewof editedCell"], _14rfku9);  
-  main.variable(observer("up")).define("up", ["Generators", "viewof up"], (G, _) => G.input(_));  
+  $def("_frzs5d", "up", ["Generators","viewof up"], _frzs5d);  
   $def("_9pymuj", "viewof paste", ["Inputs","readObservableClipboardCells","pasteObservableCellsIntoModule","editedCell"], _9pymuj);  
-  main.variable(observer("paste")).define("paste", ["Generators", "viewof paste"], (G, _) => G.input(_));  
+  $def("_1whsszt", "paste", ["Generators","viewof paste"], _1whsszt);  
   $def("_corxwl", "viewof down", ["Inputs","moveCell","viewof editedCell"], _corxwl);  
-  main.variable(observer("down")).define("down", ["Generators", "viewof down"], (G, _) => G.input(_));  
+  $def("_1to28po", "down", ["Generators","viewof down"], _1to28po);  
   $def("_gia2ci", "viewof copy", ["Inputs","html","viewof editedCell","decompile","viewof liveCellMap","getOption","cellsToClipboard"], _gia2ci);  
-  main.variable(observer("copy")).define("copy", ["Generators", "viewof copy"], (G, _) => G.input(_));  
+  $def("_fw41wt", "copy", ["Generators","viewof copy"], _fw41wt);  
   $def("_srtw8o", "module", ["editedCell"], _srtw8o);  
   $def("_rv7t7x", "code_editor_view", ["EditorView"], _rv7t7x);  
   $def("_xvo1n6", "code_editor", ["code_editor_view"], _xvo1n6);  
-  $def("_1h6etoc", null, ["md"], _1h6etoc);  
+  $def("_1eznltv", null, ["md"], _1eznltv);  
   $def("_470wv4", "moveCell", ["viewof command"], _470wv4);  
   $def("_19znal9", "createCell", ["viewof command"], _19znal9);  
   $def("_d9nzys", "deleteCell", ["viewof command"], _d9nzys);  
-  $def("_xeocn3", null, ["md"], _xeocn3);  
+  $def("_c1u9w8", null, ["md"], _c1u9w8);  
   $def("_d7ouqx", "viewof command", ["flowQueue"], _d7ouqx);  
-  main.variable(observer("command")).define("command", ["Generators", "viewof command"], (G, _) => G.input(_));  
-  $def("_1a7fx5d", null, ["command"], _1a7fx5d);  
+  $def("_118qt2v", "command", ["Generators","viewof command"], _118qt2v);  
+  $def("_19l2nem", null, ["command"], _19l2nem);  
   $def("_1f6v167", "findCellByVariable", [], _1f6v167);  
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
   $def("_geoudp", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _geoudp);  
-  $def("_o2b3f7", null, ["md"], _o2b3f7);  
+  $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
   $def("_xljfx5", "editor_manager", ["editedCell","EditorState","decompiled","cellIdFacet","EditorView","states","codemirror","compile_and_update","code_editor_view","javascriptPlugin","myDefaultTheme"], _xljfx5);  
   $def("_65mlp5", "divToCell", [], _65mlp5);  
-  $def("_1yoywvn", null, ["md"], _1yoywvn);  
+  $def("_1jt3c14", null, ["md"], _1jt3c14);  
   $def("_jh2ad1", "editor_refresh_from_runtime", ["editedCell","decompile","code_editor_view","replaceCodeMirrorDoc","queueMicrotask","onCodeChange","invalidation"], _jh2ad1);  
   $def("_dvne2z", "replaceCodeMirrorDoc", [], _dvne2z);  
-  $def("_ori9ox", null, ["md"], _ori9ox);  
+  $def("_1fpqfm0", null, ["md"], _1fpqfm0);  
   $def("_rtf009", "viewof select", ["editedCell","Inputs","getOption","setOption"], _rtf009);  
-  main.variable(observer("select")).define("select", ["Generators", "viewof select"], (G, _) => G.input(_));  
-  $def("_1he1wje", null, ["md"], _1he1wje);  
-  main.define("module @tomlarkworthy/fileattachments", async () => runtime.module((await import("/@tomlarkworthy/fileattachments.js?v=4")).default));  
+  $def("_14mwbuc", "select", ["Generators","viewof select"], _14mwbuc);  
+  $def("_l4sbcd", null, ["md"], _l4sbcd);  
   main.define("getFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachment", _));  
   main.define("setFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("setFileAttachment", _));  
   main.define("removeFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("removeFileAttachment", _));  
   main.define("jsonFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("jsonFileAttachment", _));  
   main.define("createFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("createFileAttachment", _));  
-  $def("_15ef4d1", null, ["FileAttachment"], _15ef4d1);  
+  $def("_ezl7wk", null, ["FileAttachment"], _ezl7wk);  
   $def("_kygz54", "optionsFile", ["getFileAttachment","editorModule"], _kygz54);  
   $def("_760ozq", "viewof options", ["Inputs","optionsFile"], _760ozq);  
-  main.variable(observer("options")).define("options", ["Generators", "viewof options"], (G, _) => G.input(_));  
+  $def("_4rh26k", "options", ["Generators","viewof options"], _4rh26k);  
   $def("_1lqy7cs", "setOption", ["findCell","_","viewof options","Event"], _1lqy7cs);  
   $def("_1oxe5ee", "getOption", ["findCell","_","viewof options"], _1oxe5ee);  
   $def("_kwq69p", "save_options", ["setFileAttachment","jsonFileAttachment","options","editorModule"], _kwq69p);  
-  $def("_1wls4er", null, ["md"], _1wls4er);  
+  $def("_4a056s", null, ["md"], _4a056s);  
   $def("_dbvt0t", "escapeTemplateLiteral", [], _dbvt0t);  
   $def("_1q2xn50", "inferCellGroupNameFromOJS", ["parser"], _1q2xn50);  
   $def("_1mfm13h", "normalizeObservableClipboardCell", ["inferCellGroupNameFromOJS","escapeTemplateLiteral"], _1mfm13h);  
   $def("_1pa2xc8", "readObservableClipboardCells", ["globalThis"], _1pa2xc8);  
   $def("_1w99cbu", "pasteObservableCellsIntoModule", ["viewof liveCellMap","normalizeObservableClipboardCell","findCell","compile_and_update"], _1w99cbu);  
-  $def("_rkhvti", null, ["md"], _rkhvti);  
+  $def("_nnkymf", null, ["md"], _nnkymf);  
   $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
   $def("_1j3c2uf", "decompiled", ["editedCell","decompile"], _1j3c2uf);  
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
-  main.variable(observer("editorModule")).define("editorModule", ["Generators", "viewof editorModule"], (G, _) => G.input(_));  
+  $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
-  $def("_wjug40", null, ["md"], _wjug40);  
-  $def("_1ju14cq", "compile_and_update", ["compile","runtime","repositionSetElement"], _1ju14cq);  
-  $def("_ksln5y", null, ["md"], _ksln5y);  
+  $def("_argpju", null, ["md"], _argpju);  
+  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
+  $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
-  $def("_1qcfq34", null, ["md"], _1qcfq34);  
+  $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
   $def("_rwez9", "viewof variable", ["Inputs","editedCell"], _rwez9);  
-  main.variable(observer("variable")).define("variable", ["Generators", "viewof variable"], (G, _) => G.input(_));  
+  $def("_11gvkq4", "variable", ["Generators","viewof variable"], _11gvkq4);  
   $def("_r5nvms", "name", ["variable"], _r5nvms);  
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
-  main.variable(observer("definition")).define("definition", ["Generators", "viewof definition"], (G, _) => G.input(_));  
-  $def("_71x0y8", null, ["Inputs","definition","variable","inputs"], _71x0y8);  
-  $def("_7dmbbr", null, ["md"], _7dmbbr);  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
+  $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
+  $def("_1q557s", null, ["md"], _1q557s);  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -5384,12 +5397,10 @@ export default function define(runtime, observer) {
   main.define("isnode", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("isnode", _));  
   main.define("repositionSetElement", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("repositionSetElement", _));  
   main.define("onCodeChange", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("onCodeChange", _));  
-  main.define("module @tomlarkworthy/codemirror-6-v2", async () => runtime.module((await import("/@tomlarkworthy/codemirror-6-v2.js?v=4")).default));  
   main.define("EditorState", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("EditorState", _));  
   main.define("EditorView", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("EditorView", _));  
   main.define("codemirror", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("codemirror", _));  
   main.define("myDefaultTheme", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("myDefaultTheme", _));  
-  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
   main.define("decompile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("decompile", _));  
   main.define("compile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("compile", _));  
   main.define("cellMap", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("cellMap", _));  
@@ -5397,27 +5408,18 @@ export default function define(runtime, observer) {
   main.define("findModuleName", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("findModuleName", _));  
   main.define("parser", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("parser", _));  
   $def("_1d94dks", "javascriptPlugin", ["codemirror"], _1d94dks);  
-  $def("_1xaw0at", null, ["md"], _1xaw0at);  
-  main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
+  $def("_ar9tao", null, ["md"], _ar9tao);  
   main.define("reversibleAttach", ["module @tomlarkworthy/reversible-attachment", "@variable"], (_, v) => v.import("reversibleAttach", _));  
-  main.define("module @tomlarkworthy/exporter-2", async () => runtime.module((await import("/@tomlarkworthy/exporter-2.js?v=4")).default));  
-  main.define("exporter", ["module @tomlarkworthy/exporter-2", "@variable"], (_, v) => v.import("exporter", _));  
-  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
   main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
-  main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
   main.define("flowQueue", ["module @tomlarkworthy/flow-queue", "@variable"], (_, v) => v.import("flowQueue", _));  
-  main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
   main.define("viewof liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("viewof liveCellMap", _));  
   main.define("liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("liveCellMap", _));  
-  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
   main.define("hash", ["module d/57d79353bac56631@44", "@variable"], (_, v) => v.import("hash", _));  
-  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
   main.define("extractNotebookAndCell", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("extractNotebookAndCell", _));  
   main.define("navHref", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("navHref", _));  
-  main.define("module @tomlarkworthy/cells-to-clipboard", async () => runtime.module((await import("/@tomlarkworthy/cells-to-clipboard.js?v=4")).default));  
   main.define("cellsToClipboard", ["module @tomlarkworthy/cells-to-clipboard", "@variable"], (_, v) => v.import("cellsToClipboard", _));
   return main;
 }

--- a/notebooks/@tomlarkworthy_golden-layout-2-6-0.html
+++ b/notebooks/@tomlarkworthy_golden-layout-2-6-0.html
@@ -4690,7 +4690,7 @@ export default function define(runtime, observer) {
 >
 e30K
 </script>
-<script id="@tomlarkworthy/editor-5" 
+<script id="@tomlarkworthy/editor-5"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -4737,7 +4737,6 @@ md`## TODO
 const _1ociws4 = function _6(md){return(
 md`## Sync editors`
 )};
-const _1vq49kx = (_, v) => v.import("syncers", _);
 const _hdieof = function _editors(){return(
 new Map()
 )};
@@ -4815,12 +4814,12 @@ Inputs.toggle({
   value: !isOnObservableCom()
 })
 )};
+const _1oaz8r1 = (G, _) => G.input(_);
 const _16ks4jz = function _12(md){return(
 md`## \`cellEditor\` component
 
 Using Dataflow templating to create reusable Hotbar Component builder`
 )};
-const _1deps8p = (_, v) => v.import("cloneDataflow", _);
 const _199ztvl = function _hotbarTemplate(lookupVariable,editorModule){return(
 lookupVariable(
   [
@@ -5057,6 +5056,7 @@ md`## Hotbar Prototype`
 const _1o2h65s = function _editedCell(Inputs){return(
 Inputs.input(null)
 )};
+const _7g3h7h = (G, _) => G.input(_);
 const _1urs1md = function _findCell($0,modules){return(
 (variable, dom = undefined) => {
   if (variable) {
@@ -5216,9 +5216,11 @@ Inputs.toggle({
   value: true
 })
 )};
+const _1h8337z = (G, _) => G.input(_);
 const _tct2nf = function _edit(Inputs){return(
 Inputs.toggle({ label: "edit" })
 )};
+const _7izj7k = (G, _) => G.input(_);
 const _1fwb5jc = function _toolbar(htl,reversibleAttach,combine,$0,$1,$2,$3,$4,$5,$6,$7){return(
 htl.html`<div
     class="toolbar"
@@ -5246,11 +5248,13 @@ Inputs.button("➕", {
   }
 })
 )};
+const _1aii9ps = (G, _) => G.input(_);
 const _1bn860e = function _remove(Inputs,deleteCell,$0){return(
 Inputs.button("🗑️", {
   reduce: () => deleteCell({ cell: $0.value })
 })
 )};
+const _1ad0xr8 = (G, _) => G.input(_);
 const _tw1j7n = function _apply(Inputs,compile_and_update,states,editedCell)
 {
   const button = Inputs.button("▶️", {
@@ -5269,11 +5273,13 @@ const _tw1j7n = function _apply(Inputs,compile_and_update,states,editedCell)
   button.onmousedown = (e) => e.preventDefault();
   return button;
 };
+const _1cjyuqm = (G, _) => G.input(_);
 const _14rfku9 = function _up(Inputs,moveCell,$0){return(
 Inputs.button("⬆", {
   reduce: () => moveCell($0.value, -1)
 })
 )};
+const _frzs5d = (G, _) => G.input(_);
 const _9pymuj = function _paste(Inputs,readObservableClipboardCells,pasteObservableCellsIntoModule,editedCell){return(
 Inputs.button("📋", {
   reduce: async () => {
@@ -5282,11 +5288,13 @@ Inputs.button("📋", {
   }
 })
 )};
+const _1whsszt = (G, _) => G.input(_);
 const _corxwl = function _down(Inputs,moveCell,$0){return(
 Inputs.button("⬇", {
   reduce: () => moveCell($0.value, 1)
 })
 )};
+const _1to28po = (G, _) => G.input(_);
 const _gia2ci = function _copy(Inputs,html,$0,decompile,$1,getOption,cellsToClipboard){return(
 Inputs.button(
   html`<span style="font-size: .875em; margin-right: .125em; position: relative; top: -.25em; left: -.125em">
@@ -5328,6 +5336,7 @@ Inputs.button(
   }
 )
 )};
+const _fw41wt = (G, _) => G.input(_);
 const _srtw8o = function _module(editedCell){return(
 editedCell.module.module
 )};
@@ -5382,6 +5391,7 @@ md`## API handler`
 const _d7ouqx = function _command(flowQueue){return(
 flowQueue()
 )};
+const _118qt2v = (G, _) => G.input(_);
 const _19l2nem = function _54(command){return(
 command
 )};
@@ -5654,10 +5664,10 @@ const _rtf009 = function _select(editedCell,Inputs,getOption,setOption){return(
   return el;
 })()
 )};
+const _14mwbuc = (G, _) => G.input(_);
 const _l4sbcd = function _70(md){return(
 md`## Pinning`
 )};
-const _1sxszb9 = (_, v) => v.import("getFileAttachment", _);
 const _ezl7wk = function _72(FileAttachment){return(
 FileAttachment("cell_options.json")
 )};
@@ -5667,6 +5677,7 @@ getFileAttachment("cell_options.json", editorModule)
 const _760ozq = async function _options(Inputs,optionsFile){return(
 Inputs.input(await optionsFile.json())
 )};
+const _4rh26k = (G, _) => G.input(_);
 const _1lqy7cs = function _setOption(findCell,_,$0,Event){return(
 (variable, option, value) => {
   const cell = findCell(variable);
@@ -5846,6 +5857,7 @@ const _1j3c2uf = function _decompiled(editedCell,decompile)
 const _w5q3yf = function _editorModule(thisModule){return(
 thisModule()
 )};
+const _18kaj2p = (G, _) => G.input(_);
 const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_options)
 {
   //editedCell;
@@ -5857,43 +5869,47 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1ju14cq = function _compile_and_update(compile,runtime,repositionSetElement){return(
-(source, variables = [], cell) => {
-    try {
-        debugger;
-        let reposition = false, insertionIndex = -1;
-        const newVariables = compile(source);
-        if (!variables || variables.length !== newVariables.length) {
-            reposition = true;
-            variables.forEach(v => v.delete());
-            variables.length = 0;
-            for (let i = 0; i < newVariables.length; i++) {
-                const newVariable = cell.module.module.variable({});
-                variables.push(newVariable);
+const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+{
+    return (source, variables = [], cell) => {
+        try {
+            debugger;
+            let reposition = false, insertionIndex = -1;
+            const newVariables = compile(source);
+            if (!variables || variables.length !== newVariables.length) {
+                reposition = true;
+                variables.forEach(v => v.delete());
+                variables.length = 0;
+                for (let i = 0; i < newVariables.length; i++) {
+                    const newVariable = cell.module.module.variable({});
+                    // Assign a random pid up-front so blank/identical new cells don't
+                    // collide via persistentId's contentHash. See lopecode#144.
+                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+                    variables.push(newVariable);
+                }
             }
-        }
-        if (reposition) {
-            insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-        }
-        newVariables.forEach((v, i) => {
-            const variable = variables[i];
-            let _fn;
-            eval('_fn = ' + v._definition);
-            if (v._name) {
-                variable.define(v._name, v._inputs, _fn);
-            } else {
-                variable.define(v._inputs, _fn);
+            if (reposition) {
+                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
-            if (reposition)
-                repositionSetElement(runtime._variables, variable, insertionIndex + i);
-        });
-        return variables;
-    } catch (e) {
-        console.error(e);
-        debugger;
-    }
-}
-)};
+            newVariables.forEach((v, i) => {
+                const variable = variables[i];
+                let _fn;
+                eval('_fn = ' + v._definition);
+                if (v._name) {
+                    variable.define(v._name, v._inputs, _fn);
+                } else {
+                    variable.define(v._inputs, _fn);
+                }
+                if (reposition)
+                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
+            });
+            return variables;
+        } catch (e) {
+            console.error(e);
+            debugger;
+        }
+    };
+};
 const _1jqs8in = function _91(md){return(
 md`### Remove Cells`
 )};
@@ -5912,6 +5928,7 @@ Inputs.radio(editedCell.variables, {
   value: editedCell.variables[0]
 })
 )};
+const _11gvkq4 = (G, _) => G.input(_);
 const _r5nvms = function _name(variable){return(
 variable._name
 )};
@@ -5925,6 +5942,7 @@ Inputs.textarea({
   rows: 10
 })
 )};
+const _b4rsn5 = (G, _) => G.input(_);
 const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
@@ -5938,22 +5956,12 @@ Inputs.button("update variable", {
 const _1q557s = function _99(md){return(
 md`### Editor Libraries`
 )};
-const _192vvs7 = (_, v) => v.import("descendants", _);
-const _3va6tf = (_, v) => v.import("EditorState", _);
-const _lmqjiv = (_, v) => v.import("decompile", _);
 const _1d94dks = function _javascriptPlugin(codemirror){return(
 codemirror
 )};
 const _ar9tao = function _104(md){return(
 md`### Libraries`
 )};
-const _viogn = (_, v) => v.import("reversibleAttach", _);
-const _nxg8mr = (_, v) => v.import("moduleMap", _);
-const _14a94d = (_, v) => v.import("flowQueue", _);
-const _gurtwb = (_, v) => v.import("viewof liveCellMap", _);
-const _19ebgtz = (_, v) => v.import("hash", _);
-const _n2vgkz = (_, v) => v.import("extractNotebookAndCell", _);
-const _1qucevb = (_, v) => v.import("cellsToClipboard", _);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -5967,22 +5975,34 @@ export default function define(runtime, observer) {
     return [name, {url: blob_url, mimeType: mime}]
   }));
   main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
+  main.define("module @tomlarkworthy/dataflow-templating", async () => runtime.module((await import("/@tomlarkworthy/dataflow-templating.js?v=4")).default));  
+  main.define("module @tomlarkworthy/fileattachments", async () => runtime.module((await import("/@tomlarkworthy/fileattachments.js?v=4")).default));  
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/codemirror-6-v2", async () => runtime.module((await import("/@tomlarkworthy/codemirror-6-v2.js?v=4")).default));  
+  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
+  main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
+  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
+  main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
+  main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
+  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
+  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
+  main.define("module @tomlarkworthy/cells-to-clipboard", async () => runtime.module((await import("/@tomlarkworthy/cells-to-clipboard.js?v=4")).default));  
   $def("_1tdjp0a", "title", ["md"], _1tdjp0a);  
   $def("_dm53bx", null, ["md"], _dm53bx);  
   $def("_61oxjf", "title_variable", ["lookupVariable","editorModule"], _61oxjf);  
   $def("_15uilf0", null, ["cellEditor","title_variable"], _15uilf0);  
   $def("_3x695f", null, ["md"], _3x695f);  
   $def("_1ociws4", null, ["md"], _1ociws4);  
-  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
   $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
-  main.variable(observer("attachContextManu")).define("attachContextManu", ["Generators", "viewof attachContextManu"], (G, _) => G.input(_));  
+  $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
   $def("_16ks4jz", null, ["md"], _16ks4jz);  
-  main.define("module @tomlarkworthy/dataflow-templating", async () => runtime.module((await import("/@tomlarkworthy/dataflow-templating.js?v=4")).default));  
   main.define("cloneDataflow", ["module @tomlarkworthy/dataflow-templating", "@variable"], (_, v) => v.import("cloneDataflow", _));  
   main.define("lookupVariable", ["module @tomlarkworthy/dataflow-templating", "@variable"], (_, v) => v.import("lookupVariable", _));  
   $def("_199ztvl", "hotbarTemplate", ["lookupVariable","editorModule"], _199ztvl);  
@@ -5993,7 +6013,7 @@ export default function define(runtime, observer) {
   $def("_110gwi7", "editorTemplate", ["lookupVariable","editorModule"], _110gwi7);  
   $def("_16rqzgl", null, ["md"], _16rqzgl);  
   $def("_1o2h65s", "viewof editedCell", ["Inputs"], _1o2h65s);  
-  main.variable(observer("editedCell")).define("editedCell", ["Generators", "viewof editedCell"], (G, _) => G.input(_));  
+  $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
   $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
@@ -6008,24 +6028,24 @@ export default function define(runtime, observer) {
   $def("_mrrmx3", null, ["md"], _mrrmx3);  
   $def("_14b1byw", null, ["md"], _14b1byw);  
   $def("_1j1loxx", "viewof combine", ["Inputs"], _1j1loxx);  
-  main.variable(observer("combine")).define("combine", ["Generators", "viewof combine"], (G, _) => G.input(_));  
+  $def("_1h8337z", "combine", ["Generators","viewof combine"], _1h8337z);  
   $def("_tct2nf", "viewof edit", ["Inputs"], _tct2nf);  
-  main.variable(observer("edit")).define("edit", ["Generators", "viewof edit"], (G, _) => G.input(_));  
+  $def("_7izj7k", "edit", ["Generators","viewof edit"], _7izj7k);  
   $def("_1fwb5jc", "toolbar", ["htl","reversibleAttach","combine","viewof select","viewof up","viewof down","viewof remove","viewof addCells","viewof apply","viewof copy","viewof paste"], _1fwb5jc);  
   $def("_yej3hb", "viewof addCells", ["Inputs","createCell","viewof editedCell"], _yej3hb);  
-  main.variable(observer("addCells")).define("addCells", ["Generators", "viewof addCells"], (G, _) => G.input(_));  
+  $def("_1aii9ps", "addCells", ["Generators","viewof addCells"], _1aii9ps);  
   $def("_1bn860e", "viewof remove", ["Inputs","deleteCell","viewof editedCell"], _1bn860e);  
-  main.variable(observer("remove")).define("remove", ["Generators", "viewof remove"], (G, _) => G.input(_));  
+  $def("_1ad0xr8", "remove", ["Generators","viewof remove"], _1ad0xr8);  
   $def("_tw1j7n", "viewof apply", ["Inputs","compile_and_update","states","editedCell"], _tw1j7n);  
-  main.variable(observer("apply")).define("apply", ["Generators", "viewof apply"], (G, _) => G.input(_));  
+  $def("_1cjyuqm", "apply", ["Generators","viewof apply"], _1cjyuqm);  
   $def("_14rfku9", "viewof up", ["Inputs","moveCell","viewof editedCell"], _14rfku9);  
-  main.variable(observer("up")).define("up", ["Generators", "viewof up"], (G, _) => G.input(_));  
+  $def("_frzs5d", "up", ["Generators","viewof up"], _frzs5d);  
   $def("_9pymuj", "viewof paste", ["Inputs","readObservableClipboardCells","pasteObservableCellsIntoModule","editedCell"], _9pymuj);  
-  main.variable(observer("paste")).define("paste", ["Generators", "viewof paste"], (G, _) => G.input(_));  
+  $def("_1whsszt", "paste", ["Generators","viewof paste"], _1whsszt);  
   $def("_corxwl", "viewof down", ["Inputs","moveCell","viewof editedCell"], _corxwl);  
-  main.variable(observer("down")).define("down", ["Generators", "viewof down"], (G, _) => G.input(_));  
+  $def("_1to28po", "down", ["Generators","viewof down"], _1to28po);  
   $def("_gia2ci", "viewof copy", ["Inputs","html","viewof editedCell","decompile","viewof liveCellMap","getOption","cellsToClipboard"], _gia2ci);  
-  main.variable(observer("copy")).define("copy", ["Generators", "viewof copy"], (G, _) => G.input(_));  
+  $def("_fw41wt", "copy", ["Generators","viewof copy"], _fw41wt);  
   $def("_srtw8o", "module", ["editedCell"], _srtw8o);  
   $def("_rv7t7x", "code_editor_view", ["EditorView"], _rv7t7x);  
   $def("_xvo1n6", "code_editor", ["code_editor_view"], _xvo1n6);  
@@ -6035,7 +6055,7 @@ export default function define(runtime, observer) {
   $def("_d9nzys", "deleteCell", ["viewof command"], _d9nzys);  
   $def("_c1u9w8", null, ["md"], _c1u9w8);  
   $def("_d7ouqx", "viewof command", ["flowQueue"], _d7ouqx);  
-  main.variable(observer("command")).define("command", ["Generators", "viewof command"], (G, _) => G.input(_));  
+  $def("_118qt2v", "command", ["Generators","viewof command"], _118qt2v);  
   $def("_19l2nem", null, ["command"], _19l2nem);  
   $def("_1f6v167", "findCellByVariable", [], _1f6v167);  
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
@@ -6052,9 +6072,8 @@ export default function define(runtime, observer) {
   $def("_dvne2z", "replaceCodeMirrorDoc", [], _dvne2z);  
   $def("_1fpqfm0", null, ["md"], _1fpqfm0);  
   $def("_rtf009", "viewof select", ["editedCell","Inputs","getOption","setOption"], _rtf009);  
-  main.variable(observer("select")).define("select", ["Generators", "viewof select"], (G, _) => G.input(_));  
+  $def("_14mwbuc", "select", ["Generators","viewof select"], _14mwbuc);  
   $def("_l4sbcd", null, ["md"], _l4sbcd);  
-  main.define("module @tomlarkworthy/fileattachments", async () => runtime.module((await import("/@tomlarkworthy/fileattachments.js?v=4")).default));  
   main.define("getFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachment", _));  
   main.define("setFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("setFileAttachment", _));  
   main.define("removeFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("removeFileAttachment", _));  
@@ -6063,7 +6082,7 @@ export default function define(runtime, observer) {
   $def("_ezl7wk", null, ["FileAttachment"], _ezl7wk);  
   $def("_kygz54", "optionsFile", ["getFileAttachment","editorModule"], _kygz54);  
   $def("_760ozq", "viewof options", ["Inputs","optionsFile"], _760ozq);  
-  main.variable(observer("options")).define("options", ["Generators", "viewof options"], (G, _) => G.input(_));  
+  $def("_4rh26k", "options", ["Generators","viewof options"], _4rh26k);  
   $def("_1lqy7cs", "setOption", ["findCell","_","viewof options","Event"], _1lqy7cs);  
   $def("_1oxe5ee", "getOption", ["findCell","_","viewof options"], _1oxe5ee);  
   $def("_kwq69p", "save_options", ["setFileAttachment","jsonFileAttachment","options","editorModule"], _kwq69p);  
@@ -6077,22 +6096,21 @@ export default function define(runtime, observer) {
   $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
   $def("_1j3c2uf", "decompiled", ["editedCell","decompile"], _1j3c2uf);  
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
-  main.variable(observer("editorModule")).define("editorModule", ["Generators", "viewof editorModule"], (G, _) => G.input(_));  
+  $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1ju14cq", "compile_and_update", ["compile","runtime","repositionSetElement"], _1ju14cq);  
+  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
   $def("_rwez9", "viewof variable", ["Inputs","editedCell"], _rwez9);  
-  main.variable(observer("variable")).define("variable", ["Generators", "viewof variable"], (G, _) => G.input(_));  
+  $def("_11gvkq4", "variable", ["Generators","viewof variable"], _11gvkq4);  
   $def("_r5nvms", "name", ["variable"], _r5nvms);  
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
-  main.variable(observer("definition")).define("definition", ["Generators", "viewof definition"], (G, _) => G.input(_));  
+  $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
   $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
   $def("_1q557s", null, ["md"], _1q557s);  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -6103,12 +6121,10 @@ export default function define(runtime, observer) {
   main.define("isnode", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("isnode", _));  
   main.define("repositionSetElement", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("repositionSetElement", _));  
   main.define("onCodeChange", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("onCodeChange", _));  
-  main.define("module @tomlarkworthy/codemirror-6-v2", async () => runtime.module((await import("/@tomlarkworthy/codemirror-6-v2.js?v=4")).default));  
   main.define("EditorState", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("EditorState", _));  
   main.define("EditorView", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("EditorView", _));  
   main.define("codemirror", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("codemirror", _));  
   main.define("myDefaultTheme", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("myDefaultTheme", _));  
-  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
   main.define("decompile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("decompile", _));  
   main.define("compile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("compile", _));  
   main.define("cellMap", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("cellMap", _));  
@@ -6117,27 +6133,21 @@ export default function define(runtime, observer) {
   main.define("parser", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("parser", _));  
   $def("_1d94dks", "javascriptPlugin", ["codemirror"], _1d94dks);  
   $def("_ar9tao", null, ["md"], _ar9tao);  
-  main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
   main.define("reversibleAttach", ["module @tomlarkworthy/reversible-attachment", "@variable"], (_, v) => v.import("reversibleAttach", _));  
-  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
   main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
-  main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
   main.define("flowQueue", ["module @tomlarkworthy/flow-queue", "@variable"], (_, v) => v.import("flowQueue", _));  
-  main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
   main.define("viewof liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("viewof liveCellMap", _));  
   main.define("liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("liveCellMap", _));  
-  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
   main.define("hash", ["module d/57d79353bac56631@44", "@variable"], (_, v) => v.import("hash", _));  
-  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
   main.define("extractNotebookAndCell", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("extractNotebookAndCell", _));  
   main.define("navHref", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("navHref", _));  
-  main.define("module @tomlarkworthy/cells-to-clipboard", async () => runtime.module((await import("/@tomlarkworthy/cells-to-clipboard.js?v=4")).default));  
   main.define("cellsToClipboard", ["module @tomlarkworthy/cells-to-clipboard", "@variable"], (_, v) => v.import("cellsToClipboard", _));
   return main;
-}</script>
+}
+</script>
 <script id="@tomlarkworthy/escodegen/escodegen.browser.min.js.gz" 
   type="text/plain"
   data-encoding="base64"

--- a/notebooks/@tomlarkworthy_import-notebook.html
+++ b/notebooks/@tomlarkworthy_import-notebook.html
@@ -4690,7 +4690,7 @@ export default function define(runtime, observer) {
 >
 e30K
 </script>
-<script id="@tomlarkworthy/editor-5" 
+<script id="@tomlarkworthy/editor-5"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -4737,7 +4737,6 @@ md`## TODO
 const _1ociws4 = function _6(md){return(
 md`## Sync editors`
 )};
-const _1vq49kx = (_, v) => v.import("syncers", _);
 const _hdieof = function _editors(){return(
 new Map()
 )};
@@ -4815,12 +4814,12 @@ Inputs.toggle({
   value: !isOnObservableCom()
 })
 )};
+const _1oaz8r1 = (G, _) => G.input(_);
 const _16ks4jz = function _12(md){return(
 md`## \`cellEditor\` component
 
 Using Dataflow templating to create reusable Hotbar Component builder`
 )};
-const _1deps8p = (_, v) => v.import("cloneDataflow", _);
 const _199ztvl = function _hotbarTemplate(lookupVariable,editorModule){return(
 lookupVariable(
   [
@@ -5057,6 +5056,7 @@ md`## Hotbar Prototype`
 const _1o2h65s = function _editedCell(Inputs){return(
 Inputs.input(null)
 )};
+const _7g3h7h = (G, _) => G.input(_);
 const _1urs1md = function _findCell($0,modules){return(
 (variable, dom = undefined) => {
   if (variable) {
@@ -5216,9 +5216,11 @@ Inputs.toggle({
   value: true
 })
 )};
+const _1h8337z = (G, _) => G.input(_);
 const _tct2nf = function _edit(Inputs){return(
 Inputs.toggle({ label: "edit" })
 )};
+const _7izj7k = (G, _) => G.input(_);
 const _1fwb5jc = function _toolbar(htl,reversibleAttach,combine,$0,$1,$2,$3,$4,$5,$6,$7){return(
 htl.html`<div
     class="toolbar"
@@ -5246,11 +5248,13 @@ Inputs.button("➕", {
   }
 })
 )};
+const _1aii9ps = (G, _) => G.input(_);
 const _1bn860e = function _remove(Inputs,deleteCell,$0){return(
 Inputs.button("🗑️", {
   reduce: () => deleteCell({ cell: $0.value })
 })
 )};
+const _1ad0xr8 = (G, _) => G.input(_);
 const _tw1j7n = function _apply(Inputs,compile_and_update,states,editedCell)
 {
   const button = Inputs.button("▶️", {
@@ -5269,11 +5273,13 @@ const _tw1j7n = function _apply(Inputs,compile_and_update,states,editedCell)
   button.onmousedown = (e) => e.preventDefault();
   return button;
 };
+const _1cjyuqm = (G, _) => G.input(_);
 const _14rfku9 = function _up(Inputs,moveCell,$0){return(
 Inputs.button("⬆", {
   reduce: () => moveCell($0.value, -1)
 })
 )};
+const _frzs5d = (G, _) => G.input(_);
 const _9pymuj = function _paste(Inputs,readObservableClipboardCells,pasteObservableCellsIntoModule,editedCell){return(
 Inputs.button("📋", {
   reduce: async () => {
@@ -5282,11 +5288,13 @@ Inputs.button("📋", {
   }
 })
 )};
+const _1whsszt = (G, _) => G.input(_);
 const _corxwl = function _down(Inputs,moveCell,$0){return(
 Inputs.button("⬇", {
   reduce: () => moveCell($0.value, 1)
 })
 )};
+const _1to28po = (G, _) => G.input(_);
 const _gia2ci = function _copy(Inputs,html,$0,decompile,$1,getOption,cellsToClipboard){return(
 Inputs.button(
   html`<span style="font-size: .875em; margin-right: .125em; position: relative; top: -.25em; left: -.125em">
@@ -5328,6 +5336,7 @@ Inputs.button(
   }
 )
 )};
+const _fw41wt = (G, _) => G.input(_);
 const _srtw8o = function _module(editedCell){return(
 editedCell.module.module
 )};
@@ -5382,6 +5391,7 @@ md`## API handler`
 const _d7ouqx = function _command(flowQueue){return(
 flowQueue()
 )};
+const _118qt2v = (G, _) => G.input(_);
 const _19l2nem = function _54(command){return(
 command
 )};
@@ -5654,10 +5664,10 @@ const _rtf009 = function _select(editedCell,Inputs,getOption,setOption){return(
   return el;
 })()
 )};
+const _14mwbuc = (G, _) => G.input(_);
 const _l4sbcd = function _70(md){return(
 md`## Pinning`
 )};
-const _1sxszb9 = (_, v) => v.import("getFileAttachment", _);
 const _ezl7wk = function _72(FileAttachment){return(
 FileAttachment("cell_options.json")
 )};
@@ -5667,6 +5677,7 @@ getFileAttachment("cell_options.json", editorModule)
 const _760ozq = async function _options(Inputs,optionsFile){return(
 Inputs.input(await optionsFile.json())
 )};
+const _4rh26k = (G, _) => G.input(_);
 const _1lqy7cs = function _setOption(findCell,_,$0,Event){return(
 (variable, option, value) => {
   const cell = findCell(variable);
@@ -5846,6 +5857,7 @@ const _1j3c2uf = function _decompiled(editedCell,decompile)
 const _w5q3yf = function _editorModule(thisModule){return(
 thisModule()
 )};
+const _18kaj2p = (G, _) => G.input(_);
 const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_options)
 {
   //editedCell;
@@ -5857,43 +5869,47 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1ju14cq = function _compile_and_update(compile,runtime,repositionSetElement){return(
-(source, variables = [], cell) => {
-    try {
-        debugger;
-        let reposition = false, insertionIndex = -1;
-        const newVariables = compile(source);
-        if (!variables || variables.length !== newVariables.length) {
-            reposition = true;
-            variables.forEach(v => v.delete());
-            variables.length = 0;
-            for (let i = 0; i < newVariables.length; i++) {
-                const newVariable = cell.module.module.variable({});
-                variables.push(newVariable);
+const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+{
+    return (source, variables = [], cell) => {
+        try {
+            debugger;
+            let reposition = false, insertionIndex = -1;
+            const newVariables = compile(source);
+            if (!variables || variables.length !== newVariables.length) {
+                reposition = true;
+                variables.forEach(v => v.delete());
+                variables.length = 0;
+                for (let i = 0; i < newVariables.length; i++) {
+                    const newVariable = cell.module.module.variable({});
+                    // Assign a random pid up-front so blank/identical new cells don't
+                    // collide via persistentId's contentHash. See lopecode#144.
+                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+                    variables.push(newVariable);
+                }
             }
-        }
-        if (reposition) {
-            insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-        }
-        newVariables.forEach((v, i) => {
-            const variable = variables[i];
-            let _fn;
-            eval('_fn = ' + v._definition);
-            if (v._name) {
-                variable.define(v._name, v._inputs, _fn);
-            } else {
-                variable.define(v._inputs, _fn);
+            if (reposition) {
+                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
-            if (reposition)
-                repositionSetElement(runtime._variables, variable, insertionIndex + i);
-        });
-        return variables;
-    } catch (e) {
-        console.error(e);
-        debugger;
-    }
-}
-)};
+            newVariables.forEach((v, i) => {
+                const variable = variables[i];
+                let _fn;
+                eval('_fn = ' + v._definition);
+                if (v._name) {
+                    variable.define(v._name, v._inputs, _fn);
+                } else {
+                    variable.define(v._inputs, _fn);
+                }
+                if (reposition)
+                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
+            });
+            return variables;
+        } catch (e) {
+            console.error(e);
+            debugger;
+        }
+    };
+};
 const _1jqs8in = function _91(md){return(
 md`### Remove Cells`
 )};
@@ -5912,6 +5928,7 @@ Inputs.radio(editedCell.variables, {
   value: editedCell.variables[0]
 })
 )};
+const _11gvkq4 = (G, _) => G.input(_);
 const _r5nvms = function _name(variable){return(
 variable._name
 )};
@@ -5925,6 +5942,7 @@ Inputs.textarea({
   rows: 10
 })
 )};
+const _b4rsn5 = (G, _) => G.input(_);
 const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
@@ -5938,22 +5956,12 @@ Inputs.button("update variable", {
 const _1q557s = function _99(md){return(
 md`### Editor Libraries`
 )};
-const _192vvs7 = (_, v) => v.import("descendants", _);
-const _3va6tf = (_, v) => v.import("EditorState", _);
-const _lmqjiv = (_, v) => v.import("decompile", _);
 const _1d94dks = function _javascriptPlugin(codemirror){return(
 codemirror
 )};
 const _ar9tao = function _104(md){return(
 md`### Libraries`
 )};
-const _viogn = (_, v) => v.import("reversibleAttach", _);
-const _nxg8mr = (_, v) => v.import("moduleMap", _);
-const _14a94d = (_, v) => v.import("flowQueue", _);
-const _gurtwb = (_, v) => v.import("viewof liveCellMap", _);
-const _19ebgtz = (_, v) => v.import("hash", _);
-const _n2vgkz = (_, v) => v.import("extractNotebookAndCell", _);
-const _1qucevb = (_, v) => v.import("cellsToClipboard", _);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -5967,22 +5975,34 @@ export default function define(runtime, observer) {
     return [name, {url: blob_url, mimeType: mime}]
   }));
   main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
+  main.define("module @tomlarkworthy/dataflow-templating", async () => runtime.module((await import("/@tomlarkworthy/dataflow-templating.js?v=4")).default));  
+  main.define("module @tomlarkworthy/fileattachments", async () => runtime.module((await import("/@tomlarkworthy/fileattachments.js?v=4")).default));  
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/codemirror-6-v2", async () => runtime.module((await import("/@tomlarkworthy/codemirror-6-v2.js?v=4")).default));  
+  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
+  main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
+  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
+  main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
+  main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
+  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
+  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
+  main.define("module @tomlarkworthy/cells-to-clipboard", async () => runtime.module((await import("/@tomlarkworthy/cells-to-clipboard.js?v=4")).default));  
   $def("_1tdjp0a", "title", ["md"], _1tdjp0a);  
   $def("_dm53bx", null, ["md"], _dm53bx);  
   $def("_61oxjf", "title_variable", ["lookupVariable","editorModule"], _61oxjf);  
   $def("_15uilf0", null, ["cellEditor","title_variable"], _15uilf0);  
   $def("_3x695f", null, ["md"], _3x695f);  
   $def("_1ociws4", null, ["md"], _1ociws4);  
-  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
   $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
-  main.variable(observer("attachContextManu")).define("attachContextManu", ["Generators", "viewof attachContextManu"], (G, _) => G.input(_));  
+  $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
   $def("_16ks4jz", null, ["md"], _16ks4jz);  
-  main.define("module @tomlarkworthy/dataflow-templating", async () => runtime.module((await import("/@tomlarkworthy/dataflow-templating.js?v=4")).default));  
   main.define("cloneDataflow", ["module @tomlarkworthy/dataflow-templating", "@variable"], (_, v) => v.import("cloneDataflow", _));  
   main.define("lookupVariable", ["module @tomlarkworthy/dataflow-templating", "@variable"], (_, v) => v.import("lookupVariable", _));  
   $def("_199ztvl", "hotbarTemplate", ["lookupVariable","editorModule"], _199ztvl);  
@@ -5993,7 +6013,7 @@ export default function define(runtime, observer) {
   $def("_110gwi7", "editorTemplate", ["lookupVariable","editorModule"], _110gwi7);  
   $def("_16rqzgl", null, ["md"], _16rqzgl);  
   $def("_1o2h65s", "viewof editedCell", ["Inputs"], _1o2h65s);  
-  main.variable(observer("editedCell")).define("editedCell", ["Generators", "viewof editedCell"], (G, _) => G.input(_));  
+  $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
   $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
@@ -6008,24 +6028,24 @@ export default function define(runtime, observer) {
   $def("_mrrmx3", null, ["md"], _mrrmx3);  
   $def("_14b1byw", null, ["md"], _14b1byw);  
   $def("_1j1loxx", "viewof combine", ["Inputs"], _1j1loxx);  
-  main.variable(observer("combine")).define("combine", ["Generators", "viewof combine"], (G, _) => G.input(_));  
+  $def("_1h8337z", "combine", ["Generators","viewof combine"], _1h8337z);  
   $def("_tct2nf", "viewof edit", ["Inputs"], _tct2nf);  
-  main.variable(observer("edit")).define("edit", ["Generators", "viewof edit"], (G, _) => G.input(_));  
+  $def("_7izj7k", "edit", ["Generators","viewof edit"], _7izj7k);  
   $def("_1fwb5jc", "toolbar", ["htl","reversibleAttach","combine","viewof select","viewof up","viewof down","viewof remove","viewof addCells","viewof apply","viewof copy","viewof paste"], _1fwb5jc);  
   $def("_yej3hb", "viewof addCells", ["Inputs","createCell","viewof editedCell"], _yej3hb);  
-  main.variable(observer("addCells")).define("addCells", ["Generators", "viewof addCells"], (G, _) => G.input(_));  
+  $def("_1aii9ps", "addCells", ["Generators","viewof addCells"], _1aii9ps);  
   $def("_1bn860e", "viewof remove", ["Inputs","deleteCell","viewof editedCell"], _1bn860e);  
-  main.variable(observer("remove")).define("remove", ["Generators", "viewof remove"], (G, _) => G.input(_));  
+  $def("_1ad0xr8", "remove", ["Generators","viewof remove"], _1ad0xr8);  
   $def("_tw1j7n", "viewof apply", ["Inputs","compile_and_update","states","editedCell"], _tw1j7n);  
-  main.variable(observer("apply")).define("apply", ["Generators", "viewof apply"], (G, _) => G.input(_));  
+  $def("_1cjyuqm", "apply", ["Generators","viewof apply"], _1cjyuqm);  
   $def("_14rfku9", "viewof up", ["Inputs","moveCell","viewof editedCell"], _14rfku9);  
-  main.variable(observer("up")).define("up", ["Generators", "viewof up"], (G, _) => G.input(_));  
+  $def("_frzs5d", "up", ["Generators","viewof up"], _frzs5d);  
   $def("_9pymuj", "viewof paste", ["Inputs","readObservableClipboardCells","pasteObservableCellsIntoModule","editedCell"], _9pymuj);  
-  main.variable(observer("paste")).define("paste", ["Generators", "viewof paste"], (G, _) => G.input(_));  
+  $def("_1whsszt", "paste", ["Generators","viewof paste"], _1whsszt);  
   $def("_corxwl", "viewof down", ["Inputs","moveCell","viewof editedCell"], _corxwl);  
-  main.variable(observer("down")).define("down", ["Generators", "viewof down"], (G, _) => G.input(_));  
+  $def("_1to28po", "down", ["Generators","viewof down"], _1to28po);  
   $def("_gia2ci", "viewof copy", ["Inputs","html","viewof editedCell","decompile","viewof liveCellMap","getOption","cellsToClipboard"], _gia2ci);  
-  main.variable(observer("copy")).define("copy", ["Generators", "viewof copy"], (G, _) => G.input(_));  
+  $def("_fw41wt", "copy", ["Generators","viewof copy"], _fw41wt);  
   $def("_srtw8o", "module", ["editedCell"], _srtw8o);  
   $def("_rv7t7x", "code_editor_view", ["EditorView"], _rv7t7x);  
   $def("_xvo1n6", "code_editor", ["code_editor_view"], _xvo1n6);  
@@ -6035,7 +6055,7 @@ export default function define(runtime, observer) {
   $def("_d9nzys", "deleteCell", ["viewof command"], _d9nzys);  
   $def("_c1u9w8", null, ["md"], _c1u9w8);  
   $def("_d7ouqx", "viewof command", ["flowQueue"], _d7ouqx);  
-  main.variable(observer("command")).define("command", ["Generators", "viewof command"], (G, _) => G.input(_));  
+  $def("_118qt2v", "command", ["Generators","viewof command"], _118qt2v);  
   $def("_19l2nem", null, ["command"], _19l2nem);  
   $def("_1f6v167", "findCellByVariable", [], _1f6v167);  
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
@@ -6052,9 +6072,8 @@ export default function define(runtime, observer) {
   $def("_dvne2z", "replaceCodeMirrorDoc", [], _dvne2z);  
   $def("_1fpqfm0", null, ["md"], _1fpqfm0);  
   $def("_rtf009", "viewof select", ["editedCell","Inputs","getOption","setOption"], _rtf009);  
-  main.variable(observer("select")).define("select", ["Generators", "viewof select"], (G, _) => G.input(_));  
+  $def("_14mwbuc", "select", ["Generators","viewof select"], _14mwbuc);  
   $def("_l4sbcd", null, ["md"], _l4sbcd);  
-  main.define("module @tomlarkworthy/fileattachments", async () => runtime.module((await import("/@tomlarkworthy/fileattachments.js?v=4")).default));  
   main.define("getFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachment", _));  
   main.define("setFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("setFileAttachment", _));  
   main.define("removeFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("removeFileAttachment", _));  
@@ -6063,7 +6082,7 @@ export default function define(runtime, observer) {
   $def("_ezl7wk", null, ["FileAttachment"], _ezl7wk);  
   $def("_kygz54", "optionsFile", ["getFileAttachment","editorModule"], _kygz54);  
   $def("_760ozq", "viewof options", ["Inputs","optionsFile"], _760ozq);  
-  main.variable(observer("options")).define("options", ["Generators", "viewof options"], (G, _) => G.input(_));  
+  $def("_4rh26k", "options", ["Generators","viewof options"], _4rh26k);  
   $def("_1lqy7cs", "setOption", ["findCell","_","viewof options","Event"], _1lqy7cs);  
   $def("_1oxe5ee", "getOption", ["findCell","_","viewof options"], _1oxe5ee);  
   $def("_kwq69p", "save_options", ["setFileAttachment","jsonFileAttachment","options","editorModule"], _kwq69p);  
@@ -6077,22 +6096,21 @@ export default function define(runtime, observer) {
   $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
   $def("_1j3c2uf", "decompiled", ["editedCell","decompile"], _1j3c2uf);  
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
-  main.variable(observer("editorModule")).define("editorModule", ["Generators", "viewof editorModule"], (G, _) => G.input(_));  
+  $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1ju14cq", "compile_and_update", ["compile","runtime","repositionSetElement"], _1ju14cq);  
+  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
   $def("_rwez9", "viewof variable", ["Inputs","editedCell"], _rwez9);  
-  main.variable(observer("variable")).define("variable", ["Generators", "viewof variable"], (G, _) => G.input(_));  
+  $def("_11gvkq4", "variable", ["Generators","viewof variable"], _11gvkq4);  
   $def("_r5nvms", "name", ["variable"], _r5nvms);  
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
-  main.variable(observer("definition")).define("definition", ["Generators", "viewof definition"], (G, _) => G.input(_));  
+  $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
   $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
   $def("_1q557s", null, ["md"], _1q557s);  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -6103,12 +6121,10 @@ export default function define(runtime, observer) {
   main.define("isnode", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("isnode", _));  
   main.define("repositionSetElement", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("repositionSetElement", _));  
   main.define("onCodeChange", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("onCodeChange", _));  
-  main.define("module @tomlarkworthy/codemirror-6-v2", async () => runtime.module((await import("/@tomlarkworthy/codemirror-6-v2.js?v=4")).default));  
   main.define("EditorState", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("EditorState", _));  
   main.define("EditorView", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("EditorView", _));  
   main.define("codemirror", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("codemirror", _));  
   main.define("myDefaultTheme", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("myDefaultTheme", _));  
-  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
   main.define("decompile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("decompile", _));  
   main.define("compile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("compile", _));  
   main.define("cellMap", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("cellMap", _));  
@@ -6117,27 +6133,21 @@ export default function define(runtime, observer) {
   main.define("parser", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("parser", _));  
   $def("_1d94dks", "javascriptPlugin", ["codemirror"], _1d94dks);  
   $def("_ar9tao", null, ["md"], _ar9tao);  
-  main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
   main.define("reversibleAttach", ["module @tomlarkworthy/reversible-attachment", "@variable"], (_, v) => v.import("reversibleAttach", _));  
-  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
   main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
-  main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
   main.define("flowQueue", ["module @tomlarkworthy/flow-queue", "@variable"], (_, v) => v.import("flowQueue", _));  
-  main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
   main.define("viewof liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("viewof liveCellMap", _));  
   main.define("liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("liveCellMap", _));  
-  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
   main.define("hash", ["module d/57d79353bac56631@44", "@variable"], (_, v) => v.import("hash", _));  
-  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
   main.define("extractNotebookAndCell", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("extractNotebookAndCell", _));  
   main.define("navHref", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("navHref", _));  
-  main.define("module @tomlarkworthy/cells-to-clipboard", async () => runtime.module((await import("/@tomlarkworthy/cells-to-clipboard.js?v=4")).default));  
   main.define("cellsToClipboard", ["module @tomlarkworthy/cells-to-clipboard", "@variable"], (_, v) => v.import("cellsToClipboard", _));
   return main;
-}</script>
+}
+</script>
 <script id="@tomlarkworthy/escodegen/escodegen.browser.min.js.gz" 
   type="text/plain"
   data-encoding="base64"

--- a/notebooks/@tomlarkworthy_jest-expect-standalone.html
+++ b/notebooks/@tomlarkworthy_jest-expect-standalone.html
@@ -4690,7 +4690,7 @@ export default function define(runtime, observer) {
 >
 e30K
 </script>
-<script id="@tomlarkworthy/editor-5" 
+<script id="@tomlarkworthy/editor-5"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -4737,7 +4737,6 @@ md`## TODO
 const _1ociws4 = function _6(md){return(
 md`## Sync editors`
 )};
-const _1vq49kx = (_, v) => v.import("syncers", _);
 const _hdieof = function _editors(){return(
 new Map()
 )};
@@ -4815,12 +4814,12 @@ Inputs.toggle({
   value: !isOnObservableCom()
 })
 )};
+const _1oaz8r1 = (G, _) => G.input(_);
 const _16ks4jz = function _12(md){return(
 md`## \`cellEditor\` component
 
 Using Dataflow templating to create reusable Hotbar Component builder`
 )};
-const _1deps8p = (_, v) => v.import("cloneDataflow", _);
 const _199ztvl = function _hotbarTemplate(lookupVariable,editorModule){return(
 lookupVariable(
   [
@@ -5057,6 +5056,7 @@ md`## Hotbar Prototype`
 const _1o2h65s = function _editedCell(Inputs){return(
 Inputs.input(null)
 )};
+const _7g3h7h = (G, _) => G.input(_);
 const _1urs1md = function _findCell($0,modules){return(
 (variable, dom = undefined) => {
   if (variable) {
@@ -5216,9 +5216,11 @@ Inputs.toggle({
   value: true
 })
 )};
+const _1h8337z = (G, _) => G.input(_);
 const _tct2nf = function _edit(Inputs){return(
 Inputs.toggle({ label: "edit" })
 )};
+const _7izj7k = (G, _) => G.input(_);
 const _1fwb5jc = function _toolbar(htl,reversibleAttach,combine,$0,$1,$2,$3,$4,$5,$6,$7){return(
 htl.html`<div
     class="toolbar"
@@ -5246,11 +5248,13 @@ Inputs.button("➕", {
   }
 })
 )};
+const _1aii9ps = (G, _) => G.input(_);
 const _1bn860e = function _remove(Inputs,deleteCell,$0){return(
 Inputs.button("🗑️", {
   reduce: () => deleteCell({ cell: $0.value })
 })
 )};
+const _1ad0xr8 = (G, _) => G.input(_);
 const _tw1j7n = function _apply(Inputs,compile_and_update,states,editedCell)
 {
   const button = Inputs.button("▶️", {
@@ -5269,11 +5273,13 @@ const _tw1j7n = function _apply(Inputs,compile_and_update,states,editedCell)
   button.onmousedown = (e) => e.preventDefault();
   return button;
 };
+const _1cjyuqm = (G, _) => G.input(_);
 const _14rfku9 = function _up(Inputs,moveCell,$0){return(
 Inputs.button("⬆", {
   reduce: () => moveCell($0.value, -1)
 })
 )};
+const _frzs5d = (G, _) => G.input(_);
 const _9pymuj = function _paste(Inputs,readObservableClipboardCells,pasteObservableCellsIntoModule,editedCell){return(
 Inputs.button("📋", {
   reduce: async () => {
@@ -5282,11 +5288,13 @@ Inputs.button("📋", {
   }
 })
 )};
+const _1whsszt = (G, _) => G.input(_);
 const _corxwl = function _down(Inputs,moveCell,$0){return(
 Inputs.button("⬇", {
   reduce: () => moveCell($0.value, 1)
 })
 )};
+const _1to28po = (G, _) => G.input(_);
 const _gia2ci = function _copy(Inputs,html,$0,decompile,$1,getOption,cellsToClipboard){return(
 Inputs.button(
   html`<span style="font-size: .875em; margin-right: .125em; position: relative; top: -.25em; left: -.125em">
@@ -5328,6 +5336,7 @@ Inputs.button(
   }
 )
 )};
+const _fw41wt = (G, _) => G.input(_);
 const _srtw8o = function _module(editedCell){return(
 editedCell.module.module
 )};
@@ -5382,6 +5391,7 @@ md`## API handler`
 const _d7ouqx = function _command(flowQueue){return(
 flowQueue()
 )};
+const _118qt2v = (G, _) => G.input(_);
 const _19l2nem = function _54(command){return(
 command
 )};
@@ -5654,10 +5664,10 @@ const _rtf009 = function _select(editedCell,Inputs,getOption,setOption){return(
   return el;
 })()
 )};
+const _14mwbuc = (G, _) => G.input(_);
 const _l4sbcd = function _70(md){return(
 md`## Pinning`
 )};
-const _1sxszb9 = (_, v) => v.import("getFileAttachment", _);
 const _ezl7wk = function _72(FileAttachment){return(
 FileAttachment("cell_options.json")
 )};
@@ -5667,6 +5677,7 @@ getFileAttachment("cell_options.json", editorModule)
 const _760ozq = async function _options(Inputs,optionsFile){return(
 Inputs.input(await optionsFile.json())
 )};
+const _4rh26k = (G, _) => G.input(_);
 const _1lqy7cs = function _setOption(findCell,_,$0,Event){return(
 (variable, option, value) => {
   const cell = findCell(variable);
@@ -5846,6 +5857,7 @@ const _1j3c2uf = function _decompiled(editedCell,decompile)
 const _w5q3yf = function _editorModule(thisModule){return(
 thisModule()
 )};
+const _18kaj2p = (G, _) => G.input(_);
 const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_options)
 {
   //editedCell;
@@ -5857,43 +5869,47 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1ju14cq = function _compile_and_update(compile,runtime,repositionSetElement){return(
-(source, variables = [], cell) => {
-    try {
-        debugger;
-        let reposition = false, insertionIndex = -1;
-        const newVariables = compile(source);
-        if (!variables || variables.length !== newVariables.length) {
-            reposition = true;
-            variables.forEach(v => v.delete());
-            variables.length = 0;
-            for (let i = 0; i < newVariables.length; i++) {
-                const newVariable = cell.module.module.variable({});
-                variables.push(newVariable);
+const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+{
+    return (source, variables = [], cell) => {
+        try {
+            debugger;
+            let reposition = false, insertionIndex = -1;
+            const newVariables = compile(source);
+            if (!variables || variables.length !== newVariables.length) {
+                reposition = true;
+                variables.forEach(v => v.delete());
+                variables.length = 0;
+                for (let i = 0; i < newVariables.length; i++) {
+                    const newVariable = cell.module.module.variable({});
+                    // Assign a random pid up-front so blank/identical new cells don't
+                    // collide via persistentId's contentHash. See lopecode#144.
+                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+                    variables.push(newVariable);
+                }
             }
-        }
-        if (reposition) {
-            insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-        }
-        newVariables.forEach((v, i) => {
-            const variable = variables[i];
-            let _fn;
-            eval('_fn = ' + v._definition);
-            if (v._name) {
-                variable.define(v._name, v._inputs, _fn);
-            } else {
-                variable.define(v._inputs, _fn);
+            if (reposition) {
+                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
-            if (reposition)
-                repositionSetElement(runtime._variables, variable, insertionIndex + i);
-        });
-        return variables;
-    } catch (e) {
-        console.error(e);
-        debugger;
-    }
-}
-)};
+            newVariables.forEach((v, i) => {
+                const variable = variables[i];
+                let _fn;
+                eval('_fn = ' + v._definition);
+                if (v._name) {
+                    variable.define(v._name, v._inputs, _fn);
+                } else {
+                    variable.define(v._inputs, _fn);
+                }
+                if (reposition)
+                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
+            });
+            return variables;
+        } catch (e) {
+            console.error(e);
+            debugger;
+        }
+    };
+};
 const _1jqs8in = function _91(md){return(
 md`### Remove Cells`
 )};
@@ -5912,6 +5928,7 @@ Inputs.radio(editedCell.variables, {
   value: editedCell.variables[0]
 })
 )};
+const _11gvkq4 = (G, _) => G.input(_);
 const _r5nvms = function _name(variable){return(
 variable._name
 )};
@@ -5925,6 +5942,7 @@ Inputs.textarea({
   rows: 10
 })
 )};
+const _b4rsn5 = (G, _) => G.input(_);
 const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
@@ -5938,22 +5956,12 @@ Inputs.button("update variable", {
 const _1q557s = function _99(md){return(
 md`### Editor Libraries`
 )};
-const _192vvs7 = (_, v) => v.import("descendants", _);
-const _3va6tf = (_, v) => v.import("EditorState", _);
-const _lmqjiv = (_, v) => v.import("decompile", _);
 const _1d94dks = function _javascriptPlugin(codemirror){return(
 codemirror
 )};
 const _ar9tao = function _104(md){return(
 md`### Libraries`
 )};
-const _viogn = (_, v) => v.import("reversibleAttach", _);
-const _nxg8mr = (_, v) => v.import("moduleMap", _);
-const _14a94d = (_, v) => v.import("flowQueue", _);
-const _gurtwb = (_, v) => v.import("viewof liveCellMap", _);
-const _19ebgtz = (_, v) => v.import("hash", _);
-const _n2vgkz = (_, v) => v.import("extractNotebookAndCell", _);
-const _1qucevb = (_, v) => v.import("cellsToClipboard", _);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -5967,22 +5975,34 @@ export default function define(runtime, observer) {
     return [name, {url: blob_url, mimeType: mime}]
   }));
   main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
+  main.define("module @tomlarkworthy/dataflow-templating", async () => runtime.module((await import("/@tomlarkworthy/dataflow-templating.js?v=4")).default));  
+  main.define("module @tomlarkworthy/fileattachments", async () => runtime.module((await import("/@tomlarkworthy/fileattachments.js?v=4")).default));  
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/codemirror-6-v2", async () => runtime.module((await import("/@tomlarkworthy/codemirror-6-v2.js?v=4")).default));  
+  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
+  main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
+  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
+  main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
+  main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
+  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
+  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
+  main.define("module @tomlarkworthy/cells-to-clipboard", async () => runtime.module((await import("/@tomlarkworthy/cells-to-clipboard.js?v=4")).default));  
   $def("_1tdjp0a", "title", ["md"], _1tdjp0a);  
   $def("_dm53bx", null, ["md"], _dm53bx);  
   $def("_61oxjf", "title_variable", ["lookupVariable","editorModule"], _61oxjf);  
   $def("_15uilf0", null, ["cellEditor","title_variable"], _15uilf0);  
   $def("_3x695f", null, ["md"], _3x695f);  
   $def("_1ociws4", null, ["md"], _1ociws4);  
-  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
   $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
-  main.variable(observer("attachContextManu")).define("attachContextManu", ["Generators", "viewof attachContextManu"], (G, _) => G.input(_));  
+  $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
   $def("_16ks4jz", null, ["md"], _16ks4jz);  
-  main.define("module @tomlarkworthy/dataflow-templating", async () => runtime.module((await import("/@tomlarkworthy/dataflow-templating.js?v=4")).default));  
   main.define("cloneDataflow", ["module @tomlarkworthy/dataflow-templating", "@variable"], (_, v) => v.import("cloneDataflow", _));  
   main.define("lookupVariable", ["module @tomlarkworthy/dataflow-templating", "@variable"], (_, v) => v.import("lookupVariable", _));  
   $def("_199ztvl", "hotbarTemplate", ["lookupVariable","editorModule"], _199ztvl);  
@@ -5993,7 +6013,7 @@ export default function define(runtime, observer) {
   $def("_110gwi7", "editorTemplate", ["lookupVariable","editorModule"], _110gwi7);  
   $def("_16rqzgl", null, ["md"], _16rqzgl);  
   $def("_1o2h65s", "viewof editedCell", ["Inputs"], _1o2h65s);  
-  main.variable(observer("editedCell")).define("editedCell", ["Generators", "viewof editedCell"], (G, _) => G.input(_));  
+  $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
   $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
@@ -6008,24 +6028,24 @@ export default function define(runtime, observer) {
   $def("_mrrmx3", null, ["md"], _mrrmx3);  
   $def("_14b1byw", null, ["md"], _14b1byw);  
   $def("_1j1loxx", "viewof combine", ["Inputs"], _1j1loxx);  
-  main.variable(observer("combine")).define("combine", ["Generators", "viewof combine"], (G, _) => G.input(_));  
+  $def("_1h8337z", "combine", ["Generators","viewof combine"], _1h8337z);  
   $def("_tct2nf", "viewof edit", ["Inputs"], _tct2nf);  
-  main.variable(observer("edit")).define("edit", ["Generators", "viewof edit"], (G, _) => G.input(_));  
+  $def("_7izj7k", "edit", ["Generators","viewof edit"], _7izj7k);  
   $def("_1fwb5jc", "toolbar", ["htl","reversibleAttach","combine","viewof select","viewof up","viewof down","viewof remove","viewof addCells","viewof apply","viewof copy","viewof paste"], _1fwb5jc);  
   $def("_yej3hb", "viewof addCells", ["Inputs","createCell","viewof editedCell"], _yej3hb);  
-  main.variable(observer("addCells")).define("addCells", ["Generators", "viewof addCells"], (G, _) => G.input(_));  
+  $def("_1aii9ps", "addCells", ["Generators","viewof addCells"], _1aii9ps);  
   $def("_1bn860e", "viewof remove", ["Inputs","deleteCell","viewof editedCell"], _1bn860e);  
-  main.variable(observer("remove")).define("remove", ["Generators", "viewof remove"], (G, _) => G.input(_));  
+  $def("_1ad0xr8", "remove", ["Generators","viewof remove"], _1ad0xr8);  
   $def("_tw1j7n", "viewof apply", ["Inputs","compile_and_update","states","editedCell"], _tw1j7n);  
-  main.variable(observer("apply")).define("apply", ["Generators", "viewof apply"], (G, _) => G.input(_));  
+  $def("_1cjyuqm", "apply", ["Generators","viewof apply"], _1cjyuqm);  
   $def("_14rfku9", "viewof up", ["Inputs","moveCell","viewof editedCell"], _14rfku9);  
-  main.variable(observer("up")).define("up", ["Generators", "viewof up"], (G, _) => G.input(_));  
+  $def("_frzs5d", "up", ["Generators","viewof up"], _frzs5d);  
   $def("_9pymuj", "viewof paste", ["Inputs","readObservableClipboardCells","pasteObservableCellsIntoModule","editedCell"], _9pymuj);  
-  main.variable(observer("paste")).define("paste", ["Generators", "viewof paste"], (G, _) => G.input(_));  
+  $def("_1whsszt", "paste", ["Generators","viewof paste"], _1whsszt);  
   $def("_corxwl", "viewof down", ["Inputs","moveCell","viewof editedCell"], _corxwl);  
-  main.variable(observer("down")).define("down", ["Generators", "viewof down"], (G, _) => G.input(_));  
+  $def("_1to28po", "down", ["Generators","viewof down"], _1to28po);  
   $def("_gia2ci", "viewof copy", ["Inputs","html","viewof editedCell","decompile","viewof liveCellMap","getOption","cellsToClipboard"], _gia2ci);  
-  main.variable(observer("copy")).define("copy", ["Generators", "viewof copy"], (G, _) => G.input(_));  
+  $def("_fw41wt", "copy", ["Generators","viewof copy"], _fw41wt);  
   $def("_srtw8o", "module", ["editedCell"], _srtw8o);  
   $def("_rv7t7x", "code_editor_view", ["EditorView"], _rv7t7x);  
   $def("_xvo1n6", "code_editor", ["code_editor_view"], _xvo1n6);  
@@ -6035,7 +6055,7 @@ export default function define(runtime, observer) {
   $def("_d9nzys", "deleteCell", ["viewof command"], _d9nzys);  
   $def("_c1u9w8", null, ["md"], _c1u9w8);  
   $def("_d7ouqx", "viewof command", ["flowQueue"], _d7ouqx);  
-  main.variable(observer("command")).define("command", ["Generators", "viewof command"], (G, _) => G.input(_));  
+  $def("_118qt2v", "command", ["Generators","viewof command"], _118qt2v);  
   $def("_19l2nem", null, ["command"], _19l2nem);  
   $def("_1f6v167", "findCellByVariable", [], _1f6v167);  
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
@@ -6052,9 +6072,8 @@ export default function define(runtime, observer) {
   $def("_dvne2z", "replaceCodeMirrorDoc", [], _dvne2z);  
   $def("_1fpqfm0", null, ["md"], _1fpqfm0);  
   $def("_rtf009", "viewof select", ["editedCell","Inputs","getOption","setOption"], _rtf009);  
-  main.variable(observer("select")).define("select", ["Generators", "viewof select"], (G, _) => G.input(_));  
+  $def("_14mwbuc", "select", ["Generators","viewof select"], _14mwbuc);  
   $def("_l4sbcd", null, ["md"], _l4sbcd);  
-  main.define("module @tomlarkworthy/fileattachments", async () => runtime.module((await import("/@tomlarkworthy/fileattachments.js?v=4")).default));  
   main.define("getFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachment", _));  
   main.define("setFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("setFileAttachment", _));  
   main.define("removeFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("removeFileAttachment", _));  
@@ -6063,7 +6082,7 @@ export default function define(runtime, observer) {
   $def("_ezl7wk", null, ["FileAttachment"], _ezl7wk);  
   $def("_kygz54", "optionsFile", ["getFileAttachment","editorModule"], _kygz54);  
   $def("_760ozq", "viewof options", ["Inputs","optionsFile"], _760ozq);  
-  main.variable(observer("options")).define("options", ["Generators", "viewof options"], (G, _) => G.input(_));  
+  $def("_4rh26k", "options", ["Generators","viewof options"], _4rh26k);  
   $def("_1lqy7cs", "setOption", ["findCell","_","viewof options","Event"], _1lqy7cs);  
   $def("_1oxe5ee", "getOption", ["findCell","_","viewof options"], _1oxe5ee);  
   $def("_kwq69p", "save_options", ["setFileAttachment","jsonFileAttachment","options","editorModule"], _kwq69p);  
@@ -6077,22 +6096,21 @@ export default function define(runtime, observer) {
   $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
   $def("_1j3c2uf", "decompiled", ["editedCell","decompile"], _1j3c2uf);  
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
-  main.variable(observer("editorModule")).define("editorModule", ["Generators", "viewof editorModule"], (G, _) => G.input(_));  
+  $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1ju14cq", "compile_and_update", ["compile","runtime","repositionSetElement"], _1ju14cq);  
+  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
   $def("_rwez9", "viewof variable", ["Inputs","editedCell"], _rwez9);  
-  main.variable(observer("variable")).define("variable", ["Generators", "viewof variable"], (G, _) => G.input(_));  
+  $def("_11gvkq4", "variable", ["Generators","viewof variable"], _11gvkq4);  
   $def("_r5nvms", "name", ["variable"], _r5nvms);  
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
-  main.variable(observer("definition")).define("definition", ["Generators", "viewof definition"], (G, _) => G.input(_));  
+  $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
   $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
   $def("_1q557s", null, ["md"], _1q557s);  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -6103,12 +6121,10 @@ export default function define(runtime, observer) {
   main.define("isnode", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("isnode", _));  
   main.define("repositionSetElement", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("repositionSetElement", _));  
   main.define("onCodeChange", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("onCodeChange", _));  
-  main.define("module @tomlarkworthy/codemirror-6-v2", async () => runtime.module((await import("/@tomlarkworthy/codemirror-6-v2.js?v=4")).default));  
   main.define("EditorState", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("EditorState", _));  
   main.define("EditorView", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("EditorView", _));  
   main.define("codemirror", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("codemirror", _));  
   main.define("myDefaultTheme", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("myDefaultTheme", _));  
-  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
   main.define("decompile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("decompile", _));  
   main.define("compile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("compile", _));  
   main.define("cellMap", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("cellMap", _));  
@@ -6117,27 +6133,21 @@ export default function define(runtime, observer) {
   main.define("parser", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("parser", _));  
   $def("_1d94dks", "javascriptPlugin", ["codemirror"], _1d94dks);  
   $def("_ar9tao", null, ["md"], _ar9tao);  
-  main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
   main.define("reversibleAttach", ["module @tomlarkworthy/reversible-attachment", "@variable"], (_, v) => v.import("reversibleAttach", _));  
-  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
   main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
-  main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
   main.define("flowQueue", ["module @tomlarkworthy/flow-queue", "@variable"], (_, v) => v.import("flowQueue", _));  
-  main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
   main.define("viewof liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("viewof liveCellMap", _));  
   main.define("liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("liveCellMap", _));  
-  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
   main.define("hash", ["module d/57d79353bac56631@44", "@variable"], (_, v) => v.import("hash", _));  
-  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
   main.define("extractNotebookAndCell", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("extractNotebookAndCell", _));  
   main.define("navHref", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("navHref", _));  
-  main.define("module @tomlarkworthy/cells-to-clipboard", async () => runtime.module((await import("/@tomlarkworthy/cells-to-clipboard.js?v=4")).default));  
   main.define("cellsToClipboard", ["module @tomlarkworthy/cells-to-clipboard", "@variable"], (_, v) => v.import("cellsToClipboard", _));
   return main;
-}</script>
+}
+</script>
 <script id="@tomlarkworthy/escodegen/escodegen.browser.min.js.gz" 
   type="text/plain"
   data-encoding="base64"

--- a/notebooks/@tomlarkworthy_jumpgate.html
+++ b/notebooks/@tomlarkworthy_jumpgate.html
@@ -4668,7 +4668,7 @@ export default function define(runtime, observer) {
 >
 e30K
 </script>
-<script id="@tomlarkworthy/editor-5" 
+<script id="@tomlarkworthy/editor-5"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -5847,43 +5847,47 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1ju14cq = function _compile_and_update(compile,runtime,repositionSetElement){return(
-(source, variables = [], cell) => {
-    try {
-        debugger;
-        let reposition = false, insertionIndex = -1;
-        const newVariables = compile(source);
-        if (!variables || variables.length !== newVariables.length) {
-            reposition = true;
-            variables.forEach(v => v.delete());
-            variables.length = 0;
-            for (let i = 0; i < newVariables.length; i++) {
-                const newVariable = cell.module.module.variable({});
-                variables.push(newVariable);
+const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+{
+    return (source, variables = [], cell) => {
+        try {
+            debugger;
+            let reposition = false, insertionIndex = -1;
+            const newVariables = compile(source);
+            if (!variables || variables.length !== newVariables.length) {
+                reposition = true;
+                variables.forEach(v => v.delete());
+                variables.length = 0;
+                for (let i = 0; i < newVariables.length; i++) {
+                    const newVariable = cell.module.module.variable({});
+                    // Assign a random pid up-front so blank/identical new cells don't
+                    // collide via persistentId's contentHash. See lopecode#144.
+                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+                    variables.push(newVariable);
+                }
             }
-        }
-        if (reposition) {
-            insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-        }
-        newVariables.forEach((v, i) => {
-            const variable = variables[i];
-            let _fn;
-            eval('_fn = ' + v._definition);
-            if (v._name) {
-                variable.define(v._name, v._inputs, _fn);
-            } else {
-                variable.define(v._inputs, _fn);
+            if (reposition) {
+                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
-            if (reposition)
-                repositionSetElement(runtime._variables, variable, insertionIndex + i);
-        });
-        return variables;
-    } catch (e) {
-        console.error(e);
-        debugger;
-    }
-}
-)};
+            newVariables.forEach((v, i) => {
+                const variable = variables[i];
+                let _fn;
+                eval('_fn = ' + v._definition);
+                if (v._name) {
+                    variable.define(v._name, v._inputs, _fn);
+                } else {
+                    variable.define(v._inputs, _fn);
+                }
+                if (reposition)
+                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
+            });
+            return variables;
+        } catch (e) {
+            console.error(e);
+            debugger;
+        }
+    };
+};
 const _1jqs8in = function _91(md){return(
 md`### Remove Cells`
 )};
@@ -6073,7 +6077,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1ju14cq", "compile_and_update", ["compile","runtime","repositionSetElement"], _1ju14cq);  
+  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -6120,7 +6124,8 @@ export default function define(runtime, observer) {
   main.define("navHref", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("navHref", _));  
   main.define("cellsToClipboard", ["module @tomlarkworthy/cells-to-clipboard", "@variable"], (_, v) => v.import("cellsToClipboard", _));
   return main;
-}</script>
+}
+</script>
 <script id="@tomlarkworthy/escodegen/escodegen.browser.min.js.gz" 
   type="text/plain"
   data-encoding="base64"

--- a/notebooks/@tomlarkworthy_local-change-history.html
+++ b/notebooks/@tomlarkworthy_local-change-history.html
@@ -4668,7 +4668,7 @@ export default function define(runtime, observer) {
 >
 e30K
 </script>
-<script id="@tomlarkworthy/editor-5" 
+<script id="@tomlarkworthy/editor-5"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -5847,43 +5847,47 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1ju14cq = function _compile_and_update(compile,runtime,repositionSetElement){return(
-(source, variables = [], cell) => {
-    try {
-        debugger;
-        let reposition = false, insertionIndex = -1;
-        const newVariables = compile(source);
-        if (!variables || variables.length !== newVariables.length) {
-            reposition = true;
-            variables.forEach(v => v.delete());
-            variables.length = 0;
-            for (let i = 0; i < newVariables.length; i++) {
-                const newVariable = cell.module.module.variable({});
-                variables.push(newVariable);
+const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+{
+    return (source, variables = [], cell) => {
+        try {
+            debugger;
+            let reposition = false, insertionIndex = -1;
+            const newVariables = compile(source);
+            if (!variables || variables.length !== newVariables.length) {
+                reposition = true;
+                variables.forEach(v => v.delete());
+                variables.length = 0;
+                for (let i = 0; i < newVariables.length; i++) {
+                    const newVariable = cell.module.module.variable({});
+                    // Assign a random pid up-front so blank/identical new cells don't
+                    // collide via persistentId's contentHash. See lopecode#144.
+                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+                    variables.push(newVariable);
+                }
             }
-        }
-        if (reposition) {
-            insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-        }
-        newVariables.forEach((v, i) => {
-            const variable = variables[i];
-            let _fn;
-            eval('_fn = ' + v._definition);
-            if (v._name) {
-                variable.define(v._name, v._inputs, _fn);
-            } else {
-                variable.define(v._inputs, _fn);
+            if (reposition) {
+                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
-            if (reposition)
-                repositionSetElement(runtime._variables, variable, insertionIndex + i);
-        });
-        return variables;
-    } catch (e) {
-        console.error(e);
-        debugger;
-    }
-}
-)};
+            newVariables.forEach((v, i) => {
+                const variable = variables[i];
+                let _fn;
+                eval('_fn = ' + v._definition);
+                if (v._name) {
+                    variable.define(v._name, v._inputs, _fn);
+                } else {
+                    variable.define(v._inputs, _fn);
+                }
+                if (reposition)
+                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
+            });
+            return variables;
+        } catch (e) {
+            console.error(e);
+            debugger;
+        }
+    };
+};
 const _1jqs8in = function _91(md){return(
 md`### Remove Cells`
 )};
@@ -6073,7 +6077,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1ju14cq", "compile_and_update", ["compile","runtime","repositionSetElement"], _1ju14cq);  
+  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -6120,7 +6124,8 @@ export default function define(runtime, observer) {
   main.define("navHref", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("navHref", _));  
   main.define("cellsToClipboard", ["module @tomlarkworthy/cells-to-clipboard", "@variable"], (_, v) => v.import("cellsToClipboard", _));
   return main;
-}</script>
+}
+</script>
 <script id="@tomlarkworthy/escodegen/escodegen.browser.min.js.gz" 
   type="text/plain"
   data-encoding="base64"

--- a/notebooks/@tomlarkworthy_local-storage-view.html
+++ b/notebooks/@tomlarkworthy_local-storage-view.html
@@ -4690,7 +4690,7 @@ export default function define(runtime, observer) {
 >
 e30K
 </script>
-<script id="@tomlarkworthy/editor-5" 
+<script id="@tomlarkworthy/editor-5"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -4737,7 +4737,6 @@ md`## TODO
 const _1ociws4 = function _6(md){return(
 md`## Sync editors`
 )};
-const _1vq49kx = (_, v) => v.import("syncers", _);
 const _hdieof = function _editors(){return(
 new Map()
 )};
@@ -4815,12 +4814,12 @@ Inputs.toggle({
   value: !isOnObservableCom()
 })
 )};
+const _1oaz8r1 = (G, _) => G.input(_);
 const _16ks4jz = function _12(md){return(
 md`## \`cellEditor\` component
 
 Using Dataflow templating to create reusable Hotbar Component builder`
 )};
-const _1deps8p = (_, v) => v.import("cloneDataflow", _);
 const _199ztvl = function _hotbarTemplate(lookupVariable,editorModule){return(
 lookupVariable(
   [
@@ -5057,6 +5056,7 @@ md`## Hotbar Prototype`
 const _1o2h65s = function _editedCell(Inputs){return(
 Inputs.input(null)
 )};
+const _7g3h7h = (G, _) => G.input(_);
 const _1urs1md = function _findCell($0,modules){return(
 (variable, dom = undefined) => {
   if (variable) {
@@ -5216,9 +5216,11 @@ Inputs.toggle({
   value: true
 })
 )};
+const _1h8337z = (G, _) => G.input(_);
 const _tct2nf = function _edit(Inputs){return(
 Inputs.toggle({ label: "edit" })
 )};
+const _7izj7k = (G, _) => G.input(_);
 const _1fwb5jc = function _toolbar(htl,reversibleAttach,combine,$0,$1,$2,$3,$4,$5,$6,$7){return(
 htl.html`<div
     class="toolbar"
@@ -5246,11 +5248,13 @@ Inputs.button("➕", {
   }
 })
 )};
+const _1aii9ps = (G, _) => G.input(_);
 const _1bn860e = function _remove(Inputs,deleteCell,$0){return(
 Inputs.button("🗑️", {
   reduce: () => deleteCell({ cell: $0.value })
 })
 )};
+const _1ad0xr8 = (G, _) => G.input(_);
 const _tw1j7n = function _apply(Inputs,compile_and_update,states,editedCell)
 {
   const button = Inputs.button("▶️", {
@@ -5269,11 +5273,13 @@ const _tw1j7n = function _apply(Inputs,compile_and_update,states,editedCell)
   button.onmousedown = (e) => e.preventDefault();
   return button;
 };
+const _1cjyuqm = (G, _) => G.input(_);
 const _14rfku9 = function _up(Inputs,moveCell,$0){return(
 Inputs.button("⬆", {
   reduce: () => moveCell($0.value, -1)
 })
 )};
+const _frzs5d = (G, _) => G.input(_);
 const _9pymuj = function _paste(Inputs,readObservableClipboardCells,pasteObservableCellsIntoModule,editedCell){return(
 Inputs.button("📋", {
   reduce: async () => {
@@ -5282,11 +5288,13 @@ Inputs.button("📋", {
   }
 })
 )};
+const _1whsszt = (G, _) => G.input(_);
 const _corxwl = function _down(Inputs,moveCell,$0){return(
 Inputs.button("⬇", {
   reduce: () => moveCell($0.value, 1)
 })
 )};
+const _1to28po = (G, _) => G.input(_);
 const _gia2ci = function _copy(Inputs,html,$0,decompile,$1,getOption,cellsToClipboard){return(
 Inputs.button(
   html`<span style="font-size: .875em; margin-right: .125em; position: relative; top: -.25em; left: -.125em">
@@ -5328,6 +5336,7 @@ Inputs.button(
   }
 )
 )};
+const _fw41wt = (G, _) => G.input(_);
 const _srtw8o = function _module(editedCell){return(
 editedCell.module.module
 )};
@@ -5382,6 +5391,7 @@ md`## API handler`
 const _d7ouqx = function _command(flowQueue){return(
 flowQueue()
 )};
+const _118qt2v = (G, _) => G.input(_);
 const _19l2nem = function _54(command){return(
 command
 )};
@@ -5654,10 +5664,10 @@ const _rtf009 = function _select(editedCell,Inputs,getOption,setOption){return(
   return el;
 })()
 )};
+const _14mwbuc = (G, _) => G.input(_);
 const _l4sbcd = function _70(md){return(
 md`## Pinning`
 )};
-const _1sxszb9 = (_, v) => v.import("getFileAttachment", _);
 const _ezl7wk = function _72(FileAttachment){return(
 FileAttachment("cell_options.json")
 )};
@@ -5667,6 +5677,7 @@ getFileAttachment("cell_options.json", editorModule)
 const _760ozq = async function _options(Inputs,optionsFile){return(
 Inputs.input(await optionsFile.json())
 )};
+const _4rh26k = (G, _) => G.input(_);
 const _1lqy7cs = function _setOption(findCell,_,$0,Event){return(
 (variable, option, value) => {
   const cell = findCell(variable);
@@ -5846,6 +5857,7 @@ const _1j3c2uf = function _decompiled(editedCell,decompile)
 const _w5q3yf = function _editorModule(thisModule){return(
 thisModule()
 )};
+const _18kaj2p = (G, _) => G.input(_);
 const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_options)
 {
   //editedCell;
@@ -5857,43 +5869,47 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1ju14cq = function _compile_and_update(compile,runtime,repositionSetElement){return(
-(source, variables = [], cell) => {
-    try {
-        debugger;
-        let reposition = false, insertionIndex = -1;
-        const newVariables = compile(source);
-        if (!variables || variables.length !== newVariables.length) {
-            reposition = true;
-            variables.forEach(v => v.delete());
-            variables.length = 0;
-            for (let i = 0; i < newVariables.length; i++) {
-                const newVariable = cell.module.module.variable({});
-                variables.push(newVariable);
+const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+{
+    return (source, variables = [], cell) => {
+        try {
+            debugger;
+            let reposition = false, insertionIndex = -1;
+            const newVariables = compile(source);
+            if (!variables || variables.length !== newVariables.length) {
+                reposition = true;
+                variables.forEach(v => v.delete());
+                variables.length = 0;
+                for (let i = 0; i < newVariables.length; i++) {
+                    const newVariable = cell.module.module.variable({});
+                    // Assign a random pid up-front so blank/identical new cells don't
+                    // collide via persistentId's contentHash. See lopecode#144.
+                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+                    variables.push(newVariable);
+                }
             }
-        }
-        if (reposition) {
-            insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-        }
-        newVariables.forEach((v, i) => {
-            const variable = variables[i];
-            let _fn;
-            eval('_fn = ' + v._definition);
-            if (v._name) {
-                variable.define(v._name, v._inputs, _fn);
-            } else {
-                variable.define(v._inputs, _fn);
+            if (reposition) {
+                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
-            if (reposition)
-                repositionSetElement(runtime._variables, variable, insertionIndex + i);
-        });
-        return variables;
-    } catch (e) {
-        console.error(e);
-        debugger;
-    }
-}
-)};
+            newVariables.forEach((v, i) => {
+                const variable = variables[i];
+                let _fn;
+                eval('_fn = ' + v._definition);
+                if (v._name) {
+                    variable.define(v._name, v._inputs, _fn);
+                } else {
+                    variable.define(v._inputs, _fn);
+                }
+                if (reposition)
+                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
+            });
+            return variables;
+        } catch (e) {
+            console.error(e);
+            debugger;
+        }
+    };
+};
 const _1jqs8in = function _91(md){return(
 md`### Remove Cells`
 )};
@@ -5912,6 +5928,7 @@ Inputs.radio(editedCell.variables, {
   value: editedCell.variables[0]
 })
 )};
+const _11gvkq4 = (G, _) => G.input(_);
 const _r5nvms = function _name(variable){return(
 variable._name
 )};
@@ -5925,6 +5942,7 @@ Inputs.textarea({
   rows: 10
 })
 )};
+const _b4rsn5 = (G, _) => G.input(_);
 const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
@@ -5938,22 +5956,12 @@ Inputs.button("update variable", {
 const _1q557s = function _99(md){return(
 md`### Editor Libraries`
 )};
-const _192vvs7 = (_, v) => v.import("descendants", _);
-const _3va6tf = (_, v) => v.import("EditorState", _);
-const _lmqjiv = (_, v) => v.import("decompile", _);
 const _1d94dks = function _javascriptPlugin(codemirror){return(
 codemirror
 )};
 const _ar9tao = function _104(md){return(
 md`### Libraries`
 )};
-const _viogn = (_, v) => v.import("reversibleAttach", _);
-const _nxg8mr = (_, v) => v.import("moduleMap", _);
-const _14a94d = (_, v) => v.import("flowQueue", _);
-const _gurtwb = (_, v) => v.import("viewof liveCellMap", _);
-const _19ebgtz = (_, v) => v.import("hash", _);
-const _n2vgkz = (_, v) => v.import("extractNotebookAndCell", _);
-const _1qucevb = (_, v) => v.import("cellsToClipboard", _);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -5967,22 +5975,34 @@ export default function define(runtime, observer) {
     return [name, {url: blob_url, mimeType: mime}]
   }));
   main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
+  main.define("module @tomlarkworthy/dataflow-templating", async () => runtime.module((await import("/@tomlarkworthy/dataflow-templating.js?v=4")).default));  
+  main.define("module @tomlarkworthy/fileattachments", async () => runtime.module((await import("/@tomlarkworthy/fileattachments.js?v=4")).default));  
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/codemirror-6-v2", async () => runtime.module((await import("/@tomlarkworthy/codemirror-6-v2.js?v=4")).default));  
+  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
+  main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
+  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
+  main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
+  main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
+  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
+  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
+  main.define("module @tomlarkworthy/cells-to-clipboard", async () => runtime.module((await import("/@tomlarkworthy/cells-to-clipboard.js?v=4")).default));  
   $def("_1tdjp0a", "title", ["md"], _1tdjp0a);  
   $def("_dm53bx", null, ["md"], _dm53bx);  
   $def("_61oxjf", "title_variable", ["lookupVariable","editorModule"], _61oxjf);  
   $def("_15uilf0", null, ["cellEditor","title_variable"], _15uilf0);  
   $def("_3x695f", null, ["md"], _3x695f);  
   $def("_1ociws4", null, ["md"], _1ociws4);  
-  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
   $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
-  main.variable(observer("attachContextManu")).define("attachContextManu", ["Generators", "viewof attachContextManu"], (G, _) => G.input(_));  
+  $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
   $def("_16ks4jz", null, ["md"], _16ks4jz);  
-  main.define("module @tomlarkworthy/dataflow-templating", async () => runtime.module((await import("/@tomlarkworthy/dataflow-templating.js?v=4")).default));  
   main.define("cloneDataflow", ["module @tomlarkworthy/dataflow-templating", "@variable"], (_, v) => v.import("cloneDataflow", _));  
   main.define("lookupVariable", ["module @tomlarkworthy/dataflow-templating", "@variable"], (_, v) => v.import("lookupVariable", _));  
   $def("_199ztvl", "hotbarTemplate", ["lookupVariable","editorModule"], _199ztvl);  
@@ -5993,7 +6013,7 @@ export default function define(runtime, observer) {
   $def("_110gwi7", "editorTemplate", ["lookupVariable","editorModule"], _110gwi7);  
   $def("_16rqzgl", null, ["md"], _16rqzgl);  
   $def("_1o2h65s", "viewof editedCell", ["Inputs"], _1o2h65s);  
-  main.variable(observer("editedCell")).define("editedCell", ["Generators", "viewof editedCell"], (G, _) => G.input(_));  
+  $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
   $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
@@ -6008,24 +6028,24 @@ export default function define(runtime, observer) {
   $def("_mrrmx3", null, ["md"], _mrrmx3);  
   $def("_14b1byw", null, ["md"], _14b1byw);  
   $def("_1j1loxx", "viewof combine", ["Inputs"], _1j1loxx);  
-  main.variable(observer("combine")).define("combine", ["Generators", "viewof combine"], (G, _) => G.input(_));  
+  $def("_1h8337z", "combine", ["Generators","viewof combine"], _1h8337z);  
   $def("_tct2nf", "viewof edit", ["Inputs"], _tct2nf);  
-  main.variable(observer("edit")).define("edit", ["Generators", "viewof edit"], (G, _) => G.input(_));  
+  $def("_7izj7k", "edit", ["Generators","viewof edit"], _7izj7k);  
   $def("_1fwb5jc", "toolbar", ["htl","reversibleAttach","combine","viewof select","viewof up","viewof down","viewof remove","viewof addCells","viewof apply","viewof copy","viewof paste"], _1fwb5jc);  
   $def("_yej3hb", "viewof addCells", ["Inputs","createCell","viewof editedCell"], _yej3hb);  
-  main.variable(observer("addCells")).define("addCells", ["Generators", "viewof addCells"], (G, _) => G.input(_));  
+  $def("_1aii9ps", "addCells", ["Generators","viewof addCells"], _1aii9ps);  
   $def("_1bn860e", "viewof remove", ["Inputs","deleteCell","viewof editedCell"], _1bn860e);  
-  main.variable(observer("remove")).define("remove", ["Generators", "viewof remove"], (G, _) => G.input(_));  
+  $def("_1ad0xr8", "remove", ["Generators","viewof remove"], _1ad0xr8);  
   $def("_tw1j7n", "viewof apply", ["Inputs","compile_and_update","states","editedCell"], _tw1j7n);  
-  main.variable(observer("apply")).define("apply", ["Generators", "viewof apply"], (G, _) => G.input(_));  
+  $def("_1cjyuqm", "apply", ["Generators","viewof apply"], _1cjyuqm);  
   $def("_14rfku9", "viewof up", ["Inputs","moveCell","viewof editedCell"], _14rfku9);  
-  main.variable(observer("up")).define("up", ["Generators", "viewof up"], (G, _) => G.input(_));  
+  $def("_frzs5d", "up", ["Generators","viewof up"], _frzs5d);  
   $def("_9pymuj", "viewof paste", ["Inputs","readObservableClipboardCells","pasteObservableCellsIntoModule","editedCell"], _9pymuj);  
-  main.variable(observer("paste")).define("paste", ["Generators", "viewof paste"], (G, _) => G.input(_));  
+  $def("_1whsszt", "paste", ["Generators","viewof paste"], _1whsszt);  
   $def("_corxwl", "viewof down", ["Inputs","moveCell","viewof editedCell"], _corxwl);  
-  main.variable(observer("down")).define("down", ["Generators", "viewof down"], (G, _) => G.input(_));  
+  $def("_1to28po", "down", ["Generators","viewof down"], _1to28po);  
   $def("_gia2ci", "viewof copy", ["Inputs","html","viewof editedCell","decompile","viewof liveCellMap","getOption","cellsToClipboard"], _gia2ci);  
-  main.variable(observer("copy")).define("copy", ["Generators", "viewof copy"], (G, _) => G.input(_));  
+  $def("_fw41wt", "copy", ["Generators","viewof copy"], _fw41wt);  
   $def("_srtw8o", "module", ["editedCell"], _srtw8o);  
   $def("_rv7t7x", "code_editor_view", ["EditorView"], _rv7t7x);  
   $def("_xvo1n6", "code_editor", ["code_editor_view"], _xvo1n6);  
@@ -6035,7 +6055,7 @@ export default function define(runtime, observer) {
   $def("_d9nzys", "deleteCell", ["viewof command"], _d9nzys);  
   $def("_c1u9w8", null, ["md"], _c1u9w8);  
   $def("_d7ouqx", "viewof command", ["flowQueue"], _d7ouqx);  
-  main.variable(observer("command")).define("command", ["Generators", "viewof command"], (G, _) => G.input(_));  
+  $def("_118qt2v", "command", ["Generators","viewof command"], _118qt2v);  
   $def("_19l2nem", null, ["command"], _19l2nem);  
   $def("_1f6v167", "findCellByVariable", [], _1f6v167);  
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
@@ -6052,9 +6072,8 @@ export default function define(runtime, observer) {
   $def("_dvne2z", "replaceCodeMirrorDoc", [], _dvne2z);  
   $def("_1fpqfm0", null, ["md"], _1fpqfm0);  
   $def("_rtf009", "viewof select", ["editedCell","Inputs","getOption","setOption"], _rtf009);  
-  main.variable(observer("select")).define("select", ["Generators", "viewof select"], (G, _) => G.input(_));  
+  $def("_14mwbuc", "select", ["Generators","viewof select"], _14mwbuc);  
   $def("_l4sbcd", null, ["md"], _l4sbcd);  
-  main.define("module @tomlarkworthy/fileattachments", async () => runtime.module((await import("/@tomlarkworthy/fileattachments.js?v=4")).default));  
   main.define("getFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachment", _));  
   main.define("setFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("setFileAttachment", _));  
   main.define("removeFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("removeFileAttachment", _));  
@@ -6063,7 +6082,7 @@ export default function define(runtime, observer) {
   $def("_ezl7wk", null, ["FileAttachment"], _ezl7wk);  
   $def("_kygz54", "optionsFile", ["getFileAttachment","editorModule"], _kygz54);  
   $def("_760ozq", "viewof options", ["Inputs","optionsFile"], _760ozq);  
-  main.variable(observer("options")).define("options", ["Generators", "viewof options"], (G, _) => G.input(_));  
+  $def("_4rh26k", "options", ["Generators","viewof options"], _4rh26k);  
   $def("_1lqy7cs", "setOption", ["findCell","_","viewof options","Event"], _1lqy7cs);  
   $def("_1oxe5ee", "getOption", ["findCell","_","viewof options"], _1oxe5ee);  
   $def("_kwq69p", "save_options", ["setFileAttachment","jsonFileAttachment","options","editorModule"], _kwq69p);  
@@ -6077,22 +6096,21 @@ export default function define(runtime, observer) {
   $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
   $def("_1j3c2uf", "decompiled", ["editedCell","decompile"], _1j3c2uf);  
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
-  main.variable(observer("editorModule")).define("editorModule", ["Generators", "viewof editorModule"], (G, _) => G.input(_));  
+  $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1ju14cq", "compile_and_update", ["compile","runtime","repositionSetElement"], _1ju14cq);  
+  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
   $def("_rwez9", "viewof variable", ["Inputs","editedCell"], _rwez9);  
-  main.variable(observer("variable")).define("variable", ["Generators", "viewof variable"], (G, _) => G.input(_));  
+  $def("_11gvkq4", "variable", ["Generators","viewof variable"], _11gvkq4);  
   $def("_r5nvms", "name", ["variable"], _r5nvms);  
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
-  main.variable(observer("definition")).define("definition", ["Generators", "viewof definition"], (G, _) => G.input(_));  
+  $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
   $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
   $def("_1q557s", null, ["md"], _1q557s);  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -6103,12 +6121,10 @@ export default function define(runtime, observer) {
   main.define("isnode", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("isnode", _));  
   main.define("repositionSetElement", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("repositionSetElement", _));  
   main.define("onCodeChange", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("onCodeChange", _));  
-  main.define("module @tomlarkworthy/codemirror-6-v2", async () => runtime.module((await import("/@tomlarkworthy/codemirror-6-v2.js?v=4")).default));  
   main.define("EditorState", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("EditorState", _));  
   main.define("EditorView", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("EditorView", _));  
   main.define("codemirror", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("codemirror", _));  
   main.define("myDefaultTheme", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("myDefaultTheme", _));  
-  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
   main.define("decompile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("decompile", _));  
   main.define("compile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("compile", _));  
   main.define("cellMap", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("cellMap", _));  
@@ -6117,27 +6133,21 @@ export default function define(runtime, observer) {
   main.define("parser", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("parser", _));  
   $def("_1d94dks", "javascriptPlugin", ["codemirror"], _1d94dks);  
   $def("_ar9tao", null, ["md"], _ar9tao);  
-  main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
   main.define("reversibleAttach", ["module @tomlarkworthy/reversible-attachment", "@variable"], (_, v) => v.import("reversibleAttach", _));  
-  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
   main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
-  main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
   main.define("flowQueue", ["module @tomlarkworthy/flow-queue", "@variable"], (_, v) => v.import("flowQueue", _));  
-  main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
   main.define("viewof liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("viewof liveCellMap", _));  
   main.define("liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("liveCellMap", _));  
-  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
   main.define("hash", ["module d/57d79353bac56631@44", "@variable"], (_, v) => v.import("hash", _));  
-  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
   main.define("extractNotebookAndCell", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("extractNotebookAndCell", _));  
   main.define("navHref", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("navHref", _));  
-  main.define("module @tomlarkworthy/cells-to-clipboard", async () => runtime.module((await import("/@tomlarkworthy/cells-to-clipboard.js?v=4")).default));  
   main.define("cellsToClipboard", ["module @tomlarkworthy/cells-to-clipboard", "@variable"], (_, v) => v.import("cellsToClipboard", _));
   return main;
-}</script>
+}
+</script>
 <script id="@tomlarkworthy/escodegen/escodegen.browser.min.js.gz" 
   type="text/plain"
   data-encoding="base64"

--- a/notebooks/@tomlarkworthy_lopecode-tour.html
+++ b/notebooks/@tomlarkworthy_lopecode-tour.html
@@ -5511,7 +5511,7 @@ export default function define(runtime, observer) {
 >
 e30K
 </script>
-<script id="@tomlarkworthy/editor-5" 
+<script id="@tomlarkworthy/editor-5"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -6690,43 +6690,47 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1ju14cq = function _compile_and_update(compile,runtime,repositionSetElement){return(
-(source, variables = [], cell) => {
-    try {
-        debugger;
-        let reposition = false, insertionIndex = -1;
-        const newVariables = compile(source);
-        if (!variables || variables.length !== newVariables.length) {
-            reposition = true;
-            variables.forEach(v => v.delete());
-            variables.length = 0;
-            for (let i = 0; i < newVariables.length; i++) {
-                const newVariable = cell.module.module.variable({});
-                variables.push(newVariable);
+const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+{
+    return (source, variables = [], cell) => {
+        try {
+            debugger;
+            let reposition = false, insertionIndex = -1;
+            const newVariables = compile(source);
+            if (!variables || variables.length !== newVariables.length) {
+                reposition = true;
+                variables.forEach(v => v.delete());
+                variables.length = 0;
+                for (let i = 0; i < newVariables.length; i++) {
+                    const newVariable = cell.module.module.variable({});
+                    // Assign a random pid up-front so blank/identical new cells don't
+                    // collide via persistentId's contentHash. See lopecode#144.
+                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+                    variables.push(newVariable);
+                }
             }
-        }
-        if (reposition) {
-            insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-        }
-        newVariables.forEach((v, i) => {
-            const variable = variables[i];
-            let _fn;
-            eval('_fn = ' + v._definition);
-            if (v._name) {
-                variable.define(v._name, v._inputs, _fn);
-            } else {
-                variable.define(v._inputs, _fn);
+            if (reposition) {
+                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
-            if (reposition)
-                repositionSetElement(runtime._variables, variable, insertionIndex + i);
-        });
-        return variables;
-    } catch (e) {
-        console.error(e);
-        debugger;
-    }
-}
-)};
+            newVariables.forEach((v, i) => {
+                const variable = variables[i];
+                let _fn;
+                eval('_fn = ' + v._definition);
+                if (v._name) {
+                    variable.define(v._name, v._inputs, _fn);
+                } else {
+                    variable.define(v._inputs, _fn);
+                }
+                if (reposition)
+                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
+            });
+            return variables;
+        } catch (e) {
+            console.error(e);
+            debugger;
+        }
+    };
+};
 const _1jqs8in = function _91(md){return(
 md`### Remove Cells`
 )};
@@ -6916,7 +6920,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1ju14cq", "compile_and_update", ["compile","runtime","repositionSetElement"], _1ju14cq);  
+  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -6963,7 +6967,8 @@ export default function define(runtime, observer) {
   main.define("navHref", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("navHref", _));  
   main.define("cellsToClipboard", ["module @tomlarkworthy/cells-to-clipboard", "@variable"], (_, v) => v.import("cellsToClipboard", _));
   return main;
-}</script>
+}
+</script>
 <script id="@tomlarkworthy/escodegen/escodegen.browser.min.js.gz" 
   type="text/plain"
   data-encoding="base64"

--- a/notebooks/@tomlarkworthy_lopecode-vision.html
+++ b/notebooks/@tomlarkworthy_lopecode-vision.html
@@ -5511,7 +5511,7 @@ export default function define(runtime, observer) {
 >
 e30K
 </script>
-<script id="@tomlarkworthy/editor-5" 
+<script id="@tomlarkworthy/editor-5"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -6690,43 +6690,47 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1ju14cq = function _compile_and_update(compile,runtime,repositionSetElement){return(
-(source, variables = [], cell) => {
-    try {
-        debugger;
-        let reposition = false, insertionIndex = -1;
-        const newVariables = compile(source);
-        if (!variables || variables.length !== newVariables.length) {
-            reposition = true;
-            variables.forEach(v => v.delete());
-            variables.length = 0;
-            for (let i = 0; i < newVariables.length; i++) {
-                const newVariable = cell.module.module.variable({});
-                variables.push(newVariable);
+const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+{
+    return (source, variables = [], cell) => {
+        try {
+            debugger;
+            let reposition = false, insertionIndex = -1;
+            const newVariables = compile(source);
+            if (!variables || variables.length !== newVariables.length) {
+                reposition = true;
+                variables.forEach(v => v.delete());
+                variables.length = 0;
+                for (let i = 0; i < newVariables.length; i++) {
+                    const newVariable = cell.module.module.variable({});
+                    // Assign a random pid up-front so blank/identical new cells don't
+                    // collide via persistentId's contentHash. See lopecode#144.
+                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+                    variables.push(newVariable);
+                }
             }
-        }
-        if (reposition) {
-            insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-        }
-        newVariables.forEach((v, i) => {
-            const variable = variables[i];
-            let _fn;
-            eval('_fn = ' + v._definition);
-            if (v._name) {
-                variable.define(v._name, v._inputs, _fn);
-            } else {
-                variable.define(v._inputs, _fn);
+            if (reposition) {
+                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
-            if (reposition)
-                repositionSetElement(runtime._variables, variable, insertionIndex + i);
-        });
-        return variables;
-    } catch (e) {
-        console.error(e);
-        debugger;
-    }
-}
-)};
+            newVariables.forEach((v, i) => {
+                const variable = variables[i];
+                let _fn;
+                eval('_fn = ' + v._definition);
+                if (v._name) {
+                    variable.define(v._name, v._inputs, _fn);
+                } else {
+                    variable.define(v._inputs, _fn);
+                }
+                if (reposition)
+                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
+            });
+            return variables;
+        } catch (e) {
+            console.error(e);
+            debugger;
+        }
+    };
+};
 const _1jqs8in = function _91(md){return(
 md`### Remove Cells`
 )};
@@ -6916,7 +6920,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1ju14cq", "compile_and_update", ["compile","runtime","repositionSetElement"], _1ju14cq);  
+  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -6963,7 +6967,8 @@ export default function define(runtime, observer) {
   main.define("navHref", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("navHref", _));  
   main.define("cellsToClipboard", ["module @tomlarkworthy/cells-to-clipboard", "@variable"], (_, v) => v.import("cellsToClipboard", _));
   return main;
-}</script>
+}
+</script>
 <script id="@tomlarkworthy/escodegen/escodegen.browser.min.js.gz" 
   type="text/plain"
   data-encoding="base64"

--- a/notebooks/@tomlarkworthy_lopepage-urls.html
+++ b/notebooks/@tomlarkworthy_lopepage-urls.html
@@ -4690,7 +4690,7 @@ export default function define(runtime, observer) {
 >
 e30K
 </script>
-<script id="@tomlarkworthy/editor-5" 
+<script id="@tomlarkworthy/editor-5"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -4737,7 +4737,6 @@ md`## TODO
 const _1ociws4 = function _6(md){return(
 md`## Sync editors`
 )};
-const _1vq49kx = (_, v) => v.import("syncers", _);
 const _hdieof = function _editors(){return(
 new Map()
 )};
@@ -4815,12 +4814,12 @@ Inputs.toggle({
   value: !isOnObservableCom()
 })
 )};
+const _1oaz8r1 = (G, _) => G.input(_);
 const _16ks4jz = function _12(md){return(
 md`## \`cellEditor\` component
 
 Using Dataflow templating to create reusable Hotbar Component builder`
 )};
-const _1deps8p = (_, v) => v.import("cloneDataflow", _);
 const _199ztvl = function _hotbarTemplate(lookupVariable,editorModule){return(
 lookupVariable(
   [
@@ -5057,6 +5056,7 @@ md`## Hotbar Prototype`
 const _1o2h65s = function _editedCell(Inputs){return(
 Inputs.input(null)
 )};
+const _7g3h7h = (G, _) => G.input(_);
 const _1urs1md = function _findCell($0,modules){return(
 (variable, dom = undefined) => {
   if (variable) {
@@ -5216,9 +5216,11 @@ Inputs.toggle({
   value: true
 })
 )};
+const _1h8337z = (G, _) => G.input(_);
 const _tct2nf = function _edit(Inputs){return(
 Inputs.toggle({ label: "edit" })
 )};
+const _7izj7k = (G, _) => G.input(_);
 const _1fwb5jc = function _toolbar(htl,reversibleAttach,combine,$0,$1,$2,$3,$4,$5,$6,$7){return(
 htl.html`<div
     class="toolbar"
@@ -5246,11 +5248,13 @@ Inputs.button("➕", {
   }
 })
 )};
+const _1aii9ps = (G, _) => G.input(_);
 const _1bn860e = function _remove(Inputs,deleteCell,$0){return(
 Inputs.button("🗑️", {
   reduce: () => deleteCell({ cell: $0.value })
 })
 )};
+const _1ad0xr8 = (G, _) => G.input(_);
 const _tw1j7n = function _apply(Inputs,compile_and_update,states,editedCell)
 {
   const button = Inputs.button("▶️", {
@@ -5269,11 +5273,13 @@ const _tw1j7n = function _apply(Inputs,compile_and_update,states,editedCell)
   button.onmousedown = (e) => e.preventDefault();
   return button;
 };
+const _1cjyuqm = (G, _) => G.input(_);
 const _14rfku9 = function _up(Inputs,moveCell,$0){return(
 Inputs.button("⬆", {
   reduce: () => moveCell($0.value, -1)
 })
 )};
+const _frzs5d = (G, _) => G.input(_);
 const _9pymuj = function _paste(Inputs,readObservableClipboardCells,pasteObservableCellsIntoModule,editedCell){return(
 Inputs.button("📋", {
   reduce: async () => {
@@ -5282,11 +5288,13 @@ Inputs.button("📋", {
   }
 })
 )};
+const _1whsszt = (G, _) => G.input(_);
 const _corxwl = function _down(Inputs,moveCell,$0){return(
 Inputs.button("⬇", {
   reduce: () => moveCell($0.value, 1)
 })
 )};
+const _1to28po = (G, _) => G.input(_);
 const _gia2ci = function _copy(Inputs,html,$0,decompile,$1,getOption,cellsToClipboard){return(
 Inputs.button(
   html`<span style="font-size: .875em; margin-right: .125em; position: relative; top: -.25em; left: -.125em">
@@ -5328,6 +5336,7 @@ Inputs.button(
   }
 )
 )};
+const _fw41wt = (G, _) => G.input(_);
 const _srtw8o = function _module(editedCell){return(
 editedCell.module.module
 )};
@@ -5382,6 +5391,7 @@ md`## API handler`
 const _d7ouqx = function _command(flowQueue){return(
 flowQueue()
 )};
+const _118qt2v = (G, _) => G.input(_);
 const _19l2nem = function _54(command){return(
 command
 )};
@@ -5654,10 +5664,10 @@ const _rtf009 = function _select(editedCell,Inputs,getOption,setOption){return(
   return el;
 })()
 )};
+const _14mwbuc = (G, _) => G.input(_);
 const _l4sbcd = function _70(md){return(
 md`## Pinning`
 )};
-const _1sxszb9 = (_, v) => v.import("getFileAttachment", _);
 const _ezl7wk = function _72(FileAttachment){return(
 FileAttachment("cell_options.json")
 )};
@@ -5667,6 +5677,7 @@ getFileAttachment("cell_options.json", editorModule)
 const _760ozq = async function _options(Inputs,optionsFile){return(
 Inputs.input(await optionsFile.json())
 )};
+const _4rh26k = (G, _) => G.input(_);
 const _1lqy7cs = function _setOption(findCell,_,$0,Event){return(
 (variable, option, value) => {
   const cell = findCell(variable);
@@ -5846,6 +5857,7 @@ const _1j3c2uf = function _decompiled(editedCell,decompile)
 const _w5q3yf = function _editorModule(thisModule){return(
 thisModule()
 )};
+const _18kaj2p = (G, _) => G.input(_);
 const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_options)
 {
   //editedCell;
@@ -5857,43 +5869,47 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1ju14cq = function _compile_and_update(compile,runtime,repositionSetElement){return(
-(source, variables = [], cell) => {
-    try {
-        debugger;
-        let reposition = false, insertionIndex = -1;
-        const newVariables = compile(source);
-        if (!variables || variables.length !== newVariables.length) {
-            reposition = true;
-            variables.forEach(v => v.delete());
-            variables.length = 0;
-            for (let i = 0; i < newVariables.length; i++) {
-                const newVariable = cell.module.module.variable({});
-                variables.push(newVariable);
+const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+{
+    return (source, variables = [], cell) => {
+        try {
+            debugger;
+            let reposition = false, insertionIndex = -1;
+            const newVariables = compile(source);
+            if (!variables || variables.length !== newVariables.length) {
+                reposition = true;
+                variables.forEach(v => v.delete());
+                variables.length = 0;
+                for (let i = 0; i < newVariables.length; i++) {
+                    const newVariable = cell.module.module.variable({});
+                    // Assign a random pid up-front so blank/identical new cells don't
+                    // collide via persistentId's contentHash. See lopecode#144.
+                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+                    variables.push(newVariable);
+                }
             }
-        }
-        if (reposition) {
-            insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-        }
-        newVariables.forEach((v, i) => {
-            const variable = variables[i];
-            let _fn;
-            eval('_fn = ' + v._definition);
-            if (v._name) {
-                variable.define(v._name, v._inputs, _fn);
-            } else {
-                variable.define(v._inputs, _fn);
+            if (reposition) {
+                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
-            if (reposition)
-                repositionSetElement(runtime._variables, variable, insertionIndex + i);
-        });
-        return variables;
-    } catch (e) {
-        console.error(e);
-        debugger;
-    }
-}
-)};
+            newVariables.forEach((v, i) => {
+                const variable = variables[i];
+                let _fn;
+                eval('_fn = ' + v._definition);
+                if (v._name) {
+                    variable.define(v._name, v._inputs, _fn);
+                } else {
+                    variable.define(v._inputs, _fn);
+                }
+                if (reposition)
+                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
+            });
+            return variables;
+        } catch (e) {
+            console.error(e);
+            debugger;
+        }
+    };
+};
 const _1jqs8in = function _91(md){return(
 md`### Remove Cells`
 )};
@@ -5912,6 +5928,7 @@ Inputs.radio(editedCell.variables, {
   value: editedCell.variables[0]
 })
 )};
+const _11gvkq4 = (G, _) => G.input(_);
 const _r5nvms = function _name(variable){return(
 variable._name
 )};
@@ -5925,6 +5942,7 @@ Inputs.textarea({
   rows: 10
 })
 )};
+const _b4rsn5 = (G, _) => G.input(_);
 const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
@@ -5938,22 +5956,12 @@ Inputs.button("update variable", {
 const _1q557s = function _99(md){return(
 md`### Editor Libraries`
 )};
-const _192vvs7 = (_, v) => v.import("descendants", _);
-const _3va6tf = (_, v) => v.import("EditorState", _);
-const _lmqjiv = (_, v) => v.import("decompile", _);
 const _1d94dks = function _javascriptPlugin(codemirror){return(
 codemirror
 )};
 const _ar9tao = function _104(md){return(
 md`### Libraries`
 )};
-const _viogn = (_, v) => v.import("reversibleAttach", _);
-const _nxg8mr = (_, v) => v.import("moduleMap", _);
-const _14a94d = (_, v) => v.import("flowQueue", _);
-const _gurtwb = (_, v) => v.import("viewof liveCellMap", _);
-const _19ebgtz = (_, v) => v.import("hash", _);
-const _n2vgkz = (_, v) => v.import("extractNotebookAndCell", _);
-const _1qucevb = (_, v) => v.import("cellsToClipboard", _);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -5967,22 +5975,34 @@ export default function define(runtime, observer) {
     return [name, {url: blob_url, mimeType: mime}]
   }));
   main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
+  main.define("module @tomlarkworthy/dataflow-templating", async () => runtime.module((await import("/@tomlarkworthy/dataflow-templating.js?v=4")).default));  
+  main.define("module @tomlarkworthy/fileattachments", async () => runtime.module((await import("/@tomlarkworthy/fileattachments.js?v=4")).default));  
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/codemirror-6-v2", async () => runtime.module((await import("/@tomlarkworthy/codemirror-6-v2.js?v=4")).default));  
+  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
+  main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
+  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
+  main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
+  main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
+  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
+  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
+  main.define("module @tomlarkworthy/cells-to-clipboard", async () => runtime.module((await import("/@tomlarkworthy/cells-to-clipboard.js?v=4")).default));  
   $def("_1tdjp0a", "title", ["md"], _1tdjp0a);  
   $def("_dm53bx", null, ["md"], _dm53bx);  
   $def("_61oxjf", "title_variable", ["lookupVariable","editorModule"], _61oxjf);  
   $def("_15uilf0", null, ["cellEditor","title_variable"], _15uilf0);  
   $def("_3x695f", null, ["md"], _3x695f);  
   $def("_1ociws4", null, ["md"], _1ociws4);  
-  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
   $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
-  main.variable(observer("attachContextManu")).define("attachContextManu", ["Generators", "viewof attachContextManu"], (G, _) => G.input(_));  
+  $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
   $def("_16ks4jz", null, ["md"], _16ks4jz);  
-  main.define("module @tomlarkworthy/dataflow-templating", async () => runtime.module((await import("/@tomlarkworthy/dataflow-templating.js?v=4")).default));  
   main.define("cloneDataflow", ["module @tomlarkworthy/dataflow-templating", "@variable"], (_, v) => v.import("cloneDataflow", _));  
   main.define("lookupVariable", ["module @tomlarkworthy/dataflow-templating", "@variable"], (_, v) => v.import("lookupVariable", _));  
   $def("_199ztvl", "hotbarTemplate", ["lookupVariable","editorModule"], _199ztvl);  
@@ -5993,7 +6013,7 @@ export default function define(runtime, observer) {
   $def("_110gwi7", "editorTemplate", ["lookupVariable","editorModule"], _110gwi7);  
   $def("_16rqzgl", null, ["md"], _16rqzgl);  
   $def("_1o2h65s", "viewof editedCell", ["Inputs"], _1o2h65s);  
-  main.variable(observer("editedCell")).define("editedCell", ["Generators", "viewof editedCell"], (G, _) => G.input(_));  
+  $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
   $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
@@ -6008,24 +6028,24 @@ export default function define(runtime, observer) {
   $def("_mrrmx3", null, ["md"], _mrrmx3);  
   $def("_14b1byw", null, ["md"], _14b1byw);  
   $def("_1j1loxx", "viewof combine", ["Inputs"], _1j1loxx);  
-  main.variable(observer("combine")).define("combine", ["Generators", "viewof combine"], (G, _) => G.input(_));  
+  $def("_1h8337z", "combine", ["Generators","viewof combine"], _1h8337z);  
   $def("_tct2nf", "viewof edit", ["Inputs"], _tct2nf);  
-  main.variable(observer("edit")).define("edit", ["Generators", "viewof edit"], (G, _) => G.input(_));  
+  $def("_7izj7k", "edit", ["Generators","viewof edit"], _7izj7k);  
   $def("_1fwb5jc", "toolbar", ["htl","reversibleAttach","combine","viewof select","viewof up","viewof down","viewof remove","viewof addCells","viewof apply","viewof copy","viewof paste"], _1fwb5jc);  
   $def("_yej3hb", "viewof addCells", ["Inputs","createCell","viewof editedCell"], _yej3hb);  
-  main.variable(observer("addCells")).define("addCells", ["Generators", "viewof addCells"], (G, _) => G.input(_));  
+  $def("_1aii9ps", "addCells", ["Generators","viewof addCells"], _1aii9ps);  
   $def("_1bn860e", "viewof remove", ["Inputs","deleteCell","viewof editedCell"], _1bn860e);  
-  main.variable(observer("remove")).define("remove", ["Generators", "viewof remove"], (G, _) => G.input(_));  
+  $def("_1ad0xr8", "remove", ["Generators","viewof remove"], _1ad0xr8);  
   $def("_tw1j7n", "viewof apply", ["Inputs","compile_and_update","states","editedCell"], _tw1j7n);  
-  main.variable(observer("apply")).define("apply", ["Generators", "viewof apply"], (G, _) => G.input(_));  
+  $def("_1cjyuqm", "apply", ["Generators","viewof apply"], _1cjyuqm);  
   $def("_14rfku9", "viewof up", ["Inputs","moveCell","viewof editedCell"], _14rfku9);  
-  main.variable(observer("up")).define("up", ["Generators", "viewof up"], (G, _) => G.input(_));  
+  $def("_frzs5d", "up", ["Generators","viewof up"], _frzs5d);  
   $def("_9pymuj", "viewof paste", ["Inputs","readObservableClipboardCells","pasteObservableCellsIntoModule","editedCell"], _9pymuj);  
-  main.variable(observer("paste")).define("paste", ["Generators", "viewof paste"], (G, _) => G.input(_));  
+  $def("_1whsszt", "paste", ["Generators","viewof paste"], _1whsszt);  
   $def("_corxwl", "viewof down", ["Inputs","moveCell","viewof editedCell"], _corxwl);  
-  main.variable(observer("down")).define("down", ["Generators", "viewof down"], (G, _) => G.input(_));  
+  $def("_1to28po", "down", ["Generators","viewof down"], _1to28po);  
   $def("_gia2ci", "viewof copy", ["Inputs","html","viewof editedCell","decompile","viewof liveCellMap","getOption","cellsToClipboard"], _gia2ci);  
-  main.variable(observer("copy")).define("copy", ["Generators", "viewof copy"], (G, _) => G.input(_));  
+  $def("_fw41wt", "copy", ["Generators","viewof copy"], _fw41wt);  
   $def("_srtw8o", "module", ["editedCell"], _srtw8o);  
   $def("_rv7t7x", "code_editor_view", ["EditorView"], _rv7t7x);  
   $def("_xvo1n6", "code_editor", ["code_editor_view"], _xvo1n6);  
@@ -6035,7 +6055,7 @@ export default function define(runtime, observer) {
   $def("_d9nzys", "deleteCell", ["viewof command"], _d9nzys);  
   $def("_c1u9w8", null, ["md"], _c1u9w8);  
   $def("_d7ouqx", "viewof command", ["flowQueue"], _d7ouqx);  
-  main.variable(observer("command")).define("command", ["Generators", "viewof command"], (G, _) => G.input(_));  
+  $def("_118qt2v", "command", ["Generators","viewof command"], _118qt2v);  
   $def("_19l2nem", null, ["command"], _19l2nem);  
   $def("_1f6v167", "findCellByVariable", [], _1f6v167);  
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
@@ -6052,9 +6072,8 @@ export default function define(runtime, observer) {
   $def("_dvne2z", "replaceCodeMirrorDoc", [], _dvne2z);  
   $def("_1fpqfm0", null, ["md"], _1fpqfm0);  
   $def("_rtf009", "viewof select", ["editedCell","Inputs","getOption","setOption"], _rtf009);  
-  main.variable(observer("select")).define("select", ["Generators", "viewof select"], (G, _) => G.input(_));  
+  $def("_14mwbuc", "select", ["Generators","viewof select"], _14mwbuc);  
   $def("_l4sbcd", null, ["md"], _l4sbcd);  
-  main.define("module @tomlarkworthy/fileattachments", async () => runtime.module((await import("/@tomlarkworthy/fileattachments.js?v=4")).default));  
   main.define("getFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachment", _));  
   main.define("setFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("setFileAttachment", _));  
   main.define("removeFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("removeFileAttachment", _));  
@@ -6063,7 +6082,7 @@ export default function define(runtime, observer) {
   $def("_ezl7wk", null, ["FileAttachment"], _ezl7wk);  
   $def("_kygz54", "optionsFile", ["getFileAttachment","editorModule"], _kygz54);  
   $def("_760ozq", "viewof options", ["Inputs","optionsFile"], _760ozq);  
-  main.variable(observer("options")).define("options", ["Generators", "viewof options"], (G, _) => G.input(_));  
+  $def("_4rh26k", "options", ["Generators","viewof options"], _4rh26k);  
   $def("_1lqy7cs", "setOption", ["findCell","_","viewof options","Event"], _1lqy7cs);  
   $def("_1oxe5ee", "getOption", ["findCell","_","viewof options"], _1oxe5ee);  
   $def("_kwq69p", "save_options", ["setFileAttachment","jsonFileAttachment","options","editorModule"], _kwq69p);  
@@ -6077,22 +6096,21 @@ export default function define(runtime, observer) {
   $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
   $def("_1j3c2uf", "decompiled", ["editedCell","decompile"], _1j3c2uf);  
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
-  main.variable(observer("editorModule")).define("editorModule", ["Generators", "viewof editorModule"], (G, _) => G.input(_));  
+  $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1ju14cq", "compile_and_update", ["compile","runtime","repositionSetElement"], _1ju14cq);  
+  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
   $def("_rwez9", "viewof variable", ["Inputs","editedCell"], _rwez9);  
-  main.variable(observer("variable")).define("variable", ["Generators", "viewof variable"], (G, _) => G.input(_));  
+  $def("_11gvkq4", "variable", ["Generators","viewof variable"], _11gvkq4);  
   $def("_r5nvms", "name", ["variable"], _r5nvms);  
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
-  main.variable(observer("definition")).define("definition", ["Generators", "viewof definition"], (G, _) => G.input(_));  
+  $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
   $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
   $def("_1q557s", null, ["md"], _1q557s);  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -6103,12 +6121,10 @@ export default function define(runtime, observer) {
   main.define("isnode", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("isnode", _));  
   main.define("repositionSetElement", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("repositionSetElement", _));  
   main.define("onCodeChange", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("onCodeChange", _));  
-  main.define("module @tomlarkworthy/codemirror-6-v2", async () => runtime.module((await import("/@tomlarkworthy/codemirror-6-v2.js?v=4")).default));  
   main.define("EditorState", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("EditorState", _));  
   main.define("EditorView", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("EditorView", _));  
   main.define("codemirror", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("codemirror", _));  
   main.define("myDefaultTheme", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("myDefaultTheme", _));  
-  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
   main.define("decompile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("decompile", _));  
   main.define("compile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("compile", _));  
   main.define("cellMap", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("cellMap", _));  
@@ -6117,27 +6133,21 @@ export default function define(runtime, observer) {
   main.define("parser", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("parser", _));  
   $def("_1d94dks", "javascriptPlugin", ["codemirror"], _1d94dks);  
   $def("_ar9tao", null, ["md"], _ar9tao);  
-  main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
   main.define("reversibleAttach", ["module @tomlarkworthy/reversible-attachment", "@variable"], (_, v) => v.import("reversibleAttach", _));  
-  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
   main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
-  main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
   main.define("flowQueue", ["module @tomlarkworthy/flow-queue", "@variable"], (_, v) => v.import("flowQueue", _));  
-  main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
   main.define("viewof liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("viewof liveCellMap", _));  
   main.define("liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("liveCellMap", _));  
-  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
   main.define("hash", ["module d/57d79353bac56631@44", "@variable"], (_, v) => v.import("hash", _));  
-  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
   main.define("extractNotebookAndCell", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("extractNotebookAndCell", _));  
   main.define("navHref", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("navHref", _));  
-  main.define("module @tomlarkworthy/cells-to-clipboard", async () => runtime.module((await import("/@tomlarkworthy/cells-to-clipboard.js?v=4")).default));  
   main.define("cellsToClipboard", ["module @tomlarkworthy/cells-to-clipboard", "@variable"], (_, v) => v.import("cellsToClipboard", _));
   return main;
-}</script>
+}
+</script>
 <script id="@tomlarkworthy/escodegen/escodegen.browser.min.js.gz" 
   type="text/plain"
   data-encoding="base64"

--- a/notebooks/@tomlarkworthy_lopepage.html
+++ b/notebooks/@tomlarkworthy_lopepage.html
@@ -4668,7 +4668,7 @@ export default function define(runtime, observer) {
 >
 e30K
 </script>
-<script id="@tomlarkworthy/editor-5" 
+<script id="@tomlarkworthy/editor-5"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -5847,43 +5847,47 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1ju14cq = function _compile_and_update(compile,runtime,repositionSetElement){return(
-(source, variables = [], cell) => {
-    try {
-        debugger;
-        let reposition = false, insertionIndex = -1;
-        const newVariables = compile(source);
-        if (!variables || variables.length !== newVariables.length) {
-            reposition = true;
-            variables.forEach(v => v.delete());
-            variables.length = 0;
-            for (let i = 0; i < newVariables.length; i++) {
-                const newVariable = cell.module.module.variable({});
-                variables.push(newVariable);
+const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+{
+    return (source, variables = [], cell) => {
+        try {
+            debugger;
+            let reposition = false, insertionIndex = -1;
+            const newVariables = compile(source);
+            if (!variables || variables.length !== newVariables.length) {
+                reposition = true;
+                variables.forEach(v => v.delete());
+                variables.length = 0;
+                for (let i = 0; i < newVariables.length; i++) {
+                    const newVariable = cell.module.module.variable({});
+                    // Assign a random pid up-front so blank/identical new cells don't
+                    // collide via persistentId's contentHash. See lopecode#144.
+                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+                    variables.push(newVariable);
+                }
             }
-        }
-        if (reposition) {
-            insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-        }
-        newVariables.forEach((v, i) => {
-            const variable = variables[i];
-            let _fn;
-            eval('_fn = ' + v._definition);
-            if (v._name) {
-                variable.define(v._name, v._inputs, _fn);
-            } else {
-                variable.define(v._inputs, _fn);
+            if (reposition) {
+                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
-            if (reposition)
-                repositionSetElement(runtime._variables, variable, insertionIndex + i);
-        });
-        return variables;
-    } catch (e) {
-        console.error(e);
-        debugger;
-    }
-}
-)};
+            newVariables.forEach((v, i) => {
+                const variable = variables[i];
+                let _fn;
+                eval('_fn = ' + v._definition);
+                if (v._name) {
+                    variable.define(v._name, v._inputs, _fn);
+                } else {
+                    variable.define(v._inputs, _fn);
+                }
+                if (reposition)
+                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
+            });
+            return variables;
+        } catch (e) {
+            console.error(e);
+            debugger;
+        }
+    };
+};
 const _1jqs8in = function _91(md){return(
 md`### Remove Cells`
 )};
@@ -6073,7 +6077,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1ju14cq", "compile_and_update", ["compile","runtime","repositionSetElement"], _1ju14cq);  
+  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -6120,7 +6124,8 @@ export default function define(runtime, observer) {
   main.define("navHref", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("navHref", _));  
   main.define("cellsToClipboard", ["module @tomlarkworthy/cells-to-clipboard", "@variable"], (_, v) => v.import("cellsToClipboard", _));
   return main;
-}</script>
+}
+</script>
 <script id="@tomlarkworthy/escodegen/escodegen.browser.min.js.gz" 
   type="text/plain"
   data-encoding="base64"

--- a/notebooks/@tomlarkworthy_modern-screenshot.html
+++ b/notebooks/@tomlarkworthy_modern-screenshot.html
@@ -4690,7 +4690,7 @@ export default function define(runtime, observer) {
 >
 e30K
 </script>
-<script id="@tomlarkworthy/editor-5" 
+<script id="@tomlarkworthy/editor-5"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -4737,7 +4737,6 @@ md`## TODO
 const _1ociws4 = function _6(md){return(
 md`## Sync editors`
 )};
-const _1vq49kx = (_, v) => v.import("syncers", _);
 const _hdieof = function _editors(){return(
 new Map()
 )};
@@ -4815,12 +4814,12 @@ Inputs.toggle({
   value: !isOnObservableCom()
 })
 )};
+const _1oaz8r1 = (G, _) => G.input(_);
 const _16ks4jz = function _12(md){return(
 md`## \`cellEditor\` component
 
 Using Dataflow templating to create reusable Hotbar Component builder`
 )};
-const _1deps8p = (_, v) => v.import("cloneDataflow", _);
 const _199ztvl = function _hotbarTemplate(lookupVariable,editorModule){return(
 lookupVariable(
   [
@@ -5057,6 +5056,7 @@ md`## Hotbar Prototype`
 const _1o2h65s = function _editedCell(Inputs){return(
 Inputs.input(null)
 )};
+const _7g3h7h = (G, _) => G.input(_);
 const _1urs1md = function _findCell($0,modules){return(
 (variable, dom = undefined) => {
   if (variable) {
@@ -5216,9 +5216,11 @@ Inputs.toggle({
   value: true
 })
 )};
+const _1h8337z = (G, _) => G.input(_);
 const _tct2nf = function _edit(Inputs){return(
 Inputs.toggle({ label: "edit" })
 )};
+const _7izj7k = (G, _) => G.input(_);
 const _1fwb5jc = function _toolbar(htl,reversibleAttach,combine,$0,$1,$2,$3,$4,$5,$6,$7){return(
 htl.html`<div
     class="toolbar"
@@ -5246,11 +5248,13 @@ Inputs.button("➕", {
   }
 })
 )};
+const _1aii9ps = (G, _) => G.input(_);
 const _1bn860e = function _remove(Inputs,deleteCell,$0){return(
 Inputs.button("🗑️", {
   reduce: () => deleteCell({ cell: $0.value })
 })
 )};
+const _1ad0xr8 = (G, _) => G.input(_);
 const _tw1j7n = function _apply(Inputs,compile_and_update,states,editedCell)
 {
   const button = Inputs.button("▶️", {
@@ -5269,11 +5273,13 @@ const _tw1j7n = function _apply(Inputs,compile_and_update,states,editedCell)
   button.onmousedown = (e) => e.preventDefault();
   return button;
 };
+const _1cjyuqm = (G, _) => G.input(_);
 const _14rfku9 = function _up(Inputs,moveCell,$0){return(
 Inputs.button("⬆", {
   reduce: () => moveCell($0.value, -1)
 })
 )};
+const _frzs5d = (G, _) => G.input(_);
 const _9pymuj = function _paste(Inputs,readObservableClipboardCells,pasteObservableCellsIntoModule,editedCell){return(
 Inputs.button("📋", {
   reduce: async () => {
@@ -5282,11 +5288,13 @@ Inputs.button("📋", {
   }
 })
 )};
+const _1whsszt = (G, _) => G.input(_);
 const _corxwl = function _down(Inputs,moveCell,$0){return(
 Inputs.button("⬇", {
   reduce: () => moveCell($0.value, 1)
 })
 )};
+const _1to28po = (G, _) => G.input(_);
 const _gia2ci = function _copy(Inputs,html,$0,decompile,$1,getOption,cellsToClipboard){return(
 Inputs.button(
   html`<span style="font-size: .875em; margin-right: .125em; position: relative; top: -.25em; left: -.125em">
@@ -5328,6 +5336,7 @@ Inputs.button(
   }
 )
 )};
+const _fw41wt = (G, _) => G.input(_);
 const _srtw8o = function _module(editedCell){return(
 editedCell.module.module
 )};
@@ -5382,6 +5391,7 @@ md`## API handler`
 const _d7ouqx = function _command(flowQueue){return(
 flowQueue()
 )};
+const _118qt2v = (G, _) => G.input(_);
 const _19l2nem = function _54(command){return(
 command
 )};
@@ -5654,10 +5664,10 @@ const _rtf009 = function _select(editedCell,Inputs,getOption,setOption){return(
   return el;
 })()
 )};
+const _14mwbuc = (G, _) => G.input(_);
 const _l4sbcd = function _70(md){return(
 md`## Pinning`
 )};
-const _1sxszb9 = (_, v) => v.import("getFileAttachment", _);
 const _ezl7wk = function _72(FileAttachment){return(
 FileAttachment("cell_options.json")
 )};
@@ -5667,6 +5677,7 @@ getFileAttachment("cell_options.json", editorModule)
 const _760ozq = async function _options(Inputs,optionsFile){return(
 Inputs.input(await optionsFile.json())
 )};
+const _4rh26k = (G, _) => G.input(_);
 const _1lqy7cs = function _setOption(findCell,_,$0,Event){return(
 (variable, option, value) => {
   const cell = findCell(variable);
@@ -5846,6 +5857,7 @@ const _1j3c2uf = function _decompiled(editedCell,decompile)
 const _w5q3yf = function _editorModule(thisModule){return(
 thisModule()
 )};
+const _18kaj2p = (G, _) => G.input(_);
 const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_options)
 {
   //editedCell;
@@ -5857,43 +5869,47 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1ju14cq = function _compile_and_update(compile,runtime,repositionSetElement){return(
-(source, variables = [], cell) => {
-    try {
-        debugger;
-        let reposition = false, insertionIndex = -1;
-        const newVariables = compile(source);
-        if (!variables || variables.length !== newVariables.length) {
-            reposition = true;
-            variables.forEach(v => v.delete());
-            variables.length = 0;
-            for (let i = 0; i < newVariables.length; i++) {
-                const newVariable = cell.module.module.variable({});
-                variables.push(newVariable);
+const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+{
+    return (source, variables = [], cell) => {
+        try {
+            debugger;
+            let reposition = false, insertionIndex = -1;
+            const newVariables = compile(source);
+            if (!variables || variables.length !== newVariables.length) {
+                reposition = true;
+                variables.forEach(v => v.delete());
+                variables.length = 0;
+                for (let i = 0; i < newVariables.length; i++) {
+                    const newVariable = cell.module.module.variable({});
+                    // Assign a random pid up-front so blank/identical new cells don't
+                    // collide via persistentId's contentHash. See lopecode#144.
+                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+                    variables.push(newVariable);
+                }
             }
-        }
-        if (reposition) {
-            insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-        }
-        newVariables.forEach((v, i) => {
-            const variable = variables[i];
-            let _fn;
-            eval('_fn = ' + v._definition);
-            if (v._name) {
-                variable.define(v._name, v._inputs, _fn);
-            } else {
-                variable.define(v._inputs, _fn);
+            if (reposition) {
+                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
-            if (reposition)
-                repositionSetElement(runtime._variables, variable, insertionIndex + i);
-        });
-        return variables;
-    } catch (e) {
-        console.error(e);
-        debugger;
-    }
-}
-)};
+            newVariables.forEach((v, i) => {
+                const variable = variables[i];
+                let _fn;
+                eval('_fn = ' + v._definition);
+                if (v._name) {
+                    variable.define(v._name, v._inputs, _fn);
+                } else {
+                    variable.define(v._inputs, _fn);
+                }
+                if (reposition)
+                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
+            });
+            return variables;
+        } catch (e) {
+            console.error(e);
+            debugger;
+        }
+    };
+};
 const _1jqs8in = function _91(md){return(
 md`### Remove Cells`
 )};
@@ -5912,6 +5928,7 @@ Inputs.radio(editedCell.variables, {
   value: editedCell.variables[0]
 })
 )};
+const _11gvkq4 = (G, _) => G.input(_);
 const _r5nvms = function _name(variable){return(
 variable._name
 )};
@@ -5925,6 +5942,7 @@ Inputs.textarea({
   rows: 10
 })
 )};
+const _b4rsn5 = (G, _) => G.input(_);
 const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
@@ -5938,22 +5956,12 @@ Inputs.button("update variable", {
 const _1q557s = function _99(md){return(
 md`### Editor Libraries`
 )};
-const _192vvs7 = (_, v) => v.import("descendants", _);
-const _3va6tf = (_, v) => v.import("EditorState", _);
-const _lmqjiv = (_, v) => v.import("decompile", _);
 const _1d94dks = function _javascriptPlugin(codemirror){return(
 codemirror
 )};
 const _ar9tao = function _104(md){return(
 md`### Libraries`
 )};
-const _viogn = (_, v) => v.import("reversibleAttach", _);
-const _nxg8mr = (_, v) => v.import("moduleMap", _);
-const _14a94d = (_, v) => v.import("flowQueue", _);
-const _gurtwb = (_, v) => v.import("viewof liveCellMap", _);
-const _19ebgtz = (_, v) => v.import("hash", _);
-const _n2vgkz = (_, v) => v.import("extractNotebookAndCell", _);
-const _1qucevb = (_, v) => v.import("cellsToClipboard", _);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -5967,22 +5975,34 @@ export default function define(runtime, observer) {
     return [name, {url: blob_url, mimeType: mime}]
   }));
   main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
+  main.define("module @tomlarkworthy/dataflow-templating", async () => runtime.module((await import("/@tomlarkworthy/dataflow-templating.js?v=4")).default));  
+  main.define("module @tomlarkworthy/fileattachments", async () => runtime.module((await import("/@tomlarkworthy/fileattachments.js?v=4")).default));  
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/codemirror-6-v2", async () => runtime.module((await import("/@tomlarkworthy/codemirror-6-v2.js?v=4")).default));  
+  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
+  main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
+  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
+  main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
+  main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
+  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
+  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
+  main.define("module @tomlarkworthy/cells-to-clipboard", async () => runtime.module((await import("/@tomlarkworthy/cells-to-clipboard.js?v=4")).default));  
   $def("_1tdjp0a", "title", ["md"], _1tdjp0a);  
   $def("_dm53bx", null, ["md"], _dm53bx);  
   $def("_61oxjf", "title_variable", ["lookupVariable","editorModule"], _61oxjf);  
   $def("_15uilf0", null, ["cellEditor","title_variable"], _15uilf0);  
   $def("_3x695f", null, ["md"], _3x695f);  
   $def("_1ociws4", null, ["md"], _1ociws4);  
-  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
   $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
-  main.variable(observer("attachContextManu")).define("attachContextManu", ["Generators", "viewof attachContextManu"], (G, _) => G.input(_));  
+  $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
   $def("_16ks4jz", null, ["md"], _16ks4jz);  
-  main.define("module @tomlarkworthy/dataflow-templating", async () => runtime.module((await import("/@tomlarkworthy/dataflow-templating.js?v=4")).default));  
   main.define("cloneDataflow", ["module @tomlarkworthy/dataflow-templating", "@variable"], (_, v) => v.import("cloneDataflow", _));  
   main.define("lookupVariable", ["module @tomlarkworthy/dataflow-templating", "@variable"], (_, v) => v.import("lookupVariable", _));  
   $def("_199ztvl", "hotbarTemplate", ["lookupVariable","editorModule"], _199ztvl);  
@@ -5993,7 +6013,7 @@ export default function define(runtime, observer) {
   $def("_110gwi7", "editorTemplate", ["lookupVariable","editorModule"], _110gwi7);  
   $def("_16rqzgl", null, ["md"], _16rqzgl);  
   $def("_1o2h65s", "viewof editedCell", ["Inputs"], _1o2h65s);  
-  main.variable(observer("editedCell")).define("editedCell", ["Generators", "viewof editedCell"], (G, _) => G.input(_));  
+  $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
   $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
@@ -6008,24 +6028,24 @@ export default function define(runtime, observer) {
   $def("_mrrmx3", null, ["md"], _mrrmx3);  
   $def("_14b1byw", null, ["md"], _14b1byw);  
   $def("_1j1loxx", "viewof combine", ["Inputs"], _1j1loxx);  
-  main.variable(observer("combine")).define("combine", ["Generators", "viewof combine"], (G, _) => G.input(_));  
+  $def("_1h8337z", "combine", ["Generators","viewof combine"], _1h8337z);  
   $def("_tct2nf", "viewof edit", ["Inputs"], _tct2nf);  
-  main.variable(observer("edit")).define("edit", ["Generators", "viewof edit"], (G, _) => G.input(_));  
+  $def("_7izj7k", "edit", ["Generators","viewof edit"], _7izj7k);  
   $def("_1fwb5jc", "toolbar", ["htl","reversibleAttach","combine","viewof select","viewof up","viewof down","viewof remove","viewof addCells","viewof apply","viewof copy","viewof paste"], _1fwb5jc);  
   $def("_yej3hb", "viewof addCells", ["Inputs","createCell","viewof editedCell"], _yej3hb);  
-  main.variable(observer("addCells")).define("addCells", ["Generators", "viewof addCells"], (G, _) => G.input(_));  
+  $def("_1aii9ps", "addCells", ["Generators","viewof addCells"], _1aii9ps);  
   $def("_1bn860e", "viewof remove", ["Inputs","deleteCell","viewof editedCell"], _1bn860e);  
-  main.variable(observer("remove")).define("remove", ["Generators", "viewof remove"], (G, _) => G.input(_));  
+  $def("_1ad0xr8", "remove", ["Generators","viewof remove"], _1ad0xr8);  
   $def("_tw1j7n", "viewof apply", ["Inputs","compile_and_update","states","editedCell"], _tw1j7n);  
-  main.variable(observer("apply")).define("apply", ["Generators", "viewof apply"], (G, _) => G.input(_));  
+  $def("_1cjyuqm", "apply", ["Generators","viewof apply"], _1cjyuqm);  
   $def("_14rfku9", "viewof up", ["Inputs","moveCell","viewof editedCell"], _14rfku9);  
-  main.variable(observer("up")).define("up", ["Generators", "viewof up"], (G, _) => G.input(_));  
+  $def("_frzs5d", "up", ["Generators","viewof up"], _frzs5d);  
   $def("_9pymuj", "viewof paste", ["Inputs","readObservableClipboardCells","pasteObservableCellsIntoModule","editedCell"], _9pymuj);  
-  main.variable(observer("paste")).define("paste", ["Generators", "viewof paste"], (G, _) => G.input(_));  
+  $def("_1whsszt", "paste", ["Generators","viewof paste"], _1whsszt);  
   $def("_corxwl", "viewof down", ["Inputs","moveCell","viewof editedCell"], _corxwl);  
-  main.variable(observer("down")).define("down", ["Generators", "viewof down"], (G, _) => G.input(_));  
+  $def("_1to28po", "down", ["Generators","viewof down"], _1to28po);  
   $def("_gia2ci", "viewof copy", ["Inputs","html","viewof editedCell","decompile","viewof liveCellMap","getOption","cellsToClipboard"], _gia2ci);  
-  main.variable(observer("copy")).define("copy", ["Generators", "viewof copy"], (G, _) => G.input(_));  
+  $def("_fw41wt", "copy", ["Generators","viewof copy"], _fw41wt);  
   $def("_srtw8o", "module", ["editedCell"], _srtw8o);  
   $def("_rv7t7x", "code_editor_view", ["EditorView"], _rv7t7x);  
   $def("_xvo1n6", "code_editor", ["code_editor_view"], _xvo1n6);  
@@ -6035,7 +6055,7 @@ export default function define(runtime, observer) {
   $def("_d9nzys", "deleteCell", ["viewof command"], _d9nzys);  
   $def("_c1u9w8", null, ["md"], _c1u9w8);  
   $def("_d7ouqx", "viewof command", ["flowQueue"], _d7ouqx);  
-  main.variable(observer("command")).define("command", ["Generators", "viewof command"], (G, _) => G.input(_));  
+  $def("_118qt2v", "command", ["Generators","viewof command"], _118qt2v);  
   $def("_19l2nem", null, ["command"], _19l2nem);  
   $def("_1f6v167", "findCellByVariable", [], _1f6v167);  
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
@@ -6052,9 +6072,8 @@ export default function define(runtime, observer) {
   $def("_dvne2z", "replaceCodeMirrorDoc", [], _dvne2z);  
   $def("_1fpqfm0", null, ["md"], _1fpqfm0);  
   $def("_rtf009", "viewof select", ["editedCell","Inputs","getOption","setOption"], _rtf009);  
-  main.variable(observer("select")).define("select", ["Generators", "viewof select"], (G, _) => G.input(_));  
+  $def("_14mwbuc", "select", ["Generators","viewof select"], _14mwbuc);  
   $def("_l4sbcd", null, ["md"], _l4sbcd);  
-  main.define("module @tomlarkworthy/fileattachments", async () => runtime.module((await import("/@tomlarkworthy/fileattachments.js?v=4")).default));  
   main.define("getFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachment", _));  
   main.define("setFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("setFileAttachment", _));  
   main.define("removeFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("removeFileAttachment", _));  
@@ -6063,7 +6082,7 @@ export default function define(runtime, observer) {
   $def("_ezl7wk", null, ["FileAttachment"], _ezl7wk);  
   $def("_kygz54", "optionsFile", ["getFileAttachment","editorModule"], _kygz54);  
   $def("_760ozq", "viewof options", ["Inputs","optionsFile"], _760ozq);  
-  main.variable(observer("options")).define("options", ["Generators", "viewof options"], (G, _) => G.input(_));  
+  $def("_4rh26k", "options", ["Generators","viewof options"], _4rh26k);  
   $def("_1lqy7cs", "setOption", ["findCell","_","viewof options","Event"], _1lqy7cs);  
   $def("_1oxe5ee", "getOption", ["findCell","_","viewof options"], _1oxe5ee);  
   $def("_kwq69p", "save_options", ["setFileAttachment","jsonFileAttachment","options","editorModule"], _kwq69p);  
@@ -6077,22 +6096,21 @@ export default function define(runtime, observer) {
   $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
   $def("_1j3c2uf", "decompiled", ["editedCell","decompile"], _1j3c2uf);  
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
-  main.variable(observer("editorModule")).define("editorModule", ["Generators", "viewof editorModule"], (G, _) => G.input(_));  
+  $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1ju14cq", "compile_and_update", ["compile","runtime","repositionSetElement"], _1ju14cq);  
+  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
   $def("_rwez9", "viewof variable", ["Inputs","editedCell"], _rwez9);  
-  main.variable(observer("variable")).define("variable", ["Generators", "viewof variable"], (G, _) => G.input(_));  
+  $def("_11gvkq4", "variable", ["Generators","viewof variable"], _11gvkq4);  
   $def("_r5nvms", "name", ["variable"], _r5nvms);  
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
-  main.variable(observer("definition")).define("definition", ["Generators", "viewof definition"], (G, _) => G.input(_));  
+  $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
   $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
   $def("_1q557s", null, ["md"], _1q557s);  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -6103,12 +6121,10 @@ export default function define(runtime, observer) {
   main.define("isnode", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("isnode", _));  
   main.define("repositionSetElement", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("repositionSetElement", _));  
   main.define("onCodeChange", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("onCodeChange", _));  
-  main.define("module @tomlarkworthy/codemirror-6-v2", async () => runtime.module((await import("/@tomlarkworthy/codemirror-6-v2.js?v=4")).default));  
   main.define("EditorState", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("EditorState", _));  
   main.define("EditorView", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("EditorView", _));  
   main.define("codemirror", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("codemirror", _));  
   main.define("myDefaultTheme", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("myDefaultTheme", _));  
-  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
   main.define("decompile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("decompile", _));  
   main.define("compile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("compile", _));  
   main.define("cellMap", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("cellMap", _));  
@@ -6117,27 +6133,21 @@ export default function define(runtime, observer) {
   main.define("parser", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("parser", _));  
   $def("_1d94dks", "javascriptPlugin", ["codemirror"], _1d94dks);  
   $def("_ar9tao", null, ["md"], _ar9tao);  
-  main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
   main.define("reversibleAttach", ["module @tomlarkworthy/reversible-attachment", "@variable"], (_, v) => v.import("reversibleAttach", _));  
-  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
   main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
-  main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
   main.define("flowQueue", ["module @tomlarkworthy/flow-queue", "@variable"], (_, v) => v.import("flowQueue", _));  
-  main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
   main.define("viewof liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("viewof liveCellMap", _));  
   main.define("liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("liveCellMap", _));  
-  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
   main.define("hash", ["module d/57d79353bac56631@44", "@variable"], (_, v) => v.import("hash", _));  
-  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
   main.define("extractNotebookAndCell", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("extractNotebookAndCell", _));  
   main.define("navHref", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("navHref", _));  
-  main.define("module @tomlarkworthy/cells-to-clipboard", async () => runtime.module((await import("/@tomlarkworthy/cells-to-clipboard.js?v=4")).default));  
   main.define("cellsToClipboard", ["module @tomlarkworthy/cells-to-clipboard", "@variable"], (_, v) => v.import("cellsToClipboard", _));
   return main;
-}</script>
+}
+</script>
 <script id="@tomlarkworthy/escodegen/escodegen.browser.min.js.gz" 
   type="text/plain"
   data-encoding="base64"

--- a/notebooks/@tomlarkworthy_module-selection.html
+++ b/notebooks/@tomlarkworthy_module-selection.html
@@ -4668,7 +4668,7 @@ export default function define(runtime, observer) {
 >
 e30K
 </script>
-<script id="@tomlarkworthy/editor-5" 
+<script id="@tomlarkworthy/editor-5"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -5847,43 +5847,47 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1ju14cq = function _compile_and_update(compile,runtime,repositionSetElement){return(
-(source, variables = [], cell) => {
-    try {
-        debugger;
-        let reposition = false, insertionIndex = -1;
-        const newVariables = compile(source);
-        if (!variables || variables.length !== newVariables.length) {
-            reposition = true;
-            variables.forEach(v => v.delete());
-            variables.length = 0;
-            for (let i = 0; i < newVariables.length; i++) {
-                const newVariable = cell.module.module.variable({});
-                variables.push(newVariable);
+const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+{
+    return (source, variables = [], cell) => {
+        try {
+            debugger;
+            let reposition = false, insertionIndex = -1;
+            const newVariables = compile(source);
+            if (!variables || variables.length !== newVariables.length) {
+                reposition = true;
+                variables.forEach(v => v.delete());
+                variables.length = 0;
+                for (let i = 0; i < newVariables.length; i++) {
+                    const newVariable = cell.module.module.variable({});
+                    // Assign a random pid up-front so blank/identical new cells don't
+                    // collide via persistentId's contentHash. See lopecode#144.
+                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+                    variables.push(newVariable);
+                }
             }
-        }
-        if (reposition) {
-            insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-        }
-        newVariables.forEach((v, i) => {
-            const variable = variables[i];
-            let _fn;
-            eval('_fn = ' + v._definition);
-            if (v._name) {
-                variable.define(v._name, v._inputs, _fn);
-            } else {
-                variable.define(v._inputs, _fn);
+            if (reposition) {
+                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
-            if (reposition)
-                repositionSetElement(runtime._variables, variable, insertionIndex + i);
-        });
-        return variables;
-    } catch (e) {
-        console.error(e);
-        debugger;
-    }
-}
-)};
+            newVariables.forEach((v, i) => {
+                const variable = variables[i];
+                let _fn;
+                eval('_fn = ' + v._definition);
+                if (v._name) {
+                    variable.define(v._name, v._inputs, _fn);
+                } else {
+                    variable.define(v._inputs, _fn);
+                }
+                if (reposition)
+                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
+            });
+            return variables;
+        } catch (e) {
+            console.error(e);
+            debugger;
+        }
+    };
+};
 const _1jqs8in = function _91(md){return(
 md`### Remove Cells`
 )};
@@ -6073,7 +6077,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1ju14cq", "compile_and_update", ["compile","runtime","repositionSetElement"], _1ju14cq);  
+  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -6120,7 +6124,8 @@ export default function define(runtime, observer) {
   main.define("navHref", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("navHref", _));  
   main.define("cellsToClipboard", ["module @tomlarkworthy/cells-to-clipboard", "@variable"], (_, v) => v.import("cellsToClipboard", _));
   return main;
-}</script>
+}
+</script>
 <script id="@tomlarkworthy/escodegen/escodegen.browser.min.js.gz" 
   type="text/plain"
   data-encoding="base64"

--- a/notebooks/@tomlarkworthy_notes.html
+++ b/notebooks/@tomlarkworthy_notes.html
@@ -4717,7 +4717,7 @@ export default function define(runtime, observer) {
 >
 e30K
 </script>
-<script id="@tomlarkworthy/editor-5" 
+<script id="@tomlarkworthy/editor-5"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -5896,43 +5896,47 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1ju14cq = function _compile_and_update(compile,runtime,repositionSetElement){return(
-(source, variables = [], cell) => {
-    try {
-        debugger;
-        let reposition = false, insertionIndex = -1;
-        const newVariables = compile(source);
-        if (!variables || variables.length !== newVariables.length) {
-            reposition = true;
-            variables.forEach(v => v.delete());
-            variables.length = 0;
-            for (let i = 0; i < newVariables.length; i++) {
-                const newVariable = cell.module.module.variable({});
-                variables.push(newVariable);
+const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+{
+    return (source, variables = [], cell) => {
+        try {
+            debugger;
+            let reposition = false, insertionIndex = -1;
+            const newVariables = compile(source);
+            if (!variables || variables.length !== newVariables.length) {
+                reposition = true;
+                variables.forEach(v => v.delete());
+                variables.length = 0;
+                for (let i = 0; i < newVariables.length; i++) {
+                    const newVariable = cell.module.module.variable({});
+                    // Assign a random pid up-front so blank/identical new cells don't
+                    // collide via persistentId's contentHash. See lopecode#144.
+                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+                    variables.push(newVariable);
+                }
             }
-        }
-        if (reposition) {
-            insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-        }
-        newVariables.forEach((v, i) => {
-            const variable = variables[i];
-            let _fn;
-            eval('_fn = ' + v._definition);
-            if (v._name) {
-                variable.define(v._name, v._inputs, _fn);
-            } else {
-                variable.define(v._inputs, _fn);
+            if (reposition) {
+                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
-            if (reposition)
-                repositionSetElement(runtime._variables, variable, insertionIndex + i);
-        });
-        return variables;
-    } catch (e) {
-        console.error(e);
-        debugger;
-    }
-}
-)};
+            newVariables.forEach((v, i) => {
+                const variable = variables[i];
+                let _fn;
+                eval('_fn = ' + v._definition);
+                if (v._name) {
+                    variable.define(v._name, v._inputs, _fn);
+                } else {
+                    variable.define(v._inputs, _fn);
+                }
+                if (reposition)
+                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
+            });
+            return variables;
+        } catch (e) {
+            console.error(e);
+            debugger;
+        }
+    };
+};
 const _1jqs8in = function _91(md){return(
 md`### Remove Cells`
 )};
@@ -6122,7 +6126,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1ju14cq", "compile_and_update", ["compile","runtime","repositionSetElement"], _1ju14cq);  
+  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -6169,7 +6173,8 @@ export default function define(runtime, observer) {
   main.define("navHref", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("navHref", _));  
   main.define("cellsToClipboard", ["module @tomlarkworthy/cells-to-clipboard", "@variable"], (_, v) => v.import("cellsToClipboard", _));
   return main;
-}</script>
+}
+</script>
 <script id="@tomlarkworthy/escodegen/escodegen.browser.min.js.gz" 
   type="text/plain"
   data-encoding="base64"

--- a/notebooks/@tomlarkworthy_observablejs-toolchain.html
+++ b/notebooks/@tomlarkworthy_observablejs-toolchain.html
@@ -4668,7 +4668,7 @@ export default function define(runtime, observer) {
 >
 e30K
 </script>
-<script id="@tomlarkworthy/editor-5" 
+<script id="@tomlarkworthy/editor-5"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -5847,43 +5847,47 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1ju14cq = function _compile_and_update(compile,runtime,repositionSetElement){return(
-(source, variables = [], cell) => {
-    try {
-        debugger;
-        let reposition = false, insertionIndex = -1;
-        const newVariables = compile(source);
-        if (!variables || variables.length !== newVariables.length) {
-            reposition = true;
-            variables.forEach(v => v.delete());
-            variables.length = 0;
-            for (let i = 0; i < newVariables.length; i++) {
-                const newVariable = cell.module.module.variable({});
-                variables.push(newVariable);
+const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+{
+    return (source, variables = [], cell) => {
+        try {
+            debugger;
+            let reposition = false, insertionIndex = -1;
+            const newVariables = compile(source);
+            if (!variables || variables.length !== newVariables.length) {
+                reposition = true;
+                variables.forEach(v => v.delete());
+                variables.length = 0;
+                for (let i = 0; i < newVariables.length; i++) {
+                    const newVariable = cell.module.module.variable({});
+                    // Assign a random pid up-front so blank/identical new cells don't
+                    // collide via persistentId's contentHash. See lopecode#144.
+                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+                    variables.push(newVariable);
+                }
             }
-        }
-        if (reposition) {
-            insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-        }
-        newVariables.forEach((v, i) => {
-            const variable = variables[i];
-            let _fn;
-            eval('_fn = ' + v._definition);
-            if (v._name) {
-                variable.define(v._name, v._inputs, _fn);
-            } else {
-                variable.define(v._inputs, _fn);
+            if (reposition) {
+                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
-            if (reposition)
-                repositionSetElement(runtime._variables, variable, insertionIndex + i);
-        });
-        return variables;
-    } catch (e) {
-        console.error(e);
-        debugger;
-    }
-}
-)};
+            newVariables.forEach((v, i) => {
+                const variable = variables[i];
+                let _fn;
+                eval('_fn = ' + v._definition);
+                if (v._name) {
+                    variable.define(v._name, v._inputs, _fn);
+                } else {
+                    variable.define(v._inputs, _fn);
+                }
+                if (reposition)
+                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
+            });
+            return variables;
+        } catch (e) {
+            console.error(e);
+            debugger;
+        }
+    };
+};
 const _1jqs8in = function _91(md){return(
 md`### Remove Cells`
 )};
@@ -6073,7 +6077,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1ju14cq", "compile_and_update", ["compile","runtime","repositionSetElement"], _1ju14cq);  
+  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -6120,7 +6124,8 @@ export default function define(runtime, observer) {
   main.define("navHref", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("navHref", _));  
   main.define("cellsToClipboard", ["module @tomlarkworthy/cells-to-clipboard", "@variable"], (_, v) => v.import("cellsToClipboard", _));
   return main;
-}</script>
+}
+</script>
 <script id="@tomlarkworthy/escodegen/escodegen.browser.min.js.gz" 
   type="text/plain"
   data-encoding="base64"

--- a/notebooks/@tomlarkworthy_openai-responses-api.html
+++ b/notebooks/@tomlarkworthy_openai-responses-api.html
@@ -4690,7 +4690,7 @@ export default function define(runtime, observer) {
 >
 e30K
 </script>
-<script id="@tomlarkworthy/editor-5" 
+<script id="@tomlarkworthy/editor-5"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -4737,7 +4737,6 @@ md`## TODO
 const _1ociws4 = function _6(md){return(
 md`## Sync editors`
 )};
-const _1vq49kx = (_, v) => v.import("syncers", _);
 const _hdieof = function _editors(){return(
 new Map()
 )};
@@ -4815,12 +4814,12 @@ Inputs.toggle({
   value: !isOnObservableCom()
 })
 )};
+const _1oaz8r1 = (G, _) => G.input(_);
 const _16ks4jz = function _12(md){return(
 md`## \`cellEditor\` component
 
 Using Dataflow templating to create reusable Hotbar Component builder`
 )};
-const _1deps8p = (_, v) => v.import("cloneDataflow", _);
 const _199ztvl = function _hotbarTemplate(lookupVariable,editorModule){return(
 lookupVariable(
   [
@@ -5057,6 +5056,7 @@ md`## Hotbar Prototype`
 const _1o2h65s = function _editedCell(Inputs){return(
 Inputs.input(null)
 )};
+const _7g3h7h = (G, _) => G.input(_);
 const _1urs1md = function _findCell($0,modules){return(
 (variable, dom = undefined) => {
   if (variable) {
@@ -5216,9 +5216,11 @@ Inputs.toggle({
   value: true
 })
 )};
+const _1h8337z = (G, _) => G.input(_);
 const _tct2nf = function _edit(Inputs){return(
 Inputs.toggle({ label: "edit" })
 )};
+const _7izj7k = (G, _) => G.input(_);
 const _1fwb5jc = function _toolbar(htl,reversibleAttach,combine,$0,$1,$2,$3,$4,$5,$6,$7){return(
 htl.html`<div
     class="toolbar"
@@ -5246,11 +5248,13 @@ Inputs.button("➕", {
   }
 })
 )};
+const _1aii9ps = (G, _) => G.input(_);
 const _1bn860e = function _remove(Inputs,deleteCell,$0){return(
 Inputs.button("🗑️", {
   reduce: () => deleteCell({ cell: $0.value })
 })
 )};
+const _1ad0xr8 = (G, _) => G.input(_);
 const _tw1j7n = function _apply(Inputs,compile_and_update,states,editedCell)
 {
   const button = Inputs.button("▶️", {
@@ -5269,11 +5273,13 @@ const _tw1j7n = function _apply(Inputs,compile_and_update,states,editedCell)
   button.onmousedown = (e) => e.preventDefault();
   return button;
 };
+const _1cjyuqm = (G, _) => G.input(_);
 const _14rfku9 = function _up(Inputs,moveCell,$0){return(
 Inputs.button("⬆", {
   reduce: () => moveCell($0.value, -1)
 })
 )};
+const _frzs5d = (G, _) => G.input(_);
 const _9pymuj = function _paste(Inputs,readObservableClipboardCells,pasteObservableCellsIntoModule,editedCell){return(
 Inputs.button("📋", {
   reduce: async () => {
@@ -5282,11 +5288,13 @@ Inputs.button("📋", {
   }
 })
 )};
+const _1whsszt = (G, _) => G.input(_);
 const _corxwl = function _down(Inputs,moveCell,$0){return(
 Inputs.button("⬇", {
   reduce: () => moveCell($0.value, 1)
 })
 )};
+const _1to28po = (G, _) => G.input(_);
 const _gia2ci = function _copy(Inputs,html,$0,decompile,$1,getOption,cellsToClipboard){return(
 Inputs.button(
   html`<span style="font-size: .875em; margin-right: .125em; position: relative; top: -.25em; left: -.125em">
@@ -5328,6 +5336,7 @@ Inputs.button(
   }
 )
 )};
+const _fw41wt = (G, _) => G.input(_);
 const _srtw8o = function _module(editedCell){return(
 editedCell.module.module
 )};
@@ -5382,6 +5391,7 @@ md`## API handler`
 const _d7ouqx = function _command(flowQueue){return(
 flowQueue()
 )};
+const _118qt2v = (G, _) => G.input(_);
 const _19l2nem = function _54(command){return(
 command
 )};
@@ -5654,10 +5664,10 @@ const _rtf009 = function _select(editedCell,Inputs,getOption,setOption){return(
   return el;
 })()
 )};
+const _14mwbuc = (G, _) => G.input(_);
 const _l4sbcd = function _70(md){return(
 md`## Pinning`
 )};
-const _1sxszb9 = (_, v) => v.import("getFileAttachment", _);
 const _ezl7wk = function _72(FileAttachment){return(
 FileAttachment("cell_options.json")
 )};
@@ -5667,6 +5677,7 @@ getFileAttachment("cell_options.json", editorModule)
 const _760ozq = async function _options(Inputs,optionsFile){return(
 Inputs.input(await optionsFile.json())
 )};
+const _4rh26k = (G, _) => G.input(_);
 const _1lqy7cs = function _setOption(findCell,_,$0,Event){return(
 (variable, option, value) => {
   const cell = findCell(variable);
@@ -5846,6 +5857,7 @@ const _1j3c2uf = function _decompiled(editedCell,decompile)
 const _w5q3yf = function _editorModule(thisModule){return(
 thisModule()
 )};
+const _18kaj2p = (G, _) => G.input(_);
 const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_options)
 {
   //editedCell;
@@ -5857,43 +5869,47 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1ju14cq = function _compile_and_update(compile,runtime,repositionSetElement){return(
-(source, variables = [], cell) => {
-    try {
-        debugger;
-        let reposition = false, insertionIndex = -1;
-        const newVariables = compile(source);
-        if (!variables || variables.length !== newVariables.length) {
-            reposition = true;
-            variables.forEach(v => v.delete());
-            variables.length = 0;
-            for (let i = 0; i < newVariables.length; i++) {
-                const newVariable = cell.module.module.variable({});
-                variables.push(newVariable);
+const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+{
+    return (source, variables = [], cell) => {
+        try {
+            debugger;
+            let reposition = false, insertionIndex = -1;
+            const newVariables = compile(source);
+            if (!variables || variables.length !== newVariables.length) {
+                reposition = true;
+                variables.forEach(v => v.delete());
+                variables.length = 0;
+                for (let i = 0; i < newVariables.length; i++) {
+                    const newVariable = cell.module.module.variable({});
+                    // Assign a random pid up-front so blank/identical new cells don't
+                    // collide via persistentId's contentHash. See lopecode#144.
+                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+                    variables.push(newVariable);
+                }
             }
-        }
-        if (reposition) {
-            insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-        }
-        newVariables.forEach((v, i) => {
-            const variable = variables[i];
-            let _fn;
-            eval('_fn = ' + v._definition);
-            if (v._name) {
-                variable.define(v._name, v._inputs, _fn);
-            } else {
-                variable.define(v._inputs, _fn);
+            if (reposition) {
+                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
-            if (reposition)
-                repositionSetElement(runtime._variables, variable, insertionIndex + i);
-        });
-        return variables;
-    } catch (e) {
-        console.error(e);
-        debugger;
-    }
-}
-)};
+            newVariables.forEach((v, i) => {
+                const variable = variables[i];
+                let _fn;
+                eval('_fn = ' + v._definition);
+                if (v._name) {
+                    variable.define(v._name, v._inputs, _fn);
+                } else {
+                    variable.define(v._inputs, _fn);
+                }
+                if (reposition)
+                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
+            });
+            return variables;
+        } catch (e) {
+            console.error(e);
+            debugger;
+        }
+    };
+};
 const _1jqs8in = function _91(md){return(
 md`### Remove Cells`
 )};
@@ -5912,6 +5928,7 @@ Inputs.radio(editedCell.variables, {
   value: editedCell.variables[0]
 })
 )};
+const _11gvkq4 = (G, _) => G.input(_);
 const _r5nvms = function _name(variable){return(
 variable._name
 )};
@@ -5925,6 +5942,7 @@ Inputs.textarea({
   rows: 10
 })
 )};
+const _b4rsn5 = (G, _) => G.input(_);
 const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
@@ -5938,22 +5956,12 @@ Inputs.button("update variable", {
 const _1q557s = function _99(md){return(
 md`### Editor Libraries`
 )};
-const _192vvs7 = (_, v) => v.import("descendants", _);
-const _3va6tf = (_, v) => v.import("EditorState", _);
-const _lmqjiv = (_, v) => v.import("decompile", _);
 const _1d94dks = function _javascriptPlugin(codemirror){return(
 codemirror
 )};
 const _ar9tao = function _104(md){return(
 md`### Libraries`
 )};
-const _viogn = (_, v) => v.import("reversibleAttach", _);
-const _nxg8mr = (_, v) => v.import("moduleMap", _);
-const _14a94d = (_, v) => v.import("flowQueue", _);
-const _gurtwb = (_, v) => v.import("viewof liveCellMap", _);
-const _19ebgtz = (_, v) => v.import("hash", _);
-const _n2vgkz = (_, v) => v.import("extractNotebookAndCell", _);
-const _1qucevb = (_, v) => v.import("cellsToClipboard", _);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -5967,22 +5975,34 @@ export default function define(runtime, observer) {
     return [name, {url: blob_url, mimeType: mime}]
   }));
   main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
+  main.define("module @tomlarkworthy/dataflow-templating", async () => runtime.module((await import("/@tomlarkworthy/dataflow-templating.js?v=4")).default));  
+  main.define("module @tomlarkworthy/fileattachments", async () => runtime.module((await import("/@tomlarkworthy/fileattachments.js?v=4")).default));  
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/codemirror-6-v2", async () => runtime.module((await import("/@tomlarkworthy/codemirror-6-v2.js?v=4")).default));  
+  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
+  main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
+  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
+  main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
+  main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
+  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
+  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
+  main.define("module @tomlarkworthy/cells-to-clipboard", async () => runtime.module((await import("/@tomlarkworthy/cells-to-clipboard.js?v=4")).default));  
   $def("_1tdjp0a", "title", ["md"], _1tdjp0a);  
   $def("_dm53bx", null, ["md"], _dm53bx);  
   $def("_61oxjf", "title_variable", ["lookupVariable","editorModule"], _61oxjf);  
   $def("_15uilf0", null, ["cellEditor","title_variable"], _15uilf0);  
   $def("_3x695f", null, ["md"], _3x695f);  
   $def("_1ociws4", null, ["md"], _1ociws4);  
-  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
   $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
-  main.variable(observer("attachContextManu")).define("attachContextManu", ["Generators", "viewof attachContextManu"], (G, _) => G.input(_));  
+  $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
   $def("_16ks4jz", null, ["md"], _16ks4jz);  
-  main.define("module @tomlarkworthy/dataflow-templating", async () => runtime.module((await import("/@tomlarkworthy/dataflow-templating.js?v=4")).default));  
   main.define("cloneDataflow", ["module @tomlarkworthy/dataflow-templating", "@variable"], (_, v) => v.import("cloneDataflow", _));  
   main.define("lookupVariable", ["module @tomlarkworthy/dataflow-templating", "@variable"], (_, v) => v.import("lookupVariable", _));  
   $def("_199ztvl", "hotbarTemplate", ["lookupVariable","editorModule"], _199ztvl);  
@@ -5993,7 +6013,7 @@ export default function define(runtime, observer) {
   $def("_110gwi7", "editorTemplate", ["lookupVariable","editorModule"], _110gwi7);  
   $def("_16rqzgl", null, ["md"], _16rqzgl);  
   $def("_1o2h65s", "viewof editedCell", ["Inputs"], _1o2h65s);  
-  main.variable(observer("editedCell")).define("editedCell", ["Generators", "viewof editedCell"], (G, _) => G.input(_));  
+  $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
   $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
@@ -6008,24 +6028,24 @@ export default function define(runtime, observer) {
   $def("_mrrmx3", null, ["md"], _mrrmx3);  
   $def("_14b1byw", null, ["md"], _14b1byw);  
   $def("_1j1loxx", "viewof combine", ["Inputs"], _1j1loxx);  
-  main.variable(observer("combine")).define("combine", ["Generators", "viewof combine"], (G, _) => G.input(_));  
+  $def("_1h8337z", "combine", ["Generators","viewof combine"], _1h8337z);  
   $def("_tct2nf", "viewof edit", ["Inputs"], _tct2nf);  
-  main.variable(observer("edit")).define("edit", ["Generators", "viewof edit"], (G, _) => G.input(_));  
+  $def("_7izj7k", "edit", ["Generators","viewof edit"], _7izj7k);  
   $def("_1fwb5jc", "toolbar", ["htl","reversibleAttach","combine","viewof select","viewof up","viewof down","viewof remove","viewof addCells","viewof apply","viewof copy","viewof paste"], _1fwb5jc);  
   $def("_yej3hb", "viewof addCells", ["Inputs","createCell","viewof editedCell"], _yej3hb);  
-  main.variable(observer("addCells")).define("addCells", ["Generators", "viewof addCells"], (G, _) => G.input(_));  
+  $def("_1aii9ps", "addCells", ["Generators","viewof addCells"], _1aii9ps);  
   $def("_1bn860e", "viewof remove", ["Inputs","deleteCell","viewof editedCell"], _1bn860e);  
-  main.variable(observer("remove")).define("remove", ["Generators", "viewof remove"], (G, _) => G.input(_));  
+  $def("_1ad0xr8", "remove", ["Generators","viewof remove"], _1ad0xr8);  
   $def("_tw1j7n", "viewof apply", ["Inputs","compile_and_update","states","editedCell"], _tw1j7n);  
-  main.variable(observer("apply")).define("apply", ["Generators", "viewof apply"], (G, _) => G.input(_));  
+  $def("_1cjyuqm", "apply", ["Generators","viewof apply"], _1cjyuqm);  
   $def("_14rfku9", "viewof up", ["Inputs","moveCell","viewof editedCell"], _14rfku9);  
-  main.variable(observer("up")).define("up", ["Generators", "viewof up"], (G, _) => G.input(_));  
+  $def("_frzs5d", "up", ["Generators","viewof up"], _frzs5d);  
   $def("_9pymuj", "viewof paste", ["Inputs","readObservableClipboardCells","pasteObservableCellsIntoModule","editedCell"], _9pymuj);  
-  main.variable(observer("paste")).define("paste", ["Generators", "viewof paste"], (G, _) => G.input(_));  
+  $def("_1whsszt", "paste", ["Generators","viewof paste"], _1whsszt);  
   $def("_corxwl", "viewof down", ["Inputs","moveCell","viewof editedCell"], _corxwl);  
-  main.variable(observer("down")).define("down", ["Generators", "viewof down"], (G, _) => G.input(_));  
+  $def("_1to28po", "down", ["Generators","viewof down"], _1to28po);  
   $def("_gia2ci", "viewof copy", ["Inputs","html","viewof editedCell","decompile","viewof liveCellMap","getOption","cellsToClipboard"], _gia2ci);  
-  main.variable(observer("copy")).define("copy", ["Generators", "viewof copy"], (G, _) => G.input(_));  
+  $def("_fw41wt", "copy", ["Generators","viewof copy"], _fw41wt);  
   $def("_srtw8o", "module", ["editedCell"], _srtw8o);  
   $def("_rv7t7x", "code_editor_view", ["EditorView"], _rv7t7x);  
   $def("_xvo1n6", "code_editor", ["code_editor_view"], _xvo1n6);  
@@ -6035,7 +6055,7 @@ export default function define(runtime, observer) {
   $def("_d9nzys", "deleteCell", ["viewof command"], _d9nzys);  
   $def("_c1u9w8", null, ["md"], _c1u9w8);  
   $def("_d7ouqx", "viewof command", ["flowQueue"], _d7ouqx);  
-  main.variable(observer("command")).define("command", ["Generators", "viewof command"], (G, _) => G.input(_));  
+  $def("_118qt2v", "command", ["Generators","viewof command"], _118qt2v);  
   $def("_19l2nem", null, ["command"], _19l2nem);  
   $def("_1f6v167", "findCellByVariable", [], _1f6v167);  
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
@@ -6052,9 +6072,8 @@ export default function define(runtime, observer) {
   $def("_dvne2z", "replaceCodeMirrorDoc", [], _dvne2z);  
   $def("_1fpqfm0", null, ["md"], _1fpqfm0);  
   $def("_rtf009", "viewof select", ["editedCell","Inputs","getOption","setOption"], _rtf009);  
-  main.variable(observer("select")).define("select", ["Generators", "viewof select"], (G, _) => G.input(_));  
+  $def("_14mwbuc", "select", ["Generators","viewof select"], _14mwbuc);  
   $def("_l4sbcd", null, ["md"], _l4sbcd);  
-  main.define("module @tomlarkworthy/fileattachments", async () => runtime.module((await import("/@tomlarkworthy/fileattachments.js?v=4")).default));  
   main.define("getFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachment", _));  
   main.define("setFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("setFileAttachment", _));  
   main.define("removeFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("removeFileAttachment", _));  
@@ -6063,7 +6082,7 @@ export default function define(runtime, observer) {
   $def("_ezl7wk", null, ["FileAttachment"], _ezl7wk);  
   $def("_kygz54", "optionsFile", ["getFileAttachment","editorModule"], _kygz54);  
   $def("_760ozq", "viewof options", ["Inputs","optionsFile"], _760ozq);  
-  main.variable(observer("options")).define("options", ["Generators", "viewof options"], (G, _) => G.input(_));  
+  $def("_4rh26k", "options", ["Generators","viewof options"], _4rh26k);  
   $def("_1lqy7cs", "setOption", ["findCell","_","viewof options","Event"], _1lqy7cs);  
   $def("_1oxe5ee", "getOption", ["findCell","_","viewof options"], _1oxe5ee);  
   $def("_kwq69p", "save_options", ["setFileAttachment","jsonFileAttachment","options","editorModule"], _kwq69p);  
@@ -6077,22 +6096,21 @@ export default function define(runtime, observer) {
   $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
   $def("_1j3c2uf", "decompiled", ["editedCell","decompile"], _1j3c2uf);  
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
-  main.variable(observer("editorModule")).define("editorModule", ["Generators", "viewof editorModule"], (G, _) => G.input(_));  
+  $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1ju14cq", "compile_and_update", ["compile","runtime","repositionSetElement"], _1ju14cq);  
+  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
   $def("_rwez9", "viewof variable", ["Inputs","editedCell"], _rwez9);  
-  main.variable(observer("variable")).define("variable", ["Generators", "viewof variable"], (G, _) => G.input(_));  
+  $def("_11gvkq4", "variable", ["Generators","viewof variable"], _11gvkq4);  
   $def("_r5nvms", "name", ["variable"], _r5nvms);  
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
-  main.variable(observer("definition")).define("definition", ["Generators", "viewof definition"], (G, _) => G.input(_));  
+  $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
   $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
   $def("_1q557s", null, ["md"], _1q557s);  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -6103,12 +6121,10 @@ export default function define(runtime, observer) {
   main.define("isnode", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("isnode", _));  
   main.define("repositionSetElement", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("repositionSetElement", _));  
   main.define("onCodeChange", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("onCodeChange", _));  
-  main.define("module @tomlarkworthy/codemirror-6-v2", async () => runtime.module((await import("/@tomlarkworthy/codemirror-6-v2.js?v=4")).default));  
   main.define("EditorState", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("EditorState", _));  
   main.define("EditorView", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("EditorView", _));  
   main.define("codemirror", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("codemirror", _));  
   main.define("myDefaultTheme", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("myDefaultTheme", _));  
-  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
   main.define("decompile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("decompile", _));  
   main.define("compile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("compile", _));  
   main.define("cellMap", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("cellMap", _));  
@@ -6117,27 +6133,21 @@ export default function define(runtime, observer) {
   main.define("parser", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("parser", _));  
   $def("_1d94dks", "javascriptPlugin", ["codemirror"], _1d94dks);  
   $def("_ar9tao", null, ["md"], _ar9tao);  
-  main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
   main.define("reversibleAttach", ["module @tomlarkworthy/reversible-attachment", "@variable"], (_, v) => v.import("reversibleAttach", _));  
-  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
   main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
-  main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
   main.define("flowQueue", ["module @tomlarkworthy/flow-queue", "@variable"], (_, v) => v.import("flowQueue", _));  
-  main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
   main.define("viewof liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("viewof liveCellMap", _));  
   main.define("liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("liveCellMap", _));  
-  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
   main.define("hash", ["module d/57d79353bac56631@44", "@variable"], (_, v) => v.import("hash", _));  
-  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
   main.define("extractNotebookAndCell", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("extractNotebookAndCell", _));  
   main.define("navHref", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("navHref", _));  
-  main.define("module @tomlarkworthy/cells-to-clipboard", async () => runtime.module((await import("/@tomlarkworthy/cells-to-clipboard.js?v=4")).default));  
   main.define("cellsToClipboard", ["module @tomlarkworthy/cells-to-clipboard", "@variable"], (_, v) => v.import("cellsToClipboard", _));
   return main;
-}</script>
+}
+</script>
 <script id="@tomlarkworthy/escodegen/escodegen.browser.min.js.gz" 
   type="text/plain"
   data-encoding="base64"

--- a/notebooks/@tomlarkworthy_reversible-attachment.html
+++ b/notebooks/@tomlarkworthy_reversible-attachment.html
@@ -4690,7 +4690,7 @@ export default function define(runtime, observer) {
 >
 e30K
 </script>
-<script id="@tomlarkworthy/editor-5" 
+<script id="@tomlarkworthy/editor-5"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -4737,7 +4737,6 @@ md`## TODO
 const _1ociws4 = function _6(md){return(
 md`## Sync editors`
 )};
-const _1vq49kx = (_, v) => v.import("syncers", _);
 const _hdieof = function _editors(){return(
 new Map()
 )};
@@ -4815,12 +4814,12 @@ Inputs.toggle({
   value: !isOnObservableCom()
 })
 )};
+const _1oaz8r1 = (G, _) => G.input(_);
 const _16ks4jz = function _12(md){return(
 md`## \`cellEditor\` component
 
 Using Dataflow templating to create reusable Hotbar Component builder`
 )};
-const _1deps8p = (_, v) => v.import("cloneDataflow", _);
 const _199ztvl = function _hotbarTemplate(lookupVariable,editorModule){return(
 lookupVariable(
   [
@@ -5057,6 +5056,7 @@ md`## Hotbar Prototype`
 const _1o2h65s = function _editedCell(Inputs){return(
 Inputs.input(null)
 )};
+const _7g3h7h = (G, _) => G.input(_);
 const _1urs1md = function _findCell($0,modules){return(
 (variable, dom = undefined) => {
   if (variable) {
@@ -5216,9 +5216,11 @@ Inputs.toggle({
   value: true
 })
 )};
+const _1h8337z = (G, _) => G.input(_);
 const _tct2nf = function _edit(Inputs){return(
 Inputs.toggle({ label: "edit" })
 )};
+const _7izj7k = (G, _) => G.input(_);
 const _1fwb5jc = function _toolbar(htl,reversibleAttach,combine,$0,$1,$2,$3,$4,$5,$6,$7){return(
 htl.html`<div
     class="toolbar"
@@ -5246,11 +5248,13 @@ Inputs.button("➕", {
   }
 })
 )};
+const _1aii9ps = (G, _) => G.input(_);
 const _1bn860e = function _remove(Inputs,deleteCell,$0){return(
 Inputs.button("🗑️", {
   reduce: () => deleteCell({ cell: $0.value })
 })
 )};
+const _1ad0xr8 = (G, _) => G.input(_);
 const _tw1j7n = function _apply(Inputs,compile_and_update,states,editedCell)
 {
   const button = Inputs.button("▶️", {
@@ -5269,11 +5273,13 @@ const _tw1j7n = function _apply(Inputs,compile_and_update,states,editedCell)
   button.onmousedown = (e) => e.preventDefault();
   return button;
 };
+const _1cjyuqm = (G, _) => G.input(_);
 const _14rfku9 = function _up(Inputs,moveCell,$0){return(
 Inputs.button("⬆", {
   reduce: () => moveCell($0.value, -1)
 })
 )};
+const _frzs5d = (G, _) => G.input(_);
 const _9pymuj = function _paste(Inputs,readObservableClipboardCells,pasteObservableCellsIntoModule,editedCell){return(
 Inputs.button("📋", {
   reduce: async () => {
@@ -5282,11 +5288,13 @@ Inputs.button("📋", {
   }
 })
 )};
+const _1whsszt = (G, _) => G.input(_);
 const _corxwl = function _down(Inputs,moveCell,$0){return(
 Inputs.button("⬇", {
   reduce: () => moveCell($0.value, 1)
 })
 )};
+const _1to28po = (G, _) => G.input(_);
 const _gia2ci = function _copy(Inputs,html,$0,decompile,$1,getOption,cellsToClipboard){return(
 Inputs.button(
   html`<span style="font-size: .875em; margin-right: .125em; position: relative; top: -.25em; left: -.125em">
@@ -5328,6 +5336,7 @@ Inputs.button(
   }
 )
 )};
+const _fw41wt = (G, _) => G.input(_);
 const _srtw8o = function _module(editedCell){return(
 editedCell.module.module
 )};
@@ -5382,6 +5391,7 @@ md`## API handler`
 const _d7ouqx = function _command(flowQueue){return(
 flowQueue()
 )};
+const _118qt2v = (G, _) => G.input(_);
 const _19l2nem = function _54(command){return(
 command
 )};
@@ -5654,10 +5664,10 @@ const _rtf009 = function _select(editedCell,Inputs,getOption,setOption){return(
   return el;
 })()
 )};
+const _14mwbuc = (G, _) => G.input(_);
 const _l4sbcd = function _70(md){return(
 md`## Pinning`
 )};
-const _1sxszb9 = (_, v) => v.import("getFileAttachment", _);
 const _ezl7wk = function _72(FileAttachment){return(
 FileAttachment("cell_options.json")
 )};
@@ -5667,6 +5677,7 @@ getFileAttachment("cell_options.json", editorModule)
 const _760ozq = async function _options(Inputs,optionsFile){return(
 Inputs.input(await optionsFile.json())
 )};
+const _4rh26k = (G, _) => G.input(_);
 const _1lqy7cs = function _setOption(findCell,_,$0,Event){return(
 (variable, option, value) => {
   const cell = findCell(variable);
@@ -5846,6 +5857,7 @@ const _1j3c2uf = function _decompiled(editedCell,decompile)
 const _w5q3yf = function _editorModule(thisModule){return(
 thisModule()
 )};
+const _18kaj2p = (G, _) => G.input(_);
 const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_options)
 {
   //editedCell;
@@ -5857,43 +5869,47 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1ju14cq = function _compile_and_update(compile,runtime,repositionSetElement){return(
-(source, variables = [], cell) => {
-    try {
-        debugger;
-        let reposition = false, insertionIndex = -1;
-        const newVariables = compile(source);
-        if (!variables || variables.length !== newVariables.length) {
-            reposition = true;
-            variables.forEach(v => v.delete());
-            variables.length = 0;
-            for (let i = 0; i < newVariables.length; i++) {
-                const newVariable = cell.module.module.variable({});
-                variables.push(newVariable);
+const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+{
+    return (source, variables = [], cell) => {
+        try {
+            debugger;
+            let reposition = false, insertionIndex = -1;
+            const newVariables = compile(source);
+            if (!variables || variables.length !== newVariables.length) {
+                reposition = true;
+                variables.forEach(v => v.delete());
+                variables.length = 0;
+                for (let i = 0; i < newVariables.length; i++) {
+                    const newVariable = cell.module.module.variable({});
+                    // Assign a random pid up-front so blank/identical new cells don't
+                    // collide via persistentId's contentHash. See lopecode#144.
+                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+                    variables.push(newVariable);
+                }
             }
-        }
-        if (reposition) {
-            insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-        }
-        newVariables.forEach((v, i) => {
-            const variable = variables[i];
-            let _fn;
-            eval('_fn = ' + v._definition);
-            if (v._name) {
-                variable.define(v._name, v._inputs, _fn);
-            } else {
-                variable.define(v._inputs, _fn);
+            if (reposition) {
+                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
-            if (reposition)
-                repositionSetElement(runtime._variables, variable, insertionIndex + i);
-        });
-        return variables;
-    } catch (e) {
-        console.error(e);
-        debugger;
-    }
-}
-)};
+            newVariables.forEach((v, i) => {
+                const variable = variables[i];
+                let _fn;
+                eval('_fn = ' + v._definition);
+                if (v._name) {
+                    variable.define(v._name, v._inputs, _fn);
+                } else {
+                    variable.define(v._inputs, _fn);
+                }
+                if (reposition)
+                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
+            });
+            return variables;
+        } catch (e) {
+            console.error(e);
+            debugger;
+        }
+    };
+};
 const _1jqs8in = function _91(md){return(
 md`### Remove Cells`
 )};
@@ -5912,6 +5928,7 @@ Inputs.radio(editedCell.variables, {
   value: editedCell.variables[0]
 })
 )};
+const _11gvkq4 = (G, _) => G.input(_);
 const _r5nvms = function _name(variable){return(
 variable._name
 )};
@@ -5925,6 +5942,7 @@ Inputs.textarea({
   rows: 10
 })
 )};
+const _b4rsn5 = (G, _) => G.input(_);
 const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
@@ -5938,22 +5956,12 @@ Inputs.button("update variable", {
 const _1q557s = function _99(md){return(
 md`### Editor Libraries`
 )};
-const _192vvs7 = (_, v) => v.import("descendants", _);
-const _3va6tf = (_, v) => v.import("EditorState", _);
-const _lmqjiv = (_, v) => v.import("decompile", _);
 const _1d94dks = function _javascriptPlugin(codemirror){return(
 codemirror
 )};
 const _ar9tao = function _104(md){return(
 md`### Libraries`
 )};
-const _viogn = (_, v) => v.import("reversibleAttach", _);
-const _nxg8mr = (_, v) => v.import("moduleMap", _);
-const _14a94d = (_, v) => v.import("flowQueue", _);
-const _gurtwb = (_, v) => v.import("viewof liveCellMap", _);
-const _19ebgtz = (_, v) => v.import("hash", _);
-const _n2vgkz = (_, v) => v.import("extractNotebookAndCell", _);
-const _1qucevb = (_, v) => v.import("cellsToClipboard", _);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -5967,22 +5975,34 @@ export default function define(runtime, observer) {
     return [name, {url: blob_url, mimeType: mime}]
   }));
   main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
+  main.define("module @tomlarkworthy/dataflow-templating", async () => runtime.module((await import("/@tomlarkworthy/dataflow-templating.js?v=4")).default));  
+  main.define("module @tomlarkworthy/fileattachments", async () => runtime.module((await import("/@tomlarkworthy/fileattachments.js?v=4")).default));  
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/codemirror-6-v2", async () => runtime.module((await import("/@tomlarkworthy/codemirror-6-v2.js?v=4")).default));  
+  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
+  main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
+  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
+  main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
+  main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
+  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
+  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
+  main.define("module @tomlarkworthy/cells-to-clipboard", async () => runtime.module((await import("/@tomlarkworthy/cells-to-clipboard.js?v=4")).default));  
   $def("_1tdjp0a", "title", ["md"], _1tdjp0a);  
   $def("_dm53bx", null, ["md"], _dm53bx);  
   $def("_61oxjf", "title_variable", ["lookupVariable","editorModule"], _61oxjf);  
   $def("_15uilf0", null, ["cellEditor","title_variable"], _15uilf0);  
   $def("_3x695f", null, ["md"], _3x695f);  
   $def("_1ociws4", null, ["md"], _1ociws4);  
-  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
   $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
-  main.variable(observer("attachContextManu")).define("attachContextManu", ["Generators", "viewof attachContextManu"], (G, _) => G.input(_));  
+  $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
   $def("_16ks4jz", null, ["md"], _16ks4jz);  
-  main.define("module @tomlarkworthy/dataflow-templating", async () => runtime.module((await import("/@tomlarkworthy/dataflow-templating.js?v=4")).default));  
   main.define("cloneDataflow", ["module @tomlarkworthy/dataflow-templating", "@variable"], (_, v) => v.import("cloneDataflow", _));  
   main.define("lookupVariable", ["module @tomlarkworthy/dataflow-templating", "@variable"], (_, v) => v.import("lookupVariable", _));  
   $def("_199ztvl", "hotbarTemplate", ["lookupVariable","editorModule"], _199ztvl);  
@@ -5993,7 +6013,7 @@ export default function define(runtime, observer) {
   $def("_110gwi7", "editorTemplate", ["lookupVariable","editorModule"], _110gwi7);  
   $def("_16rqzgl", null, ["md"], _16rqzgl);  
   $def("_1o2h65s", "viewof editedCell", ["Inputs"], _1o2h65s);  
-  main.variable(observer("editedCell")).define("editedCell", ["Generators", "viewof editedCell"], (G, _) => G.input(_));  
+  $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
   $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
@@ -6008,24 +6028,24 @@ export default function define(runtime, observer) {
   $def("_mrrmx3", null, ["md"], _mrrmx3);  
   $def("_14b1byw", null, ["md"], _14b1byw);  
   $def("_1j1loxx", "viewof combine", ["Inputs"], _1j1loxx);  
-  main.variable(observer("combine")).define("combine", ["Generators", "viewof combine"], (G, _) => G.input(_));  
+  $def("_1h8337z", "combine", ["Generators","viewof combine"], _1h8337z);  
   $def("_tct2nf", "viewof edit", ["Inputs"], _tct2nf);  
-  main.variable(observer("edit")).define("edit", ["Generators", "viewof edit"], (G, _) => G.input(_));  
+  $def("_7izj7k", "edit", ["Generators","viewof edit"], _7izj7k);  
   $def("_1fwb5jc", "toolbar", ["htl","reversibleAttach","combine","viewof select","viewof up","viewof down","viewof remove","viewof addCells","viewof apply","viewof copy","viewof paste"], _1fwb5jc);  
   $def("_yej3hb", "viewof addCells", ["Inputs","createCell","viewof editedCell"], _yej3hb);  
-  main.variable(observer("addCells")).define("addCells", ["Generators", "viewof addCells"], (G, _) => G.input(_));  
+  $def("_1aii9ps", "addCells", ["Generators","viewof addCells"], _1aii9ps);  
   $def("_1bn860e", "viewof remove", ["Inputs","deleteCell","viewof editedCell"], _1bn860e);  
-  main.variable(observer("remove")).define("remove", ["Generators", "viewof remove"], (G, _) => G.input(_));  
+  $def("_1ad0xr8", "remove", ["Generators","viewof remove"], _1ad0xr8);  
   $def("_tw1j7n", "viewof apply", ["Inputs","compile_and_update","states","editedCell"], _tw1j7n);  
-  main.variable(observer("apply")).define("apply", ["Generators", "viewof apply"], (G, _) => G.input(_));  
+  $def("_1cjyuqm", "apply", ["Generators","viewof apply"], _1cjyuqm);  
   $def("_14rfku9", "viewof up", ["Inputs","moveCell","viewof editedCell"], _14rfku9);  
-  main.variable(observer("up")).define("up", ["Generators", "viewof up"], (G, _) => G.input(_));  
+  $def("_frzs5d", "up", ["Generators","viewof up"], _frzs5d);  
   $def("_9pymuj", "viewof paste", ["Inputs","readObservableClipboardCells","pasteObservableCellsIntoModule","editedCell"], _9pymuj);  
-  main.variable(observer("paste")).define("paste", ["Generators", "viewof paste"], (G, _) => G.input(_));  
+  $def("_1whsszt", "paste", ["Generators","viewof paste"], _1whsszt);  
   $def("_corxwl", "viewof down", ["Inputs","moveCell","viewof editedCell"], _corxwl);  
-  main.variable(observer("down")).define("down", ["Generators", "viewof down"], (G, _) => G.input(_));  
+  $def("_1to28po", "down", ["Generators","viewof down"], _1to28po);  
   $def("_gia2ci", "viewof copy", ["Inputs","html","viewof editedCell","decompile","viewof liveCellMap","getOption","cellsToClipboard"], _gia2ci);  
-  main.variable(observer("copy")).define("copy", ["Generators", "viewof copy"], (G, _) => G.input(_));  
+  $def("_fw41wt", "copy", ["Generators","viewof copy"], _fw41wt);  
   $def("_srtw8o", "module", ["editedCell"], _srtw8o);  
   $def("_rv7t7x", "code_editor_view", ["EditorView"], _rv7t7x);  
   $def("_xvo1n6", "code_editor", ["code_editor_view"], _xvo1n6);  
@@ -6035,7 +6055,7 @@ export default function define(runtime, observer) {
   $def("_d9nzys", "deleteCell", ["viewof command"], _d9nzys);  
   $def("_c1u9w8", null, ["md"], _c1u9w8);  
   $def("_d7ouqx", "viewof command", ["flowQueue"], _d7ouqx);  
-  main.variable(observer("command")).define("command", ["Generators", "viewof command"], (G, _) => G.input(_));  
+  $def("_118qt2v", "command", ["Generators","viewof command"], _118qt2v);  
   $def("_19l2nem", null, ["command"], _19l2nem);  
   $def("_1f6v167", "findCellByVariable", [], _1f6v167);  
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
@@ -6052,9 +6072,8 @@ export default function define(runtime, observer) {
   $def("_dvne2z", "replaceCodeMirrorDoc", [], _dvne2z);  
   $def("_1fpqfm0", null, ["md"], _1fpqfm0);  
   $def("_rtf009", "viewof select", ["editedCell","Inputs","getOption","setOption"], _rtf009);  
-  main.variable(observer("select")).define("select", ["Generators", "viewof select"], (G, _) => G.input(_));  
+  $def("_14mwbuc", "select", ["Generators","viewof select"], _14mwbuc);  
   $def("_l4sbcd", null, ["md"], _l4sbcd);  
-  main.define("module @tomlarkworthy/fileattachments", async () => runtime.module((await import("/@tomlarkworthy/fileattachments.js?v=4")).default));  
   main.define("getFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachment", _));  
   main.define("setFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("setFileAttachment", _));  
   main.define("removeFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("removeFileAttachment", _));  
@@ -6063,7 +6082,7 @@ export default function define(runtime, observer) {
   $def("_ezl7wk", null, ["FileAttachment"], _ezl7wk);  
   $def("_kygz54", "optionsFile", ["getFileAttachment","editorModule"], _kygz54);  
   $def("_760ozq", "viewof options", ["Inputs","optionsFile"], _760ozq);  
-  main.variable(observer("options")).define("options", ["Generators", "viewof options"], (G, _) => G.input(_));  
+  $def("_4rh26k", "options", ["Generators","viewof options"], _4rh26k);  
   $def("_1lqy7cs", "setOption", ["findCell","_","viewof options","Event"], _1lqy7cs);  
   $def("_1oxe5ee", "getOption", ["findCell","_","viewof options"], _1oxe5ee);  
   $def("_kwq69p", "save_options", ["setFileAttachment","jsonFileAttachment","options","editorModule"], _kwq69p);  
@@ -6077,22 +6096,21 @@ export default function define(runtime, observer) {
   $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
   $def("_1j3c2uf", "decompiled", ["editedCell","decompile"], _1j3c2uf);  
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
-  main.variable(observer("editorModule")).define("editorModule", ["Generators", "viewof editorModule"], (G, _) => G.input(_));  
+  $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1ju14cq", "compile_and_update", ["compile","runtime","repositionSetElement"], _1ju14cq);  
+  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
   $def("_rwez9", "viewof variable", ["Inputs","editedCell"], _rwez9);  
-  main.variable(observer("variable")).define("variable", ["Generators", "viewof variable"], (G, _) => G.input(_));  
+  $def("_11gvkq4", "variable", ["Generators","viewof variable"], _11gvkq4);  
   $def("_r5nvms", "name", ["variable"], _r5nvms);  
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
-  main.variable(observer("definition")).define("definition", ["Generators", "viewof definition"], (G, _) => G.input(_));  
+  $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
   $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
   $def("_1q557s", null, ["md"], _1q557s);  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -6103,12 +6121,10 @@ export default function define(runtime, observer) {
   main.define("isnode", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("isnode", _));  
   main.define("repositionSetElement", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("repositionSetElement", _));  
   main.define("onCodeChange", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("onCodeChange", _));  
-  main.define("module @tomlarkworthy/codemirror-6-v2", async () => runtime.module((await import("/@tomlarkworthy/codemirror-6-v2.js?v=4")).default));  
   main.define("EditorState", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("EditorState", _));  
   main.define("EditorView", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("EditorView", _));  
   main.define("codemirror", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("codemirror", _));  
   main.define("myDefaultTheme", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("myDefaultTheme", _));  
-  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
   main.define("decompile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("decompile", _));  
   main.define("compile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("compile", _));  
   main.define("cellMap", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("cellMap", _));  
@@ -6117,27 +6133,21 @@ export default function define(runtime, observer) {
   main.define("parser", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("parser", _));  
   $def("_1d94dks", "javascriptPlugin", ["codemirror"], _1d94dks);  
   $def("_ar9tao", null, ["md"], _ar9tao);  
-  main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
   main.define("reversibleAttach", ["module @tomlarkworthy/reversible-attachment", "@variable"], (_, v) => v.import("reversibleAttach", _));  
-  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
   main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
-  main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
   main.define("flowQueue", ["module @tomlarkworthy/flow-queue", "@variable"], (_, v) => v.import("flowQueue", _));  
-  main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
   main.define("viewof liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("viewof liveCellMap", _));  
   main.define("liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("liveCellMap", _));  
-  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
   main.define("hash", ["module d/57d79353bac56631@44", "@variable"], (_, v) => v.import("hash", _));  
-  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
   main.define("extractNotebookAndCell", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("extractNotebookAndCell", _));  
   main.define("navHref", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("navHref", _));  
-  main.define("module @tomlarkworthy/cells-to-clipboard", async () => runtime.module((await import("/@tomlarkworthy/cells-to-clipboard.js?v=4")).default));  
   main.define("cellsToClipboard", ["module @tomlarkworthy/cells-to-clipboard", "@variable"], (_, v) => v.import("cellsToClipboard", _));
   return main;
-}</script>
+}
+</script>
 <script id="@tomlarkworthy/escodegen/escodegen.browser.min.js.gz" 
   type="text/plain"
   data-encoding="base64"

--- a/notebooks/@tomlarkworthy_robocoop-2.html
+++ b/notebooks/@tomlarkworthy_robocoop-2.html
@@ -4690,7 +4690,7 @@ export default function define(runtime, observer) {
 >
 e30K
 </script>
-<script id="@tomlarkworthy/editor-5" 
+<script id="@tomlarkworthy/editor-5"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -4737,7 +4737,6 @@ md`## TODO
 const _1ociws4 = function _6(md){return(
 md`## Sync editors`
 )};
-const _1vq49kx = (_, v) => v.import("syncers", _);
 const _hdieof = function _editors(){return(
 new Map()
 )};
@@ -4815,12 +4814,12 @@ Inputs.toggle({
   value: !isOnObservableCom()
 })
 )};
+const _1oaz8r1 = (G, _) => G.input(_);
 const _16ks4jz = function _12(md){return(
 md`## \`cellEditor\` component
 
 Using Dataflow templating to create reusable Hotbar Component builder`
 )};
-const _1deps8p = (_, v) => v.import("cloneDataflow", _);
 const _199ztvl = function _hotbarTemplate(lookupVariable,editorModule){return(
 lookupVariable(
   [
@@ -5057,6 +5056,7 @@ md`## Hotbar Prototype`
 const _1o2h65s = function _editedCell(Inputs){return(
 Inputs.input(null)
 )};
+const _7g3h7h = (G, _) => G.input(_);
 const _1urs1md = function _findCell($0,modules){return(
 (variable, dom = undefined) => {
   if (variable) {
@@ -5216,9 +5216,11 @@ Inputs.toggle({
   value: true
 })
 )};
+const _1h8337z = (G, _) => G.input(_);
 const _tct2nf = function _edit(Inputs){return(
 Inputs.toggle({ label: "edit" })
 )};
+const _7izj7k = (G, _) => G.input(_);
 const _1fwb5jc = function _toolbar(htl,reversibleAttach,combine,$0,$1,$2,$3,$4,$5,$6,$7){return(
 htl.html`<div
     class="toolbar"
@@ -5246,11 +5248,13 @@ Inputs.button("➕", {
   }
 })
 )};
+const _1aii9ps = (G, _) => G.input(_);
 const _1bn860e = function _remove(Inputs,deleteCell,$0){return(
 Inputs.button("🗑️", {
   reduce: () => deleteCell({ cell: $0.value })
 })
 )};
+const _1ad0xr8 = (G, _) => G.input(_);
 const _tw1j7n = function _apply(Inputs,compile_and_update,states,editedCell)
 {
   const button = Inputs.button("▶️", {
@@ -5269,11 +5273,13 @@ const _tw1j7n = function _apply(Inputs,compile_and_update,states,editedCell)
   button.onmousedown = (e) => e.preventDefault();
   return button;
 };
+const _1cjyuqm = (G, _) => G.input(_);
 const _14rfku9 = function _up(Inputs,moveCell,$0){return(
 Inputs.button("⬆", {
   reduce: () => moveCell($0.value, -1)
 })
 )};
+const _frzs5d = (G, _) => G.input(_);
 const _9pymuj = function _paste(Inputs,readObservableClipboardCells,pasteObservableCellsIntoModule,editedCell){return(
 Inputs.button("📋", {
   reduce: async () => {
@@ -5282,11 +5288,13 @@ Inputs.button("📋", {
   }
 })
 )};
+const _1whsszt = (G, _) => G.input(_);
 const _corxwl = function _down(Inputs,moveCell,$0){return(
 Inputs.button("⬇", {
   reduce: () => moveCell($0.value, 1)
 })
 )};
+const _1to28po = (G, _) => G.input(_);
 const _gia2ci = function _copy(Inputs,html,$0,decompile,$1,getOption,cellsToClipboard){return(
 Inputs.button(
   html`<span style="font-size: .875em; margin-right: .125em; position: relative; top: -.25em; left: -.125em">
@@ -5328,6 +5336,7 @@ Inputs.button(
   }
 )
 )};
+const _fw41wt = (G, _) => G.input(_);
 const _srtw8o = function _module(editedCell){return(
 editedCell.module.module
 )};
@@ -5382,6 +5391,7 @@ md`## API handler`
 const _d7ouqx = function _command(flowQueue){return(
 flowQueue()
 )};
+const _118qt2v = (G, _) => G.input(_);
 const _19l2nem = function _54(command){return(
 command
 )};
@@ -5654,10 +5664,10 @@ const _rtf009 = function _select(editedCell,Inputs,getOption,setOption){return(
   return el;
 })()
 )};
+const _14mwbuc = (G, _) => G.input(_);
 const _l4sbcd = function _70(md){return(
 md`## Pinning`
 )};
-const _1sxszb9 = (_, v) => v.import("getFileAttachment", _);
 const _ezl7wk = function _72(FileAttachment){return(
 FileAttachment("cell_options.json")
 )};
@@ -5667,6 +5677,7 @@ getFileAttachment("cell_options.json", editorModule)
 const _760ozq = async function _options(Inputs,optionsFile){return(
 Inputs.input(await optionsFile.json())
 )};
+const _4rh26k = (G, _) => G.input(_);
 const _1lqy7cs = function _setOption(findCell,_,$0,Event){return(
 (variable, option, value) => {
   const cell = findCell(variable);
@@ -5846,6 +5857,7 @@ const _1j3c2uf = function _decompiled(editedCell,decompile)
 const _w5q3yf = function _editorModule(thisModule){return(
 thisModule()
 )};
+const _18kaj2p = (G, _) => G.input(_);
 const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_options)
 {
   //editedCell;
@@ -5857,43 +5869,47 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1ju14cq = function _compile_and_update(compile,runtime,repositionSetElement){return(
-(source, variables = [], cell) => {
-    try {
-        debugger;
-        let reposition = false, insertionIndex = -1;
-        const newVariables = compile(source);
-        if (!variables || variables.length !== newVariables.length) {
-            reposition = true;
-            variables.forEach(v => v.delete());
-            variables.length = 0;
-            for (let i = 0; i < newVariables.length; i++) {
-                const newVariable = cell.module.module.variable({});
-                variables.push(newVariable);
+const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+{
+    return (source, variables = [], cell) => {
+        try {
+            debugger;
+            let reposition = false, insertionIndex = -1;
+            const newVariables = compile(source);
+            if (!variables || variables.length !== newVariables.length) {
+                reposition = true;
+                variables.forEach(v => v.delete());
+                variables.length = 0;
+                for (let i = 0; i < newVariables.length; i++) {
+                    const newVariable = cell.module.module.variable({});
+                    // Assign a random pid up-front so blank/identical new cells don't
+                    // collide via persistentId's contentHash. See lopecode#144.
+                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+                    variables.push(newVariable);
+                }
             }
-        }
-        if (reposition) {
-            insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-        }
-        newVariables.forEach((v, i) => {
-            const variable = variables[i];
-            let _fn;
-            eval('_fn = ' + v._definition);
-            if (v._name) {
-                variable.define(v._name, v._inputs, _fn);
-            } else {
-                variable.define(v._inputs, _fn);
+            if (reposition) {
+                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
-            if (reposition)
-                repositionSetElement(runtime._variables, variable, insertionIndex + i);
-        });
-        return variables;
-    } catch (e) {
-        console.error(e);
-        debugger;
-    }
-}
-)};
+            newVariables.forEach((v, i) => {
+                const variable = variables[i];
+                let _fn;
+                eval('_fn = ' + v._definition);
+                if (v._name) {
+                    variable.define(v._name, v._inputs, _fn);
+                } else {
+                    variable.define(v._inputs, _fn);
+                }
+                if (reposition)
+                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
+            });
+            return variables;
+        } catch (e) {
+            console.error(e);
+            debugger;
+        }
+    };
+};
 const _1jqs8in = function _91(md){return(
 md`### Remove Cells`
 )};
@@ -5912,6 +5928,7 @@ Inputs.radio(editedCell.variables, {
   value: editedCell.variables[0]
 })
 )};
+const _11gvkq4 = (G, _) => G.input(_);
 const _r5nvms = function _name(variable){return(
 variable._name
 )};
@@ -5925,6 +5942,7 @@ Inputs.textarea({
   rows: 10
 })
 )};
+const _b4rsn5 = (G, _) => G.input(_);
 const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
@@ -5938,22 +5956,12 @@ Inputs.button("update variable", {
 const _1q557s = function _99(md){return(
 md`### Editor Libraries`
 )};
-const _192vvs7 = (_, v) => v.import("descendants", _);
-const _3va6tf = (_, v) => v.import("EditorState", _);
-const _lmqjiv = (_, v) => v.import("decompile", _);
 const _1d94dks = function _javascriptPlugin(codemirror){return(
 codemirror
 )};
 const _ar9tao = function _104(md){return(
 md`### Libraries`
 )};
-const _viogn = (_, v) => v.import("reversibleAttach", _);
-const _nxg8mr = (_, v) => v.import("moduleMap", _);
-const _14a94d = (_, v) => v.import("flowQueue", _);
-const _gurtwb = (_, v) => v.import("viewof liveCellMap", _);
-const _19ebgtz = (_, v) => v.import("hash", _);
-const _n2vgkz = (_, v) => v.import("extractNotebookAndCell", _);
-const _1qucevb = (_, v) => v.import("cellsToClipboard", _);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -5967,22 +5975,34 @@ export default function define(runtime, observer) {
     return [name, {url: blob_url, mimeType: mime}]
   }));
   main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
+  main.define("module @tomlarkworthy/dataflow-templating", async () => runtime.module((await import("/@tomlarkworthy/dataflow-templating.js?v=4")).default));  
+  main.define("module @tomlarkworthy/fileattachments", async () => runtime.module((await import("/@tomlarkworthy/fileattachments.js?v=4")).default));  
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/codemirror-6-v2", async () => runtime.module((await import("/@tomlarkworthy/codemirror-6-v2.js?v=4")).default));  
+  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
+  main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
+  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
+  main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
+  main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
+  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
+  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
+  main.define("module @tomlarkworthy/cells-to-clipboard", async () => runtime.module((await import("/@tomlarkworthy/cells-to-clipboard.js?v=4")).default));  
   $def("_1tdjp0a", "title", ["md"], _1tdjp0a);  
   $def("_dm53bx", null, ["md"], _dm53bx);  
   $def("_61oxjf", "title_variable", ["lookupVariable","editorModule"], _61oxjf);  
   $def("_15uilf0", null, ["cellEditor","title_variable"], _15uilf0);  
   $def("_3x695f", null, ["md"], _3x695f);  
   $def("_1ociws4", null, ["md"], _1ociws4);  
-  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
   $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
-  main.variable(observer("attachContextManu")).define("attachContextManu", ["Generators", "viewof attachContextManu"], (G, _) => G.input(_));  
+  $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
   $def("_16ks4jz", null, ["md"], _16ks4jz);  
-  main.define("module @tomlarkworthy/dataflow-templating", async () => runtime.module((await import("/@tomlarkworthy/dataflow-templating.js?v=4")).default));  
   main.define("cloneDataflow", ["module @tomlarkworthy/dataflow-templating", "@variable"], (_, v) => v.import("cloneDataflow", _));  
   main.define("lookupVariable", ["module @tomlarkworthy/dataflow-templating", "@variable"], (_, v) => v.import("lookupVariable", _));  
   $def("_199ztvl", "hotbarTemplate", ["lookupVariable","editorModule"], _199ztvl);  
@@ -5993,7 +6013,7 @@ export default function define(runtime, observer) {
   $def("_110gwi7", "editorTemplate", ["lookupVariable","editorModule"], _110gwi7);  
   $def("_16rqzgl", null, ["md"], _16rqzgl);  
   $def("_1o2h65s", "viewof editedCell", ["Inputs"], _1o2h65s);  
-  main.variable(observer("editedCell")).define("editedCell", ["Generators", "viewof editedCell"], (G, _) => G.input(_));  
+  $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
   $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
@@ -6008,24 +6028,24 @@ export default function define(runtime, observer) {
   $def("_mrrmx3", null, ["md"], _mrrmx3);  
   $def("_14b1byw", null, ["md"], _14b1byw);  
   $def("_1j1loxx", "viewof combine", ["Inputs"], _1j1loxx);  
-  main.variable(observer("combine")).define("combine", ["Generators", "viewof combine"], (G, _) => G.input(_));  
+  $def("_1h8337z", "combine", ["Generators","viewof combine"], _1h8337z);  
   $def("_tct2nf", "viewof edit", ["Inputs"], _tct2nf);  
-  main.variable(observer("edit")).define("edit", ["Generators", "viewof edit"], (G, _) => G.input(_));  
+  $def("_7izj7k", "edit", ["Generators","viewof edit"], _7izj7k);  
   $def("_1fwb5jc", "toolbar", ["htl","reversibleAttach","combine","viewof select","viewof up","viewof down","viewof remove","viewof addCells","viewof apply","viewof copy","viewof paste"], _1fwb5jc);  
   $def("_yej3hb", "viewof addCells", ["Inputs","createCell","viewof editedCell"], _yej3hb);  
-  main.variable(observer("addCells")).define("addCells", ["Generators", "viewof addCells"], (G, _) => G.input(_));  
+  $def("_1aii9ps", "addCells", ["Generators","viewof addCells"], _1aii9ps);  
   $def("_1bn860e", "viewof remove", ["Inputs","deleteCell","viewof editedCell"], _1bn860e);  
-  main.variable(observer("remove")).define("remove", ["Generators", "viewof remove"], (G, _) => G.input(_));  
+  $def("_1ad0xr8", "remove", ["Generators","viewof remove"], _1ad0xr8);  
   $def("_tw1j7n", "viewof apply", ["Inputs","compile_and_update","states","editedCell"], _tw1j7n);  
-  main.variable(observer("apply")).define("apply", ["Generators", "viewof apply"], (G, _) => G.input(_));  
+  $def("_1cjyuqm", "apply", ["Generators","viewof apply"], _1cjyuqm);  
   $def("_14rfku9", "viewof up", ["Inputs","moveCell","viewof editedCell"], _14rfku9);  
-  main.variable(observer("up")).define("up", ["Generators", "viewof up"], (G, _) => G.input(_));  
+  $def("_frzs5d", "up", ["Generators","viewof up"], _frzs5d);  
   $def("_9pymuj", "viewof paste", ["Inputs","readObservableClipboardCells","pasteObservableCellsIntoModule","editedCell"], _9pymuj);  
-  main.variable(observer("paste")).define("paste", ["Generators", "viewof paste"], (G, _) => G.input(_));  
+  $def("_1whsszt", "paste", ["Generators","viewof paste"], _1whsszt);  
   $def("_corxwl", "viewof down", ["Inputs","moveCell","viewof editedCell"], _corxwl);  
-  main.variable(observer("down")).define("down", ["Generators", "viewof down"], (G, _) => G.input(_));  
+  $def("_1to28po", "down", ["Generators","viewof down"], _1to28po);  
   $def("_gia2ci", "viewof copy", ["Inputs","html","viewof editedCell","decompile","viewof liveCellMap","getOption","cellsToClipboard"], _gia2ci);  
-  main.variable(observer("copy")).define("copy", ["Generators", "viewof copy"], (G, _) => G.input(_));  
+  $def("_fw41wt", "copy", ["Generators","viewof copy"], _fw41wt);  
   $def("_srtw8o", "module", ["editedCell"], _srtw8o);  
   $def("_rv7t7x", "code_editor_view", ["EditorView"], _rv7t7x);  
   $def("_xvo1n6", "code_editor", ["code_editor_view"], _xvo1n6);  
@@ -6035,7 +6055,7 @@ export default function define(runtime, observer) {
   $def("_d9nzys", "deleteCell", ["viewof command"], _d9nzys);  
   $def("_c1u9w8", null, ["md"], _c1u9w8);  
   $def("_d7ouqx", "viewof command", ["flowQueue"], _d7ouqx);  
-  main.variable(observer("command")).define("command", ["Generators", "viewof command"], (G, _) => G.input(_));  
+  $def("_118qt2v", "command", ["Generators","viewof command"], _118qt2v);  
   $def("_19l2nem", null, ["command"], _19l2nem);  
   $def("_1f6v167", "findCellByVariable", [], _1f6v167);  
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
@@ -6052,9 +6072,8 @@ export default function define(runtime, observer) {
   $def("_dvne2z", "replaceCodeMirrorDoc", [], _dvne2z);  
   $def("_1fpqfm0", null, ["md"], _1fpqfm0);  
   $def("_rtf009", "viewof select", ["editedCell","Inputs","getOption","setOption"], _rtf009);  
-  main.variable(observer("select")).define("select", ["Generators", "viewof select"], (G, _) => G.input(_));  
+  $def("_14mwbuc", "select", ["Generators","viewof select"], _14mwbuc);  
   $def("_l4sbcd", null, ["md"], _l4sbcd);  
-  main.define("module @tomlarkworthy/fileattachments", async () => runtime.module((await import("/@tomlarkworthy/fileattachments.js?v=4")).default));  
   main.define("getFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachment", _));  
   main.define("setFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("setFileAttachment", _));  
   main.define("removeFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("removeFileAttachment", _));  
@@ -6063,7 +6082,7 @@ export default function define(runtime, observer) {
   $def("_ezl7wk", null, ["FileAttachment"], _ezl7wk);  
   $def("_kygz54", "optionsFile", ["getFileAttachment","editorModule"], _kygz54);  
   $def("_760ozq", "viewof options", ["Inputs","optionsFile"], _760ozq);  
-  main.variable(observer("options")).define("options", ["Generators", "viewof options"], (G, _) => G.input(_));  
+  $def("_4rh26k", "options", ["Generators","viewof options"], _4rh26k);  
   $def("_1lqy7cs", "setOption", ["findCell","_","viewof options","Event"], _1lqy7cs);  
   $def("_1oxe5ee", "getOption", ["findCell","_","viewof options"], _1oxe5ee);  
   $def("_kwq69p", "save_options", ["setFileAttachment","jsonFileAttachment","options","editorModule"], _kwq69p);  
@@ -6077,22 +6096,21 @@ export default function define(runtime, observer) {
   $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
   $def("_1j3c2uf", "decompiled", ["editedCell","decompile"], _1j3c2uf);  
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
-  main.variable(observer("editorModule")).define("editorModule", ["Generators", "viewof editorModule"], (G, _) => G.input(_));  
+  $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1ju14cq", "compile_and_update", ["compile","runtime","repositionSetElement"], _1ju14cq);  
+  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
   $def("_rwez9", "viewof variable", ["Inputs","editedCell"], _rwez9);  
-  main.variable(observer("variable")).define("variable", ["Generators", "viewof variable"], (G, _) => G.input(_));  
+  $def("_11gvkq4", "variable", ["Generators","viewof variable"], _11gvkq4);  
   $def("_r5nvms", "name", ["variable"], _r5nvms);  
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
-  main.variable(observer("definition")).define("definition", ["Generators", "viewof definition"], (G, _) => G.input(_));  
+  $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
   $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
   $def("_1q557s", null, ["md"], _1q557s);  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -6103,12 +6121,10 @@ export default function define(runtime, observer) {
   main.define("isnode", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("isnode", _));  
   main.define("repositionSetElement", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("repositionSetElement", _));  
   main.define("onCodeChange", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("onCodeChange", _));  
-  main.define("module @tomlarkworthy/codemirror-6-v2", async () => runtime.module((await import("/@tomlarkworthy/codemirror-6-v2.js?v=4")).default));  
   main.define("EditorState", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("EditorState", _));  
   main.define("EditorView", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("EditorView", _));  
   main.define("codemirror", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("codemirror", _));  
   main.define("myDefaultTheme", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("myDefaultTheme", _));  
-  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
   main.define("decompile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("decompile", _));  
   main.define("compile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("compile", _));  
   main.define("cellMap", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("cellMap", _));  
@@ -6117,27 +6133,21 @@ export default function define(runtime, observer) {
   main.define("parser", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("parser", _));  
   $def("_1d94dks", "javascriptPlugin", ["codemirror"], _1d94dks);  
   $def("_ar9tao", null, ["md"], _ar9tao);  
-  main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
   main.define("reversibleAttach", ["module @tomlarkworthy/reversible-attachment", "@variable"], (_, v) => v.import("reversibleAttach", _));  
-  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
   main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
-  main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
   main.define("flowQueue", ["module @tomlarkworthy/flow-queue", "@variable"], (_, v) => v.import("flowQueue", _));  
-  main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
   main.define("viewof liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("viewof liveCellMap", _));  
   main.define("liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("liveCellMap", _));  
-  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
   main.define("hash", ["module d/57d79353bac56631@44", "@variable"], (_, v) => v.import("hash", _));  
-  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
   main.define("extractNotebookAndCell", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("extractNotebookAndCell", _));  
   main.define("navHref", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("navHref", _));  
-  main.define("module @tomlarkworthy/cells-to-clipboard", async () => runtime.module((await import("/@tomlarkworthy/cells-to-clipboard.js?v=4")).default));  
   main.define("cellsToClipboard", ["module @tomlarkworthy/cells-to-clipboard", "@variable"], (_, v) => v.import("cellsToClipboard", _));
   return main;
-}</script>
+}
+</script>
 <script id="@tomlarkworthy/escodegen/escodegen.browser.min.js.gz" 
   type="text/plain"
   data-encoding="base64"

--- a/notebooks/@tomlarkworthy_robocoop-3.html
+++ b/notebooks/@tomlarkworthy_robocoop-3.html
@@ -4690,7 +4690,7 @@ export default function define(runtime, observer) {
 >
 e30K
 </script>
-<script id="@tomlarkworthy/editor-5" 
+<script id="@tomlarkworthy/editor-5"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -4737,7 +4737,6 @@ md`## TODO
 const _1ociws4 = function _6(md){return(
 md`## Sync editors`
 )};
-const _1vq49kx = (_, v) => v.import("syncers", _);
 const _hdieof = function _editors(){return(
 new Map()
 )};
@@ -4815,12 +4814,12 @@ Inputs.toggle({
   value: !isOnObservableCom()
 })
 )};
+const _1oaz8r1 = (G, _) => G.input(_);
 const _16ks4jz = function _12(md){return(
 md`## \`cellEditor\` component
 
 Using Dataflow templating to create reusable Hotbar Component builder`
 )};
-const _1deps8p = (_, v) => v.import("cloneDataflow", _);
 const _199ztvl = function _hotbarTemplate(lookupVariable,editorModule){return(
 lookupVariable(
   [
@@ -5057,6 +5056,7 @@ md`## Hotbar Prototype`
 const _1o2h65s = function _editedCell(Inputs){return(
 Inputs.input(null)
 )};
+const _7g3h7h = (G, _) => G.input(_);
 const _1urs1md = function _findCell($0,modules){return(
 (variable, dom = undefined) => {
   if (variable) {
@@ -5216,9 +5216,11 @@ Inputs.toggle({
   value: true
 })
 )};
+const _1h8337z = (G, _) => G.input(_);
 const _tct2nf = function _edit(Inputs){return(
 Inputs.toggle({ label: "edit" })
 )};
+const _7izj7k = (G, _) => G.input(_);
 const _1fwb5jc = function _toolbar(htl,reversibleAttach,combine,$0,$1,$2,$3,$4,$5,$6,$7){return(
 htl.html`<div
     class="toolbar"
@@ -5246,11 +5248,13 @@ Inputs.button("➕", {
   }
 })
 )};
+const _1aii9ps = (G, _) => G.input(_);
 const _1bn860e = function _remove(Inputs,deleteCell,$0){return(
 Inputs.button("🗑️", {
   reduce: () => deleteCell({ cell: $0.value })
 })
 )};
+const _1ad0xr8 = (G, _) => G.input(_);
 const _tw1j7n = function _apply(Inputs,compile_and_update,states,editedCell)
 {
   const button = Inputs.button("▶️", {
@@ -5269,11 +5273,13 @@ const _tw1j7n = function _apply(Inputs,compile_and_update,states,editedCell)
   button.onmousedown = (e) => e.preventDefault();
   return button;
 };
+const _1cjyuqm = (G, _) => G.input(_);
 const _14rfku9 = function _up(Inputs,moveCell,$0){return(
 Inputs.button("⬆", {
   reduce: () => moveCell($0.value, -1)
 })
 )};
+const _frzs5d = (G, _) => G.input(_);
 const _9pymuj = function _paste(Inputs,readObservableClipboardCells,pasteObservableCellsIntoModule,editedCell){return(
 Inputs.button("📋", {
   reduce: async () => {
@@ -5282,11 +5288,13 @@ Inputs.button("📋", {
   }
 })
 )};
+const _1whsszt = (G, _) => G.input(_);
 const _corxwl = function _down(Inputs,moveCell,$0){return(
 Inputs.button("⬇", {
   reduce: () => moveCell($0.value, 1)
 })
 )};
+const _1to28po = (G, _) => G.input(_);
 const _gia2ci = function _copy(Inputs,html,$0,decompile,$1,getOption,cellsToClipboard){return(
 Inputs.button(
   html`<span style="font-size: .875em; margin-right: .125em; position: relative; top: -.25em; left: -.125em">
@@ -5328,6 +5336,7 @@ Inputs.button(
   }
 )
 )};
+const _fw41wt = (G, _) => G.input(_);
 const _srtw8o = function _module(editedCell){return(
 editedCell.module.module
 )};
@@ -5382,6 +5391,7 @@ md`## API handler`
 const _d7ouqx = function _command(flowQueue){return(
 flowQueue()
 )};
+const _118qt2v = (G, _) => G.input(_);
 const _19l2nem = function _54(command){return(
 command
 )};
@@ -5654,10 +5664,10 @@ const _rtf009 = function _select(editedCell,Inputs,getOption,setOption){return(
   return el;
 })()
 )};
+const _14mwbuc = (G, _) => G.input(_);
 const _l4sbcd = function _70(md){return(
 md`## Pinning`
 )};
-const _1sxszb9 = (_, v) => v.import("getFileAttachment", _);
 const _ezl7wk = function _72(FileAttachment){return(
 FileAttachment("cell_options.json")
 )};
@@ -5667,6 +5677,7 @@ getFileAttachment("cell_options.json", editorModule)
 const _760ozq = async function _options(Inputs,optionsFile){return(
 Inputs.input(await optionsFile.json())
 )};
+const _4rh26k = (G, _) => G.input(_);
 const _1lqy7cs = function _setOption(findCell,_,$0,Event){return(
 (variable, option, value) => {
   const cell = findCell(variable);
@@ -5846,6 +5857,7 @@ const _1j3c2uf = function _decompiled(editedCell,decompile)
 const _w5q3yf = function _editorModule(thisModule){return(
 thisModule()
 )};
+const _18kaj2p = (G, _) => G.input(_);
 const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_options)
 {
   //editedCell;
@@ -5857,43 +5869,47 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1ju14cq = function _compile_and_update(compile,runtime,repositionSetElement){return(
-(source, variables = [], cell) => {
-    try {
-        debugger;
-        let reposition = false, insertionIndex = -1;
-        const newVariables = compile(source);
-        if (!variables || variables.length !== newVariables.length) {
-            reposition = true;
-            variables.forEach(v => v.delete());
-            variables.length = 0;
-            for (let i = 0; i < newVariables.length; i++) {
-                const newVariable = cell.module.module.variable({});
-                variables.push(newVariable);
+const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+{
+    return (source, variables = [], cell) => {
+        try {
+            debugger;
+            let reposition = false, insertionIndex = -1;
+            const newVariables = compile(source);
+            if (!variables || variables.length !== newVariables.length) {
+                reposition = true;
+                variables.forEach(v => v.delete());
+                variables.length = 0;
+                for (let i = 0; i < newVariables.length; i++) {
+                    const newVariable = cell.module.module.variable({});
+                    // Assign a random pid up-front so blank/identical new cells don't
+                    // collide via persistentId's contentHash. See lopecode#144.
+                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+                    variables.push(newVariable);
+                }
             }
-        }
-        if (reposition) {
-            insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-        }
-        newVariables.forEach((v, i) => {
-            const variable = variables[i];
-            let _fn;
-            eval('_fn = ' + v._definition);
-            if (v._name) {
-                variable.define(v._name, v._inputs, _fn);
-            } else {
-                variable.define(v._inputs, _fn);
+            if (reposition) {
+                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
-            if (reposition)
-                repositionSetElement(runtime._variables, variable, insertionIndex + i);
-        });
-        return variables;
-    } catch (e) {
-        console.error(e);
-        debugger;
-    }
-}
-)};
+            newVariables.forEach((v, i) => {
+                const variable = variables[i];
+                let _fn;
+                eval('_fn = ' + v._definition);
+                if (v._name) {
+                    variable.define(v._name, v._inputs, _fn);
+                } else {
+                    variable.define(v._inputs, _fn);
+                }
+                if (reposition)
+                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
+            });
+            return variables;
+        } catch (e) {
+            console.error(e);
+            debugger;
+        }
+    };
+};
 const _1jqs8in = function _91(md){return(
 md`### Remove Cells`
 )};
@@ -5912,6 +5928,7 @@ Inputs.radio(editedCell.variables, {
   value: editedCell.variables[0]
 })
 )};
+const _11gvkq4 = (G, _) => G.input(_);
 const _r5nvms = function _name(variable){return(
 variable._name
 )};
@@ -5925,6 +5942,7 @@ Inputs.textarea({
   rows: 10
 })
 )};
+const _b4rsn5 = (G, _) => G.input(_);
 const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
@@ -5938,22 +5956,12 @@ Inputs.button("update variable", {
 const _1q557s = function _99(md){return(
 md`### Editor Libraries`
 )};
-const _192vvs7 = (_, v) => v.import("descendants", _);
-const _3va6tf = (_, v) => v.import("EditorState", _);
-const _lmqjiv = (_, v) => v.import("decompile", _);
 const _1d94dks = function _javascriptPlugin(codemirror){return(
 codemirror
 )};
 const _ar9tao = function _104(md){return(
 md`### Libraries`
 )};
-const _viogn = (_, v) => v.import("reversibleAttach", _);
-const _nxg8mr = (_, v) => v.import("moduleMap", _);
-const _14a94d = (_, v) => v.import("flowQueue", _);
-const _gurtwb = (_, v) => v.import("viewof liveCellMap", _);
-const _19ebgtz = (_, v) => v.import("hash", _);
-const _n2vgkz = (_, v) => v.import("extractNotebookAndCell", _);
-const _1qucevb = (_, v) => v.import("cellsToClipboard", _);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -5967,22 +5975,34 @@ export default function define(runtime, observer) {
     return [name, {url: blob_url, mimeType: mime}]
   }));
   main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
+  main.define("module @tomlarkworthy/dataflow-templating", async () => runtime.module((await import("/@tomlarkworthy/dataflow-templating.js?v=4")).default));  
+  main.define("module @tomlarkworthy/fileattachments", async () => runtime.module((await import("/@tomlarkworthy/fileattachments.js?v=4")).default));  
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/codemirror-6-v2", async () => runtime.module((await import("/@tomlarkworthy/codemirror-6-v2.js?v=4")).default));  
+  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
+  main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
+  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
+  main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
+  main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
+  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
+  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
+  main.define("module @tomlarkworthy/cells-to-clipboard", async () => runtime.module((await import("/@tomlarkworthy/cells-to-clipboard.js?v=4")).default));  
   $def("_1tdjp0a", "title", ["md"], _1tdjp0a);  
   $def("_dm53bx", null, ["md"], _dm53bx);  
   $def("_61oxjf", "title_variable", ["lookupVariable","editorModule"], _61oxjf);  
   $def("_15uilf0", null, ["cellEditor","title_variable"], _15uilf0);  
   $def("_3x695f", null, ["md"], _3x695f);  
   $def("_1ociws4", null, ["md"], _1ociws4);  
-  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
   $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
-  main.variable(observer("attachContextManu")).define("attachContextManu", ["Generators", "viewof attachContextManu"], (G, _) => G.input(_));  
+  $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
   $def("_16ks4jz", null, ["md"], _16ks4jz);  
-  main.define("module @tomlarkworthy/dataflow-templating", async () => runtime.module((await import("/@tomlarkworthy/dataflow-templating.js?v=4")).default));  
   main.define("cloneDataflow", ["module @tomlarkworthy/dataflow-templating", "@variable"], (_, v) => v.import("cloneDataflow", _));  
   main.define("lookupVariable", ["module @tomlarkworthy/dataflow-templating", "@variable"], (_, v) => v.import("lookupVariable", _));  
   $def("_199ztvl", "hotbarTemplate", ["lookupVariable","editorModule"], _199ztvl);  
@@ -5993,7 +6013,7 @@ export default function define(runtime, observer) {
   $def("_110gwi7", "editorTemplate", ["lookupVariable","editorModule"], _110gwi7);  
   $def("_16rqzgl", null, ["md"], _16rqzgl);  
   $def("_1o2h65s", "viewof editedCell", ["Inputs"], _1o2h65s);  
-  main.variable(observer("editedCell")).define("editedCell", ["Generators", "viewof editedCell"], (G, _) => G.input(_));  
+  $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
   $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
@@ -6008,24 +6028,24 @@ export default function define(runtime, observer) {
   $def("_mrrmx3", null, ["md"], _mrrmx3);  
   $def("_14b1byw", null, ["md"], _14b1byw);  
   $def("_1j1loxx", "viewof combine", ["Inputs"], _1j1loxx);  
-  main.variable(observer("combine")).define("combine", ["Generators", "viewof combine"], (G, _) => G.input(_));  
+  $def("_1h8337z", "combine", ["Generators","viewof combine"], _1h8337z);  
   $def("_tct2nf", "viewof edit", ["Inputs"], _tct2nf);  
-  main.variable(observer("edit")).define("edit", ["Generators", "viewof edit"], (G, _) => G.input(_));  
+  $def("_7izj7k", "edit", ["Generators","viewof edit"], _7izj7k);  
   $def("_1fwb5jc", "toolbar", ["htl","reversibleAttach","combine","viewof select","viewof up","viewof down","viewof remove","viewof addCells","viewof apply","viewof copy","viewof paste"], _1fwb5jc);  
   $def("_yej3hb", "viewof addCells", ["Inputs","createCell","viewof editedCell"], _yej3hb);  
-  main.variable(observer("addCells")).define("addCells", ["Generators", "viewof addCells"], (G, _) => G.input(_));  
+  $def("_1aii9ps", "addCells", ["Generators","viewof addCells"], _1aii9ps);  
   $def("_1bn860e", "viewof remove", ["Inputs","deleteCell","viewof editedCell"], _1bn860e);  
-  main.variable(observer("remove")).define("remove", ["Generators", "viewof remove"], (G, _) => G.input(_));  
+  $def("_1ad0xr8", "remove", ["Generators","viewof remove"], _1ad0xr8);  
   $def("_tw1j7n", "viewof apply", ["Inputs","compile_and_update","states","editedCell"], _tw1j7n);  
-  main.variable(observer("apply")).define("apply", ["Generators", "viewof apply"], (G, _) => G.input(_));  
+  $def("_1cjyuqm", "apply", ["Generators","viewof apply"], _1cjyuqm);  
   $def("_14rfku9", "viewof up", ["Inputs","moveCell","viewof editedCell"], _14rfku9);  
-  main.variable(observer("up")).define("up", ["Generators", "viewof up"], (G, _) => G.input(_));  
+  $def("_frzs5d", "up", ["Generators","viewof up"], _frzs5d);  
   $def("_9pymuj", "viewof paste", ["Inputs","readObservableClipboardCells","pasteObservableCellsIntoModule","editedCell"], _9pymuj);  
-  main.variable(observer("paste")).define("paste", ["Generators", "viewof paste"], (G, _) => G.input(_));  
+  $def("_1whsszt", "paste", ["Generators","viewof paste"], _1whsszt);  
   $def("_corxwl", "viewof down", ["Inputs","moveCell","viewof editedCell"], _corxwl);  
-  main.variable(observer("down")).define("down", ["Generators", "viewof down"], (G, _) => G.input(_));  
+  $def("_1to28po", "down", ["Generators","viewof down"], _1to28po);  
   $def("_gia2ci", "viewof copy", ["Inputs","html","viewof editedCell","decompile","viewof liveCellMap","getOption","cellsToClipboard"], _gia2ci);  
-  main.variable(observer("copy")).define("copy", ["Generators", "viewof copy"], (G, _) => G.input(_));  
+  $def("_fw41wt", "copy", ["Generators","viewof copy"], _fw41wt);  
   $def("_srtw8o", "module", ["editedCell"], _srtw8o);  
   $def("_rv7t7x", "code_editor_view", ["EditorView"], _rv7t7x);  
   $def("_xvo1n6", "code_editor", ["code_editor_view"], _xvo1n6);  
@@ -6035,7 +6055,7 @@ export default function define(runtime, observer) {
   $def("_d9nzys", "deleteCell", ["viewof command"], _d9nzys);  
   $def("_c1u9w8", null, ["md"], _c1u9w8);  
   $def("_d7ouqx", "viewof command", ["flowQueue"], _d7ouqx);  
-  main.variable(observer("command")).define("command", ["Generators", "viewof command"], (G, _) => G.input(_));  
+  $def("_118qt2v", "command", ["Generators","viewof command"], _118qt2v);  
   $def("_19l2nem", null, ["command"], _19l2nem);  
   $def("_1f6v167", "findCellByVariable", [], _1f6v167);  
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
@@ -6052,9 +6072,8 @@ export default function define(runtime, observer) {
   $def("_dvne2z", "replaceCodeMirrorDoc", [], _dvne2z);  
   $def("_1fpqfm0", null, ["md"], _1fpqfm0);  
   $def("_rtf009", "viewof select", ["editedCell","Inputs","getOption","setOption"], _rtf009);  
-  main.variable(observer("select")).define("select", ["Generators", "viewof select"], (G, _) => G.input(_));  
+  $def("_14mwbuc", "select", ["Generators","viewof select"], _14mwbuc);  
   $def("_l4sbcd", null, ["md"], _l4sbcd);  
-  main.define("module @tomlarkworthy/fileattachments", async () => runtime.module((await import("/@tomlarkworthy/fileattachments.js?v=4")).default));  
   main.define("getFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachment", _));  
   main.define("setFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("setFileAttachment", _));  
   main.define("removeFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("removeFileAttachment", _));  
@@ -6063,7 +6082,7 @@ export default function define(runtime, observer) {
   $def("_ezl7wk", null, ["FileAttachment"], _ezl7wk);  
   $def("_kygz54", "optionsFile", ["getFileAttachment","editorModule"], _kygz54);  
   $def("_760ozq", "viewof options", ["Inputs","optionsFile"], _760ozq);  
-  main.variable(observer("options")).define("options", ["Generators", "viewof options"], (G, _) => G.input(_));  
+  $def("_4rh26k", "options", ["Generators","viewof options"], _4rh26k);  
   $def("_1lqy7cs", "setOption", ["findCell","_","viewof options","Event"], _1lqy7cs);  
   $def("_1oxe5ee", "getOption", ["findCell","_","viewof options"], _1oxe5ee);  
   $def("_kwq69p", "save_options", ["setFileAttachment","jsonFileAttachment","options","editorModule"], _kwq69p);  
@@ -6077,22 +6096,21 @@ export default function define(runtime, observer) {
   $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
   $def("_1j3c2uf", "decompiled", ["editedCell","decompile"], _1j3c2uf);  
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
-  main.variable(observer("editorModule")).define("editorModule", ["Generators", "viewof editorModule"], (G, _) => G.input(_));  
+  $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1ju14cq", "compile_and_update", ["compile","runtime","repositionSetElement"], _1ju14cq);  
+  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
   $def("_rwez9", "viewof variable", ["Inputs","editedCell"], _rwez9);  
-  main.variable(observer("variable")).define("variable", ["Generators", "viewof variable"], (G, _) => G.input(_));  
+  $def("_11gvkq4", "variable", ["Generators","viewof variable"], _11gvkq4);  
   $def("_r5nvms", "name", ["variable"], _r5nvms);  
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
-  main.variable(observer("definition")).define("definition", ["Generators", "viewof definition"], (G, _) => G.input(_));  
+  $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
   $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
   $def("_1q557s", null, ["md"], _1q557s);  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -6103,12 +6121,10 @@ export default function define(runtime, observer) {
   main.define("isnode", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("isnode", _));  
   main.define("repositionSetElement", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("repositionSetElement", _));  
   main.define("onCodeChange", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("onCodeChange", _));  
-  main.define("module @tomlarkworthy/codemirror-6-v2", async () => runtime.module((await import("/@tomlarkworthy/codemirror-6-v2.js?v=4")).default));  
   main.define("EditorState", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("EditorState", _));  
   main.define("EditorView", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("EditorView", _));  
   main.define("codemirror", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("codemirror", _));  
   main.define("myDefaultTheme", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("myDefaultTheme", _));  
-  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
   main.define("decompile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("decompile", _));  
   main.define("compile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("compile", _));  
   main.define("cellMap", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("cellMap", _));  
@@ -6117,27 +6133,21 @@ export default function define(runtime, observer) {
   main.define("parser", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("parser", _));  
   $def("_1d94dks", "javascriptPlugin", ["codemirror"], _1d94dks);  
   $def("_ar9tao", null, ["md"], _ar9tao);  
-  main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
   main.define("reversibleAttach", ["module @tomlarkworthy/reversible-attachment", "@variable"], (_, v) => v.import("reversibleAttach", _));  
-  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
   main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
-  main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
   main.define("flowQueue", ["module @tomlarkworthy/flow-queue", "@variable"], (_, v) => v.import("flowQueue", _));  
-  main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
   main.define("viewof liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("viewof liveCellMap", _));  
   main.define("liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("liveCellMap", _));  
-  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
   main.define("hash", ["module d/57d79353bac56631@44", "@variable"], (_, v) => v.import("hash", _));  
-  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
   main.define("extractNotebookAndCell", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("extractNotebookAndCell", _));  
   main.define("navHref", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("navHref", _));  
-  main.define("module @tomlarkworthy/cells-to-clipboard", async () => runtime.module((await import("/@tomlarkworthy/cells-to-clipboard.js?v=4")).default));  
   main.define("cellsToClipboard", ["module @tomlarkworthy/cells-to-clipboard", "@variable"], (_, v) => v.import("cellsToClipboard", _));
   return main;
-}</script>
+}
+</script>
 <script id="@tomlarkworthy/escodegen/escodegen.browser.min.js.gz" 
   type="text/plain"
   data-encoding="base64"

--- a/notebooks/@tomlarkworthy_runtime-sdk.html
+++ b/notebooks/@tomlarkworthy_runtime-sdk.html
@@ -4690,7 +4690,7 @@ export default function define(runtime, observer) {
 >
 e30K
 </script>
-<script id="@tomlarkworthy/editor-5" 
+<script id="@tomlarkworthy/editor-5"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -4737,7 +4737,6 @@ md`## TODO
 const _1ociws4 = function _6(md){return(
 md`## Sync editors`
 )};
-const _1vq49kx = (_, v) => v.import("syncers", _);
 const _hdieof = function _editors(){return(
 new Map()
 )};
@@ -4815,12 +4814,12 @@ Inputs.toggle({
   value: !isOnObservableCom()
 })
 )};
+const _1oaz8r1 = (G, _) => G.input(_);
 const _16ks4jz = function _12(md){return(
 md`## \`cellEditor\` component
 
 Using Dataflow templating to create reusable Hotbar Component builder`
 )};
-const _1deps8p = (_, v) => v.import("cloneDataflow", _);
 const _199ztvl = function _hotbarTemplate(lookupVariable,editorModule){return(
 lookupVariable(
   [
@@ -5057,6 +5056,7 @@ md`## Hotbar Prototype`
 const _1o2h65s = function _editedCell(Inputs){return(
 Inputs.input(null)
 )};
+const _7g3h7h = (G, _) => G.input(_);
 const _1urs1md = function _findCell($0,modules){return(
 (variable, dom = undefined) => {
   if (variable) {
@@ -5216,9 +5216,11 @@ Inputs.toggle({
   value: true
 })
 )};
+const _1h8337z = (G, _) => G.input(_);
 const _tct2nf = function _edit(Inputs){return(
 Inputs.toggle({ label: "edit" })
 )};
+const _7izj7k = (G, _) => G.input(_);
 const _1fwb5jc = function _toolbar(htl,reversibleAttach,combine,$0,$1,$2,$3,$4,$5,$6,$7){return(
 htl.html`<div
     class="toolbar"
@@ -5246,11 +5248,13 @@ Inputs.button("➕", {
   }
 })
 )};
+const _1aii9ps = (G, _) => G.input(_);
 const _1bn860e = function _remove(Inputs,deleteCell,$0){return(
 Inputs.button("🗑️", {
   reduce: () => deleteCell({ cell: $0.value })
 })
 )};
+const _1ad0xr8 = (G, _) => G.input(_);
 const _tw1j7n = function _apply(Inputs,compile_and_update,states,editedCell)
 {
   const button = Inputs.button("▶️", {
@@ -5269,11 +5273,13 @@ const _tw1j7n = function _apply(Inputs,compile_and_update,states,editedCell)
   button.onmousedown = (e) => e.preventDefault();
   return button;
 };
+const _1cjyuqm = (G, _) => G.input(_);
 const _14rfku9 = function _up(Inputs,moveCell,$0){return(
 Inputs.button("⬆", {
   reduce: () => moveCell($0.value, -1)
 })
 )};
+const _frzs5d = (G, _) => G.input(_);
 const _9pymuj = function _paste(Inputs,readObservableClipboardCells,pasteObservableCellsIntoModule,editedCell){return(
 Inputs.button("📋", {
   reduce: async () => {
@@ -5282,11 +5288,13 @@ Inputs.button("📋", {
   }
 })
 )};
+const _1whsszt = (G, _) => G.input(_);
 const _corxwl = function _down(Inputs,moveCell,$0){return(
 Inputs.button("⬇", {
   reduce: () => moveCell($0.value, 1)
 })
 )};
+const _1to28po = (G, _) => G.input(_);
 const _gia2ci = function _copy(Inputs,html,$0,decompile,$1,getOption,cellsToClipboard){return(
 Inputs.button(
   html`<span style="font-size: .875em; margin-right: .125em; position: relative; top: -.25em; left: -.125em">
@@ -5328,6 +5336,7 @@ Inputs.button(
   }
 )
 )};
+const _fw41wt = (G, _) => G.input(_);
 const _srtw8o = function _module(editedCell){return(
 editedCell.module.module
 )};
@@ -5382,6 +5391,7 @@ md`## API handler`
 const _d7ouqx = function _command(flowQueue){return(
 flowQueue()
 )};
+const _118qt2v = (G, _) => G.input(_);
 const _19l2nem = function _54(command){return(
 command
 )};
@@ -5654,10 +5664,10 @@ const _rtf009 = function _select(editedCell,Inputs,getOption,setOption){return(
   return el;
 })()
 )};
+const _14mwbuc = (G, _) => G.input(_);
 const _l4sbcd = function _70(md){return(
 md`## Pinning`
 )};
-const _1sxszb9 = (_, v) => v.import("getFileAttachment", _);
 const _ezl7wk = function _72(FileAttachment){return(
 FileAttachment("cell_options.json")
 )};
@@ -5667,6 +5677,7 @@ getFileAttachment("cell_options.json", editorModule)
 const _760ozq = async function _options(Inputs,optionsFile){return(
 Inputs.input(await optionsFile.json())
 )};
+const _4rh26k = (G, _) => G.input(_);
 const _1lqy7cs = function _setOption(findCell,_,$0,Event){return(
 (variable, option, value) => {
   const cell = findCell(variable);
@@ -5846,6 +5857,7 @@ const _1j3c2uf = function _decompiled(editedCell,decompile)
 const _w5q3yf = function _editorModule(thisModule){return(
 thisModule()
 )};
+const _18kaj2p = (G, _) => G.input(_);
 const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_options)
 {
   //editedCell;
@@ -5857,43 +5869,47 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1ju14cq = function _compile_and_update(compile,runtime,repositionSetElement){return(
-(source, variables = [], cell) => {
-    try {
-        debugger;
-        let reposition = false, insertionIndex = -1;
-        const newVariables = compile(source);
-        if (!variables || variables.length !== newVariables.length) {
-            reposition = true;
-            variables.forEach(v => v.delete());
-            variables.length = 0;
-            for (let i = 0; i < newVariables.length; i++) {
-                const newVariable = cell.module.module.variable({});
-                variables.push(newVariable);
+const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+{
+    return (source, variables = [], cell) => {
+        try {
+            debugger;
+            let reposition = false, insertionIndex = -1;
+            const newVariables = compile(source);
+            if (!variables || variables.length !== newVariables.length) {
+                reposition = true;
+                variables.forEach(v => v.delete());
+                variables.length = 0;
+                for (let i = 0; i < newVariables.length; i++) {
+                    const newVariable = cell.module.module.variable({});
+                    // Assign a random pid up-front so blank/identical new cells don't
+                    // collide via persistentId's contentHash. See lopecode#144.
+                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+                    variables.push(newVariable);
+                }
             }
-        }
-        if (reposition) {
-            insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-        }
-        newVariables.forEach((v, i) => {
-            const variable = variables[i];
-            let _fn;
-            eval('_fn = ' + v._definition);
-            if (v._name) {
-                variable.define(v._name, v._inputs, _fn);
-            } else {
-                variable.define(v._inputs, _fn);
+            if (reposition) {
+                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
-            if (reposition)
-                repositionSetElement(runtime._variables, variable, insertionIndex + i);
-        });
-        return variables;
-    } catch (e) {
-        console.error(e);
-        debugger;
-    }
-}
-)};
+            newVariables.forEach((v, i) => {
+                const variable = variables[i];
+                let _fn;
+                eval('_fn = ' + v._definition);
+                if (v._name) {
+                    variable.define(v._name, v._inputs, _fn);
+                } else {
+                    variable.define(v._inputs, _fn);
+                }
+                if (reposition)
+                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
+            });
+            return variables;
+        } catch (e) {
+            console.error(e);
+            debugger;
+        }
+    };
+};
 const _1jqs8in = function _91(md){return(
 md`### Remove Cells`
 )};
@@ -5912,6 +5928,7 @@ Inputs.radio(editedCell.variables, {
   value: editedCell.variables[0]
 })
 )};
+const _11gvkq4 = (G, _) => G.input(_);
 const _r5nvms = function _name(variable){return(
 variable._name
 )};
@@ -5925,6 +5942,7 @@ Inputs.textarea({
   rows: 10
 })
 )};
+const _b4rsn5 = (G, _) => G.input(_);
 const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
@@ -5938,22 +5956,12 @@ Inputs.button("update variable", {
 const _1q557s = function _99(md){return(
 md`### Editor Libraries`
 )};
-const _192vvs7 = (_, v) => v.import("descendants", _);
-const _3va6tf = (_, v) => v.import("EditorState", _);
-const _lmqjiv = (_, v) => v.import("decompile", _);
 const _1d94dks = function _javascriptPlugin(codemirror){return(
 codemirror
 )};
 const _ar9tao = function _104(md){return(
 md`### Libraries`
 )};
-const _viogn = (_, v) => v.import("reversibleAttach", _);
-const _nxg8mr = (_, v) => v.import("moduleMap", _);
-const _14a94d = (_, v) => v.import("flowQueue", _);
-const _gurtwb = (_, v) => v.import("viewof liveCellMap", _);
-const _19ebgtz = (_, v) => v.import("hash", _);
-const _n2vgkz = (_, v) => v.import("extractNotebookAndCell", _);
-const _1qucevb = (_, v) => v.import("cellsToClipboard", _);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -5967,22 +5975,34 @@ export default function define(runtime, observer) {
     return [name, {url: blob_url, mimeType: mime}]
   }));
   main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
+  main.define("module @tomlarkworthy/dataflow-templating", async () => runtime.module((await import("/@tomlarkworthy/dataflow-templating.js?v=4")).default));  
+  main.define("module @tomlarkworthy/fileattachments", async () => runtime.module((await import("/@tomlarkworthy/fileattachments.js?v=4")).default));  
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/codemirror-6-v2", async () => runtime.module((await import("/@tomlarkworthy/codemirror-6-v2.js?v=4")).default));  
+  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
+  main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
+  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
+  main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
+  main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
+  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
+  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
+  main.define("module @tomlarkworthy/cells-to-clipboard", async () => runtime.module((await import("/@tomlarkworthy/cells-to-clipboard.js?v=4")).default));  
   $def("_1tdjp0a", "title", ["md"], _1tdjp0a);  
   $def("_dm53bx", null, ["md"], _dm53bx);  
   $def("_61oxjf", "title_variable", ["lookupVariable","editorModule"], _61oxjf);  
   $def("_15uilf0", null, ["cellEditor","title_variable"], _15uilf0);  
   $def("_3x695f", null, ["md"], _3x695f);  
   $def("_1ociws4", null, ["md"], _1ociws4);  
-  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
   $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
-  main.variable(observer("attachContextManu")).define("attachContextManu", ["Generators", "viewof attachContextManu"], (G, _) => G.input(_));  
+  $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
   $def("_16ks4jz", null, ["md"], _16ks4jz);  
-  main.define("module @tomlarkworthy/dataflow-templating", async () => runtime.module((await import("/@tomlarkworthy/dataflow-templating.js?v=4")).default));  
   main.define("cloneDataflow", ["module @tomlarkworthy/dataflow-templating", "@variable"], (_, v) => v.import("cloneDataflow", _));  
   main.define("lookupVariable", ["module @tomlarkworthy/dataflow-templating", "@variable"], (_, v) => v.import("lookupVariable", _));  
   $def("_199ztvl", "hotbarTemplate", ["lookupVariable","editorModule"], _199ztvl);  
@@ -5993,7 +6013,7 @@ export default function define(runtime, observer) {
   $def("_110gwi7", "editorTemplate", ["lookupVariable","editorModule"], _110gwi7);  
   $def("_16rqzgl", null, ["md"], _16rqzgl);  
   $def("_1o2h65s", "viewof editedCell", ["Inputs"], _1o2h65s);  
-  main.variable(observer("editedCell")).define("editedCell", ["Generators", "viewof editedCell"], (G, _) => G.input(_));  
+  $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
   $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
@@ -6008,24 +6028,24 @@ export default function define(runtime, observer) {
   $def("_mrrmx3", null, ["md"], _mrrmx3);  
   $def("_14b1byw", null, ["md"], _14b1byw);  
   $def("_1j1loxx", "viewof combine", ["Inputs"], _1j1loxx);  
-  main.variable(observer("combine")).define("combine", ["Generators", "viewof combine"], (G, _) => G.input(_));  
+  $def("_1h8337z", "combine", ["Generators","viewof combine"], _1h8337z);  
   $def("_tct2nf", "viewof edit", ["Inputs"], _tct2nf);  
-  main.variable(observer("edit")).define("edit", ["Generators", "viewof edit"], (G, _) => G.input(_));  
+  $def("_7izj7k", "edit", ["Generators","viewof edit"], _7izj7k);  
   $def("_1fwb5jc", "toolbar", ["htl","reversibleAttach","combine","viewof select","viewof up","viewof down","viewof remove","viewof addCells","viewof apply","viewof copy","viewof paste"], _1fwb5jc);  
   $def("_yej3hb", "viewof addCells", ["Inputs","createCell","viewof editedCell"], _yej3hb);  
-  main.variable(observer("addCells")).define("addCells", ["Generators", "viewof addCells"], (G, _) => G.input(_));  
+  $def("_1aii9ps", "addCells", ["Generators","viewof addCells"], _1aii9ps);  
   $def("_1bn860e", "viewof remove", ["Inputs","deleteCell","viewof editedCell"], _1bn860e);  
-  main.variable(observer("remove")).define("remove", ["Generators", "viewof remove"], (G, _) => G.input(_));  
+  $def("_1ad0xr8", "remove", ["Generators","viewof remove"], _1ad0xr8);  
   $def("_tw1j7n", "viewof apply", ["Inputs","compile_and_update","states","editedCell"], _tw1j7n);  
-  main.variable(observer("apply")).define("apply", ["Generators", "viewof apply"], (G, _) => G.input(_));  
+  $def("_1cjyuqm", "apply", ["Generators","viewof apply"], _1cjyuqm);  
   $def("_14rfku9", "viewof up", ["Inputs","moveCell","viewof editedCell"], _14rfku9);  
-  main.variable(observer("up")).define("up", ["Generators", "viewof up"], (G, _) => G.input(_));  
+  $def("_frzs5d", "up", ["Generators","viewof up"], _frzs5d);  
   $def("_9pymuj", "viewof paste", ["Inputs","readObservableClipboardCells","pasteObservableCellsIntoModule","editedCell"], _9pymuj);  
-  main.variable(observer("paste")).define("paste", ["Generators", "viewof paste"], (G, _) => G.input(_));  
+  $def("_1whsszt", "paste", ["Generators","viewof paste"], _1whsszt);  
   $def("_corxwl", "viewof down", ["Inputs","moveCell","viewof editedCell"], _corxwl);  
-  main.variable(observer("down")).define("down", ["Generators", "viewof down"], (G, _) => G.input(_));  
+  $def("_1to28po", "down", ["Generators","viewof down"], _1to28po);  
   $def("_gia2ci", "viewof copy", ["Inputs","html","viewof editedCell","decompile","viewof liveCellMap","getOption","cellsToClipboard"], _gia2ci);  
-  main.variable(observer("copy")).define("copy", ["Generators", "viewof copy"], (G, _) => G.input(_));  
+  $def("_fw41wt", "copy", ["Generators","viewof copy"], _fw41wt);  
   $def("_srtw8o", "module", ["editedCell"], _srtw8o);  
   $def("_rv7t7x", "code_editor_view", ["EditorView"], _rv7t7x);  
   $def("_xvo1n6", "code_editor", ["code_editor_view"], _xvo1n6);  
@@ -6035,7 +6055,7 @@ export default function define(runtime, observer) {
   $def("_d9nzys", "deleteCell", ["viewof command"], _d9nzys);  
   $def("_c1u9w8", null, ["md"], _c1u9w8);  
   $def("_d7ouqx", "viewof command", ["flowQueue"], _d7ouqx);  
-  main.variable(observer("command")).define("command", ["Generators", "viewof command"], (G, _) => G.input(_));  
+  $def("_118qt2v", "command", ["Generators","viewof command"], _118qt2v);  
   $def("_19l2nem", null, ["command"], _19l2nem);  
   $def("_1f6v167", "findCellByVariable", [], _1f6v167);  
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
@@ -6052,9 +6072,8 @@ export default function define(runtime, observer) {
   $def("_dvne2z", "replaceCodeMirrorDoc", [], _dvne2z);  
   $def("_1fpqfm0", null, ["md"], _1fpqfm0);  
   $def("_rtf009", "viewof select", ["editedCell","Inputs","getOption","setOption"], _rtf009);  
-  main.variable(observer("select")).define("select", ["Generators", "viewof select"], (G, _) => G.input(_));  
+  $def("_14mwbuc", "select", ["Generators","viewof select"], _14mwbuc);  
   $def("_l4sbcd", null, ["md"], _l4sbcd);  
-  main.define("module @tomlarkworthy/fileattachments", async () => runtime.module((await import("/@tomlarkworthy/fileattachments.js?v=4")).default));  
   main.define("getFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachment", _));  
   main.define("setFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("setFileAttachment", _));  
   main.define("removeFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("removeFileAttachment", _));  
@@ -6063,7 +6082,7 @@ export default function define(runtime, observer) {
   $def("_ezl7wk", null, ["FileAttachment"], _ezl7wk);  
   $def("_kygz54", "optionsFile", ["getFileAttachment","editorModule"], _kygz54);  
   $def("_760ozq", "viewof options", ["Inputs","optionsFile"], _760ozq);  
-  main.variable(observer("options")).define("options", ["Generators", "viewof options"], (G, _) => G.input(_));  
+  $def("_4rh26k", "options", ["Generators","viewof options"], _4rh26k);  
   $def("_1lqy7cs", "setOption", ["findCell","_","viewof options","Event"], _1lqy7cs);  
   $def("_1oxe5ee", "getOption", ["findCell","_","viewof options"], _1oxe5ee);  
   $def("_kwq69p", "save_options", ["setFileAttachment","jsonFileAttachment","options","editorModule"], _kwq69p);  
@@ -6077,22 +6096,21 @@ export default function define(runtime, observer) {
   $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
   $def("_1j3c2uf", "decompiled", ["editedCell","decompile"], _1j3c2uf);  
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
-  main.variable(observer("editorModule")).define("editorModule", ["Generators", "viewof editorModule"], (G, _) => G.input(_));  
+  $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1ju14cq", "compile_and_update", ["compile","runtime","repositionSetElement"], _1ju14cq);  
+  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
   $def("_rwez9", "viewof variable", ["Inputs","editedCell"], _rwez9);  
-  main.variable(observer("variable")).define("variable", ["Generators", "viewof variable"], (G, _) => G.input(_));  
+  $def("_11gvkq4", "variable", ["Generators","viewof variable"], _11gvkq4);  
   $def("_r5nvms", "name", ["variable"], _r5nvms);  
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
-  main.variable(observer("definition")).define("definition", ["Generators", "viewof definition"], (G, _) => G.input(_));  
+  $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
   $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
   $def("_1q557s", null, ["md"], _1q557s);  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -6103,12 +6121,10 @@ export default function define(runtime, observer) {
   main.define("isnode", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("isnode", _));  
   main.define("repositionSetElement", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("repositionSetElement", _));  
   main.define("onCodeChange", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("onCodeChange", _));  
-  main.define("module @tomlarkworthy/codemirror-6-v2", async () => runtime.module((await import("/@tomlarkworthy/codemirror-6-v2.js?v=4")).default));  
   main.define("EditorState", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("EditorState", _));  
   main.define("EditorView", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("EditorView", _));  
   main.define("codemirror", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("codemirror", _));  
   main.define("myDefaultTheme", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("myDefaultTheme", _));  
-  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
   main.define("decompile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("decompile", _));  
   main.define("compile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("compile", _));  
   main.define("cellMap", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("cellMap", _));  
@@ -6117,27 +6133,21 @@ export default function define(runtime, observer) {
   main.define("parser", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("parser", _));  
   $def("_1d94dks", "javascriptPlugin", ["codemirror"], _1d94dks);  
   $def("_ar9tao", null, ["md"], _ar9tao);  
-  main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
   main.define("reversibleAttach", ["module @tomlarkworthy/reversible-attachment", "@variable"], (_, v) => v.import("reversibleAttach", _));  
-  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
   main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
-  main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
   main.define("flowQueue", ["module @tomlarkworthy/flow-queue", "@variable"], (_, v) => v.import("flowQueue", _));  
-  main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
   main.define("viewof liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("viewof liveCellMap", _));  
   main.define("liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("liveCellMap", _));  
-  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
   main.define("hash", ["module d/57d79353bac56631@44", "@variable"], (_, v) => v.import("hash", _));  
-  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
   main.define("extractNotebookAndCell", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("extractNotebookAndCell", _));  
   main.define("navHref", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("navHref", _));  
-  main.define("module @tomlarkworthy/cells-to-clipboard", async () => runtime.module((await import("/@tomlarkworthy/cells-to-clipboard.js?v=4")).default));  
   main.define("cellsToClipboard", ["module @tomlarkworthy/cells-to-clipboard", "@variable"], (_, v) => v.import("cellsToClipboard", _));
   return main;
-}</script>
+}
+</script>
 <script id="@tomlarkworthy/escodegen/escodegen.browser.min.js.gz" 
   type="text/plain"
   data-encoding="base64"

--- a/notebooks/@tomlarkworthy_secrets.html
+++ b/notebooks/@tomlarkworthy_secrets.html
@@ -4690,7 +4690,7 @@ export default function define(runtime, observer) {
 >
 e30K
 </script>
-<script id="@tomlarkworthy/editor-5" 
+<script id="@tomlarkworthy/editor-5"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -4737,7 +4737,6 @@ md`## TODO
 const _1ociws4 = function _6(md){return(
 md`## Sync editors`
 )};
-const _1vq49kx = (_, v) => v.import("syncers", _);
 const _hdieof = function _editors(){return(
 new Map()
 )};
@@ -4815,12 +4814,12 @@ Inputs.toggle({
   value: !isOnObservableCom()
 })
 )};
+const _1oaz8r1 = (G, _) => G.input(_);
 const _16ks4jz = function _12(md){return(
 md`## \`cellEditor\` component
 
 Using Dataflow templating to create reusable Hotbar Component builder`
 )};
-const _1deps8p = (_, v) => v.import("cloneDataflow", _);
 const _199ztvl = function _hotbarTemplate(lookupVariable,editorModule){return(
 lookupVariable(
   [
@@ -5057,6 +5056,7 @@ md`## Hotbar Prototype`
 const _1o2h65s = function _editedCell(Inputs){return(
 Inputs.input(null)
 )};
+const _7g3h7h = (G, _) => G.input(_);
 const _1urs1md = function _findCell($0,modules){return(
 (variable, dom = undefined) => {
   if (variable) {
@@ -5216,9 +5216,11 @@ Inputs.toggle({
   value: true
 })
 )};
+const _1h8337z = (G, _) => G.input(_);
 const _tct2nf = function _edit(Inputs){return(
 Inputs.toggle({ label: "edit" })
 )};
+const _7izj7k = (G, _) => G.input(_);
 const _1fwb5jc = function _toolbar(htl,reversibleAttach,combine,$0,$1,$2,$3,$4,$5,$6,$7){return(
 htl.html`<div
     class="toolbar"
@@ -5246,11 +5248,13 @@ Inputs.button("➕", {
   }
 })
 )};
+const _1aii9ps = (G, _) => G.input(_);
 const _1bn860e = function _remove(Inputs,deleteCell,$0){return(
 Inputs.button("🗑️", {
   reduce: () => deleteCell({ cell: $0.value })
 })
 )};
+const _1ad0xr8 = (G, _) => G.input(_);
 const _tw1j7n = function _apply(Inputs,compile_and_update,states,editedCell)
 {
   const button = Inputs.button("▶️", {
@@ -5269,11 +5273,13 @@ const _tw1j7n = function _apply(Inputs,compile_and_update,states,editedCell)
   button.onmousedown = (e) => e.preventDefault();
   return button;
 };
+const _1cjyuqm = (G, _) => G.input(_);
 const _14rfku9 = function _up(Inputs,moveCell,$0){return(
 Inputs.button("⬆", {
   reduce: () => moveCell($0.value, -1)
 })
 )};
+const _frzs5d = (G, _) => G.input(_);
 const _9pymuj = function _paste(Inputs,readObservableClipboardCells,pasteObservableCellsIntoModule,editedCell){return(
 Inputs.button("📋", {
   reduce: async () => {
@@ -5282,11 +5288,13 @@ Inputs.button("📋", {
   }
 })
 )};
+const _1whsszt = (G, _) => G.input(_);
 const _corxwl = function _down(Inputs,moveCell,$0){return(
 Inputs.button("⬇", {
   reduce: () => moveCell($0.value, 1)
 })
 )};
+const _1to28po = (G, _) => G.input(_);
 const _gia2ci = function _copy(Inputs,html,$0,decompile,$1,getOption,cellsToClipboard){return(
 Inputs.button(
   html`<span style="font-size: .875em; margin-right: .125em; position: relative; top: -.25em; left: -.125em">
@@ -5328,6 +5336,7 @@ Inputs.button(
   }
 )
 )};
+const _fw41wt = (G, _) => G.input(_);
 const _srtw8o = function _module(editedCell){return(
 editedCell.module.module
 )};
@@ -5382,6 +5391,7 @@ md`## API handler`
 const _d7ouqx = function _command(flowQueue){return(
 flowQueue()
 )};
+const _118qt2v = (G, _) => G.input(_);
 const _19l2nem = function _54(command){return(
 command
 )};
@@ -5654,10 +5664,10 @@ const _rtf009 = function _select(editedCell,Inputs,getOption,setOption){return(
   return el;
 })()
 )};
+const _14mwbuc = (G, _) => G.input(_);
 const _l4sbcd = function _70(md){return(
 md`## Pinning`
 )};
-const _1sxszb9 = (_, v) => v.import("getFileAttachment", _);
 const _ezl7wk = function _72(FileAttachment){return(
 FileAttachment("cell_options.json")
 )};
@@ -5667,6 +5677,7 @@ getFileAttachment("cell_options.json", editorModule)
 const _760ozq = async function _options(Inputs,optionsFile){return(
 Inputs.input(await optionsFile.json())
 )};
+const _4rh26k = (G, _) => G.input(_);
 const _1lqy7cs = function _setOption(findCell,_,$0,Event){return(
 (variable, option, value) => {
   const cell = findCell(variable);
@@ -5846,6 +5857,7 @@ const _1j3c2uf = function _decompiled(editedCell,decompile)
 const _w5q3yf = function _editorModule(thisModule){return(
 thisModule()
 )};
+const _18kaj2p = (G, _) => G.input(_);
 const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_options)
 {
   //editedCell;
@@ -5857,43 +5869,47 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1ju14cq = function _compile_and_update(compile,runtime,repositionSetElement){return(
-(source, variables = [], cell) => {
-    try {
-        debugger;
-        let reposition = false, insertionIndex = -1;
-        const newVariables = compile(source);
-        if (!variables || variables.length !== newVariables.length) {
-            reposition = true;
-            variables.forEach(v => v.delete());
-            variables.length = 0;
-            for (let i = 0; i < newVariables.length; i++) {
-                const newVariable = cell.module.module.variable({});
-                variables.push(newVariable);
+const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+{
+    return (source, variables = [], cell) => {
+        try {
+            debugger;
+            let reposition = false, insertionIndex = -1;
+            const newVariables = compile(source);
+            if (!variables || variables.length !== newVariables.length) {
+                reposition = true;
+                variables.forEach(v => v.delete());
+                variables.length = 0;
+                for (let i = 0; i < newVariables.length; i++) {
+                    const newVariable = cell.module.module.variable({});
+                    // Assign a random pid up-front so blank/identical new cells don't
+                    // collide via persistentId's contentHash. See lopecode#144.
+                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+                    variables.push(newVariable);
+                }
             }
-        }
-        if (reposition) {
-            insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-        }
-        newVariables.forEach((v, i) => {
-            const variable = variables[i];
-            let _fn;
-            eval('_fn = ' + v._definition);
-            if (v._name) {
-                variable.define(v._name, v._inputs, _fn);
-            } else {
-                variable.define(v._inputs, _fn);
+            if (reposition) {
+                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
-            if (reposition)
-                repositionSetElement(runtime._variables, variable, insertionIndex + i);
-        });
-        return variables;
-    } catch (e) {
-        console.error(e);
-        debugger;
-    }
-}
-)};
+            newVariables.forEach((v, i) => {
+                const variable = variables[i];
+                let _fn;
+                eval('_fn = ' + v._definition);
+                if (v._name) {
+                    variable.define(v._name, v._inputs, _fn);
+                } else {
+                    variable.define(v._inputs, _fn);
+                }
+                if (reposition)
+                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
+            });
+            return variables;
+        } catch (e) {
+            console.error(e);
+            debugger;
+        }
+    };
+};
 const _1jqs8in = function _91(md){return(
 md`### Remove Cells`
 )};
@@ -5912,6 +5928,7 @@ Inputs.radio(editedCell.variables, {
   value: editedCell.variables[0]
 })
 )};
+const _11gvkq4 = (G, _) => G.input(_);
 const _r5nvms = function _name(variable){return(
 variable._name
 )};
@@ -5925,6 +5942,7 @@ Inputs.textarea({
   rows: 10
 })
 )};
+const _b4rsn5 = (G, _) => G.input(_);
 const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
@@ -5938,22 +5956,12 @@ Inputs.button("update variable", {
 const _1q557s = function _99(md){return(
 md`### Editor Libraries`
 )};
-const _192vvs7 = (_, v) => v.import("descendants", _);
-const _3va6tf = (_, v) => v.import("EditorState", _);
-const _lmqjiv = (_, v) => v.import("decompile", _);
 const _1d94dks = function _javascriptPlugin(codemirror){return(
 codemirror
 )};
 const _ar9tao = function _104(md){return(
 md`### Libraries`
 )};
-const _viogn = (_, v) => v.import("reversibleAttach", _);
-const _nxg8mr = (_, v) => v.import("moduleMap", _);
-const _14a94d = (_, v) => v.import("flowQueue", _);
-const _gurtwb = (_, v) => v.import("viewof liveCellMap", _);
-const _19ebgtz = (_, v) => v.import("hash", _);
-const _n2vgkz = (_, v) => v.import("extractNotebookAndCell", _);
-const _1qucevb = (_, v) => v.import("cellsToClipboard", _);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -5967,22 +5975,34 @@ export default function define(runtime, observer) {
     return [name, {url: blob_url, mimeType: mime}]
   }));
   main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
+  main.define("module @tomlarkworthy/dataflow-templating", async () => runtime.module((await import("/@tomlarkworthy/dataflow-templating.js?v=4")).default));  
+  main.define("module @tomlarkworthy/fileattachments", async () => runtime.module((await import("/@tomlarkworthy/fileattachments.js?v=4")).default));  
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/codemirror-6-v2", async () => runtime.module((await import("/@tomlarkworthy/codemirror-6-v2.js?v=4")).default));  
+  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
+  main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
+  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
+  main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
+  main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
+  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
+  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
+  main.define("module @tomlarkworthy/cells-to-clipboard", async () => runtime.module((await import("/@tomlarkworthy/cells-to-clipboard.js?v=4")).default));  
   $def("_1tdjp0a", "title", ["md"], _1tdjp0a);  
   $def("_dm53bx", null, ["md"], _dm53bx);  
   $def("_61oxjf", "title_variable", ["lookupVariable","editorModule"], _61oxjf);  
   $def("_15uilf0", null, ["cellEditor","title_variable"], _15uilf0);  
   $def("_3x695f", null, ["md"], _3x695f);  
   $def("_1ociws4", null, ["md"], _1ociws4);  
-  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
   $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
-  main.variable(observer("attachContextManu")).define("attachContextManu", ["Generators", "viewof attachContextManu"], (G, _) => G.input(_));  
+  $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
   $def("_16ks4jz", null, ["md"], _16ks4jz);  
-  main.define("module @tomlarkworthy/dataflow-templating", async () => runtime.module((await import("/@tomlarkworthy/dataflow-templating.js?v=4")).default));  
   main.define("cloneDataflow", ["module @tomlarkworthy/dataflow-templating", "@variable"], (_, v) => v.import("cloneDataflow", _));  
   main.define("lookupVariable", ["module @tomlarkworthy/dataflow-templating", "@variable"], (_, v) => v.import("lookupVariable", _));  
   $def("_199ztvl", "hotbarTemplate", ["lookupVariable","editorModule"], _199ztvl);  
@@ -5993,7 +6013,7 @@ export default function define(runtime, observer) {
   $def("_110gwi7", "editorTemplate", ["lookupVariable","editorModule"], _110gwi7);  
   $def("_16rqzgl", null, ["md"], _16rqzgl);  
   $def("_1o2h65s", "viewof editedCell", ["Inputs"], _1o2h65s);  
-  main.variable(observer("editedCell")).define("editedCell", ["Generators", "viewof editedCell"], (G, _) => G.input(_));  
+  $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
   $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
@@ -6008,24 +6028,24 @@ export default function define(runtime, observer) {
   $def("_mrrmx3", null, ["md"], _mrrmx3);  
   $def("_14b1byw", null, ["md"], _14b1byw);  
   $def("_1j1loxx", "viewof combine", ["Inputs"], _1j1loxx);  
-  main.variable(observer("combine")).define("combine", ["Generators", "viewof combine"], (G, _) => G.input(_));  
+  $def("_1h8337z", "combine", ["Generators","viewof combine"], _1h8337z);  
   $def("_tct2nf", "viewof edit", ["Inputs"], _tct2nf);  
-  main.variable(observer("edit")).define("edit", ["Generators", "viewof edit"], (G, _) => G.input(_));  
+  $def("_7izj7k", "edit", ["Generators","viewof edit"], _7izj7k);  
   $def("_1fwb5jc", "toolbar", ["htl","reversibleAttach","combine","viewof select","viewof up","viewof down","viewof remove","viewof addCells","viewof apply","viewof copy","viewof paste"], _1fwb5jc);  
   $def("_yej3hb", "viewof addCells", ["Inputs","createCell","viewof editedCell"], _yej3hb);  
-  main.variable(observer("addCells")).define("addCells", ["Generators", "viewof addCells"], (G, _) => G.input(_));  
+  $def("_1aii9ps", "addCells", ["Generators","viewof addCells"], _1aii9ps);  
   $def("_1bn860e", "viewof remove", ["Inputs","deleteCell","viewof editedCell"], _1bn860e);  
-  main.variable(observer("remove")).define("remove", ["Generators", "viewof remove"], (G, _) => G.input(_));  
+  $def("_1ad0xr8", "remove", ["Generators","viewof remove"], _1ad0xr8);  
   $def("_tw1j7n", "viewof apply", ["Inputs","compile_and_update","states","editedCell"], _tw1j7n);  
-  main.variable(observer("apply")).define("apply", ["Generators", "viewof apply"], (G, _) => G.input(_));  
+  $def("_1cjyuqm", "apply", ["Generators","viewof apply"], _1cjyuqm);  
   $def("_14rfku9", "viewof up", ["Inputs","moveCell","viewof editedCell"], _14rfku9);  
-  main.variable(observer("up")).define("up", ["Generators", "viewof up"], (G, _) => G.input(_));  
+  $def("_frzs5d", "up", ["Generators","viewof up"], _frzs5d);  
   $def("_9pymuj", "viewof paste", ["Inputs","readObservableClipboardCells","pasteObservableCellsIntoModule","editedCell"], _9pymuj);  
-  main.variable(observer("paste")).define("paste", ["Generators", "viewof paste"], (G, _) => G.input(_));  
+  $def("_1whsszt", "paste", ["Generators","viewof paste"], _1whsszt);  
   $def("_corxwl", "viewof down", ["Inputs","moveCell","viewof editedCell"], _corxwl);  
-  main.variable(observer("down")).define("down", ["Generators", "viewof down"], (G, _) => G.input(_));  
+  $def("_1to28po", "down", ["Generators","viewof down"], _1to28po);  
   $def("_gia2ci", "viewof copy", ["Inputs","html","viewof editedCell","decompile","viewof liveCellMap","getOption","cellsToClipboard"], _gia2ci);  
-  main.variable(observer("copy")).define("copy", ["Generators", "viewof copy"], (G, _) => G.input(_));  
+  $def("_fw41wt", "copy", ["Generators","viewof copy"], _fw41wt);  
   $def("_srtw8o", "module", ["editedCell"], _srtw8o);  
   $def("_rv7t7x", "code_editor_view", ["EditorView"], _rv7t7x);  
   $def("_xvo1n6", "code_editor", ["code_editor_view"], _xvo1n6);  
@@ -6035,7 +6055,7 @@ export default function define(runtime, observer) {
   $def("_d9nzys", "deleteCell", ["viewof command"], _d9nzys);  
   $def("_c1u9w8", null, ["md"], _c1u9w8);  
   $def("_d7ouqx", "viewof command", ["flowQueue"], _d7ouqx);  
-  main.variable(observer("command")).define("command", ["Generators", "viewof command"], (G, _) => G.input(_));  
+  $def("_118qt2v", "command", ["Generators","viewof command"], _118qt2v);  
   $def("_19l2nem", null, ["command"], _19l2nem);  
   $def("_1f6v167", "findCellByVariable", [], _1f6v167);  
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
@@ -6052,9 +6072,8 @@ export default function define(runtime, observer) {
   $def("_dvne2z", "replaceCodeMirrorDoc", [], _dvne2z);  
   $def("_1fpqfm0", null, ["md"], _1fpqfm0);  
   $def("_rtf009", "viewof select", ["editedCell","Inputs","getOption","setOption"], _rtf009);  
-  main.variable(observer("select")).define("select", ["Generators", "viewof select"], (G, _) => G.input(_));  
+  $def("_14mwbuc", "select", ["Generators","viewof select"], _14mwbuc);  
   $def("_l4sbcd", null, ["md"], _l4sbcd);  
-  main.define("module @tomlarkworthy/fileattachments", async () => runtime.module((await import("/@tomlarkworthy/fileattachments.js?v=4")).default));  
   main.define("getFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachment", _));  
   main.define("setFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("setFileAttachment", _));  
   main.define("removeFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("removeFileAttachment", _));  
@@ -6063,7 +6082,7 @@ export default function define(runtime, observer) {
   $def("_ezl7wk", null, ["FileAttachment"], _ezl7wk);  
   $def("_kygz54", "optionsFile", ["getFileAttachment","editorModule"], _kygz54);  
   $def("_760ozq", "viewof options", ["Inputs","optionsFile"], _760ozq);  
-  main.variable(observer("options")).define("options", ["Generators", "viewof options"], (G, _) => G.input(_));  
+  $def("_4rh26k", "options", ["Generators","viewof options"], _4rh26k);  
   $def("_1lqy7cs", "setOption", ["findCell","_","viewof options","Event"], _1lqy7cs);  
   $def("_1oxe5ee", "getOption", ["findCell","_","viewof options"], _1oxe5ee);  
   $def("_kwq69p", "save_options", ["setFileAttachment","jsonFileAttachment","options","editorModule"], _kwq69p);  
@@ -6077,22 +6096,21 @@ export default function define(runtime, observer) {
   $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
   $def("_1j3c2uf", "decompiled", ["editedCell","decompile"], _1j3c2uf);  
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
-  main.variable(observer("editorModule")).define("editorModule", ["Generators", "viewof editorModule"], (G, _) => G.input(_));  
+  $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1ju14cq", "compile_and_update", ["compile","runtime","repositionSetElement"], _1ju14cq);  
+  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
   $def("_rwez9", "viewof variable", ["Inputs","editedCell"], _rwez9);  
-  main.variable(observer("variable")).define("variable", ["Generators", "viewof variable"], (G, _) => G.input(_));  
+  $def("_11gvkq4", "variable", ["Generators","viewof variable"], _11gvkq4);  
   $def("_r5nvms", "name", ["variable"], _r5nvms);  
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
-  main.variable(observer("definition")).define("definition", ["Generators", "viewof definition"], (G, _) => G.input(_));  
+  $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
   $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
   $def("_1q557s", null, ["md"], _1q557s);  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -6103,12 +6121,10 @@ export default function define(runtime, observer) {
   main.define("isnode", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("isnode", _));  
   main.define("repositionSetElement", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("repositionSetElement", _));  
   main.define("onCodeChange", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("onCodeChange", _));  
-  main.define("module @tomlarkworthy/codemirror-6-v2", async () => runtime.module((await import("/@tomlarkworthy/codemirror-6-v2.js?v=4")).default));  
   main.define("EditorState", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("EditorState", _));  
   main.define("EditorView", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("EditorView", _));  
   main.define("codemirror", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("codemirror", _));  
   main.define("myDefaultTheme", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("myDefaultTheme", _));  
-  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
   main.define("decompile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("decompile", _));  
   main.define("compile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("compile", _));  
   main.define("cellMap", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("cellMap", _));  
@@ -6117,27 +6133,21 @@ export default function define(runtime, observer) {
   main.define("parser", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("parser", _));  
   $def("_1d94dks", "javascriptPlugin", ["codemirror"], _1d94dks);  
   $def("_ar9tao", null, ["md"], _ar9tao);  
-  main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
   main.define("reversibleAttach", ["module @tomlarkworthy/reversible-attachment", "@variable"], (_, v) => v.import("reversibleAttach", _));  
-  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
   main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
-  main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
   main.define("flowQueue", ["module @tomlarkworthy/flow-queue", "@variable"], (_, v) => v.import("flowQueue", _));  
-  main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
   main.define("viewof liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("viewof liveCellMap", _));  
   main.define("liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("liveCellMap", _));  
-  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
   main.define("hash", ["module d/57d79353bac56631@44", "@variable"], (_, v) => v.import("hash", _));  
-  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
   main.define("extractNotebookAndCell", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("extractNotebookAndCell", _));  
   main.define("navHref", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("navHref", _));  
-  main.define("module @tomlarkworthy/cells-to-clipboard", async () => runtime.module((await import("/@tomlarkworthy/cells-to-clipboard.js?v=4")).default));  
   main.define("cellsToClipboard", ["module @tomlarkworthy/cells-to-clipboard", "@variable"], (_, v) => v.import("cellsToClipboard", _));
   return main;
-}</script>
+}
+</script>
 <script id="@tomlarkworthy/escodegen/escodegen.browser.min.js.gz" 
   type="text/plain"
   data-encoding="base64"

--- a/notebooks/@tomlarkworthy_tests.html
+++ b/notebooks/@tomlarkworthy_tests.html
@@ -4690,7 +4690,7 @@ export default function define(runtime, observer) {
 >
 e30K
 </script>
-<script id="@tomlarkworthy/editor-5" 
+<script id="@tomlarkworthy/editor-5"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -4737,7 +4737,6 @@ md`## TODO
 const _1ociws4 = function _6(md){return(
 md`## Sync editors`
 )};
-const _1vq49kx = (_, v) => v.import("syncers", _);
 const _hdieof = function _editors(){return(
 new Map()
 )};
@@ -4815,12 +4814,12 @@ Inputs.toggle({
   value: !isOnObservableCom()
 })
 )};
+const _1oaz8r1 = (G, _) => G.input(_);
 const _16ks4jz = function _12(md){return(
 md`## \`cellEditor\` component
 
 Using Dataflow templating to create reusable Hotbar Component builder`
 )};
-const _1deps8p = (_, v) => v.import("cloneDataflow", _);
 const _199ztvl = function _hotbarTemplate(lookupVariable,editorModule){return(
 lookupVariable(
   [
@@ -5057,6 +5056,7 @@ md`## Hotbar Prototype`
 const _1o2h65s = function _editedCell(Inputs){return(
 Inputs.input(null)
 )};
+const _7g3h7h = (G, _) => G.input(_);
 const _1urs1md = function _findCell($0,modules){return(
 (variable, dom = undefined) => {
   if (variable) {
@@ -5216,9 +5216,11 @@ Inputs.toggle({
   value: true
 })
 )};
+const _1h8337z = (G, _) => G.input(_);
 const _tct2nf = function _edit(Inputs){return(
 Inputs.toggle({ label: "edit" })
 )};
+const _7izj7k = (G, _) => G.input(_);
 const _1fwb5jc = function _toolbar(htl,reversibleAttach,combine,$0,$1,$2,$3,$4,$5,$6,$7){return(
 htl.html`<div
     class="toolbar"
@@ -5246,11 +5248,13 @@ Inputs.button("➕", {
   }
 })
 )};
+const _1aii9ps = (G, _) => G.input(_);
 const _1bn860e = function _remove(Inputs,deleteCell,$0){return(
 Inputs.button("🗑️", {
   reduce: () => deleteCell({ cell: $0.value })
 })
 )};
+const _1ad0xr8 = (G, _) => G.input(_);
 const _tw1j7n = function _apply(Inputs,compile_and_update,states,editedCell)
 {
   const button = Inputs.button("▶️", {
@@ -5269,11 +5273,13 @@ const _tw1j7n = function _apply(Inputs,compile_and_update,states,editedCell)
   button.onmousedown = (e) => e.preventDefault();
   return button;
 };
+const _1cjyuqm = (G, _) => G.input(_);
 const _14rfku9 = function _up(Inputs,moveCell,$0){return(
 Inputs.button("⬆", {
   reduce: () => moveCell($0.value, -1)
 })
 )};
+const _frzs5d = (G, _) => G.input(_);
 const _9pymuj = function _paste(Inputs,readObservableClipboardCells,pasteObservableCellsIntoModule,editedCell){return(
 Inputs.button("📋", {
   reduce: async () => {
@@ -5282,11 +5288,13 @@ Inputs.button("📋", {
   }
 })
 )};
+const _1whsszt = (G, _) => G.input(_);
 const _corxwl = function _down(Inputs,moveCell,$0){return(
 Inputs.button("⬇", {
   reduce: () => moveCell($0.value, 1)
 })
 )};
+const _1to28po = (G, _) => G.input(_);
 const _gia2ci = function _copy(Inputs,html,$0,decompile,$1,getOption,cellsToClipboard){return(
 Inputs.button(
   html`<span style="font-size: .875em; margin-right: .125em; position: relative; top: -.25em; left: -.125em">
@@ -5328,6 +5336,7 @@ Inputs.button(
   }
 )
 )};
+const _fw41wt = (G, _) => G.input(_);
 const _srtw8o = function _module(editedCell){return(
 editedCell.module.module
 )};
@@ -5382,6 +5391,7 @@ md`## API handler`
 const _d7ouqx = function _command(flowQueue){return(
 flowQueue()
 )};
+const _118qt2v = (G, _) => G.input(_);
 const _19l2nem = function _54(command){return(
 command
 )};
@@ -5654,10 +5664,10 @@ const _rtf009 = function _select(editedCell,Inputs,getOption,setOption){return(
   return el;
 })()
 )};
+const _14mwbuc = (G, _) => G.input(_);
 const _l4sbcd = function _70(md){return(
 md`## Pinning`
 )};
-const _1sxszb9 = (_, v) => v.import("getFileAttachment", _);
 const _ezl7wk = function _72(FileAttachment){return(
 FileAttachment("cell_options.json")
 )};
@@ -5667,6 +5677,7 @@ getFileAttachment("cell_options.json", editorModule)
 const _760ozq = async function _options(Inputs,optionsFile){return(
 Inputs.input(await optionsFile.json())
 )};
+const _4rh26k = (G, _) => G.input(_);
 const _1lqy7cs = function _setOption(findCell,_,$0,Event){return(
 (variable, option, value) => {
   const cell = findCell(variable);
@@ -5846,6 +5857,7 @@ const _1j3c2uf = function _decompiled(editedCell,decompile)
 const _w5q3yf = function _editorModule(thisModule){return(
 thisModule()
 )};
+const _18kaj2p = (G, _) => G.input(_);
 const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_options)
 {
   //editedCell;
@@ -5857,43 +5869,47 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1ju14cq = function _compile_and_update(compile,runtime,repositionSetElement){return(
-(source, variables = [], cell) => {
-    try {
-        debugger;
-        let reposition = false, insertionIndex = -1;
-        const newVariables = compile(source);
-        if (!variables || variables.length !== newVariables.length) {
-            reposition = true;
-            variables.forEach(v => v.delete());
-            variables.length = 0;
-            for (let i = 0; i < newVariables.length; i++) {
-                const newVariable = cell.module.module.variable({});
-                variables.push(newVariable);
+const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+{
+    return (source, variables = [], cell) => {
+        try {
+            debugger;
+            let reposition = false, insertionIndex = -1;
+            const newVariables = compile(source);
+            if (!variables || variables.length !== newVariables.length) {
+                reposition = true;
+                variables.forEach(v => v.delete());
+                variables.length = 0;
+                for (let i = 0; i < newVariables.length; i++) {
+                    const newVariable = cell.module.module.variable({});
+                    // Assign a random pid up-front so blank/identical new cells don't
+                    // collide via persistentId's contentHash. See lopecode#144.
+                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+                    variables.push(newVariable);
+                }
             }
-        }
-        if (reposition) {
-            insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-        }
-        newVariables.forEach((v, i) => {
-            const variable = variables[i];
-            let _fn;
-            eval('_fn = ' + v._definition);
-            if (v._name) {
-                variable.define(v._name, v._inputs, _fn);
-            } else {
-                variable.define(v._inputs, _fn);
+            if (reposition) {
+                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
-            if (reposition)
-                repositionSetElement(runtime._variables, variable, insertionIndex + i);
-        });
-        return variables;
-    } catch (e) {
-        console.error(e);
-        debugger;
-    }
-}
-)};
+            newVariables.forEach((v, i) => {
+                const variable = variables[i];
+                let _fn;
+                eval('_fn = ' + v._definition);
+                if (v._name) {
+                    variable.define(v._name, v._inputs, _fn);
+                } else {
+                    variable.define(v._inputs, _fn);
+                }
+                if (reposition)
+                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
+            });
+            return variables;
+        } catch (e) {
+            console.error(e);
+            debugger;
+        }
+    };
+};
 const _1jqs8in = function _91(md){return(
 md`### Remove Cells`
 )};
@@ -5912,6 +5928,7 @@ Inputs.radio(editedCell.variables, {
   value: editedCell.variables[0]
 })
 )};
+const _11gvkq4 = (G, _) => G.input(_);
 const _r5nvms = function _name(variable){return(
 variable._name
 )};
@@ -5925,6 +5942,7 @@ Inputs.textarea({
   rows: 10
 })
 )};
+const _b4rsn5 = (G, _) => G.input(_);
 const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
@@ -5938,22 +5956,12 @@ Inputs.button("update variable", {
 const _1q557s = function _99(md){return(
 md`### Editor Libraries`
 )};
-const _192vvs7 = (_, v) => v.import("descendants", _);
-const _3va6tf = (_, v) => v.import("EditorState", _);
-const _lmqjiv = (_, v) => v.import("decompile", _);
 const _1d94dks = function _javascriptPlugin(codemirror){return(
 codemirror
 )};
 const _ar9tao = function _104(md){return(
 md`### Libraries`
 )};
-const _viogn = (_, v) => v.import("reversibleAttach", _);
-const _nxg8mr = (_, v) => v.import("moduleMap", _);
-const _14a94d = (_, v) => v.import("flowQueue", _);
-const _gurtwb = (_, v) => v.import("viewof liveCellMap", _);
-const _19ebgtz = (_, v) => v.import("hash", _);
-const _n2vgkz = (_, v) => v.import("extractNotebookAndCell", _);
-const _1qucevb = (_, v) => v.import("cellsToClipboard", _);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -5967,22 +5975,34 @@ export default function define(runtime, observer) {
     return [name, {url: blob_url, mimeType: mime}]
   }));
   main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
+  main.define("module @tomlarkworthy/dataflow-templating", async () => runtime.module((await import("/@tomlarkworthy/dataflow-templating.js?v=4")).default));  
+  main.define("module @tomlarkworthy/fileattachments", async () => runtime.module((await import("/@tomlarkworthy/fileattachments.js?v=4")).default));  
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/codemirror-6-v2", async () => runtime.module((await import("/@tomlarkworthy/codemirror-6-v2.js?v=4")).default));  
+  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
+  main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
+  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
+  main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
+  main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
+  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
+  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
+  main.define("module @tomlarkworthy/cells-to-clipboard", async () => runtime.module((await import("/@tomlarkworthy/cells-to-clipboard.js?v=4")).default));  
   $def("_1tdjp0a", "title", ["md"], _1tdjp0a);  
   $def("_dm53bx", null, ["md"], _dm53bx);  
   $def("_61oxjf", "title_variable", ["lookupVariable","editorModule"], _61oxjf);  
   $def("_15uilf0", null, ["cellEditor","title_variable"], _15uilf0);  
   $def("_3x695f", null, ["md"], _3x695f);  
   $def("_1ociws4", null, ["md"], _1ociws4);  
-  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
   $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
-  main.variable(observer("attachContextManu")).define("attachContextManu", ["Generators", "viewof attachContextManu"], (G, _) => G.input(_));  
+  $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
   $def("_16ks4jz", null, ["md"], _16ks4jz);  
-  main.define("module @tomlarkworthy/dataflow-templating", async () => runtime.module((await import("/@tomlarkworthy/dataflow-templating.js?v=4")).default));  
   main.define("cloneDataflow", ["module @tomlarkworthy/dataflow-templating", "@variable"], (_, v) => v.import("cloneDataflow", _));  
   main.define("lookupVariable", ["module @tomlarkworthy/dataflow-templating", "@variable"], (_, v) => v.import("lookupVariable", _));  
   $def("_199ztvl", "hotbarTemplate", ["lookupVariable","editorModule"], _199ztvl);  
@@ -5993,7 +6013,7 @@ export default function define(runtime, observer) {
   $def("_110gwi7", "editorTemplate", ["lookupVariable","editorModule"], _110gwi7);  
   $def("_16rqzgl", null, ["md"], _16rqzgl);  
   $def("_1o2h65s", "viewof editedCell", ["Inputs"], _1o2h65s);  
-  main.variable(observer("editedCell")).define("editedCell", ["Generators", "viewof editedCell"], (G, _) => G.input(_));  
+  $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
   $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
@@ -6008,24 +6028,24 @@ export default function define(runtime, observer) {
   $def("_mrrmx3", null, ["md"], _mrrmx3);  
   $def("_14b1byw", null, ["md"], _14b1byw);  
   $def("_1j1loxx", "viewof combine", ["Inputs"], _1j1loxx);  
-  main.variable(observer("combine")).define("combine", ["Generators", "viewof combine"], (G, _) => G.input(_));  
+  $def("_1h8337z", "combine", ["Generators","viewof combine"], _1h8337z);  
   $def("_tct2nf", "viewof edit", ["Inputs"], _tct2nf);  
-  main.variable(observer("edit")).define("edit", ["Generators", "viewof edit"], (G, _) => G.input(_));  
+  $def("_7izj7k", "edit", ["Generators","viewof edit"], _7izj7k);  
   $def("_1fwb5jc", "toolbar", ["htl","reversibleAttach","combine","viewof select","viewof up","viewof down","viewof remove","viewof addCells","viewof apply","viewof copy","viewof paste"], _1fwb5jc);  
   $def("_yej3hb", "viewof addCells", ["Inputs","createCell","viewof editedCell"], _yej3hb);  
-  main.variable(observer("addCells")).define("addCells", ["Generators", "viewof addCells"], (G, _) => G.input(_));  
+  $def("_1aii9ps", "addCells", ["Generators","viewof addCells"], _1aii9ps);  
   $def("_1bn860e", "viewof remove", ["Inputs","deleteCell","viewof editedCell"], _1bn860e);  
-  main.variable(observer("remove")).define("remove", ["Generators", "viewof remove"], (G, _) => G.input(_));  
+  $def("_1ad0xr8", "remove", ["Generators","viewof remove"], _1ad0xr8);  
   $def("_tw1j7n", "viewof apply", ["Inputs","compile_and_update","states","editedCell"], _tw1j7n);  
-  main.variable(observer("apply")).define("apply", ["Generators", "viewof apply"], (G, _) => G.input(_));  
+  $def("_1cjyuqm", "apply", ["Generators","viewof apply"], _1cjyuqm);  
   $def("_14rfku9", "viewof up", ["Inputs","moveCell","viewof editedCell"], _14rfku9);  
-  main.variable(observer("up")).define("up", ["Generators", "viewof up"], (G, _) => G.input(_));  
+  $def("_frzs5d", "up", ["Generators","viewof up"], _frzs5d);  
   $def("_9pymuj", "viewof paste", ["Inputs","readObservableClipboardCells","pasteObservableCellsIntoModule","editedCell"], _9pymuj);  
-  main.variable(observer("paste")).define("paste", ["Generators", "viewof paste"], (G, _) => G.input(_));  
+  $def("_1whsszt", "paste", ["Generators","viewof paste"], _1whsszt);  
   $def("_corxwl", "viewof down", ["Inputs","moveCell","viewof editedCell"], _corxwl);  
-  main.variable(observer("down")).define("down", ["Generators", "viewof down"], (G, _) => G.input(_));  
+  $def("_1to28po", "down", ["Generators","viewof down"], _1to28po);  
   $def("_gia2ci", "viewof copy", ["Inputs","html","viewof editedCell","decompile","viewof liveCellMap","getOption","cellsToClipboard"], _gia2ci);  
-  main.variable(observer("copy")).define("copy", ["Generators", "viewof copy"], (G, _) => G.input(_));  
+  $def("_fw41wt", "copy", ["Generators","viewof copy"], _fw41wt);  
   $def("_srtw8o", "module", ["editedCell"], _srtw8o);  
   $def("_rv7t7x", "code_editor_view", ["EditorView"], _rv7t7x);  
   $def("_xvo1n6", "code_editor", ["code_editor_view"], _xvo1n6);  
@@ -6035,7 +6055,7 @@ export default function define(runtime, observer) {
   $def("_d9nzys", "deleteCell", ["viewof command"], _d9nzys);  
   $def("_c1u9w8", null, ["md"], _c1u9w8);  
   $def("_d7ouqx", "viewof command", ["flowQueue"], _d7ouqx);  
-  main.variable(observer("command")).define("command", ["Generators", "viewof command"], (G, _) => G.input(_));  
+  $def("_118qt2v", "command", ["Generators","viewof command"], _118qt2v);  
   $def("_19l2nem", null, ["command"], _19l2nem);  
   $def("_1f6v167", "findCellByVariable", [], _1f6v167);  
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
@@ -6052,9 +6072,8 @@ export default function define(runtime, observer) {
   $def("_dvne2z", "replaceCodeMirrorDoc", [], _dvne2z);  
   $def("_1fpqfm0", null, ["md"], _1fpqfm0);  
   $def("_rtf009", "viewof select", ["editedCell","Inputs","getOption","setOption"], _rtf009);  
-  main.variable(observer("select")).define("select", ["Generators", "viewof select"], (G, _) => G.input(_));  
+  $def("_14mwbuc", "select", ["Generators","viewof select"], _14mwbuc);  
   $def("_l4sbcd", null, ["md"], _l4sbcd);  
-  main.define("module @tomlarkworthy/fileattachments", async () => runtime.module((await import("/@tomlarkworthy/fileattachments.js?v=4")).default));  
   main.define("getFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachment", _));  
   main.define("setFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("setFileAttachment", _));  
   main.define("removeFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("removeFileAttachment", _));  
@@ -6063,7 +6082,7 @@ export default function define(runtime, observer) {
   $def("_ezl7wk", null, ["FileAttachment"], _ezl7wk);  
   $def("_kygz54", "optionsFile", ["getFileAttachment","editorModule"], _kygz54);  
   $def("_760ozq", "viewof options", ["Inputs","optionsFile"], _760ozq);  
-  main.variable(observer("options")).define("options", ["Generators", "viewof options"], (G, _) => G.input(_));  
+  $def("_4rh26k", "options", ["Generators","viewof options"], _4rh26k);  
   $def("_1lqy7cs", "setOption", ["findCell","_","viewof options","Event"], _1lqy7cs);  
   $def("_1oxe5ee", "getOption", ["findCell","_","viewof options"], _1oxe5ee);  
   $def("_kwq69p", "save_options", ["setFileAttachment","jsonFileAttachment","options","editorModule"], _kwq69p);  
@@ -6077,22 +6096,21 @@ export default function define(runtime, observer) {
   $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
   $def("_1j3c2uf", "decompiled", ["editedCell","decompile"], _1j3c2uf);  
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
-  main.variable(observer("editorModule")).define("editorModule", ["Generators", "viewof editorModule"], (G, _) => G.input(_));  
+  $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1ju14cq", "compile_and_update", ["compile","runtime","repositionSetElement"], _1ju14cq);  
+  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
   $def("_rwez9", "viewof variable", ["Inputs","editedCell"], _rwez9);  
-  main.variable(observer("variable")).define("variable", ["Generators", "viewof variable"], (G, _) => G.input(_));  
+  $def("_11gvkq4", "variable", ["Generators","viewof variable"], _11gvkq4);  
   $def("_r5nvms", "name", ["variable"], _r5nvms);  
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
-  main.variable(observer("definition")).define("definition", ["Generators", "viewof definition"], (G, _) => G.input(_));  
+  $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
   $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
   $def("_1q557s", null, ["md"], _1q557s);  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -6103,12 +6121,10 @@ export default function define(runtime, observer) {
   main.define("isnode", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("isnode", _));  
   main.define("repositionSetElement", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("repositionSetElement", _));  
   main.define("onCodeChange", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("onCodeChange", _));  
-  main.define("module @tomlarkworthy/codemirror-6-v2", async () => runtime.module((await import("/@tomlarkworthy/codemirror-6-v2.js?v=4")).default));  
   main.define("EditorState", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("EditorState", _));  
   main.define("EditorView", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("EditorView", _));  
   main.define("codemirror", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("codemirror", _));  
   main.define("myDefaultTheme", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("myDefaultTheme", _));  
-  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
   main.define("decompile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("decompile", _));  
   main.define("compile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("compile", _));  
   main.define("cellMap", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("cellMap", _));  
@@ -6117,27 +6133,21 @@ export default function define(runtime, observer) {
   main.define("parser", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("parser", _));  
   $def("_1d94dks", "javascriptPlugin", ["codemirror"], _1d94dks);  
   $def("_ar9tao", null, ["md"], _ar9tao);  
-  main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
   main.define("reversibleAttach", ["module @tomlarkworthy/reversible-attachment", "@variable"], (_, v) => v.import("reversibleAttach", _));  
-  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
   main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
-  main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
   main.define("flowQueue", ["module @tomlarkworthy/flow-queue", "@variable"], (_, v) => v.import("flowQueue", _));  
-  main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
   main.define("viewof liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("viewof liveCellMap", _));  
   main.define("liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("liveCellMap", _));  
-  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
   main.define("hash", ["module d/57d79353bac56631@44", "@variable"], (_, v) => v.import("hash", _));  
-  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
   main.define("extractNotebookAndCell", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("extractNotebookAndCell", _));  
   main.define("navHref", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("navHref", _));  
-  main.define("module @tomlarkworthy/cells-to-clipboard", async () => runtime.module((await import("/@tomlarkworthy/cells-to-clipboard.js?v=4")).default));  
   main.define("cellsToClipboard", ["module @tomlarkworthy/cells-to-clipboard", "@variable"], (_, v) => v.import("cellsToClipboard", _));
   return main;
-}</script>
+}
+</script>
 <script id="@tomlarkworthy/escodegen/escodegen.browser.min.js.gz" 
   type="text/plain"
   data-encoding="base64"

--- a/notebooks/@tomlarkworthy_themes.html
+++ b/notebooks/@tomlarkworthy_themes.html
@@ -4690,7 +4690,7 @@ export default function define(runtime, observer) {
 >
 e30K
 </script>
-<script id="@tomlarkworthy/editor-5" 
+<script id="@tomlarkworthy/editor-5"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -4737,7 +4737,6 @@ md`## TODO
 const _1ociws4 = function _6(md){return(
 md`## Sync editors`
 )};
-const _1vq49kx = (_, v) => v.import("syncers", _);
 const _hdieof = function _editors(){return(
 new Map()
 )};
@@ -4815,12 +4814,12 @@ Inputs.toggle({
   value: !isOnObservableCom()
 })
 )};
+const _1oaz8r1 = (G, _) => G.input(_);
 const _16ks4jz = function _12(md){return(
 md`## \`cellEditor\` component
 
 Using Dataflow templating to create reusable Hotbar Component builder`
 )};
-const _1deps8p = (_, v) => v.import("cloneDataflow", _);
 const _199ztvl = function _hotbarTemplate(lookupVariable,editorModule){return(
 lookupVariable(
   [
@@ -5057,6 +5056,7 @@ md`## Hotbar Prototype`
 const _1o2h65s = function _editedCell(Inputs){return(
 Inputs.input(null)
 )};
+const _7g3h7h = (G, _) => G.input(_);
 const _1urs1md = function _findCell($0,modules){return(
 (variable, dom = undefined) => {
   if (variable) {
@@ -5216,9 +5216,11 @@ Inputs.toggle({
   value: true
 })
 )};
+const _1h8337z = (G, _) => G.input(_);
 const _tct2nf = function _edit(Inputs){return(
 Inputs.toggle({ label: "edit" })
 )};
+const _7izj7k = (G, _) => G.input(_);
 const _1fwb5jc = function _toolbar(htl,reversibleAttach,combine,$0,$1,$2,$3,$4,$5,$6,$7){return(
 htl.html`<div
     class="toolbar"
@@ -5246,11 +5248,13 @@ Inputs.button("➕", {
   }
 })
 )};
+const _1aii9ps = (G, _) => G.input(_);
 const _1bn860e = function _remove(Inputs,deleteCell,$0){return(
 Inputs.button("🗑️", {
   reduce: () => deleteCell({ cell: $0.value })
 })
 )};
+const _1ad0xr8 = (G, _) => G.input(_);
 const _tw1j7n = function _apply(Inputs,compile_and_update,states,editedCell)
 {
   const button = Inputs.button("▶️", {
@@ -5269,11 +5273,13 @@ const _tw1j7n = function _apply(Inputs,compile_and_update,states,editedCell)
   button.onmousedown = (e) => e.preventDefault();
   return button;
 };
+const _1cjyuqm = (G, _) => G.input(_);
 const _14rfku9 = function _up(Inputs,moveCell,$0){return(
 Inputs.button("⬆", {
   reduce: () => moveCell($0.value, -1)
 })
 )};
+const _frzs5d = (G, _) => G.input(_);
 const _9pymuj = function _paste(Inputs,readObservableClipboardCells,pasteObservableCellsIntoModule,editedCell){return(
 Inputs.button("📋", {
   reduce: async () => {
@@ -5282,11 +5288,13 @@ Inputs.button("📋", {
   }
 })
 )};
+const _1whsszt = (G, _) => G.input(_);
 const _corxwl = function _down(Inputs,moveCell,$0){return(
 Inputs.button("⬇", {
   reduce: () => moveCell($0.value, 1)
 })
 )};
+const _1to28po = (G, _) => G.input(_);
 const _gia2ci = function _copy(Inputs,html,$0,decompile,$1,getOption,cellsToClipboard){return(
 Inputs.button(
   html`<span style="font-size: .875em; margin-right: .125em; position: relative; top: -.25em; left: -.125em">
@@ -5328,6 +5336,7 @@ Inputs.button(
   }
 )
 )};
+const _fw41wt = (G, _) => G.input(_);
 const _srtw8o = function _module(editedCell){return(
 editedCell.module.module
 )};
@@ -5382,6 +5391,7 @@ md`## API handler`
 const _d7ouqx = function _command(flowQueue){return(
 flowQueue()
 )};
+const _118qt2v = (G, _) => G.input(_);
 const _19l2nem = function _54(command){return(
 command
 )};
@@ -5654,10 +5664,10 @@ const _rtf009 = function _select(editedCell,Inputs,getOption,setOption){return(
   return el;
 })()
 )};
+const _14mwbuc = (G, _) => G.input(_);
 const _l4sbcd = function _70(md){return(
 md`## Pinning`
 )};
-const _1sxszb9 = (_, v) => v.import("getFileAttachment", _);
 const _ezl7wk = function _72(FileAttachment){return(
 FileAttachment("cell_options.json")
 )};
@@ -5667,6 +5677,7 @@ getFileAttachment("cell_options.json", editorModule)
 const _760ozq = async function _options(Inputs,optionsFile){return(
 Inputs.input(await optionsFile.json())
 )};
+const _4rh26k = (G, _) => G.input(_);
 const _1lqy7cs = function _setOption(findCell,_,$0,Event){return(
 (variable, option, value) => {
   const cell = findCell(variable);
@@ -5846,6 +5857,7 @@ const _1j3c2uf = function _decompiled(editedCell,decompile)
 const _w5q3yf = function _editorModule(thisModule){return(
 thisModule()
 )};
+const _18kaj2p = (G, _) => G.input(_);
 const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_options)
 {
   //editedCell;
@@ -5857,43 +5869,47 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1ju14cq = function _compile_and_update(compile,runtime,repositionSetElement){return(
-(source, variables = [], cell) => {
-    try {
-        debugger;
-        let reposition = false, insertionIndex = -1;
-        const newVariables = compile(source);
-        if (!variables || variables.length !== newVariables.length) {
-            reposition = true;
-            variables.forEach(v => v.delete());
-            variables.length = 0;
-            for (let i = 0; i < newVariables.length; i++) {
-                const newVariable = cell.module.module.variable({});
-                variables.push(newVariable);
+const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+{
+    return (source, variables = [], cell) => {
+        try {
+            debugger;
+            let reposition = false, insertionIndex = -1;
+            const newVariables = compile(source);
+            if (!variables || variables.length !== newVariables.length) {
+                reposition = true;
+                variables.forEach(v => v.delete());
+                variables.length = 0;
+                for (let i = 0; i < newVariables.length; i++) {
+                    const newVariable = cell.module.module.variable({});
+                    // Assign a random pid up-front so blank/identical new cells don't
+                    // collide via persistentId's contentHash. See lopecode#144.
+                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+                    variables.push(newVariable);
+                }
             }
-        }
-        if (reposition) {
-            insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-        }
-        newVariables.forEach((v, i) => {
-            const variable = variables[i];
-            let _fn;
-            eval('_fn = ' + v._definition);
-            if (v._name) {
-                variable.define(v._name, v._inputs, _fn);
-            } else {
-                variable.define(v._inputs, _fn);
+            if (reposition) {
+                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
-            if (reposition)
-                repositionSetElement(runtime._variables, variable, insertionIndex + i);
-        });
-        return variables;
-    } catch (e) {
-        console.error(e);
-        debugger;
-    }
-}
-)};
+            newVariables.forEach((v, i) => {
+                const variable = variables[i];
+                let _fn;
+                eval('_fn = ' + v._definition);
+                if (v._name) {
+                    variable.define(v._name, v._inputs, _fn);
+                } else {
+                    variable.define(v._inputs, _fn);
+                }
+                if (reposition)
+                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
+            });
+            return variables;
+        } catch (e) {
+            console.error(e);
+            debugger;
+        }
+    };
+};
 const _1jqs8in = function _91(md){return(
 md`### Remove Cells`
 )};
@@ -5912,6 +5928,7 @@ Inputs.radio(editedCell.variables, {
   value: editedCell.variables[0]
 })
 )};
+const _11gvkq4 = (G, _) => G.input(_);
 const _r5nvms = function _name(variable){return(
 variable._name
 )};
@@ -5925,6 +5942,7 @@ Inputs.textarea({
   rows: 10
 })
 )};
+const _b4rsn5 = (G, _) => G.input(_);
 const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
@@ -5938,22 +5956,12 @@ Inputs.button("update variable", {
 const _1q557s = function _99(md){return(
 md`### Editor Libraries`
 )};
-const _192vvs7 = (_, v) => v.import("descendants", _);
-const _3va6tf = (_, v) => v.import("EditorState", _);
-const _lmqjiv = (_, v) => v.import("decompile", _);
 const _1d94dks = function _javascriptPlugin(codemirror){return(
 codemirror
 )};
 const _ar9tao = function _104(md){return(
 md`### Libraries`
 )};
-const _viogn = (_, v) => v.import("reversibleAttach", _);
-const _nxg8mr = (_, v) => v.import("moduleMap", _);
-const _14a94d = (_, v) => v.import("flowQueue", _);
-const _gurtwb = (_, v) => v.import("viewof liveCellMap", _);
-const _19ebgtz = (_, v) => v.import("hash", _);
-const _n2vgkz = (_, v) => v.import("extractNotebookAndCell", _);
-const _1qucevb = (_, v) => v.import("cellsToClipboard", _);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -5967,22 +5975,34 @@ export default function define(runtime, observer) {
     return [name, {url: blob_url, mimeType: mime}]
   }));
   main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
+  main.define("module @tomlarkworthy/dataflow-templating", async () => runtime.module((await import("/@tomlarkworthy/dataflow-templating.js?v=4")).default));  
+  main.define("module @tomlarkworthy/fileattachments", async () => runtime.module((await import("/@tomlarkworthy/fileattachments.js?v=4")).default));  
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/codemirror-6-v2", async () => runtime.module((await import("/@tomlarkworthy/codemirror-6-v2.js?v=4")).default));  
+  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
+  main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
+  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
+  main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
+  main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
+  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
+  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
+  main.define("module @tomlarkworthy/cells-to-clipboard", async () => runtime.module((await import("/@tomlarkworthy/cells-to-clipboard.js?v=4")).default));  
   $def("_1tdjp0a", "title", ["md"], _1tdjp0a);  
   $def("_dm53bx", null, ["md"], _dm53bx);  
   $def("_61oxjf", "title_variable", ["lookupVariable","editorModule"], _61oxjf);  
   $def("_15uilf0", null, ["cellEditor","title_variable"], _15uilf0);  
   $def("_3x695f", null, ["md"], _3x695f);  
   $def("_1ociws4", null, ["md"], _1ociws4);  
-  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
   $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
-  main.variable(observer("attachContextManu")).define("attachContextManu", ["Generators", "viewof attachContextManu"], (G, _) => G.input(_));  
+  $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
   $def("_16ks4jz", null, ["md"], _16ks4jz);  
-  main.define("module @tomlarkworthy/dataflow-templating", async () => runtime.module((await import("/@tomlarkworthy/dataflow-templating.js?v=4")).default));  
   main.define("cloneDataflow", ["module @tomlarkworthy/dataflow-templating", "@variable"], (_, v) => v.import("cloneDataflow", _));  
   main.define("lookupVariable", ["module @tomlarkworthy/dataflow-templating", "@variable"], (_, v) => v.import("lookupVariable", _));  
   $def("_199ztvl", "hotbarTemplate", ["lookupVariable","editorModule"], _199ztvl);  
@@ -5993,7 +6013,7 @@ export default function define(runtime, observer) {
   $def("_110gwi7", "editorTemplate", ["lookupVariable","editorModule"], _110gwi7);  
   $def("_16rqzgl", null, ["md"], _16rqzgl);  
   $def("_1o2h65s", "viewof editedCell", ["Inputs"], _1o2h65s);  
-  main.variable(observer("editedCell")).define("editedCell", ["Generators", "viewof editedCell"], (G, _) => G.input(_));  
+  $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
   $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
@@ -6008,24 +6028,24 @@ export default function define(runtime, observer) {
   $def("_mrrmx3", null, ["md"], _mrrmx3);  
   $def("_14b1byw", null, ["md"], _14b1byw);  
   $def("_1j1loxx", "viewof combine", ["Inputs"], _1j1loxx);  
-  main.variable(observer("combine")).define("combine", ["Generators", "viewof combine"], (G, _) => G.input(_));  
+  $def("_1h8337z", "combine", ["Generators","viewof combine"], _1h8337z);  
   $def("_tct2nf", "viewof edit", ["Inputs"], _tct2nf);  
-  main.variable(observer("edit")).define("edit", ["Generators", "viewof edit"], (G, _) => G.input(_));  
+  $def("_7izj7k", "edit", ["Generators","viewof edit"], _7izj7k);  
   $def("_1fwb5jc", "toolbar", ["htl","reversibleAttach","combine","viewof select","viewof up","viewof down","viewof remove","viewof addCells","viewof apply","viewof copy","viewof paste"], _1fwb5jc);  
   $def("_yej3hb", "viewof addCells", ["Inputs","createCell","viewof editedCell"], _yej3hb);  
-  main.variable(observer("addCells")).define("addCells", ["Generators", "viewof addCells"], (G, _) => G.input(_));  
+  $def("_1aii9ps", "addCells", ["Generators","viewof addCells"], _1aii9ps);  
   $def("_1bn860e", "viewof remove", ["Inputs","deleteCell","viewof editedCell"], _1bn860e);  
-  main.variable(observer("remove")).define("remove", ["Generators", "viewof remove"], (G, _) => G.input(_));  
+  $def("_1ad0xr8", "remove", ["Generators","viewof remove"], _1ad0xr8);  
   $def("_tw1j7n", "viewof apply", ["Inputs","compile_and_update","states","editedCell"], _tw1j7n);  
-  main.variable(observer("apply")).define("apply", ["Generators", "viewof apply"], (G, _) => G.input(_));  
+  $def("_1cjyuqm", "apply", ["Generators","viewof apply"], _1cjyuqm);  
   $def("_14rfku9", "viewof up", ["Inputs","moveCell","viewof editedCell"], _14rfku9);  
-  main.variable(observer("up")).define("up", ["Generators", "viewof up"], (G, _) => G.input(_));  
+  $def("_frzs5d", "up", ["Generators","viewof up"], _frzs5d);  
   $def("_9pymuj", "viewof paste", ["Inputs","readObservableClipboardCells","pasteObservableCellsIntoModule","editedCell"], _9pymuj);  
-  main.variable(observer("paste")).define("paste", ["Generators", "viewof paste"], (G, _) => G.input(_));  
+  $def("_1whsszt", "paste", ["Generators","viewof paste"], _1whsszt);  
   $def("_corxwl", "viewof down", ["Inputs","moveCell","viewof editedCell"], _corxwl);  
-  main.variable(observer("down")).define("down", ["Generators", "viewof down"], (G, _) => G.input(_));  
+  $def("_1to28po", "down", ["Generators","viewof down"], _1to28po);  
   $def("_gia2ci", "viewof copy", ["Inputs","html","viewof editedCell","decompile","viewof liveCellMap","getOption","cellsToClipboard"], _gia2ci);  
-  main.variable(observer("copy")).define("copy", ["Generators", "viewof copy"], (G, _) => G.input(_));  
+  $def("_fw41wt", "copy", ["Generators","viewof copy"], _fw41wt);  
   $def("_srtw8o", "module", ["editedCell"], _srtw8o);  
   $def("_rv7t7x", "code_editor_view", ["EditorView"], _rv7t7x);  
   $def("_xvo1n6", "code_editor", ["code_editor_view"], _xvo1n6);  
@@ -6035,7 +6055,7 @@ export default function define(runtime, observer) {
   $def("_d9nzys", "deleteCell", ["viewof command"], _d9nzys);  
   $def("_c1u9w8", null, ["md"], _c1u9w8);  
   $def("_d7ouqx", "viewof command", ["flowQueue"], _d7ouqx);  
-  main.variable(observer("command")).define("command", ["Generators", "viewof command"], (G, _) => G.input(_));  
+  $def("_118qt2v", "command", ["Generators","viewof command"], _118qt2v);  
   $def("_19l2nem", null, ["command"], _19l2nem);  
   $def("_1f6v167", "findCellByVariable", [], _1f6v167);  
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
@@ -6052,9 +6072,8 @@ export default function define(runtime, observer) {
   $def("_dvne2z", "replaceCodeMirrorDoc", [], _dvne2z);  
   $def("_1fpqfm0", null, ["md"], _1fpqfm0);  
   $def("_rtf009", "viewof select", ["editedCell","Inputs","getOption","setOption"], _rtf009);  
-  main.variable(observer("select")).define("select", ["Generators", "viewof select"], (G, _) => G.input(_));  
+  $def("_14mwbuc", "select", ["Generators","viewof select"], _14mwbuc);  
   $def("_l4sbcd", null, ["md"], _l4sbcd);  
-  main.define("module @tomlarkworthy/fileattachments", async () => runtime.module((await import("/@tomlarkworthy/fileattachments.js?v=4")).default));  
   main.define("getFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachment", _));  
   main.define("setFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("setFileAttachment", _));  
   main.define("removeFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("removeFileAttachment", _));  
@@ -6063,7 +6082,7 @@ export default function define(runtime, observer) {
   $def("_ezl7wk", null, ["FileAttachment"], _ezl7wk);  
   $def("_kygz54", "optionsFile", ["getFileAttachment","editorModule"], _kygz54);  
   $def("_760ozq", "viewof options", ["Inputs","optionsFile"], _760ozq);  
-  main.variable(observer("options")).define("options", ["Generators", "viewof options"], (G, _) => G.input(_));  
+  $def("_4rh26k", "options", ["Generators","viewof options"], _4rh26k);  
   $def("_1lqy7cs", "setOption", ["findCell","_","viewof options","Event"], _1lqy7cs);  
   $def("_1oxe5ee", "getOption", ["findCell","_","viewof options"], _1oxe5ee);  
   $def("_kwq69p", "save_options", ["setFileAttachment","jsonFileAttachment","options","editorModule"], _kwq69p);  
@@ -6077,22 +6096,21 @@ export default function define(runtime, observer) {
   $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
   $def("_1j3c2uf", "decompiled", ["editedCell","decompile"], _1j3c2uf);  
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
-  main.variable(observer("editorModule")).define("editorModule", ["Generators", "viewof editorModule"], (G, _) => G.input(_));  
+  $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1ju14cq", "compile_and_update", ["compile","runtime","repositionSetElement"], _1ju14cq);  
+  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
   $def("_rwez9", "viewof variable", ["Inputs","editedCell"], _rwez9);  
-  main.variable(observer("variable")).define("variable", ["Generators", "viewof variable"], (G, _) => G.input(_));  
+  $def("_11gvkq4", "variable", ["Generators","viewof variable"], _11gvkq4);  
   $def("_r5nvms", "name", ["variable"], _r5nvms);  
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
-  main.variable(observer("definition")).define("definition", ["Generators", "viewof definition"], (G, _) => G.input(_));  
+  $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
   $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
   $def("_1q557s", null, ["md"], _1q557s);  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -6103,12 +6121,10 @@ export default function define(runtime, observer) {
   main.define("isnode", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("isnode", _));  
   main.define("repositionSetElement", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("repositionSetElement", _));  
   main.define("onCodeChange", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("onCodeChange", _));  
-  main.define("module @tomlarkworthy/codemirror-6-v2", async () => runtime.module((await import("/@tomlarkworthy/codemirror-6-v2.js?v=4")).default));  
   main.define("EditorState", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("EditorState", _));  
   main.define("EditorView", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("EditorView", _));  
   main.define("codemirror", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("codemirror", _));  
   main.define("myDefaultTheme", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("myDefaultTheme", _));  
-  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
   main.define("decompile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("decompile", _));  
   main.define("compile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("compile", _));  
   main.define("cellMap", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("cellMap", _));  
@@ -6117,27 +6133,21 @@ export default function define(runtime, observer) {
   main.define("parser", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("parser", _));  
   $def("_1d94dks", "javascriptPlugin", ["codemirror"], _1d94dks);  
   $def("_ar9tao", null, ["md"], _ar9tao);  
-  main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
   main.define("reversibleAttach", ["module @tomlarkworthy/reversible-attachment", "@variable"], (_, v) => v.import("reversibleAttach", _));  
-  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
   main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
-  main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
   main.define("flowQueue", ["module @tomlarkworthy/flow-queue", "@variable"], (_, v) => v.import("flowQueue", _));  
-  main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
   main.define("viewof liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("viewof liveCellMap", _));  
   main.define("liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("liveCellMap", _));  
-  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
   main.define("hash", ["module d/57d79353bac56631@44", "@variable"], (_, v) => v.import("hash", _));  
-  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
   main.define("extractNotebookAndCell", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("extractNotebookAndCell", _));  
   main.define("navHref", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("navHref", _));  
-  main.define("module @tomlarkworthy/cells-to-clipboard", async () => runtime.module((await import("/@tomlarkworthy/cells-to-clipboard.js?v=4")).default));  
   main.define("cellsToClipboard", ["module @tomlarkworthy/cells-to-clipboard", "@variable"], (_, v) => v.import("cellsToClipboard", _));
   return main;
-}</script>
+}
+</script>
 <script id="@tomlarkworthy/escodegen/escodegen.browser.min.js.gz" 
   type="text/plain"
   data-encoding="base64"

--- a/notebooks/@tomlarkworthy_visualizer.html
+++ b/notebooks/@tomlarkworthy_visualizer.html
@@ -4690,7 +4690,7 @@ export default function define(runtime, observer) {
 >
 e30K
 </script>
-<script id="@tomlarkworthy/editor-5" 
+<script id="@tomlarkworthy/editor-5"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -4737,7 +4737,6 @@ md`## TODO
 const _1ociws4 = function _6(md){return(
 md`## Sync editors`
 )};
-const _1vq49kx = (_, v) => v.import("syncers", _);
 const _hdieof = function _editors(){return(
 new Map()
 )};
@@ -4815,12 +4814,12 @@ Inputs.toggle({
   value: !isOnObservableCom()
 })
 )};
+const _1oaz8r1 = (G, _) => G.input(_);
 const _16ks4jz = function _12(md){return(
 md`## \`cellEditor\` component
 
 Using Dataflow templating to create reusable Hotbar Component builder`
 )};
-const _1deps8p = (_, v) => v.import("cloneDataflow", _);
 const _199ztvl = function _hotbarTemplate(lookupVariable,editorModule){return(
 lookupVariable(
   [
@@ -5057,6 +5056,7 @@ md`## Hotbar Prototype`
 const _1o2h65s = function _editedCell(Inputs){return(
 Inputs.input(null)
 )};
+const _7g3h7h = (G, _) => G.input(_);
 const _1urs1md = function _findCell($0,modules){return(
 (variable, dom = undefined) => {
   if (variable) {
@@ -5216,9 +5216,11 @@ Inputs.toggle({
   value: true
 })
 )};
+const _1h8337z = (G, _) => G.input(_);
 const _tct2nf = function _edit(Inputs){return(
 Inputs.toggle({ label: "edit" })
 )};
+const _7izj7k = (G, _) => G.input(_);
 const _1fwb5jc = function _toolbar(htl,reversibleAttach,combine,$0,$1,$2,$3,$4,$5,$6,$7){return(
 htl.html`<div
     class="toolbar"
@@ -5246,11 +5248,13 @@ Inputs.button("➕", {
   }
 })
 )};
+const _1aii9ps = (G, _) => G.input(_);
 const _1bn860e = function _remove(Inputs,deleteCell,$0){return(
 Inputs.button("🗑️", {
   reduce: () => deleteCell({ cell: $0.value })
 })
 )};
+const _1ad0xr8 = (G, _) => G.input(_);
 const _tw1j7n = function _apply(Inputs,compile_and_update,states,editedCell)
 {
   const button = Inputs.button("▶️", {
@@ -5269,11 +5273,13 @@ const _tw1j7n = function _apply(Inputs,compile_and_update,states,editedCell)
   button.onmousedown = (e) => e.preventDefault();
   return button;
 };
+const _1cjyuqm = (G, _) => G.input(_);
 const _14rfku9 = function _up(Inputs,moveCell,$0){return(
 Inputs.button("⬆", {
   reduce: () => moveCell($0.value, -1)
 })
 )};
+const _frzs5d = (G, _) => G.input(_);
 const _9pymuj = function _paste(Inputs,readObservableClipboardCells,pasteObservableCellsIntoModule,editedCell){return(
 Inputs.button("📋", {
   reduce: async () => {
@@ -5282,11 +5288,13 @@ Inputs.button("📋", {
   }
 })
 )};
+const _1whsszt = (G, _) => G.input(_);
 const _corxwl = function _down(Inputs,moveCell,$0){return(
 Inputs.button("⬇", {
   reduce: () => moveCell($0.value, 1)
 })
 )};
+const _1to28po = (G, _) => G.input(_);
 const _gia2ci = function _copy(Inputs,html,$0,decompile,$1,getOption,cellsToClipboard){return(
 Inputs.button(
   html`<span style="font-size: .875em; margin-right: .125em; position: relative; top: -.25em; left: -.125em">
@@ -5328,6 +5336,7 @@ Inputs.button(
   }
 )
 )};
+const _fw41wt = (G, _) => G.input(_);
 const _srtw8o = function _module(editedCell){return(
 editedCell.module.module
 )};
@@ -5382,6 +5391,7 @@ md`## API handler`
 const _d7ouqx = function _command(flowQueue){return(
 flowQueue()
 )};
+const _118qt2v = (G, _) => G.input(_);
 const _19l2nem = function _54(command){return(
 command
 )};
@@ -5654,10 +5664,10 @@ const _rtf009 = function _select(editedCell,Inputs,getOption,setOption){return(
   return el;
 })()
 )};
+const _14mwbuc = (G, _) => G.input(_);
 const _l4sbcd = function _70(md){return(
 md`## Pinning`
 )};
-const _1sxszb9 = (_, v) => v.import("getFileAttachment", _);
 const _ezl7wk = function _72(FileAttachment){return(
 FileAttachment("cell_options.json")
 )};
@@ -5667,6 +5677,7 @@ getFileAttachment("cell_options.json", editorModule)
 const _760ozq = async function _options(Inputs,optionsFile){return(
 Inputs.input(await optionsFile.json())
 )};
+const _4rh26k = (G, _) => G.input(_);
 const _1lqy7cs = function _setOption(findCell,_,$0,Event){return(
 (variable, option, value) => {
   const cell = findCell(variable);
@@ -5846,6 +5857,7 @@ const _1j3c2uf = function _decompiled(editedCell,decompile)
 const _w5q3yf = function _editorModule(thisModule){return(
 thisModule()
 )};
+const _18kaj2p = (G, _) => G.input(_);
 const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_options)
 {
   //editedCell;
@@ -5857,43 +5869,47 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1ju14cq = function _compile_and_update(compile,runtime,repositionSetElement){return(
-(source, variables = [], cell) => {
-    try {
-        debugger;
-        let reposition = false, insertionIndex = -1;
-        const newVariables = compile(source);
-        if (!variables || variables.length !== newVariables.length) {
-            reposition = true;
-            variables.forEach(v => v.delete());
-            variables.length = 0;
-            for (let i = 0; i < newVariables.length; i++) {
-                const newVariable = cell.module.module.variable({});
-                variables.push(newVariable);
+const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+{
+    return (source, variables = [], cell) => {
+        try {
+            debugger;
+            let reposition = false, insertionIndex = -1;
+            const newVariables = compile(source);
+            if (!variables || variables.length !== newVariables.length) {
+                reposition = true;
+                variables.forEach(v => v.delete());
+                variables.length = 0;
+                for (let i = 0; i < newVariables.length; i++) {
+                    const newVariable = cell.module.module.variable({});
+                    // Assign a random pid up-front so blank/identical new cells don't
+                    // collide via persistentId's contentHash. See lopecode#144.
+                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+                    variables.push(newVariable);
+                }
             }
-        }
-        if (reposition) {
-            insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-        }
-        newVariables.forEach((v, i) => {
-            const variable = variables[i];
-            let _fn;
-            eval('_fn = ' + v._definition);
-            if (v._name) {
-                variable.define(v._name, v._inputs, _fn);
-            } else {
-                variable.define(v._inputs, _fn);
+            if (reposition) {
+                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
-            if (reposition)
-                repositionSetElement(runtime._variables, variable, insertionIndex + i);
-        });
-        return variables;
-    } catch (e) {
-        console.error(e);
-        debugger;
-    }
-}
-)};
+            newVariables.forEach((v, i) => {
+                const variable = variables[i];
+                let _fn;
+                eval('_fn = ' + v._definition);
+                if (v._name) {
+                    variable.define(v._name, v._inputs, _fn);
+                } else {
+                    variable.define(v._inputs, _fn);
+                }
+                if (reposition)
+                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
+            });
+            return variables;
+        } catch (e) {
+            console.error(e);
+            debugger;
+        }
+    };
+};
 const _1jqs8in = function _91(md){return(
 md`### Remove Cells`
 )};
@@ -5912,6 +5928,7 @@ Inputs.radio(editedCell.variables, {
   value: editedCell.variables[0]
 })
 )};
+const _11gvkq4 = (G, _) => G.input(_);
 const _r5nvms = function _name(variable){return(
 variable._name
 )};
@@ -5925,6 +5942,7 @@ Inputs.textarea({
   rows: 10
 })
 )};
+const _b4rsn5 = (G, _) => G.input(_);
 const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
@@ -5938,22 +5956,12 @@ Inputs.button("update variable", {
 const _1q557s = function _99(md){return(
 md`### Editor Libraries`
 )};
-const _192vvs7 = (_, v) => v.import("descendants", _);
-const _3va6tf = (_, v) => v.import("EditorState", _);
-const _lmqjiv = (_, v) => v.import("decompile", _);
 const _1d94dks = function _javascriptPlugin(codemirror){return(
 codemirror
 )};
 const _ar9tao = function _104(md){return(
 md`### Libraries`
 )};
-const _viogn = (_, v) => v.import("reversibleAttach", _);
-const _nxg8mr = (_, v) => v.import("moduleMap", _);
-const _14a94d = (_, v) => v.import("flowQueue", _);
-const _gurtwb = (_, v) => v.import("viewof liveCellMap", _);
-const _19ebgtz = (_, v) => v.import("hash", _);
-const _n2vgkz = (_, v) => v.import("extractNotebookAndCell", _);
-const _1qucevb = (_, v) => v.import("cellsToClipboard", _);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -5967,22 +5975,34 @@ export default function define(runtime, observer) {
     return [name, {url: blob_url, mimeType: mime}]
   }));
   main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
+  main.define("module @tomlarkworthy/dataflow-templating", async () => runtime.module((await import("/@tomlarkworthy/dataflow-templating.js?v=4")).default));  
+  main.define("module @tomlarkworthy/fileattachments", async () => runtime.module((await import("/@tomlarkworthy/fileattachments.js?v=4")).default));  
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/codemirror-6-v2", async () => runtime.module((await import("/@tomlarkworthy/codemirror-6-v2.js?v=4")).default));  
+  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
+  main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
+  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
+  main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
+  main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
+  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
+  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
+  main.define("module @tomlarkworthy/cells-to-clipboard", async () => runtime.module((await import("/@tomlarkworthy/cells-to-clipboard.js?v=4")).default));  
   $def("_1tdjp0a", "title", ["md"], _1tdjp0a);  
   $def("_dm53bx", null, ["md"], _dm53bx);  
   $def("_61oxjf", "title_variable", ["lookupVariable","editorModule"], _61oxjf);  
   $def("_15uilf0", null, ["cellEditor","title_variable"], _15uilf0);  
   $def("_3x695f", null, ["md"], _3x695f);  
   $def("_1ociws4", null, ["md"], _1ociws4);  
-  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
   $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
-  main.variable(observer("attachContextManu")).define("attachContextManu", ["Generators", "viewof attachContextManu"], (G, _) => G.input(_));  
+  $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
   $def("_16ks4jz", null, ["md"], _16ks4jz);  
-  main.define("module @tomlarkworthy/dataflow-templating", async () => runtime.module((await import("/@tomlarkworthy/dataflow-templating.js?v=4")).default));  
   main.define("cloneDataflow", ["module @tomlarkworthy/dataflow-templating", "@variable"], (_, v) => v.import("cloneDataflow", _));  
   main.define("lookupVariable", ["module @tomlarkworthy/dataflow-templating", "@variable"], (_, v) => v.import("lookupVariable", _));  
   $def("_199ztvl", "hotbarTemplate", ["lookupVariable","editorModule"], _199ztvl);  
@@ -5993,7 +6013,7 @@ export default function define(runtime, observer) {
   $def("_110gwi7", "editorTemplate", ["lookupVariable","editorModule"], _110gwi7);  
   $def("_16rqzgl", null, ["md"], _16rqzgl);  
   $def("_1o2h65s", "viewof editedCell", ["Inputs"], _1o2h65s);  
-  main.variable(observer("editedCell")).define("editedCell", ["Generators", "viewof editedCell"], (G, _) => G.input(_));  
+  $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
   $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
@@ -6008,24 +6028,24 @@ export default function define(runtime, observer) {
   $def("_mrrmx3", null, ["md"], _mrrmx3);  
   $def("_14b1byw", null, ["md"], _14b1byw);  
   $def("_1j1loxx", "viewof combine", ["Inputs"], _1j1loxx);  
-  main.variable(observer("combine")).define("combine", ["Generators", "viewof combine"], (G, _) => G.input(_));  
+  $def("_1h8337z", "combine", ["Generators","viewof combine"], _1h8337z);  
   $def("_tct2nf", "viewof edit", ["Inputs"], _tct2nf);  
-  main.variable(observer("edit")).define("edit", ["Generators", "viewof edit"], (G, _) => G.input(_));  
+  $def("_7izj7k", "edit", ["Generators","viewof edit"], _7izj7k);  
   $def("_1fwb5jc", "toolbar", ["htl","reversibleAttach","combine","viewof select","viewof up","viewof down","viewof remove","viewof addCells","viewof apply","viewof copy","viewof paste"], _1fwb5jc);  
   $def("_yej3hb", "viewof addCells", ["Inputs","createCell","viewof editedCell"], _yej3hb);  
-  main.variable(observer("addCells")).define("addCells", ["Generators", "viewof addCells"], (G, _) => G.input(_));  
+  $def("_1aii9ps", "addCells", ["Generators","viewof addCells"], _1aii9ps);  
   $def("_1bn860e", "viewof remove", ["Inputs","deleteCell","viewof editedCell"], _1bn860e);  
-  main.variable(observer("remove")).define("remove", ["Generators", "viewof remove"], (G, _) => G.input(_));  
+  $def("_1ad0xr8", "remove", ["Generators","viewof remove"], _1ad0xr8);  
   $def("_tw1j7n", "viewof apply", ["Inputs","compile_and_update","states","editedCell"], _tw1j7n);  
-  main.variable(observer("apply")).define("apply", ["Generators", "viewof apply"], (G, _) => G.input(_));  
+  $def("_1cjyuqm", "apply", ["Generators","viewof apply"], _1cjyuqm);  
   $def("_14rfku9", "viewof up", ["Inputs","moveCell","viewof editedCell"], _14rfku9);  
-  main.variable(observer("up")).define("up", ["Generators", "viewof up"], (G, _) => G.input(_));  
+  $def("_frzs5d", "up", ["Generators","viewof up"], _frzs5d);  
   $def("_9pymuj", "viewof paste", ["Inputs","readObservableClipboardCells","pasteObservableCellsIntoModule","editedCell"], _9pymuj);  
-  main.variable(observer("paste")).define("paste", ["Generators", "viewof paste"], (G, _) => G.input(_));  
+  $def("_1whsszt", "paste", ["Generators","viewof paste"], _1whsszt);  
   $def("_corxwl", "viewof down", ["Inputs","moveCell","viewof editedCell"], _corxwl);  
-  main.variable(observer("down")).define("down", ["Generators", "viewof down"], (G, _) => G.input(_));  
+  $def("_1to28po", "down", ["Generators","viewof down"], _1to28po);  
   $def("_gia2ci", "viewof copy", ["Inputs","html","viewof editedCell","decompile","viewof liveCellMap","getOption","cellsToClipboard"], _gia2ci);  
-  main.variable(observer("copy")).define("copy", ["Generators", "viewof copy"], (G, _) => G.input(_));  
+  $def("_fw41wt", "copy", ["Generators","viewof copy"], _fw41wt);  
   $def("_srtw8o", "module", ["editedCell"], _srtw8o);  
   $def("_rv7t7x", "code_editor_view", ["EditorView"], _rv7t7x);  
   $def("_xvo1n6", "code_editor", ["code_editor_view"], _xvo1n6);  
@@ -6035,7 +6055,7 @@ export default function define(runtime, observer) {
   $def("_d9nzys", "deleteCell", ["viewof command"], _d9nzys);  
   $def("_c1u9w8", null, ["md"], _c1u9w8);  
   $def("_d7ouqx", "viewof command", ["flowQueue"], _d7ouqx);  
-  main.variable(observer("command")).define("command", ["Generators", "viewof command"], (G, _) => G.input(_));  
+  $def("_118qt2v", "command", ["Generators","viewof command"], _118qt2v);  
   $def("_19l2nem", null, ["command"], _19l2nem);  
   $def("_1f6v167", "findCellByVariable", [], _1f6v167);  
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
@@ -6052,9 +6072,8 @@ export default function define(runtime, observer) {
   $def("_dvne2z", "replaceCodeMirrorDoc", [], _dvne2z);  
   $def("_1fpqfm0", null, ["md"], _1fpqfm0);  
   $def("_rtf009", "viewof select", ["editedCell","Inputs","getOption","setOption"], _rtf009);  
-  main.variable(observer("select")).define("select", ["Generators", "viewof select"], (G, _) => G.input(_));  
+  $def("_14mwbuc", "select", ["Generators","viewof select"], _14mwbuc);  
   $def("_l4sbcd", null, ["md"], _l4sbcd);  
-  main.define("module @tomlarkworthy/fileattachments", async () => runtime.module((await import("/@tomlarkworthy/fileattachments.js?v=4")).default));  
   main.define("getFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachment", _));  
   main.define("setFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("setFileAttachment", _));  
   main.define("removeFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("removeFileAttachment", _));  
@@ -6063,7 +6082,7 @@ export default function define(runtime, observer) {
   $def("_ezl7wk", null, ["FileAttachment"], _ezl7wk);  
   $def("_kygz54", "optionsFile", ["getFileAttachment","editorModule"], _kygz54);  
   $def("_760ozq", "viewof options", ["Inputs","optionsFile"], _760ozq);  
-  main.variable(observer("options")).define("options", ["Generators", "viewof options"], (G, _) => G.input(_));  
+  $def("_4rh26k", "options", ["Generators","viewof options"], _4rh26k);  
   $def("_1lqy7cs", "setOption", ["findCell","_","viewof options","Event"], _1lqy7cs);  
   $def("_1oxe5ee", "getOption", ["findCell","_","viewof options"], _1oxe5ee);  
   $def("_kwq69p", "save_options", ["setFileAttachment","jsonFileAttachment","options","editorModule"], _kwq69p);  
@@ -6077,22 +6096,21 @@ export default function define(runtime, observer) {
   $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
   $def("_1j3c2uf", "decompiled", ["editedCell","decompile"], _1j3c2uf);  
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
-  main.variable(observer("editorModule")).define("editorModule", ["Generators", "viewof editorModule"], (G, _) => G.input(_));  
+  $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1ju14cq", "compile_and_update", ["compile","runtime","repositionSetElement"], _1ju14cq);  
+  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
   $def("_rwez9", "viewof variable", ["Inputs","editedCell"], _rwez9);  
-  main.variable(observer("variable")).define("variable", ["Generators", "viewof variable"], (G, _) => G.input(_));  
+  $def("_11gvkq4", "variable", ["Generators","viewof variable"], _11gvkq4);  
   $def("_r5nvms", "name", ["variable"], _r5nvms);  
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
-  main.variable(observer("definition")).define("definition", ["Generators", "viewof definition"], (G, _) => G.input(_));  
+  $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
   $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
   $def("_1q557s", null, ["md"], _1q557s);  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -6103,12 +6121,10 @@ export default function define(runtime, observer) {
   main.define("isnode", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("isnode", _));  
   main.define("repositionSetElement", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("repositionSetElement", _));  
   main.define("onCodeChange", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("onCodeChange", _));  
-  main.define("module @tomlarkworthy/codemirror-6-v2", async () => runtime.module((await import("/@tomlarkworthy/codemirror-6-v2.js?v=4")).default));  
   main.define("EditorState", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("EditorState", _));  
   main.define("EditorView", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("EditorView", _));  
   main.define("codemirror", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("codemirror", _));  
   main.define("myDefaultTheme", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("myDefaultTheme", _));  
-  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
   main.define("decompile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("decompile", _));  
   main.define("compile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("compile", _));  
   main.define("cellMap", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("cellMap", _));  
@@ -6117,27 +6133,21 @@ export default function define(runtime, observer) {
   main.define("parser", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("parser", _));  
   $def("_1d94dks", "javascriptPlugin", ["codemirror"], _1d94dks);  
   $def("_ar9tao", null, ["md"], _ar9tao);  
-  main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
   main.define("reversibleAttach", ["module @tomlarkworthy/reversible-attachment", "@variable"], (_, v) => v.import("reversibleAttach", _));  
-  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
   main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
-  main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
   main.define("flowQueue", ["module @tomlarkworthy/flow-queue", "@variable"], (_, v) => v.import("flowQueue", _));  
-  main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
   main.define("viewof liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("viewof liveCellMap", _));  
   main.define("liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("liveCellMap", _));  
-  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
   main.define("hash", ["module d/57d79353bac56631@44", "@variable"], (_, v) => v.import("hash", _));  
-  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
   main.define("extractNotebookAndCell", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("extractNotebookAndCell", _));  
   main.define("navHref", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("navHref", _));  
-  main.define("module @tomlarkworthy/cells-to-clipboard", async () => runtime.module((await import("/@tomlarkworthy/cells-to-clipboard.js?v=4")).default));  
   main.define("cellsToClipboard", ["module @tomlarkworthy/cells-to-clipboard", "@variable"], (_, v) => v.import("cellsToClipboard", _));
   return main;
-}</script>
+}
+</script>
 <script id="@tomlarkworthy/escodegen/escodegen.browser.min.js.gz" 
   type="text/plain"
   data-encoding="base64"

--- a/notebooks/atproto.html
+++ b/notebooks/atproto.html
@@ -5683,7 +5683,7 @@ export default function define(runtime, observer) {
 >
 eyJAdG9tbGFya3dvcnRoeS9ibGFuay1ub3RlYm9vayI6eyJ2aWV3b2YgbG9naW5DbGljayI6eyJwaW5uZWQiOnRydWV9fSwiQHRvbWxhcmt3b3J0aHkvYXQtcmVhZCI6W251bGwseyJwaW5uZWQiOmZhbHNlfV0sIkB0b21sYXJrd29ydGh5L2F0cHJvdG8iOlt7InBpbm5lZCI6dHJ1ZX0seyJwaW5uZWQiOnRydWV9LG51bGwseyJwaW5uZWQiOmZhbHNlfV19
 </script>
-<script id="@tomlarkworthy/editor-5" 
+<script id="@tomlarkworthy/editor-5"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -6862,43 +6862,47 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1ju14cq = function _compile_and_update(compile,runtime,repositionSetElement){return(
-(source, variables = [], cell) => {
-    try {
-        debugger;
-        let reposition = false, insertionIndex = -1;
-        const newVariables = compile(source);
-        if (!variables || variables.length !== newVariables.length) {
-            reposition = true;
-            variables.forEach(v => v.delete());
-            variables.length = 0;
-            for (let i = 0; i < newVariables.length; i++) {
-                const newVariable = cell.module.module.variable({});
-                variables.push(newVariable);
+const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+{
+    return (source, variables = [], cell) => {
+        try {
+            debugger;
+            let reposition = false, insertionIndex = -1;
+            const newVariables = compile(source);
+            if (!variables || variables.length !== newVariables.length) {
+                reposition = true;
+                variables.forEach(v => v.delete());
+                variables.length = 0;
+                for (let i = 0; i < newVariables.length; i++) {
+                    const newVariable = cell.module.module.variable({});
+                    // Assign a random pid up-front so blank/identical new cells don't
+                    // collide via persistentId's contentHash. See lopecode#144.
+                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+                    variables.push(newVariable);
+                }
             }
-        }
-        if (reposition) {
-            insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-        }
-        newVariables.forEach((v, i) => {
-            const variable = variables[i];
-            let _fn;
-            eval('_fn = ' + v._definition);
-            if (v._name) {
-                variable.define(v._name, v._inputs, _fn);
-            } else {
-                variable.define(v._inputs, _fn);
+            if (reposition) {
+                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
-            if (reposition)
-                repositionSetElement(runtime._variables, variable, insertionIndex + i);
-        });
-        return variables;
-    } catch (e) {
-        console.error(e);
-        debugger;
-    }
-}
-)};
+            newVariables.forEach((v, i) => {
+                const variable = variables[i];
+                let _fn;
+                eval('_fn = ' + v._definition);
+                if (v._name) {
+                    variable.define(v._name, v._inputs, _fn);
+                } else {
+                    variable.define(v._inputs, _fn);
+                }
+                if (reposition)
+                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
+            });
+            return variables;
+        } catch (e) {
+            console.error(e);
+            debugger;
+        }
+    };
+};
 const _1jqs8in = function _91(md){return(
 md`### Remove Cells`
 )};
@@ -6965,13 +6969,25 @@ export default function define(runtime, observer) {
   }));
   main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
 
+  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
+  main.define("module @tomlarkworthy/dataflow-templating", async () => runtime.module((await import("/@tomlarkworthy/dataflow-templating.js?v=4")).default));  
+  main.define("module @tomlarkworthy/fileattachments", async () => runtime.module((await import("/@tomlarkworthy/fileattachments.js?v=4")).default));  
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/codemirror-6-v2", async () => runtime.module((await import("/@tomlarkworthy/codemirror-6-v2.js?v=4")).default));  
+  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
+  main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
+  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
+  main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
+  main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
+  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
+  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
+  main.define("module @tomlarkworthy/cells-to-clipboard", async () => runtime.module((await import("/@tomlarkworthy/cells-to-clipboard.js?v=4")).default));  
   $def("_1tdjp0a", "title", ["md"], _1tdjp0a);  
   $def("_dm53bx", null, ["md"], _dm53bx);  
   $def("_61oxjf", "title_variable", ["lookupVariable","editorModule"], _61oxjf);  
   $def("_15uilf0", null, ["cellEditor","title_variable"], _15uilf0);  
   $def("_3x695f", null, ["md"], _3x695f);  
   $def("_1ociws4", null, ["md"], _1ociws4);  
-  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
@@ -6980,7 +6996,6 @@ export default function define(runtime, observer) {
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
   $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
   $def("_16ks4jz", null, ["md"], _16ks4jz);  
-  main.define("module @tomlarkworthy/dataflow-templating", async () => runtime.module((await import("/@tomlarkworthy/dataflow-templating.js?v=4")).default));  
   main.define("cloneDataflow", ["module @tomlarkworthy/dataflow-templating", "@variable"], (_, v) => v.import("cloneDataflow", _));  
   main.define("lookupVariable", ["module @tomlarkworthy/dataflow-templating", "@variable"], (_, v) => v.import("lookupVariable", _));  
   $def("_199ztvl", "hotbarTemplate", ["lookupVariable","editorModule"], _199ztvl);  
@@ -7052,7 +7067,6 @@ export default function define(runtime, observer) {
   $def("_rtf009", "viewof select", ["editedCell","Inputs","getOption","setOption"], _rtf009);  
   $def("_14mwbuc", "select", ["Generators","viewof select"], _14mwbuc);  
   $def("_l4sbcd", null, ["md"], _l4sbcd);  
-  main.define("module @tomlarkworthy/fileattachments", async () => runtime.module((await import("/@tomlarkworthy/fileattachments.js?v=4")).default));  
   main.define("getFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachment", _));  
   main.define("setFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("setFileAttachment", _));  
   main.define("removeFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("removeFileAttachment", _));  
@@ -7078,7 +7092,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1ju14cq", "compile_and_update", ["compile","runtime","repositionSetElement"], _1ju14cq);  
+  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -7090,7 +7104,6 @@ export default function define(runtime, observer) {
   $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
   $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
   $def("_1q557s", null, ["md"], _1q557s);  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -7101,12 +7114,10 @@ export default function define(runtime, observer) {
   main.define("isnode", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("isnode", _));  
   main.define("repositionSetElement", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("repositionSetElement", _));  
   main.define("onCodeChange", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("onCodeChange", _));  
-  main.define("module @tomlarkworthy/codemirror-6-v2", async () => runtime.module((await import("/@tomlarkworthy/codemirror-6-v2.js?v=4")).default));  
   main.define("EditorState", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("EditorState", _));  
   main.define("EditorView", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("EditorView", _));  
   main.define("codemirror", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("codemirror", _));  
   main.define("myDefaultTheme", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("myDefaultTheme", _));  
-  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
   main.define("decompile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("decompile", _));  
   main.define("compile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("compile", _));  
   main.define("cellMap", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("cellMap", _));  
@@ -7115,27 +7126,21 @@ export default function define(runtime, observer) {
   main.define("parser", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("parser", _));  
   $def("_1d94dks", "javascriptPlugin", ["codemirror"], _1d94dks);  
   $def("_ar9tao", null, ["md"], _ar9tao);  
-  main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
   main.define("reversibleAttach", ["module @tomlarkworthy/reversible-attachment", "@variable"], (_, v) => v.import("reversibleAttach", _));  
-  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
   main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
-  main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
   main.define("flowQueue", ["module @tomlarkworthy/flow-queue", "@variable"], (_, v) => v.import("flowQueue", _));  
-  main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
   main.define("viewof liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("viewof liveCellMap", _));  
   main.define("liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("liveCellMap", _));  
-  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
   main.define("hash", ["module d/57d79353bac56631@44", "@variable"], (_, v) => v.import("hash", _));  
-  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
   main.define("extractNotebookAndCell", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("extractNotebookAndCell", _));  
   main.define("navHref", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("navHref", _));  
-  main.define("module @tomlarkworthy/cells-to-clipboard", async () => runtime.module((await import("/@tomlarkworthy/cells-to-clipboard.js?v=4")).default));  
   main.define("cellsToClipboard", ["module @tomlarkworthy/cells-to-clipboard", "@variable"], (_, v) => v.import("cellsToClipboard", _));
   return main;
-}</script>
+}
+</script>
 <script id="@tomlarkworthy/escodegen/escodegen.browser.min.js.gz" 
   type="text/plain"
   data-encoding="base64"


### PR DESCRIPTION
Fixes tomlarkworthy/lopecode#144.

## Root cause
`@tomlarkworthy/runtime-sdk`'s `persistentId(v)` lazily hashes `v._name + v._definition.toString()` on first call. Two blank cells freshly created by the editor-5 toolbar `➕` button both have `_name: null` and the empty `function _anonymous() {\n}` definition, so they hash to the same pid. `local-change-history` keys its replay-state map by pid — collisions silently overwrite each other, and on refresh only the most recently added cell survives.

## Fix
Patch `@tomlarkworthy/editor-5`'s `compile_and_update` so every freshly-created `module.variable({})` is assigned a random `_<base36>` pid up-front. `persistentId`'s `if (!v.pid)` guard then preserves the pre-assigned id instead of computing the colliding contentHash.

The same branch already runs for paste-with-different-structure, where two identical pasted cells would also have collided — they now also get distinct pids.

## Files regenerated
- Canonical: `notebooks/@tomlarkworthy_editor-5.html` (re-jumpgated from Observable after pushing the patched cell)
- 39 consumer notebooks in `lopecode/notebooks/` re-synced with the regenerated `<script id="@tomlarkworthy/editor-5">` block via `tools/channel/sync-module.ts`

Companion lopebooks PR: https://github.com/tomlarkworthy/lopebooks/pull/new/fix/issue-144-pid-collision-blank-cells (150 consumer notebooks).

## Targeted QA
Reproduced on canonical reload, then verified the patch:
- Before fix: two clicks of `➕` → history shows both rows with **identical** `pid: "_1nvapr1"` (collision confirmed; replay would collapse them).
- After fix on live runtime: `pid: "_sn7jviq"` and `_4c7vefk` — distinct.
- After fix on freshly jumpgated canonical (clean reload): `pid: "_f8m9wim"` and `_oq7pfn8` — distinct.
- Console: clean (only pre-existing CSS `@import` warnings; the `selectVariable is not a function` error is also pre-existing — appeared in jumpgate logs prior to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)