### PR TITLE
Fix: linkTo drops view= so module-selection clicks accumulate tabs (#150)

### DIFF
--- a/notebooks/@tomlarkworthy_atlas.html
+++ b/notebooks/@tomlarkworthy_atlas.html
@@ -15092,7 +15092,7 @@ export default function define(runtime, observer) {
   return main;
 }</script>
 
-<script id="@tomlarkworthy/lopepage-urls" 
+<script id="@tomlarkworthy/lopepage-urls"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -15443,78 +15443,71 @@ const _gxaxgb = function _links(){return(
 const _17e89y0 = function _targets(){return(
 ["@tom/bar", "d/1f41fef8b019cf4e@94", "@tom/bar#cell"]
 )};
-const _1x6cut = function _linkTo(isOnObservableCom){return(
-function linkTo(
-  target,
-  {
-    baseURI = document.baseURI,
-    onObservable = isOnObservableCom(),
-    source = null,
-    op = "open" // "open" | "close" | "focus"
-  } = {}
-) {
-  if (onObservable) {
-    const t =
-      typeof target === "string"
-        ? target
-        : target?.module || target?.open || target?.close || "";
-    return t.startsWith("#") ? t : "/" + t;
-  }
-
-  // Parse existing hash params manually to avoid percent-encoding DSL chars
-  const base = new URL(baseURI);
-  const rawHash = (base.hash || "#").slice(1);
-  const hashParams = new Map();
-  if (rawHash) {
-    for (const part of rawHash.split("&")) {
-      const eq = part.indexOf("=");
-      if (eq >= 0) hashParams.set(part.slice(0, eq), part.slice(eq + 1));
-      else if (part) hashParams.set(part, "");
-    }
-  }
-
-  if (typeof target === "string" && target.startsWith("#")) return target;
-
-  const isIntent =
-    typeof target === "object" &&
-    target !== null &&
-    ("module" in target ||
-      "open" in target ||
-      "close" in target ||
-      "focus" in target ||
-      "op" in target);
-
-  let module = null;
-  let cell = null;
-
-  if (!isIntent) {
-    module = String(target ?? "");
-    const parts = module.split("#");
-    module = parts[0] || null;
-    cell = parts[1] || null;
-    op = "open";
-  } else {
-    module =
-      target.module || target.open || target.close || target.focus || null;
-    cell = target.cell || null;
-    source = target.source ?? source;
-    op =
-      target.op || (target.close ? "close" : target.focus ? "focus" : "open");
-  }
-
-  if (!module) return base.toString();
-
-  hashParams.set(op, cell ? `${module}#${cell}` : module);
-  if (source) hashParams.set("from", source);
-
-  // Build hash without URLSearchParams to preserve DSL chars unencoded.
-  // Return hash-only for same-page links to avoid page reload.
-  const hashStr = [...hashParams]
-    .map(([k, v]) => (v ? `${k}=${v}` : k))
-    .join("&");
-  return "#" + hashStr;
-}
-)};
+const _bsoqwx = function _linkTo(isOnObservableCom)
+{
+    return function linkTo(target, {baseURI = document.baseURI, onObservable = isOnObservableCom(), source = null, op = 'open'    // "open" | "close" | "focus"
+} = {}) {
+        if (onObservable) {
+            const t = typeof target === 'string' ? target : target?.module || target?.open || target?.close || '';
+            return t.startsWith('#') ? t : '/' + t;
+        }
+        // Parse existing hash params manually to avoid percent-encoding DSL chars
+        const base = new URL(baseURI);
+        const rawHash = (base.hash || '#').slice(1);
+        const hashParams = new Map();
+        // open/close/focus/from are transient intents that lopepage consumes and
+        // clears, so we do NOT deep-link them. view= is canonical layout state owned
+        // by lopepage; if we baked the baseURI's view= into every link, the href
+        // would be a snapshot from link-render time and clicking it would rewind the
+        // layout (issue #150 — clicking a second module wiped the first because the
+        // link carried the boot view=). Dropping view= here makes the link a pure
+        // intent (e.g. "#cc=...&open=X"); sync_layout_from_url's
+        // `if (!view && open)` branch then merges the intent into the live layout.
+        const drop = new Set([
+            'view',
+            'open',
+            'close',
+            'focus',
+            'from'
+        ]);
+        if (rawHash) {
+            for (const part of rawHash.split('&')) {
+                const eq = part.indexOf('=');
+                const key = eq >= 0 ? part.slice(0, eq) : part;
+                if (drop.has(key))
+                    continue;
+                const val = eq >= 0 ? part.slice(eq + 1) : '';
+                hashParams.set(key, val);
+            }
+        }
+        if (typeof target === 'string' && target.startsWith('#'))
+            return target;
+        const isIntent = typeof target === 'object' && target !== null && ('module' in target || 'open' in target || 'close' in target || 'focus' in target || 'op' in target);
+        let module = null;
+        let cell = null;
+        if (!isIntent) {
+            module = String(target ?? '');
+            const parts = module.split('#');
+            module = parts[0] || null;
+            cell = parts[1] || null;
+            op = 'open';
+        } else {
+            module = target.module || target.open || target.close || target.focus || null;
+            cell = target.cell || null;
+            source = target.source ?? source;
+            op = target.op || (target.close ? 'close' : target.focus ? 'focus' : 'open');
+        }
+        if (!module)
+            return base.toString();
+        hashParams.set(op, cell ? `${ module }#${ cell }` : module);
+        if (source)
+            hashParams.set('from', source);
+        // Build hash without URLSearchParams to preserve DSL chars unencoded.
+        // Return hash-only for same-page links to avoid page reload.
+        const hashStr = [...hashParams].map(([k, v]) => v ? `${ k }=${ v }` : k).join('&');
+        return '#' + hashStr;
+    };
+};
 const _jdyayh = function _vars(variables,runtime){return(
 variables(runtime)
 )};
@@ -15627,7 +15620,7 @@ export default function define(runtime, observer) {
   $def("_1xjzq9r", "isOnObservableCom", ["location"], _1xjzq9r);  
   $def("_gxaxgb", "links", [], _gxaxgb);  
   $def("_17e89y0", "targets", [], _17e89y0);  
-  $def("_1x6cut", "linkTo", ["isOnObservableCom"], _1x6cut);  
+  $def("_bsoqwx", "linkTo", ["isOnObservableCom"], _bsoqwx);  
   $def("_jdyayh", "viewof vars", ["variables","runtime"], _jdyayh);  
   $def("_mfvz6q", "vars", ["Generators","viewof vars"], _mfvz6q);  
   $def("_1f44wsz", "test_linkTo", ["links","targets","linkTo"], _1f44wsz);  
@@ -15640,7 +15633,8 @@ export default function define(runtime, observer) {
   $def("_1xxtf0r", "updateNotebookImports", ["vars","extractNotebookAndCell","linkTo"], _1xxtf0r);  
   main.define("tests", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("tests", _));
   return main;
-}</script>
+}
+</script>
 <script id="@tomlarkworthy/modern-screenshot/modern-screenshot-4.6.6.js.gz" 
   type="text/plain"
   data-encoding="base64"

--- a/notebooks/@tomlarkworthy_atproto-comments.html
+++ b/notebooks/@tomlarkworthy_atproto-comments.html
@@ -14325,7 +14325,7 @@ export default function define(runtime, observer) {
   return main;
 }</script>
 
-<script id="@tomlarkworthy/lopepage-urls" 
+<script id="@tomlarkworthy/lopepage-urls"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -14676,81 +14676,75 @@ const _gxaxgb = function _links(){return(
 const _17e89y0 = function _targets(){return(
 ["@tom/bar", "d/1f41fef8b019cf4e@94", "@tom/bar#cell"]
 )};
-const _1x6cut = function _linkTo(isOnObservableCom){return(
-function linkTo(
-  target,
-  {
-    baseURI = document.baseURI,
-    onObservable = isOnObservableCom(),
-    source = null,
-    op = "open" // "open" | "close" | "focus"
-  } = {}
-) {
-  if (onObservable) {
-    const t =
-      typeof target === "string"
-        ? target
-        : target?.module || target?.open || target?.close || "";
-    return t.startsWith("#") ? t : "/" + t;
-  }
-
-  // Parse existing hash params manually to avoid percent-encoding DSL chars
-  const base = new URL(baseURI);
-  const rawHash = (base.hash || "#").slice(1);
-  const hashParams = new Map();
-  if (rawHash) {
-    for (const part of rawHash.split("&")) {
-      const eq = part.indexOf("=");
-      if (eq >= 0) hashParams.set(part.slice(0, eq), part.slice(eq + 1));
-      else if (part) hashParams.set(part, "");
-    }
-  }
-
-  if (typeof target === "string" && target.startsWith("#")) return target;
-
-  const isIntent =
-    typeof target === "object" &&
-    target !== null &&
-    ("module" in target ||
-      "open" in target ||
-      "close" in target ||
-      "focus" in target ||
-      "op" in target);
-
-  let module = null;
-  let cell = null;
-
-  if (!isIntent) {
-    module = String(target ?? "");
-    const parts = module.split("#");
-    module = parts[0] || null;
-    cell = parts[1] || null;
-    op = "open";
-  } else {
-    module =
-      target.module || target.open || target.close || target.focus || null;
-    cell = target.cell || null;
-    source = target.source ?? source;
-    op =
-      target.op || (target.close ? "close" : target.focus ? "focus" : "open");
-  }
-
-  if (!module) return base.toString();
-
-  hashParams.set(op, cell ? `${module}#${cell}` : module);
-  if (source) hashParams.set("from", source);
-
-  // Build hash without URLSearchParams to preserve DSL chars unencoded.
-  // Return hash-only for same-page links to avoid page reload.
-  const hashStr = [...hashParams]
-    .map(([k, v]) => (v ? `${k}=${v}` : k))
-    .join("&");
-  return "#" + hashStr;
-}
-)};
+const _bsoqwx = function _linkTo(isOnObservableCom)
+{
+    return function linkTo(target, {baseURI = document.baseURI, onObservable = isOnObservableCom(), source = null, op = 'open'    // "open" | "close" | "focus"
+} = {}) {
+        if (onObservable) {
+            const t = typeof target === 'string' ? target : target?.module || target?.open || target?.close || '';
+            return t.startsWith('#') ? t : '/' + t;
+        }
+        // Parse existing hash params manually to avoid percent-encoding DSL chars
+        const base = new URL(baseURI);
+        const rawHash = (base.hash || '#').slice(1);
+        const hashParams = new Map();
+        // open/close/focus/from are transient intents that lopepage consumes and
+        // clears, so we do NOT deep-link them. view= is canonical layout state owned
+        // by lopepage; if we baked the baseURI's view= into every link, the href
+        // would be a snapshot from link-render time and clicking it would rewind the
+        // layout (issue #150 — clicking a second module wiped the first because the
+        // link carried the boot view=). Dropping view= here makes the link a pure
+        // intent (e.g. "#cc=...&open=X"); sync_layout_from_url's
+        // `if (!view && open)` branch then merges the intent into the live layout.
+        const drop = new Set([
+            'view',
+            'open',
+            'close',
+            'focus',
+            'from'
+        ]);
+        if (rawHash) {
+            for (const part of rawHash.split('&')) {
+                const eq = part.indexOf('=');
+                const key = eq >= 0 ? part.slice(0, eq) : part;
+                if (drop.has(key))
+                    continue;
+                const val = eq >= 0 ? part.slice(eq + 1) : '';
+                hashParams.set(key, val);
+            }
+        }
+        if (typeof target === 'string' && target.startsWith('#'))
+            return target;
+        const isIntent = typeof target === 'object' && target !== null && ('module' in target || 'open' in target || 'close' in target || 'focus' in target || 'op' in target);
+        let module = null;
+        let cell = null;
+        if (!isIntent) {
+            module = String(target ?? '');
+            const parts = module.split('#');
+            module = parts[0] || null;
+            cell = parts[1] || null;
+            op = 'open';
+        } else {
+            module = target.module || target.open || target.close || target.focus || null;
+            cell = target.cell || null;
+            source = target.source ?? source;
+            op = target.op || (target.close ? 'close' : target.focus ? 'focus' : 'open');
+        }
+        if (!module)
+            return base.toString();
+        hashParams.set(op, cell ? `${ module }#${ cell }` : module);
+        if (source)
+            hashParams.set('from', source);
+        // Build hash without URLSearchParams to preserve DSL chars unencoded.
+        // Return hash-only for same-page links to avoid page reload.
+        const hashStr = [...hashParams].map(([k, v]) => v ? `${ k }=${ v }` : k).join('&');
+        return '#' + hashStr;
+    };
+};
 const _jdyayh = function _vars(variables,runtime){return(
 variables(runtime)
 )};
+const _mfvz6q = (G, _) => G.input(_);
 const _1f44wsz = function _test_linkTo(links,targets,linkTo){return(
 links.map((link) =>
   targets.map((target) =>
@@ -14763,7 +14757,6 @@ md`## Auto switch to url structure
 
 Watch the runtime for imports and swap them for our structure`
 )};
-const _w93ki7 = (_, v) => v.import("runtime", _);
 const _1gllckt = function _href_examples(){return(
 [
   "https://tomlarkworthy/import-notebook",
@@ -14822,20 +14815,15 @@ const _1xxtf0r = function _updateNotebookImports(vars,extractNotebookAndCell,lin
     }
   }
 };
-const _1txhfy5 = (_, v) => v.import("tests", _);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
   const $def = (pid, name, deps, fn) => {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
-  const fileAttachments = new Map([].map((name) => {
-    const module_name = "@tomlarkworthy/lopepage-urls";
-    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
-    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
-    return [name, {url: blob_url, mimeType: mime}]
-  }));
-  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
   $def("_1g7wjzc", null, ["md"], _1g7wjzc);  
   $def("_1hsbxxe", null, ["md"], _1hsbxxe);  
   $def("_1buq9dd", null, ["tests"], _1buq9dd);  
@@ -14865,22 +14853,21 @@ export default function define(runtime, observer) {
   $def("_1xjzq9r", "isOnObservableCom", ["location"], _1xjzq9r);  
   $def("_gxaxgb", "links", [], _gxaxgb);  
   $def("_17e89y0", "targets", [], _17e89y0);  
-  $def("_1x6cut", "linkTo", ["isOnObservableCom"], _1x6cut);  
+  $def("_bsoqwx", "linkTo", ["isOnObservableCom"], _bsoqwx);  
   $def("_jdyayh", "viewof vars", ["variables","runtime"], _jdyayh);  
-  main.variable(observer("vars")).define("vars", ["Generators", "viewof vars"], (G, _) => G.input(_));  
+  $def("_mfvz6q", "vars", ["Generators","viewof vars"], _mfvz6q);  
   $def("_1f44wsz", "test_linkTo", ["links","targets","linkTo"], _1f44wsz);  
   $def("_1hdknc", null, ["md"], _1hdknc);  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("variables", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("variables", _));  
   $def("_1gllckt", "href_examples", [], _1gllckt);  
   $def("_133ucsn", "test_extractNotebookAndCell", ["href_examples","extractNotebookAndCell"], _133ucsn);  
   $def("_cb1ope", "extractNotebookAndCell", [], _cb1ope);  
   $def("_1xxtf0r", "updateNotebookImports", ["vars","extractNotebookAndCell","linkTo"], _1xxtf0r);  
-  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
   main.define("tests", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("tests", _));
   return main;
-}</script>
+}
+</script>
 
 <script id="@tomlarkworthy/module-map" 
   type="text/plain"

--- a/notebooks/@tomlarkworthy_blank-notebook.html
+++ b/notebooks/@tomlarkworthy_blank-notebook.html
@@ -14216,7 +14216,7 @@ export default function define(runtime, observer) {
   return main;
 }</script>
 
-<script id="@tomlarkworthy/lopepage-urls" 
+<script id="@tomlarkworthy/lopepage-urls"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -14567,81 +14567,75 @@ const _gxaxgb = function _links(){return(
 const _17e89y0 = function _targets(){return(
 ["@tom/bar", "d/1f41fef8b019cf4e@94", "@tom/bar#cell"]
 )};
-const _1x6cut = function _linkTo(isOnObservableCom){return(
-function linkTo(
-  target,
-  {
-    baseURI = document.baseURI,
-    onObservable = isOnObservableCom(),
-    source = null,
-    op = "open" // "open" | "close" | "focus"
-  } = {}
-) {
-  if (onObservable) {
-    const t =
-      typeof target === "string"
-        ? target
-        : target?.module || target?.open || target?.close || "";
-    return t.startsWith("#") ? t : "/" + t;
-  }
-
-  // Parse existing hash params manually to avoid percent-encoding DSL chars
-  const base = new URL(baseURI);
-  const rawHash = (base.hash || "#").slice(1);
-  const hashParams = new Map();
-  if (rawHash) {
-    for (const part of rawHash.split("&")) {
-      const eq = part.indexOf("=");
-      if (eq >= 0) hashParams.set(part.slice(0, eq), part.slice(eq + 1));
-      else if (part) hashParams.set(part, "");
-    }
-  }
-
-  if (typeof target === "string" && target.startsWith("#")) return target;
-
-  const isIntent =
-    typeof target === "object" &&
-    target !== null &&
-    ("module" in target ||
-      "open" in target ||
-      "close" in target ||
-      "focus" in target ||
-      "op" in target);
-
-  let module = null;
-  let cell = null;
-
-  if (!isIntent) {
-    module = String(target ?? "");
-    const parts = module.split("#");
-    module = parts[0] || null;
-    cell = parts[1] || null;
-    op = "open";
-  } else {
-    module =
-      target.module || target.open || target.close || target.focus || null;
-    cell = target.cell || null;
-    source = target.source ?? source;
-    op =
-      target.op || (target.close ? "close" : target.focus ? "focus" : "open");
-  }
-
-  if (!module) return base.toString();
-
-  hashParams.set(op, cell ? `${module}#${cell}` : module);
-  if (source) hashParams.set("from", source);
-
-  // Build hash without URLSearchParams to preserve DSL chars unencoded.
-  // Return hash-only for same-page links to avoid page reload.
-  const hashStr = [...hashParams]
-    .map(([k, v]) => (v ? `${k}=${v}` : k))
-    .join("&");
-  return "#" + hashStr;
-}
-)};
+const _bsoqwx = function _linkTo(isOnObservableCom)
+{
+    return function linkTo(target, {baseURI = document.baseURI, onObservable = isOnObservableCom(), source = null, op = 'open'    // "open" | "close" | "focus"
+} = {}) {
+        if (onObservable) {
+            const t = typeof target === 'string' ? target : target?.module || target?.open || target?.close || '';
+            return t.startsWith('#') ? t : '/' + t;
+        }
+        // Parse existing hash params manually to avoid percent-encoding DSL chars
+        const base = new URL(baseURI);
+        const rawHash = (base.hash || '#').slice(1);
+        const hashParams = new Map();
+        // open/close/focus/from are transient intents that lopepage consumes and
+        // clears, so we do NOT deep-link them. view= is canonical layout state owned
+        // by lopepage; if we baked the baseURI's view= into every link, the href
+        // would be a snapshot from link-render time and clicking it would rewind the
+        // layout (issue #150 — clicking a second module wiped the first because the
+        // link carried the boot view=). Dropping view= here makes the link a pure
+        // intent (e.g. "#cc=...&open=X"); sync_layout_from_url's
+        // `if (!view && open)` branch then merges the intent into the live layout.
+        const drop = new Set([
+            'view',
+            'open',
+            'close',
+            'focus',
+            'from'
+        ]);
+        if (rawHash) {
+            for (const part of rawHash.split('&')) {
+                const eq = part.indexOf('=');
+                const key = eq >= 0 ? part.slice(0, eq) : part;
+                if (drop.has(key))
+                    continue;
+                const val = eq >= 0 ? part.slice(eq + 1) : '';
+                hashParams.set(key, val);
+            }
+        }
+        if (typeof target === 'string' && target.startsWith('#'))
+            return target;
+        const isIntent = typeof target === 'object' && target !== null && ('module' in target || 'open' in target || 'close' in target || 'focus' in target || 'op' in target);
+        let module = null;
+        let cell = null;
+        if (!isIntent) {
+            module = String(target ?? '');
+            const parts = module.split('#');
+            module = parts[0] || null;
+            cell = parts[1] || null;
+            op = 'open';
+        } else {
+            module = target.module || target.open || target.close || target.focus || null;
+            cell = target.cell || null;
+            source = target.source ?? source;
+            op = target.op || (target.close ? 'close' : target.focus ? 'focus' : 'open');
+        }
+        if (!module)
+            return base.toString();
+        hashParams.set(op, cell ? `${ module }#${ cell }` : module);
+        if (source)
+            hashParams.set('from', source);
+        // Build hash without URLSearchParams to preserve DSL chars unencoded.
+        // Return hash-only for same-page links to avoid page reload.
+        const hashStr = [...hashParams].map(([k, v]) => v ? `${ k }=${ v }` : k).join('&');
+        return '#' + hashStr;
+    };
+};
 const _jdyayh = function _vars(variables,runtime){return(
 variables(runtime)
 )};
+const _mfvz6q = (G, _) => G.input(_);
 const _1f44wsz = function _test_linkTo(links,targets,linkTo){return(
 links.map((link) =>
   targets.map((target) =>
@@ -14654,7 +14648,6 @@ md`## Auto switch to url structure
 
 Watch the runtime for imports and swap them for our structure`
 )};
-const _w93ki7 = (_, v) => v.import("runtime", _);
 const _1gllckt = function _href_examples(){return(
 [
   "https://tomlarkworthy/import-notebook",
@@ -14713,20 +14706,15 @@ const _1xxtf0r = function _updateNotebookImports(vars,extractNotebookAndCell,lin
     }
   }
 };
-const _1txhfy5 = (_, v) => v.import("tests", _);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
   const $def = (pid, name, deps, fn) => {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
-  const fileAttachments = new Map([].map((name) => {
-    const module_name = "@tomlarkworthy/lopepage-urls";
-    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
-    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
-    return [name, {url: blob_url, mimeType: mime}]
-  }));
-  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
   $def("_1g7wjzc", null, ["md"], _1g7wjzc);  
   $def("_1hsbxxe", null, ["md"], _1hsbxxe);  
   $def("_1buq9dd", null, ["tests"], _1buq9dd);  
@@ -14756,22 +14744,21 @@ export default function define(runtime, observer) {
   $def("_1xjzq9r", "isOnObservableCom", ["location"], _1xjzq9r);  
   $def("_gxaxgb", "links", [], _gxaxgb);  
   $def("_17e89y0", "targets", [], _17e89y0);  
-  $def("_1x6cut", "linkTo", ["isOnObservableCom"], _1x6cut);  
+  $def("_bsoqwx", "linkTo", ["isOnObservableCom"], _bsoqwx);  
   $def("_jdyayh", "viewof vars", ["variables","runtime"], _jdyayh);  
-  main.variable(observer("vars")).define("vars", ["Generators", "viewof vars"], (G, _) => G.input(_));  
+  $def("_mfvz6q", "vars", ["Generators","viewof vars"], _mfvz6q);  
   $def("_1f44wsz", "test_linkTo", ["links","targets","linkTo"], _1f44wsz);  
   $def("_1hdknc", null, ["md"], _1hdknc);  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("variables", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("variables", _));  
   $def("_1gllckt", "href_examples", [], _1gllckt);  
   $def("_133ucsn", "test_extractNotebookAndCell", ["href_examples","extractNotebookAndCell"], _133ucsn);  
   $def("_cb1ope", "extractNotebookAndCell", [], _cb1ope);  
   $def("_1xxtf0r", "updateNotebookImports", ["vars","extractNotebookAndCell","linkTo"], _1xxtf0r);  
-  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
   main.define("tests", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("tests", _));
   return main;
-}</script>
+}
+</script>
 
 <script id="@tomlarkworthy/module-map" 
   type="text/plain"

--- a/notebooks/@tomlarkworthy_bulk-jumpgate.html
+++ b/notebooks/@tomlarkworthy_bulk-jumpgate.html
@@ -15035,7 +15035,7 @@ export default function define(runtime, observer) {
   return main;
 }</script>
 
-<script id="@tomlarkworthy/lopepage-urls" 
+<script id="@tomlarkworthy/lopepage-urls"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -15386,78 +15386,71 @@ const _gxaxgb = function _links(){return(
 const _17e89y0 = function _targets(){return(
 ["@tom/bar", "d/1f41fef8b019cf4e@94", "@tom/bar#cell"]
 )};
-const _1x6cut = function _linkTo(isOnObservableCom){return(
-function linkTo(
-  target,
-  {
-    baseURI = document.baseURI,
-    onObservable = isOnObservableCom(),
-    source = null,
-    op = "open" // "open" | "close" | "focus"
-  } = {}
-) {
-  if (onObservable) {
-    const t =
-      typeof target === "string"
-        ? target
-        : target?.module || target?.open || target?.close || "";
-    return t.startsWith("#") ? t : "/" + t;
-  }
-
-  // Parse existing hash params manually to avoid percent-encoding DSL chars
-  const base = new URL(baseURI);
-  const rawHash = (base.hash || "#").slice(1);
-  const hashParams = new Map();
-  if (rawHash) {
-    for (const part of rawHash.split("&")) {
-      const eq = part.indexOf("=");
-      if (eq >= 0) hashParams.set(part.slice(0, eq), part.slice(eq + 1));
-      else if (part) hashParams.set(part, "");
-    }
-  }
-
-  if (typeof target === "string" && target.startsWith("#")) return target;
-
-  const isIntent =
-    typeof target === "object" &&
-    target !== null &&
-    ("module" in target ||
-      "open" in target ||
-      "close" in target ||
-      "focus" in target ||
-      "op" in target);
-
-  let module = null;
-  let cell = null;
-
-  if (!isIntent) {
-    module = String(target ?? "");
-    const parts = module.split("#");
-    module = parts[0] || null;
-    cell = parts[1] || null;
-    op = "open";
-  } else {
-    module =
-      target.module || target.open || target.close || target.focus || null;
-    cell = target.cell || null;
-    source = target.source ?? source;
-    op =
-      target.op || (target.close ? "close" : target.focus ? "focus" : "open");
-  }
-
-  if (!module) return base.toString();
-
-  hashParams.set(op, cell ? `${module}#${cell}` : module);
-  if (source) hashParams.set("from", source);
-
-  // Build hash without URLSearchParams to preserve DSL chars unencoded.
-  // Return hash-only for same-page links to avoid page reload.
-  const hashStr = [...hashParams]
-    .map(([k, v]) => (v ? `${k}=${v}` : k))
-    .join("&");
-  return "#" + hashStr;
-}
-)};
+const _bsoqwx = function _linkTo(isOnObservableCom)
+{
+    return function linkTo(target, {baseURI = document.baseURI, onObservable = isOnObservableCom(), source = null, op = 'open'    // "open" | "close" | "focus"
+} = {}) {
+        if (onObservable) {
+            const t = typeof target === 'string' ? target : target?.module || target?.open || target?.close || '';
+            return t.startsWith('#') ? t : '/' + t;
+        }
+        // Parse existing hash params manually to avoid percent-encoding DSL chars
+        const base = new URL(baseURI);
+        const rawHash = (base.hash || '#').slice(1);
+        const hashParams = new Map();
+        // open/close/focus/from are transient intents that lopepage consumes and
+        // clears, so we do NOT deep-link them. view= is canonical layout state owned
+        // by lopepage; if we baked the baseURI's view= into every link, the href
+        // would be a snapshot from link-render time and clicking it would rewind the
+        // layout (issue #150 — clicking a second module wiped the first because the
+        // link carried the boot view=). Dropping view= here makes the link a pure
+        // intent (e.g. "#cc=...&open=X"); sync_layout_from_url's
+        // `if (!view && open)` branch then merges the intent into the live layout.
+        const drop = new Set([
+            'view',
+            'open',
+            'close',
+            'focus',
+            'from'
+        ]);
+        if (rawHash) {
+            for (const part of rawHash.split('&')) {
+                const eq = part.indexOf('=');
+                const key = eq >= 0 ? part.slice(0, eq) : part;
+                if (drop.has(key))
+                    continue;
+                const val = eq >= 0 ? part.slice(eq + 1) : '';
+                hashParams.set(key, val);
+            }
+        }
+        if (typeof target === 'string' && target.startsWith('#'))
+            return target;
+        const isIntent = typeof target === 'object' && target !== null && ('module' in target || 'open' in target || 'close' in target || 'focus' in target || 'op' in target);
+        let module = null;
+        let cell = null;
+        if (!isIntent) {
+            module = String(target ?? '');
+            const parts = module.split('#');
+            module = parts[0] || null;
+            cell = parts[1] || null;
+            op = 'open';
+        } else {
+            module = target.module || target.open || target.close || target.focus || null;
+            cell = target.cell || null;
+            source = target.source ?? source;
+            op = target.op || (target.close ? 'close' : target.focus ? 'focus' : 'open');
+        }
+        if (!module)
+            return base.toString();
+        hashParams.set(op, cell ? `${ module }#${ cell }` : module);
+        if (source)
+            hashParams.set('from', source);
+        // Build hash without URLSearchParams to preserve DSL chars unencoded.
+        // Return hash-only for same-page links to avoid page reload.
+        const hashStr = [...hashParams].map(([k, v]) => v ? `${ k }=${ v }` : k).join('&');
+        return '#' + hashStr;
+    };
+};
 const _jdyayh = function _vars(variables,runtime){return(
 variables(runtime)
 )};
@@ -15570,7 +15563,7 @@ export default function define(runtime, observer) {
   $def("_1xjzq9r", "isOnObservableCom", ["location"], _1xjzq9r);  
   $def("_gxaxgb", "links", [], _gxaxgb);  
   $def("_17e89y0", "targets", [], _17e89y0);  
-  $def("_1x6cut", "linkTo", ["isOnObservableCom"], _1x6cut);  
+  $def("_bsoqwx", "linkTo", ["isOnObservableCom"], _bsoqwx);  
   $def("_jdyayh", "viewof vars", ["variables","runtime"], _jdyayh);  
   $def("_mfvz6q", "vars", ["Generators","viewof vars"], _mfvz6q);  
   $def("_1f44wsz", "test_linkTo", ["links","targets","linkTo"], _1f44wsz);  
@@ -15583,7 +15576,8 @@ export default function define(runtime, observer) {
   $def("_1xxtf0r", "updateNotebookImports", ["vars","extractNotebookAndCell","linkTo"], _1xxtf0r);  
   main.define("tests", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("tests", _));
   return main;
-}</script>
+}
+</script>
 
 <script id="@tomlarkworthy/module-map" 
   type="text/plain"

--- a/notebooks/@tomlarkworthy_cells-to-clipboard.html
+++ b/notebooks/@tomlarkworthy_cells-to-clipboard.html
@@ -14177,7 +14177,7 @@ export default function define(runtime, observer) {
   return main;
 }</script>
 
-<script id="@tomlarkworthy/lopepage-urls" 
+<script id="@tomlarkworthy/lopepage-urls"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -14528,81 +14528,75 @@ const _gxaxgb = function _links(){return(
 const _17e89y0 = function _targets(){return(
 ["@tom/bar", "d/1f41fef8b019cf4e@94", "@tom/bar#cell"]
 )};
-const _1x6cut = function _linkTo(isOnObservableCom){return(
-function linkTo(
-  target,
-  {
-    baseURI = document.baseURI,
-    onObservable = isOnObservableCom(),
-    source = null,
-    op = "open" // "open" | "close" | "focus"
-  } = {}
-) {
-  if (onObservable) {
-    const t =
-      typeof target === "string"
-        ? target
-        : target?.module || target?.open || target?.close || "";
-    return t.startsWith("#") ? t : "/" + t;
-  }
-
-  // Parse existing hash params manually to avoid percent-encoding DSL chars
-  const base = new URL(baseURI);
-  const rawHash = (base.hash || "#").slice(1);
-  const hashParams = new Map();
-  if (rawHash) {
-    for (const part of rawHash.split("&")) {
-      const eq = part.indexOf("=");
-      if (eq >= 0) hashParams.set(part.slice(0, eq), part.slice(eq + 1));
-      else if (part) hashParams.set(part, "");
-    }
-  }
-
-  if (typeof target === "string" && target.startsWith("#")) return target;
-
-  const isIntent =
-    typeof target === "object" &&
-    target !== null &&
-    ("module" in target ||
-      "open" in target ||
-      "close" in target ||
-      "focus" in target ||
-      "op" in target);
-
-  let module = null;
-  let cell = null;
-
-  if (!isIntent) {
-    module = String(target ?? "");
-    const parts = module.split("#");
-    module = parts[0] || null;
-    cell = parts[1] || null;
-    op = "open";
-  } else {
-    module =
-      target.module || target.open || target.close || target.focus || null;
-    cell = target.cell || null;
-    source = target.source ?? source;
-    op =
-      target.op || (target.close ? "close" : target.focus ? "focus" : "open");
-  }
-
-  if (!module) return base.toString();
-
-  hashParams.set(op, cell ? `${module}#${cell}` : module);
-  if (source) hashParams.set("from", source);
-
-  // Build hash without URLSearchParams to preserve DSL chars unencoded.
-  // Return hash-only for same-page links to avoid page reload.
-  const hashStr = [...hashParams]
-    .map(([k, v]) => (v ? `${k}=${v}` : k))
-    .join("&");
-  return "#" + hashStr;
-}
-)};
+const _bsoqwx = function _linkTo(isOnObservableCom)
+{
+    return function linkTo(target, {baseURI = document.baseURI, onObservable = isOnObservableCom(), source = null, op = 'open'    // "open" | "close" | "focus"
+} = {}) {
+        if (onObservable) {
+            const t = typeof target === 'string' ? target : target?.module || target?.open || target?.close || '';
+            return t.startsWith('#') ? t : '/' + t;
+        }
+        // Parse existing hash params manually to avoid percent-encoding DSL chars
+        const base = new URL(baseURI);
+        const rawHash = (base.hash || '#').slice(1);
+        const hashParams = new Map();
+        // open/close/focus/from are transient intents that lopepage consumes and
+        // clears, so we do NOT deep-link them. view= is canonical layout state owned
+        // by lopepage; if we baked the baseURI's view= into every link, the href
+        // would be a snapshot from link-render time and clicking it would rewind the
+        // layout (issue #150 — clicking a second module wiped the first because the
+        // link carried the boot view=). Dropping view= here makes the link a pure
+        // intent (e.g. "#cc=...&open=X"); sync_layout_from_url's
+        // `if (!view && open)` branch then merges the intent into the live layout.
+        const drop = new Set([
+            'view',
+            'open',
+            'close',
+            'focus',
+            'from'
+        ]);
+        if (rawHash) {
+            for (const part of rawHash.split('&')) {
+                const eq = part.indexOf('=');
+                const key = eq >= 0 ? part.slice(0, eq) : part;
+                if (drop.has(key))
+                    continue;
+                const val = eq >= 0 ? part.slice(eq + 1) : '';
+                hashParams.set(key, val);
+            }
+        }
+        if (typeof target === 'string' && target.startsWith('#'))
+            return target;
+        const isIntent = typeof target === 'object' && target !== null && ('module' in target || 'open' in target || 'close' in target || 'focus' in target || 'op' in target);
+        let module = null;
+        let cell = null;
+        if (!isIntent) {
+            module = String(target ?? '');
+            const parts = module.split('#');
+            module = parts[0] || null;
+            cell = parts[1] || null;
+            op = 'open';
+        } else {
+            module = target.module || target.open || target.close || target.focus || null;
+            cell = target.cell || null;
+            source = target.source ?? source;
+            op = target.op || (target.close ? 'close' : target.focus ? 'focus' : 'open');
+        }
+        if (!module)
+            return base.toString();
+        hashParams.set(op, cell ? `${ module }#${ cell }` : module);
+        if (source)
+            hashParams.set('from', source);
+        // Build hash without URLSearchParams to preserve DSL chars unencoded.
+        // Return hash-only for same-page links to avoid page reload.
+        const hashStr = [...hashParams].map(([k, v]) => v ? `${ k }=${ v }` : k).join('&');
+        return '#' + hashStr;
+    };
+};
 const _jdyayh = function _vars(variables,runtime){return(
 variables(runtime)
 )};
+const _mfvz6q = (G, _) => G.input(_);
 const _1f44wsz = function _test_linkTo(links,targets,linkTo){return(
 links.map((link) =>
   targets.map((target) =>
@@ -14615,7 +14609,6 @@ md`## Auto switch to url structure
 
 Watch the runtime for imports and swap them for our structure`
 )};
-const _w93ki7 = (_, v) => v.import("runtime", _);
 const _1gllckt = function _href_examples(){return(
 [
   "https://tomlarkworthy/import-notebook",
@@ -14674,20 +14667,15 @@ const _1xxtf0r = function _updateNotebookImports(vars,extractNotebookAndCell,lin
     }
   }
 };
-const _1txhfy5 = (_, v) => v.import("tests", _);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
   const $def = (pid, name, deps, fn) => {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
-  const fileAttachments = new Map([].map((name) => {
-    const module_name = "@tomlarkworthy/lopepage-urls";
-    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
-    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
-    return [name, {url: blob_url, mimeType: mime}]
-  }));
-  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
   $def("_1g7wjzc", null, ["md"], _1g7wjzc);  
   $def("_1hsbxxe", null, ["md"], _1hsbxxe);  
   $def("_1buq9dd", null, ["tests"], _1buq9dd);  
@@ -14717,22 +14705,21 @@ export default function define(runtime, observer) {
   $def("_1xjzq9r", "isOnObservableCom", ["location"], _1xjzq9r);  
   $def("_gxaxgb", "links", [], _gxaxgb);  
   $def("_17e89y0", "targets", [], _17e89y0);  
-  $def("_1x6cut", "linkTo", ["isOnObservableCom"], _1x6cut);  
+  $def("_bsoqwx", "linkTo", ["isOnObservableCom"], _bsoqwx);  
   $def("_jdyayh", "viewof vars", ["variables","runtime"], _jdyayh);  
-  main.variable(observer("vars")).define("vars", ["Generators", "viewof vars"], (G, _) => G.input(_));  
+  $def("_mfvz6q", "vars", ["Generators","viewof vars"], _mfvz6q);  
   $def("_1f44wsz", "test_linkTo", ["links","targets","linkTo"], _1f44wsz);  
   $def("_1hdknc", null, ["md"], _1hdknc);  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("variables", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("variables", _));  
   $def("_1gllckt", "href_examples", [], _1gllckt);  
   $def("_133ucsn", "test_extractNotebookAndCell", ["href_examples","extractNotebookAndCell"], _133ucsn);  
   $def("_cb1ope", "extractNotebookAndCell", [], _cb1ope);  
   $def("_1xxtf0r", "updateNotebookImports", ["vars","extractNotebookAndCell","linkTo"], _1xxtf0r);  
-  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
   main.define("tests", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("tests", _));
   return main;
-}</script>
+}
+</script>
 
 <script id="@tomlarkworthy/module-map" 
   type="text/plain"

--- a/notebooks/@tomlarkworthy_claude-code-pairing.html
+++ b/notebooks/@tomlarkworthy_claude-code-pairing.html
@@ -14120,7 +14120,7 @@ export default function define(runtime, observer) {
   return main;
 }</script>
 
-<script id="@tomlarkworthy/lopepage-urls" 
+<script id="@tomlarkworthy/lopepage-urls"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -14471,78 +14471,71 @@ const _gxaxgb = function _links(){return(
 const _17e89y0 = function _targets(){return(
 ["@tom/bar", "d/1f41fef8b019cf4e@94", "@tom/bar#cell"]
 )};
-const _1x6cut = function _linkTo(isOnObservableCom){return(
-function linkTo(
-  target,
-  {
-    baseURI = document.baseURI,
-    onObservable = isOnObservableCom(),
-    source = null,
-    op = "open" // "open" | "close" | "focus"
-  } = {}
-) {
-  if (onObservable) {
-    const t =
-      typeof target === "string"
-        ? target
-        : target?.module || target?.open || target?.close || "";
-    return t.startsWith("#") ? t : "/" + t;
-  }
-
-  // Parse existing hash params manually to avoid percent-encoding DSL chars
-  const base = new URL(baseURI);
-  const rawHash = (base.hash || "#").slice(1);
-  const hashParams = new Map();
-  if (rawHash) {
-    for (const part of rawHash.split("&")) {
-      const eq = part.indexOf("=");
-      if (eq >= 0) hashParams.set(part.slice(0, eq), part.slice(eq + 1));
-      else if (part) hashParams.set(part, "");
-    }
-  }
-
-  if (typeof target === "string" && target.startsWith("#")) return target;
-
-  const isIntent =
-    typeof target === "object" &&
-    target !== null &&
-    ("module" in target ||
-      "open" in target ||
-      "close" in target ||
-      "focus" in target ||
-      "op" in target);
-
-  let module = null;
-  let cell = null;
-
-  if (!isIntent) {
-    module = String(target ?? "");
-    const parts = module.split("#");
-    module = parts[0] || null;
-    cell = parts[1] || null;
-    op = "open";
-  } else {
-    module =
-      target.module || target.open || target.close || target.focus || null;
-    cell = target.cell || null;
-    source = target.source ?? source;
-    op =
-      target.op || (target.close ? "close" : target.focus ? "focus" : "open");
-  }
-
-  if (!module) return base.toString();
-
-  hashParams.set(op, cell ? `${module}#${cell}` : module);
-  if (source) hashParams.set("from", source);
-
-  // Build hash without URLSearchParams to preserve DSL chars unencoded.
-  // Return hash-only for same-page links to avoid page reload.
-  const hashStr = [...hashParams]
-    .map(([k, v]) => (v ? `${k}=${v}` : k))
-    .join("&");
-  return "#" + hashStr;
-}
-)};
+const _bsoqwx = function _linkTo(isOnObservableCom)
+{
+    return function linkTo(target, {baseURI = document.baseURI, onObservable = isOnObservableCom(), source = null, op = 'open'    // "open" | "close" | "focus"
+} = {}) {
+        if (onObservable) {
+            const t = typeof target === 'string' ? target : target?.module || target?.open || target?.close || '';
+            return t.startsWith('#') ? t : '/' + t;
+        }
+        // Parse existing hash params manually to avoid percent-encoding DSL chars
+        const base = new URL(baseURI);
+        const rawHash = (base.hash || '#').slice(1);
+        const hashParams = new Map();
+        // open/close/focus/from are transient intents that lopepage consumes and
+        // clears, so we do NOT deep-link them. view= is canonical layout state owned
+        // by lopepage; if we baked the baseURI's view= into every link, the href
+        // would be a snapshot from link-render time and clicking it would rewind the
+        // layout (issue #150 — clicking a second module wiped the first because the
+        // link carried the boot view=). Dropping view= here makes the link a pure
+        // intent (e.g. "#cc=...&open=X"); sync_layout_from_url's
+        // `if (!view && open)` branch then merges the intent into the live layout.
+        const drop = new Set([
+            'view',
+            'open',
+            'close',
+            'focus',
+            'from'
+        ]);
+        if (rawHash) {
+            for (const part of rawHash.split('&')) {
+                const eq = part.indexOf('=');
+                const key = eq >= 0 ? part.slice(0, eq) : part;
+                if (drop.has(key))
+                    continue;
+                const val = eq >= 0 ? part.slice(eq + 1) : '';
+                hashParams.set(key, val);
+            }
+        }
+        if (typeof target === 'string' && target.startsWith('#'))
+            return target;
+        const isIntent = typeof target === 'object' && target !== null && ('module' in target || 'open' in target || 'close' in target || 'focus' in target || 'op' in target);
+        let module = null;
+        let cell = null;
+        if (!isIntent) {
+            module = String(target ?? '');
+            const parts = module.split('#');
+            module = parts[0] || null;
+            cell = parts[1] || null;
+            op = 'open';
+        } else {
+            module = target.module || target.open || target.close || target.focus || null;
+            cell = target.cell || null;
+            source = target.source ?? source;
+            op = target.op || (target.close ? 'close' : target.focus ? 'focus' : 'open');
+        }
+        if (!module)
+            return base.toString();
+        hashParams.set(op, cell ? `${ module }#${ cell }` : module);
+        if (source)
+            hashParams.set('from', source);
+        // Build hash without URLSearchParams to preserve DSL chars unencoded.
+        // Return hash-only for same-page links to avoid page reload.
+        const hashStr = [...hashParams].map(([k, v]) => v ? `${ k }=${ v }` : k).join('&');
+        return '#' + hashStr;
+    };
+};
 const _jdyayh = function _vars(variables,runtime){return(
 variables(runtime)
 )};
@@ -14655,7 +14648,7 @@ export default function define(runtime, observer) {
   $def("_1xjzq9r", "isOnObservableCom", ["location"], _1xjzq9r);  
   $def("_gxaxgb", "links", [], _gxaxgb);  
   $def("_17e89y0", "targets", [], _17e89y0);  
-  $def("_1x6cut", "linkTo", ["isOnObservableCom"], _1x6cut);  
+  $def("_bsoqwx", "linkTo", ["isOnObservableCom"], _bsoqwx);  
   $def("_jdyayh", "viewof vars", ["variables","runtime"], _jdyayh);  
   $def("_mfvz6q", "vars", ["Generators","viewof vars"], _mfvz6q);  
   $def("_1f44wsz", "test_linkTo", ["links","targets","linkTo"], _1f44wsz);  
@@ -14668,7 +14661,8 @@ export default function define(runtime, observer) {
   $def("_1xxtf0r", "updateNotebookImports", ["vars","extractNotebookAndCell","linkTo"], _1xxtf0r);  
   main.define("tests", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("tests", _));
   return main;
-}</script>
+}
+</script>
 
 <script id="@tomlarkworthy/module-map" 
   type="text/plain"

--- a/notebooks/@tomlarkworthy_codemirror-6-v2.html
+++ b/notebooks/@tomlarkworthy_codemirror-6-v2.html
@@ -14177,7 +14177,7 @@ export default function define(runtime, observer) {
   return main;
 }</script>
 
-<script id="@tomlarkworthy/lopepage-urls" 
+<script id="@tomlarkworthy/lopepage-urls"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -14528,81 +14528,75 @@ const _gxaxgb = function _links(){return(
 const _17e89y0 = function _targets(){return(
 ["@tom/bar", "d/1f41fef8b019cf4e@94", "@tom/bar#cell"]
 )};
-const _1x6cut = function _linkTo(isOnObservableCom){return(
-function linkTo(
-  target,
-  {
-    baseURI = document.baseURI,
-    onObservable = isOnObservableCom(),
-    source = null,
-    op = "open" // "open" | "close" | "focus"
-  } = {}
-) {
-  if (onObservable) {
-    const t =
-      typeof target === "string"
-        ? target
-        : target?.module || target?.open || target?.close || "";
-    return t.startsWith("#") ? t : "/" + t;
-  }
-
-  // Parse existing hash params manually to avoid percent-encoding DSL chars
-  const base = new URL(baseURI);
-  const rawHash = (base.hash || "#").slice(1);
-  const hashParams = new Map();
-  if (rawHash) {
-    for (const part of rawHash.split("&")) {
-      const eq = part.indexOf("=");
-      if (eq >= 0) hashParams.set(part.slice(0, eq), part.slice(eq + 1));
-      else if (part) hashParams.set(part, "");
-    }
-  }
-
-  if (typeof target === "string" && target.startsWith("#")) return target;
-
-  const isIntent =
-    typeof target === "object" &&
-    target !== null &&
-    ("module" in target ||
-      "open" in target ||
-      "close" in target ||
-      "focus" in target ||
-      "op" in target);
-
-  let module = null;
-  let cell = null;
-
-  if (!isIntent) {
-    module = String(target ?? "");
-    const parts = module.split("#");
-    module = parts[0] || null;
-    cell = parts[1] || null;
-    op = "open";
-  } else {
-    module =
-      target.module || target.open || target.close || target.focus || null;
-    cell = target.cell || null;
-    source = target.source ?? source;
-    op =
-      target.op || (target.close ? "close" : target.focus ? "focus" : "open");
-  }
-
-  if (!module) return base.toString();
-
-  hashParams.set(op, cell ? `${module}#${cell}` : module);
-  if (source) hashParams.set("from", source);
-
-  // Build hash without URLSearchParams to preserve DSL chars unencoded.
-  // Return hash-only for same-page links to avoid page reload.
-  const hashStr = [...hashParams]
-    .map(([k, v]) => (v ? `${k}=${v}` : k))
-    .join("&");
-  return "#" + hashStr;
-}
-)};
+const _bsoqwx = function _linkTo(isOnObservableCom)
+{
+    return function linkTo(target, {baseURI = document.baseURI, onObservable = isOnObservableCom(), source = null, op = 'open'    // "open" | "close" | "focus"
+} = {}) {
+        if (onObservable) {
+            const t = typeof target === 'string' ? target : target?.module || target?.open || target?.close || '';
+            return t.startsWith('#') ? t : '/' + t;
+        }
+        // Parse existing hash params manually to avoid percent-encoding DSL chars
+        const base = new URL(baseURI);
+        const rawHash = (base.hash || '#').slice(1);
+        const hashParams = new Map();
+        // open/close/focus/from are transient intents that lopepage consumes and
+        // clears, so we do NOT deep-link them. view= is canonical layout state owned
+        // by lopepage; if we baked the baseURI's view= into every link, the href
+        // would be a snapshot from link-render time and clicking it would rewind the
+        // layout (issue #150 — clicking a second module wiped the first because the
+        // link carried the boot view=). Dropping view= here makes the link a pure
+        // intent (e.g. "#cc=...&open=X"); sync_layout_from_url's
+        // `if (!view && open)` branch then merges the intent into the live layout.
+        const drop = new Set([
+            'view',
+            'open',
+            'close',
+            'focus',
+            'from'
+        ]);
+        if (rawHash) {
+            for (const part of rawHash.split('&')) {
+                const eq = part.indexOf('=');
+                const key = eq >= 0 ? part.slice(0, eq) : part;
+                if (drop.has(key))
+                    continue;
+                const val = eq >= 0 ? part.slice(eq + 1) : '';
+                hashParams.set(key, val);
+            }
+        }
+        if (typeof target === 'string' && target.startsWith('#'))
+            return target;
+        const isIntent = typeof target === 'object' && target !== null && ('module' in target || 'open' in target || 'close' in target || 'focus' in target || 'op' in target);
+        let module = null;
+        let cell = null;
+        if (!isIntent) {
+            module = String(target ?? '');
+            const parts = module.split('#');
+            module = parts[0] || null;
+            cell = parts[1] || null;
+            op = 'open';
+        } else {
+            module = target.module || target.open || target.close || target.focus || null;
+            cell = target.cell || null;
+            source = target.source ?? source;
+            op = target.op || (target.close ? 'close' : target.focus ? 'focus' : 'open');
+        }
+        if (!module)
+            return base.toString();
+        hashParams.set(op, cell ? `${ module }#${ cell }` : module);
+        if (source)
+            hashParams.set('from', source);
+        // Build hash without URLSearchParams to preserve DSL chars unencoded.
+        // Return hash-only for same-page links to avoid page reload.
+        const hashStr = [...hashParams].map(([k, v]) => v ? `${ k }=${ v }` : k).join('&');
+        return '#' + hashStr;
+    };
+};
 const _jdyayh = function _vars(variables,runtime){return(
 variables(runtime)
 )};
+const _mfvz6q = (G, _) => G.input(_);
 const _1f44wsz = function _test_linkTo(links,targets,linkTo){return(
 links.map((link) =>
   targets.map((target) =>
@@ -14615,7 +14609,6 @@ md`## Auto switch to url structure
 
 Watch the runtime for imports and swap them for our structure`
 )};
-const _w93ki7 = (_, v) => v.import("runtime", _);
 const _1gllckt = function _href_examples(){return(
 [
   "https://tomlarkworthy/import-notebook",
@@ -14674,20 +14667,15 @@ const _1xxtf0r = function _updateNotebookImports(vars,extractNotebookAndCell,lin
     }
   }
 };
-const _1txhfy5 = (_, v) => v.import("tests", _);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
   const $def = (pid, name, deps, fn) => {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
-  const fileAttachments = new Map([].map((name) => {
-    const module_name = "@tomlarkworthy/lopepage-urls";
-    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
-    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
-    return [name, {url: blob_url, mimeType: mime}]
-  }));
-  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
   $def("_1g7wjzc", null, ["md"], _1g7wjzc);  
   $def("_1hsbxxe", null, ["md"], _1hsbxxe);  
   $def("_1buq9dd", null, ["tests"], _1buq9dd);  
@@ -14717,22 +14705,21 @@ export default function define(runtime, observer) {
   $def("_1xjzq9r", "isOnObservableCom", ["location"], _1xjzq9r);  
   $def("_gxaxgb", "links", [], _gxaxgb);  
   $def("_17e89y0", "targets", [], _17e89y0);  
-  $def("_1x6cut", "linkTo", ["isOnObservableCom"], _1x6cut);  
+  $def("_bsoqwx", "linkTo", ["isOnObservableCom"], _bsoqwx);  
   $def("_jdyayh", "viewof vars", ["variables","runtime"], _jdyayh);  
-  main.variable(observer("vars")).define("vars", ["Generators", "viewof vars"], (G, _) => G.input(_));  
+  $def("_mfvz6q", "vars", ["Generators","viewof vars"], _mfvz6q);  
   $def("_1f44wsz", "test_linkTo", ["links","targets","linkTo"], _1f44wsz);  
   $def("_1hdknc", null, ["md"], _1hdknc);  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("variables", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("variables", _));  
   $def("_1gllckt", "href_examples", [], _1gllckt);  
   $def("_133ucsn", "test_extractNotebookAndCell", ["href_examples","extractNotebookAndCell"], _133ucsn);  
   $def("_cb1ope", "extractNotebookAndCell", [], _cb1ope);  
   $def("_1xxtf0r", "updateNotebookImports", ["vars","extractNotebookAndCell","linkTo"], _1xxtf0r);  
-  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
   main.define("tests", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("tests", _));
   return main;
-}</script>
+}
+</script>
 
 <script id="@tomlarkworthy/module-map" 
   type="text/plain"

--- a/notebooks/@tomlarkworthy_dataflow-templating.html
+++ b/notebooks/@tomlarkworthy_dataflow-templating.html
@@ -14177,7 +14177,7 @@ export default function define(runtime, observer) {
   return main;
 }</script>
 
-<script id="@tomlarkworthy/lopepage-urls" 
+<script id="@tomlarkworthy/lopepage-urls"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -14528,81 +14528,75 @@ const _gxaxgb = function _links(){return(
 const _17e89y0 = function _targets(){return(
 ["@tom/bar", "d/1f41fef8b019cf4e@94", "@tom/bar#cell"]
 )};
-const _1x6cut = function _linkTo(isOnObservableCom){return(
-function linkTo(
-  target,
-  {
-    baseURI = document.baseURI,
-    onObservable = isOnObservableCom(),
-    source = null,
-    op = "open" // "open" | "close" | "focus"
-  } = {}
-) {
-  if (onObservable) {
-    const t =
-      typeof target === "string"
-        ? target
-        : target?.module || target?.open || target?.close || "";
-    return t.startsWith("#") ? t : "/" + t;
-  }
-
-  // Parse existing hash params manually to avoid percent-encoding DSL chars
-  const base = new URL(baseURI);
-  const rawHash = (base.hash || "#").slice(1);
-  const hashParams = new Map();
-  if (rawHash) {
-    for (const part of rawHash.split("&")) {
-      const eq = part.indexOf("=");
-      if (eq >= 0) hashParams.set(part.slice(0, eq), part.slice(eq + 1));
-      else if (part) hashParams.set(part, "");
-    }
-  }
-
-  if (typeof target === "string" && target.startsWith("#")) return target;
-
-  const isIntent =
-    typeof target === "object" &&
-    target !== null &&
-    ("module" in target ||
-      "open" in target ||
-      "close" in target ||
-      "focus" in target ||
-      "op" in target);
-
-  let module = null;
-  let cell = null;
-
-  if (!isIntent) {
-    module = String(target ?? "");
-    const parts = module.split("#");
-    module = parts[0] || null;
-    cell = parts[1] || null;
-    op = "open";
-  } else {
-    module =
-      target.module || target.open || target.close || target.focus || null;
-    cell = target.cell || null;
-    source = target.source ?? source;
-    op =
-      target.op || (target.close ? "close" : target.focus ? "focus" : "open");
-  }
-
-  if (!module) return base.toString();
-
-  hashParams.set(op, cell ? `${module}#${cell}` : module);
-  if (source) hashParams.set("from", source);
-
-  // Build hash without URLSearchParams to preserve DSL chars unencoded.
-  // Return hash-only for same-page links to avoid page reload.
-  const hashStr = [...hashParams]
-    .map(([k, v]) => (v ? `${k}=${v}` : k))
-    .join("&");
-  return "#" + hashStr;
-}
-)};
+const _bsoqwx = function _linkTo(isOnObservableCom)
+{
+    return function linkTo(target, {baseURI = document.baseURI, onObservable = isOnObservableCom(), source = null, op = 'open'    // "open" | "close" | "focus"
+} = {}) {
+        if (onObservable) {
+            const t = typeof target === 'string' ? target : target?.module || target?.open || target?.close || '';
+            return t.startsWith('#') ? t : '/' + t;
+        }
+        // Parse existing hash params manually to avoid percent-encoding DSL chars
+        const base = new URL(baseURI);
+        const rawHash = (base.hash || '#').slice(1);
+        const hashParams = new Map();
+        // open/close/focus/from are transient intents that lopepage consumes and
+        // clears, so we do NOT deep-link them. view= is canonical layout state owned
+        // by lopepage; if we baked the baseURI's view= into every link, the href
+        // would be a snapshot from link-render time and clicking it would rewind the
+        // layout (issue #150 — clicking a second module wiped the first because the
+        // link carried the boot view=). Dropping view= here makes the link a pure
+        // intent (e.g. "#cc=...&open=X"); sync_layout_from_url's
+        // `if (!view && open)` branch then merges the intent into the live layout.
+        const drop = new Set([
+            'view',
+            'open',
+            'close',
+            'focus',
+            'from'
+        ]);
+        if (rawHash) {
+            for (const part of rawHash.split('&')) {
+                const eq = part.indexOf('=');
+                const key = eq >= 0 ? part.slice(0, eq) : part;
+                if (drop.has(key))
+                    continue;
+                const val = eq >= 0 ? part.slice(eq + 1) : '';
+                hashParams.set(key, val);
+            }
+        }
+        if (typeof target === 'string' && target.startsWith('#'))
+            return target;
+        const isIntent = typeof target === 'object' && target !== null && ('module' in target || 'open' in target || 'close' in target || 'focus' in target || 'op' in target);
+        let module = null;
+        let cell = null;
+        if (!isIntent) {
+            module = String(target ?? '');
+            const parts = module.split('#');
+            module = parts[0] || null;
+            cell = parts[1] || null;
+            op = 'open';
+        } else {
+            module = target.module || target.open || target.close || target.focus || null;
+            cell = target.cell || null;
+            source = target.source ?? source;
+            op = target.op || (target.close ? 'close' : target.focus ? 'focus' : 'open');
+        }
+        if (!module)
+            return base.toString();
+        hashParams.set(op, cell ? `${ module }#${ cell }` : module);
+        if (source)
+            hashParams.set('from', source);
+        // Build hash without URLSearchParams to preserve DSL chars unencoded.
+        // Return hash-only for same-page links to avoid page reload.
+        const hashStr = [...hashParams].map(([k, v]) => v ? `${ k }=${ v }` : k).join('&');
+        return '#' + hashStr;
+    };
+};
 const _jdyayh = function _vars(variables,runtime){return(
 variables(runtime)
 )};
+const _mfvz6q = (G, _) => G.input(_);
 const _1f44wsz = function _test_linkTo(links,targets,linkTo){return(
 links.map((link) =>
   targets.map((target) =>
@@ -14615,7 +14609,6 @@ md`## Auto switch to url structure
 
 Watch the runtime for imports and swap them for our structure`
 )};
-const _w93ki7 = (_, v) => v.import("runtime", _);
 const _1gllckt = function _href_examples(){return(
 [
   "https://tomlarkworthy/import-notebook",
@@ -14674,20 +14667,15 @@ const _1xxtf0r = function _updateNotebookImports(vars,extractNotebookAndCell,lin
     }
   }
 };
-const _1txhfy5 = (_, v) => v.import("tests", _);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
   const $def = (pid, name, deps, fn) => {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
-  const fileAttachments = new Map([].map((name) => {
-    const module_name = "@tomlarkworthy/lopepage-urls";
-    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
-    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
-    return [name, {url: blob_url, mimeType: mime}]
-  }));
-  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
   $def("_1g7wjzc", null, ["md"], _1g7wjzc);  
   $def("_1hsbxxe", null, ["md"], _1hsbxxe);  
   $def("_1buq9dd", null, ["tests"], _1buq9dd);  
@@ -14717,22 +14705,21 @@ export default function define(runtime, observer) {
   $def("_1xjzq9r", "isOnObservableCom", ["location"], _1xjzq9r);  
   $def("_gxaxgb", "links", [], _gxaxgb);  
   $def("_17e89y0", "targets", [], _17e89y0);  
-  $def("_1x6cut", "linkTo", ["isOnObservableCom"], _1x6cut);  
+  $def("_bsoqwx", "linkTo", ["isOnObservableCom"], _bsoqwx);  
   $def("_jdyayh", "viewof vars", ["variables","runtime"], _jdyayh);  
-  main.variable(observer("vars")).define("vars", ["Generators", "viewof vars"], (G, _) => G.input(_));  
+  $def("_mfvz6q", "vars", ["Generators","viewof vars"], _mfvz6q);  
   $def("_1f44wsz", "test_linkTo", ["links","targets","linkTo"], _1f44wsz);  
   $def("_1hdknc", null, ["md"], _1hdknc);  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("variables", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("variables", _));  
   $def("_1gllckt", "href_examples", [], _1gllckt);  
   $def("_133ucsn", "test_extractNotebookAndCell", ["href_examples","extractNotebookAndCell"], _133ucsn);  
   $def("_cb1ope", "extractNotebookAndCell", [], _cb1ope);  
   $def("_1xxtf0r", "updateNotebookImports", ["vars","extractNotebookAndCell","linkTo"], _1xxtf0r);  
-  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
   main.define("tests", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("tests", _));
   return main;
-}</script>
+}
+</script>
 
 <script id="@tomlarkworthy/module-map" 
   type="text/plain"

--- a/notebooks/@tomlarkworthy_debugger.html
+++ b/notebooks/@tomlarkworthy_debugger.html
@@ -14590,7 +14590,7 @@ export default function define(runtime, observer) {
   return main;
 }</script>
 
-<script id="@tomlarkworthy/lopepage-urls" 
+<script id="@tomlarkworthy/lopepage-urls"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -14941,81 +14941,75 @@ const _gxaxgb = function _links(){return(
 const _17e89y0 = function _targets(){return(
 ["@tom/bar", "d/1f41fef8b019cf4e@94", "@tom/bar#cell"]
 )};
-const _1x6cut = function _linkTo(isOnObservableCom){return(
-function linkTo(
-  target,
-  {
-    baseURI = document.baseURI,
-    onObservable = isOnObservableCom(),
-    source = null,
-    op = "open" // "open" | "close" | "focus"
-  } = {}
-) {
-  if (onObservable) {
-    const t =
-      typeof target === "string"
-        ? target
-        : target?.module || target?.open || target?.close || "";
-    return t.startsWith("#") ? t : "/" + t;
-  }
-
-  // Parse existing hash params manually to avoid percent-encoding DSL chars
-  const base = new URL(baseURI);
-  const rawHash = (base.hash || "#").slice(1);
-  const hashParams = new Map();
-  if (rawHash) {
-    for (const part of rawHash.split("&")) {
-      const eq = part.indexOf("=");
-      if (eq >= 0) hashParams.set(part.slice(0, eq), part.slice(eq + 1));
-      else if (part) hashParams.set(part, "");
-    }
-  }
-
-  if (typeof target === "string" && target.startsWith("#")) return target;
-
-  const isIntent =
-    typeof target === "object" &&
-    target !== null &&
-    ("module" in target ||
-      "open" in target ||
-      "close" in target ||
-      "focus" in target ||
-      "op" in target);
-
-  let module = null;
-  let cell = null;
-
-  if (!isIntent) {
-    module = String(target ?? "");
-    const parts = module.split("#");
-    module = parts[0] || null;
-    cell = parts[1] || null;
-    op = "open";
-  } else {
-    module =
-      target.module || target.open || target.close || target.focus || null;
-    cell = target.cell || null;
-    source = target.source ?? source;
-    op =
-      target.op || (target.close ? "close" : target.focus ? "focus" : "open");
-  }
-
-  if (!module) return base.toString();
-
-  hashParams.set(op, cell ? `${module}#${cell}` : module);
-  if (source) hashParams.set("from", source);
-
-  // Build hash without URLSearchParams to preserve DSL chars unencoded.
-  // Return hash-only for same-page links to avoid page reload.
-  const hashStr = [...hashParams]
-    .map(([k, v]) => (v ? `${k}=${v}` : k))
-    .join("&");
-  return "#" + hashStr;
-}
-)};
+const _bsoqwx = function _linkTo(isOnObservableCom)
+{
+    return function linkTo(target, {baseURI = document.baseURI, onObservable = isOnObservableCom(), source = null, op = 'open'    // "open" | "close" | "focus"
+} = {}) {
+        if (onObservable) {
+            const t = typeof target === 'string' ? target : target?.module || target?.open || target?.close || '';
+            return t.startsWith('#') ? t : '/' + t;
+        }
+        // Parse existing hash params manually to avoid percent-encoding DSL chars
+        const base = new URL(baseURI);
+        const rawHash = (base.hash || '#').slice(1);
+        const hashParams = new Map();
+        // open/close/focus/from are transient intents that lopepage consumes and
+        // clears, so we do NOT deep-link them. view= is canonical layout state owned
+        // by lopepage; if we baked the baseURI's view= into every link, the href
+        // would be a snapshot from link-render time and clicking it would rewind the
+        // layout (issue #150 — clicking a second module wiped the first because the
+        // link carried the boot view=). Dropping view= here makes the link a pure
+        // intent (e.g. "#cc=...&open=X"); sync_layout_from_url's
+        // `if (!view && open)` branch then merges the intent into the live layout.
+        const drop = new Set([
+            'view',
+            'open',
+            'close',
+            'focus',
+            'from'
+        ]);
+        if (rawHash) {
+            for (const part of rawHash.split('&')) {
+                const eq = part.indexOf('=');
+                const key = eq >= 0 ? part.slice(0, eq) : part;
+                if (drop.has(key))
+                    continue;
+                const val = eq >= 0 ? part.slice(eq + 1) : '';
+                hashParams.set(key, val);
+            }
+        }
+        if (typeof target === 'string' && target.startsWith('#'))
+            return target;
+        const isIntent = typeof target === 'object' && target !== null && ('module' in target || 'open' in target || 'close' in target || 'focus' in target || 'op' in target);
+        let module = null;
+        let cell = null;
+        if (!isIntent) {
+            module = String(target ?? '');
+            const parts = module.split('#');
+            module = parts[0] || null;
+            cell = parts[1] || null;
+            op = 'open';
+        } else {
+            module = target.module || target.open || target.close || target.focus || null;
+            cell = target.cell || null;
+            source = target.source ?? source;
+            op = target.op || (target.close ? 'close' : target.focus ? 'focus' : 'open');
+        }
+        if (!module)
+            return base.toString();
+        hashParams.set(op, cell ? `${ module }#${ cell }` : module);
+        if (source)
+            hashParams.set('from', source);
+        // Build hash without URLSearchParams to preserve DSL chars unencoded.
+        // Return hash-only for same-page links to avoid page reload.
+        const hashStr = [...hashParams].map(([k, v]) => v ? `${ k }=${ v }` : k).join('&');
+        return '#' + hashStr;
+    };
+};
 const _jdyayh = function _vars(variables,runtime){return(
 variables(runtime)
 )};
+const _mfvz6q = (G, _) => G.input(_);
 const _1f44wsz = function _test_linkTo(links,targets,linkTo){return(
 links.map((link) =>
   targets.map((target) =>
@@ -15028,7 +15022,6 @@ md`## Auto switch to url structure
 
 Watch the runtime for imports and swap them for our structure`
 )};
-const _w93ki7 = (_, v) => v.import("runtime", _);
 const _1gllckt = function _href_examples(){return(
 [
   "https://tomlarkworthy/import-notebook",
@@ -15087,20 +15080,15 @@ const _1xxtf0r = function _updateNotebookImports(vars,extractNotebookAndCell,lin
     }
   }
 };
-const _1txhfy5 = (_, v) => v.import("tests", _);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
   const $def = (pid, name, deps, fn) => {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
-  const fileAttachments = new Map([].map((name) => {
-    const module_name = "@tomlarkworthy/lopepage-urls";
-    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
-    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
-    return [name, {url: blob_url, mimeType: mime}]
-  }));
-  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
   $def("_1g7wjzc", null, ["md"], _1g7wjzc);  
   $def("_1hsbxxe", null, ["md"], _1hsbxxe);  
   $def("_1buq9dd", null, ["tests"], _1buq9dd);  
@@ -15130,22 +15118,21 @@ export default function define(runtime, observer) {
   $def("_1xjzq9r", "isOnObservableCom", ["location"], _1xjzq9r);  
   $def("_gxaxgb", "links", [], _gxaxgb);  
   $def("_17e89y0", "targets", [], _17e89y0);  
-  $def("_1x6cut", "linkTo", ["isOnObservableCom"], _1x6cut);  
+  $def("_bsoqwx", "linkTo", ["isOnObservableCom"], _bsoqwx);  
   $def("_jdyayh", "viewof vars", ["variables","runtime"], _jdyayh);  
-  main.variable(observer("vars")).define("vars", ["Generators", "viewof vars"], (G, _) => G.input(_));  
+  $def("_mfvz6q", "vars", ["Generators","viewof vars"], _mfvz6q);  
   $def("_1f44wsz", "test_linkTo", ["links","targets","linkTo"], _1f44wsz);  
   $def("_1hdknc", null, ["md"], _1hdknc);  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("variables", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("variables", _));  
   $def("_1gllckt", "href_examples", [], _1gllckt);  
   $def("_133ucsn", "test_extractNotebookAndCell", ["href_examples","extractNotebookAndCell"], _133ucsn);  
   $def("_cb1ope", "extractNotebookAndCell", [], _cb1ope);  
   $def("_1xxtf0r", "updateNotebookImports", ["vars","extractNotebookAndCell","linkTo"], _1xxtf0r);  
-  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
   main.define("tests", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("tests", _));
   return main;
-}</script>
+}
+</script>
 
 <script id="@tomlarkworthy/module-map" 
   type="text/plain"

--- a/notebooks/@tomlarkworthy_dom-view.html
+++ b/notebooks/@tomlarkworthy_dom-view.html
@@ -14177,7 +14177,7 @@ export default function define(runtime, observer) {
   return main;
 }</script>
 
-<script id="@tomlarkworthy/lopepage-urls" 
+<script id="@tomlarkworthy/lopepage-urls"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -14528,81 +14528,75 @@ const _gxaxgb = function _links(){return(
 const _17e89y0 = function _targets(){return(
 ["@tom/bar", "d/1f41fef8b019cf4e@94", "@tom/bar#cell"]
 )};
-const _1x6cut = function _linkTo(isOnObservableCom){return(
-function linkTo(
-  target,
-  {
-    baseURI = document.baseURI,
-    onObservable = isOnObservableCom(),
-    source = null,
-    op = "open" // "open" | "close" | "focus"
-  } = {}
-) {
-  if (onObservable) {
-    const t =
-      typeof target === "string"
-        ? target
-        : target?.module || target?.open || target?.close || "";
-    return t.startsWith("#") ? t : "/" + t;
-  }
-
-  // Parse existing hash params manually to avoid percent-encoding DSL chars
-  const base = new URL(baseURI);
-  const rawHash = (base.hash || "#").slice(1);
-  const hashParams = new Map();
-  if (rawHash) {
-    for (const part of rawHash.split("&")) {
-      const eq = part.indexOf("=");
-      if (eq >= 0) hashParams.set(part.slice(0, eq), part.slice(eq + 1));
-      else if (part) hashParams.set(part, "");
-    }
-  }
-
-  if (typeof target === "string" && target.startsWith("#")) return target;
-
-  const isIntent =
-    typeof target === "object" &&
-    target !== null &&
-    ("module" in target ||
-      "open" in target ||
-      "close" in target ||
-      "focus" in target ||
-      "op" in target);
-
-  let module = null;
-  let cell = null;
-
-  if (!isIntent) {
-    module = String(target ?? "");
-    const parts = module.split("#");
-    module = parts[0] || null;
-    cell = parts[1] || null;
-    op = "open";
-  } else {
-    module =
-      target.module || target.open || target.close || target.focus || null;
-    cell = target.cell || null;
-    source = target.source ?? source;
-    op =
-      target.op || (target.close ? "close" : target.focus ? "focus" : "open");
-  }
-
-  if (!module) return base.toString();
-
-  hashParams.set(op, cell ? `${module}#${cell}` : module);
-  if (source) hashParams.set("from", source);
-
-  // Build hash without URLSearchParams to preserve DSL chars unencoded.
-  // Return hash-only for same-page links to avoid page reload.
-  const hashStr = [...hashParams]
-    .map(([k, v]) => (v ? `${k}=${v}` : k))
-    .join("&");
-  return "#" + hashStr;
-}
-)};
+const _bsoqwx = function _linkTo(isOnObservableCom)
+{
+    return function linkTo(target, {baseURI = document.baseURI, onObservable = isOnObservableCom(), source = null, op = 'open'    // "open" | "close" | "focus"
+} = {}) {
+        if (onObservable) {
+            const t = typeof target === 'string' ? target : target?.module || target?.open || target?.close || '';
+            return t.startsWith('#') ? t : '/' + t;
+        }
+        // Parse existing hash params manually to avoid percent-encoding DSL chars
+        const base = new URL(baseURI);
+        const rawHash = (base.hash || '#').slice(1);
+        const hashParams = new Map();
+        // open/close/focus/from are transient intents that lopepage consumes and
+        // clears, so we do NOT deep-link them. view= is canonical layout state owned
+        // by lopepage; if we baked the baseURI's view= into every link, the href
+        // would be a snapshot from link-render time and clicking it would rewind the
+        // layout (issue #150 — clicking a second module wiped the first because the
+        // link carried the boot view=). Dropping view= here makes the link a pure
+        // intent (e.g. "#cc=...&open=X"); sync_layout_from_url's
+        // `if (!view && open)` branch then merges the intent into the live layout.
+        const drop = new Set([
+            'view',
+            'open',
+            'close',
+            'focus',
+            'from'
+        ]);
+        if (rawHash) {
+            for (const part of rawHash.split('&')) {
+                const eq = part.indexOf('=');
+                const key = eq >= 0 ? part.slice(0, eq) : part;
+                if (drop.has(key))
+                    continue;
+                const val = eq >= 0 ? part.slice(eq + 1) : '';
+                hashParams.set(key, val);
+            }
+        }
+        if (typeof target === 'string' && target.startsWith('#'))
+            return target;
+        const isIntent = typeof target === 'object' && target !== null && ('module' in target || 'open' in target || 'close' in target || 'focus' in target || 'op' in target);
+        let module = null;
+        let cell = null;
+        if (!isIntent) {
+            module = String(target ?? '');
+            const parts = module.split('#');
+            module = parts[0] || null;
+            cell = parts[1] || null;
+            op = 'open';
+        } else {
+            module = target.module || target.open || target.close || target.focus || null;
+            cell = target.cell || null;
+            source = target.source ?? source;
+            op = target.op || (target.close ? 'close' : target.focus ? 'focus' : 'open');
+        }
+        if (!module)
+            return base.toString();
+        hashParams.set(op, cell ? `${ module }#${ cell }` : module);
+        if (source)
+            hashParams.set('from', source);
+        // Build hash without URLSearchParams to preserve DSL chars unencoded.
+        // Return hash-only for same-page links to avoid page reload.
+        const hashStr = [...hashParams].map(([k, v]) => v ? `${ k }=${ v }` : k).join('&');
+        return '#' + hashStr;
+    };
+};
 const _jdyayh = function _vars(variables,runtime){return(
 variables(runtime)
 )};
+const _mfvz6q = (G, _) => G.input(_);
 const _1f44wsz = function _test_linkTo(links,targets,linkTo){return(
 links.map((link) =>
   targets.map((target) =>
@@ -14615,7 +14609,6 @@ md`## Auto switch to url structure
 
 Watch the runtime for imports and swap them for our structure`
 )};
-const _w93ki7 = (_, v) => v.import("runtime", _);
 const _1gllckt = function _href_examples(){return(
 [
   "https://tomlarkworthy/import-notebook",
@@ -14674,20 +14667,15 @@ const _1xxtf0r = function _updateNotebookImports(vars,extractNotebookAndCell,lin
     }
   }
 };
-const _1txhfy5 = (_, v) => v.import("tests", _);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
   const $def = (pid, name, deps, fn) => {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
-  const fileAttachments = new Map([].map((name) => {
-    const module_name = "@tomlarkworthy/lopepage-urls";
-    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
-    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
-    return [name, {url: blob_url, mimeType: mime}]
-  }));
-  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
   $def("_1g7wjzc", null, ["md"], _1g7wjzc);  
   $def("_1hsbxxe", null, ["md"], _1hsbxxe);  
   $def("_1buq9dd", null, ["tests"], _1buq9dd);  
@@ -14717,22 +14705,21 @@ export default function define(runtime, observer) {
   $def("_1xjzq9r", "isOnObservableCom", ["location"], _1xjzq9r);  
   $def("_gxaxgb", "links", [], _gxaxgb);  
   $def("_17e89y0", "targets", [], _17e89y0);  
-  $def("_1x6cut", "linkTo", ["isOnObservableCom"], _1x6cut);  
+  $def("_bsoqwx", "linkTo", ["isOnObservableCom"], _bsoqwx);  
   $def("_jdyayh", "viewof vars", ["variables","runtime"], _jdyayh);  
-  main.variable(observer("vars")).define("vars", ["Generators", "viewof vars"], (G, _) => G.input(_));  
+  $def("_mfvz6q", "vars", ["Generators","viewof vars"], _mfvz6q);  
   $def("_1f44wsz", "test_linkTo", ["links","targets","linkTo"], _1f44wsz);  
   $def("_1hdknc", null, ["md"], _1hdknc);  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("variables", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("variables", _));  
   $def("_1gllckt", "href_examples", [], _1gllckt);  
   $def("_133ucsn", "test_extractNotebookAndCell", ["href_examples","extractNotebookAndCell"], _133ucsn);  
   $def("_cb1ope", "extractNotebookAndCell", [], _cb1ope);  
   $def("_1xxtf0r", "updateNotebookImports", ["vars","extractNotebookAndCell","linkTo"], _1xxtf0r);  
-  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
   main.define("tests", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("tests", _));
   return main;
-}</script>
+}
+</script>
 
 <script id="@tomlarkworthy/module-map" 
   type="text/plain"

--- a/notebooks/@tomlarkworthy_editor-5.html
+++ b/notebooks/@tomlarkworthy_editor-5.html
@@ -14117,7 +14117,7 @@ export default function define(runtime, observer) {
   return main;
 }</script>
 
-<script id="@tomlarkworthy/lopepage-urls" 
+<script id="@tomlarkworthy/lopepage-urls"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -14468,78 +14468,71 @@ const _gxaxgb = function _links(){return(
 const _17e89y0 = function _targets(){return(
 ["@tom/bar", "d/1f41fef8b019cf4e@94", "@tom/bar#cell"]
 )};
-const _1x6cut = function _linkTo(isOnObservableCom){return(
-function linkTo(
-  target,
-  {
-    baseURI = document.baseURI,
-    onObservable = isOnObservableCom(),
-    source = null,
-    op = "open" // "open" | "close" | "focus"
-  } = {}
-) {
-  if (onObservable) {
-    const t =
-      typeof target === "string"
-        ? target
-        : target?.module || target?.open || target?.close || "";
-    return t.startsWith("#") ? t : "/" + t;
-  }
-
-  // Parse existing hash params manually to avoid percent-encoding DSL chars
-  const base = new URL(baseURI);
-  const rawHash = (base.hash || "#").slice(1);
-  const hashParams = new Map();
-  if (rawHash) {
-    for (const part of rawHash.split("&")) {
-      const eq = part.indexOf("=");
-      if (eq >= 0) hashParams.set(part.slice(0, eq), part.slice(eq + 1));
-      else if (part) hashParams.set(part, "");
-    }
-  }
-
-  if (typeof target === "string" && target.startsWith("#")) return target;
-
-  const isIntent =
-    typeof target === "object" &&
-    target !== null &&
-    ("module" in target ||
-      "open" in target ||
-      "close" in target ||
-      "focus" in target ||
-      "op" in target);
-
-  let module = null;
-  let cell = null;
-
-  if (!isIntent) {
-    module = String(target ?? "");
-    const parts = module.split("#");
-    module = parts[0] || null;
-    cell = parts[1] || null;
-    op = "open";
-  } else {
-    module =
-      target.module || target.open || target.close || target.focus || null;
-    cell = target.cell || null;
-    source = target.source ?? source;
-    op =
-      target.op || (target.close ? "close" : target.focus ? "focus" : "open");
-  }
-
-  if (!module) return base.toString();
-
-  hashParams.set(op, cell ? `${module}#${cell}` : module);
-  if (source) hashParams.set("from", source);
-
-  // Build hash without URLSearchParams to preserve DSL chars unencoded.
-  // Return hash-only for same-page links to avoid page reload.
-  const hashStr = [...hashParams]
-    .map(([k, v]) => (v ? `${k}=${v}` : k))
-    .join("&");
-  return "#" + hashStr;
-}
-)};
+const _bsoqwx = function _linkTo(isOnObservableCom)
+{
+    return function linkTo(target, {baseURI = document.baseURI, onObservable = isOnObservableCom(), source = null, op = 'open'    // "open" | "close" | "focus"
+} = {}) {
+        if (onObservable) {
+            const t = typeof target === 'string' ? target : target?.module || target?.open || target?.close || '';
+            return t.startsWith('#') ? t : '/' + t;
+        }
+        // Parse existing hash params manually to avoid percent-encoding DSL chars
+        const base = new URL(baseURI);
+        const rawHash = (base.hash || '#').slice(1);
+        const hashParams = new Map();
+        // open/close/focus/from are transient intents that lopepage consumes and
+        // clears, so we do NOT deep-link them. view= is canonical layout state owned
+        // by lopepage; if we baked the baseURI's view= into every link, the href
+        // would be a snapshot from link-render time and clicking it would rewind the
+        // layout (issue #150 — clicking a second module wiped the first because the
+        // link carried the boot view=). Dropping view= here makes the link a pure
+        // intent (e.g. "#cc=...&open=X"); sync_layout_from_url's
+        // `if (!view && open)` branch then merges the intent into the live layout.
+        const drop = new Set([
+            'view',
+            'open',
+            'close',
+            'focus',
+            'from'
+        ]);
+        if (rawHash) {
+            for (const part of rawHash.split('&')) {
+                const eq = part.indexOf('=');
+                const key = eq >= 0 ? part.slice(0, eq) : part;
+                if (drop.has(key))
+                    continue;
+                const val = eq >= 0 ? part.slice(eq + 1) : '';
+                hashParams.set(key, val);
+            }
+        }
+        if (typeof target === 'string' && target.startsWith('#'))
+            return target;
+        const isIntent = typeof target === 'object' && target !== null && ('module' in target || 'open' in target || 'close' in target || 'focus' in target || 'op' in target);
+        let module = null;
+        let cell = null;
+        if (!isIntent) {
+            module = String(target ?? '');
+            const parts = module.split('#');
+            module = parts[0] || null;
+            cell = parts[1] || null;
+            op = 'open';
+        } else {
+            module = target.module || target.open || target.close || target.focus || null;
+            cell = target.cell || null;
+            source = target.source ?? source;
+            op = target.op || (target.close ? 'close' : target.focus ? 'focus' : 'open');
+        }
+        if (!module)
+            return base.toString();
+        hashParams.set(op, cell ? `${ module }#${ cell }` : module);
+        if (source)
+            hashParams.set('from', source);
+        // Build hash without URLSearchParams to preserve DSL chars unencoded.
+        // Return hash-only for same-page links to avoid page reload.
+        const hashStr = [...hashParams].map(([k, v]) => v ? `${ k }=${ v }` : k).join('&');
+        return '#' + hashStr;
+    };
+};
 const _jdyayh = function _vars(variables,runtime){return(
 variables(runtime)
 )};
@@ -14652,7 +14645,7 @@ export default function define(runtime, observer) {
   $def("_1xjzq9r", "isOnObservableCom", ["location"], _1xjzq9r);  
   $def("_gxaxgb", "links", [], _gxaxgb);  
   $def("_17e89y0", "targets", [], _17e89y0);  
-  $def("_1x6cut", "linkTo", ["isOnObservableCom"], _1x6cut);  
+  $def("_bsoqwx", "linkTo", ["isOnObservableCom"], _bsoqwx);  
   $def("_jdyayh", "viewof vars", ["variables","runtime"], _jdyayh);  
   $def("_mfvz6q", "vars", ["Generators","viewof vars"], _mfvz6q);  
   $def("_1f44wsz", "test_linkTo", ["links","targets","linkTo"], _1f44wsz);  
@@ -14665,7 +14658,8 @@ export default function define(runtime, observer) {
   $def("_1xxtf0r", "updateNotebookImports", ["vars","extractNotebookAndCell","linkTo"], _1xxtf0r);  
   main.define("tests", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("tests", _));
   return main;
-}</script>
+}
+</script>
 
 <script id="@tomlarkworthy/module-map" 
   type="text/plain"

--- a/notebooks/@tomlarkworthy_exporter-2.html
+++ b/notebooks/@tomlarkworthy_exporter-2.html
@@ -16271,7 +16271,7 @@ export default function define(runtime, observer) {
   return main;
 }</script>
 
-<script id="@tomlarkworthy/lopepage-urls" 
+<script id="@tomlarkworthy/lopepage-urls"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -16622,81 +16622,75 @@ const _gxaxgb = function _links(){return(
 const _17e89y0 = function _targets(){return(
 ["@tom/bar", "d/1f41fef8b019cf4e@94", "@tom/bar#cell"]
 )};
-const _1x6cut = function _linkTo(isOnObservableCom){return(
-function linkTo(
-  target,
-  {
-    baseURI = document.baseURI,
-    onObservable = isOnObservableCom(),
-    source = null,
-    op = "open" // "open" | "close" | "focus"
-  } = {}
-) {
-  if (onObservable) {
-    const t =
-      typeof target === "string"
-        ? target
-        : target?.module || target?.open || target?.close || "";
-    return t.startsWith("#") ? t : "/" + t;
-  }
-
-  // Parse existing hash params manually to avoid percent-encoding DSL chars
-  const base = new URL(baseURI);
-  const rawHash = (base.hash || "#").slice(1);
-  const hashParams = new Map();
-  if (rawHash) {
-    for (const part of rawHash.split("&")) {
-      const eq = part.indexOf("=");
-      if (eq >= 0) hashParams.set(part.slice(0, eq), part.slice(eq + 1));
-      else if (part) hashParams.set(part, "");
-    }
-  }
-
-  if (typeof target === "string" && target.startsWith("#")) return target;
-
-  const isIntent =
-    typeof target === "object" &&
-    target !== null &&
-    ("module" in target ||
-      "open" in target ||
-      "close" in target ||
-      "focus" in target ||
-      "op" in target);
-
-  let module = null;
-  let cell = null;
-
-  if (!isIntent) {
-    module = String(target ?? "");
-    const parts = module.split("#");
-    module = parts[0] || null;
-    cell = parts[1] || null;
-    op = "open";
-  } else {
-    module =
-      target.module || target.open || target.close || target.focus || null;
-    cell = target.cell || null;
-    source = target.source ?? source;
-    op =
-      target.op || (target.close ? "close" : target.focus ? "focus" : "open");
-  }
-
-  if (!module) return base.toString();
-
-  hashParams.set(op, cell ? `${module}#${cell}` : module);
-  if (source) hashParams.set("from", source);
-
-  // Build hash without URLSearchParams to preserve DSL chars unencoded.
-  // Return hash-only for same-page links to avoid page reload.
-  const hashStr = [...hashParams]
-    .map(([k, v]) => (v ? `${k}=${v}` : k))
-    .join("&");
-  return "#" + hashStr;
-}
-)};
+const _bsoqwx = function _linkTo(isOnObservableCom)
+{
+    return function linkTo(target, {baseURI = document.baseURI, onObservable = isOnObservableCom(), source = null, op = 'open'    // "open" | "close" | "focus"
+} = {}) {
+        if (onObservable) {
+            const t = typeof target === 'string' ? target : target?.module || target?.open || target?.close || '';
+            return t.startsWith('#') ? t : '/' + t;
+        }
+        // Parse existing hash params manually to avoid percent-encoding DSL chars
+        const base = new URL(baseURI);
+        const rawHash = (base.hash || '#').slice(1);
+        const hashParams = new Map();
+        // open/close/focus/from are transient intents that lopepage consumes and
+        // clears, so we do NOT deep-link them. view= is canonical layout state owned
+        // by lopepage; if we baked the baseURI's view= into every link, the href
+        // would be a snapshot from link-render time and clicking it would rewind the
+        // layout (issue #150 — clicking a second module wiped the first because the
+        // link carried the boot view=). Dropping view= here makes the link a pure
+        // intent (e.g. "#cc=...&open=X"); sync_layout_from_url's
+        // `if (!view && open)` branch then merges the intent into the live layout.
+        const drop = new Set([
+            'view',
+            'open',
+            'close',
+            'focus',
+            'from'
+        ]);
+        if (rawHash) {
+            for (const part of rawHash.split('&')) {
+                const eq = part.indexOf('=');
+                const key = eq >= 0 ? part.slice(0, eq) : part;
+                if (drop.has(key))
+                    continue;
+                const val = eq >= 0 ? part.slice(eq + 1) : '';
+                hashParams.set(key, val);
+            }
+        }
+        if (typeof target === 'string' && target.startsWith('#'))
+            return target;
+        const isIntent = typeof target === 'object' && target !== null && ('module' in target || 'open' in target || 'close' in target || 'focus' in target || 'op' in target);
+        let module = null;
+        let cell = null;
+        if (!isIntent) {
+            module = String(target ?? '');
+            const parts = module.split('#');
+            module = parts[0] || null;
+            cell = parts[1] || null;
+            op = 'open';
+        } else {
+            module = target.module || target.open || target.close || target.focus || null;
+            cell = target.cell || null;
+            source = target.source ?? source;
+            op = target.op || (target.close ? 'close' : target.focus ? 'focus' : 'open');
+        }
+        if (!module)
+            return base.toString();
+        hashParams.set(op, cell ? `${ module }#${ cell }` : module);
+        if (source)
+            hashParams.set('from', source);
+        // Build hash without URLSearchParams to preserve DSL chars unencoded.
+        // Return hash-only for same-page links to avoid page reload.
+        const hashStr = [...hashParams].map(([k, v]) => v ? `${ k }=${ v }` : k).join('&');
+        return '#' + hashStr;
+    };
+};
 const _jdyayh = function _vars(variables,runtime){return(
 variables(runtime)
 )};
+const _mfvz6q = (G, _) => G.input(_);
 const _1f44wsz = function _test_linkTo(links,targets,linkTo){return(
 links.map((link) =>
   targets.map((target) =>
@@ -16709,7 +16703,6 @@ md`## Auto switch to url structure
 
 Watch the runtime for imports and swap them for our structure`
 )};
-const _w93ki7 = (_, v) => v.import("runtime", _);
 const _1gllckt = function _href_examples(){return(
 [
   "https://tomlarkworthy/import-notebook",
@@ -16768,20 +16761,15 @@ const _1xxtf0r = function _updateNotebookImports(vars,extractNotebookAndCell,lin
     }
   }
 };
-const _1txhfy5 = (_, v) => v.import("tests", _);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
   const $def = (pid, name, deps, fn) => {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
-  const fileAttachments = new Map([].map((name) => {
-    const module_name = "@tomlarkworthy/lopepage-urls";
-    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
-    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
-    return [name, {url: blob_url, mimeType: mime}]
-  }));
-  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
   $def("_1g7wjzc", null, ["md"], _1g7wjzc);  
   $def("_1hsbxxe", null, ["md"], _1hsbxxe);  
   $def("_1buq9dd", null, ["tests"], _1buq9dd);  
@@ -16811,22 +16799,21 @@ export default function define(runtime, observer) {
   $def("_1xjzq9r", "isOnObservableCom", ["location"], _1xjzq9r);  
   $def("_gxaxgb", "links", [], _gxaxgb);  
   $def("_17e89y0", "targets", [], _17e89y0);  
-  $def("_1x6cut", "linkTo", ["isOnObservableCom"], _1x6cut);  
+  $def("_bsoqwx", "linkTo", ["isOnObservableCom"], _bsoqwx);  
   $def("_jdyayh", "viewof vars", ["variables","runtime"], _jdyayh);  
-  main.variable(observer("vars")).define("vars", ["Generators", "viewof vars"], (G, _) => G.input(_));  
+  $def("_mfvz6q", "vars", ["Generators","viewof vars"], _mfvz6q);  
   $def("_1f44wsz", "test_linkTo", ["links","targets","linkTo"], _1f44wsz);  
   $def("_1hdknc", null, ["md"], _1hdknc);  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("variables", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("variables", _));  
   $def("_1gllckt", "href_examples", [], _1gllckt);  
   $def("_133ucsn", "test_extractNotebookAndCell", ["href_examples","extractNotebookAndCell"], _133ucsn);  
   $def("_cb1ope", "extractNotebookAndCell", [], _cb1ope);  
   $def("_1xxtf0r", "updateNotebookImports", ["vars","extractNotebookAndCell","linkTo"], _1xxtf0r);  
-  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
   main.define("tests", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("tests", _));
   return main;
-}</script>
+}
+</script>
 
 <script id="@tomlarkworthy/module-map" 
   type="text/plain"

--- a/notebooks/@tomlarkworthy_exporter-3.html
+++ b/notebooks/@tomlarkworthy_exporter-3.html
@@ -14119,7 +14119,7 @@ export default function define(runtime, observer) {
   return main;
 }</script>
 
-<script id="@tomlarkworthy/lopepage-urls" 
+<script id="@tomlarkworthy/lopepage-urls"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -14470,78 +14470,71 @@ const _gxaxgb = function _links(){return(
 const _17e89y0 = function _targets(){return(
 ["@tom/bar", "d/1f41fef8b019cf4e@94", "@tom/bar#cell"]
 )};
-const _1x6cut = function _linkTo(isOnObservableCom){return(
-function linkTo(
-  target,
-  {
-    baseURI = document.baseURI,
-    onObservable = isOnObservableCom(),
-    source = null,
-    op = "open" // "open" | "close" | "focus"
-  } = {}
-) {
-  if (onObservable) {
-    const t =
-      typeof target === "string"
-        ? target
-        : target?.module || target?.open || target?.close || "";
-    return t.startsWith("#") ? t : "/" + t;
-  }
-
-  // Parse existing hash params manually to avoid percent-encoding DSL chars
-  const base = new URL(baseURI);
-  const rawHash = (base.hash || "#").slice(1);
-  const hashParams = new Map();
-  if (rawHash) {
-    for (const part of rawHash.split("&")) {
-      const eq = part.indexOf("=");
-      if (eq >= 0) hashParams.set(part.slice(0, eq), part.slice(eq + 1));
-      else if (part) hashParams.set(part, "");
-    }
-  }
-
-  if (typeof target === "string" && target.startsWith("#")) return target;
-
-  const isIntent =
-    typeof target === "object" &&
-    target !== null &&
-    ("module" in target ||
-      "open" in target ||
-      "close" in target ||
-      "focus" in target ||
-      "op" in target);
-
-  let module = null;
-  let cell = null;
-
-  if (!isIntent) {
-    module = String(target ?? "");
-    const parts = module.split("#");
-    module = parts[0] || null;
-    cell = parts[1] || null;
-    op = "open";
-  } else {
-    module =
-      target.module || target.open || target.close || target.focus || null;
-    cell = target.cell || null;
-    source = target.source ?? source;
-    op =
-      target.op || (target.close ? "close" : target.focus ? "focus" : "open");
-  }
-
-  if (!module) return base.toString();
-
-  hashParams.set(op, cell ? `${module}#${cell}` : module);
-  if (source) hashParams.set("from", source);
-
-  // Build hash without URLSearchParams to preserve DSL chars unencoded.
-  // Return hash-only for same-page links to avoid page reload.
-  const hashStr = [...hashParams]
-    .map(([k, v]) => (v ? `${k}=${v}` : k))
-    .join("&");
-  return "#" + hashStr;
-}
-)};
+const _bsoqwx = function _linkTo(isOnObservableCom)
+{
+    return function linkTo(target, {baseURI = document.baseURI, onObservable = isOnObservableCom(), source = null, op = 'open'    // "open" | "close" | "focus"
+} = {}) {
+        if (onObservable) {
+            const t = typeof target === 'string' ? target : target?.module || target?.open || target?.close || '';
+            return t.startsWith('#') ? t : '/' + t;
+        }
+        // Parse existing hash params manually to avoid percent-encoding DSL chars
+        const base = new URL(baseURI);
+        const rawHash = (base.hash || '#').slice(1);
+        const hashParams = new Map();
+        // open/close/focus/from are transient intents that lopepage consumes and
+        // clears, so we do NOT deep-link them. view= is canonical layout state owned
+        // by lopepage; if we baked the baseURI's view= into every link, the href
+        // would be a snapshot from link-render time and clicking it would rewind the
+        // layout (issue #150 — clicking a second module wiped the first because the
+        // link carried the boot view=). Dropping view= here makes the link a pure
+        // intent (e.g. "#cc=...&open=X"); sync_layout_from_url's
+        // `if (!view && open)` branch then merges the intent into the live layout.
+        const drop = new Set([
+            'view',
+            'open',
+            'close',
+            'focus',
+            'from'
+        ]);
+        if (rawHash) {
+            for (const part of rawHash.split('&')) {
+                const eq = part.indexOf('=');
+                const key = eq >= 0 ? part.slice(0, eq) : part;
+                if (drop.has(key))
+                    continue;
+                const val = eq >= 0 ? part.slice(eq + 1) : '';
+                hashParams.set(key, val);
+            }
+        }
+        if (typeof target === 'string' && target.startsWith('#'))
+            return target;
+        const isIntent = typeof target === 'object' && target !== null && ('module' in target || 'open' in target || 'close' in target || 'focus' in target || 'op' in target);
+        let module = null;
+        let cell = null;
+        if (!isIntent) {
+            module = String(target ?? '');
+            const parts = module.split('#');
+            module = parts[0] || null;
+            cell = parts[1] || null;
+            op = 'open';
+        } else {
+            module = target.module || target.open || target.close || target.focus || null;
+            cell = target.cell || null;
+            source = target.source ?? source;
+            op = target.op || (target.close ? 'close' : target.focus ? 'focus' : 'open');
+        }
+        if (!module)
+            return base.toString();
+        hashParams.set(op, cell ? `${ module }#${ cell }` : module);
+        if (source)
+            hashParams.set('from', source);
+        // Build hash without URLSearchParams to preserve DSL chars unencoded.
+        // Return hash-only for same-page links to avoid page reload.
+        const hashStr = [...hashParams].map(([k, v]) => v ? `${ k }=${ v }` : k).join('&');
+        return '#' + hashStr;
+    };
+};
 const _jdyayh = function _vars(variables,runtime){return(
 variables(runtime)
 )};
@@ -14654,7 +14647,7 @@ export default function define(runtime, observer) {
   $def("_1xjzq9r", "isOnObservableCom", ["location"], _1xjzq9r);  
   $def("_gxaxgb", "links", [], _gxaxgb);  
   $def("_17e89y0", "targets", [], _17e89y0);  
-  $def("_1x6cut", "linkTo", ["isOnObservableCom"], _1x6cut);  
+  $def("_bsoqwx", "linkTo", ["isOnObservableCom"], _bsoqwx);  
   $def("_jdyayh", "viewof vars", ["variables","runtime"], _jdyayh);  
   $def("_mfvz6q", "vars", ["Generators","viewof vars"], _mfvz6q);  
   $def("_1f44wsz", "test_linkTo", ["links","targets","linkTo"], _1f44wsz);  
@@ -14667,7 +14660,8 @@ export default function define(runtime, observer) {
   $def("_1xxtf0r", "updateNotebookImports", ["vars","extractNotebookAndCell","linkTo"], _1xxtf0r);  
   main.define("tests", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("tests", _));
   return main;
-}</script>
+}
+</script>
 
 <script id="@tomlarkworthy/module-map" 
   type="text/plain"

--- a/notebooks/@tomlarkworthy_fileattachments.html
+++ b/notebooks/@tomlarkworthy_fileattachments.html
@@ -14118,7 +14118,7 @@ export default function define(runtime, observer) {
   return main;
 }</script>
 
-<script id="@tomlarkworthy/lopepage-urls" 
+<script id="@tomlarkworthy/lopepage-urls"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -14469,78 +14469,71 @@ const _gxaxgb = function _links(){return(
 const _17e89y0 = function _targets(){return(
 ["@tom/bar", "d/1f41fef8b019cf4e@94", "@tom/bar#cell"]
 )};
-const _1x6cut = function _linkTo(isOnObservableCom){return(
-function linkTo(
-  target,
-  {
-    baseURI = document.baseURI,
-    onObservable = isOnObservableCom(),
-    source = null,
-    op = "open" // "open" | "close" | "focus"
-  } = {}
-) {
-  if (onObservable) {
-    const t =
-      typeof target === "string"
-        ? target
-        : target?.module || target?.open || target?.close || "";
-    return t.startsWith("#") ? t : "/" + t;
-  }
-
-  // Parse existing hash params manually to avoid percent-encoding DSL chars
-  const base = new URL(baseURI);
-  const rawHash = (base.hash || "#").slice(1);
-  const hashParams = new Map();
-  if (rawHash) {
-    for (const part of rawHash.split("&")) {
-      const eq = part.indexOf("=");
-      if (eq >= 0) hashParams.set(part.slice(0, eq), part.slice(eq + 1));
-      else if (part) hashParams.set(part, "");
-    }
-  }
-
-  if (typeof target === "string" && target.startsWith("#")) return target;
-
-  const isIntent =
-    typeof target === "object" &&
-    target !== null &&
-    ("module" in target ||
-      "open" in target ||
-      "close" in target ||
-      "focus" in target ||
-      "op" in target);
-
-  let module = null;
-  let cell = null;
-
-  if (!isIntent) {
-    module = String(target ?? "");
-    const parts = module.split("#");
-    module = parts[0] || null;
-    cell = parts[1] || null;
-    op = "open";
-  } else {
-    module =
-      target.module || target.open || target.close || target.focus || null;
-    cell = target.cell || null;
-    source = target.source ?? source;
-    op =
-      target.op || (target.close ? "close" : target.focus ? "focus" : "open");
-  }
-
-  if (!module) return base.toString();
-
-  hashParams.set(op, cell ? `${module}#${cell}` : module);
-  if (source) hashParams.set("from", source);
-
-  // Build hash without URLSearchParams to preserve DSL chars unencoded.
-  // Return hash-only for same-page links to avoid page reload.
-  const hashStr = [...hashParams]
-    .map(([k, v]) => (v ? `${k}=${v}` : k))
-    .join("&");
-  return "#" + hashStr;
-}
-)};
+const _bsoqwx = function _linkTo(isOnObservableCom)
+{
+    return function linkTo(target, {baseURI = document.baseURI, onObservable = isOnObservableCom(), source = null, op = 'open'    // "open" | "close" | "focus"
+} = {}) {
+        if (onObservable) {
+            const t = typeof target === 'string' ? target : target?.module || target?.open || target?.close || '';
+            return t.startsWith('#') ? t : '/' + t;
+        }
+        // Parse existing hash params manually to avoid percent-encoding DSL chars
+        const base = new URL(baseURI);
+        const rawHash = (base.hash || '#').slice(1);
+        const hashParams = new Map();
+        // open/close/focus/from are transient intents that lopepage consumes and
+        // clears, so we do NOT deep-link them. view= is canonical layout state owned
+        // by lopepage; if we baked the baseURI's view= into every link, the href
+        // would be a snapshot from link-render time and clicking it would rewind the
+        // layout (issue #150 — clicking a second module wiped the first because the
+        // link carried the boot view=). Dropping view= here makes the link a pure
+        // intent (e.g. "#cc=...&open=X"); sync_layout_from_url's
+        // `if (!view && open)` branch then merges the intent into the live layout.
+        const drop = new Set([
+            'view',
+            'open',
+            'close',
+            'focus',
+            'from'
+        ]);
+        if (rawHash) {
+            for (const part of rawHash.split('&')) {
+                const eq = part.indexOf('=');
+                const key = eq >= 0 ? part.slice(0, eq) : part;
+                if (drop.has(key))
+                    continue;
+                const val = eq >= 0 ? part.slice(eq + 1) : '';
+                hashParams.set(key, val);
+            }
+        }
+        if (typeof target === 'string' && target.startsWith('#'))
+            return target;
+        const isIntent = typeof target === 'object' && target !== null && ('module' in target || 'open' in target || 'close' in target || 'focus' in target || 'op' in target);
+        let module = null;
+        let cell = null;
+        if (!isIntent) {
+            module = String(target ?? '');
+            const parts = module.split('#');
+            module = parts[0] || null;
+            cell = parts[1] || null;
+            op = 'open';
+        } else {
+            module = target.module || target.open || target.close || target.focus || null;
+            cell = target.cell || null;
+            source = target.source ?? source;
+            op = target.op || (target.close ? 'close' : target.focus ? 'focus' : 'open');
+        }
+        if (!module)
+            return base.toString();
+        hashParams.set(op, cell ? `${ module }#${ cell }` : module);
+        if (source)
+            hashParams.set('from', source);
+        // Build hash without URLSearchParams to preserve DSL chars unencoded.
+        // Return hash-only for same-page links to avoid page reload.
+        const hashStr = [...hashParams].map(([k, v]) => v ? `${ k }=${ v }` : k).join('&');
+        return '#' + hashStr;
+    };
+};
 const _jdyayh = function _vars(variables,runtime){return(
 variables(runtime)
 )};
@@ -14653,7 +14646,7 @@ export default function define(runtime, observer) {
   $def("_1xjzq9r", "isOnObservableCom", ["location"], _1xjzq9r);  
   $def("_gxaxgb", "links", [], _gxaxgb);  
   $def("_17e89y0", "targets", [], _17e89y0);  
-  $def("_1x6cut", "linkTo", ["isOnObservableCom"], _1x6cut);  
+  $def("_bsoqwx", "linkTo", ["isOnObservableCom"], _bsoqwx);  
   $def("_jdyayh", "viewof vars", ["variables","runtime"], _jdyayh);  
   $def("_mfvz6q", "vars", ["Generators","viewof vars"], _mfvz6q);  
   $def("_1f44wsz", "test_linkTo", ["links","targets","linkTo"], _1f44wsz);  
@@ -14666,7 +14659,8 @@ export default function define(runtime, observer) {
   $def("_1xxtf0r", "updateNotebookImports", ["vars","extractNotebookAndCell","linkTo"], _1xxtf0r);  
   main.define("tests", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("tests", _));
   return main;
-}</script>
+}
+</script>
 
 <script id="@tomlarkworthy/module-map" 
   type="text/plain"

--- a/notebooks/@tomlarkworthy_flow-queue.html
+++ b/notebooks/@tomlarkworthy_flow-queue.html
@@ -14177,7 +14177,7 @@ export default function define(runtime, observer) {
   return main;
 }</script>
 
-<script id="@tomlarkworthy/lopepage-urls" 
+<script id="@tomlarkworthy/lopepage-urls"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -14528,81 +14528,75 @@ const _gxaxgb = function _links(){return(
 const _17e89y0 = function _targets(){return(
 ["@tom/bar", "d/1f41fef8b019cf4e@94", "@tom/bar#cell"]
 )};
-const _1x6cut = function _linkTo(isOnObservableCom){return(
-function linkTo(
-  target,
-  {
-    baseURI = document.baseURI,
-    onObservable = isOnObservableCom(),
-    source = null,
-    op = "open" // "open" | "close" | "focus"
-  } = {}
-) {
-  if (onObservable) {
-    const t =
-      typeof target === "string"
-        ? target
-        : target?.module || target?.open || target?.close || "";
-    return t.startsWith("#") ? t : "/" + t;
-  }
-
-  // Parse existing hash params manually to avoid percent-encoding DSL chars
-  const base = new URL(baseURI);
-  const rawHash = (base.hash || "#").slice(1);
-  const hashParams = new Map();
-  if (rawHash) {
-    for (const part of rawHash.split("&")) {
-      const eq = part.indexOf("=");
-      if (eq >= 0) hashParams.set(part.slice(0, eq), part.slice(eq + 1));
-      else if (part) hashParams.set(part, "");
-    }
-  }
-
-  if (typeof target === "string" && target.startsWith("#")) return target;
-
-  const isIntent =
-    typeof target === "object" &&
-    target !== null &&
-    ("module" in target ||
-      "open" in target ||
-      "close" in target ||
-      "focus" in target ||
-      "op" in target);
-
-  let module = null;
-  let cell = null;
-
-  if (!isIntent) {
-    module = String(target ?? "");
-    const parts = module.split("#");
-    module = parts[0] || null;
-    cell = parts[1] || null;
-    op = "open";
-  } else {
-    module =
-      target.module || target.open || target.close || target.focus || null;
-    cell = target.cell || null;
-    source = target.source ?? source;
-    op =
-      target.op || (target.close ? "close" : target.focus ? "focus" : "open");
-  }
-
-  if (!module) return base.toString();
-
-  hashParams.set(op, cell ? `${module}#${cell}` : module);
-  if (source) hashParams.set("from", source);
-
-  // Build hash without URLSearchParams to preserve DSL chars unencoded.
-  // Return hash-only for same-page links to avoid page reload.
-  const hashStr = [...hashParams]
-    .map(([k, v]) => (v ? `${k}=${v}` : k))
-    .join("&");
-  return "#" + hashStr;
-}
-)};
+const _bsoqwx = function _linkTo(isOnObservableCom)
+{
+    return function linkTo(target, {baseURI = document.baseURI, onObservable = isOnObservableCom(), source = null, op = 'open'    // "open" | "close" | "focus"
+} = {}) {
+        if (onObservable) {
+            const t = typeof target === 'string' ? target : target?.module || target?.open || target?.close || '';
+            return t.startsWith('#') ? t : '/' + t;
+        }
+        // Parse existing hash params manually to avoid percent-encoding DSL chars
+        const base = new URL(baseURI);
+        const rawHash = (base.hash || '#').slice(1);
+        const hashParams = new Map();
+        // open/close/focus/from are transient intents that lopepage consumes and
+        // clears, so we do NOT deep-link them. view= is canonical layout state owned
+        // by lopepage; if we baked the baseURI's view= into every link, the href
+        // would be a snapshot from link-render time and clicking it would rewind the
+        // layout (issue #150 — clicking a second module wiped the first because the
+        // link carried the boot view=). Dropping view= here makes the link a pure
+        // intent (e.g. "#cc=...&open=X"); sync_layout_from_url's
+        // `if (!view && open)` branch then merges the intent into the live layout.
+        const drop = new Set([
+            'view',
+            'open',
+            'close',
+            'focus',
+            'from'
+        ]);
+        if (rawHash) {
+            for (const part of rawHash.split('&')) {
+                const eq = part.indexOf('=');
+                const key = eq >= 0 ? part.slice(0, eq) : part;
+                if (drop.has(key))
+                    continue;
+                const val = eq >= 0 ? part.slice(eq + 1) : '';
+                hashParams.set(key, val);
+            }
+        }
+        if (typeof target === 'string' && target.startsWith('#'))
+            return target;
+        const isIntent = typeof target === 'object' && target !== null && ('module' in target || 'open' in target || 'close' in target || 'focus' in target || 'op' in target);
+        let module = null;
+        let cell = null;
+        if (!isIntent) {
+            module = String(target ?? '');
+            const parts = module.split('#');
+            module = parts[0] || null;
+            cell = parts[1] || null;
+            op = 'open';
+        } else {
+            module = target.module || target.open || target.close || target.focus || null;
+            cell = target.cell || null;
+            source = target.source ?? source;
+            op = target.op || (target.close ? 'close' : target.focus ? 'focus' : 'open');
+        }
+        if (!module)
+            return base.toString();
+        hashParams.set(op, cell ? `${ module }#${ cell }` : module);
+        if (source)
+            hashParams.set('from', source);
+        // Build hash without URLSearchParams to preserve DSL chars unencoded.
+        // Return hash-only for same-page links to avoid page reload.
+        const hashStr = [...hashParams].map(([k, v]) => v ? `${ k }=${ v }` : k).join('&');
+        return '#' + hashStr;
+    };
+};
 const _jdyayh = function _vars(variables,runtime){return(
 variables(runtime)
 )};
+const _mfvz6q = (G, _) => G.input(_);
 const _1f44wsz = function _test_linkTo(links,targets,linkTo){return(
 links.map((link) =>
   targets.map((target) =>
@@ -14615,7 +14609,6 @@ md`## Auto switch to url structure
 
 Watch the runtime for imports and swap them for our structure`
 )};
-const _w93ki7 = (_, v) => v.import("runtime", _);
 const _1gllckt = function _href_examples(){return(
 [
   "https://tomlarkworthy/import-notebook",
@@ -14674,20 +14667,15 @@ const _1xxtf0r = function _updateNotebookImports(vars,extractNotebookAndCell,lin
     }
   }
 };
-const _1txhfy5 = (_, v) => v.import("tests", _);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
   const $def = (pid, name, deps, fn) => {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
-  const fileAttachments = new Map([].map((name) => {
-    const module_name = "@tomlarkworthy/lopepage-urls";
-    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
-    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
-    return [name, {url: blob_url, mimeType: mime}]
-  }));
-  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
   $def("_1g7wjzc", null, ["md"], _1g7wjzc);  
   $def("_1hsbxxe", null, ["md"], _1hsbxxe);  
   $def("_1buq9dd", null, ["tests"], _1buq9dd);  
@@ -14717,22 +14705,21 @@ export default function define(runtime, observer) {
   $def("_1xjzq9r", "isOnObservableCom", ["location"], _1xjzq9r);  
   $def("_gxaxgb", "links", [], _gxaxgb);  
   $def("_17e89y0", "targets", [], _17e89y0);  
-  $def("_1x6cut", "linkTo", ["isOnObservableCom"], _1x6cut);  
+  $def("_bsoqwx", "linkTo", ["isOnObservableCom"], _bsoqwx);  
   $def("_jdyayh", "viewof vars", ["variables","runtime"], _jdyayh);  
-  main.variable(observer("vars")).define("vars", ["Generators", "viewof vars"], (G, _) => G.input(_));  
+  $def("_mfvz6q", "vars", ["Generators","viewof vars"], _mfvz6q);  
   $def("_1f44wsz", "test_linkTo", ["links","targets","linkTo"], _1f44wsz);  
   $def("_1hdknc", null, ["md"], _1hdknc);  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("variables", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("variables", _));  
   $def("_1gllckt", "href_examples", [], _1gllckt);  
   $def("_133ucsn", "test_extractNotebookAndCell", ["href_examples","extractNotebookAndCell"], _133ucsn);  
   $def("_cb1ope", "extractNotebookAndCell", [], _cb1ope);  
   $def("_1xxtf0r", "updateNotebookImports", ["vars","extractNotebookAndCell","linkTo"], _1xxtf0r);  
-  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
   main.define("tests", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("tests", _));
   return main;
-}</script>
+}
+</script>
 
 <script id="@tomlarkworthy/module-map" 
   type="text/plain"

--- a/notebooks/@tomlarkworthy_global-search.html
+++ b/notebooks/@tomlarkworthy_global-search.html
@@ -12651,7 +12651,7 @@ export default function define(runtime, observer) {
   return main;
 }</script>
 
-<script id="@tomlarkworthy/lopepage-urls" 
+<script id="@tomlarkworthy/lopepage-urls"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -13002,81 +13002,75 @@ const _gxaxgb = function _links(){return(
 const _17e89y0 = function _targets(){return(
 ["@tom/bar", "d/1f41fef8b019cf4e@94", "@tom/bar#cell"]
 )};
-const _1x6cut = function _linkTo(isOnObservableCom){return(
-function linkTo(
-  target,
-  {
-    baseURI = document.baseURI,
-    onObservable = isOnObservableCom(),
-    source = null,
-    op = "open" // "open" | "close" | "focus"
-  } = {}
-) {
-  if (onObservable) {
-    const t =
-      typeof target === "string"
-        ? target
-        : target?.module || target?.open || target?.close || "";
-    return t.startsWith("#") ? t : "/" + t;
-  }
-
-  // Parse existing hash params manually to avoid percent-encoding DSL chars
-  const base = new URL(baseURI);
-  const rawHash = (base.hash || "#").slice(1);
-  const hashParams = new Map();
-  if (rawHash) {
-    for (const part of rawHash.split("&")) {
-      const eq = part.indexOf("=");
-      if (eq >= 0) hashParams.set(part.slice(0, eq), part.slice(eq + 1));
-      else if (part) hashParams.set(part, "");
-    }
-  }
-
-  if (typeof target === "string" && target.startsWith("#")) return target;
-
-  const isIntent =
-    typeof target === "object" &&
-    target !== null &&
-    ("module" in target ||
-      "open" in target ||
-      "close" in target ||
-      "focus" in target ||
-      "op" in target);
-
-  let module = null;
-  let cell = null;
-
-  if (!isIntent) {
-    module = String(target ?? "");
-    const parts = module.split("#");
-    module = parts[0] || null;
-    cell = parts[1] || null;
-    op = "open";
-  } else {
-    module =
-      target.module || target.open || target.close || target.focus || null;
-    cell = target.cell || null;
-    source = target.source ?? source;
-    op =
-      target.op || (target.close ? "close" : target.focus ? "focus" : "open");
-  }
-
-  if (!module) return base.toString();
-
-  hashParams.set(op, cell ? `${module}#${cell}` : module);
-  if (source) hashParams.set("from", source);
-
-  // Build hash without URLSearchParams to preserve DSL chars unencoded.
-  // Return hash-only for same-page links to avoid page reload.
-  const hashStr = [...hashParams]
-    .map(([k, v]) => (v ? `${k}=${v}` : k))
-    .join("&");
-  return "#" + hashStr;
-}
-)};
+const _bsoqwx = function _linkTo(isOnObservableCom)
+{
+    return function linkTo(target, {baseURI = document.baseURI, onObservable = isOnObservableCom(), source = null, op = 'open'    // "open" | "close" | "focus"
+} = {}) {
+        if (onObservable) {
+            const t = typeof target === 'string' ? target : target?.module || target?.open || target?.close || '';
+            return t.startsWith('#') ? t : '/' + t;
+        }
+        // Parse existing hash params manually to avoid percent-encoding DSL chars
+        const base = new URL(baseURI);
+        const rawHash = (base.hash || '#').slice(1);
+        const hashParams = new Map();
+        // open/close/focus/from are transient intents that lopepage consumes and
+        // clears, so we do NOT deep-link them. view= is canonical layout state owned
+        // by lopepage; if we baked the baseURI's view= into every link, the href
+        // would be a snapshot from link-render time and clicking it would rewind the
+        // layout (issue #150 — clicking a second module wiped the first because the
+        // link carried the boot view=). Dropping view= here makes the link a pure
+        // intent (e.g. "#cc=...&open=X"); sync_layout_from_url's
+        // `if (!view && open)` branch then merges the intent into the live layout.
+        const drop = new Set([
+            'view',
+            'open',
+            'close',
+            'focus',
+            'from'
+        ]);
+        if (rawHash) {
+            for (const part of rawHash.split('&')) {
+                const eq = part.indexOf('=');
+                const key = eq >= 0 ? part.slice(0, eq) : part;
+                if (drop.has(key))
+                    continue;
+                const val = eq >= 0 ? part.slice(eq + 1) : '';
+                hashParams.set(key, val);
+            }
+        }
+        if (typeof target === 'string' && target.startsWith('#'))
+            return target;
+        const isIntent = typeof target === 'object' && target !== null && ('module' in target || 'open' in target || 'close' in target || 'focus' in target || 'op' in target);
+        let module = null;
+        let cell = null;
+        if (!isIntent) {
+            module = String(target ?? '');
+            const parts = module.split('#');
+            module = parts[0] || null;
+            cell = parts[1] || null;
+            op = 'open';
+        } else {
+            module = target.module || target.open || target.close || target.focus || null;
+            cell = target.cell || null;
+            source = target.source ?? source;
+            op = target.op || (target.close ? 'close' : target.focus ? 'focus' : 'open');
+        }
+        if (!module)
+            return base.toString();
+        hashParams.set(op, cell ? `${ module }#${ cell }` : module);
+        if (source)
+            hashParams.set('from', source);
+        // Build hash without URLSearchParams to preserve DSL chars unencoded.
+        // Return hash-only for same-page links to avoid page reload.
+        const hashStr = [...hashParams].map(([k, v]) => v ? `${ k }=${ v }` : k).join('&');
+        return '#' + hashStr;
+    };
+};
 const _jdyayh = function _vars(variables,runtime){return(
 variables(runtime)
 )};
+const _mfvz6q = (G, _) => G.input(_);
 const _1f44wsz = function _test_linkTo(links,targets,linkTo){return(
 links.map((link) =>
   targets.map((target) =>
@@ -13089,7 +13083,6 @@ md`## Auto switch to url structure
 
 Watch the runtime for imports and swap them for our structure`
 )};
-const _w93ki7 = (_, v) => v.import("runtime", _);
 const _1gllckt = function _href_examples(){return(
 [
   "https://tomlarkworthy/import-notebook",
@@ -13148,24 +13141,15 @@ const _1xxtf0r = function _updateNotebookImports(vars,extractNotebookAndCell,lin
     }
   }
 };
-const _1txhfy5 = (_, v) => v.import("tests", _);
-const _z20jdt = (_, v) => v.import("robocoop2", _);
-const _zu2mjd = function _41(robocoop2){return(
-robocoop2()
-)};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
   const $def = (pid, name, deps, fn) => {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
-  const fileAttachments = new Map([].map((name) => {
-    const module_name = "@tomlarkworthy/lopepage-urls";
-    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
-    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
-    return [name, {url: blob_url, mimeType: mime}]
-  }));
-  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
   $def("_1g7wjzc", null, ["md"], _1g7wjzc);  
   $def("_1hsbxxe", null, ["md"], _1hsbxxe);  
   $def("_1buq9dd", null, ["tests"], _1buq9dd);  
@@ -13195,25 +13179,21 @@ export default function define(runtime, observer) {
   $def("_1xjzq9r", "isOnObservableCom", ["location"], _1xjzq9r);  
   $def("_gxaxgb", "links", [], _gxaxgb);  
   $def("_17e89y0", "targets", [], _17e89y0);  
-  $def("_1x6cut", "linkTo", ["isOnObservableCom"], _1x6cut);  
+  $def("_bsoqwx", "linkTo", ["isOnObservableCom"], _bsoqwx);  
   $def("_jdyayh", "viewof vars", ["variables","runtime"], _jdyayh);  
-  main.variable(observer("vars")).define("vars", ["Generators", "viewof vars"], (G, _) => G.input(_));  
+  $def("_mfvz6q", "vars", ["Generators","viewof vars"], _mfvz6q);  
   $def("_1f44wsz", "test_linkTo", ["links","targets","linkTo"], _1f44wsz);  
   $def("_1hdknc", null, ["md"], _1hdknc);  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("variables", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("variables", _));  
   $def("_1gllckt", "href_examples", [], _1gllckt);  
   $def("_133ucsn", "test_extractNotebookAndCell", ["href_examples","extractNotebookAndCell"], _133ucsn);  
   $def("_cb1ope", "extractNotebookAndCell", [], _cb1ope);  
   $def("_1xxtf0r", "updateNotebookImports", ["vars","extractNotebookAndCell","linkTo"], _1xxtf0r);  
-  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
-  main.define("tests", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("tests", _));  
-  main.define("module @tomlarkworthy/robocoop-2", async () => runtime.module((await import("/@tomlarkworthy/robocoop-2.js?v=4")).default));  
-  main.define("robocoop2", ["module @tomlarkworthy/robocoop-2", "@variable"], (_, v) => v.import("robocoop2", _));  
-  $def("_zu2mjd", null, ["robocoop2"], _zu2mjd);
+  main.define("tests", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("tests", _));
   return main;
-}</script>
+}
+</script>
 <script id="@tomlarkworthy/modern-screenshot/modern-screenshot-4.6.6.js.gz" 
   type="text/plain"
   data-encoding="base64"

--- a/notebooks/@tomlarkworthy_golden-layout-2-6-0.html
+++ b/notebooks/@tomlarkworthy_golden-layout-2-6-0.html
@@ -14177,7 +14177,7 @@ export default function define(runtime, observer) {
   return main;
 }</script>
 
-<script id="@tomlarkworthy/lopepage-urls" 
+<script id="@tomlarkworthy/lopepage-urls"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -14528,81 +14528,75 @@ const _gxaxgb = function _links(){return(
 const _17e89y0 = function _targets(){return(
 ["@tom/bar", "d/1f41fef8b019cf4e@94", "@tom/bar#cell"]
 )};
-const _1x6cut = function _linkTo(isOnObservableCom){return(
-function linkTo(
-  target,
-  {
-    baseURI = document.baseURI,
-    onObservable = isOnObservableCom(),
-    source = null,
-    op = "open" // "open" | "close" | "focus"
-  } = {}
-) {
-  if (onObservable) {
-    const t =
-      typeof target === "string"
-        ? target
-        : target?.module || target?.open || target?.close || "";
-    return t.startsWith("#") ? t : "/" + t;
-  }
-
-  // Parse existing hash params manually to avoid percent-encoding DSL chars
-  const base = new URL(baseURI);
-  const rawHash = (base.hash || "#").slice(1);
-  const hashParams = new Map();
-  if (rawHash) {
-    for (const part of rawHash.split("&")) {
-      const eq = part.indexOf("=");
-      if (eq >= 0) hashParams.set(part.slice(0, eq), part.slice(eq + 1));
-      else if (part) hashParams.set(part, "");
-    }
-  }
-
-  if (typeof target === "string" && target.startsWith("#")) return target;
-
-  const isIntent =
-    typeof target === "object" &&
-    target !== null &&
-    ("module" in target ||
-      "open" in target ||
-      "close" in target ||
-      "focus" in target ||
-      "op" in target);
-
-  let module = null;
-  let cell = null;
-
-  if (!isIntent) {
-    module = String(target ?? "");
-    const parts = module.split("#");
-    module = parts[0] || null;
-    cell = parts[1] || null;
-    op = "open";
-  } else {
-    module =
-      target.module || target.open || target.close || target.focus || null;
-    cell = target.cell || null;
-    source = target.source ?? source;
-    op =
-      target.op || (target.close ? "close" : target.focus ? "focus" : "open");
-  }
-
-  if (!module) return base.toString();
-
-  hashParams.set(op, cell ? `${module}#${cell}` : module);
-  if (source) hashParams.set("from", source);
-
-  // Build hash without URLSearchParams to preserve DSL chars unencoded.
-  // Return hash-only for same-page links to avoid page reload.
-  const hashStr = [...hashParams]
-    .map(([k, v]) => (v ? `${k}=${v}` : k))
-    .join("&");
-  return "#" + hashStr;
-}
-)};
+const _bsoqwx = function _linkTo(isOnObservableCom)
+{
+    return function linkTo(target, {baseURI = document.baseURI, onObservable = isOnObservableCom(), source = null, op = 'open'    // "open" | "close" | "focus"
+} = {}) {
+        if (onObservable) {
+            const t = typeof target === 'string' ? target : target?.module || target?.open || target?.close || '';
+            return t.startsWith('#') ? t : '/' + t;
+        }
+        // Parse existing hash params manually to avoid percent-encoding DSL chars
+        const base = new URL(baseURI);
+        const rawHash = (base.hash || '#').slice(1);
+        const hashParams = new Map();
+        // open/close/focus/from are transient intents that lopepage consumes and
+        // clears, so we do NOT deep-link them. view= is canonical layout state owned
+        // by lopepage; if we baked the baseURI's view= into every link, the href
+        // would be a snapshot from link-render time and clicking it would rewind the
+        // layout (issue #150 — clicking a second module wiped the first because the
+        // link carried the boot view=). Dropping view= here makes the link a pure
+        // intent (e.g. "#cc=...&open=X"); sync_layout_from_url's
+        // `if (!view && open)` branch then merges the intent into the live layout.
+        const drop = new Set([
+            'view',
+            'open',
+            'close',
+            'focus',
+            'from'
+        ]);
+        if (rawHash) {
+            for (const part of rawHash.split('&')) {
+                const eq = part.indexOf('=');
+                const key = eq >= 0 ? part.slice(0, eq) : part;
+                if (drop.has(key))
+                    continue;
+                const val = eq >= 0 ? part.slice(eq + 1) : '';
+                hashParams.set(key, val);
+            }
+        }
+        if (typeof target === 'string' && target.startsWith('#'))
+            return target;
+        const isIntent = typeof target === 'object' && target !== null && ('module' in target || 'open' in target || 'close' in target || 'focus' in target || 'op' in target);
+        let module = null;
+        let cell = null;
+        if (!isIntent) {
+            module = String(target ?? '');
+            const parts = module.split('#');
+            module = parts[0] || null;
+            cell = parts[1] || null;
+            op = 'open';
+        } else {
+            module = target.module || target.open || target.close || target.focus || null;
+            cell = target.cell || null;
+            source = target.source ?? source;
+            op = target.op || (target.close ? 'close' : target.focus ? 'focus' : 'open');
+        }
+        if (!module)
+            return base.toString();
+        hashParams.set(op, cell ? `${ module }#${ cell }` : module);
+        if (source)
+            hashParams.set('from', source);
+        // Build hash without URLSearchParams to preserve DSL chars unencoded.
+        // Return hash-only for same-page links to avoid page reload.
+        const hashStr = [...hashParams].map(([k, v]) => v ? `${ k }=${ v }` : k).join('&');
+        return '#' + hashStr;
+    };
+};
 const _jdyayh = function _vars(variables,runtime){return(
 variables(runtime)
 )};
+const _mfvz6q = (G, _) => G.input(_);
 const _1f44wsz = function _test_linkTo(links,targets,linkTo){return(
 links.map((link) =>
   targets.map((target) =>
@@ -14615,7 +14609,6 @@ md`## Auto switch to url structure
 
 Watch the runtime for imports and swap them for our structure`
 )};
-const _w93ki7 = (_, v) => v.import("runtime", _);
 const _1gllckt = function _href_examples(){return(
 [
   "https://tomlarkworthy/import-notebook",
@@ -14674,20 +14667,15 @@ const _1xxtf0r = function _updateNotebookImports(vars,extractNotebookAndCell,lin
     }
   }
 };
-const _1txhfy5 = (_, v) => v.import("tests", _);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
   const $def = (pid, name, deps, fn) => {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
-  const fileAttachments = new Map([].map((name) => {
-    const module_name = "@tomlarkworthy/lopepage-urls";
-    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
-    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
-    return [name, {url: blob_url, mimeType: mime}]
-  }));
-  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
   $def("_1g7wjzc", null, ["md"], _1g7wjzc);  
   $def("_1hsbxxe", null, ["md"], _1hsbxxe);  
   $def("_1buq9dd", null, ["tests"], _1buq9dd);  
@@ -14717,22 +14705,21 @@ export default function define(runtime, observer) {
   $def("_1xjzq9r", "isOnObservableCom", ["location"], _1xjzq9r);  
   $def("_gxaxgb", "links", [], _gxaxgb);  
   $def("_17e89y0", "targets", [], _17e89y0);  
-  $def("_1x6cut", "linkTo", ["isOnObservableCom"], _1x6cut);  
+  $def("_bsoqwx", "linkTo", ["isOnObservableCom"], _bsoqwx);  
   $def("_jdyayh", "viewof vars", ["variables","runtime"], _jdyayh);  
-  main.variable(observer("vars")).define("vars", ["Generators", "viewof vars"], (G, _) => G.input(_));  
+  $def("_mfvz6q", "vars", ["Generators","viewof vars"], _mfvz6q);  
   $def("_1f44wsz", "test_linkTo", ["links","targets","linkTo"], _1f44wsz);  
   $def("_1hdknc", null, ["md"], _1hdknc);  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("variables", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("variables", _));  
   $def("_1gllckt", "href_examples", [], _1gllckt);  
   $def("_133ucsn", "test_extractNotebookAndCell", ["href_examples","extractNotebookAndCell"], _133ucsn);  
   $def("_cb1ope", "extractNotebookAndCell", [], _cb1ope);  
   $def("_1xxtf0r", "updateNotebookImports", ["vars","extractNotebookAndCell","linkTo"], _1xxtf0r);  
-  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
   main.define("tests", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("tests", _));
   return main;
-}</script>
+}
+</script>
 
 <script id="@tomlarkworthy/module-map" 
   type="text/plain"

--- a/notebooks/@tomlarkworthy_import-notebook.html
+++ b/notebooks/@tomlarkworthy_import-notebook.html
@@ -14177,7 +14177,7 @@ export default function define(runtime, observer) {
   return main;
 }</script>
 
-<script id="@tomlarkworthy/lopepage-urls" 
+<script id="@tomlarkworthy/lopepage-urls"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -14528,81 +14528,75 @@ const _gxaxgb = function _links(){return(
 const _17e89y0 = function _targets(){return(
 ["@tom/bar", "d/1f41fef8b019cf4e@94", "@tom/bar#cell"]
 )};
-const _1x6cut = function _linkTo(isOnObservableCom){return(
-function linkTo(
-  target,
-  {
-    baseURI = document.baseURI,
-    onObservable = isOnObservableCom(),
-    source = null,
-    op = "open" // "open" | "close" | "focus"
-  } = {}
-) {
-  if (onObservable) {
-    const t =
-      typeof target === "string"
-        ? target
-        : target?.module || target?.open || target?.close || "";
-    return t.startsWith("#") ? t : "/" + t;
-  }
-
-  // Parse existing hash params manually to avoid percent-encoding DSL chars
-  const base = new URL(baseURI);
-  const rawHash = (base.hash || "#").slice(1);
-  const hashParams = new Map();
-  if (rawHash) {
-    for (const part of rawHash.split("&")) {
-      const eq = part.indexOf("=");
-      if (eq >= 0) hashParams.set(part.slice(0, eq), part.slice(eq + 1));
-      else if (part) hashParams.set(part, "");
-    }
-  }
-
-  if (typeof target === "string" && target.startsWith("#")) return target;
-
-  const isIntent =
-    typeof target === "object" &&
-    target !== null &&
-    ("module" in target ||
-      "open" in target ||
-      "close" in target ||
-      "focus" in target ||
-      "op" in target);
-
-  let module = null;
-  let cell = null;
-
-  if (!isIntent) {
-    module = String(target ?? "");
-    const parts = module.split("#");
-    module = parts[0] || null;
-    cell = parts[1] || null;
-    op = "open";
-  } else {
-    module =
-      target.module || target.open || target.close || target.focus || null;
-    cell = target.cell || null;
-    source = target.source ?? source;
-    op =
-      target.op || (target.close ? "close" : target.focus ? "focus" : "open");
-  }
-
-  if (!module) return base.toString();
-
-  hashParams.set(op, cell ? `${module}#${cell}` : module);
-  if (source) hashParams.set("from", source);
-
-  // Build hash without URLSearchParams to preserve DSL chars unencoded.
-  // Return hash-only for same-page links to avoid page reload.
-  const hashStr = [...hashParams]
-    .map(([k, v]) => (v ? `${k}=${v}` : k))
-    .join("&");
-  return "#" + hashStr;
-}
-)};
+const _bsoqwx = function _linkTo(isOnObservableCom)
+{
+    return function linkTo(target, {baseURI = document.baseURI, onObservable = isOnObservableCom(), source = null, op = 'open'    // "open" | "close" | "focus"
+} = {}) {
+        if (onObservable) {
+            const t = typeof target === 'string' ? target : target?.module || target?.open || target?.close || '';
+            return t.startsWith('#') ? t : '/' + t;
+        }
+        // Parse existing hash params manually to avoid percent-encoding DSL chars
+        const base = new URL(baseURI);
+        const rawHash = (base.hash || '#').slice(1);
+        const hashParams = new Map();
+        // open/close/focus/from are transient intents that lopepage consumes and
+        // clears, so we do NOT deep-link them. view= is canonical layout state owned
+        // by lopepage; if we baked the baseURI's view= into every link, the href
+        // would be a snapshot from link-render time and clicking it would rewind the
+        // layout (issue #150 — clicking a second module wiped the first because the
+        // link carried the boot view=). Dropping view= here makes the link a pure
+        // intent (e.g. "#cc=...&open=X"); sync_layout_from_url's
+        // `if (!view && open)` branch then merges the intent into the live layout.
+        const drop = new Set([
+            'view',
+            'open',
+            'close',
+            'focus',
+            'from'
+        ]);
+        if (rawHash) {
+            for (const part of rawHash.split('&')) {
+                const eq = part.indexOf('=');
+                const key = eq >= 0 ? part.slice(0, eq) : part;
+                if (drop.has(key))
+                    continue;
+                const val = eq >= 0 ? part.slice(eq + 1) : '';
+                hashParams.set(key, val);
+            }
+        }
+        if (typeof target === 'string' && target.startsWith('#'))
+            return target;
+        const isIntent = typeof target === 'object' && target !== null && ('module' in target || 'open' in target || 'close' in target || 'focus' in target || 'op' in target);
+        let module = null;
+        let cell = null;
+        if (!isIntent) {
+            module = String(target ?? '');
+            const parts = module.split('#');
+            module = parts[0] || null;
+            cell = parts[1] || null;
+            op = 'open';
+        } else {
+            module = target.module || target.open || target.close || target.focus || null;
+            cell = target.cell || null;
+            source = target.source ?? source;
+            op = target.op || (target.close ? 'close' : target.focus ? 'focus' : 'open');
+        }
+        if (!module)
+            return base.toString();
+        hashParams.set(op, cell ? `${ module }#${ cell }` : module);
+        if (source)
+            hashParams.set('from', source);
+        // Build hash without URLSearchParams to preserve DSL chars unencoded.
+        // Return hash-only for same-page links to avoid page reload.
+        const hashStr = [...hashParams].map(([k, v]) => v ? `${ k }=${ v }` : k).join('&');
+        return '#' + hashStr;
+    };
+};
 const _jdyayh = function _vars(variables,runtime){return(
 variables(runtime)
 )};
+const _mfvz6q = (G, _) => G.input(_);
 const _1f44wsz = function _test_linkTo(links,targets,linkTo){return(
 links.map((link) =>
   targets.map((target) =>
@@ -14615,7 +14609,6 @@ md`## Auto switch to url structure
 
 Watch the runtime for imports and swap them for our structure`
 )};
-const _w93ki7 = (_, v) => v.import("runtime", _);
 const _1gllckt = function _href_examples(){return(
 [
   "https://tomlarkworthy/import-notebook",
@@ -14674,20 +14667,15 @@ const _1xxtf0r = function _updateNotebookImports(vars,extractNotebookAndCell,lin
     }
   }
 };
-const _1txhfy5 = (_, v) => v.import("tests", _);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
   const $def = (pid, name, deps, fn) => {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
-  const fileAttachments = new Map([].map((name) => {
-    const module_name = "@tomlarkworthy/lopepage-urls";
-    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
-    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
-    return [name, {url: blob_url, mimeType: mime}]
-  }));
-  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
   $def("_1g7wjzc", null, ["md"], _1g7wjzc);  
   $def("_1hsbxxe", null, ["md"], _1hsbxxe);  
   $def("_1buq9dd", null, ["tests"], _1buq9dd);  
@@ -14717,22 +14705,21 @@ export default function define(runtime, observer) {
   $def("_1xjzq9r", "isOnObservableCom", ["location"], _1xjzq9r);  
   $def("_gxaxgb", "links", [], _gxaxgb);  
   $def("_17e89y0", "targets", [], _17e89y0);  
-  $def("_1x6cut", "linkTo", ["isOnObservableCom"], _1x6cut);  
+  $def("_bsoqwx", "linkTo", ["isOnObservableCom"], _bsoqwx);  
   $def("_jdyayh", "viewof vars", ["variables","runtime"], _jdyayh);  
-  main.variable(observer("vars")).define("vars", ["Generators", "viewof vars"], (G, _) => G.input(_));  
+  $def("_mfvz6q", "vars", ["Generators","viewof vars"], _mfvz6q);  
   $def("_1f44wsz", "test_linkTo", ["links","targets","linkTo"], _1f44wsz);  
   $def("_1hdknc", null, ["md"], _1hdknc);  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("variables", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("variables", _));  
   $def("_1gllckt", "href_examples", [], _1gllckt);  
   $def("_133ucsn", "test_extractNotebookAndCell", ["href_examples","extractNotebookAndCell"], _133ucsn);  
   $def("_cb1ope", "extractNotebookAndCell", [], _cb1ope);  
   $def("_1xxtf0r", "updateNotebookImports", ["vars","extractNotebookAndCell","linkTo"], _1xxtf0r);  
-  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
   main.define("tests", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("tests", _));
   return main;
-}</script>
+}
+</script>
 
 <script id="@tomlarkworthy/module-map" 
   type="text/plain"

--- a/notebooks/@tomlarkworthy_jest-expect-standalone.html
+++ b/notebooks/@tomlarkworthy_jest-expect-standalone.html
@@ -14177,7 +14177,7 @@ export default function define(runtime, observer) {
   return main;
 }</script>
 
-<script id="@tomlarkworthy/lopepage-urls" 
+<script id="@tomlarkworthy/lopepage-urls"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -14528,81 +14528,75 @@ const _gxaxgb = function _links(){return(
 const _17e89y0 = function _targets(){return(
 ["@tom/bar", "d/1f41fef8b019cf4e@94", "@tom/bar#cell"]
 )};
-const _1x6cut = function _linkTo(isOnObservableCom){return(
-function linkTo(
-  target,
-  {
-    baseURI = document.baseURI,
-    onObservable = isOnObservableCom(),
-    source = null,
-    op = "open" // "open" | "close" | "focus"
-  } = {}
-) {
-  if (onObservable) {
-    const t =
-      typeof target === "string"
-        ? target
-        : target?.module || target?.open || target?.close || "";
-    return t.startsWith("#") ? t : "/" + t;
-  }
-
-  // Parse existing hash params manually to avoid percent-encoding DSL chars
-  const base = new URL(baseURI);
-  const rawHash = (base.hash || "#").slice(1);
-  const hashParams = new Map();
-  if (rawHash) {
-    for (const part of rawHash.split("&")) {
-      const eq = part.indexOf("=");
-      if (eq >= 0) hashParams.set(part.slice(0, eq), part.slice(eq + 1));
-      else if (part) hashParams.set(part, "");
-    }
-  }
-
-  if (typeof target === "string" && target.startsWith("#")) return target;
-
-  const isIntent =
-    typeof target === "object" &&
-    target !== null &&
-    ("module" in target ||
-      "open" in target ||
-      "close" in target ||
-      "focus" in target ||
-      "op" in target);
-
-  let module = null;
-  let cell = null;
-
-  if (!isIntent) {
-    module = String(target ?? "");
-    const parts = module.split("#");
-    module = parts[0] || null;
-    cell = parts[1] || null;
-    op = "open";
-  } else {
-    module =
-      target.module || target.open || target.close || target.focus || null;
-    cell = target.cell || null;
-    source = target.source ?? source;
-    op =
-      target.op || (target.close ? "close" : target.focus ? "focus" : "open");
-  }
-
-  if (!module) return base.toString();
-
-  hashParams.set(op, cell ? `${module}#${cell}` : module);
-  if (source) hashParams.set("from", source);
-
-  // Build hash without URLSearchParams to preserve DSL chars unencoded.
-  // Return hash-only for same-page links to avoid page reload.
-  const hashStr = [...hashParams]
-    .map(([k, v]) => (v ? `${k}=${v}` : k))
-    .join("&");
-  return "#" + hashStr;
-}
-)};
+const _bsoqwx = function _linkTo(isOnObservableCom)
+{
+    return function linkTo(target, {baseURI = document.baseURI, onObservable = isOnObservableCom(), source = null, op = 'open'    // "open" | "close" | "focus"
+} = {}) {
+        if (onObservable) {
+            const t = typeof target === 'string' ? target : target?.module || target?.open || target?.close || '';
+            return t.startsWith('#') ? t : '/' + t;
+        }
+        // Parse existing hash params manually to avoid percent-encoding DSL chars
+        const base = new URL(baseURI);
+        const rawHash = (base.hash || '#').slice(1);
+        const hashParams = new Map();
+        // open/close/focus/from are transient intents that lopepage consumes and
+        // clears, so we do NOT deep-link them. view= is canonical layout state owned
+        // by lopepage; if we baked the baseURI's view= into every link, the href
+        // would be a snapshot from link-render time and clicking it would rewind the
+        // layout (issue #150 — clicking a second module wiped the first because the
+        // link carried the boot view=). Dropping view= here makes the link a pure
+        // intent (e.g. "#cc=...&open=X"); sync_layout_from_url's
+        // `if (!view && open)` branch then merges the intent into the live layout.
+        const drop = new Set([
+            'view',
+            'open',
+            'close',
+            'focus',
+            'from'
+        ]);
+        if (rawHash) {
+            for (const part of rawHash.split('&')) {
+                const eq = part.indexOf('=');
+                const key = eq >= 0 ? part.slice(0, eq) : part;
+                if (drop.has(key))
+                    continue;
+                const val = eq >= 0 ? part.slice(eq + 1) : '';
+                hashParams.set(key, val);
+            }
+        }
+        if (typeof target === 'string' && target.startsWith('#'))
+            return target;
+        const isIntent = typeof target === 'object' && target !== null && ('module' in target || 'open' in target || 'close' in target || 'focus' in target || 'op' in target);
+        let module = null;
+        let cell = null;
+        if (!isIntent) {
+            module = String(target ?? '');
+            const parts = module.split('#');
+            module = parts[0] || null;
+            cell = parts[1] || null;
+            op = 'open';
+        } else {
+            module = target.module || target.open || target.close || target.focus || null;
+            cell = target.cell || null;
+            source = target.source ?? source;
+            op = target.op || (target.close ? 'close' : target.focus ? 'focus' : 'open');
+        }
+        if (!module)
+            return base.toString();
+        hashParams.set(op, cell ? `${ module }#${ cell }` : module);
+        if (source)
+            hashParams.set('from', source);
+        // Build hash without URLSearchParams to preserve DSL chars unencoded.
+        // Return hash-only for same-page links to avoid page reload.
+        const hashStr = [...hashParams].map(([k, v]) => v ? `${ k }=${ v }` : k).join('&');
+        return '#' + hashStr;
+    };
+};
 const _jdyayh = function _vars(variables,runtime){return(
 variables(runtime)
 )};
+const _mfvz6q = (G, _) => G.input(_);
 const _1f44wsz = function _test_linkTo(links,targets,linkTo){return(
 links.map((link) =>
   targets.map((target) =>
@@ -14615,7 +14609,6 @@ md`## Auto switch to url structure
 
 Watch the runtime for imports and swap them for our structure`
 )};
-const _w93ki7 = (_, v) => v.import("runtime", _);
 const _1gllckt = function _href_examples(){return(
 [
   "https://tomlarkworthy/import-notebook",
@@ -14674,20 +14667,15 @@ const _1xxtf0r = function _updateNotebookImports(vars,extractNotebookAndCell,lin
     }
   }
 };
-const _1txhfy5 = (_, v) => v.import("tests", _);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
   const $def = (pid, name, deps, fn) => {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
-  const fileAttachments = new Map([].map((name) => {
-    const module_name = "@tomlarkworthy/lopepage-urls";
-    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
-    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
-    return [name, {url: blob_url, mimeType: mime}]
-  }));
-  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
   $def("_1g7wjzc", null, ["md"], _1g7wjzc);  
   $def("_1hsbxxe", null, ["md"], _1hsbxxe);  
   $def("_1buq9dd", null, ["tests"], _1buq9dd);  
@@ -14717,22 +14705,21 @@ export default function define(runtime, observer) {
   $def("_1xjzq9r", "isOnObservableCom", ["location"], _1xjzq9r);  
   $def("_gxaxgb", "links", [], _gxaxgb);  
   $def("_17e89y0", "targets", [], _17e89y0);  
-  $def("_1x6cut", "linkTo", ["isOnObservableCom"], _1x6cut);  
+  $def("_bsoqwx", "linkTo", ["isOnObservableCom"], _bsoqwx);  
   $def("_jdyayh", "viewof vars", ["variables","runtime"], _jdyayh);  
-  main.variable(observer("vars")).define("vars", ["Generators", "viewof vars"], (G, _) => G.input(_));  
+  $def("_mfvz6q", "vars", ["Generators","viewof vars"], _mfvz6q);  
   $def("_1f44wsz", "test_linkTo", ["links","targets","linkTo"], _1f44wsz);  
   $def("_1hdknc", null, ["md"], _1hdknc);  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("variables", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("variables", _));  
   $def("_1gllckt", "href_examples", [], _1gllckt);  
   $def("_133ucsn", "test_extractNotebookAndCell", ["href_examples","extractNotebookAndCell"], _133ucsn);  
   $def("_cb1ope", "extractNotebookAndCell", [], _cb1ope);  
   $def("_1xxtf0r", "updateNotebookImports", ["vars","extractNotebookAndCell","linkTo"], _1xxtf0r);  
-  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
   main.define("tests", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("tests", _));
   return main;
-}</script>
+}
+</script>
 
 <script id="@tomlarkworthy/module-map" 
   type="text/plain"

--- a/notebooks/@tomlarkworthy_jumpgate.html
+++ b/notebooks/@tomlarkworthy_jumpgate.html
@@ -13527,7 +13527,7 @@ export default function define(runtime, observer) {
   return main;
 }</script>
 
-<script id="@tomlarkworthy/lopepage-urls" 
+<script id="@tomlarkworthy/lopepage-urls"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -13878,78 +13878,71 @@ const _gxaxgb = function _links(){return(
 const _17e89y0 = function _targets(){return(
 ["@tom/bar", "d/1f41fef8b019cf4e@94", "@tom/bar#cell"]
 )};
-const _1x6cut = function _linkTo(isOnObservableCom){return(
-function linkTo(
-  target,
-  {
-    baseURI = document.baseURI,
-    onObservable = isOnObservableCom(),
-    source = null,
-    op = "open" // "open" | "close" | "focus"
-  } = {}
-) {
-  if (onObservable) {
-    const t =
-      typeof target === "string"
-        ? target
-        : target?.module || target?.open || target?.close || "";
-    return t.startsWith("#") ? t : "/" + t;
-  }
-
-  // Parse existing hash params manually to avoid percent-encoding DSL chars
-  const base = new URL(baseURI);
-  const rawHash = (base.hash || "#").slice(1);
-  const hashParams = new Map();
-  if (rawHash) {
-    for (const part of rawHash.split("&")) {
-      const eq = part.indexOf("=");
-      if (eq >= 0) hashParams.set(part.slice(0, eq), part.slice(eq + 1));
-      else if (part) hashParams.set(part, "");
-    }
-  }
-
-  if (typeof target === "string" && target.startsWith("#")) return target;
-
-  const isIntent =
-    typeof target === "object" &&
-    target !== null &&
-    ("module" in target ||
-      "open" in target ||
-      "close" in target ||
-      "focus" in target ||
-      "op" in target);
-
-  let module = null;
-  let cell = null;
-
-  if (!isIntent) {
-    module = String(target ?? "");
-    const parts = module.split("#");
-    module = parts[0] || null;
-    cell = parts[1] || null;
-    op = "open";
-  } else {
-    module =
-      target.module || target.open || target.close || target.focus || null;
-    cell = target.cell || null;
-    source = target.source ?? source;
-    op =
-      target.op || (target.close ? "close" : target.focus ? "focus" : "open");
-  }
-
-  if (!module) return base.toString();
-
-  hashParams.set(op, cell ? `${module}#${cell}` : module);
-  if (source) hashParams.set("from", source);
-
-  // Build hash without URLSearchParams to preserve DSL chars unencoded.
-  // Return hash-only for same-page links to avoid page reload.
-  const hashStr = [...hashParams]
-    .map(([k, v]) => (v ? `${k}=${v}` : k))
-    .join("&");
-  return "#" + hashStr;
-}
-)};
+const _bsoqwx = function _linkTo(isOnObservableCom)
+{
+    return function linkTo(target, {baseURI = document.baseURI, onObservable = isOnObservableCom(), source = null, op = 'open'    // "open" | "close" | "focus"
+} = {}) {
+        if (onObservable) {
+            const t = typeof target === 'string' ? target : target?.module || target?.open || target?.close || '';
+            return t.startsWith('#') ? t : '/' + t;
+        }
+        // Parse existing hash params manually to avoid percent-encoding DSL chars
+        const base = new URL(baseURI);
+        const rawHash = (base.hash || '#').slice(1);
+        const hashParams = new Map();
+        // open/close/focus/from are transient intents that lopepage consumes and
+        // clears, so we do NOT deep-link them. view= is canonical layout state owned
+        // by lopepage; if we baked the baseURI's view= into every link, the href
+        // would be a snapshot from link-render time and clicking it would rewind the
+        // layout (issue #150 — clicking a second module wiped the first because the
+        // link carried the boot view=). Dropping view= here makes the link a pure
+        // intent (e.g. "#cc=...&open=X"); sync_layout_from_url's
+        // `if (!view && open)` branch then merges the intent into the live layout.
+        const drop = new Set([
+            'view',
+            'open',
+            'close',
+            'focus',
+            'from'
+        ]);
+        if (rawHash) {
+            for (const part of rawHash.split('&')) {
+                const eq = part.indexOf('=');
+                const key = eq >= 0 ? part.slice(0, eq) : part;
+                if (drop.has(key))
+                    continue;
+                const val = eq >= 0 ? part.slice(eq + 1) : '';
+                hashParams.set(key, val);
+            }
+        }
+        if (typeof target === 'string' && target.startsWith('#'))
+            return target;
+        const isIntent = typeof target === 'object' && target !== null && ('module' in target || 'open' in target || 'close' in target || 'focus' in target || 'op' in target);
+        let module = null;
+        let cell = null;
+        if (!isIntent) {
+            module = String(target ?? '');
+            const parts = module.split('#');
+            module = parts[0] || null;
+            cell = parts[1] || null;
+            op = 'open';
+        } else {
+            module = target.module || target.open || target.close || target.focus || null;
+            cell = target.cell || null;
+            source = target.source ?? source;
+            op = target.op || (target.close ? 'close' : target.focus ? 'focus' : 'open');
+        }
+        if (!module)
+            return base.toString();
+        hashParams.set(op, cell ? `${ module }#${ cell }` : module);
+        if (source)
+            hashParams.set('from', source);
+        // Build hash without URLSearchParams to preserve DSL chars unencoded.
+        // Return hash-only for same-page links to avoid page reload.
+        const hashStr = [...hashParams].map(([k, v]) => v ? `${ k }=${ v }` : k).join('&');
+        return '#' + hashStr;
+    };
+};
 const _jdyayh = function _vars(variables,runtime){return(
 variables(runtime)
 )};
@@ -14062,7 +14055,7 @@ export default function define(runtime, observer) {
   $def("_1xjzq9r", "isOnObservableCom", ["location"], _1xjzq9r);  
   $def("_gxaxgb", "links", [], _gxaxgb);  
   $def("_17e89y0", "targets", [], _17e89y0);  
-  $def("_1x6cut", "linkTo", ["isOnObservableCom"], _1x6cut);  
+  $def("_bsoqwx", "linkTo", ["isOnObservableCom"], _bsoqwx);  
   $def("_jdyayh", "viewof vars", ["variables","runtime"], _jdyayh);  
   $def("_mfvz6q", "vars", ["Generators","viewof vars"], _mfvz6q);  
   $def("_1f44wsz", "test_linkTo", ["links","targets","linkTo"], _1f44wsz);  
@@ -14075,7 +14068,8 @@ export default function define(runtime, observer) {
   $def("_1xxtf0r", "updateNotebookImports", ["vars","extractNotebookAndCell","linkTo"], _1xxtf0r);  
   main.define("tests", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("tests", _));
   return main;
-}</script>
+}
+</script>
 
 <script id="@tomlarkworthy/module-map" 
   type="text/plain"

--- a/notebooks/@tomlarkworthy_local-change-history.html
+++ b/notebooks/@tomlarkworthy_local-change-history.html
@@ -12973,7 +12973,7 @@ export default function define(runtime, observer) {
   return main;
 }</script>
 
-<script id="@tomlarkworthy/lopepage-urls" 
+<script id="@tomlarkworthy/lopepage-urls"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -13324,78 +13324,71 @@ const _gxaxgb = function _links(){return(
 const _17e89y0 = function _targets(){return(
 ["@tom/bar", "d/1f41fef8b019cf4e@94", "@tom/bar#cell"]
 )};
-const _1x6cut = function _linkTo(isOnObservableCom){return(
-function linkTo(
-  target,
-  {
-    baseURI = document.baseURI,
-    onObservable = isOnObservableCom(),
-    source = null,
-    op = "open" // "open" | "close" | "focus"
-  } = {}
-) {
-  if (onObservable) {
-    const t =
-      typeof target === "string"
-        ? target
-        : target?.module || target?.open || target?.close || "";
-    return t.startsWith("#") ? t : "/" + t;
-  }
-
-  // Parse existing hash params manually to avoid percent-encoding DSL chars
-  const base = new URL(baseURI);
-  const rawHash = (base.hash || "#").slice(1);
-  const hashParams = new Map();
-  if (rawHash) {
-    for (const part of rawHash.split("&")) {
-      const eq = part.indexOf("=");
-      if (eq >= 0) hashParams.set(part.slice(0, eq), part.slice(eq + 1));
-      else if (part) hashParams.set(part, "");
-    }
-  }
-
-  if (typeof target === "string" && target.startsWith("#")) return target;
-
-  const isIntent =
-    typeof target === "object" &&
-    target !== null &&
-    ("module" in target ||
-      "open" in target ||
-      "close" in target ||
-      "focus" in target ||
-      "op" in target);
-
-  let module = null;
-  let cell = null;
-
-  if (!isIntent) {
-    module = String(target ?? "");
-    const parts = module.split("#");
-    module = parts[0] || null;
-    cell = parts[1] || null;
-    op = "open";
-  } else {
-    module =
-      target.module || target.open || target.close || target.focus || null;
-    cell = target.cell || null;
-    source = target.source ?? source;
-    op =
-      target.op || (target.close ? "close" : target.focus ? "focus" : "open");
-  }
-
-  if (!module) return base.toString();
-
-  hashParams.set(op, cell ? `${module}#${cell}` : module);
-  if (source) hashParams.set("from", source);
-
-  // Build hash without URLSearchParams to preserve DSL chars unencoded.
-  // Return hash-only for same-page links to avoid page reload.
-  const hashStr = [...hashParams]
-    .map(([k, v]) => (v ? `${k}=${v}` : k))
-    .join("&");
-  return "#" + hashStr;
-}
-)};
+const _bsoqwx = function _linkTo(isOnObservableCom)
+{
+    return function linkTo(target, {baseURI = document.baseURI, onObservable = isOnObservableCom(), source = null, op = 'open'    // "open" | "close" | "focus"
+} = {}) {
+        if (onObservable) {
+            const t = typeof target === 'string' ? target : target?.module || target?.open || target?.close || '';
+            return t.startsWith('#') ? t : '/' + t;
+        }
+        // Parse existing hash params manually to avoid percent-encoding DSL chars
+        const base = new URL(baseURI);
+        const rawHash = (base.hash || '#').slice(1);
+        const hashParams = new Map();
+        // open/close/focus/from are transient intents that lopepage consumes and
+        // clears, so we do NOT deep-link them. view= is canonical layout state owned
+        // by lopepage; if we baked the baseURI's view= into every link, the href
+        // would be a snapshot from link-render time and clicking it would rewind the
+        // layout (issue #150 — clicking a second module wiped the first because the
+        // link carried the boot view=). Dropping view= here makes the link a pure
+        // intent (e.g. "#cc=...&open=X"); sync_layout_from_url's
+        // `if (!view && open)` branch then merges the intent into the live layout.
+        const drop = new Set([
+            'view',
+            'open',
+            'close',
+            'focus',
+            'from'
+        ]);
+        if (rawHash) {
+            for (const part of rawHash.split('&')) {
+                const eq = part.indexOf('=');
+                const key = eq >= 0 ? part.slice(0, eq) : part;
+                if (drop.has(key))
+                    continue;
+                const val = eq >= 0 ? part.slice(eq + 1) : '';
+                hashParams.set(key, val);
+            }
+        }
+        if (typeof target === 'string' && target.startsWith('#'))
+            return target;
+        const isIntent = typeof target === 'object' && target !== null && ('module' in target || 'open' in target || 'close' in target || 'focus' in target || 'op' in target);
+        let module = null;
+        let cell = null;
+        if (!isIntent) {
+            module = String(target ?? '');
+            const parts = module.split('#');
+            module = parts[0] || null;
+            cell = parts[1] || null;
+            op = 'open';
+        } else {
+            module = target.module || target.open || target.close || target.focus || null;
+            cell = target.cell || null;
+            source = target.source ?? source;
+            op = target.op || (target.close ? 'close' : target.focus ? 'focus' : 'open');
+        }
+        if (!module)
+            return base.toString();
+        hashParams.set(op, cell ? `${ module }#${ cell }` : module);
+        if (source)
+            hashParams.set('from', source);
+        // Build hash without URLSearchParams to preserve DSL chars unencoded.
+        // Return hash-only for same-page links to avoid page reload.
+        const hashStr = [...hashParams].map(([k, v]) => v ? `${ k }=${ v }` : k).join('&');
+        return '#' + hashStr;
+    };
+};
 const _jdyayh = function _vars(variables,runtime){return(
 variables(runtime)
 )};
@@ -13508,7 +13501,7 @@ export default function define(runtime, observer) {
   $def("_1xjzq9r", "isOnObservableCom", ["location"], _1xjzq9r);  
   $def("_gxaxgb", "links", [], _gxaxgb);  
   $def("_17e89y0", "targets", [], _17e89y0);  
-  $def("_1x6cut", "linkTo", ["isOnObservableCom"], _1x6cut);  
+  $def("_bsoqwx", "linkTo", ["isOnObservableCom"], _bsoqwx);  
   $def("_jdyayh", "viewof vars", ["variables","runtime"], _jdyayh);  
   $def("_mfvz6q", "vars", ["Generators","viewof vars"], _mfvz6q);  
   $def("_1f44wsz", "test_linkTo", ["links","targets","linkTo"], _1f44wsz);  
@@ -13521,7 +13514,8 @@ export default function define(runtime, observer) {
   $def("_1xxtf0r", "updateNotebookImports", ["vars","extractNotebookAndCell","linkTo"], _1xxtf0r);  
   main.define("tests", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("tests", _));
   return main;
-}</script>
+}
+</script>
 
 <script id="@tomlarkworthy/module-map" 
   type="text/plain"

--- a/notebooks/@tomlarkworthy_local-storage-view.html
+++ b/notebooks/@tomlarkworthy_local-storage-view.html
@@ -14177,7 +14177,7 @@ export default function define(runtime, observer) {
   return main;
 }</script>
 
-<script id="@tomlarkworthy/lopepage-urls" 
+<script id="@tomlarkworthy/lopepage-urls"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -14528,81 +14528,75 @@ const _gxaxgb = function _links(){return(
 const _17e89y0 = function _targets(){return(
 ["@tom/bar", "d/1f41fef8b019cf4e@94", "@tom/bar#cell"]
 )};
-const _1x6cut = function _linkTo(isOnObservableCom){return(
-function linkTo(
-  target,
-  {
-    baseURI = document.baseURI,
-    onObservable = isOnObservableCom(),
-    source = null,
-    op = "open" // "open" | "close" | "focus"
-  } = {}
-) {
-  if (onObservable) {
-    const t =
-      typeof target === "string"
-        ? target
-        : target?.module || target?.open || target?.close || "";
-    return t.startsWith("#") ? t : "/" + t;
-  }
-
-  // Parse existing hash params manually to avoid percent-encoding DSL chars
-  const base = new URL(baseURI);
-  const rawHash = (base.hash || "#").slice(1);
-  const hashParams = new Map();
-  if (rawHash) {
-    for (const part of rawHash.split("&")) {
-      const eq = part.indexOf("=");
-      if (eq >= 0) hashParams.set(part.slice(0, eq), part.slice(eq + 1));
-      else if (part) hashParams.set(part, "");
-    }
-  }
-
-  if (typeof target === "string" && target.startsWith("#")) return target;
-
-  const isIntent =
-    typeof target === "object" &&
-    target !== null &&
-    ("module" in target ||
-      "open" in target ||
-      "close" in target ||
-      "focus" in target ||
-      "op" in target);
-
-  let module = null;
-  let cell = null;
-
-  if (!isIntent) {
-    module = String(target ?? "");
-    const parts = module.split("#");
-    module = parts[0] || null;
-    cell = parts[1] || null;
-    op = "open";
-  } else {
-    module =
-      target.module || target.open || target.close || target.focus || null;
-    cell = target.cell || null;
-    source = target.source ?? source;
-    op =
-      target.op || (target.close ? "close" : target.focus ? "focus" : "open");
-  }
-
-  if (!module) return base.toString();
-
-  hashParams.set(op, cell ? `${module}#${cell}` : module);
-  if (source) hashParams.set("from", source);
-
-  // Build hash without URLSearchParams to preserve DSL chars unencoded.
-  // Return hash-only for same-page links to avoid page reload.
-  const hashStr = [...hashParams]
-    .map(([k, v]) => (v ? `${k}=${v}` : k))
-    .join("&");
-  return "#" + hashStr;
-}
-)};
+const _bsoqwx = function _linkTo(isOnObservableCom)
+{
+    return function linkTo(target, {baseURI = document.baseURI, onObservable = isOnObservableCom(), source = null, op = 'open'    // "open" | "close" | "focus"
+} = {}) {
+        if (onObservable) {
+            const t = typeof target === 'string' ? target : target?.module || target?.open || target?.close || '';
+            return t.startsWith('#') ? t : '/' + t;
+        }
+        // Parse existing hash params manually to avoid percent-encoding DSL chars
+        const base = new URL(baseURI);
+        const rawHash = (base.hash || '#').slice(1);
+        const hashParams = new Map();
+        // open/close/focus/from are transient intents that lopepage consumes and
+        // clears, so we do NOT deep-link them. view= is canonical layout state owned
+        // by lopepage; if we baked the baseURI's view= into every link, the href
+        // would be a snapshot from link-render time and clicking it would rewind the
+        // layout (issue #150 — clicking a second module wiped the first because the
+        // link carried the boot view=). Dropping view= here makes the link a pure
+        // intent (e.g. "#cc=...&open=X"); sync_layout_from_url's
+        // `if (!view && open)` branch then merges the intent into the live layout.
+        const drop = new Set([
+            'view',
+            'open',
+            'close',
+            'focus',
+            'from'
+        ]);
+        if (rawHash) {
+            for (const part of rawHash.split('&')) {
+                const eq = part.indexOf('=');
+                const key = eq >= 0 ? part.slice(0, eq) : part;
+                if (drop.has(key))
+                    continue;
+                const val = eq >= 0 ? part.slice(eq + 1) : '';
+                hashParams.set(key, val);
+            }
+        }
+        if (typeof target === 'string' && target.startsWith('#'))
+            return target;
+        const isIntent = typeof target === 'object' && target !== null && ('module' in target || 'open' in target || 'close' in target || 'focus' in target || 'op' in target);
+        let module = null;
+        let cell = null;
+        if (!isIntent) {
+            module = String(target ?? '');
+            const parts = module.split('#');
+            module = parts[0] || null;
+            cell = parts[1] || null;
+            op = 'open';
+        } else {
+            module = target.module || target.open || target.close || target.focus || null;
+            cell = target.cell || null;
+            source = target.source ?? source;
+            op = target.op || (target.close ? 'close' : target.focus ? 'focus' : 'open');
+        }
+        if (!module)
+            return base.toString();
+        hashParams.set(op, cell ? `${ module }#${ cell }` : module);
+        if (source)
+            hashParams.set('from', source);
+        // Build hash without URLSearchParams to preserve DSL chars unencoded.
+        // Return hash-only for same-page links to avoid page reload.
+        const hashStr = [...hashParams].map(([k, v]) => v ? `${ k }=${ v }` : k).join('&');
+        return '#' + hashStr;
+    };
+};
 const _jdyayh = function _vars(variables,runtime){return(
 variables(runtime)
 )};
+const _mfvz6q = (G, _) => G.input(_);
 const _1f44wsz = function _test_linkTo(links,targets,linkTo){return(
 links.map((link) =>
   targets.map((target) =>
@@ -14615,7 +14609,6 @@ md`## Auto switch to url structure
 
 Watch the runtime for imports and swap them for our structure`
 )};
-const _w93ki7 = (_, v) => v.import("runtime", _);
 const _1gllckt = function _href_examples(){return(
 [
   "https://tomlarkworthy/import-notebook",
@@ -14674,20 +14667,15 @@ const _1xxtf0r = function _updateNotebookImports(vars,extractNotebookAndCell,lin
     }
   }
 };
-const _1txhfy5 = (_, v) => v.import("tests", _);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
   const $def = (pid, name, deps, fn) => {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
-  const fileAttachments = new Map([].map((name) => {
-    const module_name = "@tomlarkworthy/lopepage-urls";
-    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
-    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
-    return [name, {url: blob_url, mimeType: mime}]
-  }));
-  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
   $def("_1g7wjzc", null, ["md"], _1g7wjzc);  
   $def("_1hsbxxe", null, ["md"], _1hsbxxe);  
   $def("_1buq9dd", null, ["tests"], _1buq9dd);  
@@ -14717,22 +14705,21 @@ export default function define(runtime, observer) {
   $def("_1xjzq9r", "isOnObservableCom", ["location"], _1xjzq9r);  
   $def("_gxaxgb", "links", [], _gxaxgb);  
   $def("_17e89y0", "targets", [], _17e89y0);  
-  $def("_1x6cut", "linkTo", ["isOnObservableCom"], _1x6cut);  
+  $def("_bsoqwx", "linkTo", ["isOnObservableCom"], _bsoqwx);  
   $def("_jdyayh", "viewof vars", ["variables","runtime"], _jdyayh);  
-  main.variable(observer("vars")).define("vars", ["Generators", "viewof vars"], (G, _) => G.input(_));  
+  $def("_mfvz6q", "vars", ["Generators","viewof vars"], _mfvz6q);  
   $def("_1f44wsz", "test_linkTo", ["links","targets","linkTo"], _1f44wsz);  
   $def("_1hdknc", null, ["md"], _1hdknc);  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("variables", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("variables", _));  
   $def("_1gllckt", "href_examples", [], _1gllckt);  
   $def("_133ucsn", "test_extractNotebookAndCell", ["href_examples","extractNotebookAndCell"], _133ucsn);  
   $def("_cb1ope", "extractNotebookAndCell", [], _cb1ope);  
   $def("_1xxtf0r", "updateNotebookImports", ["vars","extractNotebookAndCell","linkTo"], _1xxtf0r);  
-  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
   main.define("tests", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("tests", _));
   return main;
-}</script>
+}
+</script>
 
 <script id="@tomlarkworthy/module-map" 
   type="text/plain"

--- a/notebooks/@tomlarkworthy_lopecode-tour.html
+++ b/notebooks/@tomlarkworthy_lopecode-tour.html
@@ -15943,7 +15943,7 @@ export default function define(runtime, observer) {
   return main;
 }</script>
 
-<script id="@tomlarkworthy/lopepage-urls" 
+<script id="@tomlarkworthy/lopepage-urls"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -16294,78 +16294,71 @@ const _gxaxgb = function _links(){return(
 const _17e89y0 = function _targets(){return(
 ["@tom/bar", "d/1f41fef8b019cf4e@94", "@tom/bar#cell"]
 )};
-const _1x6cut = function _linkTo(isOnObservableCom){return(
-function linkTo(
-  target,
-  {
-    baseURI = document.baseURI,
-    onObservable = isOnObservableCom(),
-    source = null,
-    op = "open" // "open" | "close" | "focus"
-  } = {}
-) {
-  if (onObservable) {
-    const t =
-      typeof target === "string"
-        ? target
-        : target?.module || target?.open || target?.close || "";
-    return t.startsWith("#") ? t : "/" + t;
-  }
-
-  // Parse existing hash params manually to avoid percent-encoding DSL chars
-  const base = new URL(baseURI);
-  const rawHash = (base.hash || "#").slice(1);
-  const hashParams = new Map();
-  if (rawHash) {
-    for (const part of rawHash.split("&")) {
-      const eq = part.indexOf("=");
-      if (eq >= 0) hashParams.set(part.slice(0, eq), part.slice(eq + 1));
-      else if (part) hashParams.set(part, "");
-    }
-  }
-
-  if (typeof target === "string" && target.startsWith("#")) return target;
-
-  const isIntent =
-    typeof target === "object" &&
-    target !== null &&
-    ("module" in target ||
-      "open" in target ||
-      "close" in target ||
-      "focus" in target ||
-      "op" in target);
-
-  let module = null;
-  let cell = null;
-
-  if (!isIntent) {
-    module = String(target ?? "");
-    const parts = module.split("#");
-    module = parts[0] || null;
-    cell = parts[1] || null;
-    op = "open";
-  } else {
-    module =
-      target.module || target.open || target.close || target.focus || null;
-    cell = target.cell || null;
-    source = target.source ?? source;
-    op =
-      target.op || (target.close ? "close" : target.focus ? "focus" : "open");
-  }
-
-  if (!module) return base.toString();
-
-  hashParams.set(op, cell ? `${module}#${cell}` : module);
-  if (source) hashParams.set("from", source);
-
-  // Build hash without URLSearchParams to preserve DSL chars unencoded.
-  // Return hash-only for same-page links to avoid page reload.
-  const hashStr = [...hashParams]
-    .map(([k, v]) => (v ? `${k}=${v}` : k))
-    .join("&");
-  return "#" + hashStr;
-}
-)};
+const _bsoqwx = function _linkTo(isOnObservableCom)
+{
+    return function linkTo(target, {baseURI = document.baseURI, onObservable = isOnObservableCom(), source = null, op = 'open'    // "open" | "close" | "focus"
+} = {}) {
+        if (onObservable) {
+            const t = typeof target === 'string' ? target : target?.module || target?.open || target?.close || '';
+            return t.startsWith('#') ? t : '/' + t;
+        }
+        // Parse existing hash params manually to avoid percent-encoding DSL chars
+        const base = new URL(baseURI);
+        const rawHash = (base.hash || '#').slice(1);
+        const hashParams = new Map();
+        // open/close/focus/from are transient intents that lopepage consumes and
+        // clears, so we do NOT deep-link them. view= is canonical layout state owned
+        // by lopepage; if we baked the baseURI's view= into every link, the href
+        // would be a snapshot from link-render time and clicking it would rewind the
+        // layout (issue #150 — clicking a second module wiped the first because the
+        // link carried the boot view=). Dropping view= here makes the link a pure
+        // intent (e.g. "#cc=...&open=X"); sync_layout_from_url's
+        // `if (!view && open)` branch then merges the intent into the live layout.
+        const drop = new Set([
+            'view',
+            'open',
+            'close',
+            'focus',
+            'from'
+        ]);
+        if (rawHash) {
+            for (const part of rawHash.split('&')) {
+                const eq = part.indexOf('=');
+                const key = eq >= 0 ? part.slice(0, eq) : part;
+                if (drop.has(key))
+                    continue;
+                const val = eq >= 0 ? part.slice(eq + 1) : '';
+                hashParams.set(key, val);
+            }
+        }
+        if (typeof target === 'string' && target.startsWith('#'))
+            return target;
+        const isIntent = typeof target === 'object' && target !== null && ('module' in target || 'open' in target || 'close' in target || 'focus' in target || 'op' in target);
+        let module = null;
+        let cell = null;
+        if (!isIntent) {
+            module = String(target ?? '');
+            const parts = module.split('#');
+            module = parts[0] || null;
+            cell = parts[1] || null;
+            op = 'open';
+        } else {
+            module = target.module || target.open || target.close || target.focus || null;
+            cell = target.cell || null;
+            source = target.source ?? source;
+            op = target.op || (target.close ? 'close' : target.focus ? 'focus' : 'open');
+        }
+        if (!module)
+            return base.toString();
+        hashParams.set(op, cell ? `${ module }#${ cell }` : module);
+        if (source)
+            hashParams.set('from', source);
+        // Build hash without URLSearchParams to preserve DSL chars unencoded.
+        // Return hash-only for same-page links to avoid page reload.
+        const hashStr = [...hashParams].map(([k, v]) => v ? `${ k }=${ v }` : k).join('&');
+        return '#' + hashStr;
+    };
+};
 const _jdyayh = function _vars(variables,runtime){return(
 variables(runtime)
 )};
@@ -16478,7 +16471,7 @@ export default function define(runtime, observer) {
   $def("_1xjzq9r", "isOnObservableCom", ["location"], _1xjzq9r);  
   $def("_gxaxgb", "links", [], _gxaxgb);  
   $def("_17e89y0", "targets", [], _17e89y0);  
-  $def("_1x6cut", "linkTo", ["isOnObservableCom"], _1x6cut);  
+  $def("_bsoqwx", "linkTo", ["isOnObservableCom"], _bsoqwx);  
   $def("_jdyayh", "viewof vars", ["variables","runtime"], _jdyayh);  
   $def("_mfvz6q", "vars", ["Generators","viewof vars"], _mfvz6q);  
   $def("_1f44wsz", "test_linkTo", ["links","targets","linkTo"], _1f44wsz);  
@@ -16491,7 +16484,8 @@ export default function define(runtime, observer) {
   $def("_1xxtf0r", "updateNotebookImports", ["vars","extractNotebookAndCell","linkTo"], _1xxtf0r);  
   main.define("tests", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("tests", _));
   return main;
-}</script>
+}
+</script>
 
 <script id="@tomlarkworthy/manipulate" 
   type="text/plain"

--- a/notebooks/@tomlarkworthy_lopecode-vision.html
+++ b/notebooks/@tomlarkworthy_lopecode-vision.html
@@ -15268,7 +15268,7 @@ export default function define(runtime, observer) {
   return main;
 }</script>
 
-<script id="@tomlarkworthy/lopepage-urls" 
+<script id="@tomlarkworthy/lopepage-urls"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -15619,78 +15619,71 @@ const _gxaxgb = function _links(){return(
 const _17e89y0 = function _targets(){return(
 ["@tom/bar", "d/1f41fef8b019cf4e@94", "@tom/bar#cell"]
 )};
-const _1x6cut = function _linkTo(isOnObservableCom){return(
-function linkTo(
-  target,
-  {
-    baseURI = document.baseURI,
-    onObservable = isOnObservableCom(),
-    source = null,
-    op = "open" // "open" | "close" | "focus"
-  } = {}
-) {
-  if (onObservable) {
-    const t =
-      typeof target === "string"
-        ? target
-        : target?.module || target?.open || target?.close || "";
-    return t.startsWith("#") ? t : "/" + t;
-  }
-
-  // Parse existing hash params manually to avoid percent-encoding DSL chars
-  const base = new URL(baseURI);
-  const rawHash = (base.hash || "#").slice(1);
-  const hashParams = new Map();
-  if (rawHash) {
-    for (const part of rawHash.split("&")) {
-      const eq = part.indexOf("=");
-      if (eq >= 0) hashParams.set(part.slice(0, eq), part.slice(eq + 1));
-      else if (part) hashParams.set(part, "");
-    }
-  }
-
-  if (typeof target === "string" && target.startsWith("#")) return target;
-
-  const isIntent =
-    typeof target === "object" &&
-    target !== null &&
-    ("module" in target ||
-      "open" in target ||
-      "close" in target ||
-      "focus" in target ||
-      "op" in target);
-
-  let module = null;
-  let cell = null;
-
-  if (!isIntent) {
-    module = String(target ?? "");
-    const parts = module.split("#");
-    module = parts[0] || null;
-    cell = parts[1] || null;
-    op = "open";
-  } else {
-    module =
-      target.module || target.open || target.close || target.focus || null;
-    cell = target.cell || null;
-    source = target.source ?? source;
-    op =
-      target.op || (target.close ? "close" : target.focus ? "focus" : "open");
-  }
-
-  if (!module) return base.toString();
-
-  hashParams.set(op, cell ? `${module}#${cell}` : module);
-  if (source) hashParams.set("from", source);
-
-  // Build hash without URLSearchParams to preserve DSL chars unencoded.
-  // Return hash-only for same-page links to avoid page reload.
-  const hashStr = [...hashParams]
-    .map(([k, v]) => (v ? `${k}=${v}` : k))
-    .join("&");
-  return "#" + hashStr;
-}
-)};
+const _bsoqwx = function _linkTo(isOnObservableCom)
+{
+    return function linkTo(target, {baseURI = document.baseURI, onObservable = isOnObservableCom(), source = null, op = 'open'    // "open" | "close" | "focus"
+} = {}) {
+        if (onObservable) {
+            const t = typeof target === 'string' ? target : target?.module || target?.open || target?.close || '';
+            return t.startsWith('#') ? t : '/' + t;
+        }
+        // Parse existing hash params manually to avoid percent-encoding DSL chars
+        const base = new URL(baseURI);
+        const rawHash = (base.hash || '#').slice(1);
+        const hashParams = new Map();
+        // open/close/focus/from are transient intents that lopepage consumes and
+        // clears, so we do NOT deep-link them. view= is canonical layout state owned
+        // by lopepage; if we baked the baseURI's view= into every link, the href
+        // would be a snapshot from link-render time and clicking it would rewind the
+        // layout (issue #150 — clicking a second module wiped the first because the
+        // link carried the boot view=). Dropping view= here makes the link a pure
+        // intent (e.g. "#cc=...&open=X"); sync_layout_from_url's
+        // `if (!view && open)` branch then merges the intent into the live layout.
+        const drop = new Set([
+            'view',
+            'open',
+            'close',
+            'focus',
+            'from'
+        ]);
+        if (rawHash) {
+            for (const part of rawHash.split('&')) {
+                const eq = part.indexOf('=');
+                const key = eq >= 0 ? part.slice(0, eq) : part;
+                if (drop.has(key))
+                    continue;
+                const val = eq >= 0 ? part.slice(eq + 1) : '';
+                hashParams.set(key, val);
+            }
+        }
+        if (typeof target === 'string' && target.startsWith('#'))
+            return target;
+        const isIntent = typeof target === 'object' && target !== null && ('module' in target || 'open' in target || 'close' in target || 'focus' in target || 'op' in target);
+        let module = null;
+        let cell = null;
+        if (!isIntent) {
+            module = String(target ?? '');
+            const parts = module.split('#');
+            module = parts[0] || null;
+            cell = parts[1] || null;
+            op = 'open';
+        } else {
+            module = target.module || target.open || target.close || target.focus || null;
+            cell = target.cell || null;
+            source = target.source ?? source;
+            op = target.op || (target.close ? 'close' : target.focus ? 'focus' : 'open');
+        }
+        if (!module)
+            return base.toString();
+        hashParams.set(op, cell ? `${ module }#${ cell }` : module);
+        if (source)
+            hashParams.set('from', source);
+        // Build hash without URLSearchParams to preserve DSL chars unencoded.
+        // Return hash-only for same-page links to avoid page reload.
+        const hashStr = [...hashParams].map(([k, v]) => v ? `${ k }=${ v }` : k).join('&');
+        return '#' + hashStr;
+    };
+};
 const _jdyayh = function _vars(variables,runtime){return(
 variables(runtime)
 )};
@@ -15803,7 +15796,7 @@ export default function define(runtime, observer) {
   $def("_1xjzq9r", "isOnObservableCom", ["location"], _1xjzq9r);  
   $def("_gxaxgb", "links", [], _gxaxgb);  
   $def("_17e89y0", "targets", [], _17e89y0);  
-  $def("_1x6cut", "linkTo", ["isOnObservableCom"], _1x6cut);  
+  $def("_bsoqwx", "linkTo", ["isOnObservableCom"], _bsoqwx);  
   $def("_jdyayh", "viewof vars", ["variables","runtime"], _jdyayh);  
   $def("_mfvz6q", "vars", ["Generators","viewof vars"], _mfvz6q);  
   $def("_1f44wsz", "test_linkTo", ["links","targets","linkTo"], _1f44wsz);  
@@ -15816,7 +15809,8 @@ export default function define(runtime, observer) {
   $def("_1xxtf0r", "updateNotebookImports", ["vars","extractNotebookAndCell","linkTo"], _1xxtf0r);  
   main.define("tests", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("tests", _));
   return main;
-}</script>
+}
+</script>
 <script id="@tomlarkworthy/modern-screenshot/modern-screenshot-4.6.6.js.gz" 
   type="text/plain"
   data-encoding="base64"

--- a/notebooks/@tomlarkworthy_lopepage-urls.html
+++ b/notebooks/@tomlarkworthy_lopepage-urls.html
@@ -9,14 +9,8 @@
 <body>
 <!-- Networking -->
 <script id="networking_script">
-  const normalize = (url) =>
-  url
-    .replace(
-      /^(?:https:\/\/api\.observablehq\.com)?\/(.*?)\.js(?:\?.*)?$/,
-      "$1"
-    )
-    .replace(/^(d\/[a-f0-9]{16})@\d+$/, "$1");
-  const isNotebook = (id) => /^(@[^/]+\/[^/]+|d\/[a-f0-9]{16})$/.test(id);
+  const normalize = url => url.replace(/^(?:https:\/\/api\.observablehq\.com)?\/(.*?)\.js(?:\?.*)?$/, '$1').replace(/^(d\/[a-f0-9]{16})@\d+$/, '$1');
+  const isNotebook = id => /^(@[^/]+\/[^/]+|d\/[a-f0-9]{16})$/.test(id);
 
   const b64ToBytes = (b64) => {
     const bin = atob(b64);
@@ -906,13 +900,7 @@ export default function define(runtime, observer) {
   const $def = (pid, name, deps, fn) => {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
-  const fileAttachments = new Map([].map((name) => {
-    const module_name = "@mbostock/safe-local-storage";
-    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
-    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
-    return [name, {url: blob_url, mimeType: mime}]
-  }));
-  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
   $def("_gi5bv7", null, ["md"], _gi5bv7);  
   $def("_x8ty32", "localStorage", ["MemoryStorage"], _x8ty32);  
   $def("_jodvzd", "MemoryStorage", [], _jodvzd);
@@ -1050,6 +1038,7 @@ md`---
 const _qzbmro = function _ex_refresh(Inputs){return(
 Inputs.button('Refresh')
 )};
+const _1taed3h = (G, _) => G.input(_);
 const _1sbpgcs = function _17(md){return(
 md`### Defined variables`
 )};
@@ -1085,6 +1074,7 @@ const _2couch = function _ex_vars_filters(ex_vars,Inputs)
     })
   });
 };
+const _350we = (G, _) => G.input(_);
 const _1ij3t3 = function _ex_vars_table(ex_vars_filters,ex_vars,Inputs)
 {
   const flags = (arr) => Object.fromEntries(arr.map(v => [v, true]));
@@ -1165,13 +1155,7 @@ export default function define(runtime, observer) {
   const $def = (pid, name, deps, fn) => {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
-  const fileAttachments = new Map([].map((name) => {
-    const module_name = "@mootari/access-runtime";
-    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
-    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
-    return [name, {url: blob_url, mimeType: mime}]
-  }));
-  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
   $def("_xuj1uh", null, ["md"], _xuj1uh);  
   $def("_1k2rjj6", null, ["md"], _1k2rjj6);  
   $def("_1qopri0", null, ["md"], _1qopri0);  
@@ -1188,11 +1172,11 @@ export default function define(runtime, observer) {
   $def("_1trrrv5", "recomputeTrigger", ["mutable_recomputeTrigger"], _1trrrv5);  
   $def("_1l3masu", null, ["md"], _1l3masu);  
   $def("_qzbmro", "viewof ex_refresh", ["Inputs"], _qzbmro);  
-  main.variable(observer("ex_refresh")).define("ex_refresh", ["Generators", "viewof ex_refresh"], (G, _) => G.input(_));  
+  $def("_1taed3h", "ex_refresh", ["Generators","viewof ex_refresh"], _1taed3h);  
   $def("_1sbpgcs", null, ["md"], _1sbpgcs);  
   $def("_mcd64l", "ex_vars", ["ex_refresh","runtime","modules","no_observer"], _mcd64l);  
   $def("_2couch", "viewof ex_vars_filters", ["ex_vars","Inputs"], _2couch);  
-  main.variable(observer("ex_vars_filters")).define("ex_vars_filters", ["Generators", "viewof ex_vars_filters"], (G, _) => G.input(_));  
+  $def("_350we", "ex_vars_filters", ["Generators","viewof ex_vars_filters"], _350we);  
   $def("_1ij3t3", "ex_vars_table", ["ex_vars_filters","ex_vars","Inputs"], _1ij3t3);  
   $def("_8awat", null, ["md"], _8awat);  
   $def("_1tb2c5q", "ex_deps", ["ex_refresh","observed","Inputs","htl"], _1tb2c5q);  
@@ -1250,6 +1234,7 @@ export default function define(runtime, observer) {
     return [name, {url: blob_url, mimeType: mime}]
   }));
   main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
   $def("_k54r8u", null, ["md"], _k54r8u);  
   $def("_1xdqqxo", "acorn", ["acorn_url"], _1xdqqxo);  
   $def("_jdtsxp", "acorn_url", ["unzip","FileAttachment"], _jdtsxp);  
@@ -1268,9 +1253,11 @@ md`# \`cellMap\`
 const _199r1h0 = function _showBuiltins(Inputs){return(
 Inputs.toggle({ label: "builtins?", value: false })
 )};
+const _v3idap = (G, _) => G.input(_);
 const _jqf42f = function _showAnon(Inputs){return(
 Inputs.toggle({ label: "anonymous?", value: false })
 )};
+const _10za42b = (G, _) => G.input(_);
 const _125g1nt = function _cellMapViz(hash,Plot,width,d3,filteredMap,edges,linkTo,isOnObservableCom)
 {
   hash; // update links on hash change
@@ -1337,6 +1324,7 @@ const _125g1nt = function _cellMapViz(hash,Plot,width,d3,filteredMap,edges,linkT
     ]
   });
 };
+const _cjxin = (G, _) => G.input(_);
 const _1nt2irf = function _detailVizTitle(cellMapViz,linkTo,md){return(
 md`${cellMapViz ? `### [\`${cellMapViz?.module}#${cellMapViz?.name}\`](${linkTo(`${cellMapViz?.module}#${cellMapViz?.name}`)})` : `\`<click the above viz to pin a cell and open its dependancy graph below>\``}`
 )};
@@ -1414,6 +1402,7 @@ Plot.plot({
   ]
 })
 )};
+const _j5pb2k = (G, _) => G.input(_);
 const _glmq4i = function _7(md){return(
 md`## cellMap`
 )};
@@ -1435,6 +1424,7 @@ const _1xnzq7y = async function _liveCellMap(keepalive,cellMapModule,Inputs,cell
   keepalive(cellMapModule, "maintain_live_cell_map");
   return Inputs.input(await cellMap());
 };
+const _14vvdt2 = (G, _) => G.input(_);
 const _193osz9 = async function _maintain_live_cell_map(runtime_variables,$0,cellMap,Event)
 {
   runtime_variables;
@@ -1829,14 +1819,10 @@ filteredMap.flatMap((cell) =>
   )
 )
 )};
-const _16y0lz3 = (_, v) => v.import("linkTo", _);
-const _nxg8mr = (_, v) => v.import("moduleMap", _);
-const _1a10r2f = (_, v) => v.import("keepalive", _);
-const _nywbgn = (_, v) => v.import("expect", _);
 const _qb7351 = function _cellMapModule(thisModule){return(
 thisModule()
 )};
-const _1txhfy5 = (_, v) => v.import("tests", _);
+const _120483s = (G, _) => G.input(_);
 const _2ufyg8 = function _38(md){return(
 md`## testing`
 )};
@@ -1888,6 +1874,8 @@ runtime && lookupVariable("runtime", cellMapModule)
 const _1x88m7u = function _main_mutable(){return(
 "OK"
 )};
+const _1c3nv1y = (M, _) => new M(_);
+const _kbdqj3 = _ => _.generator;
 const _1q0qa04 = async function _test_importedModule(expect,modules,importedModule,reached_main_import,unreached_main_import)
 {
   expect(modules.get(await importedModule(reached_main_import)).name).toBe(
@@ -2134,36 +2122,35 @@ async (v, moduleMapLike) => {
   };
 }
 )};
-const _19ebgtz = (_, v) => v.import("hash", _);
-const _1vrh8lp = (_, v) => v.import("decompileImport", _);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
   const $def = (pid, name, deps, fn) => {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
-  const fileAttachments = new Map([].map((name) => {
-    const module_name = "@tomlarkworthy/cell-map";
-    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
-    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
-    return [name, {url: blob_url, mimeType: mime}]
-  }));
-  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
+  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/jest-expect-standalone", async () => runtime.module((await import("/@tomlarkworthy/jest-expect-standalone.js?v=4")).default));  
+  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
+  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
+  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
   $def("_1t29kxm", null, ["md"], _1t29kxm);  
   $def("_199r1h0", "viewof showBuiltins", ["Inputs"], _199r1h0);  
-  main.variable(observer("showBuiltins")).define("showBuiltins", ["Generators", "viewof showBuiltins"], (G, _) => G.input(_));  
+  $def("_v3idap", "showBuiltins", ["Generators","viewof showBuiltins"], _v3idap);  
   $def("_jqf42f", "viewof showAnon", ["Inputs"], _jqf42f);  
-  main.variable(observer("showAnon")).define("showAnon", ["Generators", "viewof showAnon"], (G, _) => G.input(_));  
+  $def("_10za42b", "showAnon", ["Generators","viewof showAnon"], _10za42b);  
   $def("_125g1nt", "viewof cellMapViz", ["hash","Plot","width","d3","filteredMap","edges","linkTo","isOnObservableCom"], _125g1nt);  
-  main.variable(observer("cellMapViz")).define("cellMapViz", ["Generators", "viewof cellMapViz"], (G, _) => G.input(_));  
+  $def("_cjxin", "cellMapViz", ["Generators","viewof cellMapViz"], _cjxin);  
   $def("_1nt2irf", "detailVizTitle", ["cellMapViz","linkTo","md"], _1nt2irf);  
   $def("_1lxiffy", "viewof detailViz", ["Plot","width","nodes","variableToCell","modules","linkTo","isOnObservableCom"], _1lxiffy);  
-  main.variable(observer("detailViz")).define("detailViz", ["Generators", "viewof detailViz"], (G, _) => G.input(_));  
+  $def("_j5pb2k", "detailViz", ["Generators","viewof detailViz"], _j5pb2k);  
   $def("_glmq4i", null, ["md"], _glmq4i);  
   $def("_izhsfx", null, ["Inputs","filteredMap"], _izhsfx);  
   $def("_7t7pwf", null, ["md"], _7t7pwf);  
   $def("_1xnzq7y", "viewof liveCellMap", ["keepalive","cellMapModule","Inputs","cellMap"], _1xnzq7y);  
-  main.variable(observer("liveCellMap")).define("liveCellMap", ["Generators", "viewof liveCellMap"], (G, _) => G.input(_));  
+  $def("_14vvdt2", "liveCellMap", ["Generators","viewof liveCellMap"], _14vvdt2);  
   $def("_193osz9", "maintain_live_cell_map", ["runtime_variables","viewof liveCellMap","cellMap","Event"], _193osz9);  
   $def("_1vhxngh", "usage", ["md"], _1vhxngh);  
   $def("_17c6bac", "cellMap", ["runtime","moduleMap","moduleVarInfo","importedModule","findModuleName","decompileImport"], _17c6bac);  
@@ -2185,13 +2172,10 @@ export default function define(runtime, observer) {
   $def("_szpnyp", "filteredMap", ["runtimeMap","filter"], _szpnyp);  
   $def("_1jdpo9p", "filter", ["showBuiltins","showAnon"], _1jdpo9p);  
   $def("_10gdqhm", "edges", ["filteredMap","variableToCell","filter"], _10gdqhm);  
-  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
   main.define("linkTo", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("linkTo", _));  
   main.define("isOnObservableCom", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("isOnObservableCom", _));  
-  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("runtime", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("runtime", _));  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("keepalive", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("keepalive", _));  
   main.define("runtime_variables", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime_variables", _));  
   main.define("lookupVariable", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("lookupVariable", _));  
@@ -2200,11 +2184,9 @@ export default function define(runtime, observer) {
   main.define("repositionSetElement", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("repositionSetElement", _));  
   main.define("ascendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("ascendants", _));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
-  main.define("module @tomlarkworthy/jest-expect-standalone", async () => runtime.module((await import("/@tomlarkworthy/jest-expect-standalone.js?v=4")).default));  
   main.define("expect", ["module @tomlarkworthy/jest-expect-standalone", "@variable"], (_, v) => v.import("expect", _));  
   $def("_qb7351", "viewof cellMapModule", ["thisModule"], _qb7351);  
-  main.variable(observer("cellMapModule")).define("cellMapModule", ["Generators", "viewof cellMapModule"], (G, _) => G.input(_));  
-  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
+  $def("_120483s", "cellMapModule", ["Generators","viewof cellMapModule"], _120483s);  
   main.define("tests", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("tests", _));  
   $def("_2ufyg8", null, ["md"], _2ufyg8);  
   $def("_18tubss", null, ["tests"], _18tubss);  
@@ -2215,8 +2197,8 @@ export default function define(runtime, observer) {
   $def("_pyrytd", "unreached_main_import", ["toObject","lookupVariable","cellMapModule"], _pyrytd);  
   $def("_12euivr", "reached_main_import", ["runtime","lookupVariable","cellMapModule"], _12euivr);  
   $def("_1x88m7u", "initial main_mutable", [], _1x88m7u);  
-  main.variable(observer("mutable main_mutable")).define("mutable main_mutable", ["Mutable", "initial main_mutable"], (M, _) => new M(_));  
-  main.variable(observer("main_mutable")).define("main_mutable", ["mutable main_mutable"], _ => _.generator);  
+  $def("_1c3nv1y", "mutable main_mutable", ["Mutable","initial main_mutable"], _1c3nv1y);  
+  $def("_kbdqj3", "main_mutable", ["mutable main_mutable"], _kbdqj3);  
   $def("_1q0qa04", "test_importedModule", ["expect","modules","importedModule","reached_main_import","unreached_main_import"], _1q0qa04);  
   $def("_1tqu9mu", "test_findModuleName", ["expect","findModuleName","importedModule","reached_main_import","modules","unreached_main_import"], _1tqu9mu);  
   $def("_1mk5ruc", "test_cellmap_mutable", ["main_mutable","lookupVariable","cellMapModule","cellMap","modules","expect"], _1mk5ruc);  
@@ -2231,9 +2213,7 @@ export default function define(runtime, observer) {
   $def("_n7jdgk", "findModuleName", [], _n7jdgk);  
   $def("_1ii3nc0", "extractObservableNotebookNameFromSpecifier", [], _1ii3nc0);  
   $def("_ejsyo1", "moduleVarInfo", ["extractObservableNotebookNameFromSpecifier"], _ejsyo1);  
-  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
   main.define("hash", ["module d/57d79353bac56631@44", "@variable"], (_, v) => v.import("hash", _));  
-  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
   main.define("decompileImport", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("decompileImport", _));
   return main;
 }</script>
@@ -2321,19 +2301,15 @@ const _but2s9 = function _defaultOther(){return(
 const _lj7470 = function _id(){return(
 0
 )};
+const _1bwa5dj = (M, _) => new M(_);
+const _mshfha = _ => _.generator;
 
 export default function define(runtime, observer) {
   const main = runtime.module();
   const $def = (pid, name, deps, fn) => {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
-  const fileAttachments = new Map([].map((name) => {
-    const module_name = "@tomlarkworthy/cells-to-clipboard";
-    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
-    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
-    return [name, {url: blob_url, mimeType: mime}]
-  }));
-  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
   $def("_y5656o", null, ["md"], _y5656o);  
   $def("_11ad3zw", null, ["copyCellButton"], _11ad3zw);  
   $def("_22fbf0", null, ["copyCellButton"], _22fbf0);  
@@ -2345,12 +2321,12 @@ export default function define(runtime, observer) {
   $def("_h1t91h", "defaultJS", [], _h1t91h);  
   $def("_but2s9", "defaultOther", [], _but2s9);  
   $def("_lj7470", "initial id", [], _lj7470);  
-  main.variable(observer("mutable id")).define("mutable id", ["Mutable", "initial id"], (M, _) => new M(_));  
-  main.variable(observer("id")).define("id", ["mutable id"], _ => _.generator);
+  $def("_1bwa5dj", "mutable id", ["Mutable","initial id"], _1bwa5dj);  
+  $def("_mshfha", "id", ["mutable id"], _mshfha);
   return main;
 }</script>
 
-<script id="@tomlarkworthy/claude-code-pairing"
+<script id="@tomlarkworthy/claude-code-pairing" 
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -4066,8 +4042,7 @@ export default function define(runtime, observer) {
   main.define("syncEnabled", ["module @tomlarkworthy/file-sync", "@variable"], (_, v) => v.import("syncEnabled", _));  
   main.define("syncStatus", ["module @tomlarkworthy/file-sync", "@variable"], (_, v) => v.import("syncStatus", _));
   return main;
-}
-</script>
+}</script>
 <script id="@tomlarkworthy/codemirror-6-v2/codemirror_javascript%405.js.gz" 
   type="text/plain"
   data-encoding="base64"
@@ -4180,6 +4155,7 @@ export default function define(runtime, observer) {
     return [name, {url: blob_url, mimeType: mime}]
   }));
   main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
   $def("_1intxg", null, ["md"], _1intxg);  
   $def("_ijajk5", null, ["md"], _ijajk5);  
   $def("_2noyiv", null, ["EditorView","codemirror","myDefaultTheme"], _2noyiv);  
@@ -4250,12 +4226,14 @@ Inputs.date({
   value: d3.min(dataset, (d) => d.order_date)
 })
 )};
+const _1k1jdoe = (G, _) => G.input(_);
 const _2dyf7j = function _endDay(Inputs,d3,dataset){return(
 Inputs.date({
   label: "endDay",
   value: d3.max(dataset, (d) => d.order_date)
 })
 )};
+const _1hf869l = (G, _) => G.input(_);
 const _uaibrg = function _11(md){return(
 md`For each widget should look at a different dimension.`
 )};
@@ -4265,6 +4243,7 @@ Inputs.select(Object.getOwnPropertyNames(dataset[0]), {
   value: "orders"
 })
 )};
+const _l8gwg6 = (G, _) => G.input(_);
 const _1xcup9l = function _pizzaChoices(dataset){return(
 [...new Set(dataset.map((d) => d.name))]
 )};
@@ -4276,6 +4255,7 @@ Inputs.select(pizzaChoices, {
   label: "pizza"
 })
 )};
+const _1k33rhf = (G, _) => G.input(_);
 const _1k27be5 = function _16(md){return(
 md`With a dimension and slice, we can plot a timeseries. Note the chart is reactive to the UI earlier in the dataflow. If you change the \`startDay\` or \`endDay\` the chart axis updates`
 )};
@@ -4303,6 +4283,7 @@ md`We want to combine all our UI controls and the chart into a single HTML widge
 const _1qzri0n = function _combine(Inputs){return(
 Inputs.toggle({ label: "smoosh into single component" })
 )};
+const _1h8337z = (G, _) => G.input(_);
 const _c6rtsv = function _20(md){return(
 md`#### assembled widget prototype`
 )};
@@ -4326,6 +4307,7 @@ First we gain access to the enclosing module hosting the variables via \`thisMod
 const _14bivfb = function _myModule(thisModule){return(
 thisModule()
 )};
+const _1cir47e = (G, _) => G.input(_);
 const _13lls96 = function _25(md){return(
 md`Then we find the variables we wish to clone, using \`lookupVariable\` from \`runtime-sdk\`. Note a \`viewof\` is really two reactive variables so you need them both (\`viewof foo\` _and_ \`foo\`)`
 )};
@@ -4430,6 +4412,7 @@ Inputs.range([1, 4], {
   value: 2
 })
 )};
+const _1f1j1ct = (G, _) => G.input(_);
 const _m7ki73 = function _36(md){return(
 md`From the array of DOM elements we can easily render them to a container HTML element`
 )};
@@ -4542,8 +4525,6 @@ md`## References
 
 While this Dataflow Templating implementation is for Observable Runtime Dataflow. The overarching concept is applicable to any dataflow languages in the style of \`FrTime\`, see _"Embedding Dynamic Dataflow in a Call-by-Value Language"_ 2006, Gregory H. Cooper, Shriram Krishnamurthi ([pdf](https://cs.brown.edu/~sk/Publications/Papers/Published/ck-frtime/paper.pdf))`
 )};
-const _eb0bcj = (_, v) => v.import("getPromiseState", _);
-const _1z7eev = (_, v) => v.import("inspect", _);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -4557,6 +4538,9 @@ export default function define(runtime, observer) {
     return [name, {url: blob_url, mimeType: mime}]
   }));
   main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/inspector", async () => runtime.module((await import("/@tomlarkworthy/inspector.js?v=4")).default));  
   $def("_vnsmd3", null, ["md"], _vnsmd3);  
   $def("_1edhe6y", null, ["md"], _1edhe6y);  
   $def("_190zbgd", null, ["md"], _190zbgd);  
@@ -4566,27 +4550,27 @@ export default function define(runtime, observer) {
   $def("_zsq9gu", "dataset", ["pizza"], _zsq9gu);  
   $def("_1nczpsq", "time", ["startDay","endDay"], _1nczpsq);  
   $def("_zjnnri", "viewof startDay", ["Inputs","d3","dataset"], _zjnnri);  
-  main.variable(observer("startDay")).define("startDay", ["Generators", "viewof startDay"], (G, _) => G.input(_));  
+  $def("_1k1jdoe", "startDay", ["Generators","viewof startDay"], _1k1jdoe);  
   $def("_2dyf7j", "viewof endDay", ["Inputs","d3","dataset"], _2dyf7j);  
-  main.variable(observer("endDay")).define("endDay", ["Generators", "viewof endDay"], (G, _) => G.input(_));  
+  $def("_1hf869l", "endDay", ["Generators","viewof endDay"], _1hf869l);  
   $def("_uaibrg", null, ["md"], _uaibrg);  
   $def("_ymldlm", "viewof dimension", ["Inputs","dataset"], _ymldlm);  
-  main.variable(observer("dimension")).define("dimension", ["Generators", "viewof dimension"], (G, _) => G.input(_));  
+  $def("_l8gwg6", "dimension", ["Generators","viewof dimension"], _l8gwg6);  
   $def("_1xcup9l", "pizzaChoices", ["dataset"], _1xcup9l);  
   $def("_zi7ddc", null, ["md"], _zi7ddc);  
   $def("_fr8ij5", "viewof pizzaChoice", ["Inputs","pizzaChoices"], _fr8ij5);  
-  main.variable(observer("pizzaChoice")).define("pizzaChoice", ["Generators", "viewof pizzaChoice"], (G, _) => G.input(_));  
+  $def("_1k33rhf", "pizzaChoice", ["Generators","viewof pizzaChoice"], _1k33rhf);  
   $def("_1k27be5", null, ["md"], _1k27be5);  
   $def("_tanvcq", "chart", ["Plot","pizzaChoice","dimension","time","dataset"], _tanvcq);  
   $def("_1n5lea9", null, ["md"], _1n5lea9);  
   $def("_1qzri0n", "viewof combine", ["Inputs"], _1qzri0n);  
-  main.variable(observer("combine")).define("combine", ["Generators", "viewof combine"], (G, _) => G.input(_));  
+  $def("_1h8337z", "combine", ["Generators","viewof combine"], _1h8337z);  
   $def("_c6rtsv", null, ["md"], _c6rtsv);  
   $def("_gwotsx", "widget", ["combine","htl","viewof dimension","viewof pizzaChoice","chart"], _gwotsx);  
   $def("_19pbjd6", null, ["md"], _19pbjd6);  
   $def("_9j1dnu", null, ["md"], _9j1dnu);  
   $def("_14bivfb", "viewof myModule", ["thisModule"], _14bivfb);  
-  main.variable(observer("myModule")).define("myModule", ["Generators", "viewof myModule"], (G, _) => G.input(_));  
+  $def("_1cir47e", "myModule", ["Generators","viewof myModule"], _1cir47e);  
   $def("_13lls96", null, ["md"], _13lls96);  
   $def("_1of2lsp", "template", ["lookupVariable","myModule"], _1of2lsp);  
   $def("_16o06u5", null, ["md"], _16o06u5);  
@@ -4598,7 +4582,7 @@ export default function define(runtime, observer) {
   $def("_ogdjgg", null, ["md"], _ogdjgg);  
   $def("_1qtev37", "dataflows", ["widgetCount","invalidation","cloneDataflow","template","Inspector"], _1qtev37);  
   $def("_1zsm12", "viewof widgetCount", ["Inputs"], _1zsm12);  
-  main.variable(observer("widgetCount")).define("widgetCount", ["Generators", "viewof widgetCount"], (G, _) => G.input(_));  
+  $def("_1f1j1ct", "widgetCount", ["Generators","viewof widgetCount"], _1f1j1ct);  
   $def("_m7ki73", null, ["md"], _m7ki73);  
   $def("_13jogyr", null, ["htl","width","widgetCount","dataflows"], _13jogyr);  
   $def("_4t7fj0", null, ["Inputs","viewof startDay"], _4t7fj0);  
@@ -4613,7 +4597,6 @@ export default function define(runtime, observer) {
   $def("_12alikv", null, ["md"], _12alikv);  
   $def("_ifa1z4", "cloneDataflow", ["observeSet"], _ifa1z4);  
   $def("_1nie1nr", null, ["md"], _1nie1nr);  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("getPromiseState", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("getPromiseState", _));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
@@ -4622,7 +4605,6 @@ export default function define(runtime, observer) {
   main.define("toObject", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("toObject", _));  
   main.define("observeSet", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("observeSet", _));  
   main.define("observe", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("observe", _));  
-  main.define("module @tomlarkworthy/inspector", async () => runtime.module((await import("/@tomlarkworthy/inspector.js?v=4")).default));  
   main.define("inspect", ["module @tomlarkworthy/inspector", "@variable"], (_, v) => v.import("inspect", _));  
   main.define("Inspector", ["module @tomlarkworthy/inspector", "@variable"], (_, v) => v.import("Inspector", _));
   return main;
@@ -4660,6 +4642,7 @@ const _1n5sb7x = function _domView(invalidation){return(
 const _p5gppf = function _example(domView){return(
 domView()
 )};
+const _4me580 = (G, _) => G.input(_);
 const _ngavq7 = function _4($0,html){return(
 $0.value = html`<button>❤️</button>`
 )};
@@ -4669,17 +4652,11 @@ export default function define(runtime, observer) {
   const $def = (pid, name, deps, fn) => {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
-  const fileAttachments = new Map([].map((name) => {
-    const module_name = "@tomlarkworthy/dom-view";
-    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
-    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
-    return [name, {url: blob_url, mimeType: mime}]
-  }));
-  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
   $def("_pm5sek", null, ["md"], _pm5sek);  
   $def("_1n5sb7x", "domView", ["invalidation"], _1n5sb7x);  
   $def("_p5gppf", "viewof example", ["domView"], _p5gppf);  
-  main.variable(observer("example")).define("example", ["Generators", "viewof example"], (G, _) => G.input(_));  
+  $def("_4me580", "example", ["Generators","viewof example"], _4me580);  
   $def("_ngavq7", null, ["viewof example","html"], _ngavq7);
   return main;
 }</script>
@@ -4690,7 +4667,7 @@ export default function define(runtime, observer) {
 >
 e30K
 </script>
-<script id="@tomlarkworthy/editor-5"
+<script id="@tomlarkworthy/editor-5" 
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -6156,8 +6133,7 @@ export default function define(runtime, observer) {
   main.define("navHref", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("navHref", _));  
   main.define("cellsToClipboard", ["module @tomlarkworthy/cells-to-clipboard", "@variable"], (_, v) => v.import("cellsToClipboard", _));
   return main;
-}
-</script>
+}</script>
 <script id="@tomlarkworthy/escodegen/escodegen.browser.min.js.gz" 
   type="text/plain"
   data-encoding="base64"
@@ -6202,6 +6178,7 @@ export default function define(runtime, observer) {
     return [name, {url: blob_url, mimeType: mime}]
   }));
   main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
   $def("_hsp23a", null, ["md"], _hsp23a);  
   $def("_rg6wi4", "escodegen", ["Response","FileAttachment","DecompressionStream"], _rg6wi4);
   return main;
@@ -7179,15 +7156,52 @@ module => {
     return fileMap;
 }
 )};
-const _pvnegh = async function _book(lopebook,task,module_specs)
+const _1x463u7 = function _book(task,inlineModule,inlineGzipModule,es_module_shims,runtime_gz,inspector_gz,module_specs,lopemodule,lopebook){return(
+(async () => {
+    const cssBlocks = task.options.style.map(([url, content]) => inlineModule(url, content, { mime: 'text/css' })).join('\n');
+    const cssUrls = task.options.style.map(([url]) => url);
+    const systemBlocks = [
+        inlineGzipModule('es-module-shims@2.6.2', es_module_shims),
+        inlineGzipModule('@observablehq/runtime@6.0.0', runtime_gz),
+        inlineGzipModule('@observablehq/inspector@5.0.1', inspector_gz)
+    ].join('\n');
+    const userBlocks = (await Promise.all([...module_specs.values()].sort((a, b) => a.url.localeCompare(b.url)).map(m => lopemodule(m)))).join('');
+    const bootloader = task.options.bootloader || '@tomlarkworthy/bootloader';
+    const bootconfBlock = `<script id="bootconf.json"
+        type="text/plain"
+        data-mime="application/json"
+>
 {
-    const book = await lopebook({
-        url: task.notebook,
-        modules: module_specs
-    }, { ...task.options });
-    console.log('book', book);
-    return book;
-};
+  "mains": ${ JSON.stringify([...task.mains.keys()]) },
+  "hash": "${ task.options.hash || '' }",
+  "headless": ${ !!task.options.headless }
+}
+</scr` + `ipt>`;
+    const bootloaderBlock = inlineModule(bootloader, await (await fetch(`https://api.observablehq.com/${ bootloader }.js?v=4`)).text());
+    const blocks = [
+        '<!-- CSS -->',
+        cssBlocks,
+        `<style>
+body .inputs-3a86ea-table thead th {
+  background: var(--theme-foreground-faintest);
+}
+</style>`,
+        '<!-- System Modules -->',
+        systemBlocks,
+        userBlocks,
+        '<!-- Bootloader -->',
+        bootconfBlock,
+        bootloaderBlock
+    ].join('\n');
+    return lopebook({
+        blocks,
+        cssUrls,
+        bootloader,
+        title: task.options.title || 'Lopecode notebook',
+        head: task.options.head
+    });
+})()
+)};
 const _18javdl = function _47(Inputs,module_specs){return(
 Inputs.table([...module_specs.entries().map(([name, spec]) => ({
         name,
@@ -7691,8 +7705,11 @@ const _1pcnq22 = function _networking_script(normalize,isNotebook){return(
     }
   })();`
 )};
-const _13sd8x8 = function _lopebook(diskDataUrl,networking_script,task,inlineModule,inlineGzipModule,es_module_shims,runtime_gz,inspector_gz,lopemodule){return(
-async (bundle, {title, head, bootloader, headless = false, hash} = {}) => `<!DOCTYPE html>
+const _1crzwh0 = function _lopebook(diskDataUrl,networking_script){return(
+({blocks = '', cssUrls = [], bootloader = '@tomlarkworthy/bootloader', title = 'Lopecode notebook', head} = {}) => {
+    const styleImports = cssUrls.map((url, i) => `  const style${ i } = await importShim(${ JSON.stringify(url) }, { with: { type: 'css' } });`).join('\n');
+    const styleAdopt = cssUrls.map((_, i) => `style${ i }.default`).join(',');
+    return `<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
@@ -7701,52 +7718,10 @@ async (bundle, {title, head, bootloader, headless = false, hash} = {}) => `<!DOC
   ${ head ? head : `<link rel="icon" href="${ diskDataUrl }">` }
 </head>
 <body>
-<!-- Networking -->
 <script id="networking_script">${ networking_script }
 </scr\ipt>
 
-<!-- CSS -->
-<!-- Style sheets from https://github.com/observablehq/notebook-kit
-Copyright 2025 Observable, Inc.
-
-Permission to use, copy, modify, and/or distribute this software for any purpose
-with or without fee is hereby granted, provided that the above copyright notice
-and this permission notice appear in all copies.
-
-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
-REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
-FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
-INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
-OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
-TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
-THIS SOFTWARE.
--->
-${ task.options.style.map(([url, content]) => inlineModule(url, content, { mime: 'text/css' })).join('\n') }
-<style>
-body .inputs-3a86ea-table thead th {
-  background: var(--theme-foreground-faintest);
-}
-</style>
-
-<!-- System Modules -->
-${ inlineGzipModule('es-module-shims@2.6.2', es_module_shims) }
-${ inlineGzipModule('@observablehq/runtime@6.0.0', runtime_gz) }
-${ inlineGzipModule('@observablehq/inspector@5.0.1', inspector_gz) }
-
-${ (await Promise.all([...bundle.modules.values()].sort((a, b) => a.url.localeCompare(b.url)).map(module => lopemodule(module)))).join('') }
-
-<!-- Bootloader -->
-<script id="bootconf.json" 
-        type="text/plain"
-        data-mime="application/json"
->
-{
-  "mains": ${ JSON.stringify([...task.mains.keys()]) },
-  "hash": "${ hash }",
-  "headless": ${ headless }
-}
-</scr\ipt>
-${ inlineModule(bootloader, await (await fetch(`https://api.observablehq.com/${ bootloader }.js?v=4`)).text()) }
+${ blocks }
 
 <script type="module" id="main">
   await window.esmsInitOptions.fetch("file://es-module-shims@2.6.2").text().then(src => {
@@ -7755,19 +7730,20 @@ ${ inlineModule(bootloader, await (await fetch(`https://api.observablehq.com/${ 
     document.head.appendChild(script);
   });
 
-${ task.options.style.map(([url, content], i) => `  const style${ i } = await importShim("${ url }", { with: { type: 'css' } });`).join('\n') }
-  document.adoptedStyleSheets = [${ task.options.style.map(([url, content], i) => `style${ i }.default`) }];
-  
+${ styleImports }
+  document.adoptedStyleSheets = [${ styleAdopt }];
+
   const { Runtime } = await importShim("@observablehq/runtime@6.0.0");
   const { Inspector } = await importShim("@observablehq/inspector@5.0.1");
   const notebook = document.querySelector("notebook");
   const runtime = new Runtime({__ojs_runtime: () => runtime, __ojs_observer: () => observer});
   const observer = Inspector.into(document.body);
-  const {default: define} = await importShim("${ bootloader }");
+  const {default: define} = await importShim(${ JSON.stringify(bootloader) });
   runtime.bootloader = runtime.module(define, () => ({}));
 </scr\ipt>
 </body>
-</html>`
+</html>`;
+}
 )};
 const _1tiwgkp = function _lopemodule(TRACE_MODULE,CSS,arrayBufferToBase64,inlineModule,escapeScriptTags)
 {
@@ -7841,39 +7817,34 @@ const _8765p8 = function _diskDataUrl(disk_svg){return(
 const _z4k2or = function _task(flowQueue){return(
 flowQueue({ timeout_ms: 20000 })
 )};
+const _ngmf1x = (G, _) => G.input(_);
 const _pfhond = function _output(Inputs){return(
 Inputs.input(undefined)
 )};
+const _ei7ugd = (G, _) => G.input(_);
 const _blfbdd = function _exporter_module(thisModule){return(
 thisModule()
 )};
-const _10aqd0g = (_, v) => v.import("source_gz", "runtime_gz", _);
-const _tukxqk = function identity(x) {
-  return x;
-};
-const _so9603 = (_, v) => v.import("cellMap", _);
-const _xutvuj = (_, v) => v.import("findModuleName", _);
-const _1qa5h1f = (_, v) => v.import("view", _);
-const _viogn = (_, v) => v.import("reversibleAttach", _);
-const _1chja5j = (_, v) => v.import("localStorageView", _);
-const _1w6whg1 = (_, v) => v.import("domView", _);
-const _nxg8mr = (_, v) => v.import("moduleMap", _);
-const _1yrwds5 = (_, v) => v.import("persistentId", "pid", _);
-const _nywbgn = (_, v) => v.import("expect", _);
-const _6fqvz = (_, v) => v.import("themes", _);
+const _1iao5e4 = (G, _) => G.input(_);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
   const $def = (pid, name, deps, fn) => {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
-  const fileAttachments = new Map([].map((name) => {
-    const module_name = "@tomlarkworthy/exporter-3";
-    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
-    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
-    return [name, {url: blob_url, mimeType: mime}]
-  }));
-  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/observable-runtime-v6", async () => runtime.module((await import("/@tomlarkworthy/observable-runtime-v6.js?v=4")).default));  
+  main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
+  main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
+  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
+  main.define("module @tomlarkworthy/view", async () => runtime.module((await import("/@tomlarkworthy/view.js?v=4")).default));  
+  main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
+  main.define("module @tomlarkworthy/local-storage-view", async () => runtime.module((await import("/@tomlarkworthy/local-storage-view.js?v=4")).default));  
+  main.define("module @tomlarkworthy/dom-view", async () => runtime.module((await import("/@tomlarkworthy/dom-view.js?v=4")).default));  
+  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/jest-expect-standalone", async () => runtime.module((await import("/@tomlarkworthy/jest-expect-standalone.js?v=4")).default));  
+  main.define("module @tomlarkworthy/themes", async () => runtime.module((await import("/@tomlarkworthy/themes.js?v=4")).default));  
   $def("_1noor04", null, ["md"], _1noor04);  
   $def("_1xs1o58", null, ["exporter","viewof output","Event"], _1xs1o58);  
   $def("_16yvadj", null, ["md","downloadAnchor","forkAnchor"], _16yvadj);  
@@ -7919,7 +7890,7 @@ export default function define(runtime, observer) {
   $def("_1y5e5x8", "module_specs", ["task","included_modules","TRACE_MODULE","task_runtime","isModuleVar","isDynamicVar","getFileAttachments","main","generate_module_source","moduleNames"], _1y5e5x8);  
   $def("_1r3eg9r", "findImports", [], _1r3eg9r);  
   $def("_ipv4ft", "getFileAttachments", [], _ipv4ft);  
-  $def("_pvnegh", "book", ["lopebook","task","module_specs"], _pvnegh);  
+  $def("_1x463u7", "book", ["task","inlineModule","inlineGzipModule","es_module_shims","runtime_gz","inspector_gz","module_specs","lopemodule","lopebook"], _1x463u7);  
   $def("_18javdl", null, ["Inputs","module_specs"], _18javdl);  
   $def("_1gb47v", null, ["md"], _1gb47v);  
   $def("_5m8hbe", "report", ["DOMParser","book"], _5m8hbe);  
@@ -7942,7 +7913,7 @@ export default function define(runtime, observer) {
   $def("_eoywzy", "test_normalize", ["expect","normalize"], _eoywzy);  
   $def("_1vgrzwk", "isNotebook", [], _1vgrzwk);  
   $def("_1pcnq22", "networking_script", ["normalize","isNotebook"], _1pcnq22);  
-  $def("_13sd8x8", "lopebook", ["diskDataUrl","networking_script","task","inlineModule","inlineGzipModule","es_module_shims","runtime_gz","inspector_gz","lopemodule"], _13sd8x8);  
+  $def("_1crzwh0", "lopebook", ["diskDataUrl","networking_script"], _1crzwh0);  
   $def("_1tiwgkp", "lopemodule", ["TRACE_MODULE","CSS","arrayBufferToBase64","inlineModule","escapeScriptTags"], _1tiwgkp);  
   $def("_19l1umr", "escapeScriptTags", [], _19l1umr);  
   $def("_1hwkszj", "arrayBufferToBase64", [], _1hwkszj);  
@@ -7952,41 +7923,31 @@ export default function define(runtime, observer) {
   $def("_4t2ire", null, ["md"], _4t2ire);  
   $def("_8765p8", "diskDataUrl", ["disk_svg"], _8765p8);  
   $def("_z4k2or", "viewof task", ["flowQueue"], _z4k2or);  
-  main.variable(observer("task")).define("task", ["Generators", "viewof task"], (G, _) => G.input(_));  
+  $def("_ngmf1x", "task", ["Generators","viewof task"], _ngmf1x);  
   $def("_pfhond", "viewof output", ["Inputs"], _pfhond);  
-  main.variable(observer("output")).define("output", ["Generators", "viewof output"], (G, _) => G.input(_));  
+  $def("_ei7ugd", "output", ["Generators","viewof output"], _ei7ugd);  
   $def("_blfbdd", "viewof exporter_module", ["thisModule"], _blfbdd);  
-  main.variable(observer("exporter_module")).define("exporter_module", ["Generators", "viewof exporter_module"], (G, _) => G.input(_));  
-  main.define("module @tomlarkworthy/observable-runtime-v6", async () => runtime.module((await import("/@tomlarkworthy/observable-runtime-v6.js?v=4")).default));  
+  $def("_1iao5e4", "exporter_module", ["Generators","viewof exporter_module"], _1iao5e4);  
   main.define("runtime_gz", ["module @tomlarkworthy/observable-runtime-v6", "@variable"], (_, v) => v.import("source_gz", "runtime_gz", _));  
-  main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
   main.define("flowQueue", ["module @tomlarkworthy/flow-queue", "@variable"], (_, v) => v.import("flowQueue", _));  
-  main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
   main.define("cellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("cellMap", _));  
-  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
   main.define("findModuleName", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("findModuleName", _));  
   main.define("sourceModule", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("sourceModule", _));  
   main.define("findImportedName", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("findImportedName", _));  
   main.define("variableToObject", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("variableToObject", _));  
   main.define("parser", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("parser", _));  
   main.define("decompress_url", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("decompress_url", _));  
-  main.define("module @tomlarkworthy/view", async () => runtime.module((await import("/@tomlarkworthy/view.js?v=4")).default));  
   main.define("view", ["module @tomlarkworthy/view", "@variable"], (_, v) => v.import("view", _));  
   main.define("variable", ["module @tomlarkworthy/view", "@variable"], (_, v) => v.import("variable", _));  
   main.define("bindOneWay", ["module @tomlarkworthy/view", "@variable"], (_, v) => v.import("bindOneWay", _));  
-  main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
   main.define("reversibleAttach", ["module @tomlarkworthy/reversible-attachment", "@variable"], (_, v) => v.import("reversibleAttach", _));  
-  main.define("module @tomlarkworthy/local-storage-view", async () => runtime.module((await import("/@tomlarkworthy/local-storage-view.js?v=4")).default));  
   main.define("localStorageView", ["module @tomlarkworthy/local-storage-view", "@variable"], (_, v) => v.import("localStorageView", _));  
-  main.define("module @tomlarkworthy/dom-view", async () => runtime.module((await import("/@tomlarkworthy/dom-view.js?v=4")).default));  
   main.define("domView", ["module @tomlarkworthy/dom-view", "@variable"], (_, v) => v.import("domView", _));  
-  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("resolve_modules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("resolve_modules", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("pid", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("persistentId", "pid", _));  
   main.define("thisModule", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("thisModule", _));  
   main.define("keepalive", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("keepalive", _));  
@@ -7994,9 +7955,7 @@ export default function define(runtime, observer) {
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
   main.define("id", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("id", _));  
   main.define("importShim", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("importShim", _));  
-  main.define("module @tomlarkworthy/jest-expect-standalone", async () => runtime.module((await import("/@tomlarkworthy/jest-expect-standalone.js?v=4")).default));  
   main.define("expect", ["module @tomlarkworthy/jest-expect-standalone", "@variable"], (_, v) => v.import("expect", _));  
-  main.define("module @tomlarkworthy/themes", async () => runtime.module((await import("/@tomlarkworthy/themes.js?v=4")).default));  
   main.define("themes", ["module @tomlarkworthy/themes", "@variable"], (_, v) => v.import("themes", _));  
   main.define("extra_css", ["module @tomlarkworthy/themes", "@variable"], (_, v) => v.import("extra_css", _));  
   main.define("current_theme", ["module @tomlarkworthy/themes", "@variable"], (_, v) => v.import("current_theme", _));  
@@ -8129,6 +8088,7 @@ const _1t1i3ml = function _directory(notebookId,htl,hashParam,location,history)
     })();
     return container;
 };
+const _jnt0bt = (G, _) => G.input(_);
 const _yqx7l8 = function _syncEnabled(notebookId,htl)
 {
     const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
@@ -8144,6 +8104,7 @@ const _yqx7l8 = function _syncEnabled(notebookId,htl)
     };
     return container;
 };
+const _xltqf6 = (G, _) => G.input(_);
 const _122juai = function _disassemble(htl,directory,notebookId,manifestWriter,readFile,writeFile,syncableModules,exportModuleJS,hashSource)
 {
     const container = htl.html`<div>
@@ -8218,6 +8179,7 @@ const _122juai = function _disassemble(htl,directory,notebookId,manifestWriter,r
     container.value = undefined;
     return container;
 };
+const _eoa5ga = (G, _) => G.input(_);
 const _1jyon1g = function _syncStatus(htl,directory,syncableModules,notebookToFiles,filesToNotebook){return(
 htl.html`<div style="font-family:monospace; font-size:12px; padding:8px 12px; background:#f8f8f8; border:1px solid #ddd; border-radius:4px; line-height:1.8;">
   <div><strong>Directory:</strong> ${ directory ? directory.name : '\u2014 (not set)' }</div>
@@ -9012,31 +8974,25 @@ md`## TODO
 - **Import cell validation**: verify import bridges survive round-trip correctly
 - **Conflict resolution**: when both disk and runtime edit the same cell simultaneously, detect and surface the conflict instead of last-write-wins`
 )};
-const _lk52un = (_, v) => v.import("viewof currentModules", _);
-const _mp6qa3 = (_, v) => v.import("exportModuleJS", _);
-const _1h78qvr = (_, v) => v.import("onCodeChange", _);
-const _ujqxnr = (_, v) => v.import("tag", _);
-const _1evinj7 = (_, v) => v.import("getFileAttachmentsMap", _);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
   const $def = (pid, name, deps, fn) => {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
-  const fileAttachments = new Map([].map((name) => {
-    const module_name = "@tomlarkworthy/file-sync";
-    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
-    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
-    return [name, {url: blob_url, mimeType: mime}]
-  }));
-  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
+  main.define("module @tomlarkworthy/exporter-3", async () => runtime.module((await import("/@tomlarkworthy/exporter-3.js?v=4")).default));  
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/local-change-history", async () => runtime.module((await import("/@tomlarkworthy/local-change-history.js?v=4")).default));  
+  main.define("module @tomlarkworthy/fileattachments", async () => runtime.module((await import("/@tomlarkworthy/fileattachments.js?v=4")).default));  
   $def("_1th1rci", null, ["md"], _1th1rci);  
   $def("_1t1i3ml", "viewof directory", ["notebookId","htl","hashParam","location","history"], _1t1i3ml);  
-  main.variable(observer("directory")).define("directory", ["Generators", "viewof directory"], (G, _) => G.input(_));  
+  $def("_jnt0bt", "directory", ["Generators","viewof directory"], _jnt0bt);  
   $def("_yqx7l8", "viewof syncEnabled", ["notebookId","htl"], _yqx7l8);  
-  main.variable(observer("syncEnabled")).define("syncEnabled", ["Generators", "viewof syncEnabled"], (G, _) => G.input(_));  
+  $def("_xltqf6", "syncEnabled", ["Generators","viewof syncEnabled"], _xltqf6);  
   $def("_122juai", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource"], _122juai);  
-  main.variable(observer("disassemble")).define("disassemble", ["Generators", "viewof disassemble"], (G, _) => G.input(_));  
+  $def("_eoa5ga", "disassemble", ["Generators","viewof disassemble"], _eoa5ga);  
   $def("_1jyon1g", "syncStatus", ["htl","directory","syncableModules","notebookToFiles","filesToNotebook"], _1jyon1g);  
   $def("_1dl3i63", null, ["md"], _1dl3i63);  
   $def("_19lc4kb", null, ["md"], _19lc4kb);  
@@ -9055,22 +9011,17 @@ export default function define(runtime, observer) {
   $def("_1srrp0d", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _1srrp0d);  
   $def("_1b4kluo", null, ["md"], _1b4kluo);  
   $def("_1h2nj16", null, ["md"], _1h2nj16);  
-  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
   main.define("viewof currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("viewof currentModules", _));  
   main.define("currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("currentModules", _));  
-  main.define("module @tomlarkworthy/exporter-3", async () => runtime.module((await import("/@tomlarkworthy/exporter-3.js?v=4")).default));  
   main.define("exportModuleJS", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("exportModuleJS", _));  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("onCodeChange", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("onCodeChange", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
-  main.define("module @tomlarkworthy/local-change-history", async () => runtime.module((await import("/@tomlarkworthy/local-change-history.js?v=4")).default));  
   main.define("tag", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("tag", _));  
-  main.define("module @tomlarkworthy/fileattachments", async () => runtime.module((await import("/@tomlarkworthy/fileattachments.js?v=4")).default));  
   main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));
   return main;
 }</script>
 
-<script id="@tomlarkworthy/fileattachments"
+<script id="@tomlarkworthy/fileattachments" 
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -9377,8 +9328,7 @@ export default function define(runtime, observer) {
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
   main.define("thisModule", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("thisModule", _));
   return main;
-}
-</script>
+}</script>
 <script id="@tomlarkworthy/flow-queue/flowQuery%401.svg" 
   type="text/plain"
   data-encoding="base64"
@@ -9540,6 +9490,7 @@ md`## Uses
 const _1dh4cq1 = function _sqrt(flowQueue){return(
 flowQueue()
 )};
+const _1aloau2 = (G, _) => G.input(_);
 const _7s1qq7 = function _6($0,sqrt){return(
 $0.resolve(Math.sqrt(sqrt))
 )};
@@ -9563,6 +9514,7 @@ testing.createSuite({
   name: "Unit Tests"
 })
 )};
+const _1heh2ju = (G, _) => G.input(_);
 const _at0ppe = function _9(suite,flowQueue,testing){return(
 suite.test("resolve after send resolves", async () => {
   const q = flowQueue();
@@ -9576,6 +9528,7 @@ suite.test("resolve after send resolves", async () => {
 const _1ju8ima = function _maybeReply(flowQueue){return(
 flowQueue({ timeout_ms: 100 })
 )};
+const _c792zo = (G, _) => G.input(_);
 const _3sd24y = function _maybeReplyReplier(maybeReply,$0)
 {
   if (maybeReply === "reply") $0.resolve("reply");
@@ -9639,19 +9592,20 @@ export default function define(runtime, observer) {
     return [name, {url: blob_url, mimeType: mime}]
   }));
   main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
   $def("_1ahuxfa", null, ["FileAttachment","width","md"], _1ahuxfa);  
   $def("_1yskhxl", null, ["md"], _1yskhxl);  
   $def("_9rx18r", "flowQueue", ["htl","Event"], _9rx18r);  
   $def("_1heyr0d", null, ["md"], _1heyr0d);  
   $def("_1dh4cq1", "viewof sqrt", ["flowQueue"], _1dh4cq1);  
-  main.variable(observer("sqrt")).define("sqrt", ["Generators", "viewof sqrt"], (G, _) => G.input(_));  
+  $def("_1aloau2", "sqrt", ["Generators","viewof sqrt"], _1aloau2);  
   $def("_7s1qq7", null, ["viewof sqrt","sqrt"], _7s1qq7);  
   $def("_x7qi6y", "testing", ["flowQueue"], _x7qi6y);  
   $def("_8ggfj7", "viewof suite", ["testing"], _8ggfj7);  
-  main.variable(observer("suite")).define("suite", ["Generators", "viewof suite"], (G, _) => G.input(_));  
+  $def("_1heh2ju", "suite", ["Generators","viewof suite"], _1heh2ju);  
   $def("_at0ppe", null, ["suite","flowQueue","testing"], _at0ppe);  
   $def("_1ju8ima", "viewof maybeReply", ["flowQueue"], _1ju8ima);  
-  main.variable(observer("maybeReply")).define("maybeReply", ["Generators", "viewof maybeReply"], (G, _) => G.input(_));  
+  $def("_c792zo", "maybeReply", ["Generators","viewof maybeReply"], _c792zo);  
   $def("_3sd24y", "maybeReplyReplier", ["maybeReply","viewof maybeReply"], _3sd24y);  
   $def("_fvtimb", null, ["suite","viewof maybeReply","testing"], _fvtimb);  
   $def("_hlzk1q", null, ["suite","flowQueue","testing"], _hlzk1q);  
@@ -10213,6 +10167,7 @@ export default function define(runtime, observer) {
     return [name, {url: blob_url, mimeType: mime}]
   }));
   main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
   $def("_4d16qe", null, ["md"], _4d16qe);  
   $def("_14q4rx6", "base_css", ["htl"], _14q4rx6);  
   $def("_1oj1z48", "light_theme_css", ["lm_close_black","lm_popout_black","lm_maximise_black","lm_minimize_black","lm_popin_black","htl"], _1oj1z48);  
@@ -10318,20 +10273,14 @@ const _huzc31 = function _resolutions_key(isOnObservableCom,runtime)
     }
   }
 };
-const _1a10r2f = (_, v) => v.import("keepalive", _);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
   const $def = (pid, name, deps, fn) => {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
-  const fileAttachments = new Map([].map((name) => {
-    const module_name = "@tomlarkworthy/import-notebook";
-    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
-    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
-    return [name, {url: blob_url, mimeType: mime}]
-  }));
-  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   $def("_1iogq99", null, ["md"], _1iogq99);  
   $def("_1n7w35r", null, ["runtime"], _1n7w35r);  
   $def("_192ug1m", null, ["importNotebook"], _192ug1m);  
@@ -10339,7 +10288,6 @@ export default function define(runtime, observer) {
   $def("_1phzazj", null, ["exporter2"], _1phzazj);  
   $def("_1g7x12j", "importNotebook", ["runtime","resolutions_key","main","md"], _1g7x12j);  
   $def("_huzc31", "resolutions_key", ["isOnObservableCom","runtime"], _huzc31);  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("keepalive", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("keepalive", _));  
   main.define("thisModule", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("thisModule", _));  
   main.define("isOnObservableCom", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("isOnObservableCom", _));  
@@ -10419,6 +10367,7 @@ export default function define(runtime, observer) {
     return [name, {url: blob_url, mimeType: mime}]
   }));
   main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
   $def("_wjdo00", null, ["md"], _wjdo00);  
   $def("_1q5hkak", "inspect", ["Inspector"], _1q5hkak);  
   $def("_rod2q7", "src", ["unzip","FileAttachment"], _rod2q7);  
@@ -10532,6 +10481,7 @@ export default function define(runtime, observer) {
     return [name, {url: blob_url, mimeType: mime}]
   }));
   main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
   $def("_s7e7uu", null, ["md"], _s7e7uu);  
   $def("_vz8us1", "git", ["unzip","FileAttachment"], _vz8us1);  
   $def("_2acekr", "http", ["unzip","FileAttachment"], _2acekr);  
@@ -10592,6 +10542,7 @@ export default function define(runtime, observer) {
     return [name, {url: blob_url, mimeType: mime}]
   }));
   main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
   $def("_p8qjpk", null, ["md"], _p8qjpk);  
   $def("_mh1f13", "expect", ["unzip","FileAttachment"], _mh1f13);  
   $def("_17n6uge", "unzip", ["Response","DecompressionStream"], _17n6uge);
@@ -10650,6 +10601,7 @@ export default function define(runtime, observer) {
     return [name, {url: blob_url, mimeType: mime}]
   }));
   main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
   $def("_76n9lc", null, ["md"], _76n9lc);  
   $def("_umavbe", "JSZip", ["unzip","FileAttachment"], _umavbe);  
   $def("_g5fwfs", "unzip", ["Response","DecompressionStream"], _g5fwfs);
@@ -10723,6 +10675,7 @@ export default function define(runtime, observer) {
     return [name, {url: blob_url, mimeType: mime}]
   }));
   main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
   $def("_1fc4llj", null, ["md"], _1fc4llj);  
   $def("_1tds3ro", "FS", ["unzip","FileAttachment"], _1tds3ro);  
   $def("_dqri64", null, ["md"], _dqri64);  
@@ -12459,6 +12412,7 @@ Inputs.select([
     value: 'discrete'
 })
 )};
+const _d0qi2e = (G, _) => G.input(_);
 const _1enjs3i = function _rewind(Plot,width,temporal,d3,history,timeline){return(
 Plot.plot({
     marginLeft: 200,
@@ -12500,6 +12454,7 @@ Plot.plot({
     ]
 })
 )};
+const _apj797 = (G, _) => G.input(_);
 const _138eq5p = function _selectedChanges(Inputs,history,html){return(
 Inputs.table(history, {
     columns: [
@@ -12531,55 +12486,57 @@ Inputs.table(history, {
     required: false
 })
 )};
+const _1a64yt8 = (G, _) => G.input(_);
 const _20mogr = function _history(Inputs){return(
 Inputs.input([])
 )};
+const _bmiya2 = (G, _) => G.input(_);
 const _1ve4ius = function _fs(Inputs,FS){return(
 Inputs.button('wipe filesystem', {
     reduce: () => new FS('lopecode_history', { wipe: true }).promises,
     value: new FS('lopecode_history', { wipe: false }).promises
 })
 )};
+const _1dt24ln = (G, _) => G.input(_);
 const _1uk8yq0 = function _selected_repo(Inputs,repos,config){return(
 Inputs.select(repos, {
     label: 'select repo',
     value: config.repo
 })
 )};
+const _9lv1oo = (G, _) => G.input(_);
 const _1j6kx3r = function _selected_branch(Inputs,branches,selected_repo,config){return(
 Inputs.select(branches, {
     label: 'select branch',
     value: selected_repo == config.repo ? config.branch : undefined
 })
 )};
+const _1u33aug = (G, _) => G.input(_);
 const _1lp66j8 = function _initial_state(Inputs){return(
 Inputs.input(new Map())
 )};
+const _8pswzc = (G, _) => G.input(_);
 const _1kbsmg2 = function _module_load_time(Inputs){return(
 Inputs.input(new Map())
 )};
+const _1g6l5w7 = (G, _) => G.input(_);
 const _1tpet0t = function _historyModule(thisModule){return(
 thisModule()
 )};
-const _w7yjw3 = (_, v) => v.import("thisModule", _);
-const _2lkohn = (_, v) => v.import("FS", _);
-const _1mwfgtz = (_, v) => v.import("git", _);
-const _guob57 = (_, v) => v.import("JSZip", _);
-const _nxg8mr = (_, v) => v.import("moduleMap", _);
-const _1utt65b = (_, v) => v.import("notebook_title", _);
+const _1ryokzy = (G, _) => G.input(_);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
   const $def = (pid, name, deps, fn) => {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
-  const fileAttachments = new Map([].map((name) => {
-    const module_name = "@tomlarkworthy/local-change-history";
-    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
-    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
-    return [name, {url: blob_url, mimeType: mime}]
-  }));
-  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/lightning-fs-4-6-0", async () => runtime.module((await import("/@tomlarkworthy/lightning-fs-4-6-0.js?v=4")).default));  
+  main.define("module @tomlarkworthy/isomorphic-git-1-30-1", async () => runtime.module((await import("/@tomlarkworthy/isomorphic-git-1-30-1.js?v=4")).default));  
+  main.define("module @tomlarkworthy/jszip-3-10-1", async () => runtime.module((await import("/@tomlarkworthy/jszip-3-10-1.js?v=4")).default));  
+  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
+  main.define("module @tomlarkworthy/exporter-3", async () => runtime.module((await import("/@tomlarkworthy/exporter-3.js?v=4")).default));  
   $def("_1f8tza", null, ["md"], _1f8tza);  
   $def("_lprfj9", null, ["rewind","Inputs","rewindToTime","md"], _lprfj9);  
   $def("_ta70mv", null, ["selectedChanges","Inputs","revertVariables","md"], _ta70mv);  
@@ -12647,26 +12604,25 @@ export default function define(runtime, observer) {
   $def("_1ostthv", "timeline", ["history"], _1ostthv);  
   $def("_36jocw", "moduleBaseHash", [], _36jocw);  
   $def("_1lydoz3", "viewof temporal", ["Inputs"], _1lydoz3);  
-  main.variable(observer("temporal")).define("temporal", ["Generators", "viewof temporal"], (G, _) => G.input(_));  
+  $def("_d0qi2e", "temporal", ["Generators","viewof temporal"], _d0qi2e);  
   $def("_1enjs3i", "viewof rewind", ["Plot","width","temporal","d3","history","timeline"], _1enjs3i);  
-  main.variable(observer("rewind")).define("rewind", ["Generators", "viewof rewind"], (G, _) => G.input(_));  
+  $def("_apj797", "rewind", ["Generators","viewof rewind"], _apj797);  
   $def("_138eq5p", "viewof selectedChanges", ["Inputs","history","html"], _138eq5p);  
-  main.variable(observer("selectedChanges")).define("selectedChanges", ["Generators", "viewof selectedChanges"], (G, _) => G.input(_));  
+  $def("_1a64yt8", "selectedChanges", ["Generators","viewof selectedChanges"], _1a64yt8);  
   $def("_20mogr", "viewof history", ["Inputs"], _20mogr);  
-  main.variable(observer("history")).define("history", ["Generators", "viewof history"], (G, _) => G.input(_));  
+  $def("_bmiya2", "history", ["Generators","viewof history"], _bmiya2);  
   $def("_1ve4ius", "viewof fs", ["Inputs","FS"], _1ve4ius);  
-  main.variable(observer("fs")).define("fs", ["Generators", "viewof fs"], (G, _) => G.input(_));  
+  $def("_1dt24ln", "fs", ["Generators","viewof fs"], _1dt24ln);  
   $def("_1uk8yq0", "viewof selected_repo", ["Inputs","repos","config"], _1uk8yq0);  
-  main.variable(observer("selected_repo")).define("selected_repo", ["Generators", "viewof selected_repo"], (G, _) => G.input(_));  
+  $def("_9lv1oo", "selected_repo", ["Generators","viewof selected_repo"], _9lv1oo);  
   $def("_1j6kx3r", "viewof selected_branch", ["Inputs","branches","selected_repo","config"], _1j6kx3r);  
-  main.variable(observer("selected_branch")).define("selected_branch", ["Generators", "viewof selected_branch"], (G, _) => G.input(_));  
+  $def("_1u33aug", "selected_branch", ["Generators","viewof selected_branch"], _1u33aug);  
   $def("_1lp66j8", "viewof initial_state", ["Inputs"], _1lp66j8);  
-  main.variable(observer("initial_state")).define("initial_state", ["Generators", "viewof initial_state"], (G, _) => G.input(_));  
+  $def("_8pswzc", "initial_state", ["Generators","viewof initial_state"], _8pswzc);  
   $def("_1kbsmg2", "viewof module_load_time", ["Inputs"], _1kbsmg2);  
-  main.variable(observer("module_load_time")).define("module_load_time", ["Generators", "viewof module_load_time"], (G, _) => G.input(_));  
+  $def("_1g6l5w7", "module_load_time", ["Generators","viewof module_load_time"], _1g6l5w7);  
   $def("_1tpet0t", "viewof historyModule", ["thisModule"], _1tpet0t);  
-  main.variable(observer("historyModule")).define("historyModule", ["Generators", "viewof historyModule"], (G, _) => G.input(_));  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  $def("_1ryokzy", "historyModule", ["Generators","viewof historyModule"], _1ryokzy);  
   main.define("thisModule", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("thisModule", _));  
   main.define("lookupVariable", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("lookupVariable", _));  
   main.define("onCodeChange", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("onCodeChange", _));  
@@ -12675,16 +12631,11 @@ export default function define(runtime, observer) {
   main.define("getVariableByPersistentId", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("getVariableByPersistentId", _));  
   main.define("isOnObservableCom", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("isOnObservableCom", _));  
   main.define("realize", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("realize", _));  
-  main.define("module @tomlarkworthy/lightning-fs-4-6-0", async () => runtime.module((await import("/@tomlarkworthy/lightning-fs-4-6-0.js?v=4")).default));  
   main.define("FS", ["module @tomlarkworthy/lightning-fs-4-6-0", "@variable"], (_, v) => v.import("FS", _));  
-  main.define("module @tomlarkworthy/isomorphic-git-1-30-1", async () => runtime.module((await import("/@tomlarkworthy/isomorphic-git-1-30-1.js?v=4")).default));  
   main.define("git", ["module @tomlarkworthy/isomorphic-git-1-30-1", "@variable"], (_, v) => v.import("git", _));  
   main.define("http", ["module @tomlarkworthy/isomorphic-git-1-30-1", "@variable"], (_, v) => v.import("http", _));  
-  main.define("module @tomlarkworthy/jszip-3-10-1", async () => runtime.module((await import("/@tomlarkworthy/jszip-3-10-1.js?v=4")).default));  
   main.define("JSZip", ["module @tomlarkworthy/jszip-3-10-1", "@variable"], (_, v) => v.import("JSZip", _));  
-  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
-  main.define("module @tomlarkworthy/exporter-3", async () => runtime.module((await import("/@tomlarkworthy/exporter-3.js?v=4")).default));  
   main.define("notebook_title", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("notebook_title", _));
   return main;
 }</script>
@@ -12727,16 +12678,17 @@ So starting with an ordinary control:`
 const _mmuwnm = function _example1(Inputs){return(
 Inputs.range()
 )};
+const _1jzejjl = (G, _) => G.input(_);
 const _3wyikd = function _5(md){return(
 md`We will use the excellent  [@mbostock/safe-local-storage](/@mbostock/safe-local-storage) which very nicely abstracts over enhanced privacy controls with an in memory fallback.`
 )};
-const _bfdktv = (_, v) => v.import("localStorage", _);
 const _12vgtec = function _7(md){return(
 md`However, we don't want to have to mess around with our original control to add local persistence. Instead we create a writable [view](https://observablehq.com/@observablehq/introduction-to-views) of a local storage key`
 )};
 const _73wbaa = function _example1storage(localStorageView){return(
 localStorageView("example1")
 )};
+const _1jqow1s = (G, _) => G.input(_);
 const _gkyhag = function _localStorageView(DOM,htl,inspect,localStorage,Inputs){return(
 (
   key,
@@ -12795,6 +12747,7 @@ localStorageView("json", {
   json: true
 })
 )};
+const _17aqur = (G, _) => G.input(_);
 const _kfjf9m = function _16(jsonView){return(
 jsonView
 )};
@@ -12820,6 +12773,7 @@ It is quite likely we often just want to create the view and bind it to a ui con
 const _1a7s05z = function _example2(Inputs){return(
 Inputs.textarea()
 )};
+const _36jjyw = (G, _) => G.input(_);
 const _l1d220 = function _22(localStorageView,$0){return(
 localStorageView("example2", {
   bindTo: $0
@@ -12834,31 +12788,26 @@ You can even declare a UI control, wrap it with local storage and return in a si
 const _1vldl4e = function _example3(Inputs,localStorageView){return(
 Inputs.bind(Inputs.textarea(), localStorageView("example3"))
 )};
-const _1z7eev = (_, v) => v.import("inspect", _);
+const _fyim03 = (G, _) => G.input(_);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
   const $def = (pid, name, deps, fn) => {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
-  const fileAttachments = new Map([].map((name) => {
-    const module_name = "@tomlarkworthy/local-storage-view";
-    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
-    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
-    return [name, {url: blob_url, mimeType: mime}]
-  }));
-  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @mbostock/safe-local-storage", async () => runtime.module((await import("/@mbostock/safe-local-storage.js?v=4")).default));  
+  main.define("module @tomlarkworthy/inspector", async () => runtime.module((await import("/@tomlarkworthy/inspector.js?v=4")).default));  
   $def("_182981h", null, ["md"], _182981h);  
   $def("_8spwep", null, ["md"], _8spwep);  
   $def("_1e6fj3u", null, ["md"], _1e6fj3u);  
   $def("_mmuwnm", "viewof example1", ["Inputs"], _mmuwnm);  
-  main.variable(observer("example1")).define("example1", ["Generators", "viewof example1"], (G, _) => G.input(_));  
+  $def("_1jzejjl", "example1", ["Generators","viewof example1"], _1jzejjl);  
   $def("_3wyikd", null, ["md"], _3wyikd);  
-  main.define("module @mbostock/safe-local-storage", async () => runtime.module((await import("/@mbostock/safe-local-storage.js?v=4")).default));  
   main.define("localStorage", ["module @mbostock/safe-local-storage", "@variable"], (_, v) => v.import("localStorage", _));  
   $def("_12vgtec", null, ["md"], _12vgtec);  
   $def("_73wbaa", "viewof example1storage", ["localStorageView"], _73wbaa);  
-  main.variable(observer("example1storage")).define("example1storage", ["Generators", "viewof example1storage"], (G, _) => G.input(_));  
+  $def("_1jqow1s", "example1storage", ["Generators","viewof example1storage"], _1jqow1s);  
   $def("_gkyhag", "localStorageView", ["DOM","htl","inspect","localStorage","Inputs"], _gkyhag);  
   $def("_1iqrn5d", null, ["localStorageView"], _1iqrn5d);  
   $def("_z63pz7", null, ["md"], _z63pz7);  
@@ -12866,19 +12815,18 @@ export default function define(runtime, observer) {
   $def("_qmvxa6", null, ["md"], _qmvxa6);  
   $def("_miawoh", null, ["md"], _miawoh);  
   $def("_1987pc1", "viewof jsonView", ["localStorageView"], _1987pc1);  
-  main.variable(observer("jsonView")).define("jsonView", ["Generators", "viewof jsonView"], (G, _) => G.input(_));  
+  $def("_17aqur", "jsonView", ["Generators","viewof jsonView"], _17aqur);  
   $def("_kfjf9m", null, ["jsonView"], _kfjf9m);  
   $def("_19gwt0c", null, ["viewof jsonView"], _19gwt0c);  
   $def("_1dz41gz", null, ["md"], _1dz41gz);  
   $def("_17vm6d3", null, ["viewof jsonView","Event"], _17vm6d3);  
   $def("_1g2fr6s", null, ["md"], _1g2fr6s);  
   $def("_1a7s05z", "viewof example2", ["Inputs"], _1a7s05z);  
-  main.variable(observer("example2")).define("example2", ["Generators", "viewof example2"], (G, _) => G.input(_));  
+  $def("_36jjyw", "example2", ["Generators","viewof example2"], _36jjyw);  
   $def("_l1d220", null, ["localStorageView","viewof example2"], _l1d220);  
   $def("_dwfe65", null, ["md"], _dwfe65);  
   $def("_1vldl4e", "viewof example3", ["Inputs","localStorageView"], _1vldl4e);  
-  main.variable(observer("example3")).define("example3", ["Generators", "viewof example3"], (G, _) => G.input(_));  
-  main.define("module @tomlarkworthy/inspector", async () => runtime.module((await import("/@tomlarkworthy/inspector.js?v=4")).default));  
+  $def("_fyim03", "example3", ["Generators","viewof example3"], _fyim03);  
   main.define("inspect", ["module @tomlarkworthy/inspector", "@variable"], (_, v) => v.import("inspect", _));
   return main;
 }</script>
@@ -12930,6 +12878,7 @@ htl.html`<h2>Manual Testing links</h2>
 const _43b44a = function _reload(Inputs){return(
 Inputs.button("reload")
 )};
+const _1we0ggl = (G, _) => G.input(_);
 const _1j75x4m = function _onLoadConfig(parseGoldenDSL,URLSearchParams,location)
 {
   try {
@@ -13097,6 +13046,8 @@ const _t7jike = function _config(onLoadConfig,settings)
     settings: settings
   };
 };
+const _15lk82w = (M, _) => new M(_);
+const _1bki6eh = _ => _.generator;
 const _1l87437 = function _resize(Generators,addEventListener,invalidation,removeEventListener){return(
 Generators.observe((notify) => {
   notify(undefined);
@@ -13145,6 +13096,7 @@ const _ztvs13 = function _layout_state(appendScrollLog,layout,gl,$0)
 const _11nrwvj = function _lopepageModule(thisModule){return(
 thisModule()
 )};
+const _r97569 = (G, _) => G.input(_);
 const _1sp5wo4 = function _16(md){return(
 md`## Scrolling
 
@@ -13156,6 +13108,7 @@ Inputs.toggle({
   value: true
 })
 )};
+const _7jxivy = (G, _) => G.input(_);
 const _14j4ek0 = function _appendScrollLog($0,$1){return(
 (type, detail = {}) => {
   if (!$0.value) return null;
@@ -13167,6 +13120,8 @@ const _14j4ek0 = function _appendScrollLog($0,$1){return(
 const _1nbnzwx = function _scrollLog(scrollDebug){return(
 scrollDebug ? [] : []
 )};
+const _1f7xtz1 = (M, _) => new M(_);
+const _1dyz4o0 = _ => _.generator;
 const _13pxuns = function _scrollKeyFor(appendScrollLog){return(
 (container) => {
   // can return undefined if the container is loading still
@@ -14069,36 +14024,30 @@ const _teqmji = function _background_jobs(onLoadConfig,layout_state,sync_layout_
 const _1n78po6 = function _imports(md){return(
 md`## Imports`
 )};
-const _vjrhz7 = (_, v) => v.import("gl", _);
-const _k60fw9 = (_, v) => v.import("unorderedSync", _);
-const _1xkkai5 = (_, v) => v.import("viewof notebookModule", _);
-const _1g6301z = (_, v) => v.import("lookupVariable", _);
-const _14sud0h = (_, v) => v.import("auto_attach", _);
 const _i8rpui = function _37(exporter){return(
 exporter()
 )};
-const _10vtplb = (_, v) => v.import("exporter", _);
-const _19ebgtz = (_, v) => v.import("hash", _);
-const _qky0on = (_, v) => v.import("commit_history", _);
-const _1cp2971 = (_, v) => v.import("cc_chat", _);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
   const $def = (pid, name, deps, fn) => {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
-  const fileAttachments = new Map([].map((name) => {
-    const module_name = "@tomlarkworthy/lopepage";
-    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
-    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
-    return [name, {url: blob_url, mimeType: mime}]
-  }));
-  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/golden-layout-2-6-0", async () => runtime.module((await import("/@tomlarkworthy/golden-layout-2-6-0.js?v=4")).default));  
+  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
+  main.define("module @tomlarkworthy/module-selection", async () => runtime.module((await import("/@tomlarkworthy/module-selection.js?v=4")).default));  
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/editor-5", async () => runtime.module((await import("/@tomlarkworthy/editor-5.js?v=4")).default));  
+  main.define("module @tomlarkworthy/exporter-3", async () => runtime.module((await import("/@tomlarkworthy/exporter-3.js?v=4")).default));  
+  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
+  main.define("module @tomlarkworthy/local-change-history", async () => runtime.module((await import("/@tomlarkworthy/local-change-history.js?v=4")).default));  
+  main.define("module @tomlarkworthy/claude-code-pairing", async () => runtime.module((await import("/@tomlarkworthy/claude-code-pairing.js?v=4")).default));  
   $def("_q5ezn4", "page", ["isOnObservableCom","lopeviz_handle_css","base_css","light_theme_css","linkTo","htl"], _q5ezn4);  
   $def("_2vxw8d", "append_to_body", ["page"], _2vxw8d);  
   $def("_1lfs5sc", "testNavigation", ["linkTo","htl"], _1lfs5sc);  
   $def("_43b44a", "viewof reload", ["Inputs"], _43b44a);  
-  main.variable(observer("reload")).define("reload", ["Generators", "viewof reload"], (G, _) => G.input(_));  
+  $def("_1we0ggl", "reload", ["Generators","viewof reload"], _1we0ggl);  
   $def("_1j75x4m", "onLoadConfig", ["parseGoldenDSL","URLSearchParams","location"], _1j75x4m);  
   $def("_1f4891m", "visualizer_cache", ["reload"], _1f4891m);  
   $def("_1v9gq8e", "modulePanel", ["appendScrollLog","currentModules","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1v9gq8e);  
@@ -14106,20 +14055,20 @@ export default function define(runtime, observer) {
   $def("_1h0ajx6", "settings", [], _1h0ajx6);  
   $def("_lp1ggk", "is_mobile", ["width"], _lp1ggk);  
   $def("_t7jike", "initial config", ["onLoadConfig","settings"], _t7jike);  
-  main.variable(observer("mutable config")).define("mutable config", ["Mutable", "initial config"], (M, _) => new M(_));  
-  main.variable(observer("config")).define("config", ["mutable config"], _ => _.generator);  
+  $def("_15lk82w", "mutable config", ["Mutable","initial config"], _15lk82w);  
+  $def("_1bki6eh", "config", ["mutable config"], _1bki6eh);  
   $def("_1l87437", "resize", ["Generators","addEventListener","invalidation","removeEventListener"], _1l87437);  
   $def("_g41wgt", "layout", ["resize","gl","mutable config","page","modulePanel","blobPanel"], _g41wgt);  
   $def("_ztvs13", "layout_state", ["appendScrollLog","layout","gl","mutable config"], _ztvs13);  
   $def("_11nrwvj", "viewof lopepageModule", ["thisModule"], _11nrwvj);  
-  main.variable(observer("lopepageModule")).define("lopepageModule", ["Generators", "viewof lopepageModule"], (G, _) => G.input(_));  
+  $def("_r97569", "lopepageModule", ["Generators","viewof lopepageModule"], _r97569);  
   $def("_1sp5wo4", null, ["md"], _1sp5wo4);  
   $def("_liop9s", "viewof scrollDebug", ["Inputs"], _liop9s);  
-  main.variable(observer("scrollDebug")).define("scrollDebug", ["Generators", "viewof scrollDebug"], (G, _) => G.input(_));  
+  $def("_7jxivy", "scrollDebug", ["Generators","viewof scrollDebug"], _7jxivy);  
   $def("_14j4ek0", "appendScrollLog", ["viewof scrollDebug","mutable scrollLog"], _14j4ek0);  
   $def("_1nbnzwx", "initial scrollLog", ["scrollDebug"], _1nbnzwx);  
-  main.variable(observer("mutable scrollLog")).define("mutable scrollLog", ["Mutable", "initial scrollLog"], (M, _) => new M(_));  
-  main.variable(observer("scrollLog")).define("scrollLog", ["mutable scrollLog"], _ => _.generator);  
+  $def("_1f7xtz1", "mutable scrollLog", ["Mutable","initial scrollLog"], _1f7xtz1);  
+  $def("_1dyz4o0", "scrollLog", ["mutable scrollLog"], _1dyz4o0);  
   $def("_13pxuns", "scrollKeyFor", ["appendScrollLog"], _13pxuns);  
   $def("_tb217h", "scroll_cache", [], _tb217h);  
   $def("_1kx6o6m", "fix_scroll", ["scrollKeyFor","appendScrollLog","scroll_cache"], _1kx6o6m);  
@@ -14132,17 +14081,14 @@ export default function define(runtime, observer) {
   $def("_kshoao", "treeSyncGolden", ["appendScrollLog","gl"], _kshoao);  
   $def("_teqmji", "background_jobs", ["onLoadConfig","layout_state","sync_layout_from_url","test_url_roundtrip","sync_layout_to_url","runtime","navigator_jobs","auto_attach","scroll_fix_sync_layout","commit_history","replay_git","change_listener","cc_chat"], _teqmji);  
   $def("_1n78po6", "imports", ["md"], _1n78po6);  
-  main.define("module @tomlarkworthy/golden-layout-2-6-0", async () => runtime.module((await import("/@tomlarkworthy/golden-layout-2-6-0.js?v=4")).default));  
   main.define("gl", ["module @tomlarkworthy/golden-layout-2-6-0", "@variable"], (_, v) => v.import("gl", _));  
   main.define("base_css", ["module @tomlarkworthy/golden-layout-2-6-0", "@variable"], (_, v) => v.import("base_css", _));  
   main.define("light_theme_css", ["module @tomlarkworthy/golden-layout-2-6-0", "@variable"], (_, v) => v.import("light_theme_css", _));  
-  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
   main.define("unorderedSync", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("unorderedSync", _));  
   main.define("runtime", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("visualizer", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("visualizer", _));  
   main.define("Inspector", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("Inspector", _));  
   main.define("lopeviz_handle_css", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("lopeviz_handle_css", _));  
-  main.define("module @tomlarkworthy/module-selection", async () => runtime.module((await import("/@tomlarkworthy/module-selection.js?v=4")).default));  
   main.define("viewof notebookModule", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("viewof notebookModule", _));  
   main.define("notebookModule", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("notebookModule", _));  
   main.define("currentModules", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("currentModules", _));  
@@ -14154,30 +14100,24 @@ export default function define(runtime, observer) {
   main.define("linkTo", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("linkTo", _));  
   main.define("persistedAttachments", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("persistedAttachments", _));  
   main.define("getHashModules", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("getHashModules", _));  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("lookupVariable", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("lookupVariable", _));  
   main.define("getPromiseState", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("getPromiseState", _));  
   main.define("thisModule", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("thisModule", _));  
   main.define("ascendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("ascendants", _));  
   main.define("toObject", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("toObject", _));  
   main.define("isOnObservableCom", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("isOnObservableCom", _));  
-  main.define("module @tomlarkworthy/editor-5", async () => runtime.module((await import("/@tomlarkworthy/editor-5.js?v=4")).default));  
   main.define("auto_attach", ["module @tomlarkworthy/editor-5", "@variable"], (_, v) => v.import("auto_attach", _));  
   $def("_i8rpui", null, ["exporter"], _i8rpui);  
-  main.define("module @tomlarkworthy/exporter-3", async () => runtime.module((await import("/@tomlarkworthy/exporter-3.js?v=4")).default));  
   main.define("exporter", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("exporter", _));  
-  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
   main.define("hash", ["module d/57d79353bac56631@44", "@variable"], (_, v) => v.import("hash", _));  
-  main.define("module @tomlarkworthy/local-change-history", async () => runtime.module((await import("/@tomlarkworthy/local-change-history.js?v=4")).default));  
   main.define("commit_history", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("commit_history", _));  
   main.define("change_listener", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("change_listener", _));  
   main.define("replay_git", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("replay_git", _));  
-  main.define("module @tomlarkworthy/claude-code-pairing", async () => runtime.module((await import("/@tomlarkworthy/claude-code-pairing.js?v=4")).default));  
   main.define("cc_chat", ["module @tomlarkworthy/claude-code-pairing", "@variable"], (_, v) => v.import("cc_chat", _));
   return main;
 }</script>
 
-<script id="@tomlarkworthy/lopepage-urls"
+<script id="@tomlarkworthy/lopepage-urls" 
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -14528,68 +14468,71 @@ const _gxaxgb = function _links(){return(
 const _17e89y0 = function _targets(){return(
 ["@tom/bar", "d/1f41fef8b019cf4e@94", "@tom/bar#cell"]
 )};
-const _1x6cut = function _linkTo(isOnObservableCom) {return (function linkTo(target, {baseURI = document.baseURI, onObservable = isOnObservableCom(), source = null, op = 'open'    // "open" | "close" | "focus"
+const _bsoqwx = function _linkTo(isOnObservableCom)
+{
+    return function linkTo(target, {baseURI = document.baseURI, onObservable = isOnObservableCom(), source = null, op = 'open'    // "open" | "close" | "focus"
 } = {}) {
-    if (onObservable) {
-        const t = typeof target === 'string' ? target : target?.module || target?.open || target?.close || '';
-        return t.startsWith('#') ? t : '/' + t;
-    }
-    // Parse existing hash params manually to avoid percent-encoding DSL chars
-    const base = new URL(baseURI);
-    const rawHash = (base.hash || '#').slice(1);
-    const hashParams = new Map();
-    // open/close/focus/from are transient intents that lopepage consumes and
-    // clears, so we do NOT deep-link them. view= is canonical layout state owned
-    // by lopepage; if we baked the baseURI's view= into every link, the href
-    // would be a snapshot from link-render time and clicking it would rewind the
-    // layout (issue #150 — clicking a second module wiped the first because the
-    // link carried the boot view=). Dropping view= here makes the link a pure
-    // intent (e.g. "#cc=...&open=X"); sync_layout_from_url's
-    // `if (!view && open)` branch then merges the intent into the live layout.
-    const drop = new Set([
-        'view',
-        'open',
-        'close',
-        'focus',
-        'from'
-    ]);
-    if (rawHash) {
-        for (const part of rawHash.split('&')) {
-            const eq = part.indexOf('=');
-            const key = eq >= 0 ? part.slice(0, eq) : part;
-            if (drop.has(key))
-                continue;
-            const val = eq >= 0 ? part.slice(eq + 1) : '';
-            hashParams.set(key, val);
+        if (onObservable) {
+            const t = typeof target === 'string' ? target : target?.module || target?.open || target?.close || '';
+            return t.startsWith('#') ? t : '/' + t;
         }
-    }
-    if (typeof target === 'string' && target.startsWith('#'))
-        return target;
-    const isIntent = typeof target === 'object' && target !== null && ('module' in target || 'open' in target || 'close' in target || 'focus' in target || 'op' in target);
-    let module = null;
-    let cell = null;
-    if (!isIntent) {
-        module = String(target ?? '');
-        const parts = module.split('#');
-        module = parts[0] || null;
-        cell = parts[1] || null;
-        op = 'open';
-    } else {
-        module = target.module || target.open || target.close || target.focus || null;
-        cell = target.cell || null;
-        source = target.source ?? source;
-        op = target.op || (target.close ? 'close' : target.focus ? 'focus' : 'open');
-    }
-    if (!module)
-        return base.toString();
-    hashParams.set(op, cell ? `${ module }#${ cell }` : module);
-    if (source)
-        hashParams.set('from', source);
-    // Build hash without URLSearchParams to preserve DSL chars unencoded.
-    // Return hash-only for same-page links to avoid page reload.
-    const hashStr = [...hashParams].map(([k, v]) => v ? `${ k }=${ v }` : k).join('&');
-    return '#' + hashStr;
-});};
+        // Parse existing hash params manually to avoid percent-encoding DSL chars
+        const base = new URL(baseURI);
+        const rawHash = (base.hash || '#').slice(1);
+        const hashParams = new Map();
+        // open/close/focus/from are transient intents that lopepage consumes and
+        // clears, so we do NOT deep-link them. view= is canonical layout state owned
+        // by lopepage; if we baked the baseURI's view= into every link, the href
+        // would be a snapshot from link-render time and clicking it would rewind the
+        // layout (issue #150 — clicking a second module wiped the first because the
+        // link carried the boot view=). Dropping view= here makes the link a pure
+        // intent (e.g. "#cc=...&open=X"); sync_layout_from_url's
+        // `if (!view && open)` branch then merges the intent into the live layout.
+        const drop = new Set([
+            'view',
+            'open',
+            'close',
+            'focus',
+            'from'
+        ]);
+        if (rawHash) {
+            for (const part of rawHash.split('&')) {
+                const eq = part.indexOf('=');
+                const key = eq >= 0 ? part.slice(0, eq) : part;
+                if (drop.has(key))
+                    continue;
+                const val = eq >= 0 ? part.slice(eq + 1) : '';
+                hashParams.set(key, val);
+            }
+        }
+        if (typeof target === 'string' && target.startsWith('#'))
+            return target;
+        const isIntent = typeof target === 'object' && target !== null && ('module' in target || 'open' in target || 'close' in target || 'focus' in target || 'op' in target);
+        let module = null;
+        let cell = null;
+        if (!isIntent) {
+            module = String(target ?? '');
+            const parts = module.split('#');
+            module = parts[0] || null;
+            cell = parts[1] || null;
+            op = 'open';
+        } else {
+            module = target.module || target.open || target.close || target.focus || null;
+            cell = target.cell || null;
+            source = target.source ?? source;
+            op = target.op || (target.close ? 'close' : target.focus ? 'focus' : 'open');
+        }
+        if (!module)
+            return base.toString();
+        hashParams.set(op, cell ? `${ module }#${ cell }` : module);
+        if (source)
+            hashParams.set('from', source);
+        // Build hash without URLSearchParams to preserve DSL chars unencoded.
+        // Return hash-only for same-page links to avoid page reload.
+        const hashStr = [...hashParams].map(([k, v]) => v ? `${ k }=${ v }` : k).join('&');
+        return '#' + hashStr;
+    };
+};
 const _jdyayh = function _vars(variables,runtime){return(
 variables(runtime)
 )};
@@ -14671,6 +14614,8 @@ export default function define(runtime, observer) {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
 
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
   $def("_1g7wjzc", null, ["md"], _1g7wjzc);  
   $def("_1hsbxxe", null, ["md"], _1hsbxxe);  
   $def("_1buq9dd", null, ["tests"], _1buq9dd);  
@@ -14700,23 +14645,20 @@ export default function define(runtime, observer) {
   $def("_1xjzq9r", "isOnObservableCom", ["location"], _1xjzq9r);  
   $def("_gxaxgb", "links", [], _gxaxgb);  
   $def("_17e89y0", "targets", [], _17e89y0);  
-  $def("_1x6cut", "linkTo", ["isOnObservableCom"], _1x6cut);  
+  $def("_bsoqwx", "linkTo", ["isOnObservableCom"], _bsoqwx);  
   $def("_jdyayh", "viewof vars", ["variables","runtime"], _jdyayh);  
   $def("_mfvz6q", "vars", ["Generators","viewof vars"], _mfvz6q);  
   $def("_1f44wsz", "test_linkTo", ["links","targets","linkTo"], _1f44wsz);  
   $def("_1hdknc", null, ["md"], _1hdknc);  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("variables", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("variables", _));  
   $def("_1gllckt", "href_examples", [], _1gllckt);  
   $def("_133ucsn", "test_extractNotebookAndCell", ["href_examples","extractNotebookAndCell"], _133ucsn);  
   $def("_cb1ope", "extractNotebookAndCell", [], _cb1ope);  
   $def("_1xxtf0r", "updateNotebookImports", ["vars","extractNotebookAndCell","linkTo"], _1xxtf0r);  
-  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
   main.define("tests", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("tests", _));
   return main;
-}
-</script>
+}</script>
 
 <script id="@tomlarkworthy/module-map" 
   type="text/plain"
@@ -14776,6 +14718,7 @@ const _1fcoh6x = async function _sync_modules(runtime_variables,moduleMap,_,$0,E
 const _wi39n0 = async function _currentModules(Inputs,moduleMap){return(
 Inputs.input(await moduleMap())
 )};
+const _1gxgyd6 = (G, _) => G.input(_);
 const _1qag34d = function _8(Inputs,currentModules){return(
 Inputs.table([...currentModules.values()], {
   format: {
@@ -15037,6 +14980,7 @@ md`### Random helpers`
 const _14bivfb = function _myModule(thisModule){return(
 thisModule()
 )};
+const _1cir47e = (G, _) => G.input(_);
 const _1nfaybn = function _tag(){return(
 Symbol()
 )};
@@ -15072,6 +15016,7 @@ md`### Implementation`
 const _gmxfu7 = function _queue(flowQueue){return(
 flowQueue({ timeout_ms: 15000 })
 )};
+const _648shl = (G, _) => G.input(_);
 const _1acbzli = function _19(md){return(
 md`We resolve what we can using variables named with prefix \`module\` that hold module values. We \`forcePeek\` the variables to make them resolve, which forces loading of the modules.`
 )};
@@ -15419,30 +15364,18 @@ const _1pou2g6 = function _submit_summary(resolve_modules,queue,notebookImports,
   notebookImports;
   $0.resolve(summary);
 };
-const _16y0lz3 = (_, v) => v.import("linkTo", _);
-const _tukxqk = function identity(x) {
-  return x;
-};
-const _1flnnw2 = function identity(x) {
-  return x;
-};
-const _wlucl3 = function identity(x) {
-  return x;
-};
-const _18lqx0n = (_, v) => v.import("spectralCircleOrder", _);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
   const $def = (pid, name, deps, fn) => {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
-  const fileAttachments = new Map([].map((name) => {
-    const module_name = "@tomlarkworthy/module-map";
-    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
-    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
-    return [name, {url: blob_url, mimeType: mime}]
-  }));
-  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
+  main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
+  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/spectral-layout", async () => runtime.module((await import("/@tomlarkworthy/spectral-layout.js?v=4")).default));  
   $def("_1w9yf3l", null, ["md"], _1w9yf3l);  
   $def("_b6n8js", null, ["visualizeModules"], _b6n8js);  
   $def("_1sznqfl", null, ["md"], _1sznqfl);  
@@ -15450,20 +15383,20 @@ export default function define(runtime, observer) {
   $def("_1yso65r", null, ["md"], _1yso65r);  
   $def("_1fcoh6x", "sync_modules", ["runtime_variables","moduleMap","_","viewof currentModules","Event"], _1fcoh6x);  
   $def("_wi39n0", "viewof currentModules", ["Inputs","moduleMap"], _wi39n0);  
-  main.variable(observer("currentModules")).define("currentModules", ["Generators", "viewof currentModules"], (G, _) => G.input(_));  
+  $def("_1gxgyd6", "currentModules", ["Generators","viewof currentModules"], _1gxgyd6);  
   $def("_1qag34d", null, ["Inputs","currentModules"], _1qag34d);  
   $def("_1xamz8j", null, ["md"], _1xamz8j);  
   $def("_1n4p4hn", "tipTitle", [], _1n4p4hn);  
   $def("_1kdcb71", "visualizeModules", ["currentModules","htl","d3","spectralCircleOrder","improveOrderSifting","bestOfRandomOrders","Plot","tipTitle","linkTo","isOnObservableCom"], _1kdcb71);  
   $def("_hgwvol", null, ["md"], _hgwvol);  
   $def("_14bivfb", "viewof myModule", ["thisModule"], _14bivfb);  
-  main.variable(observer("myModule")).define("myModule", ["Generators", "viewof myModule"], (G, _) => G.input(_));  
+  $def("_1cir47e", "myModule", ["Generators","viewof myModule"], _1cir47e);  
   $def("_1nfaybn", "tag", [], _1nfaybn);  
   $def("_17qqkoj", "forcePeek", [], _17qqkoj);  
   $def("_v9hg2i", "observe", [], _v9hg2i);  
   $def("_1bm642i", null, ["md"], _1bm642i);  
   $def("_gmxfu7", "viewof queue", ["flowQueue"], _gmxfu7);  
-  main.variable(observer("queue")).define("queue", ["Generators", "viewof queue"], (G, _) => G.input(_));  
+  $def("_648shl", "queue", ["Generators","viewof queue"], _648shl);  
   $def("_1acbzli", null, ["md"], _1acbzli);  
   $def("_qmt1ut", "module_definition_variables", ["notebookImports","queue","forcePeek"], _qmt1ut);  
   $def("_dcxoxy", "modules", ["module_definition_variables","queue"], _dcxoxy);  
@@ -15481,15 +15414,11 @@ export default function define(runtime, observer) {
   $def("_197sgjt", "titles", ["modules","moduleTitle"], _197sgjt);  
   $def("_11z3pt0", "summary", ["main_modules","titles","bootloader","builtin","queue","notebookImportMatches","bootloaded_mains","resolve_modules","module_definition_variables"], _11z3pt0);  
   $def("_1pou2g6", "submit_summary", ["resolve_modules","queue","notebookImports","viewof queue","summary"], _1pou2g6);  
-  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
   main.define("linkTo", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("linkTo", _));  
-  main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
   main.define("flowQueue", ["module @tomlarkworthy/flow-queue", "@variable"], (_, v) => v.import("flowQueue", _));  
-  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
   main.define("parser", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("parser", _));  
   main.define("sourceModule", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("sourceModule", _));  
   main.define("findModuleName", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("findModuleName", _));  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
   main.define("keepalive", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("keepalive", _));  
@@ -15499,7 +15428,6 @@ export default function define(runtime, observer) {
   main.define("viewof runtime_variables", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("viewof runtime_variables", _));  
   main.define("runtime_variables", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime_variables", _));  
   main.define("observeVariable", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("observe", "observeVariable", _));  
-  main.define("module @tomlarkworthy/spectral-layout", async () => runtime.module((await import("/@tomlarkworthy/spectral-layout.js?v=4")).default));  
   main.define("spectralCircleOrder", ["module @tomlarkworthy/spectral-layout", "@variable"], (_, v) => v.import("spectralCircleOrder", _));  
   main.define("improveOrderSifting", ["module @tomlarkworthy/spectral-layout", "@variable"], (_, v) => v.import("improveOrderSifting", _));  
   main.define("bestOfRandomOrders", ["module @tomlarkworthy/spectral-layout", "@variable"], (_, v) => v.import("bestOfRandomOrders", _));
@@ -15536,6 +15464,7 @@ const _1y97u4c = function _selected_modules(persistedAttachments,hash,getHashMod
     }
   });
 };
+const _1j5tq63 = (G, _) => G.input(_);
 const _yiedgc = function _4(currentModules){return(
 currentModules.values()
 )};
@@ -15549,6 +15478,7 @@ Inputs.text({
   pattern: "^@[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*/[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*$"
 })
 )};
+const _1ll7bx3 = (G, _) => G.input(_);
 const _1vrx9jk = function _additional_module(Inputs){return(
 Inputs.text({
   label: "load module",
@@ -15558,6 +15488,7 @@ Inputs.text({
   submit: "import"
 })
 )};
+const _3ukf68 = (G, _) => G.input(_);
 const _au41oe = function _remove_module(Inputs,currentModules){return(
 Inputs.select([null, currentModules.values()], {
   label: "remove module",
@@ -15565,7 +15496,7 @@ Inputs.select([null, currentModules.values()], {
   format: (module) => module?.name
 })
 )};
-const _so9603 = (_, v) => v.import("cellMap", _);
+const _1iasv3r = (G, _) => G.input(_);
 const _hj6sn = function _9(md){return(
 md`## Additional Modules
 
@@ -15574,8 +15505,7 @@ Extra modules for dynamic loading are named as a JSON list in file attachment \`
 const _17w9o9j = function _notebookModule(thisModule){return(
 thisModule()
 )};
-const _1sw0yij = (_, v) => v.import("importNotebook", _);
-const _yy2ban = (_, v) => v.import("jsonFileAttachment", _);
+const _1f136ll = (G, _) => G.input(_);
 const _ngwjdv = async function _persistedAttachments(getFileAttachments,notebookModule,importNotebook)
 {
   const attachments = getFileAttachments(notebookModule);
@@ -15680,7 +15610,6 @@ moduleMap()
 const _1y8y9do = function _21(md){return(
 md`## URL encoding`
 )};
-const _3fgnj = (_, v) => v.import("parseGoldenDSL", _);
 const _1tr0cuo = function _getHashModules(URLSearchParams,location,listModules){return(
 () => {
   const hashParams = new URLSearchParams(location.hash.slice(1));
@@ -15704,7 +15633,6 @@ const _1tr0cuo = function _getHashModules(URLSearchParams,location,listModules){
   return new Map(base);
 }
 )};
-const _19ebgtz = (_, v) => v.import("hash", _);
 const _lru2lz = function _25(md){return(
 md`## Model`
 )};
@@ -15715,40 +15643,36 @@ const _a3xgg4 = function _navigator_jobs(updateNotebookImports,submit_summary,$0
 {
   updateNotebookImports, submit_summary, $0, currentModules;
 };
-const _nxg8mr = (_, v) => v.import("moduleMap", _);
-const _w7yjw3 = (_, v) => v.import("thisModule", _);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
   const $def = (pid, name, deps, fn) => {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
-  const fileAttachments = new Map([].map((name) => {
-    const module_name = "@tomlarkworthy/module-selection";
-    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
-    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
-    return [name, {url: blob_url, mimeType: mime}]
-  }));
-  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
+  main.define("module @tomlarkworthy/import-notebook", async () => runtime.module((await import("/@tomlarkworthy/import-notebook.js?v=4")).default));  
+  main.define("module @tomlarkworthy/fileattachments", async () => runtime.module((await import("/@tomlarkworthy/fileattachments.js?v=4")).default));  
+  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
+  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
+  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   $def("_1umhlcn", null, ["md"], _1umhlcn);  
   $def("_b6n8js", null, ["visualizeModules"], _b6n8js);  
   $def("_1y97u4c", "viewof selected_modules", ["persistedAttachments","hash","getHashModules","currentModules","Inputs","html","linkTo"], _1y97u4c);  
-  main.variable(observer("selected_modules")).define("selected_modules", ["Generators", "viewof selected_modules"], (G, _) => G.input(_));  
+  $def("_1j5tq63", "selected_modules", ["Generators","viewof selected_modules"], _1j5tq63);  
   $def("_yiedgc", null, ["currentModules"], _yiedgc);  
   $def("_y5ux30", "viewof create_module", ["Inputs"], _y5ux30);  
-  main.variable(observer("create_module")).define("create_module", ["Generators", "viewof create_module"], (G, _) => G.input(_));  
+  $def("_1ll7bx3", "create_module", ["Generators","viewof create_module"], _1ll7bx3);  
   $def("_1vrx9jk", "viewof additional_module", ["Inputs"], _1vrx9jk);  
-  main.variable(observer("additional_module")).define("additional_module", ["Generators", "viewof additional_module"], (G, _) => G.input(_));  
+  $def("_3ukf68", "additional_module", ["Generators","viewof additional_module"], _3ukf68);  
   $def("_au41oe", "viewof remove_module", ["Inputs","currentModules"], _au41oe);  
-  main.variable(observer("remove_module")).define("remove_module", ["Generators", "viewof remove_module"], (G, _) => G.input(_));  
-  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
+  $def("_1iasv3r", "remove_module", ["Generators","viewof remove_module"], _1iasv3r);  
   main.define("cellMap", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("cellMap", _));  
   $def("_hj6sn", null, ["md"], _hj6sn);  
   $def("_17w9o9j", "viewof notebookModule", ["thisModule"], _17w9o9j);  
-  main.variable(observer("notebookModule")).define("notebookModule", ["Generators", "viewof notebookModule"], (G, _) => G.input(_));  
-  main.define("module @tomlarkworthy/import-notebook", async () => runtime.module((await import("/@tomlarkworthy/import-notebook.js?v=4")).default));  
+  $def("_1f136ll", "notebookModule", ["Generators","viewof notebookModule"], _1f136ll);  
   main.define("importNotebook", ["module @tomlarkworthy/import-notebook", "@variable"], (_, v) => v.import("importNotebook", _));  
-  main.define("module @tomlarkworthy/fileattachments", async () => runtime.module((await import("/@tomlarkworthy/fileattachments.js?v=4")).default));  
   main.define("jsonFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("jsonFileAttachment", _));  
   main.define("setFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("setFileAttachment", _));  
   main.define("removeFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("removeFileAttachment", _));  
@@ -15762,28 +15686,96 @@ export default function define(runtime, observer) {
   $def("_7048bu", "removeModule", ["remove_module","removeModuleAndPersist"], _7048bu);  
   $def("_krx5v2", null, ["moduleMap"], _krx5v2);  
   $def("_1y8y9do", null, ["md"], _1y8y9do);  
-  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
   main.define("parseGoldenDSL", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("parseGoldenDSL", _));  
   main.define("listModules", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("listModules", _));  
   main.define("serializeGoldenDSL", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("serializeGoldenDSL", _));  
   main.define("linkTo", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("linkTo", _));  
   main.define("updateNotebookImports", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("updateNotebookImports", _));  
   $def("_1tr0cuo", "getHashModules", ["URLSearchParams","location","listModules"], _1tr0cuo);  
-  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
   main.define("hash", ["module d/57d79353bac56631@44", "@variable"], (_, v) => v.import("hash", _));  
   $def("_lru2lz", null, ["md"], _lru2lz);  
   $def("_wcovkr", null, ["md"], _wcovkr);  
   $def("_a3xgg4", "navigator_jobs", ["updateNotebookImports","submit_summary","viewof currentModules","currentModules"], _a3xgg4);  
-  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("viewof currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("viewof currentModules", _));  
   main.define("currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("currentModules", _));  
   main.define("visualizeModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("visualizeModules", _));  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("thisModule", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("thisModule", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));
+  return main;
+}</script>
+<script id="@tomlarkworthy/observable-runtime/runtime.js.gz" 
+  type="text/plain"
+  data-encoding="base64"
+  data-mime="application/gzip"
+>
+H4sICP/9J2cCA3J1bnRpbWUuanMA7L1dbxxJsij2rl9R6tU5qhKbRVLSzoyaw+FSFDXDcyhSS1IzO0vxkMXuIlmj7q7eqmpSXKqBfTVgwIBfjAvY8JOP/4HhZxvwD9k/YP8Ex1d+VnWzqdXcPXfvXeyIXfkRmRkZGRkZGRF5Ph52qywfBr2sHCVV9zIc5r20HVQ3I/i3l1ZJ1o+C2weB/A7W1I9Pn4LbySpkXCVF0Mu740E6rCAb68f59TAtXkliO0ivOE8Vi3vpeTLuVz9m6XW8OS6rfLCFRRBcdh6E2Hp+rqqtrQWtc+lnizsTaJDD9Jp/h9zlW+5eR7o5iRDmJEj7ZerV1J3pFmlSpdSBsEV/WlRLisbZMKu2rCbOEwAmf5yCHoqoZfiPMKLwy4CoPNSdPHiwtBQc7r3aCy6ralR2lpaq66yq0iLu5oOlwVkOuOl+WCqrpBqXS18vP/362dfLX/125enK18+ffvP8mwcKMUFWJkWR3IRXSX+cMpaKtBoXw2AD0+Os3LDyqdcBTiJ9B9kQmhh2Eevbw+obKjq7zMpXcxR69vSuQu+yOZqjQpv9ZDBKe/OUvbtvWOruzr3u58m8xb56TsXUnO7mw0VoI71Ii+BDelNC+YAmqITlEF/EwdFKO3jaDpbj33aCFoFsHcf2dGbDXvoxhLrOZMI3rQjMCD4Fy1GwELRa1KqpOyxHabfaTQZpOIR/GEA3hx4HwwbK76cDon2g0CGT/jDu9pOyRAhQvpWflWlxlZz108s/LS52034fwba4ZJV+rDZzGCqtqtNHt5g3wZ+rpttD6iF3obwBuu4f5gdVkQ0voOABJcSjIq9yXGJxJXmrhErOLqHbsJQqGEdadNOgyoOSCpWrQXUJyBgAHwnO0iD9OOpn3azq3+CQr9KiSnsWYs/zYpBUDDPkrjgIdnsXd5O+LmaN4fYirfauh2+LfAQN3EgX24EeQye4vUxKq0gncL8frUwQSXtnv8BUrSqwauSHycVEY2ZVtfp6b//l9qtXW7uQhczXQWgJlLgWNPZr1SaOEphzmFOz7cAnL7+PPH67tEtqVXKRn0u+A4iTjqzxHJsVJBVi6n4x7lZ5EfzzPwf11JjI11RsMbo8eqfVk58/WqkPqypuhO0zqnjtrqnuQblj5uC47QjrpD92L1YDZNIpVAfiCQ7S7rjIqputooAOUmUZM1Xk/aaLvD4Is4thXqRqz5JiehZ5g9A0dfDzm5d7OwfQuyPIuJVpBe7wu9+dnGy/efPucOPlztbJ9u6rrT9svTo5+d3vWu0AEQRFtpFZpD1IGOS97DxLiw6MHYY6ac+C9a9bP/uQ/jW9uT+cne2DQxfMTlZW8EUsLysv54LyZuOtC+RNMmpJHULglHp7+6+29tU4qKDU3yt6aYGjoUR3RJw2KtLz7COn4GzM7N/+1iY05XZxP+3mRW+eXh5sHdZ7eJBWkuBiitPKtNIpd/bu4HBj81/dzh1USfdDwyw8OHY4wmAwrpC504YBK8NfOv1U8xjkSUym8XnWBzklDFWHgkkUrH2HK+uIE45po8IWI7PGHgqguJ8OL6rLSBYF9Mcs0iFvO6rkOeyEYYmwH5axmkQByRV4FoM1YRRYP2YgKDsSFQF7qcMz4Cg/ZjiR0xmFO6tDZQ54EgAq2+kPz9uUGpypGhGecGt1vYObqAxpXcbGw4EpbU14g6WEyWlb6klD6tNMuO4+DPAhN63r0Bd9TByu5TOs4bjf93gV7n9v1V63d9729p1XadktshHwzrK+yTHv1bV507KAhbcotdfEma2PIJ700p5m8idM57Lpcp+RVK0ZU0KxbFCrUgJ2LZDfs7Tfgy17CPJLO2AKRArlsrZ8BwSkMNJcoL5xRXpGoS2UhQBG+OhWCpbZn9NJdLoqRbgn2F1YUCCQQdlHK5ypTi64AyVXedaDZuFkAEeJDBYsTFA3zUDECVLcjGh70hKI0z4ugjBqTWuRJ0g3ao5MzeMFrvU3IwRgzI0QKPvFEYLtfyZC9JqXMcmI9Gh8AWZiBspcTw/Vb5aOENyq1V6IQnuNSyNBR14XtlWhGLgEt61+MC9U29U6cBJgJ6e1KZhIz6xFNNRMzuu0yRAsrqtxbA9kJJLRgbIWu3FK0uTqcjrZngELF9ZaV6N2ZNBmvBJ3qWkC5q7u9OWBPkvheWmu4xT+mnWiSoW1tZQCxJzapHIyGqXD3uZl1u+FteNdpDQNsmPhxuNXmtbJpMXVkzgbDtPih8M3O0hI35ZXF8F11qsu174JLtPs4rKCHzSEtcfecTCBbeLxd9TXb2EdXga9tcdvngdf7ywHK5ff/PkxoLPfX3sMUnMBTW7m/bx4HCxhhW+XoJnvTrn9Gb09BBa9m/fSENYYTBfQtCZPIOTgCEm5Fdy2JqdqMEmvR5oWFENTGFfYGuTjMh2PQBpSG4toYWy1UFxW+Qg3seQioSJCEEU66idd2MIBrW21IcFI+smotHYk3CjdTYmnhjd7TVX8wyY55FMh7kwZZC+vBg9D3JV00Ri/wiiKe/kwxZ08C74NnkK5hYVsKplgnZiPNJpuSQKjDIQUOUejzyIbxPUMwqbut1TBsrrpsyasn9xg4bN+DvKpyp6LAILgr3/5dxDli/TU9OD+s33HfAs6YaJBmnmZwvSkFj7bnAvDrqi3KDdeZdDiAexBcNjVQD5nWldeONP6xfoykb/EXgwFUO0iHeRXKWN+TnBaX8xLotXPk55Sm04Mwd1FUHpi7QV9TOt5QiRmKWYAlHPuf+LIS+FASWmEdaZpPOC3+Vx+HIBcMjCS3A1OgWiDAMBr/AQopoLmqlTyib8XUHvN/aEdLSyVkGT1h9UP0JHSSFB2R6AmdSScqwcIpLkHsqt+uT40NSJbPE+d1Ywm+DZpGylbBJ9VIvGhQ+FIkJlWjxq6t/ukZidrW8oeKg/cOGr7bIdUp5oaBYkWClB36jdIrNHRuuKCJGWZNISJs7tniMfuINardRESZ3RQTtQ4SUq3J2humjHVvOE6NQ2nOvPVOufle73k3BZlzqAELe7ZtEBksEKMzx2cIQqUOVexkKKJlVnDy1ZEkxHDeRG+AKlaudDcLxL7HO1knQimHly1jD2jS96E2+rH6TM+x1zP0fS9Jlt17N6z/cCoWACV9aO6JcNo6RwXDv94uLbmn/abhqQzRbqfPqGa9c2eUztXGExN632vlTzfxM69lP/b9E7jI3dNsL+huzM9eyZnrUj7OsHvtXWjyp2A3g5mnPt62RWDdU6JWGku0ZqPjYxzrDOXeH3XCVMrQWjQuoZ3d4cHOFWQj2V39VrLby2Q2KxON5xXQ5mEMeyw59kw7U37SUw9si4PEeJqwxQ1TbHGwX9pE6Z/T5+cR7cw0smvMy9zIbxZTv4MRM+Pp/kHGtw5UGL79wS69t0XxJ8nWv8Xg7h5RniZlAdpP5WzNnTcHl6ZolnMNQjX+TVKb6akDTSUS69+zPcCpLBMhhcpXt9QXoiZALJKoGvUe2xJWEbw6ZO+2ejHybB7mRdYJs6wZ+d7BQp3MLYEDXCog06Fc8BPObM8XkRHjaYWdVVQeZn0+/n1P/AVxd/hguI/7vXE3+Fy4u9xNfGrXUw85ouJx8F68PjxF7yYqF1JWFcR3iVE/fLhb70wcNSuwhBcnevcNwh3S3gCv2Wu2u1LhLmvEZSicG7FHWAjsrv4ObpY7K2zfyCkyNgGzKWxnUtHHzkqSk+3+Otc7nRVF/6Bbne+Dp7vrATf/Lj897jd+Uwym4fI7n8JVLNKmHYHpJVVv/pNECtUv0Pb0LlXMWCt5S7je94k3aelv/7l31v2VP761wNf4nJg3quB2RcD91TJe2dnS985pfE77gS+WPMz1MA1JfAykO/iSvvztcFE0StA0gBqIYBke362BqPqBrMXMXsRslcbRjBNcRxw97IVhdV7tzX1auRz8aCvSqZjon5b8lkoapxm527Fw5WDLaPu/IzGf+3bmL/rXUzYqLadfvkyRVN7pyL811WD/52V4Hci0dd63x+LStD/Qtrmz9Y18xJxFEJfzrYIYU/T+PLhawV3VS6HRy/6Ffzf/1Pw6Dad2E4ctS126uAbtbDnRXIxaPS9Up5ir6VEWNfGqsr31cjeW88KwyD+NEd7DUrWxmpNu6it91KVZqlcpyhc74vTmf2jJkzv7ocCS1P6xZEQ9qAp8rjrnyXdD4wA2iIox1btvIJv4CmUzN6BmBIuYIK+x8qAAHapqpb/A/E5VG14boewQlQO14OFohIMrV7m4wLFeiyBssa7w80fMMmm50E2HFepV+oNJzp0n8LfnlfugBNdeP1+1lj4jZXj6FnhnMV4/TlNCmCkVp3XcHrBVDhiTBYf3Y6Snpv/BtbJZYhOZ+i+1lyGEB5R9iPmlIyXT5/04OGn6jKlWkNYD04PFVCqR4A6Kkkg2NCDWbB0RUlzKwa18rFpyGS0g2fR5BR546myprK+Jn/UH8gu6+QraL6BP46PFCaAiLeM7WpELmJqO/gKGnzAJrFU7LvgBfwPSy6okrWCdvJzT1HNebL46OjvdAVIgvImpzGUPKiSogqpFGxky62oaVQ4zTLxDihnyba2hwA369EqFDjoMEwaUMsFkJ2pGj0A/b0SSzZ4ubLXVokeL0gHTgPsxaaObtKFIr2Aw7vVh31KmKsTXLShFy7QWrtLT4K07GfDarGXlbhDB8N8Ee8ziry/CHXTj8GTJXGT2N36aWd7F32r3mwfQvfglF+/UKJmQnaEtC4dlEExKyIMv5QCxNzYf1lkGXSzZDxcJmVwnl6jlrrsJiNYrGKwmfaAblD/k4+x438a57AOtWTZzcdDsjiTriwdtd4Pj5cuouBb2HP9zNNP7x/dQqaRPu+tD7VVaXPrNlU7uOX/KK6AcyvTLKmClMEKxkytLI24Va/jCh3/crC3G3PZ7PxG8GRpNh0lpVLR8lCAmmg34ToxTFUGfX2v8YRYojJyrgRO4lIWOgYpevHno5ddzXMr6c4GJH/2ZPh1/w5z0TptwfZWgRTcTyqcDcYeLNtuGi63XexF8S95NmR8e8OimYBzxuePStBTwJqHUr1NXEUAzZnNRbc/xnyZG/eNCA4uYfU/unVhTkwbBNzPB5KhI0LZIge001UD/k50i29Dq9axeRS4gX9RcOclgNHSAs61krbOIMnHMnCpceIvOABRX2/3YFGfwaC+FHtqXhCnTTMEpzxZ/aRun+KZEsjUP7jX0hFGhjEKTltf7Mbl3nj9Mli9L5O5F7M33HllGQRCQhUIZYqrK+bz2+Vo8te//LuXsfj8Bcun1sYx9czeMD12+AOGq1bR0tH796fvPy4vL8I/L+C/M/ix8uKY9++2BWzzMimiaS1hZti9VPIvil9dODXicRwSY/xnE743qnCZT+0gaaAnKhbSN6ZJmQbLH7/pqK623r8/E6KSvBd2XuXmndl5V25e1847d/N6dl7RUmpiSaNRgAj/cQWleCjxcRmXACZr8TFc+SrS/m26wlNVYXZ5KEEFAEMucn2ZSoUZQNwOlX75Gmg7DcIijdOPaVfNN6zHhWEtOAdWVF14hBrq19JUg0TMFqaHP7/dOtk4+Hl3E+NRKFf6VlLeDLvB//M/tiZ+sZPvt3a39jcO9/YbKzxxamzubBwcOOVo2TllXr/b3Tzc3tt1inktN7dJrTV4GatBh+e27Ey4oeA/aGyENgAaUSzjn/NdlKLbcz+0xXk9qoVN1q0NRIFqG7ZZcYw2qFsNzoAxfVj163yPe2cCQGdVNjhoAHMXhOa6EsFJF136N5qd92dLwO3KKoRNe92ex447YRYs2gHg/LHBqrl2MMrLMjvr3xD+ezHnUl6APNeKEUXnGNOI57Yuykk1oTx/LYmOEDlN0+0DSEaaGuikkwQlTDEsoKS44M2Bi5/nebD2Hf9m2tUpZBUzIHyE6x3KfF8+idbD99cLEfxa+26Jl6JlIjOzuyGu/sHRyjHuodE9Oj9K8D7+MsVbtZ4eQSlDCGETiewRqIRpA3gfwh8cBaTCrzb8h0PCHPgV3W9UNJ51a3BmvxHYuLfQnTQPGxlh2Dx6PWxDOB0eEwYlENJuB8kwH96ghAlCYAbb0k0NJRp92IaFH3Nr4GXI1E+p5ua6lachWRsuEI7fI93wL8A04fk/6CQc5IO0ukTtQUqh0frZhxQ4BPO7Me9P3XxA2A6AIQrzYJ0N4X/2GkC0mXYbLiDcCjCzMM0qTJXh4F/sTkWrhZU06rZ1h1WPLqxv8lXnDpmXfo5wqqrP6vaH9OYavf+d8q5sSrs8b5L3tM+4KKNGuVPihdiBsdTm6QTAqu3ESlnpKbWmWNTKNiRafB2JSW3Itm8Kb3tned5PAX0dK007IcAWeCtmEQtrGF9Ntit1EqTSw/HgLC2somvqL+xKy7jrrwRLksRa3tbiMq4iATwN7ll2kQ2rBrhQY9hcRa467SrO7amoIJuqnptd/1Zbd3uykMwErz+3YT7uWHUdxeSsKdSQtChh2zIYTKJBFUydmmG2r1KjbOGnjxMbgn81ZAC1UEPdansIE612I8L8nulAXjZUAHOW9Xrp0ALdOtKpx/XOahpt0Brbqg/G+JGYM7MK+phQr9omDfKoNiZHW11r3gdMCnaEC4xdBaW8AIlifEYxKft5Lykv1Z+zfn62NEjKKi2WspK1+L+Uv9l5+tUU6K/23mx97KYjpCu386Sxr/XdVvc3dF3TjnIhYApD017XPg+tez2T0KhGnjZn8f3mLdl34hhk/tpqi+Fn7gjDWaqfR7eIdtbn+DfgmnlOVSHYlpB7/R7HINhNr62LBs7hLqCKT3tthDVfbRo6dFpBsSolvd7U8mp/wmZY2CXnDembCWYAENuqIFVyQhdQro5eoPernb3NDTynnLzZONz8ASW19+UCiF+9hQ789z56tDTA8It0KNnmHoFco+/l+ZxHsXQdiyZOqC5RXMe7aabuViaXZJitlIcgT5XxyZC1JPiHkymY7AwEGRdjJBbkwa7F+S2BxI0XG2CYJx5QDgfhI57XZ9RcpWGiivFwiHuD8Xke99FWOO05+8mdvRNTMMxQF24YQpLv+8zE435bS0MPVQJpMVLFXzwxQ6L68sDOs0ICYAQqPu+rnPoUnKWkvtYcKMCG/VoGM/OWm7o+tAY2sgRvPY57rBXFyuabbTV7NUMmhwxwbmoYQ6RbN6PTytlbm+ipuIgOPmKmz6nGKXbMEq+edRugylo8Qea7BlczfNvjw8Cwua8xAjZoFVlG8ZYTjqPdGo96cvOt9Ia4DcIaIDzOuwbuN2fzr1FnMpsnYX58UyDweS8M8UpsxlFFUa5/kTLv3eIdN2763MLTQLJ4pM+/LvNHnVEUOTh1IGdXuk1v7pVEc0s/OmyTMDFWgHrjiEHeR+97ff4XZpAWZkeVk43OYQMlkb8tClK5ZhL+NE6LG3Z7gM3GgF61Lu8NUJG3a3uUKYNBmM9zOCvZVM2yv+q/H0ASwOjBmtbmkmiIZuSoDBs0h4TeJ7glhzOFEVSXaXCRXaVDFZy7DEqtk6guE5DSLvMxcJSzNIBlAOJglVMlEEcR3tkNfWWqj+2gSCChwLpDqIRgJDPtxcEhbgS9tJ+dkRlp/wYONt3+uJeWCMy3vEMtYhfaHcmOHCTGbO+vf/mfgWzKvH+Vln/9y/8ShOgmV6UlTkCKwFRJ1GD1gus0uEYvCLRRdTqM48F5uUyuUmivly6m5+eQU8bBRr/M2wgKvX8ErUalj6hKhvYxSYq0g7NxRTAhO+W0h3YYaXtDti6Q6ucuAdgYOh0XorrsgP2xXrkWjNkY8Gzt7VAcbNb1b+29tr5+/27vcAu+nz3nb7kkh5SVZU7Z3zp8t48XByvPbOUDH1M2JXA4Emt/PBiWzhCRnPXZuIXBklsqjCtf5lCVeJCMQr0i+GiReQvDuwpkHgfMqBP0jhBUhh/HiLn3rfctvnxSJgdt1stNfOusLr2nUBsBSDhGEyaHsbWpw11tWNQFHpH8ESg7bswFCSVrBzaIiQqHv5kPRuMqDcbDDNiRKkNG6hijGY2rYR10YYcpbuwo+MPztNjkwthCad8fYir6bSodknCOkBhYW9tQcEtrwdExuwsBlBjWz1YCnNoemxoY2X+bFrCPVq6yOzWZuiPuYV2IYDQuL0Nd5Ih/HePFJ/1qECImjluTwKkZ8zWY8pEW0VYWAWHKrTKcIJVbiQEted8yDDgyI12z5wqnLKoi6NPBVEfvDZR40zzN0HGmmWNrEakau6/NHBuNHFsLqpxXzCQ9n2qUaJkkIkqmG+UqGpltktv2jEybDXINrHub41rWyDh0x2JS3wNbCG4218UJ19idbrE7rZgx2pUmF4LQs41tHap62i6XeJVKtUxznXTL8hbTY1PetbDFzD+aEX/xhi3Ylh0yk8e9G7GAtXwO3Cuv0DAW5IMBOpoYUizS1zSNYpkuernWEbB2gKkrIPz3w/fFcUuT1astMu/a2qfXZaScbzdBZ2zNIooyDSsKHHGuGBNzNeL1mk+3iSMCWKqxD79VrWa+ryVGhBIZNkXfUtZxMTMcmDKlJEq7gHV/s6Ii52hd7+9MyIM9323k5Aa6+gVzenTs2BphQX1d5WLIHq+NJcHJ0XEbFQD5uILdixI1g0fRASsKX23rjG0OfYh31uwTTcYbSRcnlvzZdMlhrSRa3wV8r6BLVU6JKv+QDo01HL35sYs2tsv1YsA0UK8J0i7ItyAfrVv1MB4LqTxW76q2s/7ANhEekeBZFUmG8UCRjrHTsT5LEE4swtwlYqDTighhUbC4uLs6TwWW0aQ8b87atgh7GrpECdjQBAnDXXWy+jrLGnwbxyegaYTvhmz1LObNsda1FCja/AL1toGEbch+93/hrpMA2qDi2F5YgL1wF4Vdv+Z2RAoPFl2Biv38hYVtG7ZRctB1MvqLQ/53gOZI6AJPR6aUidrRVaRrN76wEHmzxHiaAqTrTNCtXbgRLdsecBiMrcdXTjhYi23afuEdi3mJuZputehW+n2rZYlOZv5ewwqjcDkWNwV5zqFSMxc4E/YcTcUOIffviyELLlKJ3hAiOvTD5pSuzsImcvAmhO2LLJiUavWfUYhhXECxaw5riKrtgd7VCkZbkRSyoRStUyZtgGnrYYnNimTuTEwlpXdomZiqUJwF6ipSZlgE3V6P53SOZMDnvJ8MZeZEteHji/YRAmvtMQ/m2ECKlKWyl3nvhk4n5vDjHpKoBec46JwoXFHfLSjHBItInXtWsi9FaOpkYVkzs8RuxJBacGbfy65xCLzbyyZrUKh23foJzdl6j5xBmS7XOneMZ/wudGIWVm1r+2mjmD4Zf9tIZvVrjm6RoGFOsA2koYrNCc0mIQPrTjxPg8iE5KjtbccqhTB6OEKTYidovGRHZ0lzGnMeHMQ6SgpmQ0HLyoKOPywLs9rHcH1h+sj2STqud0IPzHlRh4S8Dv9pmxScjY752X5gYq2qo5adhlPesX7beQzK/PbyrCw7h9DdsT+0toSE9JLU6HSOQEXPqk5+i31Gabe8iqn/q07OPsutOnefOBfb9tow31caaGWAVi7QygVaeUA1BSXjKkdborobPUJpDEaAGQ1vscUgYA7wGMoycDsYWHeA9vNsYggiUXvU1mhMM1q4TbVMYbNHNxUmWdAqzYLx1OJwXLcKw5dX9CGf6HkMUGJB2XKYrmOOV2ugVDewhvEWYenfwqPFheP3vdunk2gd/jyfhIv0JX+i9Wg9PKSfHU6XP+9j+PuM8//4SQPp6FqPliJXcj7PPlZ/Jk+wh4Oj58f0a3D09XHkWiCZBblIC3LJujRZOlyClKDl3k/aPtj2rdnEjN3dji1isE0RJv7Lgkqx2GCh0nsG/18EQl/KynKclkvPfyu3+jxMq0utp8srLxaXV+D/h8vLneVlGNBFWol+CIVwv+jXzUXt5dBLUdGfDrs3ovWFE2xJBqqDJBs6qjHFaOkCIKTwWmtWKYsLq3c1f/foVsBNltARuLpUTjkTzUHEd+8Z6Qp0X1q9Z6ip/jp+ES/jj15WVoCoeJAN419KnDcJRTqEs27p1f2dfT23xEUQyHK8smKB44wayFE/r2YCxAIM7qt45SsNDpPj8aBXA3hRJKPLq+zPM4GqQgz4abyi4aqcGtzL7OKyj+HQZgLWpbAuwHwaLzMOTIYP+AOQ0MeZQKmERqnpK6XX4LH5lQeQE7Hm83jl6/gpAeHE+kirvlcbUrj5Z1brkFir+kv552zkVaY0rAWVl636lF6DMEiKD2nPA8GJugtP8Ren1eqXf/I7DykyGSvxNxZBQvridVIOnOpX6UXi1cckrPTb+KkQytk46/eWML3WPCb2Mwow4cNYxHQG9BV3w8ChvKnANkbZNHiLyShjmMuNMDG/Bpd8Ap57IJNR0r2E8pjHdCKTtYEpcVoCk/ttM6gXd4B6oTq3kJYDr+7Kyh2VkYk018bL69yvzak8gG/ib/RsS0ZtAFU+yn8p86EHRyUvdvsZvvrN5GtRj1egBjf92E37v/i8UlK5e88scJJRXw4pSIFZ75GPJUln7D6Nn2pAklHnCmly3seHX3zGwOm8PF7EzzQgyXCA9MbdD70zn1dx6hL/oSXF0J4+d+dND6lKStlpKVYwJ8P0jFPqHp75FTMYPXoKKZKHJxi9znOyDVE5+Kn5l/NQsVXIzdCbGoyjopc+99lbKQzXO787+rel3x0vvF+K1vlXhIkh/Iaf7HuxFMZPIhSYzHKlzVegoC1grP4JF4/eXy/GC1DZqpB+rNKhqYJAY2zhySdoF4uJFeF++qdxVqRkbcGVeiXbXtTMCgdpWSYXxtlgDEPVidq6xAZoufDJ46pO7pDCIT1wVePbGmWhwZ4de4jEVDw4W7hlDxSrvHXPxeVBtLy1XsClxKOVYz4cCXZV8tNjdWarLlXas2Mt51j2qCRAvS7yQZgXaD6PFkVKNOz2cJXgEfgKhppWS8PRYKnF0hgp+Vvj4egDmbqpYsRk8WieFrwNZcPWsRV2aOn90iNxdOP2ogaLGekJSMcfSqMwL/u4R3u3NdhAiGvGuYQ2wdwoOmVmVBns86AkbKxoPWXt2AtZxxbPVsixZ8fAKUVV/gRSdNiKl1qRL/mzru9pVFMyWvRtHejxKM8AOia2DMzCacN9t4MJmco3MKQQunRhIlIyNsZFXwJaE3YnGDIWS6mY0vIlhITxcn7nJ5KndKs1WYJN6AMsmRhZvHQM0YroFKyWFDES2rRfMOZ54uySs9uq0nmKRzesEFeX6TCE4Yyg3ylGx3IMCFRGnH+wScdeliHQJcWIqfIADZQDu79u4A0NrUh7UB2tlPgMR50ElmhKYN/s3tsZPAw/DIIuge2GWo3oqsewoq+C8Rzk1DGHD0VnSenYRtOjxhYV6nUlDIvzx2dMxZKtXpE2swOc/f31QicC7vp+aSljkmTLQG2+I8HfVIWj+Ph2uf10MrU8zMu7/R2r35Y2rJ93KQQFkBSNKL4s0nOLWKjbYkYBx0lo7X0ZnxwvWQ1R+vvy0ZLT+DSaQAtqkBhpFC03agRRubrJtdi3ZTZMfVLryhwt9WLiV6VrZfV6AqIiBDwUBMh348S5oWRkgSTXSVY5q9zvLcObMtFWyBe3Y7xeYy2zZGmJnaslHlnsggyrqMQoTYtXTVX9DKe6rcoglst5dIznqDoea7QK4AxbxVH/iVLY6jRg9XnQkogDW1Kjxtm1WWWdLS7pFFutcMfsCS05vMBukrCoGqSP5uZoKswuCF8tuixHpHBXJlbkLloQaFHAv2jjt4WAyFHINJRyBJkuHkZsYVVlSMWXtOTV136KMS2uxM5s1du9qMjGGTQyrlLaCCweJ3sy7mEPnR1ZEAcZ1jaU98Z9UvVi9xo3IioRSQGzFamKOB4QhAdZmYZq4G2xQI/sHUmkbXr5bpYrExUwOw9/x/mQdqe1IHSAwhItbsgvkNm+EtBH+SiMQh+ZtC1FrlcaP0aPbC8iOGRn2MARxWCKx91yoUgfxWDe3I7VxsCG4PVBTG3W25xN6/dtm7dJ9x5ZssoCMzRZBOoJHXZTpTMa/tCPsqqJu0yTnmNdzfCm7d3U9dUGWcydI3vLtvZSxJeQWawmWy0ze7PXIpGzRqKp7W70MxBcEvw3rV2bWUvaESg8OYv6h8GlXSjq/IEsjXOOiKOr7d26XPDWLtVqXLxGrDBOg0aCqmFj+m2sjM15JkJJVDpmgQkXpHu5rmcB/UfpWM2upLpW2+Zoaj4GKTBh935OlwldV3/JiQlnhiPSRK1a+TJeKsEjt01apZR7hKNehEyJpc2cc7Lq9kKGD+hEZBd2j0w45YPa+yKWXoARM2gHHyL/PDQ4+nBs7ofFtJjXmaod5lCxHdwCT+7gk4lon0awJpFnCJITsABhNp18zKWGiw2Bqd+U0JSgjOyJ0OWuRGQR51mqElWEVTa0iMiSo9n3/IG3ipGo04+jHAS5Fl196FThbZ6VI6FESNoWsdCXDvUUN/Y0cnh7l3q1Uyy+YRGpWtJHF6a2EtHXZVjpmV3J7YJX2V699mEYFs3RMb4JJItXb1JoDoL6JiYUF7bGLp5ytTDynXNOFURq4tWClNqcb6XExGHFU1aw275iuopum2a2xqOd2V3X/evUpxlypZcdlxfp3YMZh4ti0x2ZEtx/+jch++vbZf3zJTcWS48cvmh6YBq4D6ak8l099kNAC0nVI0DfMTAKCk1lnFGweTCvlzgZ9IQoHijX0g2KyUrepSBNnAHXAI5ZULiAYFyyC1Ma7GRnRVLc/PUv/6nUbDUWJWO3V9N4mculMfzosnc33Y+S+guaRyFTEPRKArKsGeZsFjoIlpIvApDawhVLmgZiUpfBC08A9zZI62Dtge00S/HUiKdnOPj9TlZ5nZR4/tkwA3aKqu9jfZqxCelI0TveJylZJora/s7m5LMqHSS/Y8eqH5oKb0k9kL7O+mjsgbZtQHVwPMIacDjClMmp0Aergbnzr5IqQSlhk+4dagrg3pnatJq2J6DEEImpren7pHfWCVgJ1wl6ZxNH9ABhswL5rivqGgAxBM43LrqeX+oRdA2dws7P02IK9lzMy9QB9nzpUMDzokTpOTp2JVKUtpswEUpGrJJD7o8JpcODIJfHkP5tozokGfgCJPee4yWRp33vrB24FRpAot3VLKghgyWITX2IjpZJ6aDESwMeuF8fj7+N0OU0ymY4tSZOt/7wdmdjezf4/but/Z8D+L0bPLqlvMmpMxqjtOUjHVoCjQq8r7zVvridaa64k3ZwZIXOffQ01LZrZG35Hdmf9eD4nvWdsLhU6dhDZ48eWj9LD7GZMrwt4Qg7SCbEGj2k2kM92NrZ2jwMdt/t7Gy/DrlSO3iMmoPHUbBxEKgk2tVe7++9CUboQZmc0OuDJ31YeCA8/fTD1v6WijzymLIeP5I+OKZuqL4ONnZfBSovWD+dUAI1sLt3GOxs/+tW8BgYAlDryT89Dvb2X23tBy9/droC81CDToLHESdPQ4+yR7xVwKivLppYW4Rn0aneu6ew/HgjwXKnjtpwKlkJrlkYk1Bcw7yiiDsNqM2G53m4PhWLbcRcZLDTzXqNSCFghBn6pYoc24oPIjzRCNbHWklgdfFS7mC8Y8LaabTaaHoZ3tpjlCFOSMS2szoBTzKZulFAqTb6dxEfOqR8AQC1sb1O8FDDmjK9oWsV1zAh6vVSFEZ0eKoH6sA3Zbp4doQkOTpPI8mfmjijDZCeTJ3kCGZOAvocR3NPTGvXdRzXAQ/EjHbCLkLlNE5FPUBeJRsZlrWYkl0S9R9Q8shOw5s82xq5i/PrVMIawtq6sCPhht5uAH6W925abUM+hQ/ozpZ6VkvFUfeYGpvCKGEWw+kMMY5j83WYXIhsytu/Pm8Z8lPlJBQsFAIIjVvZkZQQTr6O8Ue44LG+Ym4+HDdt3OYCmkwPEgxG0GqLYxzNZovJtfWA/F8ty77r6+uY8+K8uFjCFYdwnsWX1aBvSane2iTY08O/4Q4isd/0kCWYmFVqe/fQCRAH31vfb+07aYfbuz/75Q7ebMAG5SW+2Xq1/e6Nn/py+3s/6d3uwfb3u1uvAsgLGrrw1E/4pjaSDMT9i7RwBnO49QcX1ObO3staTSdKPpfb39rYcSq+2nv3cmerISl4u7+1uX2wvbfrZL7e2dtwm95992Zrf3uzYQYopp7d+sumXrLY55R7tXHodQkSDrffbE0doo7to3wSheTxFPbKfleIHNXZxMyJWOfCpWCe/P8fN/aBJr7/tLtxuP3jVhRE65s/bOxvbB5u7X+C7N1PUODTLvwTYXr0PlRRc4lO13UXLa0cQX8F2AXS+iToa6goCLQqtnKMZNGqvz2Ggrcj6bvHYM7xtSV8wV0X4MU/WypZDgH76gYc3/yp5b7s52cAlTP41eaXNLXhXMA3TAXxX38HlP8NO7FLJ53KTedFOgTUxX/73AgHF5hvc+rpnbGhS/3AoC738eCjWemxuVK61W63HPx0wkpSKG5dO7EAINFRLQFb+O05HKe2hjAlKbmUsAwj8QAyEluU281Rdqzer5Or02anWevcyjuwTSdm59Lx8Ubo/IIXC0U6NGYxNe000s7TSJfEq2muS38CS6Ixg5fWpl9DaVUUNsmAHtrCUWRrgke4cqlQpCAfjY5VR+CnjuCq+jgdVheVzmbUAs65ZunaGgAp4MfEp12/HjdlWoQi6/Ug43BRdiW4G5wIzhwwRpaG9XZmCda7yS6sgiT4NsAFt7hCH9/Rh/xeo49l+CCXBkcfTX1Sxj3k+TTAMGu4IFRfTCzWQULBY/Gn4NH2qWA3LKpu04l+4lQg/KhM/x3NvqIOZdlU+mYGympJWgilgmMt40rRLEkblMpCUl2I8CVlq2inXlQmk8K+2rcJAALfWFRkYCX/aNtWrdrRLAVb9l2gdWFghyZresDXx8m00SrsmLHWh+mVmT3I+w7Etgr86GsK0UJA2i1rAbA4+YgD28b8kGdeHPOdnNbW2qcPlAnlBMKVMeYRHg+pMp4p7FVLewexWNWDWPUo8i9ZNtjemHQY9pLGuORiuUyHlpLjMiXBaZWTpTVvWad6D/KeMSODD2u4sVPNU0wrT5immFhXyVhFeNogk+uA4HCvJI7VuIT+JRSJatz9gEGocKUjRIyuVsFJit5the2mW1l7bxScpd0EKlNQqmSI6ETB6TovPqjw+UUyvEC6RGBO+2IDAu2S0TKQ8NdoAI6u2slZfpXG9gGArMRjNhnnI0DeLZegwtIv5RLprdJyieCe9PJBTLPhHQ5wqiC/NlFKbffAOCz98z9z+E0b/RepBCT0rgSaytJUJTdTiooxJWs9JI0pjroIUotdIuZH31GEiWoXhGZEB1SYdUCuJEeocGCRsKBq08uiXHsKfKtESAAa3JfYkJdyydKnrZHSMf3EcxkXYc0J19SaEqkt35zr6lYkorQFw44v1eAGxgTD1MNxir95cf4iWX7x/JsXX62cf5W+eH6+kp7/Nn1+/mxl+ezr5a97T58mz7orK0hXZdFdSkGYjqvyNzsrz5cX4Z+VBvxPP29SJ7d7zrHzKUVV3h5Wdx/XnlHR1yD/Vibxa0p8lXazQdK/8+j0nEq/zIZJcWNSV37LkLOPae8g+3Nq5c86X3Gtd9X5N3ceGL/idvPc76KKuW6V/YZHBNKFSXtBaYfZwEpbWdaJwIEGIw8yBdm0wK4wpnUEVk78yh25FZ9VwaETiAOI5+GArl6sZMbtuyEzbxsE68UcGCtq2lGt3rcyeD7fJKMZx0r//OadXvCARKQYunIgnVOyAd6phqePbrs9tMYTbxxztUU6UV5CG71khHbDuPXp9WRfBdCq+l13MO5lF8oRhB1jOMLb6KYg17mny09Xgs0373BWEx51wn39vsjHIyjM2xVeghXZ2ZhF2mEPdyI6aPMxD1POiDbJTbps864CWwT+zcfU6iDvZecZm+CiwisNRmkxwBfmeijiX2UU6xEDQOJ2yIFtUA+OgaGyircgqDRIAevcr5XY61oZmMMwvd40GJNpIMawJKi0Y0GWGj+IFlk3pZCLEsc5wGuHgKN36maHPa9PGACvnwCBF7H05Wm9L9CmhRTVFxgqTEj6K3UnkIGqIwphW+BBvSWYEqJR9NBIiwwEfYN7mjOqbA1Dje9ZHOymmQTaTFl1nbPkYvp/mfd7FHXUFKIpyaqSfIcJaF6U0qEB7L1nKdISBfkEST1H53aoDX0a5FUaMLIqjOBZZFeK4gkxZX5eXQNBCCwhtAAvwJDMoGqG9FcggQ2Z1MrSGtDhD9sHwcHe68OfNva3Avj9dn/vx+1XqMr7GTK3gs29tz/vb3//w2Hww97Oq639A7pL2tzbPdzffvnucA8SWhsHULNFSxLyNnZ/Drb+8HZ/6+Ag2NsPtt+83dkGeNDA/sbu4fbWQTvY3t3cefdqe/f7dgAw5FIKg8O8Cg732tguAqvXDPZeB2+29jd/gM+Nl9s724c/U5Ovtw93sbnX0N5G8HZj/3B7893Oxn7w9t3+270Dgobje7V9sLmzsf1m61UMfYB2g60ft3YPg4MfNnZ2GoeLI3AG+5KA7WxvoPKQ2oPhvtre39o8xHGZX5uARejlTjs4eLu1uY0/tv6wBUPa2P+5DWCJBe3tHmz9/h2Ug/zg1cabje9hkOEd6IEp2ny3v/UGe773GuEcvHt5cLh9+O5wK/h+b+8V4f1ga//H7c2tg9VgZ++AMPfuYKsNjRxuYPMIBdAG2fD75buDbUQgYX33cGt//91bjCccARZ+AhQBDjag9itC9t4ujRmwtbf/M8JFZNBctPHOBtJh0ndleIeoQwQUAAI3D+2S0Crg89AabLC79f3O9vdbu5tbmLuHgH7aPtiKePa2D7DMNjf+0wa0/A6HT7MGfeOfFjG3aW6D7dfBxqsft7HzXBihAU0cbAv9QOrBu80fBPsxW5mM+P5f+7q9gs3j1cv/HMYN7vU97OJpMph1xw7/DlPerJwrUWgkljxlyMvmM0kPw1Scoa2yxO1Ho2fr+M2trBuDzWU3TChZXmPMX9F6caOmH/gaD53DqdeO/xW2rWtoGHEJPC801zpT45p7AKwmCYLbnn4GQ5z+lCcAgogx4JYbhYmKxb182PTcgbqMpuDrDFGHqPfNvgVmrYvdfl5aNtXcBlWyvTKcc0ogV8mdxtMT95jPhurWj0nnCY6S4vdEvnG7pTCR0FUP7ZHb+UFwg0eXwGpHnRXt52vnxLE9JYg1WCFJv+/26C6cGQiyZpqWzEyDFNJbN9gONK6z1VrN0or9hdosufG2lOCwzXPR2MyBQaulAcPZx8JWgCWJrIHt+NG93Jj9qpA28ZAm+ds1GeCiTYiaahr0t+NKlmkNE3WGI3cMSH2isZvMpiOtfB7SBQ3H2FG8ap11xxJg6WhZOTzVqM1pgEGG0arr4Wlus+2rZ3o3rMkyy7rjbriIpmp6Fr7gpTZaGFMAyCbr+9OWOMi1Tj0K8KyZ3KkXFWCjiQ0IBMEhCj8HnnEKV7LMU2x7FG1PMt1eqMFOSO1w6u6n3p1XWwebIJptocUMJgsqWLHkm8/YFg6hXGud8A2RfBhzmI5W9ahhWKbLncCurBi6Uh+xrEB6FgusZtFGhaR+sSZ4d6+lirh6JAuI7QxDuHQNIc/lBpGNuCly7Xl20YBSipYg3JYuSrjPofvCAtRlPK/HcPivtCbjMKe75jX33sla0dIo0DR/yEVlx0qKhX00AO6QQngy8Z0V6z16mV3AYR1q5WM2JvtCHXLhNvVHX6qS8SlDEOTVrUylHyIcpnIPKlMVETnKk6ZHTI2cdez5ddErVbULZbTU3aiqpHs54IfnUT9zhioCtNWtba5QE2RSrEQXyHZ79jZrvBYcRbQUtFtJjHp+SmNW/fmadNXLzW0mFGKANVfl9Iah/vzDtK5GTKNTYVul52sCVX5Jy+iLZESYGiwEOT0wZw9FbY2QT/uDlEAWqUwDTOHaVGG1yBfo7pwWbkxacmU3Xxi/C9szQDViB8m1jh0yQZ+BHcy/GzszaJ8B1LvZMN6a3aby4+QG0WyTf+mNxxFZ2a6jbjZuny3xLHmHsZpdfA4jNVZ7ipGap4m1ESJbTjNaLMsSDmfBCMVCGIUh1NYN8OEE5sBbjE4rcnefM7kUtKE4hjQ2I1UdAyntIkO7UOyuFKSa3F/PksYxsrdncgZQjJjgQ4Qk8lBWQRM4WgK95UBrl5Ab85Sg8vgtzgds2PEPh4dvnUcXG87puhfOOd1Ix/ptduzUADbJQ8soUNmMoXnGUre80jZjVjKAXyzxLA67am+RL4dbnXpk3tq5iwlj8+BH9F15m8BMWoixl4QtANnnVQ5AY+eYJWpWRhTT2VntfnKCdjY9uprePifnFKDvIKmqdDCie1vuZAC9lING2iPHWTGOK81Fh4CRB8wQwckF9K8tHkyA2QDPNBU9dQTnByVxJqUysIs9VkugYvX+aRgBxvg5pbC1Sc824W29GOm1amzYvfGgYbwb4iruwWBCMw9qGTqv6LkctEGRYL84YIoyWaCxrVw+LFFQls6ctIDv/vzKxKB9wt1LJQl68j4mSeORinii++Bh12MxHl+YxnEc7M7GBN8yAyq2327KUZhba3uz7KNjFkIaUWIjxZ5zwceIgsdVd2Jk2nD4COV04nRzf2vjcCv4cXvrp+CxnB0fo5eKZ2HPTZ/AaWsYPma3MI6Z8Tg6tSA2dr+2jY6HH4b59ZD3ej5GCUjF9PSGyjZF7ml+ltao6f5x3gVnbXpzqTsf2BikI/IsFKLu4QT49gnGIg7X28HGzs7Jjxt4t7G/drj/bosQadv5NGpNzaSvTh2qJxXa27x4rDTs85+xX81aMNy8NGefpdsPZq0Nb1UoJ9svQQCuBO/hxTYyVjbXP12mQzQd4hfrql4/O1NmQbRxDHvAZIfBeHRRJL3U2FPlqlTw2zaDAyBYEs2FA/QBVtbEYjQV4quRGBOrfyNXyDVERnqe+Pylpsi6WzcGquJqxUVj+hL+FboNO9ywYZO6i5Bm0yCeDrxaxIMbye/zh4U7VUiAP3cY9nGg2XxBqUvs2ILKTb7ZjkEkRdeMwexWw55VV9zLS3oA8yXlifppcDUy4hsulDdUlCLWNbYjMZPZ9AFqxxQHE1pvW0B+yosPaTEnEAkyyMCoIsXinDDbl8cM08u/oZvp5ZfrJcKqd/KB4iQqNPHFhRYWBPmbkJP30x3Kch4/u+USbZm1tlSfNNGKq1zThqFyu+grrHSyQ2OWJf6UljXh6FtLVYPH7hMW94rxGTKs2GDYapDUhBZSNnB00i9uuy1NUCWtFGP1FMjrVWrDZyqwcdk7883hZFK10WT5pz45UJH6s1zCOANXWXrt2LVZCtd5HKka/Jd+ePf9Vs2nySlnmYRhnLDKdeSpexfVPJBsj6KZ3kNNHluN3llNblzvGku+a4L5zq0/2xPr5d7eztbGbh0Zdfu4ulsTujQdHG68educGvy0ffhDgJ/BH/d2685PvqVcS6QkdzTvtl/N9gzDR8N89yydRkYPP+op0+mWN5Z3LOFIjOLe5Ho1RVNQOdVATgLObF6mGHh1LXi6TNoFeY5Bm5CjKNHFMnjMTROgbtrmaP38lGJUXdxzguo6D/rpVdqn20jPqzE4vMTndgejPnTXy0Q4lEMuMUE+7PMjwxJLGmOYVwms+l6AZ/A+3gH0ySK9Hwdv8AWmpHeFWuneAzaQtECXBrACR8cPlpqsBD5RtfFyGsYnQ0J4JWUoQSs5ywt5YdjqobpWm9bNgI3HqX/4nHKRDEvKZ/stCjhCSEswZEPQTUE0y4uARAX+omevyWZthP44BbI4hKYdieiKF2U6stmzR4rptYHGwWu0EtMNoM0gA+yxnRuJuSqijNT3rs54Tr08vtdDM8HLnMYLQ2epBmbLNjP3wlUo/4q8d6fBuePfQNThWZB/+iRk75bUs9RscD6lwlTgNXt2C71epQiWpuo8jpAv3thLm96vs8F4WPZBOfbxBOjkhDuKesF8+Ne//CcVcBpkbCSctADcB5dpf0RvJUaz3SDkUfCEOtWTK4+QjA7wee6LfrooL/qy6N1GAsvIcSGrKOROMuRacbDN1pB9VJ4VxNnalJDqpc6tciNkoXlGVIiMCfWjwwpZAXakE4j5IwX/UBcwbKyIDzZlVyl9IdMua4RmOQw0UFfY4FcQGbIIs/L3ZLdAyr6DtBI7GNv/ILLpwi+vrprVC93y1pZVgxCwya+9l6x+L1U/phV7q8d9V0m83FSFIl0sK1Fy6dljtqnje3okXs1lmzeA0lgIe4/Iq4JcoJenpVJFYheIswxvzFypnSXUbi3qoXY2dToH4U9tPggQT67YgYh4L/FRbapMFST4g7RXBuiRwD5LGBYcGirTlBy1xpXYMVGLl3DYY8ZHj5oJQ5a3ynBzS8pyjGpa1ZrNrel5T2oCLwcv80F+kQ7zcUkWxPgm/HWqV6S8GwrknA6hYbJAzkrHe6duQe48e6KOjGJJvqhMbUmp+pv/63+3fC5mkZMbaO5NUtGLJ6EIAWILY0eLJtshNOHDVzdAQMiCb4PharCwkLm3K1fKue0oOzbX+VfEv5SbpWJ0zADF/l+LLdrx0XJ6G6IdIHp5ceEfknJLz+y/wsSGyuJGE+47spij6V3EoPJ5PgLmR6brydAiJ6RY3M2D5By5E5yFelRREWQ+JLpwCSkIrxFWUqpbdSKua1K9q91S2XZnf1YBydS9MS0DwARWUqIG1z1Lmef1qKmboMRnZQuXK19CqwNcRVj9YUS0Q35plrcrEquM0V6a8hJUgIugiTgshjkTz9aDZTzpJygSSpayxxE/RndSXXfARn7KnLRsYNDexbwqJxxavmP0PbwBZs3sVpy16g5h07iz8waiat5tWRcBelRGPdyqGEGtfTc1fmJU64bdz1BtI1bj2vdNxxlg97R6aMZaEQ5eYxW5e89H14i0JNameTkAtHbXMIvTGPgvScUNkoB4SZaXRNEkxQNZj9DrsKeYOZIO0T2LhnpvljFzx2KPk22bvW7qHt6wm6mNbr5dc+qOeZ9NkfeioRFwyM/GQqG81icHC0BiO5CjLPygA37E5wAjAdHUxlOYe3049+bvFIchJD4b1VkxMn7sgPoNTEi36TyMnQ7LcUEurumwm49R7AxWFqzBf5GtxH+YFlvOLoZ4CKQ9hpyjnOBPorM1kU2vVp0o49Ost7QexzFCp8O5KE86XrLSSfjpsgRrxVmf0/GOE9hR+1LwDHabD46/uHtJGdSmzLLaNWYu/DZw5Vzk1ytyNW+OFUO3dmW7xN+0Nnxxfeoq/DXoGkbBBoV3kzH18+9EwTyQK//t2IZBBdaQmmcNM/19qM44p5y/rQ5sq5ttxT6bSqx8dWeRZ09nFzFX6LOLbPaTgRrFzJJ39QnL3NUpcjWeq9BXz6mQvYWo07qohIKzG1sNs6rySa9hlVF6oVIFslVw1pQkCvss0FGoDZ3ljg0vlTDyA94rtQOxHBMvUC20iN2PxDGyLr9InYO79AHliR2Dguw9l1JT6mhrRhXnBbEEFPh7tlYXKIPkA6ccitostHssMNyu1xr1TDalvROOxdeACTsUn7pznep9Q5aSXEp539TKKpO8Wlm6mRL8okm/dKVpIjy+7N3phA1Pm7sINdN28Kf+7EmzQt41Yla/vcBeCRJo7ifyFgXp5Br2JHyOjjTDFK0CW02d4ZdItnhkKnN96FKnYbzKFmVoGl/Ecl8VKJuxxoi2cKZHUZvNpq5TgAMsk9aAHLNIqELZmGuzWUeiTZTj4CAbyrmbNVxqFG1guLTOivQcDncUxuw66/fpGJ8GF0lxllyQXqDPD0Zd4wU6tHhDe9gQ37UY4k1eLy3hANiLg92czMmVpy6LxALOSHZtNPTCO1vWlcDYK+3US0gF7D204vYRWjcxh4J9HVi2AvXnWX6Cwb1JRs4VYujQgFn41jKwTumS4B7V5yd83mPN3aJ5nMUxVqa2VSlovGlB4wFHLAbE4QY7JZXiE5DH0M3HMj9CWk0KNI/oAM0RdnkR4OH9IdLxMGWv51E+GhtVPOEPlx2MEjU5/RtlgOfekcrCauCDQa1b2jBYxfIP1LkdaYw8sNV2T+KFR/XajE69XKMalXaiBi8+6z7Wfue4gaHrzjFZeTuHQyZzugE4FqQy8LttSPWZlytAmvG8utuw1K1c1SvXzQ+9OvaDbU2VPi5y1MxntZqcHka+18jS+zgkC5FPYrQWaYM5qem+nWau3p3N0yGuBgs2ualC2rGt2DzEi9XH5EEw1bcC1940Z4S5uzhlQ8b1WzvJK+g24VohpRRsJZOSLxQ76jl2QjpaoXlStbYD/keh8nkJek7anYdk/msg5ukCYK0fvAskdfrXcpFHy7/SQmkiXk/eczopZ2rfPnSmtZp+CclbeGyj9kCi+blGbITGMrzlp3I6XHmiIoPOsnjz46U643+gDhdt87zOXatMOggCA6bzQsaw+1600pYI+a0HzrnV8VbJz82IxFOmHsXLawUp0IGoLV6p4bhI4awCMsDS7/BB4/W19/GnR9FSO2iBkCTavREczdQFDlO0MshkDZIH6H38/nrhEYNYNTCoon4gsSkqa+OpCh1/PdHevMp73yPPA+UOQcKz9+aGrNpSXacMe8Zook0HBhT/Yzc4oazpKXfyrjKF4KJSqEAJXBnMbbipoeMKLoaU6HyJp+Kk3/GhxJwuxxwbTxxOlx+O8ivRtxZ6kWm37LDuDYNrNgionfW63fGABNHfu9bxdVAYsMLDnsQyt6c+MsakDxyb+Mmszt7VTbvsvfvhubkDQe3hjf51hmYB50m/f5Z0PwRi5wL0lZET/FTTn0Z6qluDeJ7pplxTZ1etzqHtdYciPGI7ilvhudE7WLI5kLKCQregtOpi92qrS4Do23FjmyROwI4pEpwFoJstc/mQDjmEp1n6dK6maBmlRUI9hqNjR9TNfzwW8qRGfxyoIYU/ZWXC1ZLh+BpGc8KQWsi146FrGy311FPOsjHZ0ExZuRJSkS0kiDMFWLCC4EqyenRSvQcjyToShdOwFZDCeAlMjZvhVm0Kn0G2s/6gg0XGx3fBym/phlq61By+hkOacJFVyyVlOkJt55WmCLZ+BA9pngJ4qFDI9RAeLpZNzFm/f83hZbzJsJy/avWJaJ88eRA80ZeObN0m6s+hBFErBsHREao+ymMrGsVxQPfspBMpbfsShIfLfQxys8Sgx9XHtUgdg2DpM0XdvbFgPEvFDB8Vqml1naZszIgQDThYt0+WrMcW59FNWgIZx4EA3NjhToXncF79sTQ3uwNSJ209mWWAzSb5bYq/Rr5CFZpAl2SLSO/Noy226Zm+/sDyLK9FzWpLHWCIAruZEL90DKJGdQh01ME4KXZM6uUp8G1rCrkyV3ZeAi2VN07kbodi1ukHhi1sk+hVrjtBNFggntiB3DlJ3lrx43h4I1r3B0Sw+YNgOlKIPDWn3g/kB++lsONbrQuuo8+AUIQqOUGPLJOqykaTU5h5ryw/iScRWEAsxFfzWk9aq5b4f0H8k1o/Uq/RPDLPxJDH16NbYi4VnyQMSbRVe9D4MYA4nmbtw/Sm1VfWZRdHdIezdpjhaN8PMU4bjgR+8jM6p9bOqsr/hEsbw/LfhAyagu+zwKq6pE54Tf1Bup+jN23VE/2SUlNn9opeWrxEOaCoZvTD6AVi8XeXlyBL3KPNkw1ubl4kXVxSlp6VlmsM/OihZRfFibQIH+orQnv3eWiN2X+G9aFLxdGMyAGO02UQzFye+M5a1s3QZE1MzVCzvZ92UwoF+fjJ47jV7HJp5mE68usTYMESAu546/No+bgtHmrAEToY/3GzNbHdWWnurG+ZxQe1TqqN1e3q69cHW7h+rOmAyVmeBPt7Px34/TdVNXiA8XrrcPOHYHfrDwjH9kmuTfu6SVtUZKGbxKW+kr6wokJgF4K93Z2fT9sP7OHWpXsn7sDnkVzz2CgWpEbPfccyubPjdm/v7Nhp0DBdE3eSvAD6mOMe+23G6PFEP5q+ejfOvgyhSCFsFUVXDBwlhgUJvWgKfRdCY1rTz87q1+hiZdoJA5bxUtGFNb0juOUifLw2roERYfgOIMrSzALRXFC5VtqmIlCwFtpC3UXalaP6Izpm6oBjyjQ5rs4szdHjx6WEUJNEHYxMJI7FYOUY+wuAVhvaUBxFSwmaZ0x89k4dsIiqYb/GN0ilOtD3OyhbbOJ7mpFFbPU+WHvcLcdJIVFm2Cub+4CzqEqoYX6LT33URKptuXCT0gEXNlqadxTz2AhOnPqThJoITq9OSWI+HeKPMjjF970kCQO+8ufYA4LyOr5qysBKuUhNtWt2kPTx4HQTKL1IqbYT8p+Lp4yQnjNRV468uK5a7vfwquXu73sMQ8OiXaG+aTd74mkTLk/JPryyDLFsJrN9wBipbV5M9a6SfeiDnQVV4foOyDWDr6kEwbKUmbRWg8aFQ9i71DFtYp7aYstRC73jYYjw59hEHRG/s1VjaHbU6lK5bkMx63qWtSu4kPDxjKhE7SZqp9cdRj/3XE+bbTURXcfOzp4KepS0Pgk1wzuZ4emA9AundwKbNI6xn31Ia+NdOY6mDdgmEy9o1BdGXvqnqYNeuwfq0qlQvv1ufjAX1VQw94DSnw7l2/v0ZfqYvlu7T29m4GYuOA1moffmE9MI0yLGuWjRYjc7FD7fZjb3Is3pvtSZ4bQOX90NQh9bFqaEEKdUxgV8BwAPzfdE8USPH/EiOCgN7yU5Nlyxo7aa/rWi1gxxQyN0unBhOQXw1tyqn5u1WkKFd7bU4k40M0hlTaMquarTYS45q9UyUqDm+AeiJhfpQI2dDHPW/VF5aCptqZEEajIpNmpMS02ajyhO46i0NzEqH+lqlt0sjc1CdrvlqgrMeEfzDdjchdbZuvsyEIWaofS2Cp53+k+PbiWNW5v806l+wGeTXhtruAcY5OhiQOcx5V2nLYs4uGwb36uL5IqFnZt6jg+mZYktFevv5oXOw3kPQ3oPD0M+wsnvzM06o6fyoujOrpd0f6jeHLOe7QvygsLGUzQae2hJxU6AaKfdixse/Hs1rf/uwNDibOpTf8v37zl6787uOjmBVQ1dN1Xv1ffv7L5/29D319KA+IijvTxZTCI7IHaVVTdiOZOVP2LCLgcAWLONb2wfZZHM2Q0CFcMPuUaclUBg+vbBgbnNIQlcoLqa5Brf23lAchC8u7qpPaCcui/ZWeOuyibOhFubfDfurKwidjh1xT7fqlmzHaciiIMZg1cv3M0EZL366lWXp9fs2k1e0F6tPXliffa4RT+i78S0HseHRg7dDSN4qIrb5Its6yJVXrgFHsk1+Rqq1qsJT6XohUb9cww90IboRz6m5nTOP6wFb3ESp/jxyJJ0aNEWMzz/Hrc4E5BT3PMe8spzriPGuF5IbnlePKuOxMQhQZrLy/qzK1D4k+bS7EVi9Z3fQJvSdSE/yxaNng5rLk3EZxcWYmouzfToFKcIJ50Zr4TZxGfLJxvdbjrCt45Ie2HfT6KrysGecBtUlOzk3YSsaNMDceLzHtwiI3UhdgxLc3K4dXAIlL70b2F4tLhw/L53+3QSrcOf55Nwkb7kTxR9CuHHSht+vl/yfj5tP4cC4dFhwBA6XFP+vI/h7zMAG62Hf/ykm+lIY9H6o6VVSzDp5mnRTQ9zil8k4TfmCWPUvAym8l3cpVSqUhbzt36p0BaomheD/6qp61lbeyUG0gfOw7ExpuBD2fkO+lWz/s7XuNjVKD4HSJUt5zFYTHFefvVqkEDpVqEkp46yYLAPXFORqBBRw+ID0wSlW8+YC69oQmsjS5q6cd2n0dpOPp0gcGOzZ0U/ubygHW5VKxwQX+0PKLDCGWlYLfayErXMi/CB/heLJOdavXFey65xQIpxRPr6CuR3cXBl4QjXBHnkYPgGDBFAVgPAvwrlTurwXt8+aqqQNANz7uJAmW5+1Nm4AhzW5sOhgUmNuTtXjM1SiE8CkfP87urM9Sljj5yg42hD4Zqn1NeswxdkqKvzsAJCkIZkGraWnN8XzZ4lkJapvG71iV76bsCjvZU17FcN22N9mwoaUHqHouH03ZCuo9D9itg4nenEXLqybaQ9I1cVbaBmuGJsBuw49njIvuULIzeD7p1nxnHQ6l5tokXryOlA++5gDOvafMNa1e6llHSwrReqPJzheb82FCPmrA/WbiwNKoU2S9J/efowVZaA/MwA4AGvztGib/i4UrcgdLT+mJViGjhIgcuUzGUwGkKhrlQq8YyTqA1sYJuqFq+TUgemKVCWVfFACg4448Fr07PSFNqVSKIkWGTkxsIM+ceZzitLS7qgMVf8SvKRPjkqmf4NCgtlkz+lRUrZcDSuppGRQT8SVI0irSir1C1jCST9Mc/8sLQixj8mQUx/9KUGGw8RtKj+HrwNiRVGzVUCucdCByxTRTMlwOx41CMXRpk7lAfHGAlUWTkF+h0dueaWZbG2xgjT97J6vciIWSvIFuH41ieeafBdzdRhn7BKtmF5fDT1MKANJZFJE6EJHwjQ0UMcJxF+50ZAfBcsrqh+HKnUY3nIxk8W5NmssXSdbmjOetw+Eia+/9XjamhDJ9zC0jGS54VQiZoA0sGkmnaTLhwBScsCVIwkoqhrPOynpUQduCSFHnqljpFBKjj+HLfVS+p/W99tTiPrQzhnTWHbv0EXg+nriLirb/oW+U4jvmFa+ZLAzrCe49UzlCUTa4u54waPKi7bw7L2E5PIBrfkJSErBBIU5AofnHcUapZzXl/Jhu6D/8bakSq1ztS6vh58aAe9ow/H6l21yInK4gVBQk8n5H4meqJ1jw3kkiBzXxykg7xQvvehHaFJYsvBikOv6UsVnwmjO8EOTRFZcqOFQLNhIkRt2xpz2O53JXFc5wXPc45Ql7C2FSioynMdTZKCfFM4KHaSJhdVjOGHMerFywUhnlsKkV4uI7CGmNvjw9YsvfoMj3jbihWFDJv5Wny5zt0Nv+6h9cbMbWL1gbXEqErsbhOa+0mmNuT2GDq/SGxxh1fyRLESF/B14146Ig232hJNGCK1mecFHnWSvu3w0lYgyxxnhOzhlI8Nv4QsiObAYQhGvRJCXAsdyDm+qJwmNLwqHcX2a2jcZe2jqF54rA3T2fXEB9JeZog4HveWmjkFqwE3pNQY9xPGkfZ5h1/YgMZg2xq/ASUh9Bw85CwxqPrCP4If4Kh9RRpwcvx/XPEb5BTb1QBUjhUVbJTnvG8qQGwMPB5WWd/CNT+gbdE7vkKtwfHqBxZ9lnYT9D2yCuJVjLqaI5cNvIgy41e0YA+W8MW807VdCDbw9W/9MLaiOliSFkDqqVckNjePM7YBnnEQ3lBegm3We52GX9Sl+OO91akPraquqjs31TPkVqcEVux+UEg81W+XU381l4mdSEPcpFKrOA+FTn+SlinekCfflt1SD9rMbCbeQyi6He8kX3+QxFlERwTz2G26qYQIM01Z7UC5CqpuTGa+zuXAkKHVIDS+y+UJXwY/ys6X+bAldNql1Gk00mGmOb6FT5J4VBjzoyMYkUNOlrIq4XyDAdroElDJp+rMUeNjsgiZBajYhqo5cQ2xY25hk4r1OBuDg7KGsCzQgzd4ZtLAhUnQorUEbO84BniaLsTJYhJHcph7+oa/djdlMzrKjifKrU9vSEda+G2oRunHjtG6HDA84z/vkMHcyHV3PFJPdPMMTo6VbwfUt30ctf9UzYBA9gtrp7A1Ls3GPoBztl0IKXiwHB8tI77It2yrqV2P5NrkWPEHy9PJufjhk1/zPcyq5/poZpFxxdK4AAp74vZxbL+k1GhsJTo/GaM6sHOg5JkjHf6dh/rw/mM1Zlv1jlNvm7o9VQfY9M4VBeFZE43tqhIM6I3M0sT8s+3fm0fIB4xgQY+NjqYIffaTiLPBudBcbaO9f8xA3jC9F/Lm7c/Dhv7M6EX3S3TCQpv0R/SnLppsHarOMSacnm5+vv4P/14DePilRoC2YrURwEYjh6ODVG4nSlbQkLylXIHpJnF9ThrBzesyKe+9yof/2Xr48LO76HRw/qXLFw7zNfF5bTy8TxtoM/orsIRv78MQ+tWvw5e+vRdbuvh1MPHd/frw62Diuzkxcaddvv28IJ1d69czxkPJlhjrXivk7o1n6dL2P47x/Br5b9bzLrxmajNvROMydDauGZmh2ZiXZPyKFNKUkjqqodHWTgNK0Iz/KiU9tSWJU09DsVojXSr1MkwU1iHD5SkTdWvAHs9V7jo4c7Nk8sk+VfxHGxgsw6g4RGzyMVxmv2l+NDBH1VJuFd0enqP25sarUeX6GoFgYxR69EvJYb2qKpEfN9PBSa39tt+AHing7i0G3y6uUvsCiCIWmGdhY2X1Ch0/mHJJUFeUec6htlugFXLc2jkotaZKtq9fSlYgl/IUa2ntA/q0NLUH4mTNe57VFrtTR9FdFwmWSrpRKT1Xw0dd1Cd3j48j63HsSR15onhvcgP/m7XtzZPg3/5YCPd53R1q9TL2nu9V9rt0i0Nn2NByVSftYkdD4ldVxVwlsp71rflrGnI0o3BI1Hz8Bx+NiX87UzdXdwknsV4YZH19Ka7gzqyCorajZowZfXmslfL8oymKWM26C6+r+DrDv7NyXlxl3fhacDvxrOiBZgP9qoC7DlSscroWlVAI9hzZ0UrW5E7lSJU5VmWoZZMsAHnLKpLrlmUsNtVezbt9E6AeOijALFbdxKDeoWuCT50RU6tOsNyWkFBkLqS/2ZpFf6LorD/45KE/6XZHf/HY9ScbV5lPMg4xYHkLhm8dvBOvPpMxu7zznUUPxImzFPXPA3paqXwY/H//63//f/y//+f/QE9yyYs4Q3m2hl5gYHXOX/+7/+3F8j9RUCOyBtCXWwRXVaDHdnKMyiQ3U0V6nnNklVLbC+iqfQxmS8FtaaMc5LiJyNs0uF9ygAGVosJXq+t9jF2hrdwQBdpMiz7EhIh+k80S/RL7NPrNFjj0U0xvuAjb3PDmyuF4xeiGBqXPiigsZfSkj3r0LB9kgNMeP5ZCWH744FjHP1ZxY0t8OegJVHjC7wvJ4xlKia7fz5AHVhwjnI1+n55UMRF8GCcEyJzaIm8xonjpxf3BC4+rPOsBfSflJXIdLJSJFwhUrUeSR5W9rfSjdzqsR27weTm0KEnLeuwhjOYMA3RAGCAo69Zqc6OyT0NuldNzFnCM3LsevuXSNzE+XMcKWmjCe0YcbSuG2Z/GdtfaCs+8FjgU82iUJoVVEdEZJ71eiDAb9O9NIQKsAKRY3X+zpcGCyUSXsWZWB4S0/Nu1HvnYXJqWCUYAO8j+jDxyZXnZz/FlSpAbTZWomVl7kp7OI8aHcZh9VrjqG8WQTxC3Ezl3jIqbE8c+Xq0ZD9ZfN3BN/MyWoaz3fKs+jjbdYNi7sKCGENcuhLByk/NCZNdKjGG5dviaofK029PW7rMrWs4WTv0zywDegWA5uStLSZvwLRBDy5zfjHmK94zTeGYb9rvaTwxHTozUeoMGiIC56JTeZkNNSnYzR2R5paUqX1971WCL7U7fQzHx9Qln9sRbeaXlf2GeSQ3REPATmfmZiLUKS1NwfWa7WnivqKh3KF3PnL912hbmmjfTC89ktaG2TbJ29DcUJXBn59D0+XBRPUKEv/m6mqZZ365dELMgBoLcg8QDjMbWL7U5FcsUq2KeOIStcYxXKghmkKaV2GJ10WKtINNqO9SjxErJzn1oFNkCBAfYV+zy1Ef7knGQDRVj06frlXbg00zwJFiOXziiKa8+QZIaZyhSslyO6YNmELikjmoi3fS6n9mxjLEjNF8KPTr1qmtpRAspzuWjXCoLQD7ZAMC2ZZnYoX9VimUIqy51J76YrE4hGB2+j1fA+Ao30P4Hs2cV4y5eV11LhiJz2cwZs2/1nhxibNi2XgonnUDdYyoAOlRTeQmEQeerjs8lTGl6QJ1Klva5UQ6CJpaQkV06toPGxBs2QZJrdBWR1NkiS7aMfOC87GreWqsb8tMDjmYofOdvmeB7+eYignqB8WtaLceCXwcX9h1F6DQpXZEdtqZtPMCG6IrzHKiqh5pGOvSeOkRP3cE9GPt2gue2nxSWuQXXtDr9WBVJF7KwgBvJ1TUt9wreFsnwAhB9mSYgn5FR+e3E+G0fHXVBkinQ6f+oC6u1WDnGo98oKcp0H2uGUp/AWcZnDG+fYl4LbIw9haXiExSMj4rlhYVjC3nYnB1UEAXro9ZvWsfu25boCNpdXoW/38KPFfixsOC96CR7mOmCHE33zkOdRka3mykIs8NgIViJImcaVV+0y6PxkFyguNGkYGQT+FAFFby+xGizIWuU8PZFIq1rGjqRIE5cAuVdPY8TibatBi+vGC5HMYypm1ShJe6yqoujCIlGZlyxqZ+pWqwEizBvNDYHf+jGWQD+CsRfAfgrfPxxoPKQgR4VBOfYvF7EUmnIXuq3MEGGfRTY3EQbZMjzRwyPpx7IGDUdhe4XLxksgyj7ka+/7PMMWczJnHfVnHdNn+vzruaagOpp7vI0N92i6zBcUIF4Q3lEpY/17YS9Q1PEDEZObI4UPKfqqoKvPgu8m8Ct8jXfK5S0bJTYbxg8A3MPMGoQaBVrmRrzpwniIRcRbD+CWEqZhB0RaKbf78MpcrWtH2NpUIwRtaMRcEw4k/dec3ItAjWX4cjGevnIt8SlVe5kdpavtJS8rHt5CKyr1orKaPCfMrUrpybdVmDSxJ9eEp4hw2oOP3HFqGYI1GrTSC8By0U/G34wgzVJ9KQfVLX2kNNHt14pjGBG/Tq19yZIaHg4RvfbEhQkzSYjDz22Ls1FrKWxD3qMMAln2vKO1hbv14HzMFZep9VWN2IkLbVxOdEv2U9M6QUVWo+DYqr0mGx84DBwtLH4x+Mn73tPOvrXo6VoSuDaN0kfKRMfhcJOmWbsaLW4j2FYUtzL8C/vZ7hgTIcxWB3ucDjd0nOKX3csoobpZznqZ1UII2b7LeTKyGP2lT2pbaMvIV/VNipfvJVyKFfvvVey1KMbS9uqla+Ygj+nRb7IDvOSSaaQ9MIwLETY3UkZ0AmWg8XvgtYGzMkK/XoJv57+ln7+EX9+xflY4OnX/Ptly/Ih0rtb1wgDZVfHRAQGjH96uXYd086AtEltAmvYzHtp+NVz4KTAfP8JmwTO8fQrPP9AefYikT0z7KpTwXk/h0mF70UMqbdE5R2Xh24Twiy0ED6U4XjCXgXa0LeOp9bGSguHfwTzg1TRevmUv2GGMIoSoGhlmVOeftUOXhxbOKrNe+goCY9QhQ//FbiNlJq4Q6bpKASqhqNupGSfLoXNVbcV3eiBswXaQXW7OqRuBvugUtzgqiIUjmCDxb7qcoDLjPH5BCHHXZmcjQoDWC8GXz13CLaLxyQsbzvy4TggfaEs/BymYO+liyId5FV6cp7imM0DHSJg+FHnuZj8xsc7xkU/NN5hD1WFGI82Mzws8TUTAoAytX4FRARrtWEILJepyVPvnsawfgPzN/q6SR/cdyDv47/U1k6eURPae+UVYbsNLKSPpn1o1H+bSAQR0q60tf8H+1RaAr8MkXc8azYwxXYsYTFmDS26pRGWKt5XLXkKRrx04ORVXr2l/QKdGzv6Uz0Jo8t13XLq09CAdBqbScZVzqILv2jjng3VzSB10t6u1UGpcaab9MXqhTPR0vrHctOAQim+nQV9E4tRfVzfOCvpyIXP1tSO7Ewi/oNUTQf3Gzm2t7AK7rUidDME/2w9saRrBZ2kEOsB5ZmtqEpWSxoOnoGmNTnRz5qe9fOz0HvUQxa5wx6wwSiKubgLIjGK2ntAcmq5AJmU54ZkKN+A4Afo5gZh3qszIPjRnfvgJu/duCDw3T1POaIiT0GOzCHGRnM1ARoP81SH9TytfjZIQP7Dax5PNwOcWzMPUl0QK3dWIPLOt/zuYRiK3wWIQykSY4NPYibsdpuadFwxMPnd/k4IbQDHy7v0TGqMcsC7/e0oZjchjmkkJfs5v6ymMp0I7XC0zctyj2shoxnmw5tBPi5bvkmZy8AzeuJxZOIQZnE+pL1oLeCjoIwStlu7iHqcQ5VBmOHdGxuhVTY2C15ZoAQBqFj19Gl6KcGOcqvetVoLntus3/gaSAEvDO/zBgM+esCsrTfUYz3vMrkxXhUeFeiNWaSvWKTlt+mexwohuKPVCf64bj1CjcUU/5u1IKrZqNHo8MVn9zcboL0txpfu9oaTR7fU4Remw4D0e3VZv8G2/Xbzjk6vrHzZXq+s/NrdVqaVs58I5LfvhLCQguVnzbZSuKM8bejypaaHhjEc4zBsYJgu6f85G4We486/HPwxG7XFpGM+yv2lBDgO4dJCdDab4zqng3Y2iu4lPedHbVDTMb0AiL0LuQ9+nz8O+mbfXvNehRz0/ceyiG282ntDUlMRxSSc4PRJgBaLIfOeZskcbsOXFbTsQad62CN+ChOLtPz+9suPPpK3PsLp618O7ofmFCv9Ut4f0epWRMZKtMgdiHVWFGM/Cfke3rW05j5tyM/59e4Q4mj/aZbkYBWkNSlv9W4h7wRgWqIXfPkMnTbWRgmCrwwgn54OaNXvAHZzd5SiqiZgtZVMI26+rbBh+hBl/hyVk7ttal14fc8XreGa3jitexhbAFDlpt61zOh8LUiRBuYqSFs4E2RMQ/l1vfMtTb9+85R7rTWZHpW6aGqknCkhxxpqczvOW61yc3erDXg6XiVj2jNh/1Gl9tVxGngdGL5VI/eE0+c6rJxYRCz1JvpZ2Yw05qm6+LCjVEhZyi8jpVhX1PLQyeb7vLiXWY8RQXo4SswTPHJRoqJiyq2aLubQFgf14KKfPkklAl8nsPMagSE4TWCNGwE/NsFgffbjlZqP/wgoh+VIry3SmHueuOrkPmwKw9xMPwk2sCrNoziOmv6SqeHDIL/vCXK7XDpxV+A7muOoKVNMBcIWlmjNf7p0K1NBsVOc40DpVsYSrTnOkPhGL+/b9d264R63mwyvkjK8znrVJV7fZheXQgFXSSG5aACmTkWMwS1+xTJscQFRkdPvmEBBFfprpTNsulDFH5Yeiwv45sxD7PPTnts1OJ+NMnORBR+Ga9MHyJJXWTd9m31M+/so56x+qaEET7CF6QOq5ZfVDZwyXBiwkY4+tnSfeJB4f8BVLlJ6exYnq/XUvJNHl0klhiDFETMObPxxCReBvfyaDo/KclruoVsYXaPqpz1Ybv3kLMWl0jpIrtSbZfLO3Aw8JfaFyBkKYzHHUd+8zPq9cFq1s3FVYVx8qnxGBElDJUse6gmFv49Vv+UylK6na1phDJCgg9lrOU1pAwp+eHRjmA1I0n1dGO6FXKBIr/IPhguESXxZpOcqwHuMB4Er3OqKDDqdhi3MVUx9as8xS6JU9uxQ83TPm8AxvQuC9wdEFw0mvaL6SmJx6ppHOpHGpXeW4plMhXHX3ZA3eMoEYxI09g/nFiT3v/7l30X7YMcM8XYzeSy1fs9rP17JcUAidd1qHk3wG34lE6m1HjwQyGrgxHobmxbzU8T7xaSCOe4ucvC18oEThQSkwbywLFhnzJW52qWJiOnft5f01NYMRCviNNhunHIiWvUGGS1LXO0kn4ySLgkp2EegzstO0LqsqlFnaen6+jq+fhbnxcXSyosX3yzhJQz982aHLNzLq4vGwk+Xl5eXIJMKfcRD1TSYL5YomwviTfGMgpjNBafA+8ObHe6nHpYqPiyn95Oyl1oPJnZg4lR4BAuwiVp4pdmHRkA42UdhCSxktUmjxxkx3dbtndNdattcalNcOTS9o+d6QweKMbDOooitkKlzrUixSqtUpg1NsDfSX2WuQVPqGbhLW7NC2GoBevFsDGJpNlQW9OtTWO/uQWjaO+IGjkVqf6Du+aewXy2/EUexMEw3gzgoMfX3sR8Y3EOJu5COTEQDOIIKx4aPNU0ElJgxD9glu0zmmfvcif1ITRVG1NEMfQoeaXjC0+4/bWSr29RaaMN1r36kuO9yMBpXj1asYC04OyoI27TdlfJbzjWXsUficJOWMb4lO1CeZ+yB9g/Qg0E2hONk8rFNccyM0JUUF9QH91G3CIsGZOWKh9Ch83T3/QZA3WUQ1r+Or+8CJFlluWXzry67QmWTj6YsjgUv0umPLtdKhjdojSu5C/jX1BHUtQgzrdnYYx9UFYFBTyAnz0AAF2AMsJWecZ6BRboF5272mmHIbS0O2TY53BbftcxoiwsokYa/Yu25x5/u1mnZN4mTrS3zcRV5vti2sqCiHn6uLoC2ppw3IHNqt2HZztz9ghb+4YCDVxfuGmxdZen1y/wjlCILjXbgdOB4Si0q1JLCU8owhJYeiz38qwt37IhTGHzdiMobMVpS7aLZi2IbIkF0xfB92d49x1nP0rtZmoLtXtjaW2yh4YxtSozUjqTOW2nQWmyhfg99CdDHw+0wgMh6SqEHx0gKb5SRQwZ9i0CnrsVOf/PoNuvhM5n6gkxUhwB0u2dRdJXrt1w0HTsDQHVZiH037QCkCEGtMjJe7b3BBxae/Obk5O27/a2TkydL2js8Tf+ckv38yQm1eXLCZrltfTrryN+2OWE97XXMzzaZJbG019G/MFW4dkf9aCs20VG8G1OIVXQULyX5jRaDeuJYS3S0HvAL2+0IieA3zGsH/3mAS8pMCesPLGOYhutQjdLatahhEgWZMMvkoTponxKUvgl/m+tHe460MlUKiT5zNZh4ddW9JLftZOKfjdLyn+LxKAbir5l/iNEe6oE0DRPJ/R9hlHizhqzAHyh2D3tUftaaVT7T/NddLbRWij5dbnhrBR2RXLaC3MTTk2TlKCcRT2lKOCU1Bos9dJS2zneWsl/Kstyqj8lqTmpGpqo4OuzSexSmih9Smi08D24GZ3k/RuMojCR33KExiX86oYBv/amL68Et/hXlKdpFSc/xu60yxXxLYgW2Ld2hAuZWkz6H6oFAuw2pTuPUtaWABWQSad92NeAnEiUnVENrk5O6EQXUpUQmQc4XVxBDYuj5UF/ZBKp+PGQVZ4zt2lbn5OUl9uIywwsLHGPVqApusrTfC+xS9pWyTS/5GYVtCSUCMLrlGsvWKuk7lKJ9aNWHrDOjQFMUsRYYgGH3ErcNds0gNaemMt7BjTH+/ejPrURqcU/BYxmWt8RER3er4NCiSLj6Ur5lmZi3rKJCURTJc5DCqkOfQ3xihcleddsnf7xy0RpgQkL40Z5LfRuo+NVHMkeg39aBQ45jajqMPs22WYeMj/VWhw2K+IaF02HgFrpCZ/Lb+nJa9VScNm13L4u7n9DKMSM5iaKJ7tz8LKFxIdor1V/odcJSy715pQ/Z+WDScGYNrXgoyiNF1oreaoSwrS1L9KD8Nz8XIG3XC0eni+e60y5QIW1hQi9uBdzCJLgHHuSSXm8LG8J3RlPYzFj719aALOWCecjOMnW023Cv5pzdlBtjPfId7fEO60sD7iCc97nMidR9pYvPpp2mN4vswyozt42y/l6cvBDUVNh//o0e3zuD45RXnNLdN5hQDvCLDYDJZhjsYF0S6Po16NhfR8vHNhgWmhdVTQPRcmiT8708v7E3kkdScqR099VabW9UH2yDp6NDmXPNhdx12JNRjs8GmftKUB2LLbojaE3HX4sJsNU8DFGi1IbwJBgkIzh3WlstUEuJ7i5feL/lbVRDn7Lt1nH8p3E6bt5SaxsmFfWiajRuouhD/V/5Fkpu5HoDJczFkrY6fU/lcuVldl6JYWV9fxWK+1s2UG6GVYgWzvx90+3NP+L2+YS1BChAFBUqW/ORrXKlZNZJwg9SQkEJTshH/E1KyxBVfr5yNgq+DZ6yeJKz3lMaYaDLbdTcdtANOnim9KVK+Ul6W2IFbfKXtqMZ0u9umvVDhrzIINHXiroeBZ/YDUk4CKx9aGLoMgruxQI08iRQjU7qGyE6GGnWZd3+P8zK17hg8GYA0JGRPzU2s8w/KEgb9sN2df2iZwvhaBwvs+5UOsdxAmMegFxQf5+NrViarkqR8F+ipcoR1zpuc9B5YB9kV/lLcpWU3SIbVS3xoWaI3JRoB37idtG6z9JYWodhLt0WUueRcVoMWBlkQ/TennGpriBb5//vUQRCfH6eEsB0rmP9brOZVoXqAf7rK+TadNU66vAuiF8il3bUD0wjPiNcyVfgtR8EihI76gemMT468tdXPqSDUR+RVKRDfhe8QJ154UjIWmzkgCClLRqXSkMqeUfK75Nu5RJ8hhy3wTb9NjlFnlfCq03iMO+hDQj8W5rE66T/gdElRoxQoh380g4G7eCDLAvzFhfGD0hx1vkRObRbGZfYwW4+II5DkeD7STe9zPsYqCE2roe4PoWJ+AyKnRGHqygdmBU0YvakCx9lTvQpyrZczVFZbltUEnaOFhY+SJQJy4hSsIp3yN8+XFzMO6hk/kCK8MXvWl5Eo3qgKQTmxP+h8f3CrHQgremh/QJDG+DQfnFDBuFESNmjX479eEGUO2N0JrJbznamfM3nFvCQIFThXTS8ks/XRXJBV0POqyzzo8uPNKXo0LklwmE58BvC/Dvk60I3PUFADpyGWFcNYGrNGYg2iSgYJletP0WDE70q9mlp6wXBFC9N87KXhR2ZlfQTrDr1fBIUIBdsvmajt4RoBak11bCeeNv5gPGJzZTTwnYCd5g31niV1+f+EJjtT5RHhNQmMuMQE/HBD3s/nWzuvXmztXvYZlbC0puBypslA6f9kS6snKUhVC5luuOiwGs8Z/I4alfeWeLIVlgjxn9+bIizRYM8WnDLiGnA0wiJ3CWMiTehmhOJA/QHj+dYi29NGsuO611A40oZRyzTxfTN6y07Zj47IwChooTtspEOdGSsv/w7vdaDrWGAviRAdotP3GFz68GrFI2xKXCW1m5LZuzCUDMfnMs6XwfKZUKjN88llaOAJdowwYGChxB54AqHty6O8yAjxbaoT6ue+oAIck0EQL6kbFaMMNIogeKX0rct4FMWtnWowuatIIhQTZHspyiX2WwGq0UyBx60VS17S3ShakCmwmqn9nZjczhWJWbcqasifA5TX3E2BJnnh8M3O3oft8Lh+be/7H5FC0kDEKJoSxyYB5P2lBvTqYYFo4QOhySdeJaU/TQ5h1N2KNZ1tvy5ow0CJTOUwo8sdzDjW78Tn5C9q2soT0FLpuOMjMz+/9qetbmN48jv+hUw6yoFlEFosQtgATGO4sTJlaos22X7krqSVco+ScQggAAgaVpm1f2N+3v3S65fM9MzuwuCkqIPNrEz0/Pq7unp6YcQCv4NgMkelSBRpJ8zVSiPzd6g7FCag8PHlsNz+T4q9vsz4+ZoxqpHhhGdPDTCLsNHma99Ld116S+cFft5va4zkApLtVhsh253j8tDo2+DizawdgtKmvBpu45j3S5wubw90655SFEaI3kIfRMU8P0KpN3vyCAKLhNwe2iEbmQrBCI/Akb5L38gldtm9+Vq1T/b7iqq8YYcEd6eBaGSsMgwBe8I4zXglbtaXl6t0Jqie/GuGgIPQRZLGVcvX22Kn5uykTKTXjsfQf3vajWyw/gTAhFQF42a9F2fCjRzVPlScK4zvmTgXeXqX+fn1+U5LNFZA85D8BsXC8ZwWR2+hk25Qadl7oigf8MxwZrD5vk0gLdJWsdXnHVX5yvpfP+cI8T8c69D2Ll/vD1yG/5DS0/WDJDAYFyzU6YT3KdPHixKqdwTRipv9CTYZOp3j1gwYVddogZ/17UVaEvPJS34EWb/O77vXLdzhXF/h7TLj2CQ399DazosdWZb6XcYMh69LY8cNR67eVCJFlqjjFxXu+tsWbYdPtcksPrHj1RvHD/XGFrVqX3f7yuQNJeH+6+r2wpNl1ebzR7DT8DyYRzNs3V1c9hlqzPPUq0xqDCW3alstsliyTSCrgJoqTUYLcuhCXG0y+5GlHqg/4NwYHvhHfjPS4/KTRfNV7nXNwdn1uA06vyEgPVPiet5aXQ2L5RfF7/qkdKVgpHLu54oXofPVHDP90B/Rl8qzwB7/EJcQj+n4XPs4OGI4S00Awo85wWxloanPtV5+tb15k42WK4xJFt5qkl88hpRvaZSsqxWcMMqbzg/hDHuPdVwx/rXVYcfl9fV5ubQb6E1/9nYOGX2TKehau3AkFRMIU8VJf2sMQQA5dpzkq20eGy0pgPAFkAikE9dxj4EQ0vS40R+vXNcYOUD2edSPO6bro9nyzWnaMSm2nXSNvolrflfS+PDBqNacFZ45BY2jq5bXGsvRQCVkaqdEvp54A9YG80TAsPVO2S/XE1tODl28GytDz0FqrTQLwU6qqhp1QYY+RVjIyBARRnOiF9AOBwcoO08AXnZYVhg2zb3utlRYGG3BOHmGDbTzJXC342LDPJ7zx1aohNcAMniqAz8A5W/uHkv+H9k/wWDfkH/JUUsjPAF/TdQwmrH72Evz4xZl0QL/+nu8xeD3356/tNzEytcgq0aOiYPNFP9zejt+2gYP3TWFjNY15myuTUWsbBFNAy6ztjrE/maiFj822896Oun/ejd2+eqG/r+0/4/nntdN8lptaousxUN/UyjMxlP7188f36z3v58CffKa5KSeIr2SswW2I/fiI+eiI+baouhduO07Lois4jyxLvvicMgjKE5ZXcu/CD80IhEF8Y+e+J9hIXmv+NCbBBJvrYbaUqR2H6qV/XeSXfgplFu69XXi8jxTF8wfoZp/qKjcehS+92vxTd4/na9XMsdntkZKxsw8mV4M9SeF7zoBMFmCMRnlB5/EM0bhffyLYtsSRDdqtXe5yNu5GbCJB8eEweHPVbS6jhaDSH+UQmRpAhPiY3dC0y1IBe2jC46eqne49MbMOHXcNP1Y8RZDcYv3TL/7apN3H9zC4fFCqa7XXZEd7kFngZ1kLMtD5X760to4UIeGmTTShcvYiJ0YO9yfeo0QGzy9Og/1YjN+HiLzOlCiG3Ke7gkYoyhv1sXEg/L9nBlKRUOETSNPiEI/Qp2RzIvO6eYvq27uRfD+A7uwiBxNMzfzngEZ0MzlG6jNqP3Z0httm1dwLSFm+gWl/ku2927WB0SyqXrQmIXTBoaDrvzw4HS5hOu0l87V+3x245LNSR5F/xwJ+YK0wh5w3xMrlqmlvwUmw8QxGQT0OXIav9/zC4vMbWUUS2vyNpgtReebLs0SH25y7ZXt8tfG0z06rAK68KnlmrXth7+zV+vS/NNaTMlxxm6p3AZ/Dk0LMF802fAUL2I8dNVCVNb0W6Z1FBQaCQQrREjQeSP+svznYNx7sN4F050tSmz/VVjrtm/gorARZYZbO1ZtoWdq84pltjZi14YR+5h0M92qNTceJGjTBrlmy3sQkmx9DSgPy6oVwp5Fo6wJVLdadDKJARVJo2JfnVT/PzVnziMmamuv3GtV2gGsQ/BkXHEvqFi5cpsATUajfjnUMIG8i8y0fy27utoMrB0MqavTUfh64JgHGtYLNoFWiCu9N2qSQDb1ebQWIB370gFberKT0+6COCYMoLzwo+sOOSstlvAwIxSwt3sKwnYEIgq9D4P8hIB46ByBhb/CibUFnfOb+CXCbltthsM8hIuhfneWI5bS+LqpHXU+QMnGSuhK7j0PpUuOUPYudc6y7a2y5bQUvbSsT/A7acYOXiwsjt526KuyOr3eVIUdb1I6zIuF0mZpcmkSmfzeJHHeTSbAT6VWVbMsnENf1VFBP+bVXkxmSRxOi7qYhwtynhRzaOyjMfpZDavizzO6npczfK6Los0qZPprCgm87rKZ9MUfiXpvJplOfybJfnibDDCkKhkT1X6tnvZanuV5U6b9Qlmm07LaVzNimScRPm4yKp5UpTZfJFE02qc5tOoTpIqncRRVcfRdDpPs3EyrebTWZwXsERxNYEG9aTO4jqflvWsrOvZrF4U03K8SCdRXsGaZPUE/pzF81kV05wn+WRR18VsPi2PzLbIdvtPONNoMq+KpKxhvvPxOCpgM2HAWTJLYKfmeTEdz+o6T+NJGifjOsnyeBpF0yiZpeO0nhaTIk7ibFrVRZrnMIMiSqIkHU+nBbTJx7At82mWJCVMMl/UY/hzNl7MoBJgRl5N6tmxmS4P93f4aPAp0XgxT9IKZhWP66IYz2CDx2VexHU1L8ZZXEV5MomTDPapWszyaVHBZKo4K+IqjrJ4EZXpPE/H2aTOozlMKJtl0ThK03QGaAHLNM9qgJjPqyyN6klRzGaA0Fk5m5dlHc3qNDsy3XKZXW/W5aec7TxdTGAX6mkZzWB2QJyTPJ/X8XgWl/lkUiVVHdVpsgAsH9fzWZrl0zxLx/M8jqfZLIkW4wzwe5ZO6yivq7RexNAuWqQ50HCepCkgfRwlWVplsGyzKazUOJuX0aIG0Gk8jY/Mtl5l7gD4BFPNZnlULiYZIOU8ntflOEnS2TRbJBPYB6C5WRnDTlVxDftbJsl0ESeLBSD0OB9PxnFU8nbnk3o8i8opcKt5WczitMbtLQEo0HwalTGSQzSuJsUcSH2aT2DRpkkSRdGRqYJgfrOnlNifkkPN6nGSTsbjeJ5MoqKYw17PiyiL8rTOpllc1oDoUT1Np9MJDC9NJxmgZbXIqnQ+rWvEZdj0qADkhHlNFskCULdaFOO0AhY3r9IKWF0Z58k8n0/mQADAw7MIuEMG/42m9ZH54uWQwoZ/UsIdl4sI+AWgWAk7OFnMkqqA8c7hzKjzMkUWlJfFJJrk9XQ8zot0sQCKi7JxXs3m+RTotFok0xqwNAbmFVVlBEg6LbI5cPekiPPFJKnncV7PgTKAUWeztJgDQuRT+BARKnNQN8kkvLq/3i6z9aedYpHFk+kExgocsiyqaLEoAWer+aKqprBxMRyhsLlw0AC7LeCsgLOlKuHwKeYJNCnnUQ2rBCtUT+DEqvJoUoyhMZw3aTxPy3G6ADZHFefArMY1nFz1JAGiGCOGFEe2dFutL2+Wn3S2cEiU+TiOkwoYTI1nSpTOEVFBAChmRZXnJex4MZ6OywS4bjKG/YjiNAHWBEdunOVRhfsIDD2FH4siTctZVS8W1bSewgrCiZUn07Is5ot5Ni4WiwIIHc7zLEkB0+fRMU68Xf76a/YJp1rMpsk4mmf5OJ1Fc0A4QKskgUOijpPJBPB3ms7Hs/k4jeK8nGWwrdPZIs2SejHOAZfhFJnDITyZLYBCkyxOi5RoOgKWniSTMi+BeCeTBezuBJhYlM1zQGg8qMq4ho2eHpnqXZWh5dgnnOxskWQwjBhYRwKUU0eTGLEviqoIpDwQpGY1CEslsCXgyfV8AcwX5Ej4nSSLYlbmaVHAHqYT3PWkjicV/AZqBvEhKxbZGBjTOJrA/6tpXERRBotapVA6jmI4xopxF2MyEjUnoOb82eTxYwIOSbS1vUm1fbPvVb+gx0gJJzNcOzD/5S7jxJxX2drAyyu0RWWLt5LiNFnlzKj34xVl6Fxh0gu+L9+PlK09mZXy9caAUz1QgmsEfr0pb1YVeyuwSd9X374eWl2IaDocXLmoyaMOqXjYPI11Z3K9Mq/I4W1O4jSPvJGFqSCG5gm+Xl7e+Bkf6ZXZXvAe6WVo3gQx+sZBPn6vr4NP6fnZw8CbJMbHVqPBn8ErlFIuae20H84YfRgxWCvWkk+V/JRGpOgUWPeDMJ+WiX31xgWceuv1wwX99/IM78dabcvD8VbF8f0e40ZeV/TIZKPJ8q8wjCxg+j67rMTL1Q8nK2U6dK+JDCWxlOSxXfen4saYKJa6+EwvtbVXWO6vurKViSozSGlHRsztvnxhTQHm123EL0X7/YNxvzOPw4SdvwTu0yVmo4et8+sGteArvvX16XWnBaj2V6Q6obWrXUVYwCDC1IVUAQSj+G5mua99O4L1ZkMh8C3IH//7u7+8++bb719/iY93Y4qblkG13XW2Ql32EtFJ1331+ruvX/351Y9QO6ba/DxS9miCkv9KN/jqv7DBlz/+BVokYYvyhqPZU6ozsgHarM3Q1pt3ornHpzD2+uufrTfn5uuZR6J/k8GSg+dQmOHQKP93QQpZCe3MZYOe6kh1e6qJjW3QMLHZhVQqtjXv3HRdG7Pc71SyrY7WZtlc49Pb7J/QCC3wLneV6ueb7JtmZVKIYn5q8knnlPbXwAwoUTQrHA081mMaaOj81NUzGZV4c0Ts7arP++3q8m9TyhmYLRxyh2iHwzk41RAlBW1X/S0fn65+aN3hLJq6QAA5FFf8OUQfzlnjMLJ96ckNASQIg0Dsvw3YdVuBMHK73C/h40vT2T/J1LcF7UwR584wo9tfZSUqxU11RNsf6Fvf0phQlmnCvoymAYWYlxJjU3Yq/tlcIaZF1Kjpnqa6SNVwBsctmXDf4Ts5oGjLUkhJ84xtChQ01Hf1zapGw42yBZgtOx0cb0UrNFP0FGBGlGvCEqX5iaB4aVsAccET4KAJWiscLDgZDrtbtMDhgpPgBJLeEfRWBwd/eTli4nD2Q+KspmxLMDmgDp9vJEIBYSCInMIJBCVfoDsj3uo0guQ+bE8771A2xx46OtOO9JHBOjiDtwOb3UF5aMuiZXSZ65vf1lSIiUc47OjdjiW30Tu47hzuyULeNrnwWggvpSrEUzo6Lqt/U8fG1PFI35YF9XXak2ZxR3OKGdTelIo6mllW68/ZiIMiIVqZkMJcs03QF18EPQxCibGzurKtdUZnWg7vUypis4iUIMUEOpOW/xj2/AqDsEfl9cqXCxC9qWRkbg5dnXu1Ovo5fdzF5mZV0tDzytzzOob/0IWWRmJqRudsCuxtY7IrKKsH1Lmr+M6+gSX6x/HemYCZ5pfyhqtI2Ytj0wwaoaLZqGxirr3EvrZpBZbyaOw53OYgmvyszVAIXtwBj0G0JNSR4KVkBodmUWeD9u7YY9uW6OEdGZWX+NpbvFfX2xWH3CVpXeUZskad9L8XYjLI+zx04ab2quabtz0KQMAAzYZwig97jhKnkZdfiTOjViiMxK/KXrj7ptrjI8xa28U2AiSORGp7SbbLXOXlSymy7FRDOIqEuI6PIKLYnhYbDlHtdURfhz1h341i+U4GfFwiVwbjChacE7LKNrhzS0U+yVRFDdfDVC7w0Nj9cBWMg4M6Dp71tOgNJJ0VKHA7IbyPYWkAY+6tYZPEvFgNXpqYRj5y4P1m0LPHnIEUnmNCKC311EHLw/sKzfKv3KD+73/+d88kwNZmL3toZI8Kxi1lYLA3+P1nz1yIds5aTwtBP3/7jXdaYZepYRgP+qkQQx9yQiQxzySmYAFhpDU7SH1/2e6q2+XmZg+3l6sM1jSjMb/UnIWAmHN+zxGnKNHDGvWwpTg626VxM/O7euliCdCM1Ep7Bw+7n8NEmugrZNTdxI7TtpXfQ/+nOHLAZbMLQNM7kgtw7vyXQfI3/k8b6p+TPWKQQ9oV9EixWHW0R4ttkrgDcW3YC79qq9amtEagBxpL/cUnNw67jII5g5aIHn2zFQ4N1fIPiJgEGwnBNkBanxAjiPAPREv7rCby4VqfNYcqy3kwHvC+TswNMBwdG1Ty0DTy2w1y+hyfPbAuRlPTmj1sADwD3TuoIwtVGKHVx3m8Trt/NrtH6jMpBN67sAgUJu0OJB2gYowka8fDo0DdUMvsHJk1O6KEcAOJ5SRRmZjm7xXnkgBtd716+UtVfqYgG7P6Vqy5CIeg6ZJlU0e3/u82wv30pMuXAk27bWP2jrJwCYeNL+373Eq93L8i5Nb6ij20VDuFzlW4jdDpOfCVuWgLy9F1OjTaellILCFWoS7NHEDQMDyEmlxI+E8XUTuWs9kdofCn8A0birPBQEzGI9rcdlJrkX66bj/DFg7hS0rd/KmF4T/GIY1Gw5zqu8qTYzS557vNz9W6OS1HnD4lDpvkbaiXH37vsKt7YO/QaYOH+Kj10UTNqP9WJIO28/iJJ6mmMaau9pV36J6tfdQ5ijEt/KPBeB5BleYiK1Rp4dZNdZclg6Eni3mrIBxaZYJqKfUwv4UY2nhqF4G0gP8ADOwE8ilRjVVFwflhlsTuhRtV/w2/dhGEt0/ATT4yTjwnOlqE6BzW6DwsjtKBd2Soq41DlQdzw6uZEnaV0eJYQrnDeHnuqlKhRJKRat69XmF4pV6fgFQM0Gu+rvCVR7WkeLTI6hyIUmJpi0qLWuCp9EwMS6CBsUBBk5S7CjOj9DJy7Kehg7y0yyjG4WjwTJ+Q8rzCcVw+/9z7yCnw2rbLLqQt5de+ynP4bCZqCLTzkq/dpj1mGu5OUvX7XjKQWqF2iCFdnKoI8tU9vTfhVU6KGepg8HZoH/i79SQkgQeWCkfHwI+QbyjYGFz7OwDLQ1TfrYscQPIgOJIKg177934XYPsopW0sWuDbeo0eAgjDnidMH1F7V6U2gWjp01RrdOm3b/bIWijbnaU0Zz5gPqHtQFDbEhzzedNCf25pRa+ryxXghu7FfvRtFF4Topm7NAaD5gR0FAaUl+MkewMB4B6+5IN9s0XW5z9hv862ptT02qggHr+93puzP9qFGjbX00YxfeOvzrB9MVV1tTDDtjW0VUejkZed7617j6aQuY885j/+KMxb0XgSbryVMm948kupOS1aAD35rbQVzpOh7Ja3bVDw8we/twqUJ7y22kC8DSAdRm2dMBh3WsBwwcmQBM0agOT7h7whB1utdPTCPKy0GdwcbTSJ28Epz0r6Yc7F0jlyafzIpypzsAk1iav7rfZyD+LraVzth0vQFOzZEE2Jah/ao0gYH9Mjgzi5R4N3/Q6DM2US0D2CNnO11sBbimQUdlGyon8zbjlLOd8yyXrTm/7tglBoJmuPgB34AlWY09p4+lMMAUtKPFd5bjPn561xUId7+hpEKwfk1ihFlRe9d0OQXk6BT+as5iagdBDepSCvaqSY5WEv0rqcGKjkh8lll9lyPerYR9O769ezCpAoaq3Ctls4b9ncK7fYp9E8TJptJX09ZlvQvkzNgV602q62MwM8cvrLtVjR8x+vlfSvLVmNZKKi4DMcfT1VhYDzy2ov2UX4gvSf0B2a2xtzHh4AP9mhTzmaK/JTHd8tTAxdCUm3uj+vrreHewbmVAEjsnh0+rY7kIXR1oBGUPYwIsCO7fz3FYyt7G3RCjuvVpu7kU63wX7tOn0AE/IBGE51oBCfW6JiqeIMLriG3SP+KRthGtP6sdTJ7RV2mw9G0BrotiMRtFC9SX9wIQ5mbwczlMrSkhefE5S84RLTi9EayObRPdKbUGMS9v5N+EGUd0k7qd9IoBleVyuRTPaw4IcN1eVdLo1ThMs0Q98xRgmtu+X7FFuaqzBGIloIkvqhBN9TS757Pkg+ZluXH/nZReSM0iPRV5Au2ASVfz+Y9D84FjlpTPJ0QklloIA33Bc96dMjFm+VKNFF1dsgawak9TjVHmbGsbtX92h6wVoBWRlka9la0HuHnvN7zgWwlkU9J4LoL0fVaOi+cjxrj2SMbE66YtFOOEtUD9r1zf7giAXqbzZD3E72oJFpUkgbfD/P6hp+NgHaWiNy12EqDsZdkAQDJwP2JobnWMDQZA0EKVB7ckXq+SW/7uEhuN3syX6WMCQADrgGYAGXq5LhEdVf8OsXnQd3FfeOPjocJgLECV5/yh5F0tWQosn5SCgrC6ssJGOQUNURg0B7LXO15fR3UV84yqI5FAK7A3sYs1aYZ+i9Rhi1i7yrUp4cRl4RMzAcrDx+oKvXci1Pc4iPuyUs0LqX37sde+Zi/hLFXXMmpddGu+OGKjrN6K3R8vqvkX5Lw7QGQt1+aUP558jnryw+DBmTkXbMKWNMx1Du3977AoBbxn2weyH3Y5N45I7d28hV/6Y303DoYDO5GXfxN6fjsIy7Kfj5R4Ztg24x3he5O3zWfIbxdpWYxE6ToOrDn8cTkU3siAjEK/ErCgFalLhobWaRSEFpIo8slvBer6pTLQ6Dw9dIKWgAoz+ECSpwYuvN+jyYnPTpWfa1T47sgK0sJnrK7oXtwmwTXI9ItfXa0jQj44ynDqna7hJDlxOVrxSevNrT7Y8ZKyuNvNMCGmlEsxQVXIvn7i2htZwLALgHWXtNsI+OnqBv27Rws0bX3mndDsbvzkDQd5yeTY8ZQLhcbfJs5RNuu9zuZUNtWxbf3WwQZkdxcXe/8OPuvg9sQtw7im87a5XwwSWg5SnmkX2TzKptSNyYYysWy7r3zXisQjvACPcY1BZG1aO3dstsfwWUzrne8YqIMIgWf9X+8OV6eU0q0L/urAmsNgBtrfaMgsAyHBjwq+vrqlzSK2rYXJdSq5pCfamwxMNe5Gmm5LrfV4pnJFCJyjbsMfph9DmKEifoqK9l0tJgLm9Af3Cyqxy9Eza8q4xyV56ZOsu3FFkMr78nOZFZL7TTfL+Qm55WU6SDThW7lbw7ZyJpBpWHjyRXbO+woaWUD6acN8oV8+8HL8q2vedp4YMoGfbTFfJGHfUyMXxu4BM0boSBw4oepz/pQg7ByKZvlt3pxiuHKjvdCaoT2IdC+mGj/dICaFj4ZIjfaDe7AOA3GAz6VF0/o1YTlhScDCj0qTRwjCblRDC1H3DRwQsjMX6Aqj2YWl+zfeeD+kXDK1NZhRtKVHnGjdG3sau2BubO6+N2pFxUjZbx1j2pf4Gesm2Rd/1F7Jt3HM8DebN1spgTXK3FeMeRrS9q1uJ9eXAnuvsWeFR4Wj7t76Ed2Xi8VmZ7sAgSmESz4MVjs7zHvO43evLG5F73Wzr0+9jbPqzpgK8PFc7kq9V55IG2uHVZlOhhBtu2i44V9fFtP89MrhoGqs4rVovZShcBmlb9DjyxxU0nD4fgcCHpN5Heg48sqT843gnX6QyPjdKJF4w+IKCXDidRhNG9f0NB8NveMpqMru+Q3+WKHgZy+D78YH6rJbdLoL5daLMetFFGa+Fsfd/bZjc4h0sXHoXSv16T4eG10e+75d2TnlH0ZqhlYtml1wd0xxmC7L3e3MB52mgJghXG2qiyazebkdCJRhjflasxE5tC21MmGARD9YGqPLAFhld5rwp4l6x2/cTTKf6Z20qKO/JRZ0OHDT+EKFVcsdrsb3akriIBz5+YmGgDLq3uz623u7slkjYQpJ8N++rJmEvddHPOJuydzXNM4ChZbamlU366hwKDrzt5eGpyeBWEvP1K2+mdJB4R9qfViXNoYzPqL7Q1jHzsBzcoTuptWvxB9W2/hkxd22cF0NSt1wH9/XGgerbhIfcQrIeem/2b8Mje8Jv41I47NAvyu29u8/74pmoHlCdsq68XfWQlOBYG5Z9slIZmmo+gRXBFbu1FBAiP65lnzXCPRdBolX3MkeZjSrGqsp0vB6EFp/3c3DM7NLVTHdvzFHrqWjlYimJHQfdtBgMUbjcCAHk4qRJr1spS2H714nG4wsTupM9db9x4mXoHo2f+sj463hBV3D6BKOZlweN893TaNzUjz0wuL5eW2S2wGz2+0Wy2m9Xmcgl8u7fZldWOhyz5jpSGTfrDwD5NtLXiQ2Mo3RsAh/mBgA5ORz8zHXbFuc6Waw856JQtlrviZpWhbQPmG0ILRYwBhMfrR27HOwPa1Ru0qJ/ekSqs70yEGhYQZwaQ0u2fDfz0iY+hbVlptD1tATVmIHMIdll8WAhrXLwws02tTO38/HFc7cbUB2X28He0VObkxvgA60lIy1qb8Yvop6QffFLJyNcU3ew2CE7EpNOkIvZk43e7PT6lO9DP6B2CJFPsAChGxBJ+JQb8opec7NC7Q7fX1UokHunYiBnQNUJql8ma10wSkxi2XUoUVLddd0wSzbCGyltM7SV3MYXr0jL1ey+t3bZDRdlEeKWjcy70ckSGwkvjxZsfu6lI4dDSMwlxhgZyS4ZKDWlIftKZp/pStylSc3UZhhuOH0zr88+byNxpid0Ooo0eOkCwjcsj+l9BvRGp5j0RgiN7DDqnKPJUV/CPU3K5tYlnflKgh+7+D2gwQcFHtJFuaHSEKCtpmkUX/cq0hNrfaiswpZP+3e80hzSVWr+O3plk3/TixEGqoLfP8PPQzEXUISYTk/0py+9u9kbRQFmjZZm0TgVWtW0C/f4bjMhzzxF2+m4Y9HW03LtGaGQPM+kbpvOFaIhVppoLr9uRSTyjsonrJddUb80GR3CbBqJcQ4/9ga8Wkt7+SUWDBl156ZM8+ZYnNQhzPLVlKAzi4jVacOeqrqzGoKeWRWFwHw6ANc/Q7ei93s4gT6ahq5aUd92xUhpCThBBKLzEdNAPopZfrLwonCEpDifyjBTsa6jUsDpAzbi0Xw2cOF9nvy7hOmzjblJUWOWBYB+82IDEq1c7/8cSzWbIWg3froWaAlcGvgBovYeyYdhU+zWcjwdxdF3f2xgf4kiEhqjX6OK9p5S9q3tnTOX2vMEY4Vvj2BGNhkgfL70EUbdHX8DlhVAy6LJq0SZM1PhmkewPKgFn88GcHXF4JzHD1DOXn1fEm6rjCkQ2gfJ6u/HX0jPrE/Vj81BtIARZW8jfg44gUi45z3aFMYgz7fGOkpm349aIxXLJFSHbyCmLrEQC5GkDosj+sJCyFgHFCIsm1JBYXyzfagmb4gK1On+88PIy28bUp4ekx09I7RGo4v/42ZD9UTivkmAMyLZ054MPH4qez1OO2A+ZjvN4eGQAJwD33B8bso2iEzF/J0IJJLqAnyBBYCAcdz8QZ0YAv1tWt2wbTensTB7hjGK1kPIYaEns+67UDUPuF57JtfKL1GZ/WK2oQMq/zkQnaxzgia+Rl6R2qUTdL04Ir1rFFa81MDxjp2d1ic6UUY3KPLqv7j/TNG9YR8sR/CFEbxq3RER2tOdhGL4DHEdeYaFKB4l7H1pghB6MamLm6ixjH/a8/MY+PsmhSKjin+uyQO41zT9KTarHi6AwdFoULeOT4uXpNerYDp7ARcfIgngZoehfaSfmTjH82Ira/faS49noWZ2BEY0sLba+f7PxUeipAmiEE2Mbx4SeWErTV+NkLFT9vaFZrEBhtXn2GOLcJ9ELXOz9TVFU+z1sD7k+b35WZLPfVsWyRpN48wLBlvO8yPDZCAxHx4U6I2EQG/XKJPxBkeYeJJq1fxQb6XCzVs6s78P3zSMShAXPoWf0+g4MRfXfY79CDg8KF1WK23UVPJG1S+IMUI/2QiuHPn6LBHDTJX1o1qpVH8IMe19cVfRKG/RLttAMbnuDo24ZSU8YNRAiW5BbGJkxgWJLKrJKX2/E5luPXS4O+lQ4ZdS8Bx5auJdb377fCbCmvMGuPpKp9zwS9Zldj/R67kJDuG8uWfpWZE0G1RO0/WvQouZtY55t7LpnA0P4Oo4Gl/2kfNaftwoMbebenFALvw2J5Mv6QFkyNA7KOuxRC80gAEf2KA+DfCIb0/MXfigShUZ/FMHb8I3ka1ZyjkJ1bce2Pu0QdPipfLuOaaafFLrNJCNu9TYzy/p3JddxHK9KS3YtlD/U95EeZUIFXu0LatUejX9AyMFthzMr9J1gYwDLMpDLjJz+o5NYP4pUuwn1OP1dtEtCXeJA+DChLH0/rRaj166SOP4C2W9DvkAnJFbGwiskpMWj4tMRYu4IIEHiaiAhdSU7due2tDuqRGp5jrcBKlqUmp+F/q9aO85hLU02IAPYKU4agX/6DfINdfT8GQ9NU0Hhtwn5c9roWEtpmgTcQgXtHvb0WI7r8D2D4WZUWv6OrzlsGEqNMWoNyAHve6/WKCUSm7CmyN8bN0UvcQ1s3v8D4xGaW9cpAgA=
+</script>
+<script id="@tomlarkworthy/observable-runtime" 
+  type="text/plain"
+  data-mime="application/javascript"
+>
+const _kvrivm = function _1(md){return(
+md`# Observable Runtime (v5)
+
+\`\`\`js
+import {Runtime, Inspector, Library, RuntimeError} from "@tomlarkworthy/observable-runtime"
+\`\`\``
+)};
+const _a188e4 = function _Runtime(observable){return(
+observable.Runtime
+)};
+const _nz6rsh = function _Inspector(observable){return(
+observable.Inspector
+)};
+const _1s7i28f = function _Library(observable){return(
+observable.Library
+)};
+const _1iyzb44 = function _RuntimeError(observable){return(
+observable.RuntimeError
+)};
+const _b2ba5g = async function _observable(unzip,FileAttachment)
+{
+  const blob = await unzip(FileAttachment("runtime.js.gz"));
+
+  const objectURL = URL.createObjectURL(
+    new Blob([blob], { type: "application/javascript" })
+  );
+  try {
+    return await importShim(objectURL, 'https://api.observablehq.com/@tomlarkworthy/observable-runtime.js?v=4');
+  } finally {
+    URL.revokeObjectURL(objectURL);
+  }
+};
+const _17n6uge = function _unzip(Response,DecompressionStream){return(
+async (attachment) =>
+  await new Response(
+    (await attachment.stream()).pipeThrough(new DecompressionStream("gzip"))
+  ).blob()
+)};
+
+export default function define(runtime, observer) {
+  const main = runtime.module();
+  const $def = (pid, name, deps, fn) => {
+    main.variable(observer(name)).define(name, deps, fn).pid = pid;
+  };
+  const fileAttachments = new Map(["runtime.js.gz"].map((name) => {
+    const module_name = "@tomlarkworthy/observable-runtime";
+    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
+    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
+    return [name, {url: blob_url, mimeType: mime}]
+  }));
+  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  $def("_kvrivm", null, ["md"], _kvrivm);  
+  $def("_a188e4", "Runtime", ["observable"], _a188e4);  
+  $def("_nz6rsh", "Inspector", ["observable"], _nz6rsh);  
+  $def("_1s7i28f", "Library", ["observable"], _1s7i28f);  
+  $def("_1iyzb44", "RuntimeError", ["observable"], _1iyzb44);  
+  $def("_b2ba5g", "observable", ["unzip","FileAttachment"], _b2ba5g);  
+  $def("_17n6uge", "unzip", ["Response","DecompressionStream"], _17n6uge);
   return main;
 }</script>
 
@@ -15831,13 +15823,7 @@ export default function define(runtime, observer) {
   const $def = (pid, name, deps, fn) => {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
-  const fileAttachments = new Map([].map((name) => {
-    const module_name = "@tomlarkworthy/observable-runtime-v6";
-    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
-    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
-    return [name, {url: blob_url, mimeType: mime}]
-  }));
-  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
   $def("_pbnbpx", null, ["md"], _pbnbpx);  
   $def("_15w4y6v", "source_gz", [], _15w4y6v);  
   $def("_recuod", "blob", ["gunzipBase64ToBlob","source_gz"], _recuod);  
@@ -15861,7 +15847,7 @@ H4sICB8jLWcCA2Fjb3JuLXdhbGtAOC4zLjIuanMApVlbU+O4En6fX2E4VZQza5wAs8yC8XK47FZRNbcC
 >
 H4sICOAiLWcCA3BhcnNlckA2LjEuMC5qcwDtOmtz20aS3/MrIF6KAWIIFKX4ETCwYstKnW4V2yfJSW2ptKsh0KQmAgF6MJTEpfDfr3sewICknNzdbu1+2CqVOK/u6el3z2Dw7bdfed96bxdFlkPmjZfeb9U7yPmd8BYVL6beWZnni7l3tx+9/D4aeqzIvAsQFQjv7nk0/D7ajwj+g+BTXrDcm/AcYm9QzGeDH8sxLrtj4xxuPg/mjIB+fBENo71BJdIBLzJ4iH6rEJwwvCu99x8ucFPwzs9OvHsub7xsWbAZT1meL70pFCCYRBppi2rH+7kU4PFiUooZk7wsYu9GynkVDwb39/eIN1OniNJyNlAn2a0E3yW0uwbtrkKEew++4rN5KeTqorw9KgsJD9JjlQehLG8vlnOoqCfDj+oE1BbhFOQpL+AEt6eBop6IctZTx2ZpKYofX0XDYXQweAbVrDcy6GfsFmh1FbIihUqWChkPK5zP1Qxbx7N7z/JbRHYQ7Rtcd0x4ZVLAvXcO0r/svRGCLXuh/n27mExAYI/JckyDi4yX5kjYfZur0bdlmQMrqMWnJwXNjGXJ8CfFcYEjJLbc9i/4DMoFrUrLokJQaonlXJbYOFrgOWbHd6DQvGOS/cLhXjdpYQZpmcGnsxO3fVQiQwoNksEdT+Ejf4D8jORIQ2W6mOlZKFrwpu2CHwtR0oGhStmcNgRN+QRkeoO/P3FFL/2c8kqa5hmwTPHpp7xk8mDfMlF1X3zXdBdFSqqFzf9UEBW2TmZsCvaXDkztYsILLpeqKYcvLALstMix88ppE5W8+ongQDXfs/f4+1/nH+jnZzZX/yUdQs+8X8zGiuiC3fEpSpjaH8a/QUrHUval6LcdLdk5CGUiqHHY+4gI999RA/WMV6BbD0TSGSumYNl5BqhHyHB3INcbncH0+IGISwln/qbg2v5+EmxG+AR8XqByb4yjuuL/CqSjX9hrtetcCjRTaixn4zJXjUKyB0vCBSrxO6VCtndc2J684SQbsla7/BN3JUG9VhTUe9XpHOVsNofMjqE7BBQpZKrdKBcqX4P+7BT//wrsVouKWvqIv8L4vExvdbsUt4rAe3R35X3vKgjTpPJXJ8oj+MGqDslekKECqgq55aPXCUWwEj5EPMN27yRDTecTjmiCOvx5Icmh/mGAOhhNjBZ7cx9wHciFKBrVbhH1kiSBSCIHHx+baeR3zoSSY2ce+VTe/w4OVKwpyr4dqxtKcocSdErp7blEd6FsvkNFic7oyakPkyentk7Q8VsSFn8nZrQYb0gUwYqcpPREsqLZuOFCOC6zZXwJEf1e1WGhfDjqTohUGGOr4qpOYKSp8pgvwtURBr+WrBiS13qDFUVFgFiETEyVt6xiTsB84rsasJMkwpxDRBj2AAfk42MVqfD7YeKL4Ie9QO9IsEOc51EOxVTePD7u+L1TdE8CjRUPzC/3rhSufn/wl8tveleDSKKl+2pcsPsAeXUBGMuQ+dvB9mwXmiNVZrMgkDeoU552aBHDyWnhqzjXegH/+uuVrD1yMVxQXPYosmPszPV2XqV8iGd5ch2EqwJdRAxoB4pvl+wq4WGZuOdiirpDFqFTWkDMos8LVvGK6FQjmEOUt5Ch5a4qyYTEFeo3hCLDNv6vR0V0wyq/DA6LCHMDbETzRXXjp0FcRBUNhJfpFZpjmAZh0erMBHVmJdk0Rhtm9yjNKYZolldxEUZRhNqwqoNVDtLjJJxikec7iez3UXV5soyUm0cMlTmcx5KxGZQ0OPUZOoQiCO+pEYQ8wq0Shr+4WbKzI2rIMd/iSeaiMuo39XkIGhgbCFyj9leVl3noefHMmAZpVRSLFGMRwiLFqP/VAkOO3xXjCtIZ+wXjJ+nw8KAmfGp1DRQMztNyDq09evt91JVnz8ipRx/+apkVKsxRB6KGBy51x4FWgOlCoFHZyWiSs2nV7+/uPoG1xVPrUEq+R1u0wTtEVVkDRklE7J5xFIlvpli1LNJkZy8wiNeQaeRvCMb/MuYvIjQINLY/c8gzh31fRGfy6FKso7RYNE4ToFqkCrxA0ftBCFE1h1Q5mErv5MCcN1O4Uk2SdRFJ0V8p/bakNLh4QapCruCLuAwy9By42uS0C5b7PZUyK6LKhUgh6e6pPcJhi5m86RvMWf0gVoMY3hVKyCy9lMtVN+/Rb6DIepoS1/d3WOSSaHw/JJdXobA5+ojMt0BujzAP850z+DIaC5bCaTDa0cOsGTsLRmjiaPEBQg5H2kwna9BY2syYoZlN0CouBOM5nvaIJlpUwVhgcmJchGGycmDqiMGoiu4wB0ksDS5vaaKcIHeraKYzj2RHL+/3t603ixSArnogc6VKgcmyOb2B9PZTgX4c00HkfgvhLjgtMdJtzq3ty6pecIirclr9xzdUy7ftpieC2GJs93cX/8Lyc1W7WYiwh8LGwwsVDcygCruB4RdKqGqWmzBy3cZr75uvVy5Y/Y13Q3VhjhLMlt4YoPAypYqQXdM+LMu6+6AdqMizrsmV1eRGYXtBUBvjhrprGmtmryZ/Zssx/AmW96XInPTTqkjY6yayPcwGfh/Y6guWOuuJLSFw3JNDW63YdgR5jia35uiSvbDrN4fhpuMzY+QaUomWaVSqDSzD7zBTVLxTu9gUW7NEGFE6CiOUH8sSEer8LsHcINIEuNTgYEvFOlnWvTVxaJszInKs/zGkCet2dEaZ+VhTKEhezBcybK09UJ6oSlSGcoEZTYF78ISSipCpn5ErdIfJoevDtSH0+y4aNU2ZJckKitNDvuHK/XW3Q8bVgEE56fedfgUzjoHC2ZeUG0esuuGqSmdn/X6jRe3g46O/dlAHuUZVdDw/Lti2Xm0Nn3FjlvxzTWHTp60R3I0N8DkIOofQoaYjGFV5YRj03UGHJMxUVcKZMKcIcqhSpYJO7HtHlBtum0NJMGzyLLARnGSblrnawNpSS3c56Si+UXIeMqP1F+X8FO4g3+qjzGrMbGpZvlG5J3Gya8Bb+NtUc4cQa5+zBbx2DB6s0cmEDP/xEUZ+qZy+Vi8qhZrCrNcocDcKyO3+X1rPzzHFNrHq2uzuRK+2fG1NAoxuuxahx4wC6Y3BbvypsQDvVmskEQCGgGubH25uXa8HwK6LdMCcNV9mPLIxNox2DBOMh9eEa30kKbXeZC3HRAU67DnnwkrFKyeecoa92J2RZDjWmT5hlSr/t4kXr5yUA4I23dvIqLbmzPzJTKjj47FGqGuNeaY8OjLuuoc6TX8+JK8fIqr9iQAs+1RJtmxKsqxTkmGJBbYgU22HV+gRWHr734tSQuM6xJs8L+8xY9sZ1nQvyVluTtzUKpezKzf6GOm4sWJDHDbhV4456fVssSq28M29GMAs2uTOLdvs9cJxrq53/BWvLth0ClmMZ6Yin3JsYQr45LK4GjXk2DgzCroeJytzTKfe6kw87FDgZFIbvnHd4ZpcO7Sba9j/De2N2hRYpvO8yUuMAq1rigg3Lls2gsB2ZyqUX0c1a64hHlC+EBPvNL/mZfVDm0OYG5pm6tmzoMJKLjWs0WvSGyaOkK43JtLjOrIQhoXL9/vx01h3h02pj/MjU6oQ2MGLmC6k9g9sOfvkRs+GQWul2LcASrWMy200kheoiDyzvAs6QQRxJfsuy3R0XdMSTSVmzbUL3AVY28ZJyaIq5yn46x5MMczcsYz/33cs+/++Y/mXv2N5KpX5B1QzTV2yPc8DrZmOmf0D6xd0ej3X+Ux18pCUyoY1oYG6xt64eVHpAs0rcw4gaq/O7UR7m3S4MRLN2NynEArtdUIQY5hR9ytSLFcdjJbC/+O9ftW80soACyzcpjly2UWp74zBBoCdHUyL9RWCDJ58X2iBDvU1gEkxzYUzhM0bsZ64CoLOvTN6fNIENkMZleKYoTv3ZfIa8YSUWqiEpd+nTanlwGaaDhMCdPqmPb378BDfKESOQzdvlR+ZRM0sejFuL1BRhOTgkABEAm0QdGDVw5wDCjqIdgHRo22D/ai3WfZinNVpCK5xV5xBJU1Y1ots7r62TtcENNGQQqtzmDgrM5iwRS5j/Z5BUtBvFz3KoNNyWvC/YfY51wg8pU1e75nho2MX6hrmxqc7BX0d1U4ttQgoOxImwVcPP+2zJb37BCuK6CaFsuF2f1S8TvZGu7uFMrdulYJ6t/Alpk2B8yRUqhHMy+3YenlLrhBXmFLQF8m1rki8r1coFYUONUgXFVhTbC8D1jCYAmY7ihqp2qmUgYhg2zH+0FtSC0OVVlFKj+n0t+e+GjGdyJFk3HzJFgYQ/J4dqIFfmOB0nkZtSDLGkqk8kYFiNMlaGbHD/qfY1UpU882C/KFntFaRsQzyFCEM23eGTK8pArsvaJuWuHaO1jCDBzyNtC5tqwPYgG39wTbo1oxNsLwreUaiaE1605jXlzqG7chzrOX50Nqyzew4PcJa6TmhKFYQyWtjg+r2bIu1DZW19fs0T4qp7M7vIZ91LLvlRXY41yYX58b0lAWo5giirN1zw0vSgz8aQFCHW56ov0QhuP4A1imEgCjCgGEIwdZI+yGMAyHpfLthPAnV1c/fYWPY3f3SxrXeKG6jMkWwbowKjxjaIq5bVLC2UIU6FR90M6RT2AxDOezmYjyehWtX5c3Ie7SJao5FgDOl3nQ7emI0PF6GrSOIl+261vqcp/1xuBFdcOzTPKOSsV3WTUrWVTrsfheBCLrfUMRjRQWr1cVxnTLlukziRXbu5BcUv9WYvT6GCA9fsSk8S649/+uViHKMNXVMrbTMF7OiDq7p/aGkbKyF1AEsEWGGzkGCp+dq7ahAv0F3Ei9MlZqHicZG71ufq3Ktfn9LgrjTTRB1Skff+b2REg1HeaaE9EV9BtYOqvdD5DQbowc5ynm77l1nUL8zQorkmflz1VHjGEJQ1KmipIPj/cZE71+L9+scsinsJk/aGcuFdmTb+c1sK099xONEf+Tl9xSVyL7zZmRWZuZ9KjxpBq0a4OBtM0gRqud84HRH7FQeGJPv4xFJv40xnGIMXexifY4ZGBXT3ZJ5WAdNVluZq4tjFb69c7qJ4N3HCCU4umo4dp4l6PsW+wLRXMJ2BlUh5QzRnsk5XYlJXiygrpJbrCF4O9DduSkNHx/dUXVtQJhOWkDnKuV2jX74HDR3TYoK997lZG0xSSiwWEebjOj3OX0D8wPYL3ls6NSoTSStW4W3A/CgPovN6MtXKgz1B7bhkvr23sQZn9B4c/cY3qkuwO1JFqbUpk9l65FG6pkk3FPR56vB4D88/XUA6uKcF9NPZ6fJoJoNMjaewKv0OYwnr9hzdrB3MMmeP987eAUwefny1ffsJUvHL4bfPX+ZpbA3hvH4VXbwcnLA9sfP0zGkVFH+D3KMR1ZDLQAA
 </script>
-<script id="@tomlarkworthy/observablejs-toolchain"
+<script id="@tomlarkworthy/observablejs-toolchain" 
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -18938,8 +18924,7 @@ export default function define(runtime, observer) {
   main.define("Library", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Library", _));  
   main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));
   return main;
-}
-</script>
+}</script>
 
 <script id="@tomlarkworthy/reversible-attachment" 
   type="text/plain"
@@ -18961,12 +18946,14 @@ Inputs.toggle({
   label: "attach"
 })
 )};
+const _ekth9p = (G, _) => G.input(_);
 const _l8mvtb = function _3(md){return(
 md`## child view`
 )};
 const _1ugf292 = function _child(Inputs){return(
 Inputs.text()
 )};
+const _fkpfes = (G, _) => G.input(_);
 const _1r6zp4e = function _5(md){return(
 md`## parent view ([@tomlarkworthy/view](https://observablehq.com/@tomlarkworthy/view))`
 )};
@@ -18975,6 +18962,7 @@ view`<div>
 ${["child", reversibleAttach(attach, $0)]}
 </div>`
 )};
+const _13xot7o = (G, _) => G.input(_);
 const _17i0ywm = function _7(md){return(
 md`Note changes propogate to both`
 )};
@@ -19003,11 +18991,13 @@ Inputs.toggle({
   label: "attach gradparent"
 })
 )};
+const _1je8p4j = (G, _) => G.input(_);
 const _1apiz36 = function _grand_parent(Inputs,reversibleAttach,attach_gp,$0){return(
 Inputs.form({
   parent: reversibleAttach(attach_gp, $0)
 })
 )};
+const _1u1yv5f = (G, _) => G.input(_);
 const _1k66onn = function _15(grand_parent){return(
 grand_parent
 )};
@@ -19042,7 +19032,6 @@ function reversibleAttach(shouldBind, view, invalidation) {
   }
 }
 )};
-const _1qa5h1f = (_, v) => v.import("view", _);
 const _m6r08x = function _22(footer){return(
 footer
 )};
@@ -19052,22 +19041,17 @@ export default function define(runtime, observer) {
   const $def = (pid, name, deps, fn) => {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
-  const fileAttachments = new Map([].map((name) => {
-    const module_name = "@tomlarkworthy/reversible-attachment";
-    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
-    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
-    return [name, {url: blob_url, mimeType: mime}]
-  }));
-  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/view", async () => runtime.module((await import("/@tomlarkworthy/view.js?v=4")).default));  
   $def("_4svcg3", null, ["md"], _4svcg3);  
   $def("_1fxvri0", "viewof attach", ["Inputs"], _1fxvri0);  
-  main.variable(observer("attach")).define("attach", ["Generators", "viewof attach"], (G, _) => G.input(_));  
+  $def("_ekth9p", "attach", ["Generators","viewof attach"], _ekth9p);  
   $def("_l8mvtb", null, ["md"], _l8mvtb);  
   $def("_1ugf292", "viewof child", ["Inputs"], _1ugf292);  
-  main.variable(observer("child")).define("child", ["Generators", "viewof child"], (G, _) => G.input(_));  
+  $def("_fkpfes", "child", ["Generators","viewof child"], _fkpfes);  
   $def("_1r6zp4e", null, ["md"], _1r6zp4e);  
   $def("_11tnr8o", "viewof parent", ["view","reversibleAttach","attach","viewof child"], _11tnr8o);  
-  main.variable(observer("parent")).define("parent", ["Generators", "viewof parent"], (G, _) => G.input(_));  
+  $def("_13xot7o", "parent", ["Generators","viewof parent"], _13xot7o);  
   $def("_17i0ywm", null, ["md"], _17i0ywm);  
   $def("_1xbdgmf", null, ["child"], _1xbdgmf);  
   $def("_1tmaii0", null, ["parent"], _1tmaii0);  
@@ -19075,15 +19059,14 @@ export default function define(runtime, observer) {
   $def("_1u71rvc", null, ["Inputs","viewof parent","Event"], _1u71rvc);  
   $def("_citj9p", null, ["md"], _citj9p);  
   $def("_nqqgq0", "viewof attach_gp", ["Inputs"], _nqqgq0);  
-  main.variable(observer("attach_gp")).define("attach_gp", ["Generators", "viewof attach_gp"], (G, _) => G.input(_));  
+  $def("_1je8p4j", "attach_gp", ["Generators","viewof attach_gp"], _1je8p4j);  
   $def("_1apiz36", "viewof grand_parent", ["Inputs","reversibleAttach","attach_gp","viewof parent"], _1apiz36);  
-  main.variable(observer("grand_parent")).define("grand_parent", ["Generators", "viewof grand_parent"], (G, _) => G.input(_));  
+  $def("_1u1yv5f", "grand_parent", ["Generators","viewof grand_parent"], _1u1yv5f);  
   $def("_1k66onn", null, ["grand_parent"], _1k66onn);  
   $def("_1i4cx3s", null, ["Inputs","viewof grand_parent","Event"], _1i4cx3s);  
   $def("_67zexy", null, ["md"], _67zexy);  
   $def("_1padev5", "parents", [], _1padev5);  
   $def("_ofuojt", "reversibleAttach", ["parents","bindOneWay"], _ofuojt);  
-  main.define("module @tomlarkworthy/view", async () => runtime.module((await import("/@tomlarkworthy/view.js?v=4")).default));  
   main.define("view", ["module @tomlarkworthy/view", "@variable"], (_, v) => v.import("view", _));  
   main.define("bindOneWay", ["module @tomlarkworthy/view", "@variable"], (_, v) => v.import("bindOneWay", _));  
   $def("_m6r08x", null, ["footer"], _m6r08x);
@@ -19106,9 +19089,6 @@ import {runtime, thisModule, observe, variables, descendants, lookupVariable, to
 const _jaxte9 = function _2(md){return(
 md`### access the runtime`
 )};
-const _7rjx1q = function identity(x) {
-  return x;
-};
 const _1h5qtfr = function _runtime(_runtime)
 {
   window.__ojs_runtime = window.__ojs_runtime || _runtime;
@@ -19153,6 +19133,7 @@ tag => {
 const _14bivfb = function _myModule(thisModule){return(
 thisModule()
 )};
+const _1cir47e = (G, _) => G.input(_);
 const _qflxlf = function _9(md){return(
 md`### create/delete Module`
 )};
@@ -19216,6 +19197,7 @@ runtime_variables
 const _yg4n67 = function _runtime_variables(variables,runtime){return(
 variables(runtime)
 )};
+const _340ur0 = (G, _) => G.input(_);
 const _1jnnn39 = function _16(md){return(
 md`### \`onCodeChange(callback)\`
 
@@ -20012,22 +19994,18 @@ v => Object.fromEntries(Object.getOwnPropertyNames(v).map(p => [
 const _136vd02 = function _trace_history(){return(
 []
 )};
+const _7xa5y2 = (M, _) => new M(_);
+const _w9vom3 = _ => _.generator;
 
 export default function define(runtime, observer) {
   const main = runtime.module();
   const $def = (pid, name, deps, fn) => {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
-  const fileAttachments = new Map([].map((name) => {
-    const module_name = "@tomlarkworthy/runtime-sdk";
-    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
-    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
-    return [name, {url: blob_url, mimeType: mime}]
-  }));
-  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @mootari/access-runtime", async () => runtime.module((await import("/@mootari/access-runtime.js?v=4")).default));  
   $def("_exoevq", "title", ["md"], _exoevq);  
   $def("_jaxte9", null, ["md"], _jaxte9);  
-  main.define("module @mootari/access-runtime", async () => runtime.module((await import("/@mootari/access-runtime.js?v=4")).default));  
   main.define("_runtime", ["module @mootari/access-runtime", "@variable"], (_, v) => v.import("runtime", "_runtime", _));  
   main.define("main", ["module @mootari/access-runtime", "@variable"], (_, v) => v.import("main", _));  
   $def("_1h5qtfr", "runtime", ["_runtime"], _1h5qtfr);  
@@ -20035,7 +20013,7 @@ export default function define(runtime, observer) {
   $def("_3rh6v1", "thisModule", ["EventTarget","find_with_tag","Event"], _3rh6v1);  
   $def("_1bdarwe", "find_with_tag", ["runtime"], _1bdarwe);  
   $def("_14bivfb", "viewof myModule", ["thisModule"], _14bivfb);  
-  main.variable(observer("myModule")).define("myModule", ["Generators", "viewof myModule"], (G, _) => G.input(_));  
+  $def("_1cir47e", "myModule", ["Generators","viewof myModule"], _1cir47e);  
   $def("_qflxlf", null, ["md"], _qflxlf);  
   $def("_bxy6wl", "createModule", [], _bxy6wl);  
   $def("_mi8uf6", "deleteModule", [], _mi8uf6);  
@@ -20043,7 +20021,7 @@ export default function define(runtime, observer) {
   $def("_12t1ysb", "variables", ["Inputs","observeSet","Event"], _12t1ysb);  
   $def("_czqwrw", null, ["runtime_variables"], _czqwrw);  
   $def("_yg4n67", "viewof runtime_variables", ["variables","runtime"], _yg4n67);  
-  main.variable(observer("runtime_variables")).define("runtime_variables", ["Generators", "viewof runtime_variables"], (G, _) => G.input(_));  
+  $def("_340ur0", "runtime_variables", ["Generators","viewof runtime_variables"], _340ur0);  
   $def("_1jnnn39", null, ["md"], _1jnnn39);  
   $def("_1p5os0", "last_change", ["Generators","invalidation","onCodeChange"], _1p5os0);  
   $def("_2viczv", "onCodeChange", ["keepalive","myModule","codeChangeListeners"], _2viczv);  
@@ -20097,8 +20075,8 @@ export default function define(runtime, observer) {
   $def("_v2cm1y", "isnode", ["Element","Text"], _v2cm1y);  
   $def("_1s528dq", "toObject", [], _1s528dq);  
   $def("_136vd02", "initial trace_history", [], _136vd02);  
-  main.variable(observer("mutable trace_history")).define("mutable trace_history", ["Mutable", "initial trace_history"], (M, _) => new M(_));  
-  main.variable(observer("trace_history")).define("trace_history", ["mutable trace_history"], _ => _.generator);
+  $def("_7xa5y2", "mutable trace_history", ["Mutable","initial trace_history"], _7xa5y2);  
+  $def("_w9vom3", "trace_history", ["mutable trace_history"], _w9vom3);
   return main;
 }</script>
 
@@ -20138,10 +20116,10 @@ md`### Motivation
 
 The motivation was to enable better visualisation of code dependancies by reducing the tangles`
 )};
-const _jl44o3 = (_, v) => v.import("visualizeModules", _);
 const _1g70boa = function _useSpectral(Inputs){return(
 Inputs.toggle({ label: "use Spectral layout" })
 )};
+const _wj1l0t = (G, _) => G.input(_);
 const _1abidz3 = function _5(visualizeModules,useSpectral){return(
 visualizeModules({ useSpectral })
 )};
@@ -20192,6 +20170,7 @@ Inputs.form(
   { label: "Graph + layout parameters" }
 )
 )};
+const _gsn1g6 = (G, _) => G.input(_);
 const _aqnmq8 = function _actions(Inputs){return(
 Inputs.form(
   {
@@ -20204,6 +20183,7 @@ Inputs.form(
   { label: "Actions" }
 )
 )};
+const _wn0vd9 = (G, _) => G.input(_);
 const _9se9g7 = function _dashboard(params,$0,edgeKey,buildCSR,spectralCircleOrder,d3,crossingsCount,improveOrderSifting,bestOfRandomOrders,chordPlot,htl,$1)
 {
   const n = params.n;
@@ -20313,6 +20293,7 @@ const _sz8swa = function _normalizeEdge(){return(
 const _1q2sff7 = function _edges(Inputs){return(
 Inputs.input([])
 )};
+const _sqaqf8 = (G, _) => G.input(_);
 const _m9ar27 = function _edgesController(actions,$0,Event,params,makeRng)
 {
   const state = this ?? { randomize: 0, clear: 0 };
@@ -20535,6 +20516,7 @@ const _17mn6ii = function _plot_editor(params,edges,edgeKey,Plot,d3,edgeDomainFu
   invalidation.then(() => plot.removeEventListener("click", onClick));
   return plot;
 };
+const _jrianz = (G, _) => G.input(_);
 const _1nwm7vs = function _18(md){return(
 md`# Spectral circular ordering
 
@@ -21131,36 +21113,30 @@ export default function define(runtime, observer) {
   const $def = (pid, name, deps, fn) => {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
-  const fileAttachments = new Map([].map((name) => {
-    const module_name = "@tomlarkworthy/spectral-layout";
-    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
-    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
-    return [name, {url: blob_url, mimeType: mime}]
-  }));
-  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
   $def("_uqgdh", "introduction", ["md"], _uqgdh);  
   $def("_1h5mmgr", null, ["md"], _1h5mmgr);  
-  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
   main.define("visualizeModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("visualizeModules", _));  
   $def("_1g70boa", "viewof useSpectral", ["Inputs"], _1g70boa);  
-  main.variable(observer("useSpectral")).define("useSpectral", ["Generators", "viewof useSpectral"], (G, _) => G.input(_));  
+  $def("_wj1l0t", "useSpectral", ["Generators","viewof useSpectral"], _wj1l0t);  
   $def("_1abidz3", null, ["visualizeModules","useSpectral"], _1abidz3);  
   $def("_19bhwpo", null, ["md"], _19bhwpo);  
   $def("_crw929", "viewof params", ["Inputs"], _crw929);  
-  main.variable(observer("params")).define("params", ["Generators", "viewof params"], (G, _) => G.input(_));  
+  $def("_gsn1g6", "params", ["Generators","viewof params"], _gsn1g6);  
   $def("_aqnmq8", "viewof actions", ["Inputs"], _aqnmq8);  
-  main.variable(observer("actions")).define("actions", ["Generators", "viewof actions"], (G, _) => G.input(_));  
+  $def("_wn0vd9", "actions", ["Generators","viewof actions"], _wn0vd9);  
   $def("_9se9g7", "dashboard", ["params","viewof edges","edgeKey","buildCSR","spectralCircleOrder","d3","crossingsCount","improveOrderSifting","bestOfRandomOrders","chordPlot","htl","viewof plot_editor"], _9se9g7);  
   $def("_f2a9k8", "edgeKey", [], _f2a9k8);  
   $def("_sz8swa", "normalizeEdge", [], _sz8swa);  
   $def("_1q2sff7", "viewof edges", ["Inputs"], _1q2sff7);  
-  main.variable(observer("edges")).define("edges", ["Generators", "viewof edges"], (G, _) => G.input(_));  
+  $def("_sqaqf8", "edges", ["Generators","viewof edges"], _sqaqf8);  
   $def("_m9ar27", "edgesController", ["actions","viewof edges","Event","params","makeRng"], _m9ar27);  
   $def("_16pvnfq", "edgeDomainFull", ["params"], _16pvnfq);  
   $def("_1nxdfri", "crossingsCount", [], _1nxdfri);  
   $def("_1s807ch", "chordPlot", ["Plot"], _1s807ch);  
   $def("_17mn6ii", "viewof plot_editor", ["params","edges","edgeKey","Plot","d3","edgeDomainFull","viewof edges","Event","invalidation"], _17mn6ii);  
-  main.variable(observer("plot_editor")).define("plot_editor", ["Generators", "viewof plot_editor"], (G, _) => G.input(_));  
+  $def("_jrianz", "plot_editor", ["Generators","viewof plot_editor"], _jrianz);  
   $def("_1nwm7vs", null, ["md"], _1nwm7vs);  
   $def("_1csj35b", "assert", [], _1csj35b);  
   $def("_1jexr9", null, ["md"], _1jexr9);  
@@ -21224,6 +21200,7 @@ md`RxJS has a "creation" operator called [_interval_](https://rxjs.dev/api/index
 const _1dndbqz = function _counter(interval,invalidation){return(
 interval({ period: 500, invalidation })
 )};
+const _1day41y = (G, _) => G.input(_);
 const _5lfxcg = function _5(md){return(
 md`With our _interval_ it returns a "viewof" as opposed to an _Observable_. We also have to pass in the _invalidation_ promise so that if the cell is reevaluated the timer is removed. Note: all our stream operators need the invalidation promise passed in.
 
@@ -21247,6 +21224,7 @@ map({
   invalidation
 })
 )};
+const _1mapnw5 = (G, _) => G.input(_);
 const _117pmor = function _9(md){return(
 md`Note the result of the map is another viewof, which depends only on the previous viewof counter, so is not affected by dataflow either but the underlying data channel is recomputing at the same rate as _counter_ (see below)`
 )};
@@ -21266,6 +21244,7 @@ map({
   invalidation
 })
 )};
+const _ywap05 = (G, _) => G.input(_);
 const _fveuul = function _13(buzz){return(
 buzz
 )};
@@ -21287,6 +21266,7 @@ combineLatest({
   invalidation
 })
 )};
+const _1jk81zc = (G, _) => G.input(_);
 const _npvlk4 = function _16(md){return(
 md`_fizzBuzzCombineLatest_ shows the glitchiness of combining synchronised streams with _combineLatest_, sometimes there are extra frames merging a previous value to a new value, depending on the order of evaluation. 
 
@@ -21306,6 +21286,7 @@ scan({
   invalidation
 })
 )};
+const _10ranwj = (G, _) => G.input(_);
 const _1d21zk7 = function _20(countFizzBuzzCombineLatest){return(
 countFizzBuzzCombineLatest
 )};
@@ -21321,6 +21302,7 @@ zip({
   invalidation
 })
 )};
+const _1ig9ibk = (G, _) => G.input(_);
 const _16ge70z = function _24(fizzBuzzZipArray){return(
 fizzBuzzZipArray
 )};
@@ -21335,6 +21317,7 @@ zip({
   invalidation
 })
 )};
+const _jdyijp = (G, _) => G.input(_);
 const _brom1o = function _27(fizzBuzzZip){return(
 fizzBuzzZip
 )};
@@ -21349,6 +21332,7 @@ scan({
   invalidation
 })
 )};
+const _752dzy = (G, _) => G.input(_);
 const _1e2w7iy = function _30(countFizzBuzzZip){return(
 countFizzBuzzZip
 )};
@@ -21374,6 +21358,7 @@ map({
   invalidation
 })
 )};
+const _1lne34j = (G, _) => G.input(_);
 const _1w8vbuv = function _35(evens){return(
 evens
 )};
@@ -21389,6 +21374,7 @@ map({
   invalidation
 })
 )};
+const _1s0ueo9 = (G, _) => G.input(_);
 const _27agi2 = function _38(headsOrTails){return(
 headsOrTails
 )};
@@ -21399,6 +21385,7 @@ scan({
   invalidation
 })
 )};
+const _gf27v = (G, _) => G.input(_);
 const _jhim57 = function _40(deduped){return(
 deduped
 )};
@@ -21414,6 +21401,7 @@ map({
   invalidation
 })
 )};
+const _vvt5vq = (G, _) => G.input(_);
 const _9v84oc = function _43(timestamp){return(
 timestamp
 )};
@@ -21429,6 +21417,7 @@ scan({
   invalidation
 })
 )};
+const _1xo0xkd = (G, _) => G.input(_);
 const _1otuiko = function _45(last_5_secs){return(
 last_5_secs
 )};
@@ -21439,6 +21428,7 @@ map({
   invalidation
 })
 )};
+const _1ofwtde = (G, _) => G.input(_);
 const _41ukm9 = function _47(rate,md){return(
 md`${rate} per second`
 )};
@@ -21465,6 +21455,7 @@ map({
   invalidation
 })
 )};
+const _1ql4mhm = (G, _) => G.input(_);
 const _m6xb4n = function _50(rate2,md){return(
 md`${rate2} per second`
 )};
@@ -21609,77 +21600,71 @@ export default function define(runtime, observer) {
   const $def = (pid, name, deps, fn) => {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
-  const fileAttachments = new Map([].map((name) => {
-    const module_name = "@tomlarkworthy/stream-operators";
-    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
-    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
-    return [name, {url: blob_url, mimeType: mime}]
-  }));
-  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
   $def("_15nmfm2", null, ["md"], _15nmfm2);  
   $def("_14z8e83", null, ["md"], _14z8e83);  
   $def("_w1l87c", null, ["md"], _w1l87c);  
   $def("_1dndbqz", "viewof counter", ["interval","invalidation"], _1dndbqz);  
-  main.variable(observer("counter")).define("counter", ["Generators", "viewof counter"], (G, _) => G.input(_));  
+  $def("_1day41y", "counter", ["Generators","viewof counter"], _1day41y);  
   $def("_5lfxcg", null, ["md"], _5lfxcg);  
   $def("_i4vlqt", null, ["counter"], _i4vlqt);  
   $def("_1tfa5h8", null, ["md"], _1tfa5h8);  
   $def("_bmpx4m", "viewof fizz", ["map","viewof counter","invalidation"], _bmpx4m);  
-  main.variable(observer("fizz")).define("fizz", ["Generators", "viewof fizz"], (G, _) => G.input(_));  
+  $def("_1mapnw5", "fizz", ["Generators","viewof fizz"], _1mapnw5);  
   $def("_117pmor", null, ["md"], _117pmor);  
   $def("_1mgt0zk", null, ["fizz"], _1mgt0zk);  
   $def("_c8heb2", null, ["md"], _c8heb2);  
   $def("_prdyfg", "viewof buzz", ["map","viewof counter","invalidation"], _prdyfg);  
-  main.variable(observer("buzz")).define("buzz", ["Generators", "viewof buzz"], (G, _) => G.input(_));  
+  $def("_ywap05", "buzz", ["Generators","viewof buzz"], _ywap05);  
   $def("_fveuul", null, ["buzz"], _fveuul);  
   $def("_1w2g8rb", null, ["md"], _1w2g8rb);  
   $def("_q551p7", "viewof fizzBuzzCombineLatest", ["combineLatest","viewof counter","viewof fizz","viewof buzz","invalidation"], _q551p7);  
-  main.variable(observer("fizzBuzzCombineLatest")).define("fizzBuzzCombineLatest", ["Generators", "viewof fizzBuzzCombineLatest"], (G, _) => G.input(_));  
+  $def("_1jk81zc", "fizzBuzzCombineLatest", ["Generators","viewof fizzBuzzCombineLatest"], _1jk81zc);  
   $def("_npvlk4", null, ["md"], _npvlk4);  
   $def("_1f0lfo9", null, ["fizzBuzzCombineLatest"], _1f0lfo9);  
   $def("_ubbjca", null, ["md"], _ubbjca);  
   $def("_l6hy0u", "viewof countFizzBuzzCombineLatest", ["scan","viewof fizzBuzzCombineLatest","invalidation"], _l6hy0u);  
-  main.variable(observer("countFizzBuzzCombineLatest")).define("countFizzBuzzCombineLatest", ["Generators", "viewof countFizzBuzzCombineLatest"], (G, _) => G.input(_));  
+  $def("_10ranwj", "countFizzBuzzCombineLatest", ["Generators","viewof countFizzBuzzCombineLatest"], _10ranwj);  
   $def("_1d21zk7", null, ["countFizzBuzzCombineLatest"], _1d21zk7);  
   $def("_1e0m5bi", null, ["md"], _1e0m5bi);  
   $def("_1cdmgli", null, ["md"], _1cdmgli);  
   $def("_1uh2ovd", "viewof fizzBuzzZipArray", ["zip","viewof counter","viewof fizz","viewof buzz","invalidation"], _1uh2ovd);  
-  main.variable(observer("fizzBuzzZipArray")).define("fizzBuzzZipArray", ["Generators", "viewof fizzBuzzZipArray"], (G, _) => G.input(_));  
+  $def("_1ig9ibk", "fizzBuzzZipArray", ["Generators","viewof fizzBuzzZipArray"], _1ig9ibk);  
   $def("_16ge70z", null, ["fizzBuzzZipArray"], _16ge70z);  
   $def("_1x90ntc", null, ["md"], _1x90ntc);  
   $def("_1thkdbb", "viewof fizzBuzzZip", ["zip","viewof counter","viewof fizz","viewof buzz","invalidation"], _1thkdbb);  
-  main.variable(observer("fizzBuzzZip")).define("fizzBuzzZip", ["Generators", "viewof fizzBuzzZip"], (G, _) => G.input(_));  
+  $def("_jdyijp", "fizzBuzzZip", ["Generators","viewof fizzBuzzZip"], _jdyijp);  
   $def("_brom1o", null, ["fizzBuzzZip"], _brom1o);  
   $def("_t7mfvk", null, ["md"], _t7mfvk);  
   $def("_9m7dte", "viewof countFizzBuzzZip", ["scan","viewof fizzBuzzZip","invalidation"], _9m7dte);  
-  main.variable(observer("countFizzBuzzZip")).define("countFizzBuzzZip", ["Generators", "viewof countFizzBuzzZip"], (G, _) => G.input(_));  
+  $def("_752dzy", "countFizzBuzzZip", ["Generators","viewof countFizzBuzzZip"], _752dzy);  
   $def("_1e2w7iy", null, ["countFizzBuzzZip"], _1e2w7iy);  
   $def("_3jy2a", null, ["md"], _3jy2a);  
   $def("_85rl1b", null, ["md"], _85rl1b);  
   $def("_gdn1iy", null, ["md"], _gdn1iy);  
   $def("_7t2do9", "viewof evens", ["map","viewof counter","invalidation"], _7t2do9);  
-  main.variable(observer("evens")).define("evens", ["Generators", "viewof evens"], (G, _) => G.input(_));  
+  $def("_1lne34j", "evens", ["Generators","viewof evens"], _1lne34j);  
   $def("_1w8vbuv", null, ["evens"], _1w8vbuv);  
   $def("_1kh3ojv", null, ["md"], _1kh3ojv);  
   $def("_6023kb", "viewof headsOrTails", ["map","viewof counter","invalidation"], _6023kb);  
-  main.variable(observer("headsOrTails")).define("headsOrTails", ["Generators", "viewof headsOrTails"], (G, _) => G.input(_));  
+  $def("_1s0ueo9", "headsOrTails", ["Generators","viewof headsOrTails"], _1s0ueo9);  
   $def("_27agi2", null, ["headsOrTails"], _27agi2);  
   $def("_1c9lm9r", "viewof deduped", ["scan","viewof headsOrTails","invalidation"], _1c9lm9r);  
-  main.variable(observer("deduped")).define("deduped", ["Generators", "viewof deduped"], (G, _) => G.input(_));  
+  $def("_gf27v", "deduped", ["Generators","viewof deduped"], _gf27v);  
   $def("_jhim57", null, ["deduped"], _jhim57);  
   $def("_kzoadn", null, ["md"], _kzoadn);  
   $def("_1wtqnov", "viewof timestamp", ["map","viewof deduped","invalidation"], _1wtqnov);  
-  main.variable(observer("timestamp")).define("timestamp", ["Generators", "viewof timestamp"], (G, _) => G.input(_));  
+  $def("_vvt5vq", "timestamp", ["Generators","viewof timestamp"], _vvt5vq);  
   $def("_9v84oc", null, ["timestamp"], _9v84oc);  
   $def("_10vu0fj", "viewof last_5_secs", ["scan","viewof timestamp","invalidation"], _10vu0fj);  
-  main.variable(observer("last_5_secs")).define("last_5_secs", ["Generators", "viewof last_5_secs"], (G, _) => G.input(_));  
+  $def("_1xo0xkd", "last_5_secs", ["Generators","viewof last_5_secs"], _1xo0xkd);  
   $def("_1otuiko", null, ["last_5_secs"], _1otuiko);  
   $def("_1lqs7im", "viewof rate", ["map","viewof last_5_secs","invalidation"], _1lqs7im);  
-  main.variable(observer("rate")).define("rate", ["Generators", "viewof rate"], (G, _) => G.input(_));  
+  $def("_1ofwtde", "rate", ["Generators","viewof rate"], _1ofwtde);  
   $def("_41ukm9", null, ["rate","md"], _41ukm9);  
   $def("_ejmyr3", null, ["md"], _ejmyr3);  
   $def("_1mmc7q", "viewof rate2", ["map","scan","viewof deduped","invalidation"], _1mmc7q);  
-  main.variable(observer("rate2")).define("rate2", ["Generators", "viewof rate2"], (G, _) => G.input(_));  
+  $def("_1ql4mhm", "rate2", ["Generators","viewof rate2"], _1ql4mhm);  
   $def("_m6xb4n", null, ["rate2","md"], _m6xb4n);  
   $def("_xvoqqz", null, ["md"], _xvoqqz);  
   $def("_1sychb7", null, ["md"], _1sychb7);  
@@ -21708,15 +21693,13 @@ Wraps [Observable's inspect](https://github.com/observablehq/inspector) to a sin
 const _isrmzq = function _max_size(Inputs){return(
 Inputs.range([3, 500], { label: "max size", step: 1 })
 )};
+const _vrmeqm = (G, _) => G.input(_);
 const _ptnkl7 = function _example(summarizeJS,data,max_size){return(
 summarizeJS(data, { max_size })
 )};
 const _1m34ydj = function _4(example){return(
 example.length
 )};
-const _cztar7 = function identity(x) {
-  return x;
-};
 const _1rosxg0 = function _data(){return(
 {
   nested: {
@@ -21837,19 +21820,13 @@ export default function define(runtime, observer) {
   const $def = (pid, name, deps, fn) => {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
-  const fileAttachments = new Map([].map((name) => {
-    const module_name = "@tomlarkworthy/summarizejs";
-    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
-    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
-    return [name, {url: blob_url, mimeType: mime}]
-  }));
-  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/inspector", async () => runtime.module((await import("/@tomlarkworthy/inspector.js?v=4")).default));  
   $def("_j8bt44", null, ["md"], _j8bt44);  
   $def("_isrmzq", "viewof max_size", ["Inputs"], _isrmzq);  
-  main.variable(observer("max_size")).define("max_size", ["Generators", "viewof max_size"], (G, _) => G.input(_));  
+  $def("_vrmeqm", "max_size", ["Generators","viewof max_size"], _vrmeqm);  
   $def("_ptnkl7", "example", ["summarizeJS","data","max_size"], _ptnkl7);  
   $def("_1m34ydj", null, ["example"], _1m34ydj);  
-  main.define("module @tomlarkworthy/inspector", async () => runtime.module((await import("/@tomlarkworthy/inspector.js?v=4")).default));  
   main.define("inspect", ["module @tomlarkworthy/inspector", "@variable"], (_, v) => v.import("inspect", _));  
   main.define("Inspector", ["module @tomlarkworthy/inspector", "@variable"], (_, v) => v.import("Inspector", _));  
   main.define("src", ["module @tomlarkworthy/inspector", "@variable"], (_, v) => v.import("src", _));  
@@ -21902,6 +21879,7 @@ Inputs.radio(
   }
 )
 )};
+const _4jpb27 = (G, _) => G.input(_);
 const _17ce9dw = async function* _test_tests_example(example_type)
 {
   switch (example_type) {
@@ -21943,6 +21921,7 @@ scan({
   invalidation
 })
 )};
+const _f8uda4 = (G, _) => G.input(_);
 const _10ijqbr = function _10(Inputs,testing_variables){return(
 Inputs.table(testing_variables)
 )};
@@ -22001,7 +21980,6 @@ testing_variables
     return a.name.localeCompare(b.name);
   })
 )};
-const _16y0lz3 = (_, v) => v.import("linkTo", _);
 const _marb2k = function _url(isObservable,html,linkTo){return(
 (name) => {
   if (isObservable) {
@@ -22027,6 +22005,7 @@ Inputs.table(
 const _1yj8u7a = function _latest_state(Inputs){return(
 Inputs.input(new Map())
 )};
+const _1oauj1h = (G, _) => G.input(_);
 const _12gobz9 = function _observers(){return(
 new Map()
 )};
@@ -22098,46 +22077,41 @@ keepalive(testsModule, "tasks")
 const _1ggf21v = function _testsModule(thisModule){return(
 thisModule()
 )};
-const _nxg8mr = (_, v) => v.import("moduleMap", _);
-const _8aq9m9 = (_, v) => v.import("isOnObservableCom", _);
-const _mqwrx3 = (_, v) => v.import("scan", _);
-const _1z7eev = (_, v) => v.import("inspect", _);
+const _1t9t1fv = (G, _) => G.input(_);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
   const $def = (pid, name, deps, fn) => {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
-  const fileAttachments = new Map([].map((name) => {
-    const module_name = "@tomlarkworthy/tests";
-    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
-    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
-    return [name, {url: blob_url, mimeType: mime}]
-  }));
-  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
+  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/stream-operators", async () => runtime.module((await import("/@tomlarkworthy/stream-operators.js?v=4")).default));  
+  main.define("module @tomlarkworthy/inspector", async () => runtime.module((await import("/@tomlarkworthy/inspector.js?v=4")).default));  
   $def("_1dz4ftw", null, ["md"], _1dz4ftw);  
   $def("_svrcyh", null, ["tests"], _svrcyh);  
   $def("_1rfwb8c", null, ["md"], _1rfwb8c);  
   $def("_1sr7w7b", null, ["md"], _1sr7w7b);  
   $def("_8dmusz", "viewof example_type", ["Inputs"], _8dmusz);  
-  main.variable(observer("example_type")).define("example_type", ["Generators", "viewof example_type"], (G, _) => G.input(_));  
+  $def("_4jpb27", "example_type", ["Generators","viewof example_type"], _4jpb27);  
   $def("_17ce9dw", "test_tests_example", ["example_type"], _17ce9dw);  
   $def("_178t107", null, ["md"], _178t107);  
   $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
   $def("_pvmmyu", "viewof testing_variables", ["scan","viewof runtime_variables","modules","_","invalidation"], _pvmmyu);  
-  main.variable(observer("testing_variables")).define("testing_variables", ["Generators", "viewof testing_variables"], (G, _) => G.input(_));  
+  $def("_f8uda4", "testing_variables", ["Generators","viewof testing_variables"], _f8uda4);  
   $def("_10ijqbr", null, ["Inputs","testing_variables"], _10ijqbr);  
   $def("_1x5l69t", null, ["md"], _1x5l69t);  
   $def("_1i63u1w", "isObservable", ["isOnObservableCom"], _1i63u1w);  
   $def("_1lcc2kp", "tests", ["background_task","Inputs","current","url","inspect"], _1lcc2kp);  
   $def("_14i2w5u", "current", ["testing_variables","latest_state"], _14i2w5u);  
-  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
   main.define("linkTo", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("linkTo", _));  
   $def("_marb2k", "url", ["isObservable","html","linkTo"], _marb2k);  
   $def("_1ucl8yc", null, ["md"], _1ucl8yc);  
   $def("_jjcune", null, ["Inputs","latest_state"], _jjcune);  
   $def("_1yj8u7a", "viewof latest_state", ["Inputs"], _1yj8u7a);  
-  main.variable(observer("latest_state")).define("latest_state", ["Generators", "viewof latest_state"], (G, _) => G.input(_));  
+  $def("_1oauj1h", "latest_state", ["Generators","viewof latest_state"], _1oauj1h);  
   $def("_12gobz9", "observers", [], _12gobz9);  
   $def("_1f4s8vv", null, ["md"], _1f4s8vv);  
   $def("_1tgtkh5", "changes", ["testing_variables","unorderedSync","observers"], _1tgtkh5);  
@@ -22147,11 +22121,9 @@ export default function define(runtime, observer) {
   $def("_1ot9yzi", "tasks", ["on_add","on_remove","submit_summary"], _1ot9yzi);  
   $def("_1866ovz", "background_task", ["keepalive","testsModule"], _1866ovz);  
   $def("_1ggf21v", "viewof testsModule", ["thisModule"], _1ggf21v);  
-  main.variable(observer("testsModule")).define("testsModule", ["Generators", "viewof testsModule"], (G, _) => G.input(_));  
-  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
+  $def("_1t9t1fv", "testsModule", ["Generators","viewof testsModule"], _1t9t1fv);  
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("isOnObservableCom", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("isOnObservableCom", _));  
   main.define("viewof runtime_variables", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("viewof runtime_variables", _));  
   main.define("runtime_variables", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime_variables", _));  
@@ -22160,9 +22132,7 @@ export default function define(runtime, observer) {
   main.define("observe", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("observe", _));  
   main.define("thisModule", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("thisModule", _));  
   main.define("keepalive", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("keepalive", _));  
-  main.define("module @tomlarkworthy/stream-operators", async () => runtime.module((await import("/@tomlarkworthy/stream-operators.js?v=4")).default));  
   main.define("scan", ["module @tomlarkworthy/stream-operators", "@variable"], (_, v) => v.import("scan", _));  
-  main.define("module @tomlarkworthy/inspector", async () => runtime.module((await import("/@tomlarkworthy/inspector.js?v=4")).default));  
   main.define("inspect", ["module @tomlarkworthy/inspector", "@variable"], (_, v) => v.import("inspect", _));  
   main.define("Inspector", ["module @tomlarkworthy/inspector", "@variable"], (_, v) => v.import("Inspector", _));
   return main;
@@ -22204,6 +22174,7 @@ Choose a theme below. The selected theme's CSS is loaded and applied. All downst
 const _1fzvdss = function _theme_assets(Inputs,themes,current_theme){return(
 Inputs.select(themes, { value: current_theme || themes.get('near-midnight') })
 )};
+const _1sdw5pf = (G, _) => G.input(_);
 const _2dvbva = function _4(md){return(
 md`## Theme Properties
 
@@ -22462,17 +22433,11 @@ export default function define(runtime, observer) {
   const $def = (pid, name, deps, fn) => {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
-  const fileAttachments = new Map([].map((name) => {
-    const module_name = "@tomlarkworthy/themes";
-    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
-    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
-    return [name, {url: blob_url, mimeType: mime}]
-  }));
-  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
   $def("_xfyyu1", null, ["md"], _xfyyu1);  
   $def("_i1kq4s", null, ["md"], _i1kq4s);  
   $def("_1fzvdss", "viewof theme_assets", ["Inputs","themes","current_theme"], _1fzvdss);  
-  main.variable(observer("theme_assets")).define("theme_assets", ["Generators", "viewof theme_assets"], (G, _) => G.input(_));  
+  $def("_1sdw5pf", "theme_assets", ["Generators","viewof theme_assets"], _1sdw5pf);  
   $def("_2dvbva", null, ["md"], _2dvbva);  
   $def("_1k4keny", "theme_properties", ["css"], _1k4keny);  
   $def("_1u7rv6o", null, ["htl","theme_properties","html"], _1u7rv6o);  
@@ -22562,6 +22527,7 @@ view`<div style="display: flex; justify-content:space-between; ">
 </div>
 `
 )};
+const _1j8bed9 = (G, _) => G.input(_);
 const _1cbg1ut = function _8(md){return(
 md`## Back-writable
 
@@ -22587,6 +22553,7 @@ md`## Singletons
 const _fl8f6f = function _singleton(view,Inputs){return(
 view`<div><h4>My control</h4>${['...', Inputs.range()]}`
 )};
+const _1a6iprb = (G, _) => G.input(_);
 const _1ve06sk = function _12(singleton){return(
 singleton
 )};
@@ -22607,6 +22574,7 @@ view`<div>${[
   Array.from({ length: 5 }, () => Inputs.range())
 ]}`
 )};
+const _1kies17 = (G, _) => G.input(_);
 const _1p0uyl7 = function _16($0){return(
 $0.elements
 )};
@@ -22644,6 +22612,7 @@ view`<div>${[
   val => Inputs.range([0, 1], { value: val }) // rowBuilder
 ]}`
 )};
+const _zpp1eq = (G, _) => G.input(_);
 const _letn54 = function _23(Inputs,dynamicArrayCollection,$0,Event){return(
 Inputs.button("Add a slider", {
   reduce: () => {
@@ -22678,6 +22647,7 @@ view`${[
   }
 ]}`
 )};
+const _1rr8jsf = (G, _) => G.input(_);
 const _100x12m = function _27(objectCollection){return(
 objectCollection
 )};
@@ -22694,6 +22664,7 @@ view`<div>${[
   txt => Inputs.text({ value: txt })
 ]}`
 )};
+const _2z2c08 = (G, _) => G.input(_);
 const _16lq9yi = function _30(dynamicObjectCollection){return(
 dynamicObjectCollection
 )};
@@ -22742,6 +22713,7 @@ view`<div><h4>My hidden control</h4>${[
   $0
 ]}`
 )};
+const _v1kcx9 = (G, _) => G.input(_);
 const _1mp8wce = function _37($0,Event)
 {
   $0.hidden.value = 0.60;
@@ -22842,6 +22814,7 @@ view`
 
 `
 )};
+const _1jpx1fd = (G, _) => G.input(_);
 const _1zec06 = function _44(md){return(
 md`### bindOneWay
 
@@ -22858,6 +22831,7 @@ The signature follows Observables precedence (https://github.com/observablehq/in
 const _wss5uy = function _slider(Inputs){return(
 Inputs.range([0, 10], { value: 0, label: "Try increasing me" })
 )};
+const _1ckicdh = (G, _) => G.input(_);
 const _l5ujyt = function _levels(bindOneWay,Inputs,$0){return(
 bindOneWay(
   Inputs.radio(["0", "low", "high"], { disabled: true }),
@@ -22867,11 +22841,13 @@ bindOneWay(
   }
 )
 )};
+const _1jqrotr = (G, _) => G.input(_);
 const _1x1f14t = function _levelsText(bindOneWay,Inputs,$0){return(
 bindOneWay(Inputs.text({ disabled: true }), $0, {
   transform: l => `The level is ${l}`
 })
 )};
+const _dlcq5s = (G, _) => G.input(_);
 const _1fx1tne = function _bindOneWay(MutationObserver,Event)
 {
   function disposal(element) {
@@ -23532,12 +23508,14 @@ view`<table>
   ]}
 </table>`
 )};
+const _a54zdk = (G, _) => G.input(_);
 const _18gf0ce = function _arrayViewTests(testing){return(
 testing.createSuite({
   name: "arrayView Tests",
   timeout_ms: 1000
 })
 )};
+const _ya28c1 = (G, _) => G.input(_);
 const _15sksbm = function _64(arrayViewTests,arrayView,Inputs,view,Event){return(
 arrayViewTests.test("arrayView dispatchEvent bubbles to container", (done) => {
   const av = arrayView({ builder: (v) => Inputs.input(v) });
@@ -23687,6 +23665,7 @@ testing.createSuite({
   timeout_ms: 1000
 })
 )};
+const _1heh2ju = (G, _) => G.input(_);
 const _1d6s8il = function _expect(testing){return(
 testing.expect
 )};
@@ -23930,13 +23909,7 @@ export default function define(runtime, observer) {
   const $def = (pid, name, deps, fn) => {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
-  const fileAttachments = new Map([].map((name) => {
-    const module_name = "@tomlarkworthy/view";
-    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
-    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
-    return [name, {url: blob_url, mimeType: mime}]
-  }));
-  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
   $def("_7t08i0", null, ["md"], _7t08i0);  
   $def("_1xtmjwe", null, ["md"], _1xtmjwe);  
   $def("_1gcm0q3", null, ["toc"], _1gcm0q3);  
@@ -23944,17 +23917,17 @@ export default function define(runtime, observer) {
   $def("_1t2g6wv", null, ["md"], _1t2g6wv);  
   $def("_ens80c", null, ["md"], _ens80c);  
   $def("_thj7oa", "viewof composite", ["view","Inputs"], _thj7oa);  
-  main.variable(observer("composite")).define("composite", ["Generators", "viewof composite"], (G, _) => G.input(_));  
+  $def("_1j8bed9", "composite", ["Generators","viewof composite"], _1j8bed9);  
   $def("_1cbg1ut", null, ["md"], _1cbg1ut);  
   $def("_p6ma5r", null, ["htl","viewof composite","Event"], _p6ma5r);  
   $def("_nsci4b", null, ["md"], _nsci4b);  
   $def("_fl8f6f", "viewof singleton", ["view","Inputs"], _fl8f6f);  
-  main.variable(observer("singleton")).define("singleton", ["Generators", "viewof singleton"], (G, _) => G.input(_));  
+  $def("_1a6iprb", "singleton", ["Generators","viewof singleton"], _1a6iprb);  
   $def("_1ve06sk", null, ["singleton"], _1ve06sk);  
   $def("_tbqkol", null, ["viewof singleton"], _tbqkol);  
   $def("_11aduma", null, ["md"], _11aduma);  
   $def("_vj562f", "viewof arrayCollection", ["view","Inputs"], _vj562f);  
-  main.variable(observer("arrayCollection")).define("arrayCollection", ["Generators", "viewof arrayCollection"], (G, _) => G.input(_));  
+  $def("_1kies17", "arrayCollection", ["Generators","viewof arrayCollection"], _1kies17);  
   $def("_1p0uyl7", null, ["viewof arrayCollection"], _1p0uyl7);  
   $def("_1d6bfyh", null, ["md"], _1d6bfyh);  
   $def("_1l9a11r", null, ["Inputs","viewof arrayCollection","Event"], _1l9a11r);  
@@ -23962,16 +23935,16 @@ export default function define(runtime, observer) {
   $def("_7wc391", null, ["arrayCollection"], _7wc391);  
   $def("_poua2y", null, ["md"], _poua2y);  
   $def("_1rhiame", "viewof dynamicArrayCollection", ["view","Inputs"], _1rhiame);  
-  main.variable(observer("dynamicArrayCollection")).define("dynamicArrayCollection", ["Generators", "viewof dynamicArrayCollection"], (G, _) => G.input(_));  
+  $def("_zpp1eq", "dynamicArrayCollection", ["Generators","viewof dynamicArrayCollection"], _zpp1eq);  
   $def("_letn54", null, ["Inputs","dynamicArrayCollection","viewof dynamicArrayCollection","Event"], _letn54);  
   $def("_1ryjhdn", null, ["Inputs","dynamicArrayCollection","viewof dynamicArrayCollection","Event"], _1ryjhdn);  
   $def("_lvlsbu", "objects", ["md"], _lvlsbu);  
   $def("_l156sp", "viewof objectCollection", ["view","Inputs"], _l156sp);  
-  main.variable(observer("objectCollection")).define("objectCollection", ["Generators", "viewof objectCollection"], (G, _) => G.input(_));  
+  $def("_1rr8jsf", "objectCollection", ["Generators","viewof objectCollection"], _1rr8jsf);  
   $def("_100x12m", null, ["objectCollection"], _100x12m);  
   $def("_1bp70ju", null, ["md"], _1bp70ju);  
   $def("_qfu62l", "viewof dynamicObjectCollection", ["view","Inputs"], _qfu62l);  
-  main.variable(observer("dynamicObjectCollection")).define("dynamicObjectCollection", ["Generators", "viewof dynamicObjectCollection"], (G, _) => G.input(_));  
+  $def("_2z2c08", "dynamicObjectCollection", ["Generators","viewof dynamicObjectCollection"], _2z2c08);  
   $def("_16lq9yi", null, ["dynamicObjectCollection"], _16lq9yi);  
   $def("_3eto2x", null, ["viewof dynamicObjectCollection"], _3eto2x);  
   $def("_146kl0d", null, ["Inputs","viewof dynamicObjectCollection","Event"], _146kl0d);  
@@ -23979,7 +23952,7 @@ export default function define(runtime, observer) {
   $def("_tthqa7", null, ["viewof dynamicObjectCollection"], _tthqa7);  
   $def("_13vvgce", null, ["md"], _13vvgce);  
   $def("_rvx6v2", "viewof hiddenView", ["view","viewof singleton"], _rvx6v2);  
-  main.variable(observer("hiddenView")).define("hiddenView", ["Generators", "viewof hiddenView"], (G, _) => G.input(_));  
+  $def("_v1kcx9", "hiddenView", ["Generators","viewof hiddenView"], _v1kcx9);  
   $def("_1mp8wce", null, ["viewof hiddenView","Event"], _1mp8wce);  
   $def("_1sj8267", null, ["md"], _1sj8267);  
   $def("_vj032k", null, ["md"], _vj032k);  
@@ -23987,14 +23960,14 @@ export default function define(runtime, observer) {
   $def("_dvlpzy", null, ["md"], _dvlpzy);  
   $def("_1mi8rwf", null, ["cautiousNestedDemo"], _1mi8rwf);  
   $def("_1u3kb2b", "viewof cautiousNestedDemo", ["view","cautious","Inputs"], _1u3kb2b);  
-  main.variable(observer("cautiousNestedDemo")).define("cautiousNestedDemo", ["Generators", "viewof cautiousNestedDemo"], (G, _) => G.input(_));  
+  $def("_1jpx1fd", "cautiousNestedDemo", ["Generators","viewof cautiousNestedDemo"], _1jpx1fd);  
   $def("_1zec06", null, ["md"], _1zec06);  
   $def("_wss5uy", "viewof slider", ["Inputs"], _wss5uy);  
-  main.variable(observer("slider")).define("slider", ["Generators", "viewof slider"], (G, _) => G.input(_));  
+  $def("_1ckicdh", "slider", ["Generators","viewof slider"], _1ckicdh);  
   $def("_l5ujyt", "viewof levels", ["bindOneWay","Inputs","viewof slider"], _l5ujyt);  
-  main.variable(observer("levels")).define("levels", ["Generators", "viewof levels"], (G, _) => G.input(_));  
+  $def("_1jqrotr", "levels", ["Generators","viewof levels"], _1jqrotr);  
   $def("_1x1f14t", "viewof levelsText", ["bindOneWay","Inputs","viewof levels"], _1x1f14t);  
-  main.variable(observer("levelsText")).define("levelsText", ["Generators", "viewof levelsText"], (G, _) => G.input(_));  
+  $def("_dlcq5s", "levelsText", ["Generators","viewof levelsText"], _dlcq5s);  
   $def("_1fx1tne", "bindOneWay", ["MutationObserver","Event"], _1fx1tne);  
   $def("_adgwwv", null, ["md"], _adgwwv);  
   $def("_1a17vni", "variable", [], _1a17vni);  
@@ -24010,9 +23983,9 @@ export default function define(runtime, observer) {
   $def("_129h6pr", null, ["md","numbers"], _129h6pr);  
   $def("_1ak39tr", null, ["htl","Inputs","viewof numbers","Event","numbers"], _1ak39tr);  
   $def("_1qvueml", "viewof numbers", ["view","arrayView","Inputs"], _1qvueml);  
-  main.variable(observer("numbers")).define("numbers", ["Generators", "viewof numbers"], (G, _) => G.input(_));  
+  $def("_a54zdk", "numbers", ["Generators","viewof numbers"], _a54zdk);  
   $def("_18gf0ce", "viewof arrayViewTests", ["testing"], _18gf0ce);  
-  main.variable(observer("arrayViewTests")).define("arrayViewTests", ["Generators", "viewof arrayViewTests"], (G, _) => G.input(_));  
+  $def("_ya28c1", "arrayViewTests", ["Generators","viewof arrayViewTests"], _ya28c1);  
   $def("_15sksbm", null, ["arrayViewTests","arrayView","Inputs","view","Event"], _15sksbm);  
   $def("_12xu605", null, ["arrayViewTests","arrayView","Inputs","Event"], _12xu605);  
   $def("_w88vv4", null, ["arrayViewTests","arrayView","Inputs","expect"], _w88vv4);  
@@ -24029,7 +24002,7 @@ export default function define(runtime, observer) {
   $def("_11gtx14", "RUN_TESTS", [], _11gtx14);  
   $def("_46icxz", "testing", ["RUN_TESTS","invalidation"], _46icxz);  
   $def("_lf943y", "viewof suite", ["testing"], _lf943y);  
-  main.variable(observer("suite")).define("suite", ["Generators", "viewof suite"], (G, _) => G.input(_));  
+  $def("_1heh2ju", "suite", ["Generators","viewof suite"], _1heh2ju);  
   $def("_1d6s8il", "expect", ["testing"], _1d6s8il);  
   $def("_17jun0l", null, ["suite","view","variable","expect"], _17jun0l);  
   $def("_1bzudss", null, ["suite","variable","view","expect"], _1bzudss);  
@@ -24170,6 +24143,7 @@ md`---
 const _1dop2vt = function _allVariables(variables,runtime){return(
 variables(runtime)
 )};
+const _1b82ds4 = (G, _) => G.input(_);
 const _osnrne = function _mainVariables(allVariables,main){return(
 [...allVariables].filter((v) => v._module == main)
 )};
@@ -24214,9 +24188,11 @@ const _9i8usd = function _visualizer(main,Inspector,backgroundJobs,html,$0,Event
 const _mit3pw = function _visualizers(Inputs){return(
 Inputs.input(new Set())
 )};
+const _hut17f = (G, _) => G.input(_);
 const _1vthejs = function _visualizersToDelete(Inputs){return(
 Inputs.input(new Set())
 )};
+const _1vj8v1t = (G, _) => G.input(_);
 const _1nz4pe4 = function _inspectors(visualizers)
 {
   const inspectors = this || new Map(); // preserve state across invalidations
@@ -24522,26 +24498,21 @@ const _1wiz55o = function _backgroundJobs(keepalive,visualizerModule)
 const _1oonsyz = function _visualizerModule(thisModule){return(
 thisModule()
 )};
+const _690yio = (G, _) => G.input(_);
 const _xqi0zo = function _28(md){return(
 md`### imports`
 )};
-const _z52tkt = (_, v) => v.import("Inspector", _);
-const _1nhzr5b = (_, v) => v.import("myModule", "runtimSdkModule", _);
-const _1d84grj = (_, v) => v.import("liveCellMap", _);
-const _18lkfb = (_, v) => v.import("navHref", _);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
   const $def = (pid, name, deps, fn) => {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
-  const fileAttachments = new Map([].map((name) => {
-    const module_name = "@tomlarkworthy/visualizer";
-    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
-    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
-    return [name, {url: blob_url, mimeType: mime}]
-  }));
-  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/inspector", async () => runtime.module((await import("/@tomlarkworthy/inspector.js?v=4")).default));  
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
+  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
   $def("_1x409on", "title", ["md"], _1x409on);  
   $def("_1bc6kre", "lopeviz_handle_css", ["md"], _1bc6kre);  
   $def("_7kk8ke", null, ["md"], _7kk8ke);  
@@ -24555,13 +24526,13 @@ export default function define(runtime, observer) {
   $def("_1jhi1ns", null, ["md"], _1jhi1ns);  
   $def("_1nnmael", null, ["md"], _1nnmael);  
   $def("_1dop2vt", "viewof allVariables", ["variables","runtime"], _1dop2vt);  
-  main.variable(observer("allVariables")).define("allVariables", ["Generators", "viewof allVariables"], (G, _) => G.input(_));  
+  $def("_1b82ds4", "allVariables", ["Generators","viewof allVariables"], _1b82ds4);  
   $def("_osnrne", "mainVariables", ["allVariables","main"], _osnrne);  
   $def("_9i8usd", "visualizer", ["main","Inspector","backgroundJobs","html","viewof visualizers","Event","viewof visualizersToDelete"], _9i8usd);  
   $def("_mit3pw", "viewof visualizers", ["Inputs"], _mit3pw);  
-  main.variable(observer("visualizers")).define("visualizers", ["Generators", "viewof visualizers"], (G, _) => G.input(_));  
+  $def("_hut17f", "visualizers", ["Generators","viewof visualizers"], _hut17f);  
   $def("_1vthejs", "viewof visualizersToDelete", ["Inputs"], _1vthejs);  
-  main.variable(observer("visualizersToDelete")).define("visualizersToDelete", ["Generators", "viewof visualizersToDelete"], (G, _) => G.input(_));  
+  $def("_1vj8v1t", "visualizersToDelete", ["Generators","viewof visualizersToDelete"], _1vj8v1t);  
   $def("_1nz4pe4", "inspectors", ["visualizers"], _1nz4pe4);  
   $def("_1e4b50w", "TRACE_CELL", ["trace_variable"], _1e4b50w);  
   $def("_11ugoev", null, ["htl"], _11ugoev);  
@@ -24572,12 +24543,10 @@ export default function define(runtime, observer) {
   $def("_een5pq", null, ["md"], _een5pq);  
   $def("_1wiz55o", "backgroundJobs", ["keepalive","visualizerModule"], _1wiz55o);  
   $def("_1oonsyz", "viewof visualizerModule", ["thisModule"], _1oonsyz);  
-  main.variable(observer("visualizerModule")).define("visualizerModule", ["Generators", "viewof visualizerModule"], (G, _) => G.input(_));  
+  $def("_690yio", "visualizerModule", ["Generators","viewof visualizerModule"], _690yio);  
   $def("_xqi0zo", null, ["md"], _xqi0zo);  
-  main.define("module @tomlarkworthy/inspector", async () => runtime.module((await import("/@tomlarkworthy/inspector.js?v=4")).default));  
   main.define("Inspector", ["module @tomlarkworthy/inspector", "@variable"], (_, v) => v.import("Inspector", _));  
   main.define("isnode", ["module @tomlarkworthy/inspector", "@variable"], (_, v) => v.import("isnode", _));  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("runtimSdkModule", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("myModule", "runtimSdkModule", _));  
   main.define("unorderedSync", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("unorderedSync", _));  
   main.define("repositionSetElement", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("repositionSetElement", _));  
@@ -24591,9 +24560,7 @@ export default function define(runtime, observer) {
   main.define("keepalive", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("keepalive", _));  
   main.define("thisModule", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("thisModule", _));  
   main.define("trace_variable", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("trace_variable", _));  
-  main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
   main.define("liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("liveCellMap", _));  
-  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
   main.define("navHref", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("navHref", _));
   return main;
 }</script>
@@ -24642,13 +24609,7 @@ export default function define(runtime, observer) {
   const $def = (pid, name, deps, fn) => {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
-  const fileAttachments = new Map([].map((name) => {
-    const module_name = "d/57d79353bac56631@44";
-    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
-    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
-    return [name, {url: blob_url, mimeType: mime}]
-  }));
-  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
   $def("_10kt1ov", null, ["md"], _10kt1ov);  
   $def("_t1t65l", null, ["md","location"], _t1t65l);  
   $def("_17xb4st", null, ["md","hash"], _17xb4st);  

--- a/notebooks/@tomlarkworthy_lopepage-urls.html
+++ b/notebooks/@tomlarkworthy_lopepage-urls.html
@@ -14177,7 +14177,7 @@ export default function define(runtime, observer) {
   return main;
 }</script>
 
-<script id="@tomlarkworthy/lopepage-urls" 
+<script id="@tomlarkworthy/lopepage-urls"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -14528,81 +14528,72 @@ const _gxaxgb = function _links(){return(
 const _17e89y0 = function _targets(){return(
 ["@tom/bar", "d/1f41fef8b019cf4e@94", "@tom/bar#cell"]
 )};
-const _1x6cut = function _linkTo(isOnObservableCom){return(
-function linkTo(
-  target,
-  {
-    baseURI = document.baseURI,
-    onObservable = isOnObservableCom(),
-    source = null,
-    op = "open" // "open" | "close" | "focus"
-  } = {}
-) {
-  if (onObservable) {
-    const t =
-      typeof target === "string"
-        ? target
-        : target?.module || target?.open || target?.close || "";
-    return t.startsWith("#") ? t : "/" + t;
-  }
-
-  // Parse existing hash params manually to avoid percent-encoding DSL chars
-  const base = new URL(baseURI);
-  const rawHash = (base.hash || "#").slice(1);
-  const hashParams = new Map();
-  if (rawHash) {
-    for (const part of rawHash.split("&")) {
-      const eq = part.indexOf("=");
-      if (eq >= 0) hashParams.set(part.slice(0, eq), part.slice(eq + 1));
-      else if (part) hashParams.set(part, "");
+const _1x6cut = function _linkTo(isOnObservableCom) {return (function linkTo(target, {baseURI = document.baseURI, onObservable = isOnObservableCom(), source = null, op = 'open'    // "open" | "close" | "focus"
+} = {}) {
+    if (onObservable) {
+        const t = typeof target === 'string' ? target : target?.module || target?.open || target?.close || '';
+        return t.startsWith('#') ? t : '/' + t;
     }
-  }
-
-  if (typeof target === "string" && target.startsWith("#")) return target;
-
-  const isIntent =
-    typeof target === "object" &&
-    target !== null &&
-    ("module" in target ||
-      "open" in target ||
-      "close" in target ||
-      "focus" in target ||
-      "op" in target);
-
-  let module = null;
-  let cell = null;
-
-  if (!isIntent) {
-    module = String(target ?? "");
-    const parts = module.split("#");
-    module = parts[0] || null;
-    cell = parts[1] || null;
-    op = "open";
-  } else {
-    module =
-      target.module || target.open || target.close || target.focus || null;
-    cell = target.cell || null;
-    source = target.source ?? source;
-    op =
-      target.op || (target.close ? "close" : target.focus ? "focus" : "open");
-  }
-
-  if (!module) return base.toString();
-
-  hashParams.set(op, cell ? `${module}#${cell}` : module);
-  if (source) hashParams.set("from", source);
-
-  // Build hash without URLSearchParams to preserve DSL chars unencoded.
-  // Return hash-only for same-page links to avoid page reload.
-  const hashStr = [...hashParams]
-    .map(([k, v]) => (v ? `${k}=${v}` : k))
-    .join("&");
-  return "#" + hashStr;
-}
-)};
+    // Parse existing hash params manually to avoid percent-encoding DSL chars
+    const base = new URL(baseURI);
+    const rawHash = (base.hash || '#').slice(1);
+    const hashParams = new Map();
+    // open/close/focus/from are transient intents that lopepage consumes and
+    // clears, so we do NOT deep-link them. view= is canonical layout state owned
+    // by lopepage; if we baked the baseURI's view= into every link, the href
+    // would be a snapshot from link-render time and clicking it would rewind the
+    // layout (issue #150 — clicking a second module wiped the first because the
+    // link carried the boot view=). Dropping view= here makes the link a pure
+    // intent (e.g. "#cc=...&open=X"); sync_layout_from_url's
+    // `if (!view && open)` branch then merges the intent into the live layout.
+    const drop = new Set([
+        'view',
+        'open',
+        'close',
+        'focus',
+        'from'
+    ]);
+    if (rawHash) {
+        for (const part of rawHash.split('&')) {
+            const eq = part.indexOf('=');
+            const key = eq >= 0 ? part.slice(0, eq) : part;
+            if (drop.has(key))
+                continue;
+            const val = eq >= 0 ? part.slice(eq + 1) : '';
+            hashParams.set(key, val);
+        }
+    }
+    if (typeof target === 'string' && target.startsWith('#'))
+        return target;
+    const isIntent = typeof target === 'object' && target !== null && ('module' in target || 'open' in target || 'close' in target || 'focus' in target || 'op' in target);
+    let module = null;
+    let cell = null;
+    if (!isIntent) {
+        module = String(target ?? '');
+        const parts = module.split('#');
+        module = parts[0] || null;
+        cell = parts[1] || null;
+        op = 'open';
+    } else {
+        module = target.module || target.open || target.close || target.focus || null;
+        cell = target.cell || null;
+        source = target.source ?? source;
+        op = target.op || (target.close ? 'close' : target.focus ? 'focus' : 'open');
+    }
+    if (!module)
+        return base.toString();
+    hashParams.set(op, cell ? `${ module }#${ cell }` : module);
+    if (source)
+        hashParams.set('from', source);
+    // Build hash without URLSearchParams to preserve DSL chars unencoded.
+    // Return hash-only for same-page links to avoid page reload.
+    const hashStr = [...hashParams].map(([k, v]) => v ? `${ k }=${ v }` : k).join('&');
+    return '#' + hashStr;
+});};
 const _jdyayh = function _vars(variables,runtime){return(
 variables(runtime)
 )};
+const _mfvz6q = (G, _) => G.input(_);
 const _1f44wsz = function _test_linkTo(links,targets,linkTo){return(
 links.map((link) =>
   targets.map((target) =>
@@ -14615,7 +14606,6 @@ md`## Auto switch to url structure
 
 Watch the runtime for imports and swap them for our structure`
 )};
-const _w93ki7 = (_, v) => v.import("runtime", _);
 const _1gllckt = function _href_examples(){return(
 [
   "https://tomlarkworthy/import-notebook",
@@ -14674,20 +14664,13 @@ const _1xxtf0r = function _updateNotebookImports(vars,extractNotebookAndCell,lin
     }
   }
 };
-const _1txhfy5 = (_, v) => v.import("tests", _);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
   const $def = (pid, name, deps, fn) => {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
-  const fileAttachments = new Map([].map((name) => {
-    const module_name = "@tomlarkworthy/lopepage-urls";
-    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
-    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
-    return [name, {url: blob_url, mimeType: mime}]
-  }));
-  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
   $def("_1g7wjzc", null, ["md"], _1g7wjzc);  
   $def("_1hsbxxe", null, ["md"], _1hsbxxe);  
   $def("_1buq9dd", null, ["tests"], _1buq9dd);  
@@ -14719,7 +14702,7 @@ export default function define(runtime, observer) {
   $def("_17e89y0", "targets", [], _17e89y0);  
   $def("_1x6cut", "linkTo", ["isOnObservableCom"], _1x6cut);  
   $def("_jdyayh", "viewof vars", ["variables","runtime"], _jdyayh);  
-  main.variable(observer("vars")).define("vars", ["Generators", "viewof vars"], (G, _) => G.input(_));  
+  $def("_mfvz6q", "vars", ["Generators","viewof vars"], _mfvz6q);  
   $def("_1f44wsz", "test_linkTo", ["links","targets","linkTo"], _1f44wsz);  
   $def("_1hdknc", null, ["md"], _1hdknc);  
   main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
@@ -14732,7 +14715,8 @@ export default function define(runtime, observer) {
   main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
   main.define("tests", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("tests", _));
   return main;
-}</script>
+}
+</script>
 
 <script id="@tomlarkworthy/module-map" 
   type="text/plain"

--- a/notebooks/@tomlarkworthy_lopepage-urls.json
+++ b/notebooks/@tomlarkworthy_lopepage-urls.json
@@ -23,19 +23,19 @@
       "hash": "5658858e85affa2e1e5cd1052924c622"
     },
     "@mbostock/safe-local-storage": {
-      "hash": "8a88859739be6b76d0acd16d42370c2a",
+      "hash": "937d252019887842c8c48c634b76179a",
       "dependedBy": [
         "@tomlarkworthy/local-storage-view"
       ]
     },
     "@mootari/access-runtime": {
-      "hash": "e0c3ba2924599cde4b15780f21535fc9",
+      "hash": "824eda0a37dba52c718c3e24cd664982",
       "dependedBy": [
         "@tomlarkworthy/runtime-sdk"
       ]
     },
     "@tomlarkworthy/acorn-8-11-3": {
-      "hash": "689248bd889b27100982d16907284a3e",
+      "hash": "e483cbde82225efd3b3224d603903164",
       "files": [
         "acorn-8.11.3.js.gz"
       ],
@@ -44,7 +44,7 @@
       ]
     },
     "@tomlarkworthy/cell-map": {
-      "hash": "6822a2cb2a50363ffc9cb10e0560430c",
+      "hash": "c8281cd25de378ac872c7e289b0b715a",
       "dependsOn": [
         "@tomlarkworthy/lopepage-urls",
         "@tomlarkworthy/module-map",
@@ -62,13 +62,13 @@
       ]
     },
     "@tomlarkworthy/cells-to-clipboard": {
-      "hash": "dacd3fb8a1b01cee2c06752a74b330e2",
+      "hash": "f245a2a1ad646c1f9430b0ecdf9b0cbc",
       "dependedBy": [
         "@tomlarkworthy/editor-5"
       ]
     },
     "@tomlarkworthy/claude-code-pairing": {
-      "hash": "f813e7b2af4ecb45c34df97bb0e6691b",
+      "hash": "e3d2efd40f14f02510af61a5df5b451c",
       "dependsOn": [
         "@tomlarkworthy/module-map",
         "@tomlarkworthy/exporter-3",
@@ -84,7 +84,7 @@
       ]
     },
     "@tomlarkworthy/codemirror-6-v2": {
-      "hash": "8a9c8fbd6a5efc6ceed2ddc7cd8bf8cd",
+      "hash": "b79a37cf1dd24fd22fc89bbde24edd7a",
       "files": [
         "codemirror_javascript%405.js.gz"
       ],
@@ -93,7 +93,7 @@
       ]
     },
     "@tomlarkworthy/dataflow-templating": {
-      "hash": "e613a922d8026a606b5bfe29e82e3d4d",
+      "hash": "252c8b301ce39174ba434ed710c829e1",
       "files": [
         "dataflow_templating%401.svg"
       ],
@@ -106,13 +106,13 @@
       ]
     },
     "@tomlarkworthy/dom-view": {
-      "hash": "206ee88532568c2666b83a3c6a5651fc",
+      "hash": "5d93999f7810ce61fe36ddbeca737dff",
       "dependedBy": [
         "@tomlarkworthy/exporter-3"
       ]
     },
     "@tomlarkworthy/editor-5": {
-      "hash": "12723c9bc63feb2fd162a203e0a3c92a",
+      "hash": "7ed352ac85a30cf1540040cb29aa88b7",
       "files": [
         "cell_options.json"
       ],
@@ -136,7 +136,7 @@
       ]
     },
     "@tomlarkworthy/escodegen": {
-      "hash": "9f5f5b6dc7cbf17851e11bb8b41376e8",
+      "hash": "d5e793114a390617e9a70bfdd61a42ec",
       "files": [
         "escodegen.browser.min.js.gz"
       ],
@@ -145,7 +145,7 @@
       ]
     },
     "@tomlarkworthy/exporter-3": {
-      "hash": "b3f954458e71490d36f0311b54a567f5",
+      "hash": "12548ff77d201dd107f24d26dd2165e6",
       "dependsOn": [
         "@tomlarkworthy/observable-runtime-v6",
         "@tomlarkworthy/flow-queue",
@@ -168,7 +168,7 @@
       ]
     },
     "@tomlarkworthy/file-sync": {
-      "hash": "c90430eb45b110729154a140c57b7d2a",
+      "hash": "e379596265cd3030c6f98d97aa807b75",
       "dependsOn": [
         "@tomlarkworthy/module-map",
         "@tomlarkworthy/exporter-3",
@@ -181,7 +181,7 @@
       ]
     },
     "@tomlarkworthy/fileattachments": {
-      "hash": "545a941e68d2d3725b60338c689236d7",
+      "hash": "fba8f936fac563f937051341f9c4aaf4",
       "dependsOn": [
         "@tomlarkworthy/runtime-sdk"
       ],
@@ -192,7 +192,7 @@
       ]
     },
     "@tomlarkworthy/flow-queue": {
-      "hash": "5c3265dee24de2900c084d2037f295e4",
+      "hash": "e6efc6ff2c5841e59bf5f22a2e4fd309",
       "files": [
         "flowQuery%401.svg"
       ],
@@ -203,7 +203,7 @@
       ]
     },
     "@tomlarkworthy/golden-layout-2-6-0": {
-      "hash": "5f8e24edd4af9f5989c07fa653cd318a",
+      "hash": "17b1cfc092e7aa851102ce64ebd95314",
       "files": [
         "golden-layout-2.6.0.js.gz",
         "lm_popout_black.png",
@@ -217,7 +217,7 @@
       ]
     },
     "@tomlarkworthy/import-notebook": {
-      "hash": "10ffc2e3767383d9ebad5a72ba554df5",
+      "hash": "b6c52cc7de8b52cdf491eb76049236cc",
       "dependsOn": [
         "@tomlarkworthy/runtime-sdk"
       ],
@@ -226,7 +226,7 @@
       ]
     },
     "@tomlarkworthy/inspector": {
-      "hash": "1c9d0849628e5565203bf893f1f839be",
+      "hash": "4388a12127c9f7f4667923f96ebb6820",
       "files": [
         "inspector-5%401.0.1.js.gz"
       ],
@@ -239,7 +239,7 @@
       ]
     },
     "@tomlarkworthy/isomorphic-git-1-30-1": {
-      "hash": "ba9a496ed299d2dcc9e1103469393d6a",
+      "hash": "cc5644744fc51b6badd823767165b905",
       "files": [
         "isomorphic-git-1%401.30.1.bundle.js.gz",
         "isomorphic-git-http-1.0.0-beta.36.js.gz"
@@ -249,7 +249,7 @@
       ]
     },
     "@tomlarkworthy/jest-expect-standalone": {
-      "hash": "da16e797189285de82660c66936aaa41",
+      "hash": "5cd12f98a08cd6144369d970a42e41c9",
       "files": [
         "jest-expect-standalone-24.0.2.js.gz"
       ],
@@ -260,7 +260,7 @@
       ]
     },
     "@tomlarkworthy/jszip-3-10-1": {
-      "hash": "357c9016437fb1d7e27029ea13a66b14",
+      "hash": "104d2a3fa76149964a5ec2e78291b7fa",
       "files": [
         "jszip-3.10.1.min.js.gz"
       ],
@@ -269,7 +269,7 @@
       ]
     },
     "@tomlarkworthy/lightning-fs-4-6-0": {
-      "hash": "b95f360617df5610994d6c052a35bf39",
+      "hash": "9f29cd8f7d08a51eca9962323ede7620",
       "files": [
         "lightning-fs-4.6.0.js.gz"
       ],
@@ -278,7 +278,7 @@
       ]
     },
     "@tomlarkworthy/local-change-history": {
-      "hash": "7f08379bc5254086c368d794cb5160d9",
+      "hash": "4be33bfdca2870137e4daf135bb96919",
       "dependsOn": [
         "@tomlarkworthy/runtime-sdk",
         "@tomlarkworthy/lightning-fs-4-6-0",
@@ -294,7 +294,7 @@
       ]
     },
     "@tomlarkworthy/local-storage-view": {
-      "hash": "eed1ed18d97cf206895c430ab01622cd",
+      "hash": "da3fda1c802cba464986bb8614de354d",
       "dependsOn": [
         "@mbostock/safe-local-storage",
         "@tomlarkworthy/inspector"
@@ -304,7 +304,7 @@
       ]
     },
     "@tomlarkworthy/lopepage": {
-      "hash": "3914bcbc6ffddd0b89e18bc56b9a4acf",
+      "hash": "b1cdd444c91cac5439573be76274fb50",
       "dependsOn": [
         "@tomlarkworthy/golden-layout-2-6-0",
         "@tomlarkworthy/visualizer",
@@ -318,7 +318,7 @@
       ]
     },
     "@tomlarkworthy/lopepage-urls": {
-      "hash": "d4bd9e86437d4889fd2fa3a5c27e29cc",
+      "hash": "eee5c7951f9edd92f8fd1dba8442609b",
       "dependsOn": [
         "@tomlarkworthy/runtime-sdk",
         "@tomlarkworthy/tests"
@@ -333,7 +333,7 @@
       ]
     },
     "@tomlarkworthy/module-map": {
-      "hash": "680cd85b9ae18358014be1ec64c6fa20",
+      "hash": "fd8d3e82c52b111bd3e9f0ddd930f0af",
       "dependsOn": [
         "@tomlarkworthy/lopepage-urls",
         "@tomlarkworthy/flow-queue",
@@ -354,7 +354,7 @@
       ]
     },
     "@tomlarkworthy/module-selection": {
-      "hash": "4899c0c53f6a5ac7aafb11a6cbd26c10",
+      "hash": "4a1faa9fa20cfe945828d87c5a758c51",
       "dependsOn": [
         "@tomlarkworthy/observablejs-toolchain",
         "@tomlarkworthy/import-notebook",
@@ -368,14 +368,23 @@
         "@tomlarkworthy/lopepage"
       ]
     },
+    "@tomlarkworthy/observable-runtime": {
+      "hash": "015af244c77d1c0a73fb2aad51c8da83",
+      "files": [
+        "runtime.js.gz"
+      ],
+      "dependedBy": [
+        "@tomlarkworthy/observablejs-toolchain"
+      ]
+    },
     "@tomlarkworthy/observable-runtime-v6": {
-      "hash": "da9a8cb52bb52d056c21daaa0509bc6c",
+      "hash": "060835989c27d5cd2f82d358975a0328",
       "dependedBy": [
         "@tomlarkworthy/exporter-3"
       ]
     },
     "@tomlarkworthy/observablejs-toolchain": {
-      "hash": "d73f3d553ca45fbed58d85369e73480e",
+      "hash": "4fef8e87ae193330ccb6af2ac955aa86",
       "files": [
         "acorn-walk-8.3.2.js.gz",
         "parser-6.1.0.js.gz"
@@ -385,7 +394,8 @@
         "@tomlarkworthy/cell-map",
         "@tomlarkworthy/escodegen",
         "@tomlarkworthy/acorn-8-11-3",
-        "@tomlarkworthy/jest-expect-standalone"
+        "@tomlarkworthy/jest-expect-standalone",
+        "@tomlarkworthy/observable-runtime"
       ],
       "dependedBy": [
         "@tomlarkworthy/cell-map",
@@ -397,7 +407,7 @@
       ]
     },
     "@tomlarkworthy/reversible-attachment": {
-      "hash": "952b11138b4ebce3769da178aed7fb38",
+      "hash": "bd5c80a260b0ab92fd01205320224d30",
       "dependsOn": [
         "@tomlarkworthy/view"
       ],
@@ -407,7 +417,7 @@
       ]
     },
     "@tomlarkworthy/runtime-sdk": {
-      "hash": "391b48327c1fd5024646ff05ecd6047e",
+      "hash": "4d565b1b67254742111f1ef9d9aa8220",
       "dependsOn": [
         "@mootari/access-runtime"
       ],
@@ -430,7 +440,7 @@
       ]
     },
     "@tomlarkworthy/spectral-layout": {
-      "hash": "ab4eb8fca32ddc65dd25d6bc44a3116e",
+      "hash": "35a448bc0359085c38d622228972d60d",
       "dependsOn": [
         "@tomlarkworthy/module-map"
       ],
@@ -439,13 +449,13 @@
       ]
     },
     "@tomlarkworthy/stream-operators": {
-      "hash": "ab513d36573160b72cebfa4974f2e824",
+      "hash": "60e01583a36fc0e1abe3f5fa7b71efd7",
       "dependedBy": [
         "@tomlarkworthy/tests"
       ]
     },
     "@tomlarkworthy/summarizejs": {
-      "hash": "f4a28a55ff83097e2b6bdfa7e9384a5d",
+      "hash": "d5ca198f066bde101db6eed6086d55ed",
       "dependsOn": [
         "@tomlarkworthy/inspector"
       ],
@@ -454,7 +464,7 @@
       ]
     },
     "@tomlarkworthy/tests": {
-      "hash": "5c57cb40dd2e69574ad7599f8a5fdc2d",
+      "hash": "a4ead3e197c013250a0395848c3f4982",
       "dependsOn": [
         "@tomlarkworthy/lopepage-urls",
         "@tomlarkworthy/module-map",
@@ -469,20 +479,20 @@
       ]
     },
     "@tomlarkworthy/themes": {
-      "hash": "639751dd6c4ce04163a950e330f0574a",
+      "hash": "2d0b2196149373571f60ff4913c813fa",
       "dependedBy": [
         "@tomlarkworthy/exporter-3"
       ]
     },
     "@tomlarkworthy/view": {
-      "hash": "b5da78aba62125133c5c38cdaba42b55",
+      "hash": "16b8cf235bb51d57792ff44ac408e74a",
       "dependedBy": [
         "@tomlarkworthy/exporter-3",
         "@tomlarkworthy/reversible-attachment"
       ]
     },
     "@tomlarkworthy/visualizer": {
-      "hash": "c830db22d32748645539322616a35ac2",
+      "hash": "127e17aac7d6b39736c238001650a7cd",
       "dependsOn": [
         "@tomlarkworthy/inspector",
         "@tomlarkworthy/runtime-sdk",
@@ -495,7 +505,7 @@
       ]
     },
     "d/57d79353bac56631@44": {
-      "hash": "c37f6ffe387668e80e2e83c27d14065c",
+      "hash": "913f1f6b56a3bbdfca30148905419a98",
       "dependedBy": [
         "@tomlarkworthy/cell-map",
         "@tomlarkworthy/claude-code-pairing",
@@ -507,5 +517,6 @@
     "@tomlarkworthy/bootloader": {
       "hash": "f9e9b64ee53f0be7d70803f84a8d895f"
     }
-  }
+  },
+  "observablehq.com": "https://observablehq.com/@tomlarkworthy/lopepage-urls"
 }

--- a/notebooks/@tomlarkworthy_lopepage.html
+++ b/notebooks/@tomlarkworthy_lopepage.html
@@ -12973,7 +12973,7 @@ export default function define(runtime, observer) {
   return main;
 }</script>
 
-<script id="@tomlarkworthy/lopepage-urls" 
+<script id="@tomlarkworthy/lopepage-urls"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -13324,78 +13324,71 @@ const _gxaxgb = function _links(){return(
 const _17e89y0 = function _targets(){return(
 ["@tom/bar", "d/1f41fef8b019cf4e@94", "@tom/bar#cell"]
 )};
-const _1x6cut = function _linkTo(isOnObservableCom){return(
-function linkTo(
-  target,
-  {
-    baseURI = document.baseURI,
-    onObservable = isOnObservableCom(),
-    source = null,
-    op = "open" // "open" | "close" | "focus"
-  } = {}
-) {
-  if (onObservable) {
-    const t =
-      typeof target === "string"
-        ? target
-        : target?.module || target?.open || target?.close || "";
-    return t.startsWith("#") ? t : "/" + t;
-  }
-
-  // Parse existing hash params manually to avoid percent-encoding DSL chars
-  const base = new URL(baseURI);
-  const rawHash = (base.hash || "#").slice(1);
-  const hashParams = new Map();
-  if (rawHash) {
-    for (const part of rawHash.split("&")) {
-      const eq = part.indexOf("=");
-      if (eq >= 0) hashParams.set(part.slice(0, eq), part.slice(eq + 1));
-      else if (part) hashParams.set(part, "");
-    }
-  }
-
-  if (typeof target === "string" && target.startsWith("#")) return target;
-
-  const isIntent =
-    typeof target === "object" &&
-    target !== null &&
-    ("module" in target ||
-      "open" in target ||
-      "close" in target ||
-      "focus" in target ||
-      "op" in target);
-
-  let module = null;
-  let cell = null;
-
-  if (!isIntent) {
-    module = String(target ?? "");
-    const parts = module.split("#");
-    module = parts[0] || null;
-    cell = parts[1] || null;
-    op = "open";
-  } else {
-    module =
-      target.module || target.open || target.close || target.focus || null;
-    cell = target.cell || null;
-    source = target.source ?? source;
-    op =
-      target.op || (target.close ? "close" : target.focus ? "focus" : "open");
-  }
-
-  if (!module) return base.toString();
-
-  hashParams.set(op, cell ? `${module}#${cell}` : module);
-  if (source) hashParams.set("from", source);
-
-  // Build hash without URLSearchParams to preserve DSL chars unencoded.
-  // Return hash-only for same-page links to avoid page reload.
-  const hashStr = [...hashParams]
-    .map(([k, v]) => (v ? `${k}=${v}` : k))
-    .join("&");
-  return "#" + hashStr;
-}
-)};
+const _bsoqwx = function _linkTo(isOnObservableCom)
+{
+    return function linkTo(target, {baseURI = document.baseURI, onObservable = isOnObservableCom(), source = null, op = 'open'    // "open" | "close" | "focus"
+} = {}) {
+        if (onObservable) {
+            const t = typeof target === 'string' ? target : target?.module || target?.open || target?.close || '';
+            return t.startsWith('#') ? t : '/' + t;
+        }
+        // Parse existing hash params manually to avoid percent-encoding DSL chars
+        const base = new URL(baseURI);
+        const rawHash = (base.hash || '#').slice(1);
+        const hashParams = new Map();
+        // open/close/focus/from are transient intents that lopepage consumes and
+        // clears, so we do NOT deep-link them. view= is canonical layout state owned
+        // by lopepage; if we baked the baseURI's view= into every link, the href
+        // would be a snapshot from link-render time and clicking it would rewind the
+        // layout (issue #150 — clicking a second module wiped the first because the
+        // link carried the boot view=). Dropping view= here makes the link a pure
+        // intent (e.g. "#cc=...&open=X"); sync_layout_from_url's
+        // `if (!view && open)` branch then merges the intent into the live layout.
+        const drop = new Set([
+            'view',
+            'open',
+            'close',
+            'focus',
+            'from'
+        ]);
+        if (rawHash) {
+            for (const part of rawHash.split('&')) {
+                const eq = part.indexOf('=');
+                const key = eq >= 0 ? part.slice(0, eq) : part;
+                if (drop.has(key))
+                    continue;
+                const val = eq >= 0 ? part.slice(eq + 1) : '';
+                hashParams.set(key, val);
+            }
+        }
+        if (typeof target === 'string' && target.startsWith('#'))
+            return target;
+        const isIntent = typeof target === 'object' && target !== null && ('module' in target || 'open' in target || 'close' in target || 'focus' in target || 'op' in target);
+        let module = null;
+        let cell = null;
+        if (!isIntent) {
+            module = String(target ?? '');
+            const parts = module.split('#');
+            module = parts[0] || null;
+            cell = parts[1] || null;
+            op = 'open';
+        } else {
+            module = target.module || target.open || target.close || target.focus || null;
+            cell = target.cell || null;
+            source = target.source ?? source;
+            op = target.op || (target.close ? 'close' : target.focus ? 'focus' : 'open');
+        }
+        if (!module)
+            return base.toString();
+        hashParams.set(op, cell ? `${ module }#${ cell }` : module);
+        if (source)
+            hashParams.set('from', source);
+        // Build hash without URLSearchParams to preserve DSL chars unencoded.
+        // Return hash-only for same-page links to avoid page reload.
+        const hashStr = [...hashParams].map(([k, v]) => v ? `${ k }=${ v }` : k).join('&');
+        return '#' + hashStr;
+    };
+};
 const _jdyayh = function _vars(variables,runtime){return(
 variables(runtime)
 )};
@@ -13508,7 +13501,7 @@ export default function define(runtime, observer) {
   $def("_1xjzq9r", "isOnObservableCom", ["location"], _1xjzq9r);  
   $def("_gxaxgb", "links", [], _gxaxgb);  
   $def("_17e89y0", "targets", [], _17e89y0);  
-  $def("_1x6cut", "linkTo", ["isOnObservableCom"], _1x6cut);  
+  $def("_bsoqwx", "linkTo", ["isOnObservableCom"], _bsoqwx);  
   $def("_jdyayh", "viewof vars", ["variables","runtime"], _jdyayh);  
   $def("_mfvz6q", "vars", ["Generators","viewof vars"], _mfvz6q);  
   $def("_1f44wsz", "test_linkTo", ["links","targets","linkTo"], _1f44wsz);  
@@ -13521,7 +13514,8 @@ export default function define(runtime, observer) {
   $def("_1xxtf0r", "updateNotebookImports", ["vars","extractNotebookAndCell","linkTo"], _1xxtf0r);  
   main.define("tests", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("tests", _));
   return main;
-}</script>
+}
+</script>
 
 <script id="@tomlarkworthy/module-map" 
   type="text/plain"

--- a/notebooks/@tomlarkworthy_modern-screenshot.html
+++ b/notebooks/@tomlarkworthy_modern-screenshot.html
@@ -14177,7 +14177,7 @@ export default function define(runtime, observer) {
   return main;
 }</script>
 
-<script id="@tomlarkworthy/lopepage-urls" 
+<script id="@tomlarkworthy/lopepage-urls"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -14528,81 +14528,75 @@ const _gxaxgb = function _links(){return(
 const _17e89y0 = function _targets(){return(
 ["@tom/bar", "d/1f41fef8b019cf4e@94", "@tom/bar#cell"]
 )};
-const _1x6cut = function _linkTo(isOnObservableCom){return(
-function linkTo(
-  target,
-  {
-    baseURI = document.baseURI,
-    onObservable = isOnObservableCom(),
-    source = null,
-    op = "open" // "open" | "close" | "focus"
-  } = {}
-) {
-  if (onObservable) {
-    const t =
-      typeof target === "string"
-        ? target
-        : target?.module || target?.open || target?.close || "";
-    return t.startsWith("#") ? t : "/" + t;
-  }
-
-  // Parse existing hash params manually to avoid percent-encoding DSL chars
-  const base = new URL(baseURI);
-  const rawHash = (base.hash || "#").slice(1);
-  const hashParams = new Map();
-  if (rawHash) {
-    for (const part of rawHash.split("&")) {
-      const eq = part.indexOf("=");
-      if (eq >= 0) hashParams.set(part.slice(0, eq), part.slice(eq + 1));
-      else if (part) hashParams.set(part, "");
-    }
-  }
-
-  if (typeof target === "string" && target.startsWith("#")) return target;
-
-  const isIntent =
-    typeof target === "object" &&
-    target !== null &&
-    ("module" in target ||
-      "open" in target ||
-      "close" in target ||
-      "focus" in target ||
-      "op" in target);
-
-  let module = null;
-  let cell = null;
-
-  if (!isIntent) {
-    module = String(target ?? "");
-    const parts = module.split("#");
-    module = parts[0] || null;
-    cell = parts[1] || null;
-    op = "open";
-  } else {
-    module =
-      target.module || target.open || target.close || target.focus || null;
-    cell = target.cell || null;
-    source = target.source ?? source;
-    op =
-      target.op || (target.close ? "close" : target.focus ? "focus" : "open");
-  }
-
-  if (!module) return base.toString();
-
-  hashParams.set(op, cell ? `${module}#${cell}` : module);
-  if (source) hashParams.set("from", source);
-
-  // Build hash without URLSearchParams to preserve DSL chars unencoded.
-  // Return hash-only for same-page links to avoid page reload.
-  const hashStr = [...hashParams]
-    .map(([k, v]) => (v ? `${k}=${v}` : k))
-    .join("&");
-  return "#" + hashStr;
-}
-)};
+const _bsoqwx = function _linkTo(isOnObservableCom)
+{
+    return function linkTo(target, {baseURI = document.baseURI, onObservable = isOnObservableCom(), source = null, op = 'open'    // "open" | "close" | "focus"
+} = {}) {
+        if (onObservable) {
+            const t = typeof target === 'string' ? target : target?.module || target?.open || target?.close || '';
+            return t.startsWith('#') ? t : '/' + t;
+        }
+        // Parse existing hash params manually to avoid percent-encoding DSL chars
+        const base = new URL(baseURI);
+        const rawHash = (base.hash || '#').slice(1);
+        const hashParams = new Map();
+        // open/close/focus/from are transient intents that lopepage consumes and
+        // clears, so we do NOT deep-link them. view= is canonical layout state owned
+        // by lopepage; if we baked the baseURI's view= into every link, the href
+        // would be a snapshot from link-render time and clicking it would rewind the
+        // layout (issue #150 — clicking a second module wiped the first because the
+        // link carried the boot view=). Dropping view= here makes the link a pure
+        // intent (e.g. "#cc=...&open=X"); sync_layout_from_url's
+        // `if (!view && open)` branch then merges the intent into the live layout.
+        const drop = new Set([
+            'view',
+            'open',
+            'close',
+            'focus',
+            'from'
+        ]);
+        if (rawHash) {
+            for (const part of rawHash.split('&')) {
+                const eq = part.indexOf('=');
+                const key = eq >= 0 ? part.slice(0, eq) : part;
+                if (drop.has(key))
+                    continue;
+                const val = eq >= 0 ? part.slice(eq + 1) : '';
+                hashParams.set(key, val);
+            }
+        }
+        if (typeof target === 'string' && target.startsWith('#'))
+            return target;
+        const isIntent = typeof target === 'object' && target !== null && ('module' in target || 'open' in target || 'close' in target || 'focus' in target || 'op' in target);
+        let module = null;
+        let cell = null;
+        if (!isIntent) {
+            module = String(target ?? '');
+            const parts = module.split('#');
+            module = parts[0] || null;
+            cell = parts[1] || null;
+            op = 'open';
+        } else {
+            module = target.module || target.open || target.close || target.focus || null;
+            cell = target.cell || null;
+            source = target.source ?? source;
+            op = target.op || (target.close ? 'close' : target.focus ? 'focus' : 'open');
+        }
+        if (!module)
+            return base.toString();
+        hashParams.set(op, cell ? `${ module }#${ cell }` : module);
+        if (source)
+            hashParams.set('from', source);
+        // Build hash without URLSearchParams to preserve DSL chars unencoded.
+        // Return hash-only for same-page links to avoid page reload.
+        const hashStr = [...hashParams].map(([k, v]) => v ? `${ k }=${ v }` : k).join('&');
+        return '#' + hashStr;
+    };
+};
 const _jdyayh = function _vars(variables,runtime){return(
 variables(runtime)
 )};
+const _mfvz6q = (G, _) => G.input(_);
 const _1f44wsz = function _test_linkTo(links,targets,linkTo){return(
 links.map((link) =>
   targets.map((target) =>
@@ -14615,7 +14609,6 @@ md`## Auto switch to url structure
 
 Watch the runtime for imports and swap them for our structure`
 )};
-const _w93ki7 = (_, v) => v.import("runtime", _);
 const _1gllckt = function _href_examples(){return(
 [
   "https://tomlarkworthy/import-notebook",
@@ -14674,20 +14667,15 @@ const _1xxtf0r = function _updateNotebookImports(vars,extractNotebookAndCell,lin
     }
   }
 };
-const _1txhfy5 = (_, v) => v.import("tests", _);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
   const $def = (pid, name, deps, fn) => {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
-  const fileAttachments = new Map([].map((name) => {
-    const module_name = "@tomlarkworthy/lopepage-urls";
-    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
-    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
-    return [name, {url: blob_url, mimeType: mime}]
-  }));
-  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
   $def("_1g7wjzc", null, ["md"], _1g7wjzc);  
   $def("_1hsbxxe", null, ["md"], _1hsbxxe);  
   $def("_1buq9dd", null, ["tests"], _1buq9dd);  
@@ -14717,22 +14705,21 @@ export default function define(runtime, observer) {
   $def("_1xjzq9r", "isOnObservableCom", ["location"], _1xjzq9r);  
   $def("_gxaxgb", "links", [], _gxaxgb);  
   $def("_17e89y0", "targets", [], _17e89y0);  
-  $def("_1x6cut", "linkTo", ["isOnObservableCom"], _1x6cut);  
+  $def("_bsoqwx", "linkTo", ["isOnObservableCom"], _bsoqwx);  
   $def("_jdyayh", "viewof vars", ["variables","runtime"], _jdyayh);  
-  main.variable(observer("vars")).define("vars", ["Generators", "viewof vars"], (G, _) => G.input(_));  
+  $def("_mfvz6q", "vars", ["Generators","viewof vars"], _mfvz6q);  
   $def("_1f44wsz", "test_linkTo", ["links","targets","linkTo"], _1f44wsz);  
   $def("_1hdknc", null, ["md"], _1hdknc);  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("variables", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("variables", _));  
   $def("_1gllckt", "href_examples", [], _1gllckt);  
   $def("_133ucsn", "test_extractNotebookAndCell", ["href_examples","extractNotebookAndCell"], _133ucsn);  
   $def("_cb1ope", "extractNotebookAndCell", [], _cb1ope);  
   $def("_1xxtf0r", "updateNotebookImports", ["vars","extractNotebookAndCell","linkTo"], _1xxtf0r);  
-  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
   main.define("tests", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("tests", _));
   return main;
-}</script>
+}
+</script>
 <script id="@tomlarkworthy/modern-screenshot/modern-screenshot-4.6.6.js.gz" 
   type="text/plain"
   data-encoding="base64"

--- a/notebooks/@tomlarkworthy_module-selection.html
+++ b/notebooks/@tomlarkworthy_module-selection.html
@@ -12973,7 +12973,7 @@ export default function define(runtime, observer) {
   return main;
 }</script>
 
-<script id="@tomlarkworthy/lopepage-urls" 
+<script id="@tomlarkworthy/lopepage-urls"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -13324,78 +13324,71 @@ const _gxaxgb = function _links(){return(
 const _17e89y0 = function _targets(){return(
 ["@tom/bar", "d/1f41fef8b019cf4e@94", "@tom/bar#cell"]
 )};
-const _1x6cut = function _linkTo(isOnObservableCom){return(
-function linkTo(
-  target,
-  {
-    baseURI = document.baseURI,
-    onObservable = isOnObservableCom(),
-    source = null,
-    op = "open" // "open" | "close" | "focus"
-  } = {}
-) {
-  if (onObservable) {
-    const t =
-      typeof target === "string"
-        ? target
-        : target?.module || target?.open || target?.close || "";
-    return t.startsWith("#") ? t : "/" + t;
-  }
-
-  // Parse existing hash params manually to avoid percent-encoding DSL chars
-  const base = new URL(baseURI);
-  const rawHash = (base.hash || "#").slice(1);
-  const hashParams = new Map();
-  if (rawHash) {
-    for (const part of rawHash.split("&")) {
-      const eq = part.indexOf("=");
-      if (eq >= 0) hashParams.set(part.slice(0, eq), part.slice(eq + 1));
-      else if (part) hashParams.set(part, "");
-    }
-  }
-
-  if (typeof target === "string" && target.startsWith("#")) return target;
-
-  const isIntent =
-    typeof target === "object" &&
-    target !== null &&
-    ("module" in target ||
-      "open" in target ||
-      "close" in target ||
-      "focus" in target ||
-      "op" in target);
-
-  let module = null;
-  let cell = null;
-
-  if (!isIntent) {
-    module = String(target ?? "");
-    const parts = module.split("#");
-    module = parts[0] || null;
-    cell = parts[1] || null;
-    op = "open";
-  } else {
-    module =
-      target.module || target.open || target.close || target.focus || null;
-    cell = target.cell || null;
-    source = target.source ?? source;
-    op =
-      target.op || (target.close ? "close" : target.focus ? "focus" : "open");
-  }
-
-  if (!module) return base.toString();
-
-  hashParams.set(op, cell ? `${module}#${cell}` : module);
-  if (source) hashParams.set("from", source);
-
-  // Build hash without URLSearchParams to preserve DSL chars unencoded.
-  // Return hash-only for same-page links to avoid page reload.
-  const hashStr = [...hashParams]
-    .map(([k, v]) => (v ? `${k}=${v}` : k))
-    .join("&");
-  return "#" + hashStr;
-}
-)};
+const _bsoqwx = function _linkTo(isOnObservableCom)
+{
+    return function linkTo(target, {baseURI = document.baseURI, onObservable = isOnObservableCom(), source = null, op = 'open'    // "open" | "close" | "focus"
+} = {}) {
+        if (onObservable) {
+            const t = typeof target === 'string' ? target : target?.module || target?.open || target?.close || '';
+            return t.startsWith('#') ? t : '/' + t;
+        }
+        // Parse existing hash params manually to avoid percent-encoding DSL chars
+        const base = new URL(baseURI);
+        const rawHash = (base.hash || '#').slice(1);
+        const hashParams = new Map();
+        // open/close/focus/from are transient intents that lopepage consumes and
+        // clears, so we do NOT deep-link them. view= is canonical layout state owned
+        // by lopepage; if we baked the baseURI's view= into every link, the href
+        // would be a snapshot from link-render time and clicking it would rewind the
+        // layout (issue #150 — clicking a second module wiped the first because the
+        // link carried the boot view=). Dropping view= here makes the link a pure
+        // intent (e.g. "#cc=...&open=X"); sync_layout_from_url's
+        // `if (!view && open)` branch then merges the intent into the live layout.
+        const drop = new Set([
+            'view',
+            'open',
+            'close',
+            'focus',
+            'from'
+        ]);
+        if (rawHash) {
+            for (const part of rawHash.split('&')) {
+                const eq = part.indexOf('=');
+                const key = eq >= 0 ? part.slice(0, eq) : part;
+                if (drop.has(key))
+                    continue;
+                const val = eq >= 0 ? part.slice(eq + 1) : '';
+                hashParams.set(key, val);
+            }
+        }
+        if (typeof target === 'string' && target.startsWith('#'))
+            return target;
+        const isIntent = typeof target === 'object' && target !== null && ('module' in target || 'open' in target || 'close' in target || 'focus' in target || 'op' in target);
+        let module = null;
+        let cell = null;
+        if (!isIntent) {
+            module = String(target ?? '');
+            const parts = module.split('#');
+            module = parts[0] || null;
+            cell = parts[1] || null;
+            op = 'open';
+        } else {
+            module = target.module || target.open || target.close || target.focus || null;
+            cell = target.cell || null;
+            source = target.source ?? source;
+            op = target.op || (target.close ? 'close' : target.focus ? 'focus' : 'open');
+        }
+        if (!module)
+            return base.toString();
+        hashParams.set(op, cell ? `${ module }#${ cell }` : module);
+        if (source)
+            hashParams.set('from', source);
+        // Build hash without URLSearchParams to preserve DSL chars unencoded.
+        // Return hash-only for same-page links to avoid page reload.
+        const hashStr = [...hashParams].map(([k, v]) => v ? `${ k }=${ v }` : k).join('&');
+        return '#' + hashStr;
+    };
+};
 const _jdyayh = function _vars(variables,runtime){return(
 variables(runtime)
 )};
@@ -13508,7 +13501,7 @@ export default function define(runtime, observer) {
   $def("_1xjzq9r", "isOnObservableCom", ["location"], _1xjzq9r);  
   $def("_gxaxgb", "links", [], _gxaxgb);  
   $def("_17e89y0", "targets", [], _17e89y0);  
-  $def("_1x6cut", "linkTo", ["isOnObservableCom"], _1x6cut);  
+  $def("_bsoqwx", "linkTo", ["isOnObservableCom"], _bsoqwx);  
   $def("_jdyayh", "viewof vars", ["variables","runtime"], _jdyayh);  
   $def("_mfvz6q", "vars", ["Generators","viewof vars"], _mfvz6q);  
   $def("_1f44wsz", "test_linkTo", ["links","targets","linkTo"], _1f44wsz);  
@@ -13521,7 +13514,8 @@ export default function define(runtime, observer) {
   $def("_1xxtf0r", "updateNotebookImports", ["vars","extractNotebookAndCell","linkTo"], _1xxtf0r);  
   main.define("tests", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("tests", _));
   return main;
-}</script>
+}
+</script>
 
 <script id="@tomlarkworthy/module-map" 
   type="text/plain"

--- a/notebooks/@tomlarkworthy_notes.html
+++ b/notebooks/@tomlarkworthy_notes.html
@@ -14170,7 +14170,7 @@ export default function define(runtime, observer) {
   return main;
 }</script>
 
-<script id="@tomlarkworthy/lopepage-urls" 
+<script id="@tomlarkworthy/lopepage-urls"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -14521,78 +14521,71 @@ const _gxaxgb = function _links(){return(
 const _17e89y0 = function _targets(){return(
 ["@tom/bar", "d/1f41fef8b019cf4e@94", "@tom/bar#cell"]
 )};
-const _1x6cut = function _linkTo(isOnObservableCom){return(
-function linkTo(
-  target,
-  {
-    baseURI = document.baseURI,
-    onObservable = isOnObservableCom(),
-    source = null,
-    op = "open" // "open" | "close" | "focus"
-  } = {}
-) {
-  if (onObservable) {
-    const t =
-      typeof target === "string"
-        ? target
-        : target?.module || target?.open || target?.close || "";
-    return t.startsWith("#") ? t : "/" + t;
-  }
-
-  // Parse existing hash params manually to avoid percent-encoding DSL chars
-  const base = new URL(baseURI);
-  const rawHash = (base.hash || "#").slice(1);
-  const hashParams = new Map();
-  if (rawHash) {
-    for (const part of rawHash.split("&")) {
-      const eq = part.indexOf("=");
-      if (eq >= 0) hashParams.set(part.slice(0, eq), part.slice(eq + 1));
-      else if (part) hashParams.set(part, "");
-    }
-  }
-
-  if (typeof target === "string" && target.startsWith("#")) return target;
-
-  const isIntent =
-    typeof target === "object" &&
-    target !== null &&
-    ("module" in target ||
-      "open" in target ||
-      "close" in target ||
-      "focus" in target ||
-      "op" in target);
-
-  let module = null;
-  let cell = null;
-
-  if (!isIntent) {
-    module = String(target ?? "");
-    const parts = module.split("#");
-    module = parts[0] || null;
-    cell = parts[1] || null;
-    op = "open";
-  } else {
-    module =
-      target.module || target.open || target.close || target.focus || null;
-    cell = target.cell || null;
-    source = target.source ?? source;
-    op =
-      target.op || (target.close ? "close" : target.focus ? "focus" : "open");
-  }
-
-  if (!module) return base.toString();
-
-  hashParams.set(op, cell ? `${module}#${cell}` : module);
-  if (source) hashParams.set("from", source);
-
-  // Build hash without URLSearchParams to preserve DSL chars unencoded.
-  // Return hash-only for same-page links to avoid page reload.
-  const hashStr = [...hashParams]
-    .map(([k, v]) => (v ? `${k}=${v}` : k))
-    .join("&");
-  return "#" + hashStr;
-}
-)};
+const _bsoqwx = function _linkTo(isOnObservableCom)
+{
+    return function linkTo(target, {baseURI = document.baseURI, onObservable = isOnObservableCom(), source = null, op = 'open'    // "open" | "close" | "focus"
+} = {}) {
+        if (onObservable) {
+            const t = typeof target === 'string' ? target : target?.module || target?.open || target?.close || '';
+            return t.startsWith('#') ? t : '/' + t;
+        }
+        // Parse existing hash params manually to avoid percent-encoding DSL chars
+        const base = new URL(baseURI);
+        const rawHash = (base.hash || '#').slice(1);
+        const hashParams = new Map();
+        // open/close/focus/from are transient intents that lopepage consumes and
+        // clears, so we do NOT deep-link them. view= is canonical layout state owned
+        // by lopepage; if we baked the baseURI's view= into every link, the href
+        // would be a snapshot from link-render time and clicking it would rewind the
+        // layout (issue #150 — clicking a second module wiped the first because the
+        // link carried the boot view=). Dropping view= here makes the link a pure
+        // intent (e.g. "#cc=...&open=X"); sync_layout_from_url's
+        // `if (!view && open)` branch then merges the intent into the live layout.
+        const drop = new Set([
+            'view',
+            'open',
+            'close',
+            'focus',
+            'from'
+        ]);
+        if (rawHash) {
+            for (const part of rawHash.split('&')) {
+                const eq = part.indexOf('=');
+                const key = eq >= 0 ? part.slice(0, eq) : part;
+                if (drop.has(key))
+                    continue;
+                const val = eq >= 0 ? part.slice(eq + 1) : '';
+                hashParams.set(key, val);
+            }
+        }
+        if (typeof target === 'string' && target.startsWith('#'))
+            return target;
+        const isIntent = typeof target === 'object' && target !== null && ('module' in target || 'open' in target || 'close' in target || 'focus' in target || 'op' in target);
+        let module = null;
+        let cell = null;
+        if (!isIntent) {
+            module = String(target ?? '');
+            const parts = module.split('#');
+            module = parts[0] || null;
+            cell = parts[1] || null;
+            op = 'open';
+        } else {
+            module = target.module || target.open || target.close || target.focus || null;
+            cell = target.cell || null;
+            source = target.source ?? source;
+            op = target.op || (target.close ? 'close' : target.focus ? 'focus' : 'open');
+        }
+        if (!module)
+            return base.toString();
+        hashParams.set(op, cell ? `${ module }#${ cell }` : module);
+        if (source)
+            hashParams.set('from', source);
+        // Build hash without URLSearchParams to preserve DSL chars unencoded.
+        // Return hash-only for same-page links to avoid page reload.
+        const hashStr = [...hashParams].map(([k, v]) => v ? `${ k }=${ v }` : k).join('&');
+        return '#' + hashStr;
+    };
+};
 const _jdyayh = function _vars(variables,runtime){return(
 variables(runtime)
 )};
@@ -14705,7 +14698,7 @@ export default function define(runtime, observer) {
   $def("_1xjzq9r", "isOnObservableCom", ["location"], _1xjzq9r);  
   $def("_gxaxgb", "links", [], _gxaxgb);  
   $def("_17e89y0", "targets", [], _17e89y0);  
-  $def("_1x6cut", "linkTo", ["isOnObservableCom"], _1x6cut);  
+  $def("_bsoqwx", "linkTo", ["isOnObservableCom"], _bsoqwx);  
   $def("_jdyayh", "viewof vars", ["variables","runtime"], _jdyayh);  
   $def("_mfvz6q", "vars", ["Generators","viewof vars"], _mfvz6q);  
   $def("_1f44wsz", "test_linkTo", ["links","targets","linkTo"], _1f44wsz);  
@@ -14718,7 +14711,8 @@ export default function define(runtime, observer) {
   $def("_1xxtf0r", "updateNotebookImports", ["vars","extractNotebookAndCell","linkTo"], _1xxtf0r);  
   main.define("tests", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("tests", _));
   return main;
-}</script>
+}
+</script>
 
 <script id="@tomlarkworthy/module-map" 
   type="text/plain"

--- a/notebooks/@tomlarkworthy_observablejs-toolchain.html
+++ b/notebooks/@tomlarkworthy_observablejs-toolchain.html
@@ -14121,7 +14121,7 @@ export default function define(runtime, observer) {
   return main;
 }</script>
 
-<script id="@tomlarkworthy/lopepage-urls" 
+<script id="@tomlarkworthy/lopepage-urls"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -14472,78 +14472,71 @@ const _gxaxgb = function _links(){return(
 const _17e89y0 = function _targets(){return(
 ["@tom/bar", "d/1f41fef8b019cf4e@94", "@tom/bar#cell"]
 )};
-const _1x6cut = function _linkTo(isOnObservableCom){return(
-function linkTo(
-  target,
-  {
-    baseURI = document.baseURI,
-    onObservable = isOnObservableCom(),
-    source = null,
-    op = "open" // "open" | "close" | "focus"
-  } = {}
-) {
-  if (onObservable) {
-    const t =
-      typeof target === "string"
-        ? target
-        : target?.module || target?.open || target?.close || "";
-    return t.startsWith("#") ? t : "/" + t;
-  }
-
-  // Parse existing hash params manually to avoid percent-encoding DSL chars
-  const base = new URL(baseURI);
-  const rawHash = (base.hash || "#").slice(1);
-  const hashParams = new Map();
-  if (rawHash) {
-    for (const part of rawHash.split("&")) {
-      const eq = part.indexOf("=");
-      if (eq >= 0) hashParams.set(part.slice(0, eq), part.slice(eq + 1));
-      else if (part) hashParams.set(part, "");
-    }
-  }
-
-  if (typeof target === "string" && target.startsWith("#")) return target;
-
-  const isIntent =
-    typeof target === "object" &&
-    target !== null &&
-    ("module" in target ||
-      "open" in target ||
-      "close" in target ||
-      "focus" in target ||
-      "op" in target);
-
-  let module = null;
-  let cell = null;
-
-  if (!isIntent) {
-    module = String(target ?? "");
-    const parts = module.split("#");
-    module = parts[0] || null;
-    cell = parts[1] || null;
-    op = "open";
-  } else {
-    module =
-      target.module || target.open || target.close || target.focus || null;
-    cell = target.cell || null;
-    source = target.source ?? source;
-    op =
-      target.op || (target.close ? "close" : target.focus ? "focus" : "open");
-  }
-
-  if (!module) return base.toString();
-
-  hashParams.set(op, cell ? `${module}#${cell}` : module);
-  if (source) hashParams.set("from", source);
-
-  // Build hash without URLSearchParams to preserve DSL chars unencoded.
-  // Return hash-only for same-page links to avoid page reload.
-  const hashStr = [...hashParams]
-    .map(([k, v]) => (v ? `${k}=${v}` : k))
-    .join("&");
-  return "#" + hashStr;
-}
-)};
+const _bsoqwx = function _linkTo(isOnObservableCom)
+{
+    return function linkTo(target, {baseURI = document.baseURI, onObservable = isOnObservableCom(), source = null, op = 'open'    // "open" | "close" | "focus"
+} = {}) {
+        if (onObservable) {
+            const t = typeof target === 'string' ? target : target?.module || target?.open || target?.close || '';
+            return t.startsWith('#') ? t : '/' + t;
+        }
+        // Parse existing hash params manually to avoid percent-encoding DSL chars
+        const base = new URL(baseURI);
+        const rawHash = (base.hash || '#').slice(1);
+        const hashParams = new Map();
+        // open/close/focus/from are transient intents that lopepage consumes and
+        // clears, so we do NOT deep-link them. view= is canonical layout state owned
+        // by lopepage; if we baked the baseURI's view= into every link, the href
+        // would be a snapshot from link-render time and clicking it would rewind the
+        // layout (issue #150 — clicking a second module wiped the first because the
+        // link carried the boot view=). Dropping view= here makes the link a pure
+        // intent (e.g. "#cc=...&open=X"); sync_layout_from_url's
+        // `if (!view && open)` branch then merges the intent into the live layout.
+        const drop = new Set([
+            'view',
+            'open',
+            'close',
+            'focus',
+            'from'
+        ]);
+        if (rawHash) {
+            for (const part of rawHash.split('&')) {
+                const eq = part.indexOf('=');
+                const key = eq >= 0 ? part.slice(0, eq) : part;
+                if (drop.has(key))
+                    continue;
+                const val = eq >= 0 ? part.slice(eq + 1) : '';
+                hashParams.set(key, val);
+            }
+        }
+        if (typeof target === 'string' && target.startsWith('#'))
+            return target;
+        const isIntent = typeof target === 'object' && target !== null && ('module' in target || 'open' in target || 'close' in target || 'focus' in target || 'op' in target);
+        let module = null;
+        let cell = null;
+        if (!isIntent) {
+            module = String(target ?? '');
+            const parts = module.split('#');
+            module = parts[0] || null;
+            cell = parts[1] || null;
+            op = 'open';
+        } else {
+            module = target.module || target.open || target.close || target.focus || null;
+            cell = target.cell || null;
+            source = target.source ?? source;
+            op = target.op || (target.close ? 'close' : target.focus ? 'focus' : 'open');
+        }
+        if (!module)
+            return base.toString();
+        hashParams.set(op, cell ? `${ module }#${ cell }` : module);
+        if (source)
+            hashParams.set('from', source);
+        // Build hash without URLSearchParams to preserve DSL chars unencoded.
+        // Return hash-only for same-page links to avoid page reload.
+        const hashStr = [...hashParams].map(([k, v]) => v ? `${ k }=${ v }` : k).join('&');
+        return '#' + hashStr;
+    };
+};
 const _jdyayh = function _vars(variables,runtime){return(
 variables(runtime)
 )};
@@ -14656,7 +14649,7 @@ export default function define(runtime, observer) {
   $def("_1xjzq9r", "isOnObservableCom", ["location"], _1xjzq9r);  
   $def("_gxaxgb", "links", [], _gxaxgb);  
   $def("_17e89y0", "targets", [], _17e89y0);  
-  $def("_1x6cut", "linkTo", ["isOnObservableCom"], _1x6cut);  
+  $def("_bsoqwx", "linkTo", ["isOnObservableCom"], _bsoqwx);  
   $def("_jdyayh", "viewof vars", ["variables","runtime"], _jdyayh);  
   $def("_mfvz6q", "vars", ["Generators","viewof vars"], _mfvz6q);  
   $def("_1f44wsz", "test_linkTo", ["links","targets","linkTo"], _1f44wsz);  
@@ -14669,7 +14662,8 @@ export default function define(runtime, observer) {
   $def("_1xxtf0r", "updateNotebookImports", ["vars","extractNotebookAndCell","linkTo"], _1xxtf0r);  
   main.define("tests", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("tests", _));
   return main;
-}</script>
+}
+</script>
 
 <script id="@tomlarkworthy/module-map" 
   type="text/plain"

--- a/notebooks/@tomlarkworthy_openai-responses-api.html
+++ b/notebooks/@tomlarkworthy_openai-responses-api.html
@@ -14177,7 +14177,7 @@ export default function define(runtime, observer) {
   return main;
 }</script>
 
-<script id="@tomlarkworthy/lopepage-urls" 
+<script id="@tomlarkworthy/lopepage-urls"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -14528,81 +14528,75 @@ const _gxaxgb = function _links(){return(
 const _17e89y0 = function _targets(){return(
 ["@tom/bar", "d/1f41fef8b019cf4e@94", "@tom/bar#cell"]
 )};
-const _1x6cut = function _linkTo(isOnObservableCom){return(
-function linkTo(
-  target,
-  {
-    baseURI = document.baseURI,
-    onObservable = isOnObservableCom(),
-    source = null,
-    op = "open" // "open" | "close" | "focus"
-  } = {}
-) {
-  if (onObservable) {
-    const t =
-      typeof target === "string"
-        ? target
-        : target?.module || target?.open || target?.close || "";
-    return t.startsWith("#") ? t : "/" + t;
-  }
-
-  // Parse existing hash params manually to avoid percent-encoding DSL chars
-  const base = new URL(baseURI);
-  const rawHash = (base.hash || "#").slice(1);
-  const hashParams = new Map();
-  if (rawHash) {
-    for (const part of rawHash.split("&")) {
-      const eq = part.indexOf("=");
-      if (eq >= 0) hashParams.set(part.slice(0, eq), part.slice(eq + 1));
-      else if (part) hashParams.set(part, "");
-    }
-  }
-
-  if (typeof target === "string" && target.startsWith("#")) return target;
-
-  const isIntent =
-    typeof target === "object" &&
-    target !== null &&
-    ("module" in target ||
-      "open" in target ||
-      "close" in target ||
-      "focus" in target ||
-      "op" in target);
-
-  let module = null;
-  let cell = null;
-
-  if (!isIntent) {
-    module = String(target ?? "");
-    const parts = module.split("#");
-    module = parts[0] || null;
-    cell = parts[1] || null;
-    op = "open";
-  } else {
-    module =
-      target.module || target.open || target.close || target.focus || null;
-    cell = target.cell || null;
-    source = target.source ?? source;
-    op =
-      target.op || (target.close ? "close" : target.focus ? "focus" : "open");
-  }
-
-  if (!module) return base.toString();
-
-  hashParams.set(op, cell ? `${module}#${cell}` : module);
-  if (source) hashParams.set("from", source);
-
-  // Build hash without URLSearchParams to preserve DSL chars unencoded.
-  // Return hash-only for same-page links to avoid page reload.
-  const hashStr = [...hashParams]
-    .map(([k, v]) => (v ? `${k}=${v}` : k))
-    .join("&");
-  return "#" + hashStr;
-}
-)};
+const _bsoqwx = function _linkTo(isOnObservableCom)
+{
+    return function linkTo(target, {baseURI = document.baseURI, onObservable = isOnObservableCom(), source = null, op = 'open'    // "open" | "close" | "focus"
+} = {}) {
+        if (onObservable) {
+            const t = typeof target === 'string' ? target : target?.module || target?.open || target?.close || '';
+            return t.startsWith('#') ? t : '/' + t;
+        }
+        // Parse existing hash params manually to avoid percent-encoding DSL chars
+        const base = new URL(baseURI);
+        const rawHash = (base.hash || '#').slice(1);
+        const hashParams = new Map();
+        // open/close/focus/from are transient intents that lopepage consumes and
+        // clears, so we do NOT deep-link them. view= is canonical layout state owned
+        // by lopepage; if we baked the baseURI's view= into every link, the href
+        // would be a snapshot from link-render time and clicking it would rewind the
+        // layout (issue #150 — clicking a second module wiped the first because the
+        // link carried the boot view=). Dropping view= here makes the link a pure
+        // intent (e.g. "#cc=...&open=X"); sync_layout_from_url's
+        // `if (!view && open)` branch then merges the intent into the live layout.
+        const drop = new Set([
+            'view',
+            'open',
+            'close',
+            'focus',
+            'from'
+        ]);
+        if (rawHash) {
+            for (const part of rawHash.split('&')) {
+                const eq = part.indexOf('=');
+                const key = eq >= 0 ? part.slice(0, eq) : part;
+                if (drop.has(key))
+                    continue;
+                const val = eq >= 0 ? part.slice(eq + 1) : '';
+                hashParams.set(key, val);
+            }
+        }
+        if (typeof target === 'string' && target.startsWith('#'))
+            return target;
+        const isIntent = typeof target === 'object' && target !== null && ('module' in target || 'open' in target || 'close' in target || 'focus' in target || 'op' in target);
+        let module = null;
+        let cell = null;
+        if (!isIntent) {
+            module = String(target ?? '');
+            const parts = module.split('#');
+            module = parts[0] || null;
+            cell = parts[1] || null;
+            op = 'open';
+        } else {
+            module = target.module || target.open || target.close || target.focus || null;
+            cell = target.cell || null;
+            source = target.source ?? source;
+            op = target.op || (target.close ? 'close' : target.focus ? 'focus' : 'open');
+        }
+        if (!module)
+            return base.toString();
+        hashParams.set(op, cell ? `${ module }#${ cell }` : module);
+        if (source)
+            hashParams.set('from', source);
+        // Build hash without URLSearchParams to preserve DSL chars unencoded.
+        // Return hash-only for same-page links to avoid page reload.
+        const hashStr = [...hashParams].map(([k, v]) => v ? `${ k }=${ v }` : k).join('&');
+        return '#' + hashStr;
+    };
+};
 const _jdyayh = function _vars(variables,runtime){return(
 variables(runtime)
 )};
+const _mfvz6q = (G, _) => G.input(_);
 const _1f44wsz = function _test_linkTo(links,targets,linkTo){return(
 links.map((link) =>
   targets.map((target) =>
@@ -14615,7 +14609,6 @@ md`## Auto switch to url structure
 
 Watch the runtime for imports and swap them for our structure`
 )};
-const _w93ki7 = (_, v) => v.import("runtime", _);
 const _1gllckt = function _href_examples(){return(
 [
   "https://tomlarkworthy/import-notebook",
@@ -14674,20 +14667,15 @@ const _1xxtf0r = function _updateNotebookImports(vars,extractNotebookAndCell,lin
     }
   }
 };
-const _1txhfy5 = (_, v) => v.import("tests", _);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
   const $def = (pid, name, deps, fn) => {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
-  const fileAttachments = new Map([].map((name) => {
-    const module_name = "@tomlarkworthy/lopepage-urls";
-    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
-    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
-    return [name, {url: blob_url, mimeType: mime}]
-  }));
-  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
   $def("_1g7wjzc", null, ["md"], _1g7wjzc);  
   $def("_1hsbxxe", null, ["md"], _1hsbxxe);  
   $def("_1buq9dd", null, ["tests"], _1buq9dd);  
@@ -14717,22 +14705,21 @@ export default function define(runtime, observer) {
   $def("_1xjzq9r", "isOnObservableCom", ["location"], _1xjzq9r);  
   $def("_gxaxgb", "links", [], _gxaxgb);  
   $def("_17e89y0", "targets", [], _17e89y0);  
-  $def("_1x6cut", "linkTo", ["isOnObservableCom"], _1x6cut);  
+  $def("_bsoqwx", "linkTo", ["isOnObservableCom"], _bsoqwx);  
   $def("_jdyayh", "viewof vars", ["variables","runtime"], _jdyayh);  
-  main.variable(observer("vars")).define("vars", ["Generators", "viewof vars"], (G, _) => G.input(_));  
+  $def("_mfvz6q", "vars", ["Generators","viewof vars"], _mfvz6q);  
   $def("_1f44wsz", "test_linkTo", ["links","targets","linkTo"], _1f44wsz);  
   $def("_1hdknc", null, ["md"], _1hdknc);  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("variables", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("variables", _));  
   $def("_1gllckt", "href_examples", [], _1gllckt);  
   $def("_133ucsn", "test_extractNotebookAndCell", ["href_examples","extractNotebookAndCell"], _133ucsn);  
   $def("_cb1ope", "extractNotebookAndCell", [], _cb1ope);  
   $def("_1xxtf0r", "updateNotebookImports", ["vars","extractNotebookAndCell","linkTo"], _1xxtf0r);  
-  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
   main.define("tests", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("tests", _));
   return main;
-}</script>
+}
+</script>
 
 <script id="@tomlarkworthy/module-map" 
   type="text/plain"

--- a/notebooks/@tomlarkworthy_reversible-attachment.html
+++ b/notebooks/@tomlarkworthy_reversible-attachment.html
@@ -14177,7 +14177,7 @@ export default function define(runtime, observer) {
   return main;
 }</script>
 
-<script id="@tomlarkworthy/lopepage-urls" 
+<script id="@tomlarkworthy/lopepage-urls"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -14528,81 +14528,75 @@ const _gxaxgb = function _links(){return(
 const _17e89y0 = function _targets(){return(
 ["@tom/bar", "d/1f41fef8b019cf4e@94", "@tom/bar#cell"]
 )};
-const _1x6cut = function _linkTo(isOnObservableCom){return(
-function linkTo(
-  target,
-  {
-    baseURI = document.baseURI,
-    onObservable = isOnObservableCom(),
-    source = null,
-    op = "open" // "open" | "close" | "focus"
-  } = {}
-) {
-  if (onObservable) {
-    const t =
-      typeof target === "string"
-        ? target
-        : target?.module || target?.open || target?.close || "";
-    return t.startsWith("#") ? t : "/" + t;
-  }
-
-  // Parse existing hash params manually to avoid percent-encoding DSL chars
-  const base = new URL(baseURI);
-  const rawHash = (base.hash || "#").slice(1);
-  const hashParams = new Map();
-  if (rawHash) {
-    for (const part of rawHash.split("&")) {
-      const eq = part.indexOf("=");
-      if (eq >= 0) hashParams.set(part.slice(0, eq), part.slice(eq + 1));
-      else if (part) hashParams.set(part, "");
-    }
-  }
-
-  if (typeof target === "string" && target.startsWith("#")) return target;
-
-  const isIntent =
-    typeof target === "object" &&
-    target !== null &&
-    ("module" in target ||
-      "open" in target ||
-      "close" in target ||
-      "focus" in target ||
-      "op" in target);
-
-  let module = null;
-  let cell = null;
-
-  if (!isIntent) {
-    module = String(target ?? "");
-    const parts = module.split("#");
-    module = parts[0] || null;
-    cell = parts[1] || null;
-    op = "open";
-  } else {
-    module =
-      target.module || target.open || target.close || target.focus || null;
-    cell = target.cell || null;
-    source = target.source ?? source;
-    op =
-      target.op || (target.close ? "close" : target.focus ? "focus" : "open");
-  }
-
-  if (!module) return base.toString();
-
-  hashParams.set(op, cell ? `${module}#${cell}` : module);
-  if (source) hashParams.set("from", source);
-
-  // Build hash without URLSearchParams to preserve DSL chars unencoded.
-  // Return hash-only for same-page links to avoid page reload.
-  const hashStr = [...hashParams]
-    .map(([k, v]) => (v ? `${k}=${v}` : k))
-    .join("&");
-  return "#" + hashStr;
-}
-)};
+const _bsoqwx = function _linkTo(isOnObservableCom)
+{
+    return function linkTo(target, {baseURI = document.baseURI, onObservable = isOnObservableCom(), source = null, op = 'open'    // "open" | "close" | "focus"
+} = {}) {
+        if (onObservable) {
+            const t = typeof target === 'string' ? target : target?.module || target?.open || target?.close || '';
+            return t.startsWith('#') ? t : '/' + t;
+        }
+        // Parse existing hash params manually to avoid percent-encoding DSL chars
+        const base = new URL(baseURI);
+        const rawHash = (base.hash || '#').slice(1);
+        const hashParams = new Map();
+        // open/close/focus/from are transient intents that lopepage consumes and
+        // clears, so we do NOT deep-link them. view= is canonical layout state owned
+        // by lopepage; if we baked the baseURI's view= into every link, the href
+        // would be a snapshot from link-render time and clicking it would rewind the
+        // layout (issue #150 — clicking a second module wiped the first because the
+        // link carried the boot view=). Dropping view= here makes the link a pure
+        // intent (e.g. "#cc=...&open=X"); sync_layout_from_url's
+        // `if (!view && open)` branch then merges the intent into the live layout.
+        const drop = new Set([
+            'view',
+            'open',
+            'close',
+            'focus',
+            'from'
+        ]);
+        if (rawHash) {
+            for (const part of rawHash.split('&')) {
+                const eq = part.indexOf('=');
+                const key = eq >= 0 ? part.slice(0, eq) : part;
+                if (drop.has(key))
+                    continue;
+                const val = eq >= 0 ? part.slice(eq + 1) : '';
+                hashParams.set(key, val);
+            }
+        }
+        if (typeof target === 'string' && target.startsWith('#'))
+            return target;
+        const isIntent = typeof target === 'object' && target !== null && ('module' in target || 'open' in target || 'close' in target || 'focus' in target || 'op' in target);
+        let module = null;
+        let cell = null;
+        if (!isIntent) {
+            module = String(target ?? '');
+            const parts = module.split('#');
+            module = parts[0] || null;
+            cell = parts[1] || null;
+            op = 'open';
+        } else {
+            module = target.module || target.open || target.close || target.focus || null;
+            cell = target.cell || null;
+            source = target.source ?? source;
+            op = target.op || (target.close ? 'close' : target.focus ? 'focus' : 'open');
+        }
+        if (!module)
+            return base.toString();
+        hashParams.set(op, cell ? `${ module }#${ cell }` : module);
+        if (source)
+            hashParams.set('from', source);
+        // Build hash without URLSearchParams to preserve DSL chars unencoded.
+        // Return hash-only for same-page links to avoid page reload.
+        const hashStr = [...hashParams].map(([k, v]) => v ? `${ k }=${ v }` : k).join('&');
+        return '#' + hashStr;
+    };
+};
 const _jdyayh = function _vars(variables,runtime){return(
 variables(runtime)
 )};
+const _mfvz6q = (G, _) => G.input(_);
 const _1f44wsz = function _test_linkTo(links,targets,linkTo){return(
 links.map((link) =>
   targets.map((target) =>
@@ -14615,7 +14609,6 @@ md`## Auto switch to url structure
 
 Watch the runtime for imports and swap them for our structure`
 )};
-const _w93ki7 = (_, v) => v.import("runtime", _);
 const _1gllckt = function _href_examples(){return(
 [
   "https://tomlarkworthy/import-notebook",
@@ -14674,20 +14667,15 @@ const _1xxtf0r = function _updateNotebookImports(vars,extractNotebookAndCell,lin
     }
   }
 };
-const _1txhfy5 = (_, v) => v.import("tests", _);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
   const $def = (pid, name, deps, fn) => {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
-  const fileAttachments = new Map([].map((name) => {
-    const module_name = "@tomlarkworthy/lopepage-urls";
-    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
-    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
-    return [name, {url: blob_url, mimeType: mime}]
-  }));
-  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
   $def("_1g7wjzc", null, ["md"], _1g7wjzc);  
   $def("_1hsbxxe", null, ["md"], _1hsbxxe);  
   $def("_1buq9dd", null, ["tests"], _1buq9dd);  
@@ -14717,22 +14705,21 @@ export default function define(runtime, observer) {
   $def("_1xjzq9r", "isOnObservableCom", ["location"], _1xjzq9r);  
   $def("_gxaxgb", "links", [], _gxaxgb);  
   $def("_17e89y0", "targets", [], _17e89y0);  
-  $def("_1x6cut", "linkTo", ["isOnObservableCom"], _1x6cut);  
+  $def("_bsoqwx", "linkTo", ["isOnObservableCom"], _bsoqwx);  
   $def("_jdyayh", "viewof vars", ["variables","runtime"], _jdyayh);  
-  main.variable(observer("vars")).define("vars", ["Generators", "viewof vars"], (G, _) => G.input(_));  
+  $def("_mfvz6q", "vars", ["Generators","viewof vars"], _mfvz6q);  
   $def("_1f44wsz", "test_linkTo", ["links","targets","linkTo"], _1f44wsz);  
   $def("_1hdknc", null, ["md"], _1hdknc);  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("variables", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("variables", _));  
   $def("_1gllckt", "href_examples", [], _1gllckt);  
   $def("_133ucsn", "test_extractNotebookAndCell", ["href_examples","extractNotebookAndCell"], _133ucsn);  
   $def("_cb1ope", "extractNotebookAndCell", [], _cb1ope);  
   $def("_1xxtf0r", "updateNotebookImports", ["vars","extractNotebookAndCell","linkTo"], _1xxtf0r);  
-  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
   main.define("tests", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("tests", _));
   return main;
-}</script>
+}
+</script>
 
 <script id="@tomlarkworthy/module-map" 
   type="text/plain"

--- a/notebooks/@tomlarkworthy_robocoop-2.html
+++ b/notebooks/@tomlarkworthy_robocoop-2.html
@@ -14177,7 +14177,7 @@ export default function define(runtime, observer) {
   return main;
 }</script>
 
-<script id="@tomlarkworthy/lopepage-urls" 
+<script id="@tomlarkworthy/lopepage-urls"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -14528,81 +14528,75 @@ const _gxaxgb = function _links(){return(
 const _17e89y0 = function _targets(){return(
 ["@tom/bar", "d/1f41fef8b019cf4e@94", "@tom/bar#cell"]
 )};
-const _1x6cut = function _linkTo(isOnObservableCom){return(
-function linkTo(
-  target,
-  {
-    baseURI = document.baseURI,
-    onObservable = isOnObservableCom(),
-    source = null,
-    op = "open" // "open" | "close" | "focus"
-  } = {}
-) {
-  if (onObservable) {
-    const t =
-      typeof target === "string"
-        ? target
-        : target?.module || target?.open || target?.close || "";
-    return t.startsWith("#") ? t : "/" + t;
-  }
-
-  // Parse existing hash params manually to avoid percent-encoding DSL chars
-  const base = new URL(baseURI);
-  const rawHash = (base.hash || "#").slice(1);
-  const hashParams = new Map();
-  if (rawHash) {
-    for (const part of rawHash.split("&")) {
-      const eq = part.indexOf("=");
-      if (eq >= 0) hashParams.set(part.slice(0, eq), part.slice(eq + 1));
-      else if (part) hashParams.set(part, "");
-    }
-  }
-
-  if (typeof target === "string" && target.startsWith("#")) return target;
-
-  const isIntent =
-    typeof target === "object" &&
-    target !== null &&
-    ("module" in target ||
-      "open" in target ||
-      "close" in target ||
-      "focus" in target ||
-      "op" in target);
-
-  let module = null;
-  let cell = null;
-
-  if (!isIntent) {
-    module = String(target ?? "");
-    const parts = module.split("#");
-    module = parts[0] || null;
-    cell = parts[1] || null;
-    op = "open";
-  } else {
-    module =
-      target.module || target.open || target.close || target.focus || null;
-    cell = target.cell || null;
-    source = target.source ?? source;
-    op =
-      target.op || (target.close ? "close" : target.focus ? "focus" : "open");
-  }
-
-  if (!module) return base.toString();
-
-  hashParams.set(op, cell ? `${module}#${cell}` : module);
-  if (source) hashParams.set("from", source);
-
-  // Build hash without URLSearchParams to preserve DSL chars unencoded.
-  // Return hash-only for same-page links to avoid page reload.
-  const hashStr = [...hashParams]
-    .map(([k, v]) => (v ? `${k}=${v}` : k))
-    .join("&");
-  return "#" + hashStr;
-}
-)};
+const _bsoqwx = function _linkTo(isOnObservableCom)
+{
+    return function linkTo(target, {baseURI = document.baseURI, onObservable = isOnObservableCom(), source = null, op = 'open'    // "open" | "close" | "focus"
+} = {}) {
+        if (onObservable) {
+            const t = typeof target === 'string' ? target : target?.module || target?.open || target?.close || '';
+            return t.startsWith('#') ? t : '/' + t;
+        }
+        // Parse existing hash params manually to avoid percent-encoding DSL chars
+        const base = new URL(baseURI);
+        const rawHash = (base.hash || '#').slice(1);
+        const hashParams = new Map();
+        // open/close/focus/from are transient intents that lopepage consumes and
+        // clears, so we do NOT deep-link them. view= is canonical layout state owned
+        // by lopepage; if we baked the baseURI's view= into every link, the href
+        // would be a snapshot from link-render time and clicking it would rewind the
+        // layout (issue #150 — clicking a second module wiped the first because the
+        // link carried the boot view=). Dropping view= here makes the link a pure
+        // intent (e.g. "#cc=...&open=X"); sync_layout_from_url's
+        // `if (!view && open)` branch then merges the intent into the live layout.
+        const drop = new Set([
+            'view',
+            'open',
+            'close',
+            'focus',
+            'from'
+        ]);
+        if (rawHash) {
+            for (const part of rawHash.split('&')) {
+                const eq = part.indexOf('=');
+                const key = eq >= 0 ? part.slice(0, eq) : part;
+                if (drop.has(key))
+                    continue;
+                const val = eq >= 0 ? part.slice(eq + 1) : '';
+                hashParams.set(key, val);
+            }
+        }
+        if (typeof target === 'string' && target.startsWith('#'))
+            return target;
+        const isIntent = typeof target === 'object' && target !== null && ('module' in target || 'open' in target || 'close' in target || 'focus' in target || 'op' in target);
+        let module = null;
+        let cell = null;
+        if (!isIntent) {
+            module = String(target ?? '');
+            const parts = module.split('#');
+            module = parts[0] || null;
+            cell = parts[1] || null;
+            op = 'open';
+        } else {
+            module = target.module || target.open || target.close || target.focus || null;
+            cell = target.cell || null;
+            source = target.source ?? source;
+            op = target.op || (target.close ? 'close' : target.focus ? 'focus' : 'open');
+        }
+        if (!module)
+            return base.toString();
+        hashParams.set(op, cell ? `${ module }#${ cell }` : module);
+        if (source)
+            hashParams.set('from', source);
+        // Build hash without URLSearchParams to preserve DSL chars unencoded.
+        // Return hash-only for same-page links to avoid page reload.
+        const hashStr = [...hashParams].map(([k, v]) => v ? `${ k }=${ v }` : k).join('&');
+        return '#' + hashStr;
+    };
+};
 const _jdyayh = function _vars(variables,runtime){return(
 variables(runtime)
 )};
+const _mfvz6q = (G, _) => G.input(_);
 const _1f44wsz = function _test_linkTo(links,targets,linkTo){return(
 links.map((link) =>
   targets.map((target) =>
@@ -14615,7 +14609,6 @@ md`## Auto switch to url structure
 
 Watch the runtime for imports and swap them for our structure`
 )};
-const _w93ki7 = (_, v) => v.import("runtime", _);
 const _1gllckt = function _href_examples(){return(
 [
   "https://tomlarkworthy/import-notebook",
@@ -14674,20 +14667,15 @@ const _1xxtf0r = function _updateNotebookImports(vars,extractNotebookAndCell,lin
     }
   }
 };
-const _1txhfy5 = (_, v) => v.import("tests", _);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
   const $def = (pid, name, deps, fn) => {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
-  const fileAttachments = new Map([].map((name) => {
-    const module_name = "@tomlarkworthy/lopepage-urls";
-    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
-    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
-    return [name, {url: blob_url, mimeType: mime}]
-  }));
-  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
   $def("_1g7wjzc", null, ["md"], _1g7wjzc);  
   $def("_1hsbxxe", null, ["md"], _1hsbxxe);  
   $def("_1buq9dd", null, ["tests"], _1buq9dd);  
@@ -14717,22 +14705,21 @@ export default function define(runtime, observer) {
   $def("_1xjzq9r", "isOnObservableCom", ["location"], _1xjzq9r);  
   $def("_gxaxgb", "links", [], _gxaxgb);  
   $def("_17e89y0", "targets", [], _17e89y0);  
-  $def("_1x6cut", "linkTo", ["isOnObservableCom"], _1x6cut);  
+  $def("_bsoqwx", "linkTo", ["isOnObservableCom"], _bsoqwx);  
   $def("_jdyayh", "viewof vars", ["variables","runtime"], _jdyayh);  
-  main.variable(observer("vars")).define("vars", ["Generators", "viewof vars"], (G, _) => G.input(_));  
+  $def("_mfvz6q", "vars", ["Generators","viewof vars"], _mfvz6q);  
   $def("_1f44wsz", "test_linkTo", ["links","targets","linkTo"], _1f44wsz);  
   $def("_1hdknc", null, ["md"], _1hdknc);  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("variables", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("variables", _));  
   $def("_1gllckt", "href_examples", [], _1gllckt);  
   $def("_133ucsn", "test_extractNotebookAndCell", ["href_examples","extractNotebookAndCell"], _133ucsn);  
   $def("_cb1ope", "extractNotebookAndCell", [], _cb1ope);  
   $def("_1xxtf0r", "updateNotebookImports", ["vars","extractNotebookAndCell","linkTo"], _1xxtf0r);  
-  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
   main.define("tests", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("tests", _));
   return main;
-}</script>
+}
+</script>
 <script id="@tomlarkworthy/modern-screenshot/modern-screenshot-4.6.6.js.gz" 
   type="text/plain"
   data-encoding="base64"

--- a/notebooks/@tomlarkworthy_robocoop-3.html
+++ b/notebooks/@tomlarkworthy_robocoop-3.html
@@ -14177,7 +14177,7 @@ export default function define(runtime, observer) {
   return main;
 }</script>
 
-<script id="@tomlarkworthy/lopepage-urls" 
+<script id="@tomlarkworthy/lopepage-urls"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -14528,81 +14528,75 @@ const _gxaxgb = function _links(){return(
 const _17e89y0 = function _targets(){return(
 ["@tom/bar", "d/1f41fef8b019cf4e@94", "@tom/bar#cell"]
 )};
-const _1x6cut = function _linkTo(isOnObservableCom){return(
-function linkTo(
-  target,
-  {
-    baseURI = document.baseURI,
-    onObservable = isOnObservableCom(),
-    source = null,
-    op = "open" // "open" | "close" | "focus"
-  } = {}
-) {
-  if (onObservable) {
-    const t =
-      typeof target === "string"
-        ? target
-        : target?.module || target?.open || target?.close || "";
-    return t.startsWith("#") ? t : "/" + t;
-  }
-
-  // Parse existing hash params manually to avoid percent-encoding DSL chars
-  const base = new URL(baseURI);
-  const rawHash = (base.hash || "#").slice(1);
-  const hashParams = new Map();
-  if (rawHash) {
-    for (const part of rawHash.split("&")) {
-      const eq = part.indexOf("=");
-      if (eq >= 0) hashParams.set(part.slice(0, eq), part.slice(eq + 1));
-      else if (part) hashParams.set(part, "");
-    }
-  }
-
-  if (typeof target === "string" && target.startsWith("#")) return target;
-
-  const isIntent =
-    typeof target === "object" &&
-    target !== null &&
-    ("module" in target ||
-      "open" in target ||
-      "close" in target ||
-      "focus" in target ||
-      "op" in target);
-
-  let module = null;
-  let cell = null;
-
-  if (!isIntent) {
-    module = String(target ?? "");
-    const parts = module.split("#");
-    module = parts[0] || null;
-    cell = parts[1] || null;
-    op = "open";
-  } else {
-    module =
-      target.module || target.open || target.close || target.focus || null;
-    cell = target.cell || null;
-    source = target.source ?? source;
-    op =
-      target.op || (target.close ? "close" : target.focus ? "focus" : "open");
-  }
-
-  if (!module) return base.toString();
-
-  hashParams.set(op, cell ? `${module}#${cell}` : module);
-  if (source) hashParams.set("from", source);
-
-  // Build hash without URLSearchParams to preserve DSL chars unencoded.
-  // Return hash-only for same-page links to avoid page reload.
-  const hashStr = [...hashParams]
-    .map(([k, v]) => (v ? `${k}=${v}` : k))
-    .join("&");
-  return "#" + hashStr;
-}
-)};
+const _bsoqwx = function _linkTo(isOnObservableCom)
+{
+    return function linkTo(target, {baseURI = document.baseURI, onObservable = isOnObservableCom(), source = null, op = 'open'    // "open" | "close" | "focus"
+} = {}) {
+        if (onObservable) {
+            const t = typeof target === 'string' ? target : target?.module || target?.open || target?.close || '';
+            return t.startsWith('#') ? t : '/' + t;
+        }
+        // Parse existing hash params manually to avoid percent-encoding DSL chars
+        const base = new URL(baseURI);
+        const rawHash = (base.hash || '#').slice(1);
+        const hashParams = new Map();
+        // open/close/focus/from are transient intents that lopepage consumes and
+        // clears, so we do NOT deep-link them. view= is canonical layout state owned
+        // by lopepage; if we baked the baseURI's view= into every link, the href
+        // would be a snapshot from link-render time and clicking it would rewind the
+        // layout (issue #150 — clicking a second module wiped the first because the
+        // link carried the boot view=). Dropping view= here makes the link a pure
+        // intent (e.g. "#cc=...&open=X"); sync_layout_from_url's
+        // `if (!view && open)` branch then merges the intent into the live layout.
+        const drop = new Set([
+            'view',
+            'open',
+            'close',
+            'focus',
+            'from'
+        ]);
+        if (rawHash) {
+            for (const part of rawHash.split('&')) {
+                const eq = part.indexOf('=');
+                const key = eq >= 0 ? part.slice(0, eq) : part;
+                if (drop.has(key))
+                    continue;
+                const val = eq >= 0 ? part.slice(eq + 1) : '';
+                hashParams.set(key, val);
+            }
+        }
+        if (typeof target === 'string' && target.startsWith('#'))
+            return target;
+        const isIntent = typeof target === 'object' && target !== null && ('module' in target || 'open' in target || 'close' in target || 'focus' in target || 'op' in target);
+        let module = null;
+        let cell = null;
+        if (!isIntent) {
+            module = String(target ?? '');
+            const parts = module.split('#');
+            module = parts[0] || null;
+            cell = parts[1] || null;
+            op = 'open';
+        } else {
+            module = target.module || target.open || target.close || target.focus || null;
+            cell = target.cell || null;
+            source = target.source ?? source;
+            op = target.op || (target.close ? 'close' : target.focus ? 'focus' : 'open');
+        }
+        if (!module)
+            return base.toString();
+        hashParams.set(op, cell ? `${ module }#${ cell }` : module);
+        if (source)
+            hashParams.set('from', source);
+        // Build hash without URLSearchParams to preserve DSL chars unencoded.
+        // Return hash-only for same-page links to avoid page reload.
+        const hashStr = [...hashParams].map(([k, v]) => v ? `${ k }=${ v }` : k).join('&');
+        return '#' + hashStr;
+    };
+};
 const _jdyayh = function _vars(variables,runtime){return(
 variables(runtime)
 )};
+const _mfvz6q = (G, _) => G.input(_);
 const _1f44wsz = function _test_linkTo(links,targets,linkTo){return(
 links.map((link) =>
   targets.map((target) =>
@@ -14615,7 +14609,6 @@ md`## Auto switch to url structure
 
 Watch the runtime for imports and swap them for our structure`
 )};
-const _w93ki7 = (_, v) => v.import("runtime", _);
 const _1gllckt = function _href_examples(){return(
 [
   "https://tomlarkworthy/import-notebook",
@@ -14674,20 +14667,15 @@ const _1xxtf0r = function _updateNotebookImports(vars,extractNotebookAndCell,lin
     }
   }
 };
-const _1txhfy5 = (_, v) => v.import("tests", _);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
   const $def = (pid, name, deps, fn) => {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
-  const fileAttachments = new Map([].map((name) => {
-    const module_name = "@tomlarkworthy/lopepage-urls";
-    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
-    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
-    return [name, {url: blob_url, mimeType: mime}]
-  }));
-  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
   $def("_1g7wjzc", null, ["md"], _1g7wjzc);  
   $def("_1hsbxxe", null, ["md"], _1hsbxxe);  
   $def("_1buq9dd", null, ["tests"], _1buq9dd);  
@@ -14717,22 +14705,21 @@ export default function define(runtime, observer) {
   $def("_1xjzq9r", "isOnObservableCom", ["location"], _1xjzq9r);  
   $def("_gxaxgb", "links", [], _gxaxgb);  
   $def("_17e89y0", "targets", [], _17e89y0);  
-  $def("_1x6cut", "linkTo", ["isOnObservableCom"], _1x6cut);  
+  $def("_bsoqwx", "linkTo", ["isOnObservableCom"], _bsoqwx);  
   $def("_jdyayh", "viewof vars", ["variables","runtime"], _jdyayh);  
-  main.variable(observer("vars")).define("vars", ["Generators", "viewof vars"], (G, _) => G.input(_));  
+  $def("_mfvz6q", "vars", ["Generators","viewof vars"], _mfvz6q);  
   $def("_1f44wsz", "test_linkTo", ["links","targets","linkTo"], _1f44wsz);  
   $def("_1hdknc", null, ["md"], _1hdknc);  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("variables", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("variables", _));  
   $def("_1gllckt", "href_examples", [], _1gllckt);  
   $def("_133ucsn", "test_extractNotebookAndCell", ["href_examples","extractNotebookAndCell"], _133ucsn);  
   $def("_cb1ope", "extractNotebookAndCell", [], _cb1ope);  
   $def("_1xxtf0r", "updateNotebookImports", ["vars","extractNotebookAndCell","linkTo"], _1xxtf0r);  
-  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
   main.define("tests", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("tests", _));
   return main;
-}</script>
+}
+</script>
 <script id="@tomlarkworthy/modern-screenshot/modern-screenshot-4.6.6.js.gz" 
   type="text/plain"
   data-encoding="base64"

--- a/notebooks/@tomlarkworthy_runtime-sdk.html
+++ b/notebooks/@tomlarkworthy_runtime-sdk.html
@@ -14177,7 +14177,7 @@ export default function define(runtime, observer) {
   return main;
 }</script>
 
-<script id="@tomlarkworthy/lopepage-urls" 
+<script id="@tomlarkworthy/lopepage-urls"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -14528,81 +14528,75 @@ const _gxaxgb = function _links(){return(
 const _17e89y0 = function _targets(){return(
 ["@tom/bar", "d/1f41fef8b019cf4e@94", "@tom/bar#cell"]
 )};
-const _1x6cut = function _linkTo(isOnObservableCom){return(
-function linkTo(
-  target,
-  {
-    baseURI = document.baseURI,
-    onObservable = isOnObservableCom(),
-    source = null,
-    op = "open" // "open" | "close" | "focus"
-  } = {}
-) {
-  if (onObservable) {
-    const t =
-      typeof target === "string"
-        ? target
-        : target?.module || target?.open || target?.close || "";
-    return t.startsWith("#") ? t : "/" + t;
-  }
-
-  // Parse existing hash params manually to avoid percent-encoding DSL chars
-  const base = new URL(baseURI);
-  const rawHash = (base.hash || "#").slice(1);
-  const hashParams = new Map();
-  if (rawHash) {
-    for (const part of rawHash.split("&")) {
-      const eq = part.indexOf("=");
-      if (eq >= 0) hashParams.set(part.slice(0, eq), part.slice(eq + 1));
-      else if (part) hashParams.set(part, "");
-    }
-  }
-
-  if (typeof target === "string" && target.startsWith("#")) return target;
-
-  const isIntent =
-    typeof target === "object" &&
-    target !== null &&
-    ("module" in target ||
-      "open" in target ||
-      "close" in target ||
-      "focus" in target ||
-      "op" in target);
-
-  let module = null;
-  let cell = null;
-
-  if (!isIntent) {
-    module = String(target ?? "");
-    const parts = module.split("#");
-    module = parts[0] || null;
-    cell = parts[1] || null;
-    op = "open";
-  } else {
-    module =
-      target.module || target.open || target.close || target.focus || null;
-    cell = target.cell || null;
-    source = target.source ?? source;
-    op =
-      target.op || (target.close ? "close" : target.focus ? "focus" : "open");
-  }
-
-  if (!module) return base.toString();
-
-  hashParams.set(op, cell ? `${module}#${cell}` : module);
-  if (source) hashParams.set("from", source);
-
-  // Build hash without URLSearchParams to preserve DSL chars unencoded.
-  // Return hash-only for same-page links to avoid page reload.
-  const hashStr = [...hashParams]
-    .map(([k, v]) => (v ? `${k}=${v}` : k))
-    .join("&");
-  return "#" + hashStr;
-}
-)};
+const _bsoqwx = function _linkTo(isOnObservableCom)
+{
+    return function linkTo(target, {baseURI = document.baseURI, onObservable = isOnObservableCom(), source = null, op = 'open'    // "open" | "close" | "focus"
+} = {}) {
+        if (onObservable) {
+            const t = typeof target === 'string' ? target : target?.module || target?.open || target?.close || '';
+            return t.startsWith('#') ? t : '/' + t;
+        }
+        // Parse existing hash params manually to avoid percent-encoding DSL chars
+        const base = new URL(baseURI);
+        const rawHash = (base.hash || '#').slice(1);
+        const hashParams = new Map();
+        // open/close/focus/from are transient intents that lopepage consumes and
+        // clears, so we do NOT deep-link them. view= is canonical layout state owned
+        // by lopepage; if we baked the baseURI's view= into every link, the href
+        // would be a snapshot from link-render time and clicking it would rewind the
+        // layout (issue #150 — clicking a second module wiped the first because the
+        // link carried the boot view=). Dropping view= here makes the link a pure
+        // intent (e.g. "#cc=...&open=X"); sync_layout_from_url's
+        // `if (!view && open)` branch then merges the intent into the live layout.
+        const drop = new Set([
+            'view',
+            'open',
+            'close',
+            'focus',
+            'from'
+        ]);
+        if (rawHash) {
+            for (const part of rawHash.split('&')) {
+                const eq = part.indexOf('=');
+                const key = eq >= 0 ? part.slice(0, eq) : part;
+                if (drop.has(key))
+                    continue;
+                const val = eq >= 0 ? part.slice(eq + 1) : '';
+                hashParams.set(key, val);
+            }
+        }
+        if (typeof target === 'string' && target.startsWith('#'))
+            return target;
+        const isIntent = typeof target === 'object' && target !== null && ('module' in target || 'open' in target || 'close' in target || 'focus' in target || 'op' in target);
+        let module = null;
+        let cell = null;
+        if (!isIntent) {
+            module = String(target ?? '');
+            const parts = module.split('#');
+            module = parts[0] || null;
+            cell = parts[1] || null;
+            op = 'open';
+        } else {
+            module = target.module || target.open || target.close || target.focus || null;
+            cell = target.cell || null;
+            source = target.source ?? source;
+            op = target.op || (target.close ? 'close' : target.focus ? 'focus' : 'open');
+        }
+        if (!module)
+            return base.toString();
+        hashParams.set(op, cell ? `${ module }#${ cell }` : module);
+        if (source)
+            hashParams.set('from', source);
+        // Build hash without URLSearchParams to preserve DSL chars unencoded.
+        // Return hash-only for same-page links to avoid page reload.
+        const hashStr = [...hashParams].map(([k, v]) => v ? `${ k }=${ v }` : k).join('&');
+        return '#' + hashStr;
+    };
+};
 const _jdyayh = function _vars(variables,runtime){return(
 variables(runtime)
 )};
+const _mfvz6q = (G, _) => G.input(_);
 const _1f44wsz = function _test_linkTo(links,targets,linkTo){return(
 links.map((link) =>
   targets.map((target) =>
@@ -14615,7 +14609,6 @@ md`## Auto switch to url structure
 
 Watch the runtime for imports and swap them for our structure`
 )};
-const _w93ki7 = (_, v) => v.import("runtime", _);
 const _1gllckt = function _href_examples(){return(
 [
   "https://tomlarkworthy/import-notebook",
@@ -14674,20 +14667,15 @@ const _1xxtf0r = function _updateNotebookImports(vars,extractNotebookAndCell,lin
     }
   }
 };
-const _1txhfy5 = (_, v) => v.import("tests", _);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
   const $def = (pid, name, deps, fn) => {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
-  const fileAttachments = new Map([].map((name) => {
-    const module_name = "@tomlarkworthy/lopepage-urls";
-    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
-    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
-    return [name, {url: blob_url, mimeType: mime}]
-  }));
-  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
   $def("_1g7wjzc", null, ["md"], _1g7wjzc);  
   $def("_1hsbxxe", null, ["md"], _1hsbxxe);  
   $def("_1buq9dd", null, ["tests"], _1buq9dd);  
@@ -14717,22 +14705,21 @@ export default function define(runtime, observer) {
   $def("_1xjzq9r", "isOnObservableCom", ["location"], _1xjzq9r);  
   $def("_gxaxgb", "links", [], _gxaxgb);  
   $def("_17e89y0", "targets", [], _17e89y0);  
-  $def("_1x6cut", "linkTo", ["isOnObservableCom"], _1x6cut);  
+  $def("_bsoqwx", "linkTo", ["isOnObservableCom"], _bsoqwx);  
   $def("_jdyayh", "viewof vars", ["variables","runtime"], _jdyayh);  
-  main.variable(observer("vars")).define("vars", ["Generators", "viewof vars"], (G, _) => G.input(_));  
+  $def("_mfvz6q", "vars", ["Generators","viewof vars"], _mfvz6q);  
   $def("_1f44wsz", "test_linkTo", ["links","targets","linkTo"], _1f44wsz);  
   $def("_1hdknc", null, ["md"], _1hdknc);  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("variables", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("variables", _));  
   $def("_1gllckt", "href_examples", [], _1gllckt);  
   $def("_133ucsn", "test_extractNotebookAndCell", ["href_examples","extractNotebookAndCell"], _133ucsn);  
   $def("_cb1ope", "extractNotebookAndCell", [], _cb1ope);  
   $def("_1xxtf0r", "updateNotebookImports", ["vars","extractNotebookAndCell","linkTo"], _1xxtf0r);  
-  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
   main.define("tests", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("tests", _));
   return main;
-}</script>
+}
+</script>
 
 <script id="@tomlarkworthy/module-map" 
   type="text/plain"

--- a/notebooks/@tomlarkworthy_secrets.html
+++ b/notebooks/@tomlarkworthy_secrets.html
@@ -14177,7 +14177,7 @@ export default function define(runtime, observer) {
   return main;
 }</script>
 
-<script id="@tomlarkworthy/lopepage-urls" 
+<script id="@tomlarkworthy/lopepage-urls"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -14528,81 +14528,75 @@ const _gxaxgb = function _links(){return(
 const _17e89y0 = function _targets(){return(
 ["@tom/bar", "d/1f41fef8b019cf4e@94", "@tom/bar#cell"]
 )};
-const _1x6cut = function _linkTo(isOnObservableCom){return(
-function linkTo(
-  target,
-  {
-    baseURI = document.baseURI,
-    onObservable = isOnObservableCom(),
-    source = null,
-    op = "open" // "open" | "close" | "focus"
-  } = {}
-) {
-  if (onObservable) {
-    const t =
-      typeof target === "string"
-        ? target
-        : target?.module || target?.open || target?.close || "";
-    return t.startsWith("#") ? t : "/" + t;
-  }
-
-  // Parse existing hash params manually to avoid percent-encoding DSL chars
-  const base = new URL(baseURI);
-  const rawHash = (base.hash || "#").slice(1);
-  const hashParams = new Map();
-  if (rawHash) {
-    for (const part of rawHash.split("&")) {
-      const eq = part.indexOf("=");
-      if (eq >= 0) hashParams.set(part.slice(0, eq), part.slice(eq + 1));
-      else if (part) hashParams.set(part, "");
-    }
-  }
-
-  if (typeof target === "string" && target.startsWith("#")) return target;
-
-  const isIntent =
-    typeof target === "object" &&
-    target !== null &&
-    ("module" in target ||
-      "open" in target ||
-      "close" in target ||
-      "focus" in target ||
-      "op" in target);
-
-  let module = null;
-  let cell = null;
-
-  if (!isIntent) {
-    module = String(target ?? "");
-    const parts = module.split("#");
-    module = parts[0] || null;
-    cell = parts[1] || null;
-    op = "open";
-  } else {
-    module =
-      target.module || target.open || target.close || target.focus || null;
-    cell = target.cell || null;
-    source = target.source ?? source;
-    op =
-      target.op || (target.close ? "close" : target.focus ? "focus" : "open");
-  }
-
-  if (!module) return base.toString();
-
-  hashParams.set(op, cell ? `${module}#${cell}` : module);
-  if (source) hashParams.set("from", source);
-
-  // Build hash without URLSearchParams to preserve DSL chars unencoded.
-  // Return hash-only for same-page links to avoid page reload.
-  const hashStr = [...hashParams]
-    .map(([k, v]) => (v ? `${k}=${v}` : k))
-    .join("&");
-  return "#" + hashStr;
-}
-)};
+const _bsoqwx = function _linkTo(isOnObservableCom)
+{
+    return function linkTo(target, {baseURI = document.baseURI, onObservable = isOnObservableCom(), source = null, op = 'open'    // "open" | "close" | "focus"
+} = {}) {
+        if (onObservable) {
+            const t = typeof target === 'string' ? target : target?.module || target?.open || target?.close || '';
+            return t.startsWith('#') ? t : '/' + t;
+        }
+        // Parse existing hash params manually to avoid percent-encoding DSL chars
+        const base = new URL(baseURI);
+        const rawHash = (base.hash || '#').slice(1);
+        const hashParams = new Map();
+        // open/close/focus/from are transient intents that lopepage consumes and
+        // clears, so we do NOT deep-link them. view= is canonical layout state owned
+        // by lopepage; if we baked the baseURI's view= into every link, the href
+        // would be a snapshot from link-render time and clicking it would rewind the
+        // layout (issue #150 — clicking a second module wiped the first because the
+        // link carried the boot view=). Dropping view= here makes the link a pure
+        // intent (e.g. "#cc=...&open=X"); sync_layout_from_url's
+        // `if (!view && open)` branch then merges the intent into the live layout.
+        const drop = new Set([
+            'view',
+            'open',
+            'close',
+            'focus',
+            'from'
+        ]);
+        if (rawHash) {
+            for (const part of rawHash.split('&')) {
+                const eq = part.indexOf('=');
+                const key = eq >= 0 ? part.slice(0, eq) : part;
+                if (drop.has(key))
+                    continue;
+                const val = eq >= 0 ? part.slice(eq + 1) : '';
+                hashParams.set(key, val);
+            }
+        }
+        if (typeof target === 'string' && target.startsWith('#'))
+            return target;
+        const isIntent = typeof target === 'object' && target !== null && ('module' in target || 'open' in target || 'close' in target || 'focus' in target || 'op' in target);
+        let module = null;
+        let cell = null;
+        if (!isIntent) {
+            module = String(target ?? '');
+            const parts = module.split('#');
+            module = parts[0] || null;
+            cell = parts[1] || null;
+            op = 'open';
+        } else {
+            module = target.module || target.open || target.close || target.focus || null;
+            cell = target.cell || null;
+            source = target.source ?? source;
+            op = target.op || (target.close ? 'close' : target.focus ? 'focus' : 'open');
+        }
+        if (!module)
+            return base.toString();
+        hashParams.set(op, cell ? `${ module }#${ cell }` : module);
+        if (source)
+            hashParams.set('from', source);
+        // Build hash without URLSearchParams to preserve DSL chars unencoded.
+        // Return hash-only for same-page links to avoid page reload.
+        const hashStr = [...hashParams].map(([k, v]) => v ? `${ k }=${ v }` : k).join('&');
+        return '#' + hashStr;
+    };
+};
 const _jdyayh = function _vars(variables,runtime){return(
 variables(runtime)
 )};
+const _mfvz6q = (G, _) => G.input(_);
 const _1f44wsz = function _test_linkTo(links,targets,linkTo){return(
 links.map((link) =>
   targets.map((target) =>
@@ -14615,7 +14609,6 @@ md`## Auto switch to url structure
 
 Watch the runtime for imports and swap them for our structure`
 )};
-const _w93ki7 = (_, v) => v.import("runtime", _);
 const _1gllckt = function _href_examples(){return(
 [
   "https://tomlarkworthy/import-notebook",
@@ -14674,20 +14667,15 @@ const _1xxtf0r = function _updateNotebookImports(vars,extractNotebookAndCell,lin
     }
   }
 };
-const _1txhfy5 = (_, v) => v.import("tests", _);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
   const $def = (pid, name, deps, fn) => {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
-  const fileAttachments = new Map([].map((name) => {
-    const module_name = "@tomlarkworthy/lopepage-urls";
-    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
-    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
-    return [name, {url: blob_url, mimeType: mime}]
-  }));
-  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
   $def("_1g7wjzc", null, ["md"], _1g7wjzc);  
   $def("_1hsbxxe", null, ["md"], _1hsbxxe);  
   $def("_1buq9dd", null, ["tests"], _1buq9dd);  
@@ -14717,22 +14705,21 @@ export default function define(runtime, observer) {
   $def("_1xjzq9r", "isOnObservableCom", ["location"], _1xjzq9r);  
   $def("_gxaxgb", "links", [], _gxaxgb);  
   $def("_17e89y0", "targets", [], _17e89y0);  
-  $def("_1x6cut", "linkTo", ["isOnObservableCom"], _1x6cut);  
+  $def("_bsoqwx", "linkTo", ["isOnObservableCom"], _bsoqwx);  
   $def("_jdyayh", "viewof vars", ["variables","runtime"], _jdyayh);  
-  main.variable(observer("vars")).define("vars", ["Generators", "viewof vars"], (G, _) => G.input(_));  
+  $def("_mfvz6q", "vars", ["Generators","viewof vars"], _mfvz6q);  
   $def("_1f44wsz", "test_linkTo", ["links","targets","linkTo"], _1f44wsz);  
   $def("_1hdknc", null, ["md"], _1hdknc);  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("variables", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("variables", _));  
   $def("_1gllckt", "href_examples", [], _1gllckt);  
   $def("_133ucsn", "test_extractNotebookAndCell", ["href_examples","extractNotebookAndCell"], _133ucsn);  
   $def("_cb1ope", "extractNotebookAndCell", [], _cb1ope);  
   $def("_1xxtf0r", "updateNotebookImports", ["vars","extractNotebookAndCell","linkTo"], _1xxtf0r);  
-  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
   main.define("tests", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("tests", _));
   return main;
-}</script>
+}
+</script>
 
 <script id="@tomlarkworthy/module-map" 
   type="text/plain"

--- a/notebooks/@tomlarkworthy_tests.html
+++ b/notebooks/@tomlarkworthy_tests.html
@@ -14177,7 +14177,7 @@ export default function define(runtime, observer) {
   return main;
 }</script>
 
-<script id="@tomlarkworthy/lopepage-urls" 
+<script id="@tomlarkworthy/lopepage-urls"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -14528,81 +14528,75 @@ const _gxaxgb = function _links(){return(
 const _17e89y0 = function _targets(){return(
 ["@tom/bar", "d/1f41fef8b019cf4e@94", "@tom/bar#cell"]
 )};
-const _1x6cut = function _linkTo(isOnObservableCom){return(
-function linkTo(
-  target,
-  {
-    baseURI = document.baseURI,
-    onObservable = isOnObservableCom(),
-    source = null,
-    op = "open" // "open" | "close" | "focus"
-  } = {}
-) {
-  if (onObservable) {
-    const t =
-      typeof target === "string"
-        ? target
-        : target?.module || target?.open || target?.close || "";
-    return t.startsWith("#") ? t : "/" + t;
-  }
-
-  // Parse existing hash params manually to avoid percent-encoding DSL chars
-  const base = new URL(baseURI);
-  const rawHash = (base.hash || "#").slice(1);
-  const hashParams = new Map();
-  if (rawHash) {
-    for (const part of rawHash.split("&")) {
-      const eq = part.indexOf("=");
-      if (eq >= 0) hashParams.set(part.slice(0, eq), part.slice(eq + 1));
-      else if (part) hashParams.set(part, "");
-    }
-  }
-
-  if (typeof target === "string" && target.startsWith("#")) return target;
-
-  const isIntent =
-    typeof target === "object" &&
-    target !== null &&
-    ("module" in target ||
-      "open" in target ||
-      "close" in target ||
-      "focus" in target ||
-      "op" in target);
-
-  let module = null;
-  let cell = null;
-
-  if (!isIntent) {
-    module = String(target ?? "");
-    const parts = module.split("#");
-    module = parts[0] || null;
-    cell = parts[1] || null;
-    op = "open";
-  } else {
-    module =
-      target.module || target.open || target.close || target.focus || null;
-    cell = target.cell || null;
-    source = target.source ?? source;
-    op =
-      target.op || (target.close ? "close" : target.focus ? "focus" : "open");
-  }
-
-  if (!module) return base.toString();
-
-  hashParams.set(op, cell ? `${module}#${cell}` : module);
-  if (source) hashParams.set("from", source);
-
-  // Build hash without URLSearchParams to preserve DSL chars unencoded.
-  // Return hash-only for same-page links to avoid page reload.
-  const hashStr = [...hashParams]
-    .map(([k, v]) => (v ? `${k}=${v}` : k))
-    .join("&");
-  return "#" + hashStr;
-}
-)};
+const _bsoqwx = function _linkTo(isOnObservableCom)
+{
+    return function linkTo(target, {baseURI = document.baseURI, onObservable = isOnObservableCom(), source = null, op = 'open'    // "open" | "close" | "focus"
+} = {}) {
+        if (onObservable) {
+            const t = typeof target === 'string' ? target : target?.module || target?.open || target?.close || '';
+            return t.startsWith('#') ? t : '/' + t;
+        }
+        // Parse existing hash params manually to avoid percent-encoding DSL chars
+        const base = new URL(baseURI);
+        const rawHash = (base.hash || '#').slice(1);
+        const hashParams = new Map();
+        // open/close/focus/from are transient intents that lopepage consumes and
+        // clears, so we do NOT deep-link them. view= is canonical layout state owned
+        // by lopepage; if we baked the baseURI's view= into every link, the href
+        // would be a snapshot from link-render time and clicking it would rewind the
+        // layout (issue #150 — clicking a second module wiped the first because the
+        // link carried the boot view=). Dropping view= here makes the link a pure
+        // intent (e.g. "#cc=...&open=X"); sync_layout_from_url's
+        // `if (!view && open)` branch then merges the intent into the live layout.
+        const drop = new Set([
+            'view',
+            'open',
+            'close',
+            'focus',
+            'from'
+        ]);
+        if (rawHash) {
+            for (const part of rawHash.split('&')) {
+                const eq = part.indexOf('=');
+                const key = eq >= 0 ? part.slice(0, eq) : part;
+                if (drop.has(key))
+                    continue;
+                const val = eq >= 0 ? part.slice(eq + 1) : '';
+                hashParams.set(key, val);
+            }
+        }
+        if (typeof target === 'string' && target.startsWith('#'))
+            return target;
+        const isIntent = typeof target === 'object' && target !== null && ('module' in target || 'open' in target || 'close' in target || 'focus' in target || 'op' in target);
+        let module = null;
+        let cell = null;
+        if (!isIntent) {
+            module = String(target ?? '');
+            const parts = module.split('#');
+            module = parts[0] || null;
+            cell = parts[1] || null;
+            op = 'open';
+        } else {
+            module = target.module || target.open || target.close || target.focus || null;
+            cell = target.cell || null;
+            source = target.source ?? source;
+            op = target.op || (target.close ? 'close' : target.focus ? 'focus' : 'open');
+        }
+        if (!module)
+            return base.toString();
+        hashParams.set(op, cell ? `${ module }#${ cell }` : module);
+        if (source)
+            hashParams.set('from', source);
+        // Build hash without URLSearchParams to preserve DSL chars unencoded.
+        // Return hash-only for same-page links to avoid page reload.
+        const hashStr = [...hashParams].map(([k, v]) => v ? `${ k }=${ v }` : k).join('&');
+        return '#' + hashStr;
+    };
+};
 const _jdyayh = function _vars(variables,runtime){return(
 variables(runtime)
 )};
+const _mfvz6q = (G, _) => G.input(_);
 const _1f44wsz = function _test_linkTo(links,targets,linkTo){return(
 links.map((link) =>
   targets.map((target) =>
@@ -14615,7 +14609,6 @@ md`## Auto switch to url structure
 
 Watch the runtime for imports and swap them for our structure`
 )};
-const _w93ki7 = (_, v) => v.import("runtime", _);
 const _1gllckt = function _href_examples(){return(
 [
   "https://tomlarkworthy/import-notebook",
@@ -14674,20 +14667,15 @@ const _1xxtf0r = function _updateNotebookImports(vars,extractNotebookAndCell,lin
     }
   }
 };
-const _1txhfy5 = (_, v) => v.import("tests", _);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
   const $def = (pid, name, deps, fn) => {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
-  const fileAttachments = new Map([].map((name) => {
-    const module_name = "@tomlarkworthy/lopepage-urls";
-    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
-    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
-    return [name, {url: blob_url, mimeType: mime}]
-  }));
-  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
   $def("_1g7wjzc", null, ["md"], _1g7wjzc);  
   $def("_1hsbxxe", null, ["md"], _1hsbxxe);  
   $def("_1buq9dd", null, ["tests"], _1buq9dd);  
@@ -14717,22 +14705,21 @@ export default function define(runtime, observer) {
   $def("_1xjzq9r", "isOnObservableCom", ["location"], _1xjzq9r);  
   $def("_gxaxgb", "links", [], _gxaxgb);  
   $def("_17e89y0", "targets", [], _17e89y0);  
-  $def("_1x6cut", "linkTo", ["isOnObservableCom"], _1x6cut);  
+  $def("_bsoqwx", "linkTo", ["isOnObservableCom"], _bsoqwx);  
   $def("_jdyayh", "viewof vars", ["variables","runtime"], _jdyayh);  
-  main.variable(observer("vars")).define("vars", ["Generators", "viewof vars"], (G, _) => G.input(_));  
+  $def("_mfvz6q", "vars", ["Generators","viewof vars"], _mfvz6q);  
   $def("_1f44wsz", "test_linkTo", ["links","targets","linkTo"], _1f44wsz);  
   $def("_1hdknc", null, ["md"], _1hdknc);  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("variables", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("variables", _));  
   $def("_1gllckt", "href_examples", [], _1gllckt);  
   $def("_133ucsn", "test_extractNotebookAndCell", ["href_examples","extractNotebookAndCell"], _133ucsn);  
   $def("_cb1ope", "extractNotebookAndCell", [], _cb1ope);  
   $def("_1xxtf0r", "updateNotebookImports", ["vars","extractNotebookAndCell","linkTo"], _1xxtf0r);  
-  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
   main.define("tests", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("tests", _));
   return main;
-}</script>
+}
+</script>
 
 <script id="@tomlarkworthy/module-map" 
   type="text/plain"

--- a/notebooks/@tomlarkworthy_themes.html
+++ b/notebooks/@tomlarkworthy_themes.html
@@ -14177,7 +14177,7 @@ export default function define(runtime, observer) {
   return main;
 }</script>
 
-<script id="@tomlarkworthy/lopepage-urls" 
+<script id="@tomlarkworthy/lopepage-urls"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -14528,81 +14528,75 @@ const _gxaxgb = function _links(){return(
 const _17e89y0 = function _targets(){return(
 ["@tom/bar", "d/1f41fef8b019cf4e@94", "@tom/bar#cell"]
 )};
-const _1x6cut = function _linkTo(isOnObservableCom){return(
-function linkTo(
-  target,
-  {
-    baseURI = document.baseURI,
-    onObservable = isOnObservableCom(),
-    source = null,
-    op = "open" // "open" | "close" | "focus"
-  } = {}
-) {
-  if (onObservable) {
-    const t =
-      typeof target === "string"
-        ? target
-        : target?.module || target?.open || target?.close || "";
-    return t.startsWith("#") ? t : "/" + t;
-  }
-
-  // Parse existing hash params manually to avoid percent-encoding DSL chars
-  const base = new URL(baseURI);
-  const rawHash = (base.hash || "#").slice(1);
-  const hashParams = new Map();
-  if (rawHash) {
-    for (const part of rawHash.split("&")) {
-      const eq = part.indexOf("=");
-      if (eq >= 0) hashParams.set(part.slice(0, eq), part.slice(eq + 1));
-      else if (part) hashParams.set(part, "");
-    }
-  }
-
-  if (typeof target === "string" && target.startsWith("#")) return target;
-
-  const isIntent =
-    typeof target === "object" &&
-    target !== null &&
-    ("module" in target ||
-      "open" in target ||
-      "close" in target ||
-      "focus" in target ||
-      "op" in target);
-
-  let module = null;
-  let cell = null;
-
-  if (!isIntent) {
-    module = String(target ?? "");
-    const parts = module.split("#");
-    module = parts[0] || null;
-    cell = parts[1] || null;
-    op = "open";
-  } else {
-    module =
-      target.module || target.open || target.close || target.focus || null;
-    cell = target.cell || null;
-    source = target.source ?? source;
-    op =
-      target.op || (target.close ? "close" : target.focus ? "focus" : "open");
-  }
-
-  if (!module) return base.toString();
-
-  hashParams.set(op, cell ? `${module}#${cell}` : module);
-  if (source) hashParams.set("from", source);
-
-  // Build hash without URLSearchParams to preserve DSL chars unencoded.
-  // Return hash-only for same-page links to avoid page reload.
-  const hashStr = [...hashParams]
-    .map(([k, v]) => (v ? `${k}=${v}` : k))
-    .join("&");
-  return "#" + hashStr;
-}
-)};
+const _bsoqwx = function _linkTo(isOnObservableCom)
+{
+    return function linkTo(target, {baseURI = document.baseURI, onObservable = isOnObservableCom(), source = null, op = 'open'    // "open" | "close" | "focus"
+} = {}) {
+        if (onObservable) {
+            const t = typeof target === 'string' ? target : target?.module || target?.open || target?.close || '';
+            return t.startsWith('#') ? t : '/' + t;
+        }
+        // Parse existing hash params manually to avoid percent-encoding DSL chars
+        const base = new URL(baseURI);
+        const rawHash = (base.hash || '#').slice(1);
+        const hashParams = new Map();
+        // open/close/focus/from are transient intents that lopepage consumes and
+        // clears, so we do NOT deep-link them. view= is canonical layout state owned
+        // by lopepage; if we baked the baseURI's view= into every link, the href
+        // would be a snapshot from link-render time and clicking it would rewind the
+        // layout (issue #150 — clicking a second module wiped the first because the
+        // link carried the boot view=). Dropping view= here makes the link a pure
+        // intent (e.g. "#cc=...&open=X"); sync_layout_from_url's
+        // `if (!view && open)` branch then merges the intent into the live layout.
+        const drop = new Set([
+            'view',
+            'open',
+            'close',
+            'focus',
+            'from'
+        ]);
+        if (rawHash) {
+            for (const part of rawHash.split('&')) {
+                const eq = part.indexOf('=');
+                const key = eq >= 0 ? part.slice(0, eq) : part;
+                if (drop.has(key))
+                    continue;
+                const val = eq >= 0 ? part.slice(eq + 1) : '';
+                hashParams.set(key, val);
+            }
+        }
+        if (typeof target === 'string' && target.startsWith('#'))
+            return target;
+        const isIntent = typeof target === 'object' && target !== null && ('module' in target || 'open' in target || 'close' in target || 'focus' in target || 'op' in target);
+        let module = null;
+        let cell = null;
+        if (!isIntent) {
+            module = String(target ?? '');
+            const parts = module.split('#');
+            module = parts[0] || null;
+            cell = parts[1] || null;
+            op = 'open';
+        } else {
+            module = target.module || target.open || target.close || target.focus || null;
+            cell = target.cell || null;
+            source = target.source ?? source;
+            op = target.op || (target.close ? 'close' : target.focus ? 'focus' : 'open');
+        }
+        if (!module)
+            return base.toString();
+        hashParams.set(op, cell ? `${ module }#${ cell }` : module);
+        if (source)
+            hashParams.set('from', source);
+        // Build hash without URLSearchParams to preserve DSL chars unencoded.
+        // Return hash-only for same-page links to avoid page reload.
+        const hashStr = [...hashParams].map(([k, v]) => v ? `${ k }=${ v }` : k).join('&');
+        return '#' + hashStr;
+    };
+};
 const _jdyayh = function _vars(variables,runtime){return(
 variables(runtime)
 )};
+const _mfvz6q = (G, _) => G.input(_);
 const _1f44wsz = function _test_linkTo(links,targets,linkTo){return(
 links.map((link) =>
   targets.map((target) =>
@@ -14615,7 +14609,6 @@ md`## Auto switch to url structure
 
 Watch the runtime for imports and swap them for our structure`
 )};
-const _w93ki7 = (_, v) => v.import("runtime", _);
 const _1gllckt = function _href_examples(){return(
 [
   "https://tomlarkworthy/import-notebook",
@@ -14674,20 +14667,15 @@ const _1xxtf0r = function _updateNotebookImports(vars,extractNotebookAndCell,lin
     }
   }
 };
-const _1txhfy5 = (_, v) => v.import("tests", _);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
   const $def = (pid, name, deps, fn) => {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
-  const fileAttachments = new Map([].map((name) => {
-    const module_name = "@tomlarkworthy/lopepage-urls";
-    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
-    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
-    return [name, {url: blob_url, mimeType: mime}]
-  }));
-  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
   $def("_1g7wjzc", null, ["md"], _1g7wjzc);  
   $def("_1hsbxxe", null, ["md"], _1hsbxxe);  
   $def("_1buq9dd", null, ["tests"], _1buq9dd);  
@@ -14717,22 +14705,21 @@ export default function define(runtime, observer) {
   $def("_1xjzq9r", "isOnObservableCom", ["location"], _1xjzq9r);  
   $def("_gxaxgb", "links", [], _gxaxgb);  
   $def("_17e89y0", "targets", [], _17e89y0);  
-  $def("_1x6cut", "linkTo", ["isOnObservableCom"], _1x6cut);  
+  $def("_bsoqwx", "linkTo", ["isOnObservableCom"], _bsoqwx);  
   $def("_jdyayh", "viewof vars", ["variables","runtime"], _jdyayh);  
-  main.variable(observer("vars")).define("vars", ["Generators", "viewof vars"], (G, _) => G.input(_));  
+  $def("_mfvz6q", "vars", ["Generators","viewof vars"], _mfvz6q);  
   $def("_1f44wsz", "test_linkTo", ["links","targets","linkTo"], _1f44wsz);  
   $def("_1hdknc", null, ["md"], _1hdknc);  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("variables", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("variables", _));  
   $def("_1gllckt", "href_examples", [], _1gllckt);  
   $def("_133ucsn", "test_extractNotebookAndCell", ["href_examples","extractNotebookAndCell"], _133ucsn);  
   $def("_cb1ope", "extractNotebookAndCell", [], _cb1ope);  
   $def("_1xxtf0r", "updateNotebookImports", ["vars","extractNotebookAndCell","linkTo"], _1xxtf0r);  
-  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
   main.define("tests", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("tests", _));
   return main;
-}</script>
+}
+</script>
 
 <script id="@tomlarkworthy/module-map" 
   type="text/plain"

--- a/notebooks/@tomlarkworthy_visualizer.html
+++ b/notebooks/@tomlarkworthy_visualizer.html
@@ -14177,7 +14177,7 @@ export default function define(runtime, observer) {
   return main;
 }</script>
 
-<script id="@tomlarkworthy/lopepage-urls" 
+<script id="@tomlarkworthy/lopepage-urls"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -14528,81 +14528,75 @@ const _gxaxgb = function _links(){return(
 const _17e89y0 = function _targets(){return(
 ["@tom/bar", "d/1f41fef8b019cf4e@94", "@tom/bar#cell"]
 )};
-const _1x6cut = function _linkTo(isOnObservableCom){return(
-function linkTo(
-  target,
-  {
-    baseURI = document.baseURI,
-    onObservable = isOnObservableCom(),
-    source = null,
-    op = "open" // "open" | "close" | "focus"
-  } = {}
-) {
-  if (onObservable) {
-    const t =
-      typeof target === "string"
-        ? target
-        : target?.module || target?.open || target?.close || "";
-    return t.startsWith("#") ? t : "/" + t;
-  }
-
-  // Parse existing hash params manually to avoid percent-encoding DSL chars
-  const base = new URL(baseURI);
-  const rawHash = (base.hash || "#").slice(1);
-  const hashParams = new Map();
-  if (rawHash) {
-    for (const part of rawHash.split("&")) {
-      const eq = part.indexOf("=");
-      if (eq >= 0) hashParams.set(part.slice(0, eq), part.slice(eq + 1));
-      else if (part) hashParams.set(part, "");
-    }
-  }
-
-  if (typeof target === "string" && target.startsWith("#")) return target;
-
-  const isIntent =
-    typeof target === "object" &&
-    target !== null &&
-    ("module" in target ||
-      "open" in target ||
-      "close" in target ||
-      "focus" in target ||
-      "op" in target);
-
-  let module = null;
-  let cell = null;
-
-  if (!isIntent) {
-    module = String(target ?? "");
-    const parts = module.split("#");
-    module = parts[0] || null;
-    cell = parts[1] || null;
-    op = "open";
-  } else {
-    module =
-      target.module || target.open || target.close || target.focus || null;
-    cell = target.cell || null;
-    source = target.source ?? source;
-    op =
-      target.op || (target.close ? "close" : target.focus ? "focus" : "open");
-  }
-
-  if (!module) return base.toString();
-
-  hashParams.set(op, cell ? `${module}#${cell}` : module);
-  if (source) hashParams.set("from", source);
-
-  // Build hash without URLSearchParams to preserve DSL chars unencoded.
-  // Return hash-only for same-page links to avoid page reload.
-  const hashStr = [...hashParams]
-    .map(([k, v]) => (v ? `${k}=${v}` : k))
-    .join("&");
-  return "#" + hashStr;
-}
-)};
+const _bsoqwx = function _linkTo(isOnObservableCom)
+{
+    return function linkTo(target, {baseURI = document.baseURI, onObservable = isOnObservableCom(), source = null, op = 'open'    // "open" | "close" | "focus"
+} = {}) {
+        if (onObservable) {
+            const t = typeof target === 'string' ? target : target?.module || target?.open || target?.close || '';
+            return t.startsWith('#') ? t : '/' + t;
+        }
+        // Parse existing hash params manually to avoid percent-encoding DSL chars
+        const base = new URL(baseURI);
+        const rawHash = (base.hash || '#').slice(1);
+        const hashParams = new Map();
+        // open/close/focus/from are transient intents that lopepage consumes and
+        // clears, so we do NOT deep-link them. view= is canonical layout state owned
+        // by lopepage; if we baked the baseURI's view= into every link, the href
+        // would be a snapshot from link-render time and clicking it would rewind the
+        // layout (issue #150 — clicking a second module wiped the first because the
+        // link carried the boot view=). Dropping view= here makes the link a pure
+        // intent (e.g. "#cc=...&open=X"); sync_layout_from_url's
+        // `if (!view && open)` branch then merges the intent into the live layout.
+        const drop = new Set([
+            'view',
+            'open',
+            'close',
+            'focus',
+            'from'
+        ]);
+        if (rawHash) {
+            for (const part of rawHash.split('&')) {
+                const eq = part.indexOf('=');
+                const key = eq >= 0 ? part.slice(0, eq) : part;
+                if (drop.has(key))
+                    continue;
+                const val = eq >= 0 ? part.slice(eq + 1) : '';
+                hashParams.set(key, val);
+            }
+        }
+        if (typeof target === 'string' && target.startsWith('#'))
+            return target;
+        const isIntent = typeof target === 'object' && target !== null && ('module' in target || 'open' in target || 'close' in target || 'focus' in target || 'op' in target);
+        let module = null;
+        let cell = null;
+        if (!isIntent) {
+            module = String(target ?? '');
+            const parts = module.split('#');
+            module = parts[0] || null;
+            cell = parts[1] || null;
+            op = 'open';
+        } else {
+            module = target.module || target.open || target.close || target.focus || null;
+            cell = target.cell || null;
+            source = target.source ?? source;
+            op = target.op || (target.close ? 'close' : target.focus ? 'focus' : 'open');
+        }
+        if (!module)
+            return base.toString();
+        hashParams.set(op, cell ? `${ module }#${ cell }` : module);
+        if (source)
+            hashParams.set('from', source);
+        // Build hash without URLSearchParams to preserve DSL chars unencoded.
+        // Return hash-only for same-page links to avoid page reload.
+        const hashStr = [...hashParams].map(([k, v]) => v ? `${ k }=${ v }` : k).join('&');
+        return '#' + hashStr;
+    };
+};
 const _jdyayh = function _vars(variables,runtime){return(
 variables(runtime)
 )};
+const _mfvz6q = (G, _) => G.input(_);
 const _1f44wsz = function _test_linkTo(links,targets,linkTo){return(
 links.map((link) =>
   targets.map((target) =>
@@ -14615,7 +14609,6 @@ md`## Auto switch to url structure
 
 Watch the runtime for imports and swap them for our structure`
 )};
-const _w93ki7 = (_, v) => v.import("runtime", _);
 const _1gllckt = function _href_examples(){return(
 [
   "https://tomlarkworthy/import-notebook",
@@ -14674,20 +14667,15 @@ const _1xxtf0r = function _updateNotebookImports(vars,extractNotebookAndCell,lin
     }
   }
 };
-const _1txhfy5 = (_, v) => v.import("tests", _);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
   const $def = (pid, name, deps, fn) => {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
-  const fileAttachments = new Map([].map((name) => {
-    const module_name = "@tomlarkworthy/lopepage-urls";
-    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
-    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
-    return [name, {url: blob_url, mimeType: mime}]
-  }));
-  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
   $def("_1g7wjzc", null, ["md"], _1g7wjzc);  
   $def("_1hsbxxe", null, ["md"], _1hsbxxe);  
   $def("_1buq9dd", null, ["tests"], _1buq9dd);  
@@ -14717,22 +14705,21 @@ export default function define(runtime, observer) {
   $def("_1xjzq9r", "isOnObservableCom", ["location"], _1xjzq9r);  
   $def("_gxaxgb", "links", [], _gxaxgb);  
   $def("_17e89y0", "targets", [], _17e89y0);  
-  $def("_1x6cut", "linkTo", ["isOnObservableCom"], _1x6cut);  
+  $def("_bsoqwx", "linkTo", ["isOnObservableCom"], _bsoqwx);  
   $def("_jdyayh", "viewof vars", ["variables","runtime"], _jdyayh);  
-  main.variable(observer("vars")).define("vars", ["Generators", "viewof vars"], (G, _) => G.input(_));  
+  $def("_mfvz6q", "vars", ["Generators","viewof vars"], _mfvz6q);  
   $def("_1f44wsz", "test_linkTo", ["links","targets","linkTo"], _1f44wsz);  
   $def("_1hdknc", null, ["md"], _1hdknc);  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("variables", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("variables", _));  
   $def("_1gllckt", "href_examples", [], _1gllckt);  
   $def("_133ucsn", "test_extractNotebookAndCell", ["href_examples","extractNotebookAndCell"], _133ucsn);  
   $def("_cb1ope", "extractNotebookAndCell", [], _cb1ope);  
   $def("_1xxtf0r", "updateNotebookImports", ["vars","extractNotebookAndCell","linkTo"], _1xxtf0r);  
-  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
   main.define("tests", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("tests", _));
   return main;
-}</script>
+}
+</script>
 
 <script id="@tomlarkworthy/module-map" 
   type="text/plain"

--- a/notebooks/atproto.html
+++ b/notebooks/atproto.html
@@ -15534,7 +15534,7 @@ export default function define(runtime, observer) {
   return main;
 }</script>
 
-<script id="@tomlarkworthy/lopepage-urls" 
+<script id="@tomlarkworthy/lopepage-urls"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -15885,78 +15885,71 @@ const _gxaxgb = function _links(){return(
 const _17e89y0 = function _targets(){return(
 ["@tom/bar", "d/1f41fef8b019cf4e@94", "@tom/bar#cell"]
 )};
-const _1x6cut = function _linkTo(isOnObservableCom){return(
-function linkTo(
-  target,
-  {
-    baseURI = document.baseURI,
-    onObservable = isOnObservableCom(),
-    source = null,
-    op = "open" // "open" | "close" | "focus"
-  } = {}
-) {
-  if (onObservable) {
-    const t =
-      typeof target === "string"
-        ? target
-        : target?.module || target?.open || target?.close || "";
-    return t.startsWith("#") ? t : "/" + t;
-  }
-
-  // Parse existing hash params manually to avoid percent-encoding DSL chars
-  const base = new URL(baseURI);
-  const rawHash = (base.hash || "#").slice(1);
-  const hashParams = new Map();
-  if (rawHash) {
-    for (const part of rawHash.split("&")) {
-      const eq = part.indexOf("=");
-      if (eq >= 0) hashParams.set(part.slice(0, eq), part.slice(eq + 1));
-      else if (part) hashParams.set(part, "");
-    }
-  }
-
-  if (typeof target === "string" && target.startsWith("#")) return target;
-
-  const isIntent =
-    typeof target === "object" &&
-    target !== null &&
-    ("module" in target ||
-      "open" in target ||
-      "close" in target ||
-      "focus" in target ||
-      "op" in target);
-
-  let module = null;
-  let cell = null;
-
-  if (!isIntent) {
-    module = String(target ?? "");
-    const parts = module.split("#");
-    module = parts[0] || null;
-    cell = parts[1] || null;
-    op = "open";
-  } else {
-    module =
-      target.module || target.open || target.close || target.focus || null;
-    cell = target.cell || null;
-    source = target.source ?? source;
-    op =
-      target.op || (target.close ? "close" : target.focus ? "focus" : "open");
-  }
-
-  if (!module) return base.toString();
-
-  hashParams.set(op, cell ? `${module}#${cell}` : module);
-  if (source) hashParams.set("from", source);
-
-  // Build hash without URLSearchParams to preserve DSL chars unencoded.
-  // Return hash-only for same-page links to avoid page reload.
-  const hashStr = [...hashParams]
-    .map(([k, v]) => (v ? `${k}=${v}` : k))
-    .join("&");
-  return "#" + hashStr;
-}
-)};
+const _bsoqwx = function _linkTo(isOnObservableCom)
+{
+    return function linkTo(target, {baseURI = document.baseURI, onObservable = isOnObservableCom(), source = null, op = 'open'    // "open" | "close" | "focus"
+} = {}) {
+        if (onObservable) {
+            const t = typeof target === 'string' ? target : target?.module || target?.open || target?.close || '';
+            return t.startsWith('#') ? t : '/' + t;
+        }
+        // Parse existing hash params manually to avoid percent-encoding DSL chars
+        const base = new URL(baseURI);
+        const rawHash = (base.hash || '#').slice(1);
+        const hashParams = new Map();
+        // open/close/focus/from are transient intents that lopepage consumes and
+        // clears, so we do NOT deep-link them. view= is canonical layout state owned
+        // by lopepage; if we baked the baseURI's view= into every link, the href
+        // would be a snapshot from link-render time and clicking it would rewind the
+        // layout (issue #150 — clicking a second module wiped the first because the
+        // link carried the boot view=). Dropping view= here makes the link a pure
+        // intent (e.g. "#cc=...&open=X"); sync_layout_from_url's
+        // `if (!view && open)` branch then merges the intent into the live layout.
+        const drop = new Set([
+            'view',
+            'open',
+            'close',
+            'focus',
+            'from'
+        ]);
+        if (rawHash) {
+            for (const part of rawHash.split('&')) {
+                const eq = part.indexOf('=');
+                const key = eq >= 0 ? part.slice(0, eq) : part;
+                if (drop.has(key))
+                    continue;
+                const val = eq >= 0 ? part.slice(eq + 1) : '';
+                hashParams.set(key, val);
+            }
+        }
+        if (typeof target === 'string' && target.startsWith('#'))
+            return target;
+        const isIntent = typeof target === 'object' && target !== null && ('module' in target || 'open' in target || 'close' in target || 'focus' in target || 'op' in target);
+        let module = null;
+        let cell = null;
+        if (!isIntent) {
+            module = String(target ?? '');
+            const parts = module.split('#');
+            module = parts[0] || null;
+            cell = parts[1] || null;
+            op = 'open';
+        } else {
+            module = target.module || target.open || target.close || target.focus || null;
+            cell = target.cell || null;
+            source = target.source ?? source;
+            op = target.op || (target.close ? 'close' : target.focus ? 'focus' : 'open');
+        }
+        if (!module)
+            return base.toString();
+        hashParams.set(op, cell ? `${ module }#${ cell }` : module);
+        if (source)
+            hashParams.set('from', source);
+        // Build hash without URLSearchParams to preserve DSL chars unencoded.
+        // Return hash-only for same-page links to avoid page reload.
+        const hashStr = [...hashParams].map(([k, v]) => v ? `${ k }=${ v }` : k).join('&');
+        return '#' + hashStr;
+    };
+};
 const _jdyayh = function _vars(variables,runtime){return(
 variables(runtime)
 )};
@@ -16038,6 +16031,8 @@ export default function define(runtime, observer) {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
 
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
   $def("_1g7wjzc", null, ["md"], _1g7wjzc);  
   $def("_1hsbxxe", null, ["md"], _1hsbxxe);  
   $def("_1buq9dd", null, ["tests"], _1buq9dd);  
@@ -16067,22 +16062,21 @@ export default function define(runtime, observer) {
   $def("_1xjzq9r", "isOnObservableCom", ["location"], _1xjzq9r);  
   $def("_gxaxgb", "links", [], _gxaxgb);  
   $def("_17e89y0", "targets", [], _17e89y0);  
-  $def("_1x6cut", "linkTo", ["isOnObservableCom"], _1x6cut);  
+  $def("_bsoqwx", "linkTo", ["isOnObservableCom"], _bsoqwx);  
   $def("_jdyayh", "viewof vars", ["variables","runtime"], _jdyayh);  
   $def("_mfvz6q", "vars", ["Generators","viewof vars"], _mfvz6q);  
   $def("_1f44wsz", "test_linkTo", ["links","targets","linkTo"], _1f44wsz);  
   $def("_1hdknc", null, ["md"], _1hdknc);  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("variables", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("variables", _));  
   $def("_1gllckt", "href_examples", [], _1gllckt);  
   $def("_133ucsn", "test_extractNotebookAndCell", ["href_examples","extractNotebookAndCell"], _133ucsn);  
   $def("_cb1ope", "extractNotebookAndCell", [], _cb1ope);  
   $def("_1xxtf0r", "updateNotebookImports", ["vars","extractNotebookAndCell","linkTo"], _1xxtf0r);  
-  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
   main.define("tests", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("tests", _));
   return main;
-}</script>
+}
+</script>
 
 <script id="@tomlarkworthy/module-map" 
   type="text/plain"


### PR DESCRIPTION
Fixes #150.

**This PR is a proposal** — the canonical HTML has been updated with the new `linkTo` cell, but ObservableHQ has not been pushed and consumer notebooks have not been re-synced yet. After approval, those steps will run and additional commits will be pushed to this branch.

## Root cause

Module-selection renders link `href`s via `linkTo(name)` once. `linkTo` carries `view=` from `document.baseURI` into every link href. `sync_layout_to_url` writes the live layout to `view=` via `history.replaceState`, which **does not fire `hashchange`**, so the `hash` reactive doesn't update and `selected_modules` doesn't recompute — link `href`s stay frozen at the boot `view=`.

Click 1: `#view=<boot>&open=A` → lopepage applies, writes `view=<boot+A>`, clears `open=`.
Click 2: link still points at `#view=<boot>&open=B` → setting hash rewinds `view=` to boot, applies `B` → tab `A` is gone.

## Fix

`linkTo` no longer carries `view/open/close/focus/from` from `baseURI`. The href becomes a pure intent (e.g. `#cc=...&open=X`). On click, `sync_layout_from_url`'s existing `if (!view && open)` branch merges the intent into the **live** layout instead of a stale snapshot.

Per issue author guidance: `open=` is a transient one-shot intent that lopepage consumes and clears by rewriting `view=`. We don't deep-link `open=`, and we don't deep-link the link-render-time `view=` either.

## Self-triggering defenses preserved

- `setHashURL` uses `history.replaceState` (no `hashchange` echo).
- `test_url_roundtrip` gate in `sync_layout_to_url` still blocks bad writes.
- `currentView === dsl` early return still skips no-op writes.
- Idempotent: clicking an already-open module is a no-op (verified in QA).

## Targeted QA (live runtime)

Verified in `@tomlarkworthy_blank-notebook.html` paired session:
- Click `cell-map` → `view=R100(S70(blank-notebook,cell-map),S30(module-selection))`, `open=` cleared. ✅
- Click `cells-to-clipboard` → `view=R100(S70(blank-notebook,cell-map,cells-to-clipboard),S30(module-selection))`. ✅ (was the failure case)
- Click `claude-code-pairing` → 4 tabs accumulated. ✅
- Click `cell-map` again (already open) → idempotent, no duplicate. ✅
- Console: clean.

## Files

`notebooks/@tomlarkworthy_lopepage-urls.html` — single `<script id="@tomlarkworthy/lopepage-urls">` block diff. Most line churn is sync-module's compact reformatting; the substantive change is the `drop` Set and the filter loop in `linkTo`.