### PR TITLE
Fix: drop importShim conditional from toolchain; editor-5 uses realize (#153)

### DIFF
--- a/notebooks/@tomlarkworthy_atlas.html
+++ b/notebooks/@tomlarkworthy_atlas.html
@@ -6386,58 +6386,41 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _geoudp = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
-  if (command.processed) return;
-
-  let result = undefined;
-  if (command.command == "createCell") {
-    $0.value = true;
-    result = compile_and_update("{}", [], command.args.cell);
-    // For the new one to get focus
-    // setTimeout(() => {
-    //   debugger;
-    //   setOption(result[0], "pinned", true);
-    // }, 100);
-  } else if (command.command == "deleteCell") {
-    remove_variables(command.args.cell.variables);
-    result = true;
-  } else if (command.command == "moveCell") {
-    const cellIndex = findCellIndex(
-      command.args.cell.variables,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const targetCellIndex = cellIndex + command.args.amount;
-    const targetCell = lookupCellByIndex(
-      targetCellIndex,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const currentFirstVariableIndex = findVariableIndex(
-      command.args.cell.variables[0]
-    );
-    const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-    const change = targetFirstVariableIndex - currentFirstVariableIndex;
-    console.log(
-      "moveCell",
-      cellIndex,
-      targetCellIndex,
-      targetCell,
-      currentFirstVariableIndex,
-      targetFirstVariableIndex,
-      change
-    );
-    command.args.cell.variables.forEach((v) => {
-      const currentIndex = findVariableIndex(v);
-      repositionSetElement(runtime._variables, v, currentIndex + change);
-    });
-    // recompute
-    await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
-    result = true;
-  }
-  if (result) {
-    command.processed = true;
-    $2.resolve(result);
-  }
+    if (command.processed)
+        return;
+    let result = undefined;
+    if (command.command == 'createCell') {
+        $0.value = true;
+        result = await compile_and_update('{}', [], command.args.cell);    // For the new one to get focus
+                                                                           // setTimeout(() => {
+                                                                           //   debugger;
+                                                                           //   setOption(result[0], "pinned", true);
+                                                                           // }, 100);
+    } else if (command.command == 'deleteCell') {
+        remove_variables(command.args.cell.variables);
+        result = true;
+    } else if (command.command == 'moveCell') {
+        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const targetCellIndex = cellIndex + command.args.amount;
+        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
+        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+        const change = targetFirstVariableIndex - currentFirstVariableIndex;
+        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
+        command.args.cell.variables.forEach(v => {
+            const currentIndex = findVariableIndex(v);
+            repositionSetElement(runtime._variables, v, currentIndex + change);
+        });
+        // recompute
+        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        result = true;
+    }
+    if (result) {
+        command.processed = true;
+        $2.resolve(result);
+    }
 };
 const _1jadxoe = function _60(md){return(
 md`### UI Action`
@@ -6828,9 +6811,9 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
-    return (source, variables = [], cell) => {
+    return async (source, variables = [], cell) => {
         try {
             debugger;
             let reposition = false, insertionIndex = -1;
@@ -6850,10 +6833,10 @@ const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElemen
             if (reposition) {
                 insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
+            const fns = await realize(newVariables.map(v => v._definition), runtime);
             newVariables.forEach((v, i) => {
                 const variable = variables[i];
-                let _fn;
-                eval('_fn = ' + v._definition);
+                const _fn = fns[i];
                 if (v._name) {
                     variable.define(v._name, v._inputs, _fn);
                 } else {
@@ -6902,12 +6885,11 @@ Inputs.textarea({
 })
 )};
 const _b4rsn5 = (G, _) => G.input(_);
-const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
+const _ga6kci = function _98(Inputs,definition,variable,realize,runtime,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
-  reduce: () => {
-    let _fn;
-    eval("_fn = " + definition);
+  reduce: async () => {
+    const [_fn] = await realize([definition], runtime);
     variable.define(variable._name, inputs, _fn);
   }
 })
@@ -7020,7 +7002,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_geoudp", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _geoudp);  
+  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -7058,7 +7040,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
+  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -7068,8 +7050,9 @@ export default function define(runtime, observer) {
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
   $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
-  $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
+  $def("_ga6kci", null, ["Inputs","definition","variable","realize","runtime","inputs"], _ga6kci);  
   $def("_1q557s", null, ["md"], _1q557s);  
+  main.define("realize", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("realize", _));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -17433,10 +17416,9 @@ notebook_semantics_document.nodes.map((s) => ({
 const _1oevsow = function _28(md){return(
 md`### Runtime Representation (v4)`
 )};
-const _11lfflk = function _notebook_semantics_module(){return(
-importShim("https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4"
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _11lfflk = function _notebook_semantics_module() {
+    return import('https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4');
+};
 const _gjten6 = function _31(md){return(
 md`### Imports`
 )};
@@ -18423,65 +18405,44 @@ parser.parseCell(
   'import {runtime, viewof main as foo} from "@mootari/access-runtime"'
 )
 )};
-const _1n7gw17 = function _findModuleName(extractModuleInfo){return(
-(scope, module, { unknown_id = Math.random() } = {}) => {
-  try {
-    const scopedVariables = [...scope.values()];
-
-    // Prefer variables that *define* a module and have a real module-loader name.
-    const candidates = scopedVariables.filter(
-      (v) =>
-        v &&
-        v._value === module &&
-        typeof v._name === "string" &&
-        v._name.startsWith("module ") &&
-        !v._name.startsWith("module <unknown")
-    );
-
-    const pickBestInfo = (dfn) => {
-      // Avoid the parentUrl (2nd arg) confusing module identification.
-      // Typical patterns:
-      //   importShim("/d/<id>@<ver>.js?v=4", "https://api.observablehq.com/@ns/name.js?v=4")
-      //   import("/d/<id>@<ver>.js?v=4")
-      // Prefer the *first argument* inside importShim(...) / import(...) when present.
-      const s = String(dfn ?? "");
-
-      // Try to capture the first string literal argument to importShim(...) or import(...)
-      // Tolerates quotes ", ', ` and both importShim and plain import.
-      const m = s.match(
-        /\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/
-      );
-      const firstArg = m?.[2];
-
-      const info1 = firstArg ? extractModuleInfo(firstArg) : {};
-      if (info1?.id || info1?.notebook) return info1;
-
-      // Fallback: parse the whole definition string.
-      return extractModuleInfo(s);
+const _1n7gw17 = function _findModuleName(extractModuleInfo) {
+    return (scope, module, {
+        unknown_id = Math.random()
+    } = {}) => {
+        try {
+            const scopedVariables = [...scope.values()];
+            const candidates = scopedVariables.filter(v => v && v._value === module && typeof v._name === 'string' && v._name.startsWith('module ') && !v._name.startsWith('module <unknown'));
+            const pickBestInfo = dfn => {
+                const s = String(dfn ?? '');
+                const m = s.match(/\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/);
+                const firstArg = m?.[2];
+                const info1 = firstArg ? extractModuleInfo(firstArg) : {};
+                if (info1?.id || info1?.notebook)
+                    return info1;
+                return extractModuleInfo(s);
+            };
+            for (const v of candidates) {
+                const info = pickBestInfo(v._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            const any = scopedVariables.find(v => v && v._value === module);
+            if (any) {
+                const info = pickBestInfo(any._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            return `<unknown ${ unknown_id }>`;
+        } catch (e) {
+            debugger;
+            return 'error';
+        }
     };
-
-    // Try module loader cells first.
-    for (const v of candidates) {
-      const info = pickBestInfo(v._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    // Fallback: any scoped variable with _value==module.
-    const any = scopedVariables.find((v) => v && v._value === module);
-    if (any) {
-      const info = pickBestInfo(any._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    return `<unknown ${unknown_id}>`;
-  } catch (e) {
-    debugger;
-    return "error";
-  }
-}
-)};
+};
 const _i47chb = function _findImportedName(){return(
 async (v) => {
   if (v._inputs.length == 1 && v._inputs[0]._name === "@variable") {
@@ -19383,229 +19344,206 @@ JSON.stringify(
 const _1lt3kl6 = function _157(compile,test_case){return(
 compile(test_case.value)
 )};
-const _lpzjrv = function _compile(parser,globalThis,observableToJs){return(
-function compile(source, { anonymousName = "_anonymous" } = {}) {
-  const comments = [],
-    tokens = [];
-  let cell;
-  try {
-    cell = parser.parseCell(source, {
-      ranges: true,
-      onComment: comments,
-      onToken: tokens
-    });
-  } catch (e) {
-    if (e instanceof SyntaxError) {
-      const nameMatch = source.match(
-        /^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/
-      );
-      let _name = null;
-      let funcName = anonymousName;
-      if (nameMatch) {
-        const prefix = nameMatch[1] ? nameMatch[1] + " " : "";
-        _name = prefix + nameMatch[2];
-        funcName = "_" + nameMatch[2];
-      }
-      const escapedMsg = JSON.stringify(e.message);
-      const escapedSource = JSON.stringify(source);
-      return [
-        {
-          _name,
-          _inputs: [],
-          _definition: `function ${funcName}() { throw Object.assign(new SyntaxError(${escapedMsg}), {_sourceExpression: ${escapedSource}}); }`
+const _x1d0wm = function _compile(parser,observableToJs){return(
+function compile(source, {
+    anonymousName = '_anonymous'
+} = {}) {
+    const comments = [], tokens = [];
+    let cell;
+    try {
+        cell = parser.parseCell(source, {
+            ranges: true,
+            onComment: comments,
+            onToken: tokens
+        });
+    } catch (e) {
+        if (e instanceof SyntaxError) {
+            const nameMatch = source.match(/^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/);
+            let _name = null;
+            let funcName = anonymousName;
+            if (nameMatch) {
+                const prefix = nameMatch[1] ? nameMatch[1] + ' ' : '';
+                _name = prefix + nameMatch[2];
+                funcName = '_' + nameMatch[2];
+            }
+            const escapedMsg = JSON.stringify(e.message);
+            const escapedSource = JSON.stringify(source);
+            return [{
+                    _name,
+                    _inputs: [],
+                    _definition: `function ${ funcName }() { throw Object.assign(new SyntaxError(${ escapedMsg }), {_sourceExpression: ${ escapedSource }}); }`
+                }];
         }
-      ];
+        throw e;
     }
-    throw e;
-  }
-  if (!cell) throw new Error("Unable to parse cell");
-  const parseImportSpecifierText = (text) => {
-    const t = String(text ?? "")
-      .trim()
-      .replace(/,$/, "")
-      .trim();
-    if (!t) throw new Error("Empty import specifier");
-    const parts = t.split(/\s+as\s+/);
-    const left = parts[0].trim();
-    const right = parts[1]?.trim();
-    const parseSide = (side, { defaultPrefix = "" } = {}) => {
-      const s = String(side ?? "").trim();
-      const m = s.match(/^(viewof|mutable)\s+(.+)$/);
-      if (m)
-        return {
-          prefix: `${m[1]} `,
-          name: m[2].trim()
+    if (!cell)
+        throw new Error('Unable to parse cell');
+    const parseImportSpecifierText = text => {
+        const t = String(text ?? '').trim().replace(/,$/, '').trim();
+        if (!t)
+            throw new Error('Empty import specifier');
+        const parts = t.split(/\s+as\s+/);
+        const left = parts[0].trim();
+        const right = parts[1]?.trim();
+        const parseSide = (side, {
+            defaultPrefix = ''
+        } = {}) => {
+            const s = String(side ?? '').trim();
+            const m = s.match(/^(viewof|mutable)\s+(.+)$/);
+            if (m)
+                return {
+                    prefix: `${ m[1] } `,
+                    name: m[2].trim()
+                };
+            return {
+                prefix: defaultPrefix,
+                name: s
+            };
         };
-      return {
-        prefix: defaultPrefix,
-        name: s
-      };
+        const L = parseSide(left);
+        const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
+        const importedName = `${ L.prefix }${ L.name }`.trim();
+        const localName = `${ R.prefix }${ R.name }`.trim();
+        if (!importedName)
+            throw new Error(`Could not parse imported name from: ${ t }`);
+        if (!localName)
+            throw new Error(`Could not parse local name from: ${ t }`);
+        return {
+            importedName,
+            localName
+        };
     };
-    const L = parseSide(left);
-    const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
-    const importedName = `${L.prefix}${L.name}`.trim();
-    const localName = `${R.prefix}${R.name}`.trim();
-    if (!importedName)
-      throw new Error(`Could not parse imported name from: ${t}`);
-    if (!localName) throw new Error(`Could not parse local name from: ${t}`);
-    return {
-      importedName,
-      localName
-    };
-  };
-  if (!cell.id && cell.body?.type === "ImportDeclaration") {
-    const module_name = cell.body.source.value;
-    const importKeyword = globalThis?.importShim ? "importShim" : "import";
-    const cell_variables = [
-      {
-        _name: `module ${module_name}`,
-        _inputs: [],
-        _definition: `async () => runtime.module((await ${importKeyword}("${module_name}")).default)`
-      }
-    ];
-    for (const specifier of cell.body.specifiers ?? []) {
-      const specText =
-        typeof specifier?.start === "number" &&
-        typeof specifier?.end === "number"
-          ? source.slice(specifier.start, specifier.end)
-          : (() => {
-              if (specifier?.imported?.name && specifier?.local?.name) {
-                return specifier.imported.name === specifier.local.name
-                  ? specifier.local.name
-                  : `${specifier.imported.name} as ${specifier.local.name}`;
-              }
-              throw new Error("Import specifier missing range information");
+    if (!cell.id && cell.body?.type === 'ImportDeclaration') {
+        const module_name = cell.body.source.value;
+        const cell_variables = [{
+                _name: `module ${ module_name }`,
+                _inputs: [],
+                _definition: `async () => runtime.module((await import("${ module_name }")).default)`
+            }];
+        for (const specifier of cell.body.specifiers ?? []) {
+            const specText = typeof specifier?.start === 'number' && typeof specifier?.end === 'number' ? source.slice(specifier.start, specifier.end) : (() => {
+                if (specifier?.imported?.name && specifier?.local?.name) {
+                    return specifier.imported.name === specifier.local.name ? specifier.local.name : `${ specifier.imported.name } as ${ specifier.local.name }`;
+                }
+                throw new Error('Import specifier missing range information');
             })();
-      const { importedName, localName } = parseImportSpecifierText(specText);
-      cell_variables.push({
-        _name: localName,
-        _inputs: [`module ${module_name}`, "@variable"],
-        _definition:
-          importedName === localName
-            ? `(_, v) => v.import("${importedName}", _)`
-            : `(_, v) => v.import("${importedName}", "${localName}", _)`
-      });
+            const {importedName, localName} = parseImportSpecifierText(specText);
+            cell_variables.push({
+                _name: localName,
+                _inputs: [
+                    `module ${ module_name }`,
+                    '@variable'
+                ],
+                _definition: importedName === localName ? `(_, v) => v.import("${ importedName }", _)` : `(_, v) => v.import("${ importedName }", "${ localName }", _)`
+            });
+        }
+        return cell_variables;
     }
-    return cell_variables;
-  }
-  let dollarIdx = 0;
-  const inputToArgMap = {};
-  const dollarToMacro = {};
-  const seen = new Set();
-  const inputs = Array.from(cell.references || []).flatMap((i) => {
-    if (i.name) {
-      if (seen.has(i.name)) return [];
-      seen.add(i.name);
-      return i.name;
+    let dollarIdx = 0;
+    const inputToArgMap = {};
+    const dollarToMacro = {};
+    const seen = new Set();
+    const inputs = Array.from(cell.references || []).flatMap(i => {
+        if (i.name) {
+            if (seen.has(i.name))
+                return [];
+            seen.add(i.name);
+            return i.name;
+        } else {
+            const dedupKey = i.type + ':' + i.id.name;
+            if (seen.has(dedupKey))
+                return [];
+            seen.add(dedupKey);
+            const dollarName = '$' + dollarIdx;
+            inputToArgMap[i.id.name] = dollarName;
+            dollarToMacro[dollarName] = i.type == 'ViewExpression' ? 'viewof ' + i.id.name : 'mutable ' + i.id.name;
+            dollarIdx++;
+            return dollarName;
+        }
+    });
+    let variables;
+    if (cell.id) {
+        if (cell.id.type === 'Identifier') {
+            variables = [{
+                    functionName: '_' + cell.id.name,
+                    name: cell.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                }];
+        } else if (cell.id.type === 'ViewExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'viewof ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '(G, _) => G.input(_)',
+                    inputs: [
+                        'Generators',
+                        'viewof ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                }
+            ];
+        } else if (cell.id.type === 'MutableExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'initial ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'mutable ' + cell.id.id.name,
+                    _definition: '(M, _) => new M(_)',
+                    inputs: [
+                        'Mutable',
+                        'initial ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '_ => _.generator',
+                    inputs: ['mutable ' + cell.id.id.name],
+                    params: inputs.join(',')
+                }
+            ];
+        } else {
+            throw new Error(`Unsupported cell id type: ${ cell.id.type }`);
+        }
     } else {
-      const dedupKey = i.type + ":" + i.id.name;
-      if (seen.has(dedupKey)) return [];
-      seen.add(dedupKey);
-      const dollarName = "$" + dollarIdx;
-      inputToArgMap[i.id.name] = dollarName;
-      dollarToMacro[dollarName] =
-        i.type == "ViewExpression"
-          ? "viewof " + i.id.name
-          : "mutable " + i.id.name;
-      dollarIdx++;
-      return dollarName;
+        variables = [{
+                functionName: anonymousName,
+                name: null,
+                inputs,
+                params: inputs.join(',')
+            }];
     }
-  });
-  let variables;
-  if (cell.id) {
-    if (cell.id.type === "Identifier") {
-      variables = [
-        {
-          functionName: "_" + cell.id.name,
-          name: cell.id.name,
-          inputs,
-          params: inputs.join(",")
+    return variables.map(v => {
+        let _definition = v._definition;
+        if (!_definition) {
+            let functionBody;
+            if (cell.body.type === 'BlockStatement') {
+                functionBody = observableToJs(cell.body, inputToArgMap, comments, tokens);
+            } else {
+                const bodyCode = observableToJs(cell.body, inputToArgMap, comments, tokens);
+                functionBody = `{return (${ bodyCode });}`;
+            }
+            _definition = `${ cell.async ? 'async ' : '' }function${ cell.generator ? '*' : '' } ${ v.functionName }(${ v.inputs.join(',') }) ${ functionBody }`;
         }
-      ];
-    } else if (cell.id.type === "ViewExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "viewof " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "(G, _) => G.input(_)",
-          inputs: ["Generators", "viewof " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else if (cell.id.type === "MutableExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "initial " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "mutable " + cell.id.id.name,
-          _definition: "(M, _) => new M(_)",
-          inputs: ["Mutable", "initial " + cell.id.id.name],
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "_ => _.generator",
-          inputs: ["mutable " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else {
-      throw new Error(`Unsupported cell id type: ${cell.id.type}`);
-    }
-  } else {
-    variables = [
-      {
-        functionName: anonymousName,
-        name: null,
-        inputs,
-        params: inputs.join(",")
-      }
-    ];
-  }
-  return variables.map((v) => {
-    let _definition = v._definition;
-    if (!_definition) {
-      let functionBody;
-      if (cell.body.type === "BlockStatement") {
-        functionBody = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-      } else {
-        const bodyCode = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-        functionBody = `{return (${bodyCode});}`;
-      }
-      _definition = `${cell.async ? "async " : ""}function${
-        cell.generator ? "*" : ""
-      } ${v.functionName}(${v.inputs.join(",")}) ${functionBody}`;
-    }
-    return {
-      _name: v.name,
-      _inputs: v.inputs.map(
-        (i) => dollarToMacro[i] || (i === "$variable" ? "@variable" : i)
-      ),
-      _definition
-    };
-  });
+        return {
+            _name: v.name,
+            _inputs: v.inputs.map(i => dollarToMacro[i] || (i === '$variable' ? '@variable' : i)),
+            _definition
+        };
+    });
 }
 )};
 const _1v1i7wl = function _observableToJs(acorn_walk,parser,escodegen){return(
@@ -19672,16 +19610,15 @@ async (attachment, overrides) => {
   return URL.createObjectURL(blob);
 }
 )};
-const _s9w7ha = async function _parser(decompress_url,FileAttachment,acorn_url,acorn_walk_url){return(
-importShim(await decompress_url(FileAttachment("parser-6.1.0.js.gz"), {
-    "/npm/acorn@8.11.3/+esm": acorn_url,
-    "/npm/acorn-walk@8.3.2/+esm": acorn_walk_url
-  })
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
-const _1hiclbb = function _acorn_walk(acorn_walk_url){return(
-importShim(acorn_walk_url, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _s9w7ha = async function _parser(decompress_url, FileAttachment, acorn_url, acorn_walk_url) {
+    return import(await decompress_url(FileAttachment('parser-6.1.0.js.gz'), {
+        '/npm/acorn@8.11.3/+esm': acorn_url,
+        '/npm/acorn-walk@8.3.2/+esm': acorn_walk_url
+    }));
+};
+const _1hiclbb = function _acorn_walk(acorn_walk_url) {
+    return import(acorn_walk_url);
+};
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
@@ -19869,7 +19806,7 @@ export default function define(runtime, observer) {
   $def("_1dmmuaf", "compiled_selector", ["Generators","viewof compiled_selector"], _1dmmuaf);  
   $def("_u7t3vu", null, ["compiled_selector","normalizeJavascriptSource"], _u7t3vu);  
   $def("_1lt3kl6", null, ["compile","test_case"], _1lt3kl6);  
-  $def("_lpzjrv", "compile", ["parser","globalThis","observableToJs"], _lpzjrv);  
+  $def("_x1d0wm", "compile", ["parser","observableToJs"], _x1d0wm);  
   $def("_1v1i7wl", "observableToJs", ["acorn_walk","parser","escodegen"], _1v1i7wl);  
   $def("_19lv24l", null, ["md"], _19lv24l);  
   $def("_xhj6b8", "decompress_url", ["DecompressionStream","TextDecoderStream","TransformStream","TextEncoderStream","Response"], _xhj6b8);  

--- a/notebooks/@tomlarkworthy_atproto-comments.html
+++ b/notebooks/@tomlarkworthy_atproto-comments.html
@@ -5585,58 +5585,41 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _geoudp = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
-  if (command.processed) return;
-
-  let result = undefined;
-  if (command.command == "createCell") {
-    $0.value = true;
-    result = compile_and_update("{}", [], command.args.cell);
-    // For the new one to get focus
-    // setTimeout(() => {
-    //   debugger;
-    //   setOption(result[0], "pinned", true);
-    // }, 100);
-  } else if (command.command == "deleteCell") {
-    remove_variables(command.args.cell.variables);
-    result = true;
-  } else if (command.command == "moveCell") {
-    const cellIndex = findCellIndex(
-      command.args.cell.variables,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const targetCellIndex = cellIndex + command.args.amount;
-    const targetCell = lookupCellByIndex(
-      targetCellIndex,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const currentFirstVariableIndex = findVariableIndex(
-      command.args.cell.variables[0]
-    );
-    const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-    const change = targetFirstVariableIndex - currentFirstVariableIndex;
-    console.log(
-      "moveCell",
-      cellIndex,
-      targetCellIndex,
-      targetCell,
-      currentFirstVariableIndex,
-      targetFirstVariableIndex,
-      change
-    );
-    command.args.cell.variables.forEach((v) => {
-      const currentIndex = findVariableIndex(v);
-      repositionSetElement(runtime._variables, v, currentIndex + change);
-    });
-    // recompute
-    await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
-    result = true;
-  }
-  if (result) {
-    command.processed = true;
-    $2.resolve(result);
-  }
+    if (command.processed)
+        return;
+    let result = undefined;
+    if (command.command == 'createCell') {
+        $0.value = true;
+        result = await compile_and_update('{}', [], command.args.cell);    // For the new one to get focus
+                                                                           // setTimeout(() => {
+                                                                           //   debugger;
+                                                                           //   setOption(result[0], "pinned", true);
+                                                                           // }, 100);
+    } else if (command.command == 'deleteCell') {
+        remove_variables(command.args.cell.variables);
+        result = true;
+    } else if (command.command == 'moveCell') {
+        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const targetCellIndex = cellIndex + command.args.amount;
+        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
+        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+        const change = targetFirstVariableIndex - currentFirstVariableIndex;
+        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
+        command.args.cell.variables.forEach(v => {
+            const currentIndex = findVariableIndex(v);
+            repositionSetElement(runtime._variables, v, currentIndex + change);
+        });
+        // recompute
+        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        result = true;
+    }
+    if (result) {
+        command.processed = true;
+        $2.resolve(result);
+    }
 };
 const _1jadxoe = function _60(md){return(
 md`### UI Action`
@@ -6027,9 +6010,9 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
-    return (source, variables = [], cell) => {
+    return async (source, variables = [], cell) => {
         try {
             debugger;
             let reposition = false, insertionIndex = -1;
@@ -6049,10 +6032,10 @@ const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElemen
             if (reposition) {
                 insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
+            const fns = await realize(newVariables.map(v => v._definition), runtime);
             newVariables.forEach((v, i) => {
                 const variable = variables[i];
-                let _fn;
-                eval('_fn = ' + v._definition);
+                const _fn = fns[i];
                 if (v._name) {
                     variable.define(v._name, v._inputs, _fn);
                 } else {
@@ -6101,12 +6084,11 @@ Inputs.textarea({
 })
 )};
 const _b4rsn5 = (G, _) => G.input(_);
-const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
+const _ga6kci = function _98(Inputs,definition,variable,realize,runtime,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
-  reduce: () => {
-    let _fn;
-    eval("_fn = " + definition);
+  reduce: async () => {
+    const [_fn] = await realize([definition], runtime);
     variable.define(variable._name, inputs, _fn);
   }
 })
@@ -6219,7 +6201,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_geoudp", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _geoudp);  
+  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6257,7 +6239,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
+  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -6267,8 +6249,9 @@ export default function define(runtime, observer) {
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
   $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
-  $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
+  $def("_ga6kci", null, ["Inputs","definition","variable","realize","runtime","inputs"], _ga6kci);  
   $def("_1q557s", null, ["md"], _1q557s);  
+  main.define("realize", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("realize", _));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -16638,10 +16621,9 @@ notebook_semantics_document.nodes.map((s) => ({
 const _1oevsow = function _28(md){return(
 md`### Runtime Representation (v4)`
 )};
-const _11lfflk = function _notebook_semantics_module(){return(
-importShim("https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4"
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _11lfflk = function _notebook_semantics_module() {
+    return import('https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4');
+};
 const _gjten6 = function _31(md){return(
 md`### Imports`
 )};
@@ -17628,65 +17610,44 @@ parser.parseCell(
   'import {runtime, viewof main as foo} from "@mootari/access-runtime"'
 )
 )};
-const _1n7gw17 = function _findModuleName(extractModuleInfo){return(
-(scope, module, { unknown_id = Math.random() } = {}) => {
-  try {
-    const scopedVariables = [...scope.values()];
-
-    // Prefer variables that *define* a module and have a real module-loader name.
-    const candidates = scopedVariables.filter(
-      (v) =>
-        v &&
-        v._value === module &&
-        typeof v._name === "string" &&
-        v._name.startsWith("module ") &&
-        !v._name.startsWith("module <unknown")
-    );
-
-    const pickBestInfo = (dfn) => {
-      // Avoid the parentUrl (2nd arg) confusing module identification.
-      // Typical patterns:
-      //   importShim("/d/<id>@<ver>.js?v=4", "https://api.observablehq.com/@ns/name.js?v=4")
-      //   import("/d/<id>@<ver>.js?v=4")
-      // Prefer the *first argument* inside importShim(...) / import(...) when present.
-      const s = String(dfn ?? "");
-
-      // Try to capture the first string literal argument to importShim(...) or import(...)
-      // Tolerates quotes ", ', ` and both importShim and plain import.
-      const m = s.match(
-        /\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/
-      );
-      const firstArg = m?.[2];
-
-      const info1 = firstArg ? extractModuleInfo(firstArg) : {};
-      if (info1?.id || info1?.notebook) return info1;
-
-      // Fallback: parse the whole definition string.
-      return extractModuleInfo(s);
+const _1n7gw17 = function _findModuleName(extractModuleInfo) {
+    return (scope, module, {
+        unknown_id = Math.random()
+    } = {}) => {
+        try {
+            const scopedVariables = [...scope.values()];
+            const candidates = scopedVariables.filter(v => v && v._value === module && typeof v._name === 'string' && v._name.startsWith('module ') && !v._name.startsWith('module <unknown'));
+            const pickBestInfo = dfn => {
+                const s = String(dfn ?? '');
+                const m = s.match(/\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/);
+                const firstArg = m?.[2];
+                const info1 = firstArg ? extractModuleInfo(firstArg) : {};
+                if (info1?.id || info1?.notebook)
+                    return info1;
+                return extractModuleInfo(s);
+            };
+            for (const v of candidates) {
+                const info = pickBestInfo(v._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            const any = scopedVariables.find(v => v && v._value === module);
+            if (any) {
+                const info = pickBestInfo(any._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            return `<unknown ${ unknown_id }>`;
+        } catch (e) {
+            debugger;
+            return 'error';
+        }
     };
-
-    // Try module loader cells first.
-    for (const v of candidates) {
-      const info = pickBestInfo(v._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    // Fallback: any scoped variable with _value==module.
-    const any = scopedVariables.find((v) => v && v._value === module);
-    if (any) {
-      const info = pickBestInfo(any._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    return `<unknown ${unknown_id}>`;
-  } catch (e) {
-    debugger;
-    return "error";
-  }
-}
-)};
+};
 const _i47chb = function _findImportedName(){return(
 async (v) => {
   if (v._inputs.length == 1 && v._inputs[0]._name === "@variable") {
@@ -18588,229 +18549,206 @@ JSON.stringify(
 const _1lt3kl6 = function _157(compile,test_case){return(
 compile(test_case.value)
 )};
-const _lpzjrv = function _compile(parser,globalThis,observableToJs){return(
-function compile(source, { anonymousName = "_anonymous" } = {}) {
-  const comments = [],
-    tokens = [];
-  let cell;
-  try {
-    cell = parser.parseCell(source, {
-      ranges: true,
-      onComment: comments,
-      onToken: tokens
-    });
-  } catch (e) {
-    if (e instanceof SyntaxError) {
-      const nameMatch = source.match(
-        /^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/
-      );
-      let _name = null;
-      let funcName = anonymousName;
-      if (nameMatch) {
-        const prefix = nameMatch[1] ? nameMatch[1] + " " : "";
-        _name = prefix + nameMatch[2];
-        funcName = "_" + nameMatch[2];
-      }
-      const escapedMsg = JSON.stringify(e.message);
-      const escapedSource = JSON.stringify(source);
-      return [
-        {
-          _name,
-          _inputs: [],
-          _definition: `function ${funcName}() { throw Object.assign(new SyntaxError(${escapedMsg}), {_sourceExpression: ${escapedSource}}); }`
+const _x1d0wm = function _compile(parser,observableToJs){return(
+function compile(source, {
+    anonymousName = '_anonymous'
+} = {}) {
+    const comments = [], tokens = [];
+    let cell;
+    try {
+        cell = parser.parseCell(source, {
+            ranges: true,
+            onComment: comments,
+            onToken: tokens
+        });
+    } catch (e) {
+        if (e instanceof SyntaxError) {
+            const nameMatch = source.match(/^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/);
+            let _name = null;
+            let funcName = anonymousName;
+            if (nameMatch) {
+                const prefix = nameMatch[1] ? nameMatch[1] + ' ' : '';
+                _name = prefix + nameMatch[2];
+                funcName = '_' + nameMatch[2];
+            }
+            const escapedMsg = JSON.stringify(e.message);
+            const escapedSource = JSON.stringify(source);
+            return [{
+                    _name,
+                    _inputs: [],
+                    _definition: `function ${ funcName }() { throw Object.assign(new SyntaxError(${ escapedMsg }), {_sourceExpression: ${ escapedSource }}); }`
+                }];
         }
-      ];
+        throw e;
     }
-    throw e;
-  }
-  if (!cell) throw new Error("Unable to parse cell");
-  const parseImportSpecifierText = (text) => {
-    const t = String(text ?? "")
-      .trim()
-      .replace(/,$/, "")
-      .trim();
-    if (!t) throw new Error("Empty import specifier");
-    const parts = t.split(/\s+as\s+/);
-    const left = parts[0].trim();
-    const right = parts[1]?.trim();
-    const parseSide = (side, { defaultPrefix = "" } = {}) => {
-      const s = String(side ?? "").trim();
-      const m = s.match(/^(viewof|mutable)\s+(.+)$/);
-      if (m)
-        return {
-          prefix: `${m[1]} `,
-          name: m[2].trim()
+    if (!cell)
+        throw new Error('Unable to parse cell');
+    const parseImportSpecifierText = text => {
+        const t = String(text ?? '').trim().replace(/,$/, '').trim();
+        if (!t)
+            throw new Error('Empty import specifier');
+        const parts = t.split(/\s+as\s+/);
+        const left = parts[0].trim();
+        const right = parts[1]?.trim();
+        const parseSide = (side, {
+            defaultPrefix = ''
+        } = {}) => {
+            const s = String(side ?? '').trim();
+            const m = s.match(/^(viewof|mutable)\s+(.+)$/);
+            if (m)
+                return {
+                    prefix: `${ m[1] } `,
+                    name: m[2].trim()
+                };
+            return {
+                prefix: defaultPrefix,
+                name: s
+            };
         };
-      return {
-        prefix: defaultPrefix,
-        name: s
-      };
+        const L = parseSide(left);
+        const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
+        const importedName = `${ L.prefix }${ L.name }`.trim();
+        const localName = `${ R.prefix }${ R.name }`.trim();
+        if (!importedName)
+            throw new Error(`Could not parse imported name from: ${ t }`);
+        if (!localName)
+            throw new Error(`Could not parse local name from: ${ t }`);
+        return {
+            importedName,
+            localName
+        };
     };
-    const L = parseSide(left);
-    const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
-    const importedName = `${L.prefix}${L.name}`.trim();
-    const localName = `${R.prefix}${R.name}`.trim();
-    if (!importedName)
-      throw new Error(`Could not parse imported name from: ${t}`);
-    if (!localName) throw new Error(`Could not parse local name from: ${t}`);
-    return {
-      importedName,
-      localName
-    };
-  };
-  if (!cell.id && cell.body?.type === "ImportDeclaration") {
-    const module_name = cell.body.source.value;
-    const importKeyword = globalThis?.importShim ? "importShim" : "import";
-    const cell_variables = [
-      {
-        _name: `module ${module_name}`,
-        _inputs: [],
-        _definition: `async () => runtime.module((await ${importKeyword}("${module_name}")).default)`
-      }
-    ];
-    for (const specifier of cell.body.specifiers ?? []) {
-      const specText =
-        typeof specifier?.start === "number" &&
-        typeof specifier?.end === "number"
-          ? source.slice(specifier.start, specifier.end)
-          : (() => {
-              if (specifier?.imported?.name && specifier?.local?.name) {
-                return specifier.imported.name === specifier.local.name
-                  ? specifier.local.name
-                  : `${specifier.imported.name} as ${specifier.local.name}`;
-              }
-              throw new Error("Import specifier missing range information");
+    if (!cell.id && cell.body?.type === 'ImportDeclaration') {
+        const module_name = cell.body.source.value;
+        const cell_variables = [{
+                _name: `module ${ module_name }`,
+                _inputs: [],
+                _definition: `async () => runtime.module((await import("${ module_name }")).default)`
+            }];
+        for (const specifier of cell.body.specifiers ?? []) {
+            const specText = typeof specifier?.start === 'number' && typeof specifier?.end === 'number' ? source.slice(specifier.start, specifier.end) : (() => {
+                if (specifier?.imported?.name && specifier?.local?.name) {
+                    return specifier.imported.name === specifier.local.name ? specifier.local.name : `${ specifier.imported.name } as ${ specifier.local.name }`;
+                }
+                throw new Error('Import specifier missing range information');
             })();
-      const { importedName, localName } = parseImportSpecifierText(specText);
-      cell_variables.push({
-        _name: localName,
-        _inputs: [`module ${module_name}`, "@variable"],
-        _definition:
-          importedName === localName
-            ? `(_, v) => v.import("${importedName}", _)`
-            : `(_, v) => v.import("${importedName}", "${localName}", _)`
-      });
+            const {importedName, localName} = parseImportSpecifierText(specText);
+            cell_variables.push({
+                _name: localName,
+                _inputs: [
+                    `module ${ module_name }`,
+                    '@variable'
+                ],
+                _definition: importedName === localName ? `(_, v) => v.import("${ importedName }", _)` : `(_, v) => v.import("${ importedName }", "${ localName }", _)`
+            });
+        }
+        return cell_variables;
     }
-    return cell_variables;
-  }
-  let dollarIdx = 0;
-  const inputToArgMap = {};
-  const dollarToMacro = {};
-  const seen = new Set();
-  const inputs = Array.from(cell.references || []).flatMap((i) => {
-    if (i.name) {
-      if (seen.has(i.name)) return [];
-      seen.add(i.name);
-      return i.name;
+    let dollarIdx = 0;
+    const inputToArgMap = {};
+    const dollarToMacro = {};
+    const seen = new Set();
+    const inputs = Array.from(cell.references || []).flatMap(i => {
+        if (i.name) {
+            if (seen.has(i.name))
+                return [];
+            seen.add(i.name);
+            return i.name;
+        } else {
+            const dedupKey = i.type + ':' + i.id.name;
+            if (seen.has(dedupKey))
+                return [];
+            seen.add(dedupKey);
+            const dollarName = '$' + dollarIdx;
+            inputToArgMap[i.id.name] = dollarName;
+            dollarToMacro[dollarName] = i.type == 'ViewExpression' ? 'viewof ' + i.id.name : 'mutable ' + i.id.name;
+            dollarIdx++;
+            return dollarName;
+        }
+    });
+    let variables;
+    if (cell.id) {
+        if (cell.id.type === 'Identifier') {
+            variables = [{
+                    functionName: '_' + cell.id.name,
+                    name: cell.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                }];
+        } else if (cell.id.type === 'ViewExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'viewof ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '(G, _) => G.input(_)',
+                    inputs: [
+                        'Generators',
+                        'viewof ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                }
+            ];
+        } else if (cell.id.type === 'MutableExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'initial ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'mutable ' + cell.id.id.name,
+                    _definition: '(M, _) => new M(_)',
+                    inputs: [
+                        'Mutable',
+                        'initial ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '_ => _.generator',
+                    inputs: ['mutable ' + cell.id.id.name],
+                    params: inputs.join(',')
+                }
+            ];
+        } else {
+            throw new Error(`Unsupported cell id type: ${ cell.id.type }`);
+        }
     } else {
-      const dedupKey = i.type + ":" + i.id.name;
-      if (seen.has(dedupKey)) return [];
-      seen.add(dedupKey);
-      const dollarName = "$" + dollarIdx;
-      inputToArgMap[i.id.name] = dollarName;
-      dollarToMacro[dollarName] =
-        i.type == "ViewExpression"
-          ? "viewof " + i.id.name
-          : "mutable " + i.id.name;
-      dollarIdx++;
-      return dollarName;
+        variables = [{
+                functionName: anonymousName,
+                name: null,
+                inputs,
+                params: inputs.join(',')
+            }];
     }
-  });
-  let variables;
-  if (cell.id) {
-    if (cell.id.type === "Identifier") {
-      variables = [
-        {
-          functionName: "_" + cell.id.name,
-          name: cell.id.name,
-          inputs,
-          params: inputs.join(",")
+    return variables.map(v => {
+        let _definition = v._definition;
+        if (!_definition) {
+            let functionBody;
+            if (cell.body.type === 'BlockStatement') {
+                functionBody = observableToJs(cell.body, inputToArgMap, comments, tokens);
+            } else {
+                const bodyCode = observableToJs(cell.body, inputToArgMap, comments, tokens);
+                functionBody = `{return (${ bodyCode });}`;
+            }
+            _definition = `${ cell.async ? 'async ' : '' }function${ cell.generator ? '*' : '' } ${ v.functionName }(${ v.inputs.join(',') }) ${ functionBody }`;
         }
-      ];
-    } else if (cell.id.type === "ViewExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "viewof " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "(G, _) => G.input(_)",
-          inputs: ["Generators", "viewof " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else if (cell.id.type === "MutableExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "initial " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "mutable " + cell.id.id.name,
-          _definition: "(M, _) => new M(_)",
-          inputs: ["Mutable", "initial " + cell.id.id.name],
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "_ => _.generator",
-          inputs: ["mutable " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else {
-      throw new Error(`Unsupported cell id type: ${cell.id.type}`);
-    }
-  } else {
-    variables = [
-      {
-        functionName: anonymousName,
-        name: null,
-        inputs,
-        params: inputs.join(",")
-      }
-    ];
-  }
-  return variables.map((v) => {
-    let _definition = v._definition;
-    if (!_definition) {
-      let functionBody;
-      if (cell.body.type === "BlockStatement") {
-        functionBody = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-      } else {
-        const bodyCode = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-        functionBody = `{return (${bodyCode});}`;
-      }
-      _definition = `${cell.async ? "async " : ""}function${
-        cell.generator ? "*" : ""
-      } ${v.functionName}(${v.inputs.join(",")}) ${functionBody}`;
-    }
-    return {
-      _name: v.name,
-      _inputs: v.inputs.map(
-        (i) => dollarToMacro[i] || (i === "$variable" ? "@variable" : i)
-      ),
-      _definition
-    };
-  });
+        return {
+            _name: v.name,
+            _inputs: v.inputs.map(i => dollarToMacro[i] || (i === '$variable' ? '@variable' : i)),
+            _definition
+        };
+    });
 }
 )};
 const _1v1i7wl = function _observableToJs(acorn_walk,parser,escodegen){return(
@@ -18877,16 +18815,15 @@ async (attachment, overrides) => {
   return URL.createObjectURL(blob);
 }
 )};
-const _s9w7ha = async function _parser(decompress_url,FileAttachment,acorn_url,acorn_walk_url){return(
-importShim(await decompress_url(FileAttachment("parser-6.1.0.js.gz"), {
-    "/npm/acorn@8.11.3/+esm": acorn_url,
-    "/npm/acorn-walk@8.3.2/+esm": acorn_walk_url
-  })
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
-const _1hiclbb = function _acorn_walk(acorn_walk_url){return(
-importShim(acorn_walk_url, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _s9w7ha = async function _parser(decompress_url, FileAttachment, acorn_url, acorn_walk_url) {
+    return import(await decompress_url(FileAttachment('parser-6.1.0.js.gz'), {
+        '/npm/acorn@8.11.3/+esm': acorn_url,
+        '/npm/acorn-walk@8.3.2/+esm': acorn_walk_url
+    }));
+};
+const _1hiclbb = function _acorn_walk(acorn_walk_url) {
+    return import(acorn_walk_url);
+};
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
@@ -19074,7 +19011,7 @@ export default function define(runtime, observer) {
   $def("_1dmmuaf", "compiled_selector", ["Generators","viewof compiled_selector"], _1dmmuaf);  
   $def("_u7t3vu", null, ["compiled_selector","normalizeJavascriptSource"], _u7t3vu);  
   $def("_1lt3kl6", null, ["compile","test_case"], _1lt3kl6);  
-  $def("_lpzjrv", "compile", ["parser","globalThis","observableToJs"], _lpzjrv);  
+  $def("_x1d0wm", "compile", ["parser","observableToJs"], _x1d0wm);  
   $def("_1v1i7wl", "observableToJs", ["acorn_walk","parser","escodegen"], _1v1i7wl);  
   $def("_19lv24l", null, ["md"], _19lv24l);  
   $def("_xhj6b8", "decompress_url", ["DecompressionStream","TextDecoderStream","TransformStream","TextEncoderStream","Response"], _xhj6b8);  

--- a/notebooks/@tomlarkworthy_blank-notebook.html
+++ b/notebooks/@tomlarkworthy_blank-notebook.html
@@ -5476,58 +5476,41 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _geoudp = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
-  if (command.processed) return;
-
-  let result = undefined;
-  if (command.command == "createCell") {
-    $0.value = true;
-    result = compile_and_update("{}", [], command.args.cell);
-    // For the new one to get focus
-    // setTimeout(() => {
-    //   debugger;
-    //   setOption(result[0], "pinned", true);
-    // }, 100);
-  } else if (command.command == "deleteCell") {
-    remove_variables(command.args.cell.variables);
-    result = true;
-  } else if (command.command == "moveCell") {
-    const cellIndex = findCellIndex(
-      command.args.cell.variables,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const targetCellIndex = cellIndex + command.args.amount;
-    const targetCell = lookupCellByIndex(
-      targetCellIndex,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const currentFirstVariableIndex = findVariableIndex(
-      command.args.cell.variables[0]
-    );
-    const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-    const change = targetFirstVariableIndex - currentFirstVariableIndex;
-    console.log(
-      "moveCell",
-      cellIndex,
-      targetCellIndex,
-      targetCell,
-      currentFirstVariableIndex,
-      targetFirstVariableIndex,
-      change
-    );
-    command.args.cell.variables.forEach((v) => {
-      const currentIndex = findVariableIndex(v);
-      repositionSetElement(runtime._variables, v, currentIndex + change);
-    });
-    // recompute
-    await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
-    result = true;
-  }
-  if (result) {
-    command.processed = true;
-    $2.resolve(result);
-  }
+    if (command.processed)
+        return;
+    let result = undefined;
+    if (command.command == 'createCell') {
+        $0.value = true;
+        result = await compile_and_update('{}', [], command.args.cell);    // For the new one to get focus
+                                                                           // setTimeout(() => {
+                                                                           //   debugger;
+                                                                           //   setOption(result[0], "pinned", true);
+                                                                           // }, 100);
+    } else if (command.command == 'deleteCell') {
+        remove_variables(command.args.cell.variables);
+        result = true;
+    } else if (command.command == 'moveCell') {
+        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const targetCellIndex = cellIndex + command.args.amount;
+        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
+        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+        const change = targetFirstVariableIndex - currentFirstVariableIndex;
+        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
+        command.args.cell.variables.forEach(v => {
+            const currentIndex = findVariableIndex(v);
+            repositionSetElement(runtime._variables, v, currentIndex + change);
+        });
+        // recompute
+        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        result = true;
+    }
+    if (result) {
+        command.processed = true;
+        $2.resolve(result);
+    }
 };
 const _1jadxoe = function _60(md){return(
 md`### UI Action`
@@ -5918,9 +5901,9 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
-    return (source, variables = [], cell) => {
+    return async (source, variables = [], cell) => {
         try {
             debugger;
             let reposition = false, insertionIndex = -1;
@@ -5940,10 +5923,10 @@ const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElemen
             if (reposition) {
                 insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
+            const fns = await realize(newVariables.map(v => v._definition), runtime);
             newVariables.forEach((v, i) => {
                 const variable = variables[i];
-                let _fn;
-                eval('_fn = ' + v._definition);
+                const _fn = fns[i];
                 if (v._name) {
                     variable.define(v._name, v._inputs, _fn);
                 } else {
@@ -5992,12 +5975,11 @@ Inputs.textarea({
 })
 )};
 const _b4rsn5 = (G, _) => G.input(_);
-const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
+const _ga6kci = function _98(Inputs,definition,variable,realize,runtime,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
-  reduce: () => {
-    let _fn;
-    eval("_fn = " + definition);
+  reduce: async () => {
+    const [_fn] = await realize([definition], runtime);
     variable.define(variable._name, inputs, _fn);
   }
 })
@@ -6110,7 +6092,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_geoudp", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _geoudp);  
+  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6148,7 +6130,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
+  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -6158,8 +6140,9 @@ export default function define(runtime, observer) {
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
   $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
-  $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
+  $def("_ga6kci", null, ["Inputs","definition","variable","realize","runtime","inputs"], _ga6kci);  
   $def("_1q557s", null, ["md"], _1q557s);  
+  main.define("realize", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("realize", _));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -16529,10 +16512,9 @@ notebook_semantics_document.nodes.map((s) => ({
 const _1oevsow = function _28(md){return(
 md`### Runtime Representation (v4)`
 )};
-const _11lfflk = function _notebook_semantics_module(){return(
-importShim("https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4"
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _11lfflk = function _notebook_semantics_module() {
+    return import('https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4');
+};
 const _gjten6 = function _31(md){return(
 md`### Imports`
 )};
@@ -17519,65 +17501,44 @@ parser.parseCell(
   'import {runtime, viewof main as foo} from "@mootari/access-runtime"'
 )
 )};
-const _1n7gw17 = function _findModuleName(extractModuleInfo){return(
-(scope, module, { unknown_id = Math.random() } = {}) => {
-  try {
-    const scopedVariables = [...scope.values()];
-
-    // Prefer variables that *define* a module and have a real module-loader name.
-    const candidates = scopedVariables.filter(
-      (v) =>
-        v &&
-        v._value === module &&
-        typeof v._name === "string" &&
-        v._name.startsWith("module ") &&
-        !v._name.startsWith("module <unknown")
-    );
-
-    const pickBestInfo = (dfn) => {
-      // Avoid the parentUrl (2nd arg) confusing module identification.
-      // Typical patterns:
-      //   importShim("/d/<id>@<ver>.js?v=4", "https://api.observablehq.com/@ns/name.js?v=4")
-      //   import("/d/<id>@<ver>.js?v=4")
-      // Prefer the *first argument* inside importShim(...) / import(...) when present.
-      const s = String(dfn ?? "");
-
-      // Try to capture the first string literal argument to importShim(...) or import(...)
-      // Tolerates quotes ", ', ` and both importShim and plain import.
-      const m = s.match(
-        /\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/
-      );
-      const firstArg = m?.[2];
-
-      const info1 = firstArg ? extractModuleInfo(firstArg) : {};
-      if (info1?.id || info1?.notebook) return info1;
-
-      // Fallback: parse the whole definition string.
-      return extractModuleInfo(s);
+const _1n7gw17 = function _findModuleName(extractModuleInfo) {
+    return (scope, module, {
+        unknown_id = Math.random()
+    } = {}) => {
+        try {
+            const scopedVariables = [...scope.values()];
+            const candidates = scopedVariables.filter(v => v && v._value === module && typeof v._name === 'string' && v._name.startsWith('module ') && !v._name.startsWith('module <unknown'));
+            const pickBestInfo = dfn => {
+                const s = String(dfn ?? '');
+                const m = s.match(/\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/);
+                const firstArg = m?.[2];
+                const info1 = firstArg ? extractModuleInfo(firstArg) : {};
+                if (info1?.id || info1?.notebook)
+                    return info1;
+                return extractModuleInfo(s);
+            };
+            for (const v of candidates) {
+                const info = pickBestInfo(v._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            const any = scopedVariables.find(v => v && v._value === module);
+            if (any) {
+                const info = pickBestInfo(any._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            return `<unknown ${ unknown_id }>`;
+        } catch (e) {
+            debugger;
+            return 'error';
+        }
     };
-
-    // Try module loader cells first.
-    for (const v of candidates) {
-      const info = pickBestInfo(v._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    // Fallback: any scoped variable with _value==module.
-    const any = scopedVariables.find((v) => v && v._value === module);
-    if (any) {
-      const info = pickBestInfo(any._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    return `<unknown ${unknown_id}>`;
-  } catch (e) {
-    debugger;
-    return "error";
-  }
-}
-)};
+};
 const _i47chb = function _findImportedName(){return(
 async (v) => {
   if (v._inputs.length == 1 && v._inputs[0]._name === "@variable") {
@@ -18479,229 +18440,206 @@ JSON.stringify(
 const _1lt3kl6 = function _157(compile,test_case){return(
 compile(test_case.value)
 )};
-const _lpzjrv = function _compile(parser,globalThis,observableToJs){return(
-function compile(source, { anonymousName = "_anonymous" } = {}) {
-  const comments = [],
-    tokens = [];
-  let cell;
-  try {
-    cell = parser.parseCell(source, {
-      ranges: true,
-      onComment: comments,
-      onToken: tokens
-    });
-  } catch (e) {
-    if (e instanceof SyntaxError) {
-      const nameMatch = source.match(
-        /^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/
-      );
-      let _name = null;
-      let funcName = anonymousName;
-      if (nameMatch) {
-        const prefix = nameMatch[1] ? nameMatch[1] + " " : "";
-        _name = prefix + nameMatch[2];
-        funcName = "_" + nameMatch[2];
-      }
-      const escapedMsg = JSON.stringify(e.message);
-      const escapedSource = JSON.stringify(source);
-      return [
-        {
-          _name,
-          _inputs: [],
-          _definition: `function ${funcName}() { throw Object.assign(new SyntaxError(${escapedMsg}), {_sourceExpression: ${escapedSource}}); }`
+const _x1d0wm = function _compile(parser,observableToJs){return(
+function compile(source, {
+    anonymousName = '_anonymous'
+} = {}) {
+    const comments = [], tokens = [];
+    let cell;
+    try {
+        cell = parser.parseCell(source, {
+            ranges: true,
+            onComment: comments,
+            onToken: tokens
+        });
+    } catch (e) {
+        if (e instanceof SyntaxError) {
+            const nameMatch = source.match(/^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/);
+            let _name = null;
+            let funcName = anonymousName;
+            if (nameMatch) {
+                const prefix = nameMatch[1] ? nameMatch[1] + ' ' : '';
+                _name = prefix + nameMatch[2];
+                funcName = '_' + nameMatch[2];
+            }
+            const escapedMsg = JSON.stringify(e.message);
+            const escapedSource = JSON.stringify(source);
+            return [{
+                    _name,
+                    _inputs: [],
+                    _definition: `function ${ funcName }() { throw Object.assign(new SyntaxError(${ escapedMsg }), {_sourceExpression: ${ escapedSource }}); }`
+                }];
         }
-      ];
+        throw e;
     }
-    throw e;
-  }
-  if (!cell) throw new Error("Unable to parse cell");
-  const parseImportSpecifierText = (text) => {
-    const t = String(text ?? "")
-      .trim()
-      .replace(/,$/, "")
-      .trim();
-    if (!t) throw new Error("Empty import specifier");
-    const parts = t.split(/\s+as\s+/);
-    const left = parts[0].trim();
-    const right = parts[1]?.trim();
-    const parseSide = (side, { defaultPrefix = "" } = {}) => {
-      const s = String(side ?? "").trim();
-      const m = s.match(/^(viewof|mutable)\s+(.+)$/);
-      if (m)
-        return {
-          prefix: `${m[1]} `,
-          name: m[2].trim()
+    if (!cell)
+        throw new Error('Unable to parse cell');
+    const parseImportSpecifierText = text => {
+        const t = String(text ?? '').trim().replace(/,$/, '').trim();
+        if (!t)
+            throw new Error('Empty import specifier');
+        const parts = t.split(/\s+as\s+/);
+        const left = parts[0].trim();
+        const right = parts[1]?.trim();
+        const parseSide = (side, {
+            defaultPrefix = ''
+        } = {}) => {
+            const s = String(side ?? '').trim();
+            const m = s.match(/^(viewof|mutable)\s+(.+)$/);
+            if (m)
+                return {
+                    prefix: `${ m[1] } `,
+                    name: m[2].trim()
+                };
+            return {
+                prefix: defaultPrefix,
+                name: s
+            };
         };
-      return {
-        prefix: defaultPrefix,
-        name: s
-      };
+        const L = parseSide(left);
+        const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
+        const importedName = `${ L.prefix }${ L.name }`.trim();
+        const localName = `${ R.prefix }${ R.name }`.trim();
+        if (!importedName)
+            throw new Error(`Could not parse imported name from: ${ t }`);
+        if (!localName)
+            throw new Error(`Could not parse local name from: ${ t }`);
+        return {
+            importedName,
+            localName
+        };
     };
-    const L = parseSide(left);
-    const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
-    const importedName = `${L.prefix}${L.name}`.trim();
-    const localName = `${R.prefix}${R.name}`.trim();
-    if (!importedName)
-      throw new Error(`Could not parse imported name from: ${t}`);
-    if (!localName) throw new Error(`Could not parse local name from: ${t}`);
-    return {
-      importedName,
-      localName
-    };
-  };
-  if (!cell.id && cell.body?.type === "ImportDeclaration") {
-    const module_name = cell.body.source.value;
-    const importKeyword = globalThis?.importShim ? "importShim" : "import";
-    const cell_variables = [
-      {
-        _name: `module ${module_name}`,
-        _inputs: [],
-        _definition: `async () => runtime.module((await ${importKeyword}("${module_name}")).default)`
-      }
-    ];
-    for (const specifier of cell.body.specifiers ?? []) {
-      const specText =
-        typeof specifier?.start === "number" &&
-        typeof specifier?.end === "number"
-          ? source.slice(specifier.start, specifier.end)
-          : (() => {
-              if (specifier?.imported?.name && specifier?.local?.name) {
-                return specifier.imported.name === specifier.local.name
-                  ? specifier.local.name
-                  : `${specifier.imported.name} as ${specifier.local.name}`;
-              }
-              throw new Error("Import specifier missing range information");
+    if (!cell.id && cell.body?.type === 'ImportDeclaration') {
+        const module_name = cell.body.source.value;
+        const cell_variables = [{
+                _name: `module ${ module_name }`,
+                _inputs: [],
+                _definition: `async () => runtime.module((await import("${ module_name }")).default)`
+            }];
+        for (const specifier of cell.body.specifiers ?? []) {
+            const specText = typeof specifier?.start === 'number' && typeof specifier?.end === 'number' ? source.slice(specifier.start, specifier.end) : (() => {
+                if (specifier?.imported?.name && specifier?.local?.name) {
+                    return specifier.imported.name === specifier.local.name ? specifier.local.name : `${ specifier.imported.name } as ${ specifier.local.name }`;
+                }
+                throw new Error('Import specifier missing range information');
             })();
-      const { importedName, localName } = parseImportSpecifierText(specText);
-      cell_variables.push({
-        _name: localName,
-        _inputs: [`module ${module_name}`, "@variable"],
-        _definition:
-          importedName === localName
-            ? `(_, v) => v.import("${importedName}", _)`
-            : `(_, v) => v.import("${importedName}", "${localName}", _)`
-      });
+            const {importedName, localName} = parseImportSpecifierText(specText);
+            cell_variables.push({
+                _name: localName,
+                _inputs: [
+                    `module ${ module_name }`,
+                    '@variable'
+                ],
+                _definition: importedName === localName ? `(_, v) => v.import("${ importedName }", _)` : `(_, v) => v.import("${ importedName }", "${ localName }", _)`
+            });
+        }
+        return cell_variables;
     }
-    return cell_variables;
-  }
-  let dollarIdx = 0;
-  const inputToArgMap = {};
-  const dollarToMacro = {};
-  const seen = new Set();
-  const inputs = Array.from(cell.references || []).flatMap((i) => {
-    if (i.name) {
-      if (seen.has(i.name)) return [];
-      seen.add(i.name);
-      return i.name;
+    let dollarIdx = 0;
+    const inputToArgMap = {};
+    const dollarToMacro = {};
+    const seen = new Set();
+    const inputs = Array.from(cell.references || []).flatMap(i => {
+        if (i.name) {
+            if (seen.has(i.name))
+                return [];
+            seen.add(i.name);
+            return i.name;
+        } else {
+            const dedupKey = i.type + ':' + i.id.name;
+            if (seen.has(dedupKey))
+                return [];
+            seen.add(dedupKey);
+            const dollarName = '$' + dollarIdx;
+            inputToArgMap[i.id.name] = dollarName;
+            dollarToMacro[dollarName] = i.type == 'ViewExpression' ? 'viewof ' + i.id.name : 'mutable ' + i.id.name;
+            dollarIdx++;
+            return dollarName;
+        }
+    });
+    let variables;
+    if (cell.id) {
+        if (cell.id.type === 'Identifier') {
+            variables = [{
+                    functionName: '_' + cell.id.name,
+                    name: cell.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                }];
+        } else if (cell.id.type === 'ViewExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'viewof ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '(G, _) => G.input(_)',
+                    inputs: [
+                        'Generators',
+                        'viewof ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                }
+            ];
+        } else if (cell.id.type === 'MutableExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'initial ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'mutable ' + cell.id.id.name,
+                    _definition: '(M, _) => new M(_)',
+                    inputs: [
+                        'Mutable',
+                        'initial ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '_ => _.generator',
+                    inputs: ['mutable ' + cell.id.id.name],
+                    params: inputs.join(',')
+                }
+            ];
+        } else {
+            throw new Error(`Unsupported cell id type: ${ cell.id.type }`);
+        }
     } else {
-      const dedupKey = i.type + ":" + i.id.name;
-      if (seen.has(dedupKey)) return [];
-      seen.add(dedupKey);
-      const dollarName = "$" + dollarIdx;
-      inputToArgMap[i.id.name] = dollarName;
-      dollarToMacro[dollarName] =
-        i.type == "ViewExpression"
-          ? "viewof " + i.id.name
-          : "mutable " + i.id.name;
-      dollarIdx++;
-      return dollarName;
+        variables = [{
+                functionName: anonymousName,
+                name: null,
+                inputs,
+                params: inputs.join(',')
+            }];
     }
-  });
-  let variables;
-  if (cell.id) {
-    if (cell.id.type === "Identifier") {
-      variables = [
-        {
-          functionName: "_" + cell.id.name,
-          name: cell.id.name,
-          inputs,
-          params: inputs.join(",")
+    return variables.map(v => {
+        let _definition = v._definition;
+        if (!_definition) {
+            let functionBody;
+            if (cell.body.type === 'BlockStatement') {
+                functionBody = observableToJs(cell.body, inputToArgMap, comments, tokens);
+            } else {
+                const bodyCode = observableToJs(cell.body, inputToArgMap, comments, tokens);
+                functionBody = `{return (${ bodyCode });}`;
+            }
+            _definition = `${ cell.async ? 'async ' : '' }function${ cell.generator ? '*' : '' } ${ v.functionName }(${ v.inputs.join(',') }) ${ functionBody }`;
         }
-      ];
-    } else if (cell.id.type === "ViewExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "viewof " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "(G, _) => G.input(_)",
-          inputs: ["Generators", "viewof " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else if (cell.id.type === "MutableExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "initial " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "mutable " + cell.id.id.name,
-          _definition: "(M, _) => new M(_)",
-          inputs: ["Mutable", "initial " + cell.id.id.name],
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "_ => _.generator",
-          inputs: ["mutable " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else {
-      throw new Error(`Unsupported cell id type: ${cell.id.type}`);
-    }
-  } else {
-    variables = [
-      {
-        functionName: anonymousName,
-        name: null,
-        inputs,
-        params: inputs.join(",")
-      }
-    ];
-  }
-  return variables.map((v) => {
-    let _definition = v._definition;
-    if (!_definition) {
-      let functionBody;
-      if (cell.body.type === "BlockStatement") {
-        functionBody = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-      } else {
-        const bodyCode = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-        functionBody = `{return (${bodyCode});}`;
-      }
-      _definition = `${cell.async ? "async " : ""}function${
-        cell.generator ? "*" : ""
-      } ${v.functionName}(${v.inputs.join(",")}) ${functionBody}`;
-    }
-    return {
-      _name: v.name,
-      _inputs: v.inputs.map(
-        (i) => dollarToMacro[i] || (i === "$variable" ? "@variable" : i)
-      ),
-      _definition
-    };
-  });
+        return {
+            _name: v.name,
+            _inputs: v.inputs.map(i => dollarToMacro[i] || (i === '$variable' ? '@variable' : i)),
+            _definition
+        };
+    });
 }
 )};
 const _1v1i7wl = function _observableToJs(acorn_walk,parser,escodegen){return(
@@ -18768,16 +18706,15 @@ async (attachment, overrides) => {
   return URL.createObjectURL(blob);
 }
 )};
-const _s9w7ha = async function _parser(decompress_url,FileAttachment,acorn_url,acorn_walk_url){return(
-importShim(await decompress_url(FileAttachment("parser-6.1.0.js.gz"), {
-    "/npm/acorn@8.11.3/+esm": acorn_url,
-    "/npm/acorn-walk@8.3.2/+esm": acorn_walk_url
-  })
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
-const _1hiclbb = function _acorn_walk(acorn_walk_url){return(
-importShim(acorn_walk_url, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _s9w7ha = async function _parser(decompress_url, FileAttachment, acorn_url, acorn_walk_url) {
+    return import(await decompress_url(FileAttachment('parser-6.1.0.js.gz'), {
+        '/npm/acorn@8.11.3/+esm': acorn_url,
+        '/npm/acorn-walk@8.3.2/+esm': acorn_walk_url
+    }));
+};
+const _1hiclbb = function _acorn_walk(acorn_walk_url) {
+    return import(acorn_walk_url);
+};
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
@@ -18965,7 +18902,7 @@ export default function define(runtime, observer) {
   $def("_1dmmuaf", "compiled_selector", ["Generators","viewof compiled_selector"], _1dmmuaf);  
   $def("_u7t3vu", null, ["compiled_selector","normalizeJavascriptSource"], _u7t3vu);  
   $def("_1lt3kl6", null, ["compile","test_case"], _1lt3kl6);  
-  $def("_lpzjrv", "compile", ["parser","globalThis","observableToJs"], _lpzjrv);  
+  $def("_x1d0wm", "compile", ["parser","observableToJs"], _x1d0wm);  
   $def("_1v1i7wl", "observableToJs", ["acorn_walk","parser","escodegen"], _1v1i7wl);  
   $def("_19lv24l", null, ["md"], _19lv24l);  
   $def("_xhj6b8", "decompress_url", ["DecompressionStream","TextDecoderStream","TransformStream","TextEncoderStream","Response"], _xhj6b8);  

--- a/notebooks/@tomlarkworthy_bulk-jumpgate.html
+++ b/notebooks/@tomlarkworthy_bulk-jumpgate.html
@@ -6329,58 +6329,41 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _geoudp = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
-  if (command.processed) return;
-
-  let result = undefined;
-  if (command.command == "createCell") {
-    $0.value = true;
-    result = compile_and_update("{}", [], command.args.cell);
-    // For the new one to get focus
-    // setTimeout(() => {
-    //   debugger;
-    //   setOption(result[0], "pinned", true);
-    // }, 100);
-  } else if (command.command == "deleteCell") {
-    remove_variables(command.args.cell.variables);
-    result = true;
-  } else if (command.command == "moveCell") {
-    const cellIndex = findCellIndex(
-      command.args.cell.variables,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const targetCellIndex = cellIndex + command.args.amount;
-    const targetCell = lookupCellByIndex(
-      targetCellIndex,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const currentFirstVariableIndex = findVariableIndex(
-      command.args.cell.variables[0]
-    );
-    const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-    const change = targetFirstVariableIndex - currentFirstVariableIndex;
-    console.log(
-      "moveCell",
-      cellIndex,
-      targetCellIndex,
-      targetCell,
-      currentFirstVariableIndex,
-      targetFirstVariableIndex,
-      change
-    );
-    command.args.cell.variables.forEach((v) => {
-      const currentIndex = findVariableIndex(v);
-      repositionSetElement(runtime._variables, v, currentIndex + change);
-    });
-    // recompute
-    await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
-    result = true;
-  }
-  if (result) {
-    command.processed = true;
-    $2.resolve(result);
-  }
+    if (command.processed)
+        return;
+    let result = undefined;
+    if (command.command == 'createCell') {
+        $0.value = true;
+        result = await compile_and_update('{}', [], command.args.cell);    // For the new one to get focus
+                                                                           // setTimeout(() => {
+                                                                           //   debugger;
+                                                                           //   setOption(result[0], "pinned", true);
+                                                                           // }, 100);
+    } else if (command.command == 'deleteCell') {
+        remove_variables(command.args.cell.variables);
+        result = true;
+    } else if (command.command == 'moveCell') {
+        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const targetCellIndex = cellIndex + command.args.amount;
+        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
+        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+        const change = targetFirstVariableIndex - currentFirstVariableIndex;
+        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
+        command.args.cell.variables.forEach(v => {
+            const currentIndex = findVariableIndex(v);
+            repositionSetElement(runtime._variables, v, currentIndex + change);
+        });
+        // recompute
+        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        result = true;
+    }
+    if (result) {
+        command.processed = true;
+        $2.resolve(result);
+    }
 };
 const _1jadxoe = function _60(md){return(
 md`### UI Action`
@@ -6771,9 +6754,9 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
-    return (source, variables = [], cell) => {
+    return async (source, variables = [], cell) => {
         try {
             debugger;
             let reposition = false, insertionIndex = -1;
@@ -6793,10 +6776,10 @@ const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElemen
             if (reposition) {
                 insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
+            const fns = await realize(newVariables.map(v => v._definition), runtime);
             newVariables.forEach((v, i) => {
                 const variable = variables[i];
-                let _fn;
-                eval('_fn = ' + v._definition);
+                const _fn = fns[i];
                 if (v._name) {
                     variable.define(v._name, v._inputs, _fn);
                 } else {
@@ -6845,12 +6828,11 @@ Inputs.textarea({
 })
 )};
 const _b4rsn5 = (G, _) => G.input(_);
-const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
+const _ga6kci = function _98(Inputs,definition,variable,realize,runtime,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
-  reduce: () => {
-    let _fn;
-    eval("_fn = " + definition);
+  reduce: async () => {
+    const [_fn] = await realize([definition], runtime);
     variable.define(variable._name, inputs, _fn);
   }
 })
@@ -6963,7 +6945,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_geoudp", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _geoudp);  
+  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -7001,7 +6983,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
+  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -7011,8 +6993,9 @@ export default function define(runtime, observer) {
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
   $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
-  $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
+  $def("_ga6kci", null, ["Inputs","definition","variable","realize","runtime","inputs"], _ga6kci);  
   $def("_1q557s", null, ["md"], _1q557s);  
+  main.define("realize", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("realize", _));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -17498,10 +17481,9 @@ notebook_semantics_document.nodes.map((s) => ({
 const _1oevsow = function _28(md){return(
 md`### Runtime Representation (v4)`
 )};
-const _11lfflk = function _notebook_semantics_module(){return(
-importShim("https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4"
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _11lfflk = function _notebook_semantics_module() {
+    return import('https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4');
+};
 const _gjten6 = function _31(md){return(
 md`### Imports`
 )};
@@ -18488,65 +18470,44 @@ parser.parseCell(
   'import {runtime, viewof main as foo} from "@mootari/access-runtime"'
 )
 )};
-const _1n7gw17 = function _findModuleName(extractModuleInfo){return(
-(scope, module, { unknown_id = Math.random() } = {}) => {
-  try {
-    const scopedVariables = [...scope.values()];
-
-    // Prefer variables that *define* a module and have a real module-loader name.
-    const candidates = scopedVariables.filter(
-      (v) =>
-        v &&
-        v._value === module &&
-        typeof v._name === "string" &&
-        v._name.startsWith("module ") &&
-        !v._name.startsWith("module <unknown")
-    );
-
-    const pickBestInfo = (dfn) => {
-      // Avoid the parentUrl (2nd arg) confusing module identification.
-      // Typical patterns:
-      //   importShim("/d/<id>@<ver>.js?v=4", "https://api.observablehq.com/@ns/name.js?v=4")
-      //   import("/d/<id>@<ver>.js?v=4")
-      // Prefer the *first argument* inside importShim(...) / import(...) when present.
-      const s = String(dfn ?? "");
-
-      // Try to capture the first string literal argument to importShim(...) or import(...)
-      // Tolerates quotes ", ', ` and both importShim and plain import.
-      const m = s.match(
-        /\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/
-      );
-      const firstArg = m?.[2];
-
-      const info1 = firstArg ? extractModuleInfo(firstArg) : {};
-      if (info1?.id || info1?.notebook) return info1;
-
-      // Fallback: parse the whole definition string.
-      return extractModuleInfo(s);
+const _1n7gw17 = function _findModuleName(extractModuleInfo) {
+    return (scope, module, {
+        unknown_id = Math.random()
+    } = {}) => {
+        try {
+            const scopedVariables = [...scope.values()];
+            const candidates = scopedVariables.filter(v => v && v._value === module && typeof v._name === 'string' && v._name.startsWith('module ') && !v._name.startsWith('module <unknown'));
+            const pickBestInfo = dfn => {
+                const s = String(dfn ?? '');
+                const m = s.match(/\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/);
+                const firstArg = m?.[2];
+                const info1 = firstArg ? extractModuleInfo(firstArg) : {};
+                if (info1?.id || info1?.notebook)
+                    return info1;
+                return extractModuleInfo(s);
+            };
+            for (const v of candidates) {
+                const info = pickBestInfo(v._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            const any = scopedVariables.find(v => v && v._value === module);
+            if (any) {
+                const info = pickBestInfo(any._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            return `<unknown ${ unknown_id }>`;
+        } catch (e) {
+            debugger;
+            return 'error';
+        }
     };
-
-    // Try module loader cells first.
-    for (const v of candidates) {
-      const info = pickBestInfo(v._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    // Fallback: any scoped variable with _value==module.
-    const any = scopedVariables.find((v) => v && v._value === module);
-    if (any) {
-      const info = pickBestInfo(any._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    return `<unknown ${unknown_id}>`;
-  } catch (e) {
-    debugger;
-    return "error";
-  }
-}
-)};
+};
 const _i47chb = function _findImportedName(){return(
 async (v) => {
   if (v._inputs.length == 1 && v._inputs[0]._name === "@variable") {
@@ -19448,229 +19409,206 @@ JSON.stringify(
 const _1lt3kl6 = function _157(compile,test_case){return(
 compile(test_case.value)
 )};
-const _lpzjrv = function _compile(parser,globalThis,observableToJs){return(
-function compile(source, { anonymousName = "_anonymous" } = {}) {
-  const comments = [],
-    tokens = [];
-  let cell;
-  try {
-    cell = parser.parseCell(source, {
-      ranges: true,
-      onComment: comments,
-      onToken: tokens
-    });
-  } catch (e) {
-    if (e instanceof SyntaxError) {
-      const nameMatch = source.match(
-        /^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/
-      );
-      let _name = null;
-      let funcName = anonymousName;
-      if (nameMatch) {
-        const prefix = nameMatch[1] ? nameMatch[1] + " " : "";
-        _name = prefix + nameMatch[2];
-        funcName = "_" + nameMatch[2];
-      }
-      const escapedMsg = JSON.stringify(e.message);
-      const escapedSource = JSON.stringify(source);
-      return [
-        {
-          _name,
-          _inputs: [],
-          _definition: `function ${funcName}() { throw Object.assign(new SyntaxError(${escapedMsg}), {_sourceExpression: ${escapedSource}}); }`
+const _x1d0wm = function _compile(parser,observableToJs){return(
+function compile(source, {
+    anonymousName = '_anonymous'
+} = {}) {
+    const comments = [], tokens = [];
+    let cell;
+    try {
+        cell = parser.parseCell(source, {
+            ranges: true,
+            onComment: comments,
+            onToken: tokens
+        });
+    } catch (e) {
+        if (e instanceof SyntaxError) {
+            const nameMatch = source.match(/^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/);
+            let _name = null;
+            let funcName = anonymousName;
+            if (nameMatch) {
+                const prefix = nameMatch[1] ? nameMatch[1] + ' ' : '';
+                _name = prefix + nameMatch[2];
+                funcName = '_' + nameMatch[2];
+            }
+            const escapedMsg = JSON.stringify(e.message);
+            const escapedSource = JSON.stringify(source);
+            return [{
+                    _name,
+                    _inputs: [],
+                    _definition: `function ${ funcName }() { throw Object.assign(new SyntaxError(${ escapedMsg }), {_sourceExpression: ${ escapedSource }}); }`
+                }];
         }
-      ];
+        throw e;
     }
-    throw e;
-  }
-  if (!cell) throw new Error("Unable to parse cell");
-  const parseImportSpecifierText = (text) => {
-    const t = String(text ?? "")
-      .trim()
-      .replace(/,$/, "")
-      .trim();
-    if (!t) throw new Error("Empty import specifier");
-    const parts = t.split(/\s+as\s+/);
-    const left = parts[0].trim();
-    const right = parts[1]?.trim();
-    const parseSide = (side, { defaultPrefix = "" } = {}) => {
-      const s = String(side ?? "").trim();
-      const m = s.match(/^(viewof|mutable)\s+(.+)$/);
-      if (m)
-        return {
-          prefix: `${m[1]} `,
-          name: m[2].trim()
+    if (!cell)
+        throw new Error('Unable to parse cell');
+    const parseImportSpecifierText = text => {
+        const t = String(text ?? '').trim().replace(/,$/, '').trim();
+        if (!t)
+            throw new Error('Empty import specifier');
+        const parts = t.split(/\s+as\s+/);
+        const left = parts[0].trim();
+        const right = parts[1]?.trim();
+        const parseSide = (side, {
+            defaultPrefix = ''
+        } = {}) => {
+            const s = String(side ?? '').trim();
+            const m = s.match(/^(viewof|mutable)\s+(.+)$/);
+            if (m)
+                return {
+                    prefix: `${ m[1] } `,
+                    name: m[2].trim()
+                };
+            return {
+                prefix: defaultPrefix,
+                name: s
+            };
         };
-      return {
-        prefix: defaultPrefix,
-        name: s
-      };
+        const L = parseSide(left);
+        const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
+        const importedName = `${ L.prefix }${ L.name }`.trim();
+        const localName = `${ R.prefix }${ R.name }`.trim();
+        if (!importedName)
+            throw new Error(`Could not parse imported name from: ${ t }`);
+        if (!localName)
+            throw new Error(`Could not parse local name from: ${ t }`);
+        return {
+            importedName,
+            localName
+        };
     };
-    const L = parseSide(left);
-    const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
-    const importedName = `${L.prefix}${L.name}`.trim();
-    const localName = `${R.prefix}${R.name}`.trim();
-    if (!importedName)
-      throw new Error(`Could not parse imported name from: ${t}`);
-    if (!localName) throw new Error(`Could not parse local name from: ${t}`);
-    return {
-      importedName,
-      localName
-    };
-  };
-  if (!cell.id && cell.body?.type === "ImportDeclaration") {
-    const module_name = cell.body.source.value;
-    const importKeyword = globalThis?.importShim ? "importShim" : "import";
-    const cell_variables = [
-      {
-        _name: `module ${module_name}`,
-        _inputs: [],
-        _definition: `async () => runtime.module((await ${importKeyword}("${module_name}")).default)`
-      }
-    ];
-    for (const specifier of cell.body.specifiers ?? []) {
-      const specText =
-        typeof specifier?.start === "number" &&
-        typeof specifier?.end === "number"
-          ? source.slice(specifier.start, specifier.end)
-          : (() => {
-              if (specifier?.imported?.name && specifier?.local?.name) {
-                return specifier.imported.name === specifier.local.name
-                  ? specifier.local.name
-                  : `${specifier.imported.name} as ${specifier.local.name}`;
-              }
-              throw new Error("Import specifier missing range information");
+    if (!cell.id && cell.body?.type === 'ImportDeclaration') {
+        const module_name = cell.body.source.value;
+        const cell_variables = [{
+                _name: `module ${ module_name }`,
+                _inputs: [],
+                _definition: `async () => runtime.module((await import("${ module_name }")).default)`
+            }];
+        for (const specifier of cell.body.specifiers ?? []) {
+            const specText = typeof specifier?.start === 'number' && typeof specifier?.end === 'number' ? source.slice(specifier.start, specifier.end) : (() => {
+                if (specifier?.imported?.name && specifier?.local?.name) {
+                    return specifier.imported.name === specifier.local.name ? specifier.local.name : `${ specifier.imported.name } as ${ specifier.local.name }`;
+                }
+                throw new Error('Import specifier missing range information');
             })();
-      const { importedName, localName } = parseImportSpecifierText(specText);
-      cell_variables.push({
-        _name: localName,
-        _inputs: [`module ${module_name}`, "@variable"],
-        _definition:
-          importedName === localName
-            ? `(_, v) => v.import("${importedName}", _)`
-            : `(_, v) => v.import("${importedName}", "${localName}", _)`
-      });
+            const {importedName, localName} = parseImportSpecifierText(specText);
+            cell_variables.push({
+                _name: localName,
+                _inputs: [
+                    `module ${ module_name }`,
+                    '@variable'
+                ],
+                _definition: importedName === localName ? `(_, v) => v.import("${ importedName }", _)` : `(_, v) => v.import("${ importedName }", "${ localName }", _)`
+            });
+        }
+        return cell_variables;
     }
-    return cell_variables;
-  }
-  let dollarIdx = 0;
-  const inputToArgMap = {};
-  const dollarToMacro = {};
-  const seen = new Set();
-  const inputs = Array.from(cell.references || []).flatMap((i) => {
-    if (i.name) {
-      if (seen.has(i.name)) return [];
-      seen.add(i.name);
-      return i.name;
+    let dollarIdx = 0;
+    const inputToArgMap = {};
+    const dollarToMacro = {};
+    const seen = new Set();
+    const inputs = Array.from(cell.references || []).flatMap(i => {
+        if (i.name) {
+            if (seen.has(i.name))
+                return [];
+            seen.add(i.name);
+            return i.name;
+        } else {
+            const dedupKey = i.type + ':' + i.id.name;
+            if (seen.has(dedupKey))
+                return [];
+            seen.add(dedupKey);
+            const dollarName = '$' + dollarIdx;
+            inputToArgMap[i.id.name] = dollarName;
+            dollarToMacro[dollarName] = i.type == 'ViewExpression' ? 'viewof ' + i.id.name : 'mutable ' + i.id.name;
+            dollarIdx++;
+            return dollarName;
+        }
+    });
+    let variables;
+    if (cell.id) {
+        if (cell.id.type === 'Identifier') {
+            variables = [{
+                    functionName: '_' + cell.id.name,
+                    name: cell.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                }];
+        } else if (cell.id.type === 'ViewExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'viewof ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '(G, _) => G.input(_)',
+                    inputs: [
+                        'Generators',
+                        'viewof ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                }
+            ];
+        } else if (cell.id.type === 'MutableExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'initial ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'mutable ' + cell.id.id.name,
+                    _definition: '(M, _) => new M(_)',
+                    inputs: [
+                        'Mutable',
+                        'initial ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '_ => _.generator',
+                    inputs: ['mutable ' + cell.id.id.name],
+                    params: inputs.join(',')
+                }
+            ];
+        } else {
+            throw new Error(`Unsupported cell id type: ${ cell.id.type }`);
+        }
     } else {
-      const dedupKey = i.type + ":" + i.id.name;
-      if (seen.has(dedupKey)) return [];
-      seen.add(dedupKey);
-      const dollarName = "$" + dollarIdx;
-      inputToArgMap[i.id.name] = dollarName;
-      dollarToMacro[dollarName] =
-        i.type == "ViewExpression"
-          ? "viewof " + i.id.name
-          : "mutable " + i.id.name;
-      dollarIdx++;
-      return dollarName;
+        variables = [{
+                functionName: anonymousName,
+                name: null,
+                inputs,
+                params: inputs.join(',')
+            }];
     }
-  });
-  let variables;
-  if (cell.id) {
-    if (cell.id.type === "Identifier") {
-      variables = [
-        {
-          functionName: "_" + cell.id.name,
-          name: cell.id.name,
-          inputs,
-          params: inputs.join(",")
+    return variables.map(v => {
+        let _definition = v._definition;
+        if (!_definition) {
+            let functionBody;
+            if (cell.body.type === 'BlockStatement') {
+                functionBody = observableToJs(cell.body, inputToArgMap, comments, tokens);
+            } else {
+                const bodyCode = observableToJs(cell.body, inputToArgMap, comments, tokens);
+                functionBody = `{return (${ bodyCode });}`;
+            }
+            _definition = `${ cell.async ? 'async ' : '' }function${ cell.generator ? '*' : '' } ${ v.functionName }(${ v.inputs.join(',') }) ${ functionBody }`;
         }
-      ];
-    } else if (cell.id.type === "ViewExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "viewof " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "(G, _) => G.input(_)",
-          inputs: ["Generators", "viewof " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else if (cell.id.type === "MutableExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "initial " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "mutable " + cell.id.id.name,
-          _definition: "(M, _) => new M(_)",
-          inputs: ["Mutable", "initial " + cell.id.id.name],
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "_ => _.generator",
-          inputs: ["mutable " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else {
-      throw new Error(`Unsupported cell id type: ${cell.id.type}`);
-    }
-  } else {
-    variables = [
-      {
-        functionName: anonymousName,
-        name: null,
-        inputs,
-        params: inputs.join(",")
-      }
-    ];
-  }
-  return variables.map((v) => {
-    let _definition = v._definition;
-    if (!_definition) {
-      let functionBody;
-      if (cell.body.type === "BlockStatement") {
-        functionBody = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-      } else {
-        const bodyCode = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-        functionBody = `{return (${bodyCode});}`;
-      }
-      _definition = `${cell.async ? "async " : ""}function${
-        cell.generator ? "*" : ""
-      } ${v.functionName}(${v.inputs.join(",")}) ${functionBody}`;
-    }
-    return {
-      _name: v.name,
-      _inputs: v.inputs.map(
-        (i) => dollarToMacro[i] || (i === "$variable" ? "@variable" : i)
-      ),
-      _definition
-    };
-  });
+        return {
+            _name: v.name,
+            _inputs: v.inputs.map(i => dollarToMacro[i] || (i === '$variable' ? '@variable' : i)),
+            _definition
+        };
+    });
 }
 )};
 const _1v1i7wl = function _observableToJs(acorn_walk,parser,escodegen){return(
@@ -19737,16 +19675,15 @@ async (attachment, overrides) => {
   return URL.createObjectURL(blob);
 }
 )};
-const _s9w7ha = async function _parser(decompress_url,FileAttachment,acorn_url,acorn_walk_url){return(
-importShim(await decompress_url(FileAttachment("parser-6.1.0.js.gz"), {
-    "/npm/acorn@8.11.3/+esm": acorn_url,
-    "/npm/acorn-walk@8.3.2/+esm": acorn_walk_url
-  })
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
-const _1hiclbb = function _acorn_walk(acorn_walk_url){return(
-importShim(acorn_walk_url, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _s9w7ha = async function _parser(decompress_url, FileAttachment, acorn_url, acorn_walk_url) {
+    return import(await decompress_url(FileAttachment('parser-6.1.0.js.gz'), {
+        '/npm/acorn@8.11.3/+esm': acorn_url,
+        '/npm/acorn-walk@8.3.2/+esm': acorn_walk_url
+    }));
+};
+const _1hiclbb = function _acorn_walk(acorn_walk_url) {
+    return import(acorn_walk_url);
+};
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
@@ -19934,7 +19871,7 @@ export default function define(runtime, observer) {
   $def("_1dmmuaf", "compiled_selector", ["Generators","viewof compiled_selector"], _1dmmuaf);  
   $def("_u7t3vu", null, ["compiled_selector","normalizeJavascriptSource"], _u7t3vu);  
   $def("_1lt3kl6", null, ["compile","test_case"], _1lt3kl6);  
-  $def("_lpzjrv", "compile", ["parser","globalThis","observableToJs"], _lpzjrv);  
+  $def("_x1d0wm", "compile", ["parser","observableToJs"], _x1d0wm);  
   $def("_1v1i7wl", "observableToJs", ["acorn_walk","parser","escodegen"], _1v1i7wl);  
   $def("_19lv24l", null, ["md"], _19lv24l);  
   $def("_xhj6b8", "decompress_url", ["DecompressionStream","TextDecoderStream","TransformStream","TextEncoderStream","Response"], _xhj6b8);  

--- a/notebooks/@tomlarkworthy_cells-to-clipboard.html
+++ b/notebooks/@tomlarkworthy_cells-to-clipboard.html
@@ -5437,58 +5437,41 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _geoudp = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
-  if (command.processed) return;
-
-  let result = undefined;
-  if (command.command == "createCell") {
-    $0.value = true;
-    result = compile_and_update("{}", [], command.args.cell);
-    // For the new one to get focus
-    // setTimeout(() => {
-    //   debugger;
-    //   setOption(result[0], "pinned", true);
-    // }, 100);
-  } else if (command.command == "deleteCell") {
-    remove_variables(command.args.cell.variables);
-    result = true;
-  } else if (command.command == "moveCell") {
-    const cellIndex = findCellIndex(
-      command.args.cell.variables,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const targetCellIndex = cellIndex + command.args.amount;
-    const targetCell = lookupCellByIndex(
-      targetCellIndex,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const currentFirstVariableIndex = findVariableIndex(
-      command.args.cell.variables[0]
-    );
-    const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-    const change = targetFirstVariableIndex - currentFirstVariableIndex;
-    console.log(
-      "moveCell",
-      cellIndex,
-      targetCellIndex,
-      targetCell,
-      currentFirstVariableIndex,
-      targetFirstVariableIndex,
-      change
-    );
-    command.args.cell.variables.forEach((v) => {
-      const currentIndex = findVariableIndex(v);
-      repositionSetElement(runtime._variables, v, currentIndex + change);
-    });
-    // recompute
-    await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
-    result = true;
-  }
-  if (result) {
-    command.processed = true;
-    $2.resolve(result);
-  }
+    if (command.processed)
+        return;
+    let result = undefined;
+    if (command.command == 'createCell') {
+        $0.value = true;
+        result = await compile_and_update('{}', [], command.args.cell);    // For the new one to get focus
+                                                                           // setTimeout(() => {
+                                                                           //   debugger;
+                                                                           //   setOption(result[0], "pinned", true);
+                                                                           // }, 100);
+    } else if (command.command == 'deleteCell') {
+        remove_variables(command.args.cell.variables);
+        result = true;
+    } else if (command.command == 'moveCell') {
+        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const targetCellIndex = cellIndex + command.args.amount;
+        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
+        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+        const change = targetFirstVariableIndex - currentFirstVariableIndex;
+        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
+        command.args.cell.variables.forEach(v => {
+            const currentIndex = findVariableIndex(v);
+            repositionSetElement(runtime._variables, v, currentIndex + change);
+        });
+        // recompute
+        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        result = true;
+    }
+    if (result) {
+        command.processed = true;
+        $2.resolve(result);
+    }
 };
 const _1jadxoe = function _60(md){return(
 md`### UI Action`
@@ -5879,9 +5862,9 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
-    return (source, variables = [], cell) => {
+    return async (source, variables = [], cell) => {
         try {
             debugger;
             let reposition = false, insertionIndex = -1;
@@ -5901,10 +5884,10 @@ const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElemen
             if (reposition) {
                 insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
+            const fns = await realize(newVariables.map(v => v._definition), runtime);
             newVariables.forEach((v, i) => {
                 const variable = variables[i];
-                let _fn;
-                eval('_fn = ' + v._definition);
+                const _fn = fns[i];
                 if (v._name) {
                     variable.define(v._name, v._inputs, _fn);
                 } else {
@@ -5953,12 +5936,11 @@ Inputs.textarea({
 })
 )};
 const _b4rsn5 = (G, _) => G.input(_);
-const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
+const _ga6kci = function _98(Inputs,definition,variable,realize,runtime,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
-  reduce: () => {
-    let _fn;
-    eval("_fn = " + definition);
+  reduce: async () => {
+    const [_fn] = await realize([definition], runtime);
     variable.define(variable._name, inputs, _fn);
   }
 })
@@ -6071,7 +6053,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_geoudp", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _geoudp);  
+  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6109,7 +6091,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
+  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -6119,8 +6101,9 @@ export default function define(runtime, observer) {
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
   $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
-  $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
+  $def("_ga6kci", null, ["Inputs","definition","variable","realize","runtime","inputs"], _ga6kci);  
   $def("_1q557s", null, ["md"], _1q557s);  
+  main.define("realize", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("realize", _));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -16490,10 +16473,9 @@ notebook_semantics_document.nodes.map((s) => ({
 const _1oevsow = function _28(md){return(
 md`### Runtime Representation (v4)`
 )};
-const _11lfflk = function _notebook_semantics_module(){return(
-importShim("https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4"
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _11lfflk = function _notebook_semantics_module() {
+    return import('https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4');
+};
 const _gjten6 = function _31(md){return(
 md`### Imports`
 )};
@@ -17480,65 +17462,44 @@ parser.parseCell(
   'import {runtime, viewof main as foo} from "@mootari/access-runtime"'
 )
 )};
-const _1n7gw17 = function _findModuleName(extractModuleInfo){return(
-(scope, module, { unknown_id = Math.random() } = {}) => {
-  try {
-    const scopedVariables = [...scope.values()];
-
-    // Prefer variables that *define* a module and have a real module-loader name.
-    const candidates = scopedVariables.filter(
-      (v) =>
-        v &&
-        v._value === module &&
-        typeof v._name === "string" &&
-        v._name.startsWith("module ") &&
-        !v._name.startsWith("module <unknown")
-    );
-
-    const pickBestInfo = (dfn) => {
-      // Avoid the parentUrl (2nd arg) confusing module identification.
-      // Typical patterns:
-      //   importShim("/d/<id>@<ver>.js?v=4", "https://api.observablehq.com/@ns/name.js?v=4")
-      //   import("/d/<id>@<ver>.js?v=4")
-      // Prefer the *first argument* inside importShim(...) / import(...) when present.
-      const s = String(dfn ?? "");
-
-      // Try to capture the first string literal argument to importShim(...) or import(...)
-      // Tolerates quotes ", ', ` and both importShim and plain import.
-      const m = s.match(
-        /\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/
-      );
-      const firstArg = m?.[2];
-
-      const info1 = firstArg ? extractModuleInfo(firstArg) : {};
-      if (info1?.id || info1?.notebook) return info1;
-
-      // Fallback: parse the whole definition string.
-      return extractModuleInfo(s);
+const _1n7gw17 = function _findModuleName(extractModuleInfo) {
+    return (scope, module, {
+        unknown_id = Math.random()
+    } = {}) => {
+        try {
+            const scopedVariables = [...scope.values()];
+            const candidates = scopedVariables.filter(v => v && v._value === module && typeof v._name === 'string' && v._name.startsWith('module ') && !v._name.startsWith('module <unknown'));
+            const pickBestInfo = dfn => {
+                const s = String(dfn ?? '');
+                const m = s.match(/\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/);
+                const firstArg = m?.[2];
+                const info1 = firstArg ? extractModuleInfo(firstArg) : {};
+                if (info1?.id || info1?.notebook)
+                    return info1;
+                return extractModuleInfo(s);
+            };
+            for (const v of candidates) {
+                const info = pickBestInfo(v._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            const any = scopedVariables.find(v => v && v._value === module);
+            if (any) {
+                const info = pickBestInfo(any._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            return `<unknown ${ unknown_id }>`;
+        } catch (e) {
+            debugger;
+            return 'error';
+        }
     };
-
-    // Try module loader cells first.
-    for (const v of candidates) {
-      const info = pickBestInfo(v._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    // Fallback: any scoped variable with _value==module.
-    const any = scopedVariables.find((v) => v && v._value === module);
-    if (any) {
-      const info = pickBestInfo(any._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    return `<unknown ${unknown_id}>`;
-  } catch (e) {
-    debugger;
-    return "error";
-  }
-}
-)};
+};
 const _i47chb = function _findImportedName(){return(
 async (v) => {
   if (v._inputs.length == 1 && v._inputs[0]._name === "@variable") {
@@ -18440,229 +18401,206 @@ JSON.stringify(
 const _1lt3kl6 = function _157(compile,test_case){return(
 compile(test_case.value)
 )};
-const _lpzjrv = function _compile(parser,globalThis,observableToJs){return(
-function compile(source, { anonymousName = "_anonymous" } = {}) {
-  const comments = [],
-    tokens = [];
-  let cell;
-  try {
-    cell = parser.parseCell(source, {
-      ranges: true,
-      onComment: comments,
-      onToken: tokens
-    });
-  } catch (e) {
-    if (e instanceof SyntaxError) {
-      const nameMatch = source.match(
-        /^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/
-      );
-      let _name = null;
-      let funcName = anonymousName;
-      if (nameMatch) {
-        const prefix = nameMatch[1] ? nameMatch[1] + " " : "";
-        _name = prefix + nameMatch[2];
-        funcName = "_" + nameMatch[2];
-      }
-      const escapedMsg = JSON.stringify(e.message);
-      const escapedSource = JSON.stringify(source);
-      return [
-        {
-          _name,
-          _inputs: [],
-          _definition: `function ${funcName}() { throw Object.assign(new SyntaxError(${escapedMsg}), {_sourceExpression: ${escapedSource}}); }`
+const _x1d0wm = function _compile(parser,observableToJs){return(
+function compile(source, {
+    anonymousName = '_anonymous'
+} = {}) {
+    const comments = [], tokens = [];
+    let cell;
+    try {
+        cell = parser.parseCell(source, {
+            ranges: true,
+            onComment: comments,
+            onToken: tokens
+        });
+    } catch (e) {
+        if (e instanceof SyntaxError) {
+            const nameMatch = source.match(/^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/);
+            let _name = null;
+            let funcName = anonymousName;
+            if (nameMatch) {
+                const prefix = nameMatch[1] ? nameMatch[1] + ' ' : '';
+                _name = prefix + nameMatch[2];
+                funcName = '_' + nameMatch[2];
+            }
+            const escapedMsg = JSON.stringify(e.message);
+            const escapedSource = JSON.stringify(source);
+            return [{
+                    _name,
+                    _inputs: [],
+                    _definition: `function ${ funcName }() { throw Object.assign(new SyntaxError(${ escapedMsg }), {_sourceExpression: ${ escapedSource }}); }`
+                }];
         }
-      ];
+        throw e;
     }
-    throw e;
-  }
-  if (!cell) throw new Error("Unable to parse cell");
-  const parseImportSpecifierText = (text) => {
-    const t = String(text ?? "")
-      .trim()
-      .replace(/,$/, "")
-      .trim();
-    if (!t) throw new Error("Empty import specifier");
-    const parts = t.split(/\s+as\s+/);
-    const left = parts[0].trim();
-    const right = parts[1]?.trim();
-    const parseSide = (side, { defaultPrefix = "" } = {}) => {
-      const s = String(side ?? "").trim();
-      const m = s.match(/^(viewof|mutable)\s+(.+)$/);
-      if (m)
-        return {
-          prefix: `${m[1]} `,
-          name: m[2].trim()
+    if (!cell)
+        throw new Error('Unable to parse cell');
+    const parseImportSpecifierText = text => {
+        const t = String(text ?? '').trim().replace(/,$/, '').trim();
+        if (!t)
+            throw new Error('Empty import specifier');
+        const parts = t.split(/\s+as\s+/);
+        const left = parts[0].trim();
+        const right = parts[1]?.trim();
+        const parseSide = (side, {
+            defaultPrefix = ''
+        } = {}) => {
+            const s = String(side ?? '').trim();
+            const m = s.match(/^(viewof|mutable)\s+(.+)$/);
+            if (m)
+                return {
+                    prefix: `${ m[1] } `,
+                    name: m[2].trim()
+                };
+            return {
+                prefix: defaultPrefix,
+                name: s
+            };
         };
-      return {
-        prefix: defaultPrefix,
-        name: s
-      };
+        const L = parseSide(left);
+        const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
+        const importedName = `${ L.prefix }${ L.name }`.trim();
+        const localName = `${ R.prefix }${ R.name }`.trim();
+        if (!importedName)
+            throw new Error(`Could not parse imported name from: ${ t }`);
+        if (!localName)
+            throw new Error(`Could not parse local name from: ${ t }`);
+        return {
+            importedName,
+            localName
+        };
     };
-    const L = parseSide(left);
-    const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
-    const importedName = `${L.prefix}${L.name}`.trim();
-    const localName = `${R.prefix}${R.name}`.trim();
-    if (!importedName)
-      throw new Error(`Could not parse imported name from: ${t}`);
-    if (!localName) throw new Error(`Could not parse local name from: ${t}`);
-    return {
-      importedName,
-      localName
-    };
-  };
-  if (!cell.id && cell.body?.type === "ImportDeclaration") {
-    const module_name = cell.body.source.value;
-    const importKeyword = globalThis?.importShim ? "importShim" : "import";
-    const cell_variables = [
-      {
-        _name: `module ${module_name}`,
-        _inputs: [],
-        _definition: `async () => runtime.module((await ${importKeyword}("${module_name}")).default)`
-      }
-    ];
-    for (const specifier of cell.body.specifiers ?? []) {
-      const specText =
-        typeof specifier?.start === "number" &&
-        typeof specifier?.end === "number"
-          ? source.slice(specifier.start, specifier.end)
-          : (() => {
-              if (specifier?.imported?.name && specifier?.local?.name) {
-                return specifier.imported.name === specifier.local.name
-                  ? specifier.local.name
-                  : `${specifier.imported.name} as ${specifier.local.name}`;
-              }
-              throw new Error("Import specifier missing range information");
+    if (!cell.id && cell.body?.type === 'ImportDeclaration') {
+        const module_name = cell.body.source.value;
+        const cell_variables = [{
+                _name: `module ${ module_name }`,
+                _inputs: [],
+                _definition: `async () => runtime.module((await import("${ module_name }")).default)`
+            }];
+        for (const specifier of cell.body.specifiers ?? []) {
+            const specText = typeof specifier?.start === 'number' && typeof specifier?.end === 'number' ? source.slice(specifier.start, specifier.end) : (() => {
+                if (specifier?.imported?.name && specifier?.local?.name) {
+                    return specifier.imported.name === specifier.local.name ? specifier.local.name : `${ specifier.imported.name } as ${ specifier.local.name }`;
+                }
+                throw new Error('Import specifier missing range information');
             })();
-      const { importedName, localName } = parseImportSpecifierText(specText);
-      cell_variables.push({
-        _name: localName,
-        _inputs: [`module ${module_name}`, "@variable"],
-        _definition:
-          importedName === localName
-            ? `(_, v) => v.import("${importedName}", _)`
-            : `(_, v) => v.import("${importedName}", "${localName}", _)`
-      });
+            const {importedName, localName} = parseImportSpecifierText(specText);
+            cell_variables.push({
+                _name: localName,
+                _inputs: [
+                    `module ${ module_name }`,
+                    '@variable'
+                ],
+                _definition: importedName === localName ? `(_, v) => v.import("${ importedName }", _)` : `(_, v) => v.import("${ importedName }", "${ localName }", _)`
+            });
+        }
+        return cell_variables;
     }
-    return cell_variables;
-  }
-  let dollarIdx = 0;
-  const inputToArgMap = {};
-  const dollarToMacro = {};
-  const seen = new Set();
-  const inputs = Array.from(cell.references || []).flatMap((i) => {
-    if (i.name) {
-      if (seen.has(i.name)) return [];
-      seen.add(i.name);
-      return i.name;
+    let dollarIdx = 0;
+    const inputToArgMap = {};
+    const dollarToMacro = {};
+    const seen = new Set();
+    const inputs = Array.from(cell.references || []).flatMap(i => {
+        if (i.name) {
+            if (seen.has(i.name))
+                return [];
+            seen.add(i.name);
+            return i.name;
+        } else {
+            const dedupKey = i.type + ':' + i.id.name;
+            if (seen.has(dedupKey))
+                return [];
+            seen.add(dedupKey);
+            const dollarName = '$' + dollarIdx;
+            inputToArgMap[i.id.name] = dollarName;
+            dollarToMacro[dollarName] = i.type == 'ViewExpression' ? 'viewof ' + i.id.name : 'mutable ' + i.id.name;
+            dollarIdx++;
+            return dollarName;
+        }
+    });
+    let variables;
+    if (cell.id) {
+        if (cell.id.type === 'Identifier') {
+            variables = [{
+                    functionName: '_' + cell.id.name,
+                    name: cell.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                }];
+        } else if (cell.id.type === 'ViewExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'viewof ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '(G, _) => G.input(_)',
+                    inputs: [
+                        'Generators',
+                        'viewof ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                }
+            ];
+        } else if (cell.id.type === 'MutableExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'initial ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'mutable ' + cell.id.id.name,
+                    _definition: '(M, _) => new M(_)',
+                    inputs: [
+                        'Mutable',
+                        'initial ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '_ => _.generator',
+                    inputs: ['mutable ' + cell.id.id.name],
+                    params: inputs.join(',')
+                }
+            ];
+        } else {
+            throw new Error(`Unsupported cell id type: ${ cell.id.type }`);
+        }
     } else {
-      const dedupKey = i.type + ":" + i.id.name;
-      if (seen.has(dedupKey)) return [];
-      seen.add(dedupKey);
-      const dollarName = "$" + dollarIdx;
-      inputToArgMap[i.id.name] = dollarName;
-      dollarToMacro[dollarName] =
-        i.type == "ViewExpression"
-          ? "viewof " + i.id.name
-          : "mutable " + i.id.name;
-      dollarIdx++;
-      return dollarName;
+        variables = [{
+                functionName: anonymousName,
+                name: null,
+                inputs,
+                params: inputs.join(',')
+            }];
     }
-  });
-  let variables;
-  if (cell.id) {
-    if (cell.id.type === "Identifier") {
-      variables = [
-        {
-          functionName: "_" + cell.id.name,
-          name: cell.id.name,
-          inputs,
-          params: inputs.join(",")
+    return variables.map(v => {
+        let _definition = v._definition;
+        if (!_definition) {
+            let functionBody;
+            if (cell.body.type === 'BlockStatement') {
+                functionBody = observableToJs(cell.body, inputToArgMap, comments, tokens);
+            } else {
+                const bodyCode = observableToJs(cell.body, inputToArgMap, comments, tokens);
+                functionBody = `{return (${ bodyCode });}`;
+            }
+            _definition = `${ cell.async ? 'async ' : '' }function${ cell.generator ? '*' : '' } ${ v.functionName }(${ v.inputs.join(',') }) ${ functionBody }`;
         }
-      ];
-    } else if (cell.id.type === "ViewExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "viewof " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "(G, _) => G.input(_)",
-          inputs: ["Generators", "viewof " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else if (cell.id.type === "MutableExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "initial " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "mutable " + cell.id.id.name,
-          _definition: "(M, _) => new M(_)",
-          inputs: ["Mutable", "initial " + cell.id.id.name],
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "_ => _.generator",
-          inputs: ["mutable " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else {
-      throw new Error(`Unsupported cell id type: ${cell.id.type}`);
-    }
-  } else {
-    variables = [
-      {
-        functionName: anonymousName,
-        name: null,
-        inputs,
-        params: inputs.join(",")
-      }
-    ];
-  }
-  return variables.map((v) => {
-    let _definition = v._definition;
-    if (!_definition) {
-      let functionBody;
-      if (cell.body.type === "BlockStatement") {
-        functionBody = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-      } else {
-        const bodyCode = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-        functionBody = `{return (${bodyCode});}`;
-      }
-      _definition = `${cell.async ? "async " : ""}function${
-        cell.generator ? "*" : ""
-      } ${v.functionName}(${v.inputs.join(",")}) ${functionBody}`;
-    }
-    return {
-      _name: v.name,
-      _inputs: v.inputs.map(
-        (i) => dollarToMacro[i] || (i === "$variable" ? "@variable" : i)
-      ),
-      _definition
-    };
-  });
+        return {
+            _name: v.name,
+            _inputs: v.inputs.map(i => dollarToMacro[i] || (i === '$variable' ? '@variable' : i)),
+            _definition
+        };
+    });
 }
 )};
 const _1v1i7wl = function _observableToJs(acorn_walk,parser,escodegen){return(
@@ -18729,16 +18667,15 @@ async (attachment, overrides) => {
   return URL.createObjectURL(blob);
 }
 )};
-const _s9w7ha = async function _parser(decompress_url,FileAttachment,acorn_url,acorn_walk_url){return(
-importShim(await decompress_url(FileAttachment("parser-6.1.0.js.gz"), {
-    "/npm/acorn@8.11.3/+esm": acorn_url,
-    "/npm/acorn-walk@8.3.2/+esm": acorn_walk_url
-  })
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
-const _1hiclbb = function _acorn_walk(acorn_walk_url){return(
-importShim(acorn_walk_url, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _s9w7ha = async function _parser(decompress_url, FileAttachment, acorn_url, acorn_walk_url) {
+    return import(await decompress_url(FileAttachment('parser-6.1.0.js.gz'), {
+        '/npm/acorn@8.11.3/+esm': acorn_url,
+        '/npm/acorn-walk@8.3.2/+esm': acorn_walk_url
+    }));
+};
+const _1hiclbb = function _acorn_walk(acorn_walk_url) {
+    return import(acorn_walk_url);
+};
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
@@ -18926,7 +18863,7 @@ export default function define(runtime, observer) {
   $def("_1dmmuaf", "compiled_selector", ["Generators","viewof compiled_selector"], _1dmmuaf);  
   $def("_u7t3vu", null, ["compiled_selector","normalizeJavascriptSource"], _u7t3vu);  
   $def("_1lt3kl6", null, ["compile","test_case"], _1lt3kl6);  
-  $def("_lpzjrv", "compile", ["parser","globalThis","observableToJs"], _lpzjrv);  
+  $def("_x1d0wm", "compile", ["parser","observableToJs"], _x1d0wm);  
   $def("_1v1i7wl", "observableToJs", ["acorn_walk","parser","escodegen"], _1v1i7wl);  
   $def("_19lv24l", null, ["md"], _19lv24l);  
   $def("_xhj6b8", "decompress_url", ["DecompressionStream","TextDecoderStream","TransformStream","TextEncoderStream","Response"], _xhj6b8);  

--- a/notebooks/@tomlarkworthy_claude-code-pairing.html
+++ b/notebooks/@tomlarkworthy_claude-code-pairing.html
@@ -5414,58 +5414,41 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _geoudp = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
-  if (command.processed) return;
-
-  let result = undefined;
-  if (command.command == "createCell") {
-    $0.value = true;
-    result = compile_and_update("{}", [], command.args.cell);
-    // For the new one to get focus
-    // setTimeout(() => {
-    //   debugger;
-    //   setOption(result[0], "pinned", true);
-    // }, 100);
-  } else if (command.command == "deleteCell") {
-    remove_variables(command.args.cell.variables);
-    result = true;
-  } else if (command.command == "moveCell") {
-    const cellIndex = findCellIndex(
-      command.args.cell.variables,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const targetCellIndex = cellIndex + command.args.amount;
-    const targetCell = lookupCellByIndex(
-      targetCellIndex,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const currentFirstVariableIndex = findVariableIndex(
-      command.args.cell.variables[0]
-    );
-    const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-    const change = targetFirstVariableIndex - currentFirstVariableIndex;
-    console.log(
-      "moveCell",
-      cellIndex,
-      targetCellIndex,
-      targetCell,
-      currentFirstVariableIndex,
-      targetFirstVariableIndex,
-      change
-    );
-    command.args.cell.variables.forEach((v) => {
-      const currentIndex = findVariableIndex(v);
-      repositionSetElement(runtime._variables, v, currentIndex + change);
-    });
-    // recompute
-    await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
-    result = true;
-  }
-  if (result) {
-    command.processed = true;
-    $2.resolve(result);
-  }
+    if (command.processed)
+        return;
+    let result = undefined;
+    if (command.command == 'createCell') {
+        $0.value = true;
+        result = await compile_and_update('{}', [], command.args.cell);    // For the new one to get focus
+                                                                           // setTimeout(() => {
+                                                                           //   debugger;
+                                                                           //   setOption(result[0], "pinned", true);
+                                                                           // }, 100);
+    } else if (command.command == 'deleteCell') {
+        remove_variables(command.args.cell.variables);
+        result = true;
+    } else if (command.command == 'moveCell') {
+        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const targetCellIndex = cellIndex + command.args.amount;
+        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
+        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+        const change = targetFirstVariableIndex - currentFirstVariableIndex;
+        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
+        command.args.cell.variables.forEach(v => {
+            const currentIndex = findVariableIndex(v);
+            repositionSetElement(runtime._variables, v, currentIndex + change);
+        });
+        // recompute
+        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        result = true;
+    }
+    if (result) {
+        command.processed = true;
+        $2.resolve(result);
+    }
 };
 const _1jadxoe = function _60(md){return(
 md`### UI Action`
@@ -5856,9 +5839,9 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
-    return (source, variables = [], cell) => {
+    return async (source, variables = [], cell) => {
         try {
             debugger;
             let reposition = false, insertionIndex = -1;
@@ -5878,10 +5861,10 @@ const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElemen
             if (reposition) {
                 insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
+            const fns = await realize(newVariables.map(v => v._definition), runtime);
             newVariables.forEach((v, i) => {
                 const variable = variables[i];
-                let _fn;
-                eval('_fn = ' + v._definition);
+                const _fn = fns[i];
                 if (v._name) {
                     variable.define(v._name, v._inputs, _fn);
                 } else {
@@ -5930,12 +5913,11 @@ Inputs.textarea({
 })
 )};
 const _b4rsn5 = (G, _) => G.input(_);
-const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
+const _ga6kci = function _98(Inputs,definition,variable,realize,runtime,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
-  reduce: () => {
-    let _fn;
-    eval("_fn = " + definition);
+  reduce: async () => {
+    const [_fn] = await realize([definition], runtime);
     variable.define(variable._name, inputs, _fn);
   }
 })
@@ -6048,7 +6030,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_geoudp", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _geoudp);  
+  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6086,7 +6068,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
+  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -6096,8 +6078,9 @@ export default function define(runtime, observer) {
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
   $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
-  $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
+  $def("_ga6kci", null, ["Inputs","definition","variable","realize","runtime","inputs"], _ga6kci);  
   $def("_1q557s", null, ["md"], _1q557s);  
+  main.define("realize", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("realize", _));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -15851,7 +15834,7 @@ H4sICB8jLWcCA2Fjb3JuLXdhbGtAOC4zLjIuanMApVlbU+O4En6fX2E4VZQza5wAs8yC8XK47FZRNbcC
 >
 H4sICOAiLWcCA3BhcnNlckA2LjEuMC5qcwDtOmtz20aS3/MrIF6KAWIIFKX4ETCwYstKnW4V2yfJSW2ptKsh0KQmAgF6MJTEpfDfr3sewICknNzdbu1+2CqVOK/u6el3z2Dw7bdfed96bxdFlkPmjZfeb9U7yPmd8BYVL6beWZnni7l3tx+9/D4aeqzIvAsQFQjv7nk0/D7ajwj+g+BTXrDcm/AcYm9QzGeDH8sxLrtj4xxuPg/mjIB+fBENo71BJdIBLzJ4iH6rEJwwvCu99x8ucFPwzs9OvHsub7xsWbAZT1meL70pFCCYRBppi2rH+7kU4PFiUooZk7wsYu9GynkVDwb39/eIN1OniNJyNlAn2a0E3yW0uwbtrkKEew++4rN5KeTqorw9KgsJD9JjlQehLG8vlnOoqCfDj+oE1BbhFOQpL+AEt6eBop6IctZTx2ZpKYofX0XDYXQweAbVrDcy6GfsFmh1FbIihUqWChkPK5zP1Qxbx7N7z/JbRHYQ7Rtcd0x4ZVLAvXcO0r/svRGCLXuh/n27mExAYI/JckyDi4yX5kjYfZur0bdlmQMrqMWnJwXNjGXJ8CfFcYEjJLbc9i/4DMoFrUrLokJQaonlXJbYOFrgOWbHd6DQvGOS/cLhXjdpYQZpmcGnsxO3fVQiQwoNksEdT+Ejf4D8jORIQ2W6mOlZKFrwpu2CHwtR0oGhStmcNgRN+QRkeoO/P3FFL/2c8kqa5hmwTPHpp7xk8mDfMlF1X3zXdBdFSqqFzf9UEBW2TmZsCvaXDkztYsILLpeqKYcvLALstMix88ppE5W8+ongQDXfs/f4+1/nH+jnZzZX/yUdQs+8X8zGiuiC3fEpSpjaH8a/QUrHUval6LcdLdk5CGUiqHHY+4gI999RA/WMV6BbD0TSGSumYNl5BqhHyHB3INcbncH0+IGISwln/qbg2v5+EmxG+AR8XqByb4yjuuL/CqSjX9hrtetcCjRTaixn4zJXjUKyB0vCBSrxO6VCtndc2J684SQbsla7/BN3JUG9VhTUe9XpHOVsNofMjqE7BBQpZKrdKBcqX4P+7BT//wrsVouKWvqIv8L4vExvdbsUt4rAe3R35X3vKgjTpPJXJ8oj+MGqDslekKECqgq55aPXCUWwEj5EPMN27yRDTecTjmiCOvx5Icmh/mGAOhhNjBZ7cx9wHciFKBrVbhH1kiSBSCIHHx+baeR3zoSSY2ce+VTe/w4OVKwpyr4dqxtKcocSdErp7blEd6FsvkNFic7oyakPkyentk7Q8VsSFn8nZrQYb0gUwYqcpPREsqLZuOFCOC6zZXwJEf1e1WGhfDjqTohUGGOr4qpOYKSp8pgvwtURBr+WrBiS13qDFUVFgFiETEyVt6xiTsB84rsasJMkwpxDRBj2AAfk42MVqfD7YeKL4Ie9QO9IsEOc51EOxVTePD7u+L1TdE8CjRUPzC/3rhSufn/wl8tveleDSKKl+2pcsPsAeXUBGMuQ+dvB9mwXmiNVZrMgkDeoU552aBHDyWnhqzjXegH/+uuVrD1yMVxQXPYosmPszPV2XqV8iGd5ch2EqwJdRAxoB4pvl+wq4WGZuOdiirpDFqFTWkDMos8LVvGK6FQjmEOUt5Ch5a4qyYTEFeo3hCLDNv6vR0V0wyq/DA6LCHMDbETzRXXjp0FcRBUNhJfpFZpjmAZh0erMBHVmJdk0Rhtm9yjNKYZolldxEUZRhNqwqoNVDtLjJJxikec7iez3UXV5soyUm0cMlTmcx5KxGZQ0OPUZOoQiCO+pEYQ8wq0Shr+4WbKzI2rIMd/iSeaiMuo39XkIGhgbCFyj9leVl3noefHMmAZpVRSLFGMRwiLFqP/VAkOO3xXjCtIZ+wXjJ+nw8KAmfGp1DRQMztNyDq09evt91JVnz8ipRx/+apkVKsxRB6KGBy51x4FWgOlCoFHZyWiSs2nV7+/uPoG1xVPrUEq+R1u0wTtEVVkDRklE7J5xFIlvpli1LNJkZy8wiNeQaeRvCMb/MuYvIjQINLY/c8gzh31fRGfy6FKso7RYNE4ToFqkCrxA0ftBCFE1h1Q5mErv5MCcN1O4Uk2SdRFJ0V8p/bakNLh4QapCruCLuAwy9By42uS0C5b7PZUyK6LKhUgh6e6pPcJhi5m86RvMWf0gVoMY3hVKyCy9lMtVN+/Rb6DIepoS1/d3WOSSaHw/JJdXobA5+ojMt0BujzAP850z+DIaC5bCaTDa0cOsGTsLRmjiaPEBQg5H2kwna9BY2syYoZlN0CouBOM5nvaIJlpUwVhgcmJchGGycmDqiMGoiu4wB0ksDS5vaaKcIHeraKYzj2RHL+/3t603ixSArnogc6VKgcmyOb2B9PZTgX4c00HkfgvhLjgtMdJtzq3ty6pecIirclr9xzdUy7ftpieC2GJs93cX/8Lyc1W7WYiwh8LGwwsVDcygCruB4RdKqGqWmzBy3cZr75uvVy5Y/Y13Q3VhjhLMlt4YoPAypYqQXdM+LMu6+6AdqMizrsmV1eRGYXtBUBvjhrprGmtmryZ/Zssx/AmW96XInPTTqkjY6yayPcwGfh/Y6guWOuuJLSFw3JNDW63YdgR5jia35uiSvbDrN4fhpuMzY+QaUomWaVSqDSzD7zBTVLxTu9gUW7NEGFE6CiOUH8sSEer8LsHcINIEuNTgYEvFOlnWvTVxaJszInKs/zGkCet2dEaZ+VhTKEhezBcybK09UJ6oSlSGcoEZTYF78ISSipCpn5ErdIfJoevDtSH0+y4aNU2ZJckKitNDvuHK/XW3Q8bVgEE56fedfgUzjoHC2ZeUG0esuuGqSmdn/X6jRe3g46O/dlAHuUZVdDw/Lti2Xm0Nn3FjlvxzTWHTp60R3I0N8DkIOofQoaYjGFV5YRj03UGHJMxUVcKZMKcIcqhSpYJO7HtHlBtum0NJMGzyLLARnGSblrnawNpSS3c56Si+UXIeMqP1F+X8FO4g3+qjzGrMbGpZvlG5J3Gya8Bb+NtUc4cQa5+zBbx2DB6s0cmEDP/xEUZ+qZy+Vi8qhZrCrNcocDcKyO3+X1rPzzHFNrHq2uzuRK+2fG1NAoxuuxahx4wC6Y3BbvypsQDvVmskEQCGgGubH25uXa8HwK6LdMCcNV9mPLIxNox2DBOMh9eEa30kKbXeZC3HRAU67DnnwkrFKyeecoa92J2RZDjWmT5hlSr/t4kXr5yUA4I23dvIqLbmzPzJTKjj47FGqGuNeaY8OjLuuoc6TX8+JK8fIqr9iQAs+1RJtmxKsqxTkmGJBbYgU22HV+gRWHr734tSQuM6xJs8L+8xY9sZ1nQvyVluTtzUKpezKzf6GOm4sWJDHDbhV4456fVssSq28M29GMAs2uTOLdvs9cJxrq53/BWvLth0ClmMZ6Yin3JsYQr45LK4GjXk2DgzCroeJytzTKfe6kw87FDgZFIbvnHd4ZpcO7Sba9j/De2N2hRYpvO8yUuMAq1rigg3Lls2gsB2ZyqUX0c1a64hHlC+EBPvNL/mZfVDm0OYG5pm6tmzoMJKLjWs0WvSGyaOkK43JtLjOrIQhoXL9/vx01h3h02pj/MjU6oQ2MGLmC6k9g9sOfvkRs+GQWul2LcASrWMy200kheoiDyzvAs6QQRxJfsuy3R0XdMSTSVmzbUL3AVY28ZJyaIq5yn46x5MMczcsYz/33cs+/++Y/mXv2N5KpX5B1QzTV2yPc8DrZmOmf0D6xd0ej3X+Ux18pCUyoY1oYG6xt64eVHpAs0rcw4gaq/O7UR7m3S4MRLN2NynEArtdUIQY5hR9ytSLFcdjJbC/+O9ftW80soACyzcpjly2UWp74zBBoCdHUyL9RWCDJ58X2iBDvU1gEkxzYUzhM0bsZ64CoLOvTN6fNIENkMZleKYoTv3ZfIa8YSUWqiEpd+nTanlwGaaDhMCdPqmPb378BDfKESOQzdvlR+ZRM0sejFuL1BRhOTgkABEAm0QdGDVw5wDCjqIdgHRo22D/ai3WfZinNVpCK5xV5xBJU1Y1ots7r62TtcENNGQQqtzmDgrM5iwRS5j/Z5BUtBvFz3KoNNyWvC/YfY51wg8pU1e75nho2MX6hrmxqc7BX0d1U4ttQgoOxImwVcPP+2zJb37BCuK6CaFsuF2f1S8TvZGu7uFMrdulYJ6t/Alpk2B8yRUqhHMy+3YenlLrhBXmFLQF8m1rki8r1coFYUONUgXFVhTbC8D1jCYAmY7ihqp2qmUgYhg2zH+0FtSC0OVVlFKj+n0t+e+GjGdyJFk3HzJFgYQ/J4dqIFfmOB0nkZtSDLGkqk8kYFiNMlaGbHD/qfY1UpU882C/KFntFaRsQzyFCEM23eGTK8pArsvaJuWuHaO1jCDBzyNtC5tqwPYgG39wTbo1oxNsLwreUaiaE1605jXlzqG7chzrOX50Nqyzew4PcJa6TmhKFYQyWtjg+r2bIu1DZW19fs0T4qp7M7vIZ91LLvlRXY41yYX58b0lAWo5giirN1zw0vSgz8aQFCHW56ov0QhuP4A1imEgCjCgGEIwdZI+yGMAyHpfLthPAnV1c/fYWPY3f3SxrXeKG6jMkWwbowKjxjaIq5bVLC2UIU6FR90M6RT2AxDOezmYjyehWtX5c3Ie7SJao5FgDOl3nQ7emI0PF6GrSOIl+261vqcp/1xuBFdcOzTPKOSsV3WTUrWVTrsfheBCLrfUMRjRQWr1cVxnTLlukziRXbu5BcUv9WYvT6GCA9fsSk8S649/+uViHKMNXVMrbTMF7OiDq7p/aGkbKyF1AEsEWGGzkGCp+dq7ahAv0F3Ei9MlZqHicZG71ufq3Ktfn9LgrjTTRB1Skff+b2REg1HeaaE9EV9BtYOqvdD5DQbowc5ynm77l1nUL8zQorkmflz1VHjGEJQ1KmipIPj/cZE71+L9+scsinsJk/aGcuFdmTb+c1sK099xONEf+Tl9xSVyL7zZmRWZuZ9KjxpBq0a4OBtM0gRqud84HRH7FQeGJPv4xFJv40xnGIMXexifY4ZGBXT3ZJ5WAdNVluZq4tjFb69c7qJ4N3HCCU4umo4dp4l6PsW+wLRXMJ2BlUh5QzRnsk5XYlJXiygrpJbrCF4O9DduSkNHx/dUXVtQJhOWkDnKuV2jX74HDR3TYoK997lZG0xSSiwWEebjOj3OX0D8wPYL3ls6NSoTSStW4W3A/CgPovN6MtXKgz1B7bhkvr23sQZn9B4c/cY3qkuwO1JFqbUpk9l65FG6pkk3FPR56vB4D88/XUA6uKcF9NPZ6fJoJoNMjaewKv0OYwnr9hzdrB3MMmeP987eAUwefny1ffsJUvHL4bfPX+ZpbA3hvH4VXbwcnLA9sfP0zGkVFH+D3KMR1ZDLQAA
 </script>
-<script id="@tomlarkworthy/observablejs-toolchain" 
+<script id="@tomlarkworthy/observablejs-toolchain"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -16477,10 +16460,9 @@ notebook_semantics_document.nodes.map((s) => ({
 const _1oevsow = function _28(md){return(
 md`### Runtime Representation (v4)`
 )};
-const _11lfflk = function _notebook_semantics_module(){return(
-importShim("https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4"
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _11lfflk = function _notebook_semantics_module() {
+    return import('https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4');
+};
 const _gjten6 = function _31(md){return(
 md`### Imports`
 )};
@@ -17467,65 +17449,44 @@ parser.parseCell(
   'import {runtime, viewof main as foo} from "@mootari/access-runtime"'
 )
 )};
-const _1n7gw17 = function _findModuleName(extractModuleInfo){return(
-(scope, module, { unknown_id = Math.random() } = {}) => {
-  try {
-    const scopedVariables = [...scope.values()];
-
-    // Prefer variables that *define* a module and have a real module-loader name.
-    const candidates = scopedVariables.filter(
-      (v) =>
-        v &&
-        v._value === module &&
-        typeof v._name === "string" &&
-        v._name.startsWith("module ") &&
-        !v._name.startsWith("module <unknown")
-    );
-
-    const pickBestInfo = (dfn) => {
-      // Avoid the parentUrl (2nd arg) confusing module identification.
-      // Typical patterns:
-      //   importShim("/d/<id>@<ver>.js?v=4", "https://api.observablehq.com/@ns/name.js?v=4")
-      //   import("/d/<id>@<ver>.js?v=4")
-      // Prefer the *first argument* inside importShim(...) / import(...) when present.
-      const s = String(dfn ?? "");
-
-      // Try to capture the first string literal argument to importShim(...) or import(...)
-      // Tolerates quotes ", ', ` and both importShim and plain import.
-      const m = s.match(
-        /\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/
-      );
-      const firstArg = m?.[2];
-
-      const info1 = firstArg ? extractModuleInfo(firstArg) : {};
-      if (info1?.id || info1?.notebook) return info1;
-
-      // Fallback: parse the whole definition string.
-      return extractModuleInfo(s);
+const _1n7gw17 = function _findModuleName(extractModuleInfo) {
+    return (scope, module, {
+        unknown_id = Math.random()
+    } = {}) => {
+        try {
+            const scopedVariables = [...scope.values()];
+            const candidates = scopedVariables.filter(v => v && v._value === module && typeof v._name === 'string' && v._name.startsWith('module ') && !v._name.startsWith('module <unknown'));
+            const pickBestInfo = dfn => {
+                const s = String(dfn ?? '');
+                const m = s.match(/\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/);
+                const firstArg = m?.[2];
+                const info1 = firstArg ? extractModuleInfo(firstArg) : {};
+                if (info1?.id || info1?.notebook)
+                    return info1;
+                return extractModuleInfo(s);
+            };
+            for (const v of candidates) {
+                const info = pickBestInfo(v._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            const any = scopedVariables.find(v => v && v._value === module);
+            if (any) {
+                const info = pickBestInfo(any._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            return `<unknown ${ unknown_id }>`;
+        } catch (e) {
+            debugger;
+            return 'error';
+        }
     };
-
-    // Try module loader cells first.
-    for (const v of candidates) {
-      const info = pickBestInfo(v._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    // Fallback: any scoped variable with _value==module.
-    const any = scopedVariables.find((v) => v && v._value === module);
-    if (any) {
-      const info = pickBestInfo(any._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    return `<unknown ${unknown_id}>`;
-  } catch (e) {
-    debugger;
-    return "error";
-  }
-}
-)};
+};
 const _i47chb = function _findImportedName(){return(
 async (v) => {
   if (v._inputs.length == 1 && v._inputs[0]._name === "@variable") {
@@ -18427,229 +18388,206 @@ JSON.stringify(
 const _1lt3kl6 = function _157(compile,test_case){return(
 compile(test_case.value)
 )};
-const _lpzjrv = function _compile(parser,globalThis,observableToJs){return(
-function compile(source, { anonymousName = "_anonymous" } = {}) {
-  const comments = [],
-    tokens = [];
-  let cell;
-  try {
-    cell = parser.parseCell(source, {
-      ranges: true,
-      onComment: comments,
-      onToken: tokens
-    });
-  } catch (e) {
-    if (e instanceof SyntaxError) {
-      const nameMatch = source.match(
-        /^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/
-      );
-      let _name = null;
-      let funcName = anonymousName;
-      if (nameMatch) {
-        const prefix = nameMatch[1] ? nameMatch[1] + " " : "";
-        _name = prefix + nameMatch[2];
-        funcName = "_" + nameMatch[2];
-      }
-      const escapedMsg = JSON.stringify(e.message);
-      const escapedSource = JSON.stringify(source);
-      return [
-        {
-          _name,
-          _inputs: [],
-          _definition: `function ${funcName}() { throw Object.assign(new SyntaxError(${escapedMsg}), {_sourceExpression: ${escapedSource}}); }`
+const _x1d0wm = function _compile(parser,observableToJs){return(
+function compile(source, {
+    anonymousName = '_anonymous'
+} = {}) {
+    const comments = [], tokens = [];
+    let cell;
+    try {
+        cell = parser.parseCell(source, {
+            ranges: true,
+            onComment: comments,
+            onToken: tokens
+        });
+    } catch (e) {
+        if (e instanceof SyntaxError) {
+            const nameMatch = source.match(/^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/);
+            let _name = null;
+            let funcName = anonymousName;
+            if (nameMatch) {
+                const prefix = nameMatch[1] ? nameMatch[1] + ' ' : '';
+                _name = prefix + nameMatch[2];
+                funcName = '_' + nameMatch[2];
+            }
+            const escapedMsg = JSON.stringify(e.message);
+            const escapedSource = JSON.stringify(source);
+            return [{
+                    _name,
+                    _inputs: [],
+                    _definition: `function ${ funcName }() { throw Object.assign(new SyntaxError(${ escapedMsg }), {_sourceExpression: ${ escapedSource }}); }`
+                }];
         }
-      ];
+        throw e;
     }
-    throw e;
-  }
-  if (!cell) throw new Error("Unable to parse cell");
-  const parseImportSpecifierText = (text) => {
-    const t = String(text ?? "")
-      .trim()
-      .replace(/,$/, "")
-      .trim();
-    if (!t) throw new Error("Empty import specifier");
-    const parts = t.split(/\s+as\s+/);
-    const left = parts[0].trim();
-    const right = parts[1]?.trim();
-    const parseSide = (side, { defaultPrefix = "" } = {}) => {
-      const s = String(side ?? "").trim();
-      const m = s.match(/^(viewof|mutable)\s+(.+)$/);
-      if (m)
-        return {
-          prefix: `${m[1]} `,
-          name: m[2].trim()
+    if (!cell)
+        throw new Error('Unable to parse cell');
+    const parseImportSpecifierText = text => {
+        const t = String(text ?? '').trim().replace(/,$/, '').trim();
+        if (!t)
+            throw new Error('Empty import specifier');
+        const parts = t.split(/\s+as\s+/);
+        const left = parts[0].trim();
+        const right = parts[1]?.trim();
+        const parseSide = (side, {
+            defaultPrefix = ''
+        } = {}) => {
+            const s = String(side ?? '').trim();
+            const m = s.match(/^(viewof|mutable)\s+(.+)$/);
+            if (m)
+                return {
+                    prefix: `${ m[1] } `,
+                    name: m[2].trim()
+                };
+            return {
+                prefix: defaultPrefix,
+                name: s
+            };
         };
-      return {
-        prefix: defaultPrefix,
-        name: s
-      };
+        const L = parseSide(left);
+        const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
+        const importedName = `${ L.prefix }${ L.name }`.trim();
+        const localName = `${ R.prefix }${ R.name }`.trim();
+        if (!importedName)
+            throw new Error(`Could not parse imported name from: ${ t }`);
+        if (!localName)
+            throw new Error(`Could not parse local name from: ${ t }`);
+        return {
+            importedName,
+            localName
+        };
     };
-    const L = parseSide(left);
-    const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
-    const importedName = `${L.prefix}${L.name}`.trim();
-    const localName = `${R.prefix}${R.name}`.trim();
-    if (!importedName)
-      throw new Error(`Could not parse imported name from: ${t}`);
-    if (!localName) throw new Error(`Could not parse local name from: ${t}`);
-    return {
-      importedName,
-      localName
-    };
-  };
-  if (!cell.id && cell.body?.type === "ImportDeclaration") {
-    const module_name = cell.body.source.value;
-    const importKeyword = globalThis?.importShim ? "importShim" : "import";
-    const cell_variables = [
-      {
-        _name: `module ${module_name}`,
-        _inputs: [],
-        _definition: `async () => runtime.module((await ${importKeyword}("${module_name}")).default)`
-      }
-    ];
-    for (const specifier of cell.body.specifiers ?? []) {
-      const specText =
-        typeof specifier?.start === "number" &&
-        typeof specifier?.end === "number"
-          ? source.slice(specifier.start, specifier.end)
-          : (() => {
-              if (specifier?.imported?.name && specifier?.local?.name) {
-                return specifier.imported.name === specifier.local.name
-                  ? specifier.local.name
-                  : `${specifier.imported.name} as ${specifier.local.name}`;
-              }
-              throw new Error("Import specifier missing range information");
+    if (!cell.id && cell.body?.type === 'ImportDeclaration') {
+        const module_name = cell.body.source.value;
+        const cell_variables = [{
+                _name: `module ${ module_name }`,
+                _inputs: [],
+                _definition: `async () => runtime.module((await import("${ module_name }")).default)`
+            }];
+        for (const specifier of cell.body.specifiers ?? []) {
+            const specText = typeof specifier?.start === 'number' && typeof specifier?.end === 'number' ? source.slice(specifier.start, specifier.end) : (() => {
+                if (specifier?.imported?.name && specifier?.local?.name) {
+                    return specifier.imported.name === specifier.local.name ? specifier.local.name : `${ specifier.imported.name } as ${ specifier.local.name }`;
+                }
+                throw new Error('Import specifier missing range information');
             })();
-      const { importedName, localName } = parseImportSpecifierText(specText);
-      cell_variables.push({
-        _name: localName,
-        _inputs: [`module ${module_name}`, "@variable"],
-        _definition:
-          importedName === localName
-            ? `(_, v) => v.import("${importedName}", _)`
-            : `(_, v) => v.import("${importedName}", "${localName}", _)`
-      });
+            const {importedName, localName} = parseImportSpecifierText(specText);
+            cell_variables.push({
+                _name: localName,
+                _inputs: [
+                    `module ${ module_name }`,
+                    '@variable'
+                ],
+                _definition: importedName === localName ? `(_, v) => v.import("${ importedName }", _)` : `(_, v) => v.import("${ importedName }", "${ localName }", _)`
+            });
+        }
+        return cell_variables;
     }
-    return cell_variables;
-  }
-  let dollarIdx = 0;
-  const inputToArgMap = {};
-  const dollarToMacro = {};
-  const seen = new Set();
-  const inputs = Array.from(cell.references || []).flatMap((i) => {
-    if (i.name) {
-      if (seen.has(i.name)) return [];
-      seen.add(i.name);
-      return i.name;
+    let dollarIdx = 0;
+    const inputToArgMap = {};
+    const dollarToMacro = {};
+    const seen = new Set();
+    const inputs = Array.from(cell.references || []).flatMap(i => {
+        if (i.name) {
+            if (seen.has(i.name))
+                return [];
+            seen.add(i.name);
+            return i.name;
+        } else {
+            const dedupKey = i.type + ':' + i.id.name;
+            if (seen.has(dedupKey))
+                return [];
+            seen.add(dedupKey);
+            const dollarName = '$' + dollarIdx;
+            inputToArgMap[i.id.name] = dollarName;
+            dollarToMacro[dollarName] = i.type == 'ViewExpression' ? 'viewof ' + i.id.name : 'mutable ' + i.id.name;
+            dollarIdx++;
+            return dollarName;
+        }
+    });
+    let variables;
+    if (cell.id) {
+        if (cell.id.type === 'Identifier') {
+            variables = [{
+                    functionName: '_' + cell.id.name,
+                    name: cell.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                }];
+        } else if (cell.id.type === 'ViewExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'viewof ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '(G, _) => G.input(_)',
+                    inputs: [
+                        'Generators',
+                        'viewof ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                }
+            ];
+        } else if (cell.id.type === 'MutableExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'initial ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'mutable ' + cell.id.id.name,
+                    _definition: '(M, _) => new M(_)',
+                    inputs: [
+                        'Mutable',
+                        'initial ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '_ => _.generator',
+                    inputs: ['mutable ' + cell.id.id.name],
+                    params: inputs.join(',')
+                }
+            ];
+        } else {
+            throw new Error(`Unsupported cell id type: ${ cell.id.type }`);
+        }
     } else {
-      const dedupKey = i.type + ":" + i.id.name;
-      if (seen.has(dedupKey)) return [];
-      seen.add(dedupKey);
-      const dollarName = "$" + dollarIdx;
-      inputToArgMap[i.id.name] = dollarName;
-      dollarToMacro[dollarName] =
-        i.type == "ViewExpression"
-          ? "viewof " + i.id.name
-          : "mutable " + i.id.name;
-      dollarIdx++;
-      return dollarName;
+        variables = [{
+                functionName: anonymousName,
+                name: null,
+                inputs,
+                params: inputs.join(',')
+            }];
     }
-  });
-  let variables;
-  if (cell.id) {
-    if (cell.id.type === "Identifier") {
-      variables = [
-        {
-          functionName: "_" + cell.id.name,
-          name: cell.id.name,
-          inputs,
-          params: inputs.join(",")
+    return variables.map(v => {
+        let _definition = v._definition;
+        if (!_definition) {
+            let functionBody;
+            if (cell.body.type === 'BlockStatement') {
+                functionBody = observableToJs(cell.body, inputToArgMap, comments, tokens);
+            } else {
+                const bodyCode = observableToJs(cell.body, inputToArgMap, comments, tokens);
+                functionBody = `{return (${ bodyCode });}`;
+            }
+            _definition = `${ cell.async ? 'async ' : '' }function${ cell.generator ? '*' : '' } ${ v.functionName }(${ v.inputs.join(',') }) ${ functionBody }`;
         }
-      ];
-    } else if (cell.id.type === "ViewExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "viewof " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "(G, _) => G.input(_)",
-          inputs: ["Generators", "viewof " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else if (cell.id.type === "MutableExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "initial " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "mutable " + cell.id.id.name,
-          _definition: "(M, _) => new M(_)",
-          inputs: ["Mutable", "initial " + cell.id.id.name],
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "_ => _.generator",
-          inputs: ["mutable " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else {
-      throw new Error(`Unsupported cell id type: ${cell.id.type}`);
-    }
-  } else {
-    variables = [
-      {
-        functionName: anonymousName,
-        name: null,
-        inputs,
-        params: inputs.join(",")
-      }
-    ];
-  }
-  return variables.map((v) => {
-    let _definition = v._definition;
-    if (!_definition) {
-      let functionBody;
-      if (cell.body.type === "BlockStatement") {
-        functionBody = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-      } else {
-        const bodyCode = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-        functionBody = `{return (${bodyCode});}`;
-      }
-      _definition = `${cell.async ? "async " : ""}function${
-        cell.generator ? "*" : ""
-      } ${v.functionName}(${v.inputs.join(",")}) ${functionBody}`;
-    }
-    return {
-      _name: v.name,
-      _inputs: v.inputs.map(
-        (i) => dollarToMacro[i] || (i === "$variable" ? "@variable" : i)
-      ),
-      _definition
-    };
-  });
+        return {
+            _name: v.name,
+            _inputs: v.inputs.map(i => dollarToMacro[i] || (i === '$variable' ? '@variable' : i)),
+            _definition
+        };
+    });
 }
 )};
 const _1v1i7wl = function _observableToJs(acorn_walk,parser,escodegen){return(
@@ -18716,16 +18654,15 @@ async (attachment, overrides) => {
   return URL.createObjectURL(blob);
 }
 )};
-const _s9w7ha = async function _parser(decompress_url,FileAttachment,acorn_url,acorn_walk_url){return(
-importShim(await decompress_url(FileAttachment("parser-6.1.0.js.gz"), {
-    "/npm/acorn@8.11.3/+esm": acorn_url,
-    "/npm/acorn-walk@8.3.2/+esm": acorn_walk_url
-  })
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
-const _1hiclbb = function _acorn_walk(acorn_walk_url){return(
-importShim(acorn_walk_url, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _s9w7ha = async function _parser(decompress_url, FileAttachment, acorn_url, acorn_walk_url) {
+    return import(await decompress_url(FileAttachment('parser-6.1.0.js.gz'), {
+        '/npm/acorn@8.11.3/+esm': acorn_url,
+        '/npm/acorn-walk@8.3.2/+esm': acorn_walk_url
+    }));
+};
+const _1hiclbb = function _acorn_walk(acorn_walk_url) {
+    return import(acorn_walk_url);
+};
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
@@ -18913,7 +18850,7 @@ export default function define(runtime, observer) {
   $def("_1dmmuaf", "compiled_selector", ["Generators","viewof compiled_selector"], _1dmmuaf);  
   $def("_u7t3vu", null, ["compiled_selector","normalizeJavascriptSource"], _u7t3vu);  
   $def("_1lt3kl6", null, ["compile","test_case"], _1lt3kl6);  
-  $def("_lpzjrv", "compile", ["parser","globalThis","observableToJs"], _lpzjrv);  
+  $def("_x1d0wm", "compile", ["parser","observableToJs"], _x1d0wm);  
   $def("_1v1i7wl", "observableToJs", ["acorn_walk","parser","escodegen"], _1v1i7wl);  
   $def("_19lv24l", null, ["md"], _19lv24l);  
   $def("_xhj6b8", "decompress_url", ["DecompressionStream","TextDecoderStream","TransformStream","TextEncoderStream","Response"], _xhj6b8);  
@@ -18928,7 +18865,8 @@ export default function define(runtime, observer) {
   main.define("Library", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Library", _));  
   main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));
   return main;
-}</script>
+}
+</script>
 
 <script id="@tomlarkworthy/reversible-attachment" 
   type="text/plain"

--- a/notebooks/@tomlarkworthy_codemirror-6-v2.html
+++ b/notebooks/@tomlarkworthy_codemirror-6-v2.html
@@ -5437,58 +5437,41 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _geoudp = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
-  if (command.processed) return;
-
-  let result = undefined;
-  if (command.command == "createCell") {
-    $0.value = true;
-    result = compile_and_update("{}", [], command.args.cell);
-    // For the new one to get focus
-    // setTimeout(() => {
-    //   debugger;
-    //   setOption(result[0], "pinned", true);
-    // }, 100);
-  } else if (command.command == "deleteCell") {
-    remove_variables(command.args.cell.variables);
-    result = true;
-  } else if (command.command == "moveCell") {
-    const cellIndex = findCellIndex(
-      command.args.cell.variables,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const targetCellIndex = cellIndex + command.args.amount;
-    const targetCell = lookupCellByIndex(
-      targetCellIndex,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const currentFirstVariableIndex = findVariableIndex(
-      command.args.cell.variables[0]
-    );
-    const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-    const change = targetFirstVariableIndex - currentFirstVariableIndex;
-    console.log(
-      "moveCell",
-      cellIndex,
-      targetCellIndex,
-      targetCell,
-      currentFirstVariableIndex,
-      targetFirstVariableIndex,
-      change
-    );
-    command.args.cell.variables.forEach((v) => {
-      const currentIndex = findVariableIndex(v);
-      repositionSetElement(runtime._variables, v, currentIndex + change);
-    });
-    // recompute
-    await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
-    result = true;
-  }
-  if (result) {
-    command.processed = true;
-    $2.resolve(result);
-  }
+    if (command.processed)
+        return;
+    let result = undefined;
+    if (command.command == 'createCell') {
+        $0.value = true;
+        result = await compile_and_update('{}', [], command.args.cell);    // For the new one to get focus
+                                                                           // setTimeout(() => {
+                                                                           //   debugger;
+                                                                           //   setOption(result[0], "pinned", true);
+                                                                           // }, 100);
+    } else if (command.command == 'deleteCell') {
+        remove_variables(command.args.cell.variables);
+        result = true;
+    } else if (command.command == 'moveCell') {
+        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const targetCellIndex = cellIndex + command.args.amount;
+        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
+        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+        const change = targetFirstVariableIndex - currentFirstVariableIndex;
+        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
+        command.args.cell.variables.forEach(v => {
+            const currentIndex = findVariableIndex(v);
+            repositionSetElement(runtime._variables, v, currentIndex + change);
+        });
+        // recompute
+        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        result = true;
+    }
+    if (result) {
+        command.processed = true;
+        $2.resolve(result);
+    }
 };
 const _1jadxoe = function _60(md){return(
 md`### UI Action`
@@ -5879,9 +5862,9 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
-    return (source, variables = [], cell) => {
+    return async (source, variables = [], cell) => {
         try {
             debugger;
             let reposition = false, insertionIndex = -1;
@@ -5901,10 +5884,10 @@ const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElemen
             if (reposition) {
                 insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
+            const fns = await realize(newVariables.map(v => v._definition), runtime);
             newVariables.forEach((v, i) => {
                 const variable = variables[i];
-                let _fn;
-                eval('_fn = ' + v._definition);
+                const _fn = fns[i];
                 if (v._name) {
                     variable.define(v._name, v._inputs, _fn);
                 } else {
@@ -5953,12 +5936,11 @@ Inputs.textarea({
 })
 )};
 const _b4rsn5 = (G, _) => G.input(_);
-const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
+const _ga6kci = function _98(Inputs,definition,variable,realize,runtime,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
-  reduce: () => {
-    let _fn;
-    eval("_fn = " + definition);
+  reduce: async () => {
+    const [_fn] = await realize([definition], runtime);
     variable.define(variable._name, inputs, _fn);
   }
 })
@@ -6071,7 +6053,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_geoudp", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _geoudp);  
+  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6109,7 +6091,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
+  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -6119,8 +6101,9 @@ export default function define(runtime, observer) {
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
   $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
-  $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
+  $def("_ga6kci", null, ["Inputs","definition","variable","realize","runtime","inputs"], _ga6kci);  
   $def("_1q557s", null, ["md"], _1q557s);  
+  main.define("realize", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("realize", _));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -16490,10 +16473,9 @@ notebook_semantics_document.nodes.map((s) => ({
 const _1oevsow = function _28(md){return(
 md`### Runtime Representation (v4)`
 )};
-const _11lfflk = function _notebook_semantics_module(){return(
-importShim("https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4"
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _11lfflk = function _notebook_semantics_module() {
+    return import('https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4');
+};
 const _gjten6 = function _31(md){return(
 md`### Imports`
 )};
@@ -17480,65 +17462,44 @@ parser.parseCell(
   'import {runtime, viewof main as foo} from "@mootari/access-runtime"'
 )
 )};
-const _1n7gw17 = function _findModuleName(extractModuleInfo){return(
-(scope, module, { unknown_id = Math.random() } = {}) => {
-  try {
-    const scopedVariables = [...scope.values()];
-
-    // Prefer variables that *define* a module and have a real module-loader name.
-    const candidates = scopedVariables.filter(
-      (v) =>
-        v &&
-        v._value === module &&
-        typeof v._name === "string" &&
-        v._name.startsWith("module ") &&
-        !v._name.startsWith("module <unknown")
-    );
-
-    const pickBestInfo = (dfn) => {
-      // Avoid the parentUrl (2nd arg) confusing module identification.
-      // Typical patterns:
-      //   importShim("/d/<id>@<ver>.js?v=4", "https://api.observablehq.com/@ns/name.js?v=4")
-      //   import("/d/<id>@<ver>.js?v=4")
-      // Prefer the *first argument* inside importShim(...) / import(...) when present.
-      const s = String(dfn ?? "");
-
-      // Try to capture the first string literal argument to importShim(...) or import(...)
-      // Tolerates quotes ", ', ` and both importShim and plain import.
-      const m = s.match(
-        /\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/
-      );
-      const firstArg = m?.[2];
-
-      const info1 = firstArg ? extractModuleInfo(firstArg) : {};
-      if (info1?.id || info1?.notebook) return info1;
-
-      // Fallback: parse the whole definition string.
-      return extractModuleInfo(s);
+const _1n7gw17 = function _findModuleName(extractModuleInfo) {
+    return (scope, module, {
+        unknown_id = Math.random()
+    } = {}) => {
+        try {
+            const scopedVariables = [...scope.values()];
+            const candidates = scopedVariables.filter(v => v && v._value === module && typeof v._name === 'string' && v._name.startsWith('module ') && !v._name.startsWith('module <unknown'));
+            const pickBestInfo = dfn => {
+                const s = String(dfn ?? '');
+                const m = s.match(/\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/);
+                const firstArg = m?.[2];
+                const info1 = firstArg ? extractModuleInfo(firstArg) : {};
+                if (info1?.id || info1?.notebook)
+                    return info1;
+                return extractModuleInfo(s);
+            };
+            for (const v of candidates) {
+                const info = pickBestInfo(v._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            const any = scopedVariables.find(v => v && v._value === module);
+            if (any) {
+                const info = pickBestInfo(any._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            return `<unknown ${ unknown_id }>`;
+        } catch (e) {
+            debugger;
+            return 'error';
+        }
     };
-
-    // Try module loader cells first.
-    for (const v of candidates) {
-      const info = pickBestInfo(v._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    // Fallback: any scoped variable with _value==module.
-    const any = scopedVariables.find((v) => v && v._value === module);
-    if (any) {
-      const info = pickBestInfo(any._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    return `<unknown ${unknown_id}>`;
-  } catch (e) {
-    debugger;
-    return "error";
-  }
-}
-)};
+};
 const _i47chb = function _findImportedName(){return(
 async (v) => {
   if (v._inputs.length == 1 && v._inputs[0]._name === "@variable") {
@@ -18440,229 +18401,206 @@ JSON.stringify(
 const _1lt3kl6 = function _157(compile,test_case){return(
 compile(test_case.value)
 )};
-const _lpzjrv = function _compile(parser,globalThis,observableToJs){return(
-function compile(source, { anonymousName = "_anonymous" } = {}) {
-  const comments = [],
-    tokens = [];
-  let cell;
-  try {
-    cell = parser.parseCell(source, {
-      ranges: true,
-      onComment: comments,
-      onToken: tokens
-    });
-  } catch (e) {
-    if (e instanceof SyntaxError) {
-      const nameMatch = source.match(
-        /^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/
-      );
-      let _name = null;
-      let funcName = anonymousName;
-      if (nameMatch) {
-        const prefix = nameMatch[1] ? nameMatch[1] + " " : "";
-        _name = prefix + nameMatch[2];
-        funcName = "_" + nameMatch[2];
-      }
-      const escapedMsg = JSON.stringify(e.message);
-      const escapedSource = JSON.stringify(source);
-      return [
-        {
-          _name,
-          _inputs: [],
-          _definition: `function ${funcName}() { throw Object.assign(new SyntaxError(${escapedMsg}), {_sourceExpression: ${escapedSource}}); }`
+const _x1d0wm = function _compile(parser,observableToJs){return(
+function compile(source, {
+    anonymousName = '_anonymous'
+} = {}) {
+    const comments = [], tokens = [];
+    let cell;
+    try {
+        cell = parser.parseCell(source, {
+            ranges: true,
+            onComment: comments,
+            onToken: tokens
+        });
+    } catch (e) {
+        if (e instanceof SyntaxError) {
+            const nameMatch = source.match(/^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/);
+            let _name = null;
+            let funcName = anonymousName;
+            if (nameMatch) {
+                const prefix = nameMatch[1] ? nameMatch[1] + ' ' : '';
+                _name = prefix + nameMatch[2];
+                funcName = '_' + nameMatch[2];
+            }
+            const escapedMsg = JSON.stringify(e.message);
+            const escapedSource = JSON.stringify(source);
+            return [{
+                    _name,
+                    _inputs: [],
+                    _definition: `function ${ funcName }() { throw Object.assign(new SyntaxError(${ escapedMsg }), {_sourceExpression: ${ escapedSource }}); }`
+                }];
         }
-      ];
+        throw e;
     }
-    throw e;
-  }
-  if (!cell) throw new Error("Unable to parse cell");
-  const parseImportSpecifierText = (text) => {
-    const t = String(text ?? "")
-      .trim()
-      .replace(/,$/, "")
-      .trim();
-    if (!t) throw new Error("Empty import specifier");
-    const parts = t.split(/\s+as\s+/);
-    const left = parts[0].trim();
-    const right = parts[1]?.trim();
-    const parseSide = (side, { defaultPrefix = "" } = {}) => {
-      const s = String(side ?? "").trim();
-      const m = s.match(/^(viewof|mutable)\s+(.+)$/);
-      if (m)
-        return {
-          prefix: `${m[1]} `,
-          name: m[2].trim()
+    if (!cell)
+        throw new Error('Unable to parse cell');
+    const parseImportSpecifierText = text => {
+        const t = String(text ?? '').trim().replace(/,$/, '').trim();
+        if (!t)
+            throw new Error('Empty import specifier');
+        const parts = t.split(/\s+as\s+/);
+        const left = parts[0].trim();
+        const right = parts[1]?.trim();
+        const parseSide = (side, {
+            defaultPrefix = ''
+        } = {}) => {
+            const s = String(side ?? '').trim();
+            const m = s.match(/^(viewof|mutable)\s+(.+)$/);
+            if (m)
+                return {
+                    prefix: `${ m[1] } `,
+                    name: m[2].trim()
+                };
+            return {
+                prefix: defaultPrefix,
+                name: s
+            };
         };
-      return {
-        prefix: defaultPrefix,
-        name: s
-      };
+        const L = parseSide(left);
+        const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
+        const importedName = `${ L.prefix }${ L.name }`.trim();
+        const localName = `${ R.prefix }${ R.name }`.trim();
+        if (!importedName)
+            throw new Error(`Could not parse imported name from: ${ t }`);
+        if (!localName)
+            throw new Error(`Could not parse local name from: ${ t }`);
+        return {
+            importedName,
+            localName
+        };
     };
-    const L = parseSide(left);
-    const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
-    const importedName = `${L.prefix}${L.name}`.trim();
-    const localName = `${R.prefix}${R.name}`.trim();
-    if (!importedName)
-      throw new Error(`Could not parse imported name from: ${t}`);
-    if (!localName) throw new Error(`Could not parse local name from: ${t}`);
-    return {
-      importedName,
-      localName
-    };
-  };
-  if (!cell.id && cell.body?.type === "ImportDeclaration") {
-    const module_name = cell.body.source.value;
-    const importKeyword = globalThis?.importShim ? "importShim" : "import";
-    const cell_variables = [
-      {
-        _name: `module ${module_name}`,
-        _inputs: [],
-        _definition: `async () => runtime.module((await ${importKeyword}("${module_name}")).default)`
-      }
-    ];
-    for (const specifier of cell.body.specifiers ?? []) {
-      const specText =
-        typeof specifier?.start === "number" &&
-        typeof specifier?.end === "number"
-          ? source.slice(specifier.start, specifier.end)
-          : (() => {
-              if (specifier?.imported?.name && specifier?.local?.name) {
-                return specifier.imported.name === specifier.local.name
-                  ? specifier.local.name
-                  : `${specifier.imported.name} as ${specifier.local.name}`;
-              }
-              throw new Error("Import specifier missing range information");
+    if (!cell.id && cell.body?.type === 'ImportDeclaration') {
+        const module_name = cell.body.source.value;
+        const cell_variables = [{
+                _name: `module ${ module_name }`,
+                _inputs: [],
+                _definition: `async () => runtime.module((await import("${ module_name }")).default)`
+            }];
+        for (const specifier of cell.body.specifiers ?? []) {
+            const specText = typeof specifier?.start === 'number' && typeof specifier?.end === 'number' ? source.slice(specifier.start, specifier.end) : (() => {
+                if (specifier?.imported?.name && specifier?.local?.name) {
+                    return specifier.imported.name === specifier.local.name ? specifier.local.name : `${ specifier.imported.name } as ${ specifier.local.name }`;
+                }
+                throw new Error('Import specifier missing range information');
             })();
-      const { importedName, localName } = parseImportSpecifierText(specText);
-      cell_variables.push({
-        _name: localName,
-        _inputs: [`module ${module_name}`, "@variable"],
-        _definition:
-          importedName === localName
-            ? `(_, v) => v.import("${importedName}", _)`
-            : `(_, v) => v.import("${importedName}", "${localName}", _)`
-      });
+            const {importedName, localName} = parseImportSpecifierText(specText);
+            cell_variables.push({
+                _name: localName,
+                _inputs: [
+                    `module ${ module_name }`,
+                    '@variable'
+                ],
+                _definition: importedName === localName ? `(_, v) => v.import("${ importedName }", _)` : `(_, v) => v.import("${ importedName }", "${ localName }", _)`
+            });
+        }
+        return cell_variables;
     }
-    return cell_variables;
-  }
-  let dollarIdx = 0;
-  const inputToArgMap = {};
-  const dollarToMacro = {};
-  const seen = new Set();
-  const inputs = Array.from(cell.references || []).flatMap((i) => {
-    if (i.name) {
-      if (seen.has(i.name)) return [];
-      seen.add(i.name);
-      return i.name;
+    let dollarIdx = 0;
+    const inputToArgMap = {};
+    const dollarToMacro = {};
+    const seen = new Set();
+    const inputs = Array.from(cell.references || []).flatMap(i => {
+        if (i.name) {
+            if (seen.has(i.name))
+                return [];
+            seen.add(i.name);
+            return i.name;
+        } else {
+            const dedupKey = i.type + ':' + i.id.name;
+            if (seen.has(dedupKey))
+                return [];
+            seen.add(dedupKey);
+            const dollarName = '$' + dollarIdx;
+            inputToArgMap[i.id.name] = dollarName;
+            dollarToMacro[dollarName] = i.type == 'ViewExpression' ? 'viewof ' + i.id.name : 'mutable ' + i.id.name;
+            dollarIdx++;
+            return dollarName;
+        }
+    });
+    let variables;
+    if (cell.id) {
+        if (cell.id.type === 'Identifier') {
+            variables = [{
+                    functionName: '_' + cell.id.name,
+                    name: cell.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                }];
+        } else if (cell.id.type === 'ViewExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'viewof ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '(G, _) => G.input(_)',
+                    inputs: [
+                        'Generators',
+                        'viewof ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                }
+            ];
+        } else if (cell.id.type === 'MutableExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'initial ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'mutable ' + cell.id.id.name,
+                    _definition: '(M, _) => new M(_)',
+                    inputs: [
+                        'Mutable',
+                        'initial ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '_ => _.generator',
+                    inputs: ['mutable ' + cell.id.id.name],
+                    params: inputs.join(',')
+                }
+            ];
+        } else {
+            throw new Error(`Unsupported cell id type: ${ cell.id.type }`);
+        }
     } else {
-      const dedupKey = i.type + ":" + i.id.name;
-      if (seen.has(dedupKey)) return [];
-      seen.add(dedupKey);
-      const dollarName = "$" + dollarIdx;
-      inputToArgMap[i.id.name] = dollarName;
-      dollarToMacro[dollarName] =
-        i.type == "ViewExpression"
-          ? "viewof " + i.id.name
-          : "mutable " + i.id.name;
-      dollarIdx++;
-      return dollarName;
+        variables = [{
+                functionName: anonymousName,
+                name: null,
+                inputs,
+                params: inputs.join(',')
+            }];
     }
-  });
-  let variables;
-  if (cell.id) {
-    if (cell.id.type === "Identifier") {
-      variables = [
-        {
-          functionName: "_" + cell.id.name,
-          name: cell.id.name,
-          inputs,
-          params: inputs.join(",")
+    return variables.map(v => {
+        let _definition = v._definition;
+        if (!_definition) {
+            let functionBody;
+            if (cell.body.type === 'BlockStatement') {
+                functionBody = observableToJs(cell.body, inputToArgMap, comments, tokens);
+            } else {
+                const bodyCode = observableToJs(cell.body, inputToArgMap, comments, tokens);
+                functionBody = `{return (${ bodyCode });}`;
+            }
+            _definition = `${ cell.async ? 'async ' : '' }function${ cell.generator ? '*' : '' } ${ v.functionName }(${ v.inputs.join(',') }) ${ functionBody }`;
         }
-      ];
-    } else if (cell.id.type === "ViewExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "viewof " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "(G, _) => G.input(_)",
-          inputs: ["Generators", "viewof " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else if (cell.id.type === "MutableExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "initial " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "mutable " + cell.id.id.name,
-          _definition: "(M, _) => new M(_)",
-          inputs: ["Mutable", "initial " + cell.id.id.name],
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "_ => _.generator",
-          inputs: ["mutable " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else {
-      throw new Error(`Unsupported cell id type: ${cell.id.type}`);
-    }
-  } else {
-    variables = [
-      {
-        functionName: anonymousName,
-        name: null,
-        inputs,
-        params: inputs.join(",")
-      }
-    ];
-  }
-  return variables.map((v) => {
-    let _definition = v._definition;
-    if (!_definition) {
-      let functionBody;
-      if (cell.body.type === "BlockStatement") {
-        functionBody = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-      } else {
-        const bodyCode = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-        functionBody = `{return (${bodyCode});}`;
-      }
-      _definition = `${cell.async ? "async " : ""}function${
-        cell.generator ? "*" : ""
-      } ${v.functionName}(${v.inputs.join(",")}) ${functionBody}`;
-    }
-    return {
-      _name: v.name,
-      _inputs: v.inputs.map(
-        (i) => dollarToMacro[i] || (i === "$variable" ? "@variable" : i)
-      ),
-      _definition
-    };
-  });
+        return {
+            _name: v.name,
+            _inputs: v.inputs.map(i => dollarToMacro[i] || (i === '$variable' ? '@variable' : i)),
+            _definition
+        };
+    });
 }
 )};
 const _1v1i7wl = function _observableToJs(acorn_walk,parser,escodegen){return(
@@ -18729,16 +18667,15 @@ async (attachment, overrides) => {
   return URL.createObjectURL(blob);
 }
 )};
-const _s9w7ha = async function _parser(decompress_url,FileAttachment,acorn_url,acorn_walk_url){return(
-importShim(await decompress_url(FileAttachment("parser-6.1.0.js.gz"), {
-    "/npm/acorn@8.11.3/+esm": acorn_url,
-    "/npm/acorn-walk@8.3.2/+esm": acorn_walk_url
-  })
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
-const _1hiclbb = function _acorn_walk(acorn_walk_url){return(
-importShim(acorn_walk_url, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _s9w7ha = async function _parser(decompress_url, FileAttachment, acorn_url, acorn_walk_url) {
+    return import(await decompress_url(FileAttachment('parser-6.1.0.js.gz'), {
+        '/npm/acorn@8.11.3/+esm': acorn_url,
+        '/npm/acorn-walk@8.3.2/+esm': acorn_walk_url
+    }));
+};
+const _1hiclbb = function _acorn_walk(acorn_walk_url) {
+    return import(acorn_walk_url);
+};
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
@@ -18926,7 +18863,7 @@ export default function define(runtime, observer) {
   $def("_1dmmuaf", "compiled_selector", ["Generators","viewof compiled_selector"], _1dmmuaf);  
   $def("_u7t3vu", null, ["compiled_selector","normalizeJavascriptSource"], _u7t3vu);  
   $def("_1lt3kl6", null, ["compile","test_case"], _1lt3kl6);  
-  $def("_lpzjrv", "compile", ["parser","globalThis","observableToJs"], _lpzjrv);  
+  $def("_x1d0wm", "compile", ["parser","observableToJs"], _x1d0wm);  
   $def("_1v1i7wl", "observableToJs", ["acorn_walk","parser","escodegen"], _1v1i7wl);  
   $def("_19lv24l", null, ["md"], _19lv24l);  
   $def("_xhj6b8", "decompress_url", ["DecompressionStream","TextDecoderStream","TransformStream","TextEncoderStream","Response"], _xhj6b8);  

--- a/notebooks/@tomlarkworthy_dataflow-templating.html
+++ b/notebooks/@tomlarkworthy_dataflow-templating.html
@@ -5437,58 +5437,41 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _geoudp = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
-  if (command.processed) return;
-
-  let result = undefined;
-  if (command.command == "createCell") {
-    $0.value = true;
-    result = compile_and_update("{}", [], command.args.cell);
-    // For the new one to get focus
-    // setTimeout(() => {
-    //   debugger;
-    //   setOption(result[0], "pinned", true);
-    // }, 100);
-  } else if (command.command == "deleteCell") {
-    remove_variables(command.args.cell.variables);
-    result = true;
-  } else if (command.command == "moveCell") {
-    const cellIndex = findCellIndex(
-      command.args.cell.variables,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const targetCellIndex = cellIndex + command.args.amount;
-    const targetCell = lookupCellByIndex(
-      targetCellIndex,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const currentFirstVariableIndex = findVariableIndex(
-      command.args.cell.variables[0]
-    );
-    const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-    const change = targetFirstVariableIndex - currentFirstVariableIndex;
-    console.log(
-      "moveCell",
-      cellIndex,
-      targetCellIndex,
-      targetCell,
-      currentFirstVariableIndex,
-      targetFirstVariableIndex,
-      change
-    );
-    command.args.cell.variables.forEach((v) => {
-      const currentIndex = findVariableIndex(v);
-      repositionSetElement(runtime._variables, v, currentIndex + change);
-    });
-    // recompute
-    await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
-    result = true;
-  }
-  if (result) {
-    command.processed = true;
-    $2.resolve(result);
-  }
+    if (command.processed)
+        return;
+    let result = undefined;
+    if (command.command == 'createCell') {
+        $0.value = true;
+        result = await compile_and_update('{}', [], command.args.cell);    // For the new one to get focus
+                                                                           // setTimeout(() => {
+                                                                           //   debugger;
+                                                                           //   setOption(result[0], "pinned", true);
+                                                                           // }, 100);
+    } else if (command.command == 'deleteCell') {
+        remove_variables(command.args.cell.variables);
+        result = true;
+    } else if (command.command == 'moveCell') {
+        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const targetCellIndex = cellIndex + command.args.amount;
+        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
+        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+        const change = targetFirstVariableIndex - currentFirstVariableIndex;
+        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
+        command.args.cell.variables.forEach(v => {
+            const currentIndex = findVariableIndex(v);
+            repositionSetElement(runtime._variables, v, currentIndex + change);
+        });
+        // recompute
+        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        result = true;
+    }
+    if (result) {
+        command.processed = true;
+        $2.resolve(result);
+    }
 };
 const _1jadxoe = function _60(md){return(
 md`### UI Action`
@@ -5879,9 +5862,9 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
-    return (source, variables = [], cell) => {
+    return async (source, variables = [], cell) => {
         try {
             debugger;
             let reposition = false, insertionIndex = -1;
@@ -5901,10 +5884,10 @@ const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElemen
             if (reposition) {
                 insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
+            const fns = await realize(newVariables.map(v => v._definition), runtime);
             newVariables.forEach((v, i) => {
                 const variable = variables[i];
-                let _fn;
-                eval('_fn = ' + v._definition);
+                const _fn = fns[i];
                 if (v._name) {
                     variable.define(v._name, v._inputs, _fn);
                 } else {
@@ -5953,12 +5936,11 @@ Inputs.textarea({
 })
 )};
 const _b4rsn5 = (G, _) => G.input(_);
-const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
+const _ga6kci = function _98(Inputs,definition,variable,realize,runtime,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
-  reduce: () => {
-    let _fn;
-    eval("_fn = " + definition);
+  reduce: async () => {
+    const [_fn] = await realize([definition], runtime);
     variable.define(variable._name, inputs, _fn);
   }
 })
@@ -6071,7 +6053,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_geoudp", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _geoudp);  
+  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6109,7 +6091,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
+  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -6119,8 +6101,9 @@ export default function define(runtime, observer) {
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
   $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
-  $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
+  $def("_ga6kci", null, ["Inputs","definition","variable","realize","runtime","inputs"], _ga6kci);  
   $def("_1q557s", null, ["md"], _1q557s);  
+  main.define("realize", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("realize", _));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -16490,10 +16473,9 @@ notebook_semantics_document.nodes.map((s) => ({
 const _1oevsow = function _28(md){return(
 md`### Runtime Representation (v4)`
 )};
-const _11lfflk = function _notebook_semantics_module(){return(
-importShim("https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4"
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _11lfflk = function _notebook_semantics_module() {
+    return import('https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4');
+};
 const _gjten6 = function _31(md){return(
 md`### Imports`
 )};
@@ -17480,65 +17462,44 @@ parser.parseCell(
   'import {runtime, viewof main as foo} from "@mootari/access-runtime"'
 )
 )};
-const _1n7gw17 = function _findModuleName(extractModuleInfo){return(
-(scope, module, { unknown_id = Math.random() } = {}) => {
-  try {
-    const scopedVariables = [...scope.values()];
-
-    // Prefer variables that *define* a module and have a real module-loader name.
-    const candidates = scopedVariables.filter(
-      (v) =>
-        v &&
-        v._value === module &&
-        typeof v._name === "string" &&
-        v._name.startsWith("module ") &&
-        !v._name.startsWith("module <unknown")
-    );
-
-    const pickBestInfo = (dfn) => {
-      // Avoid the parentUrl (2nd arg) confusing module identification.
-      // Typical patterns:
-      //   importShim("/d/<id>@<ver>.js?v=4", "https://api.observablehq.com/@ns/name.js?v=4")
-      //   import("/d/<id>@<ver>.js?v=4")
-      // Prefer the *first argument* inside importShim(...) / import(...) when present.
-      const s = String(dfn ?? "");
-
-      // Try to capture the first string literal argument to importShim(...) or import(...)
-      // Tolerates quotes ", ', ` and both importShim and plain import.
-      const m = s.match(
-        /\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/
-      );
-      const firstArg = m?.[2];
-
-      const info1 = firstArg ? extractModuleInfo(firstArg) : {};
-      if (info1?.id || info1?.notebook) return info1;
-
-      // Fallback: parse the whole definition string.
-      return extractModuleInfo(s);
+const _1n7gw17 = function _findModuleName(extractModuleInfo) {
+    return (scope, module, {
+        unknown_id = Math.random()
+    } = {}) => {
+        try {
+            const scopedVariables = [...scope.values()];
+            const candidates = scopedVariables.filter(v => v && v._value === module && typeof v._name === 'string' && v._name.startsWith('module ') && !v._name.startsWith('module <unknown'));
+            const pickBestInfo = dfn => {
+                const s = String(dfn ?? '');
+                const m = s.match(/\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/);
+                const firstArg = m?.[2];
+                const info1 = firstArg ? extractModuleInfo(firstArg) : {};
+                if (info1?.id || info1?.notebook)
+                    return info1;
+                return extractModuleInfo(s);
+            };
+            for (const v of candidates) {
+                const info = pickBestInfo(v._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            const any = scopedVariables.find(v => v && v._value === module);
+            if (any) {
+                const info = pickBestInfo(any._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            return `<unknown ${ unknown_id }>`;
+        } catch (e) {
+            debugger;
+            return 'error';
+        }
     };
-
-    // Try module loader cells first.
-    for (const v of candidates) {
-      const info = pickBestInfo(v._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    // Fallback: any scoped variable with _value==module.
-    const any = scopedVariables.find((v) => v && v._value === module);
-    if (any) {
-      const info = pickBestInfo(any._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    return `<unknown ${unknown_id}>`;
-  } catch (e) {
-    debugger;
-    return "error";
-  }
-}
-)};
+};
 const _i47chb = function _findImportedName(){return(
 async (v) => {
   if (v._inputs.length == 1 && v._inputs[0]._name === "@variable") {
@@ -18440,229 +18401,206 @@ JSON.stringify(
 const _1lt3kl6 = function _157(compile,test_case){return(
 compile(test_case.value)
 )};
-const _lpzjrv = function _compile(parser,globalThis,observableToJs){return(
-function compile(source, { anonymousName = "_anonymous" } = {}) {
-  const comments = [],
-    tokens = [];
-  let cell;
-  try {
-    cell = parser.parseCell(source, {
-      ranges: true,
-      onComment: comments,
-      onToken: tokens
-    });
-  } catch (e) {
-    if (e instanceof SyntaxError) {
-      const nameMatch = source.match(
-        /^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/
-      );
-      let _name = null;
-      let funcName = anonymousName;
-      if (nameMatch) {
-        const prefix = nameMatch[1] ? nameMatch[1] + " " : "";
-        _name = prefix + nameMatch[2];
-        funcName = "_" + nameMatch[2];
-      }
-      const escapedMsg = JSON.stringify(e.message);
-      const escapedSource = JSON.stringify(source);
-      return [
-        {
-          _name,
-          _inputs: [],
-          _definition: `function ${funcName}() { throw Object.assign(new SyntaxError(${escapedMsg}), {_sourceExpression: ${escapedSource}}); }`
+const _x1d0wm = function _compile(parser,observableToJs){return(
+function compile(source, {
+    anonymousName = '_anonymous'
+} = {}) {
+    const comments = [], tokens = [];
+    let cell;
+    try {
+        cell = parser.parseCell(source, {
+            ranges: true,
+            onComment: comments,
+            onToken: tokens
+        });
+    } catch (e) {
+        if (e instanceof SyntaxError) {
+            const nameMatch = source.match(/^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/);
+            let _name = null;
+            let funcName = anonymousName;
+            if (nameMatch) {
+                const prefix = nameMatch[1] ? nameMatch[1] + ' ' : '';
+                _name = prefix + nameMatch[2];
+                funcName = '_' + nameMatch[2];
+            }
+            const escapedMsg = JSON.stringify(e.message);
+            const escapedSource = JSON.stringify(source);
+            return [{
+                    _name,
+                    _inputs: [],
+                    _definition: `function ${ funcName }() { throw Object.assign(new SyntaxError(${ escapedMsg }), {_sourceExpression: ${ escapedSource }}); }`
+                }];
         }
-      ];
+        throw e;
     }
-    throw e;
-  }
-  if (!cell) throw new Error("Unable to parse cell");
-  const parseImportSpecifierText = (text) => {
-    const t = String(text ?? "")
-      .trim()
-      .replace(/,$/, "")
-      .trim();
-    if (!t) throw new Error("Empty import specifier");
-    const parts = t.split(/\s+as\s+/);
-    const left = parts[0].trim();
-    const right = parts[1]?.trim();
-    const parseSide = (side, { defaultPrefix = "" } = {}) => {
-      const s = String(side ?? "").trim();
-      const m = s.match(/^(viewof|mutable)\s+(.+)$/);
-      if (m)
-        return {
-          prefix: `${m[1]} `,
-          name: m[2].trim()
+    if (!cell)
+        throw new Error('Unable to parse cell');
+    const parseImportSpecifierText = text => {
+        const t = String(text ?? '').trim().replace(/,$/, '').trim();
+        if (!t)
+            throw new Error('Empty import specifier');
+        const parts = t.split(/\s+as\s+/);
+        const left = parts[0].trim();
+        const right = parts[1]?.trim();
+        const parseSide = (side, {
+            defaultPrefix = ''
+        } = {}) => {
+            const s = String(side ?? '').trim();
+            const m = s.match(/^(viewof|mutable)\s+(.+)$/);
+            if (m)
+                return {
+                    prefix: `${ m[1] } `,
+                    name: m[2].trim()
+                };
+            return {
+                prefix: defaultPrefix,
+                name: s
+            };
         };
-      return {
-        prefix: defaultPrefix,
-        name: s
-      };
+        const L = parseSide(left);
+        const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
+        const importedName = `${ L.prefix }${ L.name }`.trim();
+        const localName = `${ R.prefix }${ R.name }`.trim();
+        if (!importedName)
+            throw new Error(`Could not parse imported name from: ${ t }`);
+        if (!localName)
+            throw new Error(`Could not parse local name from: ${ t }`);
+        return {
+            importedName,
+            localName
+        };
     };
-    const L = parseSide(left);
-    const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
-    const importedName = `${L.prefix}${L.name}`.trim();
-    const localName = `${R.prefix}${R.name}`.trim();
-    if (!importedName)
-      throw new Error(`Could not parse imported name from: ${t}`);
-    if (!localName) throw new Error(`Could not parse local name from: ${t}`);
-    return {
-      importedName,
-      localName
-    };
-  };
-  if (!cell.id && cell.body?.type === "ImportDeclaration") {
-    const module_name = cell.body.source.value;
-    const importKeyword = globalThis?.importShim ? "importShim" : "import";
-    const cell_variables = [
-      {
-        _name: `module ${module_name}`,
-        _inputs: [],
-        _definition: `async () => runtime.module((await ${importKeyword}("${module_name}")).default)`
-      }
-    ];
-    for (const specifier of cell.body.specifiers ?? []) {
-      const specText =
-        typeof specifier?.start === "number" &&
-        typeof specifier?.end === "number"
-          ? source.slice(specifier.start, specifier.end)
-          : (() => {
-              if (specifier?.imported?.name && specifier?.local?.name) {
-                return specifier.imported.name === specifier.local.name
-                  ? specifier.local.name
-                  : `${specifier.imported.name} as ${specifier.local.name}`;
-              }
-              throw new Error("Import specifier missing range information");
+    if (!cell.id && cell.body?.type === 'ImportDeclaration') {
+        const module_name = cell.body.source.value;
+        const cell_variables = [{
+                _name: `module ${ module_name }`,
+                _inputs: [],
+                _definition: `async () => runtime.module((await import("${ module_name }")).default)`
+            }];
+        for (const specifier of cell.body.specifiers ?? []) {
+            const specText = typeof specifier?.start === 'number' && typeof specifier?.end === 'number' ? source.slice(specifier.start, specifier.end) : (() => {
+                if (specifier?.imported?.name && specifier?.local?.name) {
+                    return specifier.imported.name === specifier.local.name ? specifier.local.name : `${ specifier.imported.name } as ${ specifier.local.name }`;
+                }
+                throw new Error('Import specifier missing range information');
             })();
-      const { importedName, localName } = parseImportSpecifierText(specText);
-      cell_variables.push({
-        _name: localName,
-        _inputs: [`module ${module_name}`, "@variable"],
-        _definition:
-          importedName === localName
-            ? `(_, v) => v.import("${importedName}", _)`
-            : `(_, v) => v.import("${importedName}", "${localName}", _)`
-      });
+            const {importedName, localName} = parseImportSpecifierText(specText);
+            cell_variables.push({
+                _name: localName,
+                _inputs: [
+                    `module ${ module_name }`,
+                    '@variable'
+                ],
+                _definition: importedName === localName ? `(_, v) => v.import("${ importedName }", _)` : `(_, v) => v.import("${ importedName }", "${ localName }", _)`
+            });
+        }
+        return cell_variables;
     }
-    return cell_variables;
-  }
-  let dollarIdx = 0;
-  const inputToArgMap = {};
-  const dollarToMacro = {};
-  const seen = new Set();
-  const inputs = Array.from(cell.references || []).flatMap((i) => {
-    if (i.name) {
-      if (seen.has(i.name)) return [];
-      seen.add(i.name);
-      return i.name;
+    let dollarIdx = 0;
+    const inputToArgMap = {};
+    const dollarToMacro = {};
+    const seen = new Set();
+    const inputs = Array.from(cell.references || []).flatMap(i => {
+        if (i.name) {
+            if (seen.has(i.name))
+                return [];
+            seen.add(i.name);
+            return i.name;
+        } else {
+            const dedupKey = i.type + ':' + i.id.name;
+            if (seen.has(dedupKey))
+                return [];
+            seen.add(dedupKey);
+            const dollarName = '$' + dollarIdx;
+            inputToArgMap[i.id.name] = dollarName;
+            dollarToMacro[dollarName] = i.type == 'ViewExpression' ? 'viewof ' + i.id.name : 'mutable ' + i.id.name;
+            dollarIdx++;
+            return dollarName;
+        }
+    });
+    let variables;
+    if (cell.id) {
+        if (cell.id.type === 'Identifier') {
+            variables = [{
+                    functionName: '_' + cell.id.name,
+                    name: cell.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                }];
+        } else if (cell.id.type === 'ViewExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'viewof ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '(G, _) => G.input(_)',
+                    inputs: [
+                        'Generators',
+                        'viewof ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                }
+            ];
+        } else if (cell.id.type === 'MutableExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'initial ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'mutable ' + cell.id.id.name,
+                    _definition: '(M, _) => new M(_)',
+                    inputs: [
+                        'Mutable',
+                        'initial ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '_ => _.generator',
+                    inputs: ['mutable ' + cell.id.id.name],
+                    params: inputs.join(',')
+                }
+            ];
+        } else {
+            throw new Error(`Unsupported cell id type: ${ cell.id.type }`);
+        }
     } else {
-      const dedupKey = i.type + ":" + i.id.name;
-      if (seen.has(dedupKey)) return [];
-      seen.add(dedupKey);
-      const dollarName = "$" + dollarIdx;
-      inputToArgMap[i.id.name] = dollarName;
-      dollarToMacro[dollarName] =
-        i.type == "ViewExpression"
-          ? "viewof " + i.id.name
-          : "mutable " + i.id.name;
-      dollarIdx++;
-      return dollarName;
+        variables = [{
+                functionName: anonymousName,
+                name: null,
+                inputs,
+                params: inputs.join(',')
+            }];
     }
-  });
-  let variables;
-  if (cell.id) {
-    if (cell.id.type === "Identifier") {
-      variables = [
-        {
-          functionName: "_" + cell.id.name,
-          name: cell.id.name,
-          inputs,
-          params: inputs.join(",")
+    return variables.map(v => {
+        let _definition = v._definition;
+        if (!_definition) {
+            let functionBody;
+            if (cell.body.type === 'BlockStatement') {
+                functionBody = observableToJs(cell.body, inputToArgMap, comments, tokens);
+            } else {
+                const bodyCode = observableToJs(cell.body, inputToArgMap, comments, tokens);
+                functionBody = `{return (${ bodyCode });}`;
+            }
+            _definition = `${ cell.async ? 'async ' : '' }function${ cell.generator ? '*' : '' } ${ v.functionName }(${ v.inputs.join(',') }) ${ functionBody }`;
         }
-      ];
-    } else if (cell.id.type === "ViewExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "viewof " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "(G, _) => G.input(_)",
-          inputs: ["Generators", "viewof " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else if (cell.id.type === "MutableExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "initial " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "mutable " + cell.id.id.name,
-          _definition: "(M, _) => new M(_)",
-          inputs: ["Mutable", "initial " + cell.id.id.name],
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "_ => _.generator",
-          inputs: ["mutable " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else {
-      throw new Error(`Unsupported cell id type: ${cell.id.type}`);
-    }
-  } else {
-    variables = [
-      {
-        functionName: anonymousName,
-        name: null,
-        inputs,
-        params: inputs.join(",")
-      }
-    ];
-  }
-  return variables.map((v) => {
-    let _definition = v._definition;
-    if (!_definition) {
-      let functionBody;
-      if (cell.body.type === "BlockStatement") {
-        functionBody = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-      } else {
-        const bodyCode = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-        functionBody = `{return (${bodyCode});}`;
-      }
-      _definition = `${cell.async ? "async " : ""}function${
-        cell.generator ? "*" : ""
-      } ${v.functionName}(${v.inputs.join(",")}) ${functionBody}`;
-    }
-    return {
-      _name: v.name,
-      _inputs: v.inputs.map(
-        (i) => dollarToMacro[i] || (i === "$variable" ? "@variable" : i)
-      ),
-      _definition
-    };
-  });
+        return {
+            _name: v.name,
+            _inputs: v.inputs.map(i => dollarToMacro[i] || (i === '$variable' ? '@variable' : i)),
+            _definition
+        };
+    });
 }
 )};
 const _1v1i7wl = function _observableToJs(acorn_walk,parser,escodegen){return(
@@ -18729,16 +18667,15 @@ async (attachment, overrides) => {
   return URL.createObjectURL(blob);
 }
 )};
-const _s9w7ha = async function _parser(decompress_url,FileAttachment,acorn_url,acorn_walk_url){return(
-importShim(await decompress_url(FileAttachment("parser-6.1.0.js.gz"), {
-    "/npm/acorn@8.11.3/+esm": acorn_url,
-    "/npm/acorn-walk@8.3.2/+esm": acorn_walk_url
-  })
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
-const _1hiclbb = function _acorn_walk(acorn_walk_url){return(
-importShim(acorn_walk_url, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _s9w7ha = async function _parser(decompress_url, FileAttachment, acorn_url, acorn_walk_url) {
+    return import(await decompress_url(FileAttachment('parser-6.1.0.js.gz'), {
+        '/npm/acorn@8.11.3/+esm': acorn_url,
+        '/npm/acorn-walk@8.3.2/+esm': acorn_walk_url
+    }));
+};
+const _1hiclbb = function _acorn_walk(acorn_walk_url) {
+    return import(acorn_walk_url);
+};
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
@@ -18926,7 +18863,7 @@ export default function define(runtime, observer) {
   $def("_1dmmuaf", "compiled_selector", ["Generators","viewof compiled_selector"], _1dmmuaf);  
   $def("_u7t3vu", null, ["compiled_selector","normalizeJavascriptSource"], _u7t3vu);  
   $def("_1lt3kl6", null, ["compile","test_case"], _1lt3kl6);  
-  $def("_lpzjrv", "compile", ["parser","globalThis","observableToJs"], _lpzjrv);  
+  $def("_x1d0wm", "compile", ["parser","observableToJs"], _x1d0wm);  
   $def("_1v1i7wl", "observableToJs", ["acorn_walk","parser","escodegen"], _1v1i7wl);  
   $def("_19lv24l", null, ["md"], _19lv24l);  
   $def("_xhj6b8", "decompress_url", ["DecompressionStream","TextDecoderStream","TransformStream","TextEncoderStream","Response"], _xhj6b8);  

--- a/notebooks/@tomlarkworthy_debugger.html
+++ b/notebooks/@tomlarkworthy_debugger.html
@@ -5850,58 +5850,41 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _geoudp = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
-  if (command.processed) return;
-
-  let result = undefined;
-  if (command.command == "createCell") {
-    $0.value = true;
-    result = compile_and_update("{}", [], command.args.cell);
-    // For the new one to get focus
-    // setTimeout(() => {
-    //   debugger;
-    //   setOption(result[0], "pinned", true);
-    // }, 100);
-  } else if (command.command == "deleteCell") {
-    remove_variables(command.args.cell.variables);
-    result = true;
-  } else if (command.command == "moveCell") {
-    const cellIndex = findCellIndex(
-      command.args.cell.variables,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const targetCellIndex = cellIndex + command.args.amount;
-    const targetCell = lookupCellByIndex(
-      targetCellIndex,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const currentFirstVariableIndex = findVariableIndex(
-      command.args.cell.variables[0]
-    );
-    const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-    const change = targetFirstVariableIndex - currentFirstVariableIndex;
-    console.log(
-      "moveCell",
-      cellIndex,
-      targetCellIndex,
-      targetCell,
-      currentFirstVariableIndex,
-      targetFirstVariableIndex,
-      change
-    );
-    command.args.cell.variables.forEach((v) => {
-      const currentIndex = findVariableIndex(v);
-      repositionSetElement(runtime._variables, v, currentIndex + change);
-    });
-    // recompute
-    await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
-    result = true;
-  }
-  if (result) {
-    command.processed = true;
-    $2.resolve(result);
-  }
+    if (command.processed)
+        return;
+    let result = undefined;
+    if (command.command == 'createCell') {
+        $0.value = true;
+        result = await compile_and_update('{}', [], command.args.cell);    // For the new one to get focus
+                                                                           // setTimeout(() => {
+                                                                           //   debugger;
+                                                                           //   setOption(result[0], "pinned", true);
+                                                                           // }, 100);
+    } else if (command.command == 'deleteCell') {
+        remove_variables(command.args.cell.variables);
+        result = true;
+    } else if (command.command == 'moveCell') {
+        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const targetCellIndex = cellIndex + command.args.amount;
+        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
+        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+        const change = targetFirstVariableIndex - currentFirstVariableIndex;
+        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
+        command.args.cell.variables.forEach(v => {
+            const currentIndex = findVariableIndex(v);
+            repositionSetElement(runtime._variables, v, currentIndex + change);
+        });
+        // recompute
+        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        result = true;
+    }
+    if (result) {
+        command.processed = true;
+        $2.resolve(result);
+    }
 };
 const _1jadxoe = function _60(md){return(
 md`### UI Action`
@@ -6292,9 +6275,9 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
-    return (source, variables = [], cell) => {
+    return async (source, variables = [], cell) => {
         try {
             debugger;
             let reposition = false, insertionIndex = -1;
@@ -6314,10 +6297,10 @@ const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElemen
             if (reposition) {
                 insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
+            const fns = await realize(newVariables.map(v => v._definition), runtime);
             newVariables.forEach((v, i) => {
                 const variable = variables[i];
-                let _fn;
-                eval('_fn = ' + v._definition);
+                const _fn = fns[i];
                 if (v._name) {
                     variable.define(v._name, v._inputs, _fn);
                 } else {
@@ -6366,12 +6349,11 @@ Inputs.textarea({
 })
 )};
 const _b4rsn5 = (G, _) => G.input(_);
-const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
+const _ga6kci = function _98(Inputs,definition,variable,realize,runtime,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
-  reduce: () => {
-    let _fn;
-    eval("_fn = " + definition);
+  reduce: async () => {
+    const [_fn] = await realize([definition], runtime);
     variable.define(variable._name, inputs, _fn);
   }
 })
@@ -6484,7 +6466,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_geoudp", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _geoudp);  
+  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6522,7 +6504,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
+  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -6532,8 +6514,9 @@ export default function define(runtime, observer) {
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
   $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
-  $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
+  $def("_ga6kci", null, ["Inputs","definition","variable","realize","runtime","inputs"], _ga6kci);  
   $def("_1q557s", null, ["md"], _1q557s);  
+  main.define("realize", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("realize", _));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -16903,10 +16886,9 @@ notebook_semantics_document.nodes.map((s) => ({
 const _1oevsow = function _28(md){return(
 md`### Runtime Representation (v4)`
 )};
-const _11lfflk = function _notebook_semantics_module(){return(
-importShim("https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4"
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _11lfflk = function _notebook_semantics_module() {
+    return import('https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4');
+};
 const _gjten6 = function _31(md){return(
 md`### Imports`
 )};
@@ -17893,65 +17875,44 @@ parser.parseCell(
   'import {runtime, viewof main as foo} from "@mootari/access-runtime"'
 )
 )};
-const _1n7gw17 = function _findModuleName(extractModuleInfo){return(
-(scope, module, { unknown_id = Math.random() } = {}) => {
-  try {
-    const scopedVariables = [...scope.values()];
-
-    // Prefer variables that *define* a module and have a real module-loader name.
-    const candidates = scopedVariables.filter(
-      (v) =>
-        v &&
-        v._value === module &&
-        typeof v._name === "string" &&
-        v._name.startsWith("module ") &&
-        !v._name.startsWith("module <unknown")
-    );
-
-    const pickBestInfo = (dfn) => {
-      // Avoid the parentUrl (2nd arg) confusing module identification.
-      // Typical patterns:
-      //   importShim("/d/<id>@<ver>.js?v=4", "https://api.observablehq.com/@ns/name.js?v=4")
-      //   import("/d/<id>@<ver>.js?v=4")
-      // Prefer the *first argument* inside importShim(...) / import(...) when present.
-      const s = String(dfn ?? "");
-
-      // Try to capture the first string literal argument to importShim(...) or import(...)
-      // Tolerates quotes ", ', ` and both importShim and plain import.
-      const m = s.match(
-        /\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/
-      );
-      const firstArg = m?.[2];
-
-      const info1 = firstArg ? extractModuleInfo(firstArg) : {};
-      if (info1?.id || info1?.notebook) return info1;
-
-      // Fallback: parse the whole definition string.
-      return extractModuleInfo(s);
+const _1n7gw17 = function _findModuleName(extractModuleInfo) {
+    return (scope, module, {
+        unknown_id = Math.random()
+    } = {}) => {
+        try {
+            const scopedVariables = [...scope.values()];
+            const candidates = scopedVariables.filter(v => v && v._value === module && typeof v._name === 'string' && v._name.startsWith('module ') && !v._name.startsWith('module <unknown'));
+            const pickBestInfo = dfn => {
+                const s = String(dfn ?? '');
+                const m = s.match(/\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/);
+                const firstArg = m?.[2];
+                const info1 = firstArg ? extractModuleInfo(firstArg) : {};
+                if (info1?.id || info1?.notebook)
+                    return info1;
+                return extractModuleInfo(s);
+            };
+            for (const v of candidates) {
+                const info = pickBestInfo(v._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            const any = scopedVariables.find(v => v && v._value === module);
+            if (any) {
+                const info = pickBestInfo(any._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            return `<unknown ${ unknown_id }>`;
+        } catch (e) {
+            debugger;
+            return 'error';
+        }
     };
-
-    // Try module loader cells first.
-    for (const v of candidates) {
-      const info = pickBestInfo(v._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    // Fallback: any scoped variable with _value==module.
-    const any = scopedVariables.find((v) => v && v._value === module);
-    if (any) {
-      const info = pickBestInfo(any._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    return `<unknown ${unknown_id}>`;
-  } catch (e) {
-    debugger;
-    return "error";
-  }
-}
-)};
+};
 const _i47chb = function _findImportedName(){return(
 async (v) => {
   if (v._inputs.length == 1 && v._inputs[0]._name === "@variable") {
@@ -18853,229 +18814,206 @@ JSON.stringify(
 const _1lt3kl6 = function _157(compile,test_case){return(
 compile(test_case.value)
 )};
-const _lpzjrv = function _compile(parser,globalThis,observableToJs){return(
-function compile(source, { anonymousName = "_anonymous" } = {}) {
-  const comments = [],
-    tokens = [];
-  let cell;
-  try {
-    cell = parser.parseCell(source, {
-      ranges: true,
-      onComment: comments,
-      onToken: tokens
-    });
-  } catch (e) {
-    if (e instanceof SyntaxError) {
-      const nameMatch = source.match(
-        /^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/
-      );
-      let _name = null;
-      let funcName = anonymousName;
-      if (nameMatch) {
-        const prefix = nameMatch[1] ? nameMatch[1] + " " : "";
-        _name = prefix + nameMatch[2];
-        funcName = "_" + nameMatch[2];
-      }
-      const escapedMsg = JSON.stringify(e.message);
-      const escapedSource = JSON.stringify(source);
-      return [
-        {
-          _name,
-          _inputs: [],
-          _definition: `function ${funcName}() { throw Object.assign(new SyntaxError(${escapedMsg}), {_sourceExpression: ${escapedSource}}); }`
+const _x1d0wm = function _compile(parser,observableToJs){return(
+function compile(source, {
+    anonymousName = '_anonymous'
+} = {}) {
+    const comments = [], tokens = [];
+    let cell;
+    try {
+        cell = parser.parseCell(source, {
+            ranges: true,
+            onComment: comments,
+            onToken: tokens
+        });
+    } catch (e) {
+        if (e instanceof SyntaxError) {
+            const nameMatch = source.match(/^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/);
+            let _name = null;
+            let funcName = anonymousName;
+            if (nameMatch) {
+                const prefix = nameMatch[1] ? nameMatch[1] + ' ' : '';
+                _name = prefix + nameMatch[2];
+                funcName = '_' + nameMatch[2];
+            }
+            const escapedMsg = JSON.stringify(e.message);
+            const escapedSource = JSON.stringify(source);
+            return [{
+                    _name,
+                    _inputs: [],
+                    _definition: `function ${ funcName }() { throw Object.assign(new SyntaxError(${ escapedMsg }), {_sourceExpression: ${ escapedSource }}); }`
+                }];
         }
-      ];
+        throw e;
     }
-    throw e;
-  }
-  if (!cell) throw new Error("Unable to parse cell");
-  const parseImportSpecifierText = (text) => {
-    const t = String(text ?? "")
-      .trim()
-      .replace(/,$/, "")
-      .trim();
-    if (!t) throw new Error("Empty import specifier");
-    const parts = t.split(/\s+as\s+/);
-    const left = parts[0].trim();
-    const right = parts[1]?.trim();
-    const parseSide = (side, { defaultPrefix = "" } = {}) => {
-      const s = String(side ?? "").trim();
-      const m = s.match(/^(viewof|mutable)\s+(.+)$/);
-      if (m)
-        return {
-          prefix: `${m[1]} `,
-          name: m[2].trim()
+    if (!cell)
+        throw new Error('Unable to parse cell');
+    const parseImportSpecifierText = text => {
+        const t = String(text ?? '').trim().replace(/,$/, '').trim();
+        if (!t)
+            throw new Error('Empty import specifier');
+        const parts = t.split(/\s+as\s+/);
+        const left = parts[0].trim();
+        const right = parts[1]?.trim();
+        const parseSide = (side, {
+            defaultPrefix = ''
+        } = {}) => {
+            const s = String(side ?? '').trim();
+            const m = s.match(/^(viewof|mutable)\s+(.+)$/);
+            if (m)
+                return {
+                    prefix: `${ m[1] } `,
+                    name: m[2].trim()
+                };
+            return {
+                prefix: defaultPrefix,
+                name: s
+            };
         };
-      return {
-        prefix: defaultPrefix,
-        name: s
-      };
+        const L = parseSide(left);
+        const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
+        const importedName = `${ L.prefix }${ L.name }`.trim();
+        const localName = `${ R.prefix }${ R.name }`.trim();
+        if (!importedName)
+            throw new Error(`Could not parse imported name from: ${ t }`);
+        if (!localName)
+            throw new Error(`Could not parse local name from: ${ t }`);
+        return {
+            importedName,
+            localName
+        };
     };
-    const L = parseSide(left);
-    const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
-    const importedName = `${L.prefix}${L.name}`.trim();
-    const localName = `${R.prefix}${R.name}`.trim();
-    if (!importedName)
-      throw new Error(`Could not parse imported name from: ${t}`);
-    if (!localName) throw new Error(`Could not parse local name from: ${t}`);
-    return {
-      importedName,
-      localName
-    };
-  };
-  if (!cell.id && cell.body?.type === "ImportDeclaration") {
-    const module_name = cell.body.source.value;
-    const importKeyword = globalThis?.importShim ? "importShim" : "import";
-    const cell_variables = [
-      {
-        _name: `module ${module_name}`,
-        _inputs: [],
-        _definition: `async () => runtime.module((await ${importKeyword}("${module_name}")).default)`
-      }
-    ];
-    for (const specifier of cell.body.specifiers ?? []) {
-      const specText =
-        typeof specifier?.start === "number" &&
-        typeof specifier?.end === "number"
-          ? source.slice(specifier.start, specifier.end)
-          : (() => {
-              if (specifier?.imported?.name && specifier?.local?.name) {
-                return specifier.imported.name === specifier.local.name
-                  ? specifier.local.name
-                  : `${specifier.imported.name} as ${specifier.local.name}`;
-              }
-              throw new Error("Import specifier missing range information");
+    if (!cell.id && cell.body?.type === 'ImportDeclaration') {
+        const module_name = cell.body.source.value;
+        const cell_variables = [{
+                _name: `module ${ module_name }`,
+                _inputs: [],
+                _definition: `async () => runtime.module((await import("${ module_name }")).default)`
+            }];
+        for (const specifier of cell.body.specifiers ?? []) {
+            const specText = typeof specifier?.start === 'number' && typeof specifier?.end === 'number' ? source.slice(specifier.start, specifier.end) : (() => {
+                if (specifier?.imported?.name && specifier?.local?.name) {
+                    return specifier.imported.name === specifier.local.name ? specifier.local.name : `${ specifier.imported.name } as ${ specifier.local.name }`;
+                }
+                throw new Error('Import specifier missing range information');
             })();
-      const { importedName, localName } = parseImportSpecifierText(specText);
-      cell_variables.push({
-        _name: localName,
-        _inputs: [`module ${module_name}`, "@variable"],
-        _definition:
-          importedName === localName
-            ? `(_, v) => v.import("${importedName}", _)`
-            : `(_, v) => v.import("${importedName}", "${localName}", _)`
-      });
+            const {importedName, localName} = parseImportSpecifierText(specText);
+            cell_variables.push({
+                _name: localName,
+                _inputs: [
+                    `module ${ module_name }`,
+                    '@variable'
+                ],
+                _definition: importedName === localName ? `(_, v) => v.import("${ importedName }", _)` : `(_, v) => v.import("${ importedName }", "${ localName }", _)`
+            });
+        }
+        return cell_variables;
     }
-    return cell_variables;
-  }
-  let dollarIdx = 0;
-  const inputToArgMap = {};
-  const dollarToMacro = {};
-  const seen = new Set();
-  const inputs = Array.from(cell.references || []).flatMap((i) => {
-    if (i.name) {
-      if (seen.has(i.name)) return [];
-      seen.add(i.name);
-      return i.name;
+    let dollarIdx = 0;
+    const inputToArgMap = {};
+    const dollarToMacro = {};
+    const seen = new Set();
+    const inputs = Array.from(cell.references || []).flatMap(i => {
+        if (i.name) {
+            if (seen.has(i.name))
+                return [];
+            seen.add(i.name);
+            return i.name;
+        } else {
+            const dedupKey = i.type + ':' + i.id.name;
+            if (seen.has(dedupKey))
+                return [];
+            seen.add(dedupKey);
+            const dollarName = '$' + dollarIdx;
+            inputToArgMap[i.id.name] = dollarName;
+            dollarToMacro[dollarName] = i.type == 'ViewExpression' ? 'viewof ' + i.id.name : 'mutable ' + i.id.name;
+            dollarIdx++;
+            return dollarName;
+        }
+    });
+    let variables;
+    if (cell.id) {
+        if (cell.id.type === 'Identifier') {
+            variables = [{
+                    functionName: '_' + cell.id.name,
+                    name: cell.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                }];
+        } else if (cell.id.type === 'ViewExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'viewof ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '(G, _) => G.input(_)',
+                    inputs: [
+                        'Generators',
+                        'viewof ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                }
+            ];
+        } else if (cell.id.type === 'MutableExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'initial ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'mutable ' + cell.id.id.name,
+                    _definition: '(M, _) => new M(_)',
+                    inputs: [
+                        'Mutable',
+                        'initial ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '_ => _.generator',
+                    inputs: ['mutable ' + cell.id.id.name],
+                    params: inputs.join(',')
+                }
+            ];
+        } else {
+            throw new Error(`Unsupported cell id type: ${ cell.id.type }`);
+        }
     } else {
-      const dedupKey = i.type + ":" + i.id.name;
-      if (seen.has(dedupKey)) return [];
-      seen.add(dedupKey);
-      const dollarName = "$" + dollarIdx;
-      inputToArgMap[i.id.name] = dollarName;
-      dollarToMacro[dollarName] =
-        i.type == "ViewExpression"
-          ? "viewof " + i.id.name
-          : "mutable " + i.id.name;
-      dollarIdx++;
-      return dollarName;
+        variables = [{
+                functionName: anonymousName,
+                name: null,
+                inputs,
+                params: inputs.join(',')
+            }];
     }
-  });
-  let variables;
-  if (cell.id) {
-    if (cell.id.type === "Identifier") {
-      variables = [
-        {
-          functionName: "_" + cell.id.name,
-          name: cell.id.name,
-          inputs,
-          params: inputs.join(",")
+    return variables.map(v => {
+        let _definition = v._definition;
+        if (!_definition) {
+            let functionBody;
+            if (cell.body.type === 'BlockStatement') {
+                functionBody = observableToJs(cell.body, inputToArgMap, comments, tokens);
+            } else {
+                const bodyCode = observableToJs(cell.body, inputToArgMap, comments, tokens);
+                functionBody = `{return (${ bodyCode });}`;
+            }
+            _definition = `${ cell.async ? 'async ' : '' }function${ cell.generator ? '*' : '' } ${ v.functionName }(${ v.inputs.join(',') }) ${ functionBody }`;
         }
-      ];
-    } else if (cell.id.type === "ViewExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "viewof " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "(G, _) => G.input(_)",
-          inputs: ["Generators", "viewof " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else if (cell.id.type === "MutableExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "initial " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "mutable " + cell.id.id.name,
-          _definition: "(M, _) => new M(_)",
-          inputs: ["Mutable", "initial " + cell.id.id.name],
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "_ => _.generator",
-          inputs: ["mutable " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else {
-      throw new Error(`Unsupported cell id type: ${cell.id.type}`);
-    }
-  } else {
-    variables = [
-      {
-        functionName: anonymousName,
-        name: null,
-        inputs,
-        params: inputs.join(",")
-      }
-    ];
-  }
-  return variables.map((v) => {
-    let _definition = v._definition;
-    if (!_definition) {
-      let functionBody;
-      if (cell.body.type === "BlockStatement") {
-        functionBody = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-      } else {
-        const bodyCode = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-        functionBody = `{return (${bodyCode});}`;
-      }
-      _definition = `${cell.async ? "async " : ""}function${
-        cell.generator ? "*" : ""
-      } ${v.functionName}(${v.inputs.join(",")}) ${functionBody}`;
-    }
-    return {
-      _name: v.name,
-      _inputs: v.inputs.map(
-        (i) => dollarToMacro[i] || (i === "$variable" ? "@variable" : i)
-      ),
-      _definition
-    };
-  });
+        return {
+            _name: v.name,
+            _inputs: v.inputs.map(i => dollarToMacro[i] || (i === '$variable' ? '@variable' : i)),
+            _definition
+        };
+    });
 }
 )};
 const _1v1i7wl = function _observableToJs(acorn_walk,parser,escodegen){return(
@@ -19142,16 +19080,15 @@ async (attachment, overrides) => {
   return URL.createObjectURL(blob);
 }
 )};
-const _s9w7ha = async function _parser(decompress_url,FileAttachment,acorn_url,acorn_walk_url){return(
-importShim(await decompress_url(FileAttachment("parser-6.1.0.js.gz"), {
-    "/npm/acorn@8.11.3/+esm": acorn_url,
-    "/npm/acorn-walk@8.3.2/+esm": acorn_walk_url
-  })
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
-const _1hiclbb = function _acorn_walk(acorn_walk_url){return(
-importShim(acorn_walk_url, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _s9w7ha = async function _parser(decompress_url, FileAttachment, acorn_url, acorn_walk_url) {
+    return import(await decompress_url(FileAttachment('parser-6.1.0.js.gz'), {
+        '/npm/acorn@8.11.3/+esm': acorn_url,
+        '/npm/acorn-walk@8.3.2/+esm': acorn_walk_url
+    }));
+};
+const _1hiclbb = function _acorn_walk(acorn_walk_url) {
+    return import(acorn_walk_url);
+};
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
@@ -19339,7 +19276,7 @@ export default function define(runtime, observer) {
   $def("_1dmmuaf", "compiled_selector", ["Generators","viewof compiled_selector"], _1dmmuaf);  
   $def("_u7t3vu", null, ["compiled_selector","normalizeJavascriptSource"], _u7t3vu);  
   $def("_1lt3kl6", null, ["compile","test_case"], _1lt3kl6);  
-  $def("_lpzjrv", "compile", ["parser","globalThis","observableToJs"], _lpzjrv);  
+  $def("_x1d0wm", "compile", ["parser","observableToJs"], _x1d0wm);  
   $def("_1v1i7wl", "observableToJs", ["acorn_walk","parser","escodegen"], _1v1i7wl);  
   $def("_19lv24l", null, ["md"], _19lv24l);  
   $def("_xhj6b8", "decompress_url", ["DecompressionStream","TextDecoderStream","TransformStream","TextEncoderStream","Response"], _xhj6b8);  

--- a/notebooks/@tomlarkworthy_dom-view.html
+++ b/notebooks/@tomlarkworthy_dom-view.html
@@ -5437,58 +5437,41 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _geoudp = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
-  if (command.processed) return;
-
-  let result = undefined;
-  if (command.command == "createCell") {
-    $0.value = true;
-    result = compile_and_update("{}", [], command.args.cell);
-    // For the new one to get focus
-    // setTimeout(() => {
-    //   debugger;
-    //   setOption(result[0], "pinned", true);
-    // }, 100);
-  } else if (command.command == "deleteCell") {
-    remove_variables(command.args.cell.variables);
-    result = true;
-  } else if (command.command == "moveCell") {
-    const cellIndex = findCellIndex(
-      command.args.cell.variables,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const targetCellIndex = cellIndex + command.args.amount;
-    const targetCell = lookupCellByIndex(
-      targetCellIndex,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const currentFirstVariableIndex = findVariableIndex(
-      command.args.cell.variables[0]
-    );
-    const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-    const change = targetFirstVariableIndex - currentFirstVariableIndex;
-    console.log(
-      "moveCell",
-      cellIndex,
-      targetCellIndex,
-      targetCell,
-      currentFirstVariableIndex,
-      targetFirstVariableIndex,
-      change
-    );
-    command.args.cell.variables.forEach((v) => {
-      const currentIndex = findVariableIndex(v);
-      repositionSetElement(runtime._variables, v, currentIndex + change);
-    });
-    // recompute
-    await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
-    result = true;
-  }
-  if (result) {
-    command.processed = true;
-    $2.resolve(result);
-  }
+    if (command.processed)
+        return;
+    let result = undefined;
+    if (command.command == 'createCell') {
+        $0.value = true;
+        result = await compile_and_update('{}', [], command.args.cell);    // For the new one to get focus
+                                                                           // setTimeout(() => {
+                                                                           //   debugger;
+                                                                           //   setOption(result[0], "pinned", true);
+                                                                           // }, 100);
+    } else if (command.command == 'deleteCell') {
+        remove_variables(command.args.cell.variables);
+        result = true;
+    } else if (command.command == 'moveCell') {
+        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const targetCellIndex = cellIndex + command.args.amount;
+        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
+        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+        const change = targetFirstVariableIndex - currentFirstVariableIndex;
+        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
+        command.args.cell.variables.forEach(v => {
+            const currentIndex = findVariableIndex(v);
+            repositionSetElement(runtime._variables, v, currentIndex + change);
+        });
+        // recompute
+        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        result = true;
+    }
+    if (result) {
+        command.processed = true;
+        $2.resolve(result);
+    }
 };
 const _1jadxoe = function _60(md){return(
 md`### UI Action`
@@ -5879,9 +5862,9 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
-    return (source, variables = [], cell) => {
+    return async (source, variables = [], cell) => {
         try {
             debugger;
             let reposition = false, insertionIndex = -1;
@@ -5901,10 +5884,10 @@ const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElemen
             if (reposition) {
                 insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
+            const fns = await realize(newVariables.map(v => v._definition), runtime);
             newVariables.forEach((v, i) => {
                 const variable = variables[i];
-                let _fn;
-                eval('_fn = ' + v._definition);
+                const _fn = fns[i];
                 if (v._name) {
                     variable.define(v._name, v._inputs, _fn);
                 } else {
@@ -5953,12 +5936,11 @@ Inputs.textarea({
 })
 )};
 const _b4rsn5 = (G, _) => G.input(_);
-const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
+const _ga6kci = function _98(Inputs,definition,variable,realize,runtime,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
-  reduce: () => {
-    let _fn;
-    eval("_fn = " + definition);
+  reduce: async () => {
+    const [_fn] = await realize([definition], runtime);
     variable.define(variable._name, inputs, _fn);
   }
 })
@@ -6071,7 +6053,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_geoudp", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _geoudp);  
+  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6109,7 +6091,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
+  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -6119,8 +6101,9 @@ export default function define(runtime, observer) {
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
   $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
-  $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
+  $def("_ga6kci", null, ["Inputs","definition","variable","realize","runtime","inputs"], _ga6kci);  
   $def("_1q557s", null, ["md"], _1q557s);  
+  main.define("realize", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("realize", _));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -16490,10 +16473,9 @@ notebook_semantics_document.nodes.map((s) => ({
 const _1oevsow = function _28(md){return(
 md`### Runtime Representation (v4)`
 )};
-const _11lfflk = function _notebook_semantics_module(){return(
-importShim("https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4"
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _11lfflk = function _notebook_semantics_module() {
+    return import('https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4');
+};
 const _gjten6 = function _31(md){return(
 md`### Imports`
 )};
@@ -17480,65 +17462,44 @@ parser.parseCell(
   'import {runtime, viewof main as foo} from "@mootari/access-runtime"'
 )
 )};
-const _1n7gw17 = function _findModuleName(extractModuleInfo){return(
-(scope, module, { unknown_id = Math.random() } = {}) => {
-  try {
-    const scopedVariables = [...scope.values()];
-
-    // Prefer variables that *define* a module and have a real module-loader name.
-    const candidates = scopedVariables.filter(
-      (v) =>
-        v &&
-        v._value === module &&
-        typeof v._name === "string" &&
-        v._name.startsWith("module ") &&
-        !v._name.startsWith("module <unknown")
-    );
-
-    const pickBestInfo = (dfn) => {
-      // Avoid the parentUrl (2nd arg) confusing module identification.
-      // Typical patterns:
-      //   importShim("/d/<id>@<ver>.js?v=4", "https://api.observablehq.com/@ns/name.js?v=4")
-      //   import("/d/<id>@<ver>.js?v=4")
-      // Prefer the *first argument* inside importShim(...) / import(...) when present.
-      const s = String(dfn ?? "");
-
-      // Try to capture the first string literal argument to importShim(...) or import(...)
-      // Tolerates quotes ", ', ` and both importShim and plain import.
-      const m = s.match(
-        /\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/
-      );
-      const firstArg = m?.[2];
-
-      const info1 = firstArg ? extractModuleInfo(firstArg) : {};
-      if (info1?.id || info1?.notebook) return info1;
-
-      // Fallback: parse the whole definition string.
-      return extractModuleInfo(s);
+const _1n7gw17 = function _findModuleName(extractModuleInfo) {
+    return (scope, module, {
+        unknown_id = Math.random()
+    } = {}) => {
+        try {
+            const scopedVariables = [...scope.values()];
+            const candidates = scopedVariables.filter(v => v && v._value === module && typeof v._name === 'string' && v._name.startsWith('module ') && !v._name.startsWith('module <unknown'));
+            const pickBestInfo = dfn => {
+                const s = String(dfn ?? '');
+                const m = s.match(/\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/);
+                const firstArg = m?.[2];
+                const info1 = firstArg ? extractModuleInfo(firstArg) : {};
+                if (info1?.id || info1?.notebook)
+                    return info1;
+                return extractModuleInfo(s);
+            };
+            for (const v of candidates) {
+                const info = pickBestInfo(v._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            const any = scopedVariables.find(v => v && v._value === module);
+            if (any) {
+                const info = pickBestInfo(any._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            return `<unknown ${ unknown_id }>`;
+        } catch (e) {
+            debugger;
+            return 'error';
+        }
     };
-
-    // Try module loader cells first.
-    for (const v of candidates) {
-      const info = pickBestInfo(v._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    // Fallback: any scoped variable with _value==module.
-    const any = scopedVariables.find((v) => v && v._value === module);
-    if (any) {
-      const info = pickBestInfo(any._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    return `<unknown ${unknown_id}>`;
-  } catch (e) {
-    debugger;
-    return "error";
-  }
-}
-)};
+};
 const _i47chb = function _findImportedName(){return(
 async (v) => {
   if (v._inputs.length == 1 && v._inputs[0]._name === "@variable") {
@@ -18440,229 +18401,206 @@ JSON.stringify(
 const _1lt3kl6 = function _157(compile,test_case){return(
 compile(test_case.value)
 )};
-const _lpzjrv = function _compile(parser,globalThis,observableToJs){return(
-function compile(source, { anonymousName = "_anonymous" } = {}) {
-  const comments = [],
-    tokens = [];
-  let cell;
-  try {
-    cell = parser.parseCell(source, {
-      ranges: true,
-      onComment: comments,
-      onToken: tokens
-    });
-  } catch (e) {
-    if (e instanceof SyntaxError) {
-      const nameMatch = source.match(
-        /^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/
-      );
-      let _name = null;
-      let funcName = anonymousName;
-      if (nameMatch) {
-        const prefix = nameMatch[1] ? nameMatch[1] + " " : "";
-        _name = prefix + nameMatch[2];
-        funcName = "_" + nameMatch[2];
-      }
-      const escapedMsg = JSON.stringify(e.message);
-      const escapedSource = JSON.stringify(source);
-      return [
-        {
-          _name,
-          _inputs: [],
-          _definition: `function ${funcName}() { throw Object.assign(new SyntaxError(${escapedMsg}), {_sourceExpression: ${escapedSource}}); }`
+const _x1d0wm = function _compile(parser,observableToJs){return(
+function compile(source, {
+    anonymousName = '_anonymous'
+} = {}) {
+    const comments = [], tokens = [];
+    let cell;
+    try {
+        cell = parser.parseCell(source, {
+            ranges: true,
+            onComment: comments,
+            onToken: tokens
+        });
+    } catch (e) {
+        if (e instanceof SyntaxError) {
+            const nameMatch = source.match(/^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/);
+            let _name = null;
+            let funcName = anonymousName;
+            if (nameMatch) {
+                const prefix = nameMatch[1] ? nameMatch[1] + ' ' : '';
+                _name = prefix + nameMatch[2];
+                funcName = '_' + nameMatch[2];
+            }
+            const escapedMsg = JSON.stringify(e.message);
+            const escapedSource = JSON.stringify(source);
+            return [{
+                    _name,
+                    _inputs: [],
+                    _definition: `function ${ funcName }() { throw Object.assign(new SyntaxError(${ escapedMsg }), {_sourceExpression: ${ escapedSource }}); }`
+                }];
         }
-      ];
+        throw e;
     }
-    throw e;
-  }
-  if (!cell) throw new Error("Unable to parse cell");
-  const parseImportSpecifierText = (text) => {
-    const t = String(text ?? "")
-      .trim()
-      .replace(/,$/, "")
-      .trim();
-    if (!t) throw new Error("Empty import specifier");
-    const parts = t.split(/\s+as\s+/);
-    const left = parts[0].trim();
-    const right = parts[1]?.trim();
-    const parseSide = (side, { defaultPrefix = "" } = {}) => {
-      const s = String(side ?? "").trim();
-      const m = s.match(/^(viewof|mutable)\s+(.+)$/);
-      if (m)
-        return {
-          prefix: `${m[1]} `,
-          name: m[2].trim()
+    if (!cell)
+        throw new Error('Unable to parse cell');
+    const parseImportSpecifierText = text => {
+        const t = String(text ?? '').trim().replace(/,$/, '').trim();
+        if (!t)
+            throw new Error('Empty import specifier');
+        const parts = t.split(/\s+as\s+/);
+        const left = parts[0].trim();
+        const right = parts[1]?.trim();
+        const parseSide = (side, {
+            defaultPrefix = ''
+        } = {}) => {
+            const s = String(side ?? '').trim();
+            const m = s.match(/^(viewof|mutable)\s+(.+)$/);
+            if (m)
+                return {
+                    prefix: `${ m[1] } `,
+                    name: m[2].trim()
+                };
+            return {
+                prefix: defaultPrefix,
+                name: s
+            };
         };
-      return {
-        prefix: defaultPrefix,
-        name: s
-      };
+        const L = parseSide(left);
+        const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
+        const importedName = `${ L.prefix }${ L.name }`.trim();
+        const localName = `${ R.prefix }${ R.name }`.trim();
+        if (!importedName)
+            throw new Error(`Could not parse imported name from: ${ t }`);
+        if (!localName)
+            throw new Error(`Could not parse local name from: ${ t }`);
+        return {
+            importedName,
+            localName
+        };
     };
-    const L = parseSide(left);
-    const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
-    const importedName = `${L.prefix}${L.name}`.trim();
-    const localName = `${R.prefix}${R.name}`.trim();
-    if (!importedName)
-      throw new Error(`Could not parse imported name from: ${t}`);
-    if (!localName) throw new Error(`Could not parse local name from: ${t}`);
-    return {
-      importedName,
-      localName
-    };
-  };
-  if (!cell.id && cell.body?.type === "ImportDeclaration") {
-    const module_name = cell.body.source.value;
-    const importKeyword = globalThis?.importShim ? "importShim" : "import";
-    const cell_variables = [
-      {
-        _name: `module ${module_name}`,
-        _inputs: [],
-        _definition: `async () => runtime.module((await ${importKeyword}("${module_name}")).default)`
-      }
-    ];
-    for (const specifier of cell.body.specifiers ?? []) {
-      const specText =
-        typeof specifier?.start === "number" &&
-        typeof specifier?.end === "number"
-          ? source.slice(specifier.start, specifier.end)
-          : (() => {
-              if (specifier?.imported?.name && specifier?.local?.name) {
-                return specifier.imported.name === specifier.local.name
-                  ? specifier.local.name
-                  : `${specifier.imported.name} as ${specifier.local.name}`;
-              }
-              throw new Error("Import specifier missing range information");
+    if (!cell.id && cell.body?.type === 'ImportDeclaration') {
+        const module_name = cell.body.source.value;
+        const cell_variables = [{
+                _name: `module ${ module_name }`,
+                _inputs: [],
+                _definition: `async () => runtime.module((await import("${ module_name }")).default)`
+            }];
+        for (const specifier of cell.body.specifiers ?? []) {
+            const specText = typeof specifier?.start === 'number' && typeof specifier?.end === 'number' ? source.slice(specifier.start, specifier.end) : (() => {
+                if (specifier?.imported?.name && specifier?.local?.name) {
+                    return specifier.imported.name === specifier.local.name ? specifier.local.name : `${ specifier.imported.name } as ${ specifier.local.name }`;
+                }
+                throw new Error('Import specifier missing range information');
             })();
-      const { importedName, localName } = parseImportSpecifierText(specText);
-      cell_variables.push({
-        _name: localName,
-        _inputs: [`module ${module_name}`, "@variable"],
-        _definition:
-          importedName === localName
-            ? `(_, v) => v.import("${importedName}", _)`
-            : `(_, v) => v.import("${importedName}", "${localName}", _)`
-      });
+            const {importedName, localName} = parseImportSpecifierText(specText);
+            cell_variables.push({
+                _name: localName,
+                _inputs: [
+                    `module ${ module_name }`,
+                    '@variable'
+                ],
+                _definition: importedName === localName ? `(_, v) => v.import("${ importedName }", _)` : `(_, v) => v.import("${ importedName }", "${ localName }", _)`
+            });
+        }
+        return cell_variables;
     }
-    return cell_variables;
-  }
-  let dollarIdx = 0;
-  const inputToArgMap = {};
-  const dollarToMacro = {};
-  const seen = new Set();
-  const inputs = Array.from(cell.references || []).flatMap((i) => {
-    if (i.name) {
-      if (seen.has(i.name)) return [];
-      seen.add(i.name);
-      return i.name;
+    let dollarIdx = 0;
+    const inputToArgMap = {};
+    const dollarToMacro = {};
+    const seen = new Set();
+    const inputs = Array.from(cell.references || []).flatMap(i => {
+        if (i.name) {
+            if (seen.has(i.name))
+                return [];
+            seen.add(i.name);
+            return i.name;
+        } else {
+            const dedupKey = i.type + ':' + i.id.name;
+            if (seen.has(dedupKey))
+                return [];
+            seen.add(dedupKey);
+            const dollarName = '$' + dollarIdx;
+            inputToArgMap[i.id.name] = dollarName;
+            dollarToMacro[dollarName] = i.type == 'ViewExpression' ? 'viewof ' + i.id.name : 'mutable ' + i.id.name;
+            dollarIdx++;
+            return dollarName;
+        }
+    });
+    let variables;
+    if (cell.id) {
+        if (cell.id.type === 'Identifier') {
+            variables = [{
+                    functionName: '_' + cell.id.name,
+                    name: cell.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                }];
+        } else if (cell.id.type === 'ViewExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'viewof ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '(G, _) => G.input(_)',
+                    inputs: [
+                        'Generators',
+                        'viewof ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                }
+            ];
+        } else if (cell.id.type === 'MutableExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'initial ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'mutable ' + cell.id.id.name,
+                    _definition: '(M, _) => new M(_)',
+                    inputs: [
+                        'Mutable',
+                        'initial ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '_ => _.generator',
+                    inputs: ['mutable ' + cell.id.id.name],
+                    params: inputs.join(',')
+                }
+            ];
+        } else {
+            throw new Error(`Unsupported cell id type: ${ cell.id.type }`);
+        }
     } else {
-      const dedupKey = i.type + ":" + i.id.name;
-      if (seen.has(dedupKey)) return [];
-      seen.add(dedupKey);
-      const dollarName = "$" + dollarIdx;
-      inputToArgMap[i.id.name] = dollarName;
-      dollarToMacro[dollarName] =
-        i.type == "ViewExpression"
-          ? "viewof " + i.id.name
-          : "mutable " + i.id.name;
-      dollarIdx++;
-      return dollarName;
+        variables = [{
+                functionName: anonymousName,
+                name: null,
+                inputs,
+                params: inputs.join(',')
+            }];
     }
-  });
-  let variables;
-  if (cell.id) {
-    if (cell.id.type === "Identifier") {
-      variables = [
-        {
-          functionName: "_" + cell.id.name,
-          name: cell.id.name,
-          inputs,
-          params: inputs.join(",")
+    return variables.map(v => {
+        let _definition = v._definition;
+        if (!_definition) {
+            let functionBody;
+            if (cell.body.type === 'BlockStatement') {
+                functionBody = observableToJs(cell.body, inputToArgMap, comments, tokens);
+            } else {
+                const bodyCode = observableToJs(cell.body, inputToArgMap, comments, tokens);
+                functionBody = `{return (${ bodyCode });}`;
+            }
+            _definition = `${ cell.async ? 'async ' : '' }function${ cell.generator ? '*' : '' } ${ v.functionName }(${ v.inputs.join(',') }) ${ functionBody }`;
         }
-      ];
-    } else if (cell.id.type === "ViewExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "viewof " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "(G, _) => G.input(_)",
-          inputs: ["Generators", "viewof " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else if (cell.id.type === "MutableExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "initial " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "mutable " + cell.id.id.name,
-          _definition: "(M, _) => new M(_)",
-          inputs: ["Mutable", "initial " + cell.id.id.name],
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "_ => _.generator",
-          inputs: ["mutable " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else {
-      throw new Error(`Unsupported cell id type: ${cell.id.type}`);
-    }
-  } else {
-    variables = [
-      {
-        functionName: anonymousName,
-        name: null,
-        inputs,
-        params: inputs.join(",")
-      }
-    ];
-  }
-  return variables.map((v) => {
-    let _definition = v._definition;
-    if (!_definition) {
-      let functionBody;
-      if (cell.body.type === "BlockStatement") {
-        functionBody = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-      } else {
-        const bodyCode = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-        functionBody = `{return (${bodyCode});}`;
-      }
-      _definition = `${cell.async ? "async " : ""}function${
-        cell.generator ? "*" : ""
-      } ${v.functionName}(${v.inputs.join(",")}) ${functionBody}`;
-    }
-    return {
-      _name: v.name,
-      _inputs: v.inputs.map(
-        (i) => dollarToMacro[i] || (i === "$variable" ? "@variable" : i)
-      ),
-      _definition
-    };
-  });
+        return {
+            _name: v.name,
+            _inputs: v.inputs.map(i => dollarToMacro[i] || (i === '$variable' ? '@variable' : i)),
+            _definition
+        };
+    });
 }
 )};
 const _1v1i7wl = function _observableToJs(acorn_walk,parser,escodegen){return(
@@ -18729,16 +18667,15 @@ async (attachment, overrides) => {
   return URL.createObjectURL(blob);
 }
 )};
-const _s9w7ha = async function _parser(decompress_url,FileAttachment,acorn_url,acorn_walk_url){return(
-importShim(await decompress_url(FileAttachment("parser-6.1.0.js.gz"), {
-    "/npm/acorn@8.11.3/+esm": acorn_url,
-    "/npm/acorn-walk@8.3.2/+esm": acorn_walk_url
-  })
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
-const _1hiclbb = function _acorn_walk(acorn_walk_url){return(
-importShim(acorn_walk_url, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _s9w7ha = async function _parser(decompress_url, FileAttachment, acorn_url, acorn_walk_url) {
+    return import(await decompress_url(FileAttachment('parser-6.1.0.js.gz'), {
+        '/npm/acorn@8.11.3/+esm': acorn_url,
+        '/npm/acorn-walk@8.3.2/+esm': acorn_walk_url
+    }));
+};
+const _1hiclbb = function _acorn_walk(acorn_walk_url) {
+    return import(acorn_walk_url);
+};
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
@@ -18926,7 +18863,7 @@ export default function define(runtime, observer) {
   $def("_1dmmuaf", "compiled_selector", ["Generators","viewof compiled_selector"], _1dmmuaf);  
   $def("_u7t3vu", null, ["compiled_selector","normalizeJavascriptSource"], _u7t3vu);  
   $def("_1lt3kl6", null, ["compile","test_case"], _1lt3kl6);  
-  $def("_lpzjrv", "compile", ["parser","globalThis","observableToJs"], _lpzjrv);  
+  $def("_x1d0wm", "compile", ["parser","observableToJs"], _x1d0wm);  
   $def("_1v1i7wl", "observableToJs", ["acorn_walk","parser","escodegen"], _1v1i7wl);  
   $def("_19lv24l", null, ["md"], _19lv24l);  
   $def("_xhj6b8", "decompress_url", ["DecompressionStream","TextDecoderStream","TransformStream","TextEncoderStream","Response"], _xhj6b8);  

--- a/notebooks/@tomlarkworthy_editor-5.html
+++ b/notebooks/@tomlarkworthy_editor-5.html
@@ -7,7 +7,6 @@
   <link rel="icon" href="data:image/svg+xml;base64,PHN2ZyBmaWxsPSJ3aGl0ZSIgd2lkdGg9IjUwcHgiIGhlaWdodD0iNTBweCIgdmlld0JveD0iMCAwIDY0IDY0IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxyZWN0IGhlaWdodD0iNCIgd2lkdGg9IjQiIHg9IjIwIiB5PSI1MCI+PC9yZWN0PjxyZWN0IGhlaWdodD0iNCIgd2lkdGg9IjE2IiB4PSIyOCIgeT0iNTAiPjwvcmVjdD48cGF0aCBkPSJNMzIsMzhhOCw4LDAsMSwwLTgtOEE4LjAwOSw4LjAwOSwwLDAsMCwzMiwzOFptMC0xMmE0LDQsMCwxLDEtNCw0QTQsNCwwLDAsMSwzMiwyNloiPjwvcGF0aD48cGF0aCBkPSJNNiw2Mkg1OGEyLDIsMCwwLDAsMi0yVjE1YTIsMiwwLDAsMC0uNTg2LTEuNDE0bC0xMS0xMUEyLDIsMCwwLDAsNDcsMkg2QTIsMiwwLDAsMCw0LDRWNjBBMiwyLDAsMCwwLDYsNjJabTQyLTRIMTZWNDZINDhaTTE2LDZIMzF2NGg0VjZoNHY4SDE2Wk04LDZoNFYxNmEyLDIsMCwwLDAsMiwySDQxYTIsMiwwLDAsMCwyLTJWNmgzLjE3Mkw1NiwxNS44MjlWNThINTJWNDRhMiwyLDAsMCwwLTItMkgxNGEyLDIsMCwwLDAtMiwyVjU4SDhaIj48L3BhdGg+PC9zdmc+">
 </head>
 <body>
-<!-- Networking -->
 <script id="networking_script">
   const normalize = url => url.replace(/^(?:https:\/\/api\.observablehq\.com)?\/(.*?)\.js(?:\?.*)?$/, '$1').replace(/^(d\/[a-f0-9]{16})@\d+$/, '$1');
   const isNotebook = id => /^(@[^/]+\/[^/]+|d\/[a-f0-9]{16})$/.test(id);
@@ -238,21 +237,6 @@
 </script>
 
 <!-- CSS -->
-<!-- Style sheets from https://github.com/observablehq/notebook-kit
-Copyright 2025 Observable, Inc.
-
-Permission to use, copy, modify, and/or distribute this software for any purpose
-with or without fee is hereby granted, provided that the above copyright notice
-and this permission notice appear in all copies.
-
-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
-REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
-FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
-INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
-OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
-TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
-THIS SOFTWARE.
--->
 <script id="https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/global.css" 
   type="text/plain"
   data-mime="text/css"
@@ -817,7 +801,6 @@ body .inputs-3a86ea-table thead th {
   background: var(--theme-foreground-faintest);
 }
 </style>
-
 <!-- System Modules -->
 <script id="es-module-shims@2.6.2" 
   type="text/plain"
@@ -837,7 +820,6 @@ H4sIAK6D82gAA7Uca2/cNvK7fwVjHAqpUTep+83bNC3uckCAJimatMDBMFx5V7bV7kp7ktaOz93/fiTn
   data-mime="application/javascript">
 H4sIAGWI82gAA+08/XfbOI6/969QdXlbuXHs2O112qRpm0ncndzko69J566X5BLFomNNZckryfnY1P/7AQRJkfqwZW96s7Pv+l5jiQRBEAABECTVblth5LGLUeRNApa0P0RXCYtv3KuADf/W9sNkzPppFLeTuN/2/GTspv1h6/fkyWAS9lM/Ci1Z6CCappXej+Gvx1LXDxrWwxNLPFtb8uH7d+thugkVN25seVF/MmJh2oV6RNCKbkMW74rSpsVu4AfbSriWxwbuJEh/89lta2eSpNGohzCI0B9YDvYfDWS7rS3LlpTaRI6lcIbslp4dIvpBUjhtILapxYKE5dpkdPRj5qaM9+3Y/MfmzQRsyw/9tKdhH7iATfwYgDn+8K7hP+eGZC4h4vDQdvrkSXsBsblx7N4bMvMTXubcuMGEEVtilk7i0NrmsH6yrdeDxPiTBXhTN+wjg/fC9DUHqqrtvJpZ/aJbXf3Fn4mcV+8E7mjMvNlQs2jA+llEfAwidz7Aq5ccAGWicdcPPXbnfGP3Bm/hnWskVljfrfWGtWrZ9sLiFG+H7oiZQs3KnRD+UN/9CCi2Qk11peYGbMR1FzQsJNUNW/3ATRLEAPC2TsPaWp8FAaK1CTJld+lOFKY0LS5XHrBuio+b2YjDhQc3iOKRmx7fj66iAEeHNiLhbyfRcRr74TV0IarHcZRGOLlaqajbzLihI3IIgyEME2mr7wYKbGGio6vf4UWS+2Bds/ToNvwUR2MWp/dEQ9K0FL0bADN0Ew0GjA3y7ogj2hRo5KhO3GteS4io9uPR55/3dnd7h1CO1jTjUwKquVVOwqauo2BoHSK8aeU11SSOmKPDGuqeutfRQFQbWKjoVBvGOU4kwS2umPEEmWj95S8lpS3UKGxgE1tso1c+HVW/2hDS+F7YbFJ9mrdbkhqAOyfri95CGDj+o/dNEGIcvJY8Qh+NseX412EUM+lPBJgSCVnwRWf1aDRJsUaq0fHXg5+P9o+B8lPA9yCku2HZHz5cXOwdHHw52f55v3exd7jb+6/e7sXFhw9200KWAcge2h/mQQF07Q98Fm8AX4AN0+YsXL/2vuYx/cruF8ezv3d8YqLZ95MU3rjX8ZNhLSwH259MJAfu2BZtON8r2h193u19luPggKL9UeyxGEfDC80RUdk4ZgP/jkpQiDPp+9zbga5MEj+zfhR7dag87p0UKTxmqSgwOUVlCUtVyVzqjk+2d341iTtO3f63Eik8OdcNg9RD7kdg0uRnVcBSaWnQJpGWtgZ+kLLYcSQ9EENZW+9w0p1SwTl3fdhhI5t+TwWiVsDC63TYEFNpU5u+ITkjCTgA1+o4CUf+NGlJITb0JiRFDPDQRRICDAS5/oCpKcOVoeIQLcJhoJVs06hJIuCRwiABjFYktMo2VN0w7A3xWSoFuFYxoPdiZDQkEKg9JbfLC6aXTdFO9CRfM3GrEcAQn1LPqg1/4y9Tw9TlrVw4CYKlDBy7gzjDY57hJj9Jl3g0aOZ81i5L+rE/huZJwTeSLVeNyd9puJwHDOHzkVFPUKB8xgVNDeGZaaCo3pqkZaQs3NumgACfB6G8zwIP/HoIoVDTCuUKhED1SBEUT3KxHKDo/BpKC6ArjKoAh7PyIAAT/+9s2rjcFCBECFILcxBCO4ClKmMJI1HhPHAadlVjyWfePlsGlRMOBusfHhngqD0ygJ01MkS11MjU1BUYBWmKrHxYMs0oJtOlaM53KpYHRm8YjRfsLKpXrvs9FRPAPKd+5QNZNOlu3oMtAINwWeDjVFClaXSo7FSO4KwC8Anq90a0/tmAWmHJtDpgN9So14y/2li1qSXHZQSM5Vzjc7mwCK/dXKNELYFwmVNrFYRPsxZC0pDZcsJniy3R2B2PWejtDP3AcwqrsoZJlouuId+oikjXpuZuyw9DFv9ycrCPevI2ubm2bn0vHW69tobMvx6m8MCHsPUst4pzwY4/e8dpfTt206HlbT07eGn9tL9udYav//4MeBkEW8/6kziGLneiIIqfWW1s8LYN3by7pP5nUHsC5vAQvIID0wdkBSqr6ZVtnaKm2taDPb2Ug3E9jyc4MEpkMC7HHkWThE3GEKxIIy6SH3o6ppWk0RjdhXvtchDlRseB22cOsrUpjT+MJHDHiWb90ZOZDoBEw/8qjaIHXd1gZWk56AR8qF7ftJ466AAUaAvfnEaj5UUhQ0/rW2+tLsCtrvqVWoJtWrQYkerB4yNejogaxprG7S6jNcDq7izF5vTbCjJJ7wPKQAVgAQD6KoggflT1tVTAss4m3fXuKwi3Y3ap0bG4zOdIXXAVxA3Rw88MpMQ0tjapFgafcooxwLvxocdj/yqAxalCsox0O28M6T4aLVPxy41Mpgm8dcxG0Q0j7tdEpzK1NDHsIHI9mbOcKr2bp1ZKtvqsPueTeioUTaZYAJO+Zn+uxSfOSMZEnOGk1rg4b9Jy+9yC4GGUxU33yH2R1IHmH/HVycAV9RzuuekHeF+lhGC8kMgQRiOEcgZAQZLFNzoF0I4oqNE5oijtnPvPx+u+pAdK4nI5aX0o5W7ytCBlhymK2eTqHBrajMrngxW1NDx5gogav6myMhwWbG+jmTcyPDWqtE4wThs75kbznXFTaGRVceLxDJboCAtnkZZpSkYctimQB4UziBNrW5SMzLUJ9paJibrO7EohHykXXznCcrU5CqnW5pXVoheBmy58LvcOt2rmqDItwKhxE4GkEnSqx+V3RCahBWsveANeqtV9KUk8pjPyhEWxVy4B8xHyHBHrWcFqGdeQ7txuFxCvJGph+WaJDeBgcbGrxSYq4sYZQg9Pt7by6+Wy0ahKEbFXilGYtdly1GuFCSkknGvP13rCrD1h/1+kRWMxW6h5v2xKd5b0Zs29aX6zJqNX25ckCoDQ0YzFm+ffEFZjqYeNagXItPYjbmObWjHyvGWi2u3hY1YtcvtmuAqTgLS2mke1ir9siLg0oksWnY6QwU3ke+ju87/cXusRGyLaLAqmKFU17j+bkNRztUBWHmCk0x8jizrcLgtvl+ByfSbVH6U1d5TcsC+IdOvd4zEvFxr/afhWPcCFkux9meUwTgYM3eSYBUysqWHEOl8ShmdPbiG4jm4xlMsgjbUcC1qUaud5Rze8ZnwvxcEKQJS6QAgfLOIXpgU3b/FVAXBoN+wPoxhhKwAGwEaOq2FuNFdmcpKhGwTR7b9uNr87K+ldJ50vETz558vnzxxbnYR++dh+cEa/m0tz/+lS+t3qnH63mNTXh7tULr6rpzXFfDVzmuiMu7US9OS4Z6YyRQ9Cc/JJeolgfp5e5uCK8FW2HjjSMKhcJtGJBBtGm6NqmPvjc/Oheh68W5kIVwM1N6F5I3Ot8mg7KMpL/QttofxkvdzvWK9/W/8jtlBo9AsrWqma5bRs8Z2WwjZ71UaLljD6sdstlMJ8hycua2e3gWm2PpEX3a5ZpCPaIrF1Wf7o/Hv3MRLw3boZ+O7MFHx3wSR4bnWrZR2rep+dg3+8/qsTsd1CJnYdVHit01w+Jcu1ugNqDahWLSjWRdQbjdN7rF7D6jWo3iwZQVX+1iLy/I6u3Qv1VbUbsTQf1AZFNSeKexRLsahUzNqeRo5TBq+yJOQSXf/oXZDuH7gN0nVK06lVWx8VGdR5Wenuj01Ld//QvPQ8FuZz0QvzUAX7j5QH7i6bCKbpYWRvHu/0DuKuSsfSGqyDHpXgcAXGn6yzu92frJUHNtXvN+Q9bPXoSxOmg9i9Hpn3isTA5AWojwLCKSZOZeNFk6cLp0RhGNw61eivJB9a2qzMg+qRi2w0IzvarUiPLsrTmfTxLjLqFmOBltf8h5lQSAKC3SJ+aLdmjJwfFTkekMQvnQVXbv8bMYo7El6jZ3Z24R2MDy/estrPrQ8XF5++fO5dXFjP2/yuHEI4qwigNqZ8UJxDjkotGyxxA0/2mbuEB3NL1lA7mGKyINPxYTSJcTmAEBiffDnZ+QWL9Hkw8sNJynJQB1RozBcGv14O7pgKTXxB4JcCH2g1RlYUlmfE56/MjR2txUdY8vAyMMMvG9O1lYex6+kABzC9hg7eAIPQp1sGwbnd4JUrD8SP79/VoOFRkspLNdLfW5cnhI234hg2qEC0FkhnIBDwokTA54FaEmlW3LReNKaXaDUv5c9/y9eSycxZdA9/jHtDWABB3jr2IfiyhmVN6xUh5wDvrDfwD2FWCcYAyQpemklkrBAzji/3jZ5BnrxuetkCuOPUjVOHQ4H7WrcXvxhGo0RJlsxNLmCaAhoJxry190Kgx/f41Fu6/14cR7E8ds/wRbtLR5U1rtJxwJIbo3R3KsG7JTydr+Onm2NyfbgU8Z/Zde9uLKmP+ZtGvqiuQT9BlgzAxPkIJAtEguTD3n/u7x3ipaiDvROguLtevKXIGzgJ/9G2M+RJY0qeZMZbAHDLSveJtYi2H03At0lc7VP7LDxvXzest+DpzarL72crD1CVRbxZgPGiZiZWT9/xdrWSqrInDDR+Q1a/ECm8F4tGMzwVrbDMTAnzYdsljcxw5z+Ojw5bBOwP7gW3tJyqCvxe6AliGk/gh9whUaNWMg58IPdMcQt5xWHEchaMmKkeeDFHSj0vFs+/qbN/acoEipeXSL7xHyIP+9IGL5lCFB64KUqEGJgEfp85602TgY3W75EfEstzI+PCgIXO8uMSHIph8gKUt4OzCbAZAl0z6ZFNZef50wbHQ5jGKw8mzmnWB0eerwet4UuUxKZLYJeFXuayXVxisAstl9mtmLsRkSWKgfMqT1y0d/yqo2Wq5TQ/9QBFceItsnlkGqx6u0C5ySGP38/cEipXowyHIaXLMinBclPYAp72r7iGYiiBhn7ONBKGDb9BcGk/2taPydwavM1xdpGtHI2vqn1Ni5PB1zD+mbHurPOgFEJnYeClEfr39caUsvi5urWXbygg1fxIVfKgRDhamCLQypnUPj07uzy7W19fgz9v4P8VPHTenJNPb2rIdoZu3KjoCOuc/lAG4Biv9CHYwawAFLbwzw68b6fOOiUPbn1+K7TPT2+QAei7CbNeb5iz1D47uxJaxevfFOtTvb7TKQLcGADdIsDAAHhRBIhtqcaijA/urdV5hRPqDLiGkwILVdzodF7hklQAvugKwCo4qONVwCiDxWaoJb8VgPwNZZr7FpSbWU7MWuyO9aXIYUKuhpqWLP4JDfH2UZAi49A0C5pVVVnYjLAnXz/1LraPvx7uAPSDuhZvu8l92LfOJuudN13bmuaBL/7aO+x93j45+lzd7LnZbmd/+/jYhOYz2IT6+OVw52Tv6NAELKOjggK97/x5IskNZ6DH2Zxl/MM9eJoJjzoYC4SBMR0G+a9ZDArnS4zZYm8jR2THtlRccZc5Y6h0fVdg+L5t5tv/FR20Cx3MR5TxpRJlPWyz8IgvM+Watf+HC/Tsqg22NkkdCBze67LfMEVcwCs3U9Tps6xt7mq6SL5KcZL0bPH9A2OjdsTpct5vcM08S5433jtnt6sNeNp616b5mGXiZ6J3cPqPTjvn6EgbNTs7c+AHe4RSeGrCf+wea+CpsRAFvO/3GiGZixCo0R3w7WwiEa2WU5dSFfNxQs+QUfQE5HJi//lGMltc5KW1RsXsvdnEja+TpiW/fpQZh0fbkVCpURk/mX3NORCjgNX4JXEnNP+WCadk81lkf2P3t3hSzYA3oynuWcgGK0bUO9lwnZSeZFjGD2bfmzC+vyTN+YZ66uY+wpT3EzJtmEvPVJw6FdZPJMPVJ4Skx9DvbJD9vYqigLnS6lLZBAL8AawAPXtDrbboXMLqFv90WMEGT7XW4WR0xeJC0y35C7Z0HZ1Vx2qLIkq62mvrOLVER/P7ufKv/TCt7AcwhPNQiL3JIgpjy1MIQM32GQjVpMpQynPVOa9fRGoQRmuGAhYjcTdLMQyc0kMaBxQyaeBBKX1ZLXSIzk9Jjtj4qvhpMMC8MVz4YN2uyjUb6G3MNdvNHMt5drqM4XN7xJGob2GV9QcdXPmex0KtU/tUlZ7PG5yaQ3Li6jlbvUMS4ak4xUwJ4HNNljpRMbsGsRXYoGeNC4zI0ZdRmO+a587PVUBlWWDHhmk6Tjba7Ws/HU6uIF4ctYPIc5Oh/LkKoqv2yE1SFrf9RCbx/22/+6qil92jg95dn41RrauGydPzhVFquf1FBpkL+PCfmB4OTQE8WGweCsSjxblzqI3C/NENal74ufn+f5eiCJf0peGsPM/KAwqGkjf5fXflM6ryBfrpy6PAo88KHLJbbaOAaogCTOllFy0K17L5yIFmiUVr5HpeJbx07NjN2MUDr+jCZeSWfZ8AMDYlIG9kfI2A16oPEizs6D12J938/tHONq4jLg62T3Z+wYD2LFmFKNVb3YD/Z42V9oiWi3sShzwCkR0ioGUb/6CtcfiKCtJhHN3yDXGaNrYvNumwWiYZ06GftC5CyqXgDxXzj7rOYGx2Lxl1DH2LeUj+wSKcGKdgF4T1IoeWvg2RFxlN/UZ5kxIRx5MwRN+nSBpMAjzZzDzDUtSgT5xcw5r8J2U1ncFQpFCGV10vdEFkoUEuLBPf16WBDfxYfA0DsebLsnHPrq2cLSr32siZy5ssB1lr5ki7Vk+CUiKFw1SGaJHbBS4gH7Wtzyo43XuK/BSBqK+LZBIxmlGJ/lGSXDvNo0hYzUIIGRbwKutv3g6SOHRTnJ1Cztgqoi5paS7oE9X2ZOyJ/XS5YkT/CXrN+VhfrxeTWv2ZZ4izXAz1Oc6/sl136xB3xmas+aTu5jdS6u4yztl4UwtAEgRfezRUEsC07JjZaTQMnhqY/RvVZ076MgR6oLMK6tM3080nyie0YEGD1/JV+kNYAhZnzlUs7VQNHXQSCwZNfWRtxv+/TVh8T7cuwH9kqDO26kjFsqDgdjKYMEohkIPFoq7StEyR9Oe/4gho1GCz3mrFNlxdRLph84mRUDVMvLZ3UVyLCGylH9ZGNWgob6DXlHynd/oEjHEUp7w7NSQk638B7sve5NpeAAA=
 </script>
-
 
 <script id="@mbostock/safe-local-storage" 
   type="text/plain"
@@ -1203,9 +1185,9 @@ md`# [Acorn@8.11.3](https://github.com/acornjs/acorn)
 import { acorn } from "@tomlarkworthy/acorn-8-11-3"
 \`\`\``
 )};
-const _1xdqqxo = function _acorn(acorn_url){return(
-importShim(acorn_url, 'https://api.observablehq.com/@tomlarkworthy/acorn-8-11-3.js?v=4')
-)};
+const _1xdqqxo = function _acorn(acorn_url) {
+    return import(acorn_url);
+};
 const _jdtsxp = async function _acorn_url(unzip,FileAttachment)
 {
   const blob = await unzip(FileAttachment("acorn-8.11.3.js.gz"));
@@ -4119,19 +4101,15 @@ codemirror.EditorView.theme({
 const _12m5h41 = function _9(md){return(
 md`---`
 )};
-const _1d6o6ga = async function _codemirror(unzip,FileAttachment)
-{
-  const blob = await unzip(FileAttachment("codemirror_javascript@5.js.gz"));
-
-  const objectURL = URL.createObjectURL(
-    new Blob([blob], { type: "application/javascript" })
-  );
-  try {
-    console.log("Loading codemirror from", objectURL);
-    return await importShim(objectURL, 'https://api.observablehq.com/@tomlarkworthy/codemirror-6-v2.js?v=4');
-  } finally {
-    URL.revokeObjectURL(objectURL); // Ensure URL is revoked after import
-  }
+const _1d6o6ga = async function _codemirror(unzip, FileAttachment) {
+    const blob = await unzip(FileAttachment('codemirror_javascript@5.js.gz'));
+    const objectURL = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
+    try {
+        console.log('Loading codemirror from', objectURL);
+        return await import(objectURL);
+    } finally {
+        URL.revokeObjectURL(objectURL);
+    }
 };
 const _g5fwfs = function _unzip(Response,DecompressionStream){return(
 async (attachment) => {
@@ -5414,58 +5392,41 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _geoudp = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
-  if (command.processed) return;
-
-  let result = undefined;
-  if (command.command == "createCell") {
-    $0.value = true;
-    result = await compile_and_update("{}", [], command.args.cell);
-    // For the new one to get focus
-    // setTimeout(() => {
-    //   debugger;
-    //   setOption(result[0], "pinned", true);
-    // }, 100);
-  } else if (command.command == "deleteCell") {
-    remove_variables(command.args.cell.variables);
-    result = true;
-  } else if (command.command == "moveCell") {
-    const cellIndex = findCellIndex(
-      command.args.cell.variables,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const targetCellIndex = cellIndex + command.args.amount;
-    const targetCell = lookupCellByIndex(
-      targetCellIndex,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const currentFirstVariableIndex = findVariableIndex(
-      command.args.cell.variables[0]
-    );
-    const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-    const change = targetFirstVariableIndex - currentFirstVariableIndex;
-    console.log(
-      "moveCell",
-      cellIndex,
-      targetCellIndex,
-      targetCell,
-      currentFirstVariableIndex,
-      targetFirstVariableIndex,
-      change
-    );
-    command.args.cell.variables.forEach((v) => {
-      const currentIndex = findVariableIndex(v);
-      repositionSetElement(runtime._variables, v, currentIndex + change);
-    });
-    // recompute
-    await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
-    result = true;
-  }
-  if (result) {
-    command.processed = true;
-    $2.resolve(result);
-  }
+    if (command.processed)
+        return;
+    let result = undefined;
+    if (command.command == 'createCell') {
+        $0.value = true;
+        result = await compile_and_update('{}', [], command.args.cell);    // For the new one to get focus
+                                                                           // setTimeout(() => {
+                                                                           //   debugger;
+                                                                           //   setOption(result[0], "pinned", true);
+                                                                           // }, 100);
+    } else if (command.command == 'deleteCell') {
+        remove_variables(command.args.cell.variables);
+        result = true;
+    } else if (command.command == 'moveCell') {
+        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const targetCellIndex = cellIndex + command.args.amount;
+        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
+        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+        const change = targetFirstVariableIndex - currentFirstVariableIndex;
+        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
+        command.args.cell.variables.forEach(v => {
+            const currentIndex = findVariableIndex(v);
+            repositionSetElement(runtime._variables, v, currentIndex + change);
+        });
+        // recompute
+        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        result = true;
+    }
+    if (result) {
+        command.processed = true;
+        $2.resolve(result);
+    }
 };
 const _1jadxoe = function _60(md){return(
 md`### UI Action`
@@ -5856,7 +5817,7 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _nzhbow = function _compile_and_update(compile,realize,runtime,repositionSetElement)
+const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
     return async (source, variables = [], cell) => {
         try {
@@ -5930,7 +5891,7 @@ Inputs.textarea({
 })
 )};
 const _b4rsn5 = (G, _) => G.input(_);
-const _t68yvv = function _98(Inputs,definition,variable,inputs,realize,runtime){return(
+const _ga6kci = function _98(Inputs,definition,variable,realize,runtime,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
   reduce: async () => {
@@ -6047,7 +6008,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_geoudp", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _geoudp);  
+  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6085,7 +6046,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_nzhbow", "compile_and_update", ["compile","realize","runtime","repositionSetElement"], _nzhbow);
+  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -6095,8 +6056,9 @@ export default function define(runtime, observer) {
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
   $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
-  $def("_t68yvv", null, ["Inputs","definition","variable","inputs","realize","runtime"], _t68yvv);
+  $def("_ga6kci", null, ["Inputs","definition","variable","realize","runtime","inputs"], _ga6kci);  
   $def("_1q557s", null, ["md"], _1q557s);  
+  main.define("realize", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("realize", _));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -6105,9 +6067,8 @@ export default function define(runtime, observer) {
   main.define("keepalive", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("keepalive", _));  
   main.define("toObject", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("toObject", _));  
   main.define("isnode", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("isnode", _));  
-  main.define("repositionSetElement", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("repositionSetElement", _));
-  main.define("realize", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("realize", _));
-  main.define("onCodeChange", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("onCodeChange", _));
+  main.define("repositionSetElement", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("repositionSetElement", _));  
+  main.define("onCodeChange", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("onCodeChange", _));  
   main.define("EditorState", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("EditorState", _));  
   main.define("EditorView", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("EditorView", _));  
   main.define("codemirror", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("codemirror", _));  
@@ -6705,15 +6666,11 @@ async (action, state, options, feedback_callback) => {
     }
 }
 )};
-const _1i2b0pi = function _exportToHTML(_runtime,importShim,cssForTheme,css,location,keepalive,exporter_module,$0)
-{
-    return async function exportToHTML({mains = new Map(), // (name -> module) Map of main modules
-        runtime = _runtime, options = {}    // Object, export options, e.g. head, title, theme
-} = {}) {
-        // defaults if conf not found
+const _1i2b0pi = function _exportToHTML(_runtime, importShim, cssForTheme, css, location, keepalive, exporter_module, $0) {
+    return async function exportToHTML({mains = new Map(), runtime = _runtime, options = {}} = {}) {
         let conf = { headless: false };
         try {
-            conf = (await importShim('file://bootconf.json', 'file://@tomlarkworthy/exporter-3')).default;
+            conf = (await import('file://bootconf.json')).default;
         } catch (_) {
         }
         if (runtime.module_names) {
@@ -6734,7 +6691,6 @@ const _1i2b0pi = function _exportToHTML(_runtime,importShim,cssForTheme,css,loca
         if (!options.hash) {
             options.hash = location.hash;
         }
-        // Force observation of response
         keepalive(exporter_module, 'tomlarkworthy_exporter_task');
         const response = await $0.send({
             mains,
@@ -6744,28 +6700,28 @@ const _1i2b0pi = function _exportToHTML(_runtime,importShim,cssForTheme,css,loca
         return response;
     };
 };
-const _17k9v19 = function _getSourceModule(notebook_name,main,_runtime,importShim){return(
-async state => {
-    if (state.source == 'this notebook')
+const _17k9v19 = function _getSourceModule(notebook_name, main, _runtime, importShim) {
+    return async state => {
+        if (state.source == 'this notebook')
+            return {
+                notebook: notebook_name,
+                module: main,
+                runtime: _runtime
+            };
+        const url = state.source == 'a notebook url' ? state.notebook_url.child : state.top_100.child;
+        const notebook = url.trim().replace('', '');
+        const [{Runtime, Inspector}, {default: define}] = await Promise.all([
+            import('https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js'),
+            import(`https://api.observablehq.com/${ notebook }.js?v=4`)
+        ]);
+        const runtime = new Runtime();
         return {
-            notebook: notebook_name,
-            module: main,
-            runtime: _runtime
+            notebook,
+            module: runtime.module(define),
+            runtime
         };
-    const url = state.source == 'a notebook url' ? state.notebook_url.child : state.top_100.child;
-    const notebook = url.trim().replace('', '');
-    const [{Runtime, Inspector}, {default: define}] = await Promise.all([
-        importShim('https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js', 'file://@tomlarkworthy/exporter-3'),
-        importShim(`https://api.observablehq.com/${ notebook }.js?v=4`, 'file://@tomlarkworthy/exporter-3')
-    ]);
-    const runtime = new Runtime();
-    return {
-        notebook,
-        module: runtime.module(define),
-        runtime
     };
-}
-)};
+};
 const _6vlf2p = function _createShowable(variable,view)
 {
     return function createShowable(child, {
@@ -7320,8 +7276,7 @@ ${ await generate_define(spec, variables, fileAttachments, { moduleNames }) }`
 const _19ft5zb = function _generate_definitions(variableToDefinition){return(
 variables => variables.map(v => variableToDefinition(v)).join('')
 )};
-const _7nr512 = function _generate_define(variableToDefine)
-{
+const _7nr512 = function _generate_define(variableToDefine) {
     return async (spec, variables, fileAttachments, {moduleNames} = {}) => {
         const fileAttachmentExpression = fileAttachments?.size ? `  const fileAttachments = new Map(${ JSON.stringify([...fileAttachments.keys()]) }.map((name) => {
     const module_name = "${ spec.name }";
@@ -7331,9 +7286,6 @@ const _7nr512 = function _generate_define(variableToDefine)
   }));
   main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));\n` : '';
         const varLines = (await Promise.all(variables.map(v => variableToDefine(v, { moduleNames })))).flat();
-        // Collect module names referenced by import-bridged variables but not defined by isModuleVar variables.
-        // On Observable, module reference variables ("module X") don't exist in the task_runtime,
-        // so we need to synthesize them from the import bridge patterns.
         const definedModules = new Set(varLines.filter(l => l.includes('runtime.module(')).map(l => {
             const m = l.match(/main\.define\("module ([^"]+)"/);
             return m ? m[1] : null;
@@ -7358,7 +7310,7 @@ ${ varLines.join('  \n') }
 const _1hslsmt = function _isLiveImport(){return(
 v => !v._name && v._definition?.toString().includes('observablehq' + '--inspect ' + 'observablehq--import')
 )};
-const _18sa1aj = function _variableToDefinition(isModuleVar,isImportBridged,isLiveImport,isDynamicVar,pid){return(
+const _g39v22 = function _variableToDefinition(isModuleVar,isImportBridged,isLiveImport,isDynamicVar,pid,restoreCanonicalImports){return(
 function variableToDefinition(v) {
     if (isModuleVar(v))
         return '';
@@ -7368,7 +7320,46 @@ function variableToDefinition(v) {
         return '';
     if (isDynamicVar(v))
         return '';
-    return `const ${ pid(v) } = ${ v._definition.toString() };\n`;
+    return `const ${ pid(v) } = ${ restoreCanonicalImports(v._definition.toString()) };\n`;
+}
+)};
+const _5zomoj = function _restoreCanonicalImports(acorn,escodegen){return(
+source => {
+    if (!/\bimportShim\s*\(/.test(source))
+        return source;
+    let ast;
+    try {
+        ast = acorn.Parser.parse(source, {
+            ecmaVersion: 'latest',
+            sourceType: 'script',
+            allowAwaitOutsideFunction: true,
+            allowReturnOutsideFunction: true,
+            allowImportExportEverywhere: true
+        });
+    } catch (e) {
+        console.warn('[exporter-3] importShim AST parse failed; leaving cell unchanged:', e.message);
+        return source;
+    }
+    const visit = node => {
+        if (!node || typeof node !== 'object')
+            return;
+        if (node.type === 'CallExpression' && node.callee && node.callee.type === 'Identifier' && node.callee.name === 'importShim' && node.arguments.length >= 1) {
+            const spec = node.arguments[0];
+            for (const k of Object.keys(node))
+                delete node[k];
+            node.type = 'ImportExpression';
+            node.source = spec;
+        }
+        for (const k of Object.keys(node)) {
+            const v = node[k];
+            if (Array.isArray(v))
+                v.forEach(visit);
+            else if (v && typeof v === 'object' && v.type)
+                visit(v);
+        }
+    };
+    visit(ast);
+    return escodegen.generate(ast);
 }
 )};
 const _1g36je3 = function _variableToDefine(isLiveImport,isDynamicVar,isModuleVar,isImportBridged,findImportedName3,pid)
@@ -7435,7 +7426,7 @@ const _1g36je3 = function _variableToDefine(isLiveImport,isDynamicVar,isModuleVa
         return [`  $def("${ pid(v) }", ${ name_literal }, ${ deps }, ${ pid(v) });`];
     };
 };
-const _1bux505 = function _60(md){return(
+const _dxkjia = function _61(md){return(
 md`## Assemble `
 )};
 const _g33g3u = function _es_module_shims(){return(
@@ -7705,11 +7696,11 @@ const _1pcnq22 = function _networking_script(normalize,isNotebook){return(
     }
   })();`
 )};
-const _1crzwh0 = function _lopebook(diskDataUrl,networking_script){return(
-({blocks = '', cssUrls = [], bootloader = '@tomlarkworthy/bootloader', title = 'Lopecode notebook', head} = {}) => {
-    const styleImports = cssUrls.map((url, i) => `  const style${ i } = await importShim(${ JSON.stringify(url) }, { with: { type: 'css' } });`).join('\n');
-    const styleAdopt = cssUrls.map((_, i) => `style${ i }.default`).join(',');
-    return `<!DOCTYPE html>
+const _1crzwh0 = function _lopebook(diskDataUrl, networking_script) {
+    return ({blocks = '', cssUrls = [], bootloader = '@tomlarkworthy/bootloader', title = 'Lopecode notebook', head} = {}) => {
+        const styleImports = cssUrls.map((url, i) => `  const style${ i } = await importShim(${ JSON.stringify(url) }, { with: { type: 'css' } });`).join('\n');
+        const styleAdopt = cssUrls.map((_, i) => `style${ i }.default`).join(',');
+        return `<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
@@ -7743,8 +7734,8 @@ ${ styleImports }
 </scr\ipt>
 </body>
 </html>`;
-}
-)};
+    };
+};
 const _1tiwgkp = function _lopemodule(TRACE_MODULE,CSS,arrayBufferToBase64,inlineModule,escapeScriptTags)
 {
     return async module => {
@@ -7790,10 +7781,10 @@ async function arrayBufferToBase64(buffer) {
     return btoa(binary);
 }
 )};
-const _1p6pb2e = function _73(md){return(
+const _am38ex = function _74(md){return(
 md`### Global Output`
 )};
-const _1yismpd = function _74(md){return(
+const _kx1h0y = function _75(md){return(
 md`## Utils`
 )};
 const _t237wb = function _getCompactISODate(){return(
@@ -7808,7 +7799,7 @@ function getCompactISODate() {
     return `${ year }${ month }${ day }T${ hours }${ minutes }${ seconds }Z`;
 }
 )};
-const _4t2ire = function _76(md){return(
+const _1nku2br = function _77(md){return(
 md`## Additional Tests`
 )};
 const _8765p8 = function _diskDataUrl(disk_svg){return(
@@ -7902,9 +7893,10 @@ export default function define(runtime, observer) {
   $def("_19ft5zb", "generate_definitions", ["variableToDefinition"], _19ft5zb);  
   $def("_7nr512", "generate_define", ["variableToDefine"], _7nr512);  
   $def("_1hslsmt", "isLiveImport", [], _1hslsmt);  
-  $def("_18sa1aj", "variableToDefinition", ["isModuleVar","isImportBridged","isLiveImport","isDynamicVar","pid"], _18sa1aj);  
+  $def("_g39v22", "variableToDefinition", ["isModuleVar","isImportBridged","isLiveImport","isDynamicVar","pid","restoreCanonicalImports"], _g39v22);  
+  $def("_5zomoj", "restoreCanonicalImports", ["acorn","escodegen"], _5zomoj);  
   $def("_1g36je3", "variableToDefine", ["isLiveImport","isDynamicVar","isModuleVar","isImportBridged","findImportedName3","pid"], _1g36je3);  
-  $def("_1bux505", null, ["md"], _1bux505);  
+  $def("_dxkjia", null, ["md"], _dxkjia);  
   $def("_g33g3u", "es_module_shims", [], _g33g3u);  
   $def("_1na8qih", "inspector_gz", [], _1na8qih);  
   $def("_3naqgd", "inlineModule", [], _3naqgd);  
@@ -7917,10 +7909,10 @@ export default function define(runtime, observer) {
   $def("_1tiwgkp", "lopemodule", ["TRACE_MODULE","CSS","arrayBufferToBase64","inlineModule","escapeScriptTags"], _1tiwgkp);  
   $def("_19l1umr", "escapeScriptTags", [], _19l1umr);  
   $def("_1hwkszj", "arrayBufferToBase64", [], _1hwkszj);  
-  $def("_1p6pb2e", null, ["md"], _1p6pb2e);  
-  $def("_1yismpd", null, ["md"], _1yismpd);  
+  $def("_am38ex", null, ["md"], _am38ex);  
+  $def("_kx1h0y", null, ["md"], _kx1h0y);  
   $def("_t237wb", "getCompactISODate", [], _t237wb);  
-  $def("_4t2ire", null, ["md"], _4t2ire);  
+  $def("_1nku2br", null, ["md"], _1nku2br);  
   $def("_8765p8", "diskDataUrl", ["disk_svg"], _8765p8);  
   $def("_z4k2or", "viewof task", ["flowQueue"], _z4k2or);  
   $def("_ngmf1x", "task", ["Generators","viewof task"], _ngmf1x);  
@@ -7937,6 +7929,8 @@ export default function define(runtime, observer) {
   main.define("variableToObject", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("variableToObject", _));  
   main.define("parser", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("parser", _));  
   main.define("decompress_url", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("decompress_url", _));  
+  main.define("acorn", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("acorn", _));  
+  main.define("escodegen", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("escodegen", _));  
   main.define("view", ["module @tomlarkworthy/view", "@variable"], (_, v) => v.import("view", _));  
   main.define("variable", ["module @tomlarkworthy/view", "@variable"], (_, v) => v.import("variable", _));  
   main.define("bindOneWay", ["module @tomlarkworthy/view", "@variable"], (_, v) => v.import("bindOneWay", _));  
@@ -8535,397 +8529,345 @@ const _1bf1rb4 = function _fileSyncLastSeen(directory)
     void directory;
     return new window.Map();
 };
-const _1srrp0d = function _filesToNotebook(directory,syncArmed,currentModules,fileSyncLastSeen,notebookId,runtime,probeDefine,tag,readFile,exportModuleJS,manifestWriter,hashSource,writeFile,getFileAttachmentsMap,invalidation)
-{
-  if (!directory) return "Waiting for directory...";
-  if (!syncArmed || !syncArmed.armed)
-    return "Sync inactive: " + ((syncArmed && syncArmed.reason) || "unknown");
-  // Compute syncable modules inline — avoid depending on syncableModules/SKIP_MODULES reactively,
-  // which would restart this cell every time SKIP_MODULES changes.
-  const SKIP = new Set(["bootloader", "builtin"]);
-  const syncableModules = [];
-  for (const [mod, info] of currentModules) {
-    if (SKIP.has(info.name)) continue;
-    if (!info.name.includes("/") && !info.name.startsWith("d/")) continue;
-    syncableModules.push(info.name);
-  }
-  const syncableSet = new Set(syncableModules);
-  // Use stable lastSeen map that survives restarts — only resets when directory changes
-  const lastSeen = fileSyncLastSeen;
-  const POLL_MS = 1000;
-  const prefix = notebookId + "/";
-  // Build lookup: module name → module object (the Observable Module instance)
-  const nameToModule = new window.Map();
-  // Build lookup: module name → Map of pid key → variable
-  const nameToVars = new window.Map();
-  for (const [mod, info] of currentModules) {
-    if (!syncableSet.has(info.name)) continue;
-    nameToModule.set(info.name, info.module);
-    const vars = new window.Map();
-    for (const v of runtime._variables) {
-      if (v._module !== info.module) continue;
-      if (v._name) vars.set(v._name, v);
-      if (v.pid) vars.set("__pid__" + v.pid, v);
+const _1srrp0d = function _filesToNotebook(directory, syncArmed, currentModules, fileSyncLastSeen, notebookId, runtime, probeDefine, tag, readFile, exportModuleJS, manifestWriter, hashSource, writeFile, getFileAttachmentsMap, invalidation) {
+    if (!directory)
+        return 'Waiting for directory...';
+    if (!syncArmed || !syncArmed.armed)
+        return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
+    const SKIP = new Set([
+        'bootloader',
+        'builtin'
+    ]);
+    const syncableModules = [];
+    for (const [mod, info] of currentModules) {
+        if (SKIP.has(info.name))
+            continue;
+        if (!info.name.includes('/') && !info.name.startsWith('d/'))
+            continue;
+        syncableModules.push(info.name);
     }
-    nameToVars.set(info.name, vars);
-  }
-  let pollTimer;
-  // Track pids seen from .js files — only delete pids we've previously seen
-  const knownFilePids = new window.Map();
-  // Track modules found on disk — for detecting additions and removals
-  let knownDiskModules = null;
-  // null = first scan (no deletions)
-  // FileAttachment helpers
-  const getModuleFA = (mod) => {
-    for (const v of runtime._variables) {
-      if (v._module === mod && v._name === "FileAttachment" && v._value)
-        return v._value;
-    }
-    return null;
-  };
-  const getSubDir = async (dirHandle, path) => {
-    let current = dirHandle;
-    for (const part of path.split("/").filter(Boolean)) {
-      current = await current.getDirectoryHandle(part);
-    }
-    return current;
-  };
-  const applyModule = (moduleId, defineFn) => {
-    const mod = nameToModule.get(moduleId);
-    if (!mod) return;
-    const existingVars = nameToVars.get(moduleId) || new window.Map();
-    const cells = probeDefine(defineFn);
-    let redefinedSelf = false;
-    const seenPids = new Set();
-    for (const cell of cells) {
-      if (cell.type === "import") continue;
-      if (!cell.pid) continue;
-      seenPids.add(cell.pid);
-      const existing = existingVars.get("__pid__" + cell.pid);
-      if (!existing) {
-        // CREATE new cell — always unobserved; lopepage visualizer will pick it up
-        const taggedDefn = cell.definition
-          ? tag(cell.definition, { source: "file-sync" })
-          : cell.definition;
-        var v = mod.variable();
-        v.define(cell.name, cell.inputs, taggedDefn);
-        v.pid = cell.pid;
-        existingVars.set("__pid__" + cell.pid, v);
-        if (cell.name) existingVars.set(cell.name, v);
-        console.log(
-          "[file-sync] created cell",
-          cell.pid,
-          cell.name || "(anonymous)"
-        );
-        continue;
-      }
-      // UPDATE existing cell — skip if definition and inputs are unchanged
-      if (existing._definition) {
-        const existingInputNames = existing._inputs.map(function (v) {
-          return typeof v === "string" ? v : v._name;
-        });
-        const inputsMatch =
-          JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-        const defnMatch =
-          existing._definition.toString() ===
-          (cell.definition ? cell.definition.toString() : "");
-        if (inputsMatch && defnMatch) continue;
-      }
-      const taggedDefn = cell.definition
-        ? tag(cell.definition, { source: "file-sync" })
-        : cell.definition;
-      existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-      if (
-        moduleId === "@tomlarkworthy/file-sync" &&
-        cell.name === "filesToNotebook"
-      ) {
-        redefinedSelf = true;
-      }
-    }
-    // DELETE: only remove pids that were in a PREVIOUS probeDefine but are now absent.
-    // This ensures we never touch variables we didn't create (implicits, import bridges, etc.)
-    const prevKnown = knownFilePids.get(moduleId);
-    if (prevKnown) {
-      for (const pid of prevKnown) {
-        if (seenPids.has(pid)) continue;
-        const v = existingVars.get("__pid__" + pid);
-        if (!v) continue;
-        console.log("[file-sync] deleting cell", pid, v._name || "(anonymous)");
-        v.delete();
-        existingVars.delete("__pid__" + pid);
-        if (v._name) existingVars.delete(v._name);
-      }
-    }
-    knownFilePids.set(moduleId, seenPids);
-    const ordered = [];
-    for (const cell of cells) {
-      if (!cell.pid) continue;
-      const v = existingVars.get("__pid__" + cell.pid);
-      if (v) ordered.push(v);
-    }
-    if (ordered.length) {
-      const orderedSet = new Set(ordered);
-      const others = [];
-      for (const v of runtime._variables) {
-        if (!orderedSet.has(v)) others.push(v);
-      }
-      runtime._variables.clear();
-      for (const v of others) runtime._variables.add(v);
-      for (const v of ordered) runtime._variables.add(v);
-    }
-    if (redefinedSelf) {
-      clearInterval(pollTimer);
-      console.log(
-        "[file-sync] filesToNotebook redefined \u2014 stopping old poll timer"
-      );
-    }
-  };
-  const pollModule = async (moduleId) => {
-    // --- Module source (.js) ---
-    try {
-      let file;
-      try {
-        file = await readFile(directory, prefix + moduleId + ".js");
-      } catch (e) {
-        // .js file doesn't exist on disk — skip source sync
-        file = null;
-      }
-      if (file) {
-        const prev = lastSeen.get(moduleId);
-        const changed = !prev || file.lastModified !== prev.lastModified;
-        if (changed) {
-          lastSeen.set(moduleId, { lastModified: file.lastModified });
-          const diskText = await file.text();
-          let needsApply = true;
-          try {
-            const runtimeResult = await exportModuleJS(moduleId);
-            if (runtimeResult.source === diskText) needsApply = false;
-          } catch (e) {}
-          if (needsApply) {
-            const blob = new window.Blob([diskText], {
-              type: "text/javascript"
-            });
-            const url = window.URL.createObjectURL(blob);
-            try {
-              const mod = await importShim(url, 'https://api.observablehq.com/@tomlarkworthy/file-sync.js?v=4');
-              if (typeof mod.default === "function") {
-                applyModule(moduleId, mod.default);
-                console.log("[file-sync] applied " + moduleId + " from disk");
-                try {
-                  const after = await exportModuleJS(moduleId);
-                  await manifestWriter(
-                    directory,
-                    prefix,
-                    { [moduleId]: hashSource(after.source) },
-                    readFile,
-                    writeFile
-                  );
-                } catch (e) {
-                  await manifestWriter(
-                    directory,
-                    prefix,
-                    { [moduleId]: hashSource(diskText) },
-                    readFile,
-                    writeFile
-                  );
-                }
-              }
-            } finally {
-              window.URL.revokeObjectURL(url);
-            }
-          }
+    const syncableSet = new Set(syncableModules);
+    const lastSeen = fileSyncLastSeen;
+    const POLL_MS = 1000;
+    const prefix = notebookId + '/';
+    const nameToModule = new window.Map();
+    const nameToVars = new window.Map();
+    for (const [mod, info] of currentModules) {
+        if (!syncableSet.has(info.name))
+            continue;
+        nameToModule.set(info.name, info.module);
+        const vars = new window.Map();
+        for (const v of runtime._variables) {
+            if (v._module !== info.module)
+                continue;
+            if (v._name)
+                vars.set(v._name, v);
+            if (v.pid)
+                vars.set('__pid__' + v.pid, v);
         }
-      }
-    } catch (e) {
-      console.error("[file-sync] poll error for " + moduleId + ":", e);
+        nameToVars.set(info.name, vars);
     }
-    // --- File attachments ---
-    try {
-      const attachDir = await getSubDir(directory, prefix + moduleId);
-      const mod = nameToModule.get(moduleId);
-      const FA = mod ? getModuleFA(mod) : null;
-      const faMap = FA ? getFileAttachmentsMap(FA) : null;
-      if (faMap) {
-        for (const key of [...faMap.keys()]) {
-          if (key.endsWith(".crswap") || key.startsWith(".")) faMap.delete(key);
+    let pollTimer;
+    const knownFilePids = new window.Map();
+    let knownDiskModules = null;
+    const getModuleFA = mod => {
+        for (const v of runtime._variables) {
+            if (v._module === mod && v._name === 'FileAttachment' && v._value)
+                return v._value;
         }
-      }
-      for await (const [name, handle] of attachDir) {
-        if (handle.kind !== "file") continue;
-        if (name.endsWith(".crswap") || name.startsWith(".")) continue;
-        const file = await handle.getFile();
-        const attKey = "__att__" + moduleId + "/" + name;
-        const prevA = lastSeen.get(attKey);
-        if (prevA && file.lastModified === prevA.lastModified) continue;
-        lastSeen.set(attKey, { lastModified: file.lastModified });
-        // Read file and create blob URL
-        const bytes = new Uint8Array(await file.arrayBuffer());
-        const blob = new window.Blob([bytes], {
-          type: file.type || "application/octet-stream"
-        });
-        const blobUrl = window.URL.createObjectURL(blob);
-        // Update runtime FileAttachment map
-        if (faMap) {
-          faMap.set(name, {
-            url: blobUrl,
-            mimeType: file.type || "application/octet-stream"
-          });
-          console.log(
-            "[file-sync] updated attachment " + moduleId + "/" + name
-          );
+        return null;
+    };
+    const getSubDir = async (dirHandle, path) => {
+        let current = dirHandle;
+        for (const part of path.split('/').filter(Boolean)) {
+            current = await current.getDirectoryHandle(part);
         }
-        // Update DOM script tag so re-exports pick up the change
-        const scriptId = moduleId + "/" + encodeURIComponent(name);
-        const script = document.getElementById(scriptId);
-        if (script) {
-          const b64 = btoa(String.fromCharCode.apply(null, bytes));
-          script.textContent = b64;
-          script.setAttribute("data-encoding", "base64");
-          script.setAttribute(
-            "data-mime",
-            file.type || "application/octet-stream"
-          );
-        }
-      }
-    } catch (e) {
-      if (e.name !== "NotFoundError") {
-        console.error(
-          "[file-sync] attachment scan error for " + moduleId + ":",
-          e
-        );
-      }
-    }
-  };
-  // Scan the notebook directory for all .js module files
-  const scanDiskModules = async () => {
-    const diskModules = new Set();
-    try {
-      const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
-      for await (const [orgName, orgHandle] of notebookDir) {
-        if (orgHandle.kind !== "directory") continue;
-        if (orgName.startsWith("@")) {
-          // Scoped modules: @org/name
-          for await (const [fname, fhandle] of orgHandle) {
-            if (fhandle.kind === "file" && fname.endsWith(".js")) {
-              diskModules.add(orgName + "/" + fname.slice(0, -3));
-            }
-          }
-        } else if (orgName === "d") {
-          // Observable hash modules: d/hash@version
-          for await (const [fname, fhandle] of orgHandle) {
-            if (fhandle.kind === "file" && fname.endsWith(".js")) {
-              diskModules.add("d/" + fname.slice(0, -3));
-            }
-          }
-        }
-      }
-    } catch (e) {}
-    return diskModules;
-  };
-  const poll = async () => {
-    // Poll existing syncable modules
-    for (const moduleId of syncableModules) {
-      await pollModule(moduleId);
-    }
-    // Scan disk for new/removed modules
-    const diskModules = await scanDiskModules();
-    // ADD: new modules on disk not in the runtime
-    const newOnDisk = [...diskModules].filter(
-      (m) => !syncableSet.has(m) && !nameToModule.has(m)
-    );
-    if (newOnDisk.length)
-      console.log("[file-sync] new modules on disk:", newOnDisk);
-    for (const moduleId of diskModules) {
-      if (syncableSet.has(moduleId)) continue;
-      // already known
-      if (nameToModule.has(moduleId)) continue;
-      // already added by a previous scan
-      try {
-        const file = await readFile(directory, prefix + moduleId + ".js");
-        const diskText = await file.text();
-        const blob = new window.Blob([diskText], { type: "text/javascript" });
-        const url = window.URL.createObjectURL(blob);
-        try {
-          const imported = await importShim(url, 'https://api.observablehq.com/@tomlarkworthy/file-sync.js?v=4');
-          if (typeof imported.default === "function") {
-            // Create a new runtime module — unobserved (lopepage visualizer discovers it)
-            const newMod = runtime.module(imported.default, () => null);
-            runtime.mains.set(moduleId, newMod);
-            nameToModule.set(moduleId, newMod);
-            syncableModules.push(moduleId);
-            syncableSet.add(moduleId);
-            // Index its variables for future pid tracking
-            const vars = new window.Map();
-            for (const v of runtime._variables) {
-              if (v._module !== newMod) continue;
-              if (v._name) vars.set(v._name, v);
-              if (v.pid) vars.set("__pid__" + v.pid, v);
-            }
-            nameToVars.set(moduleId, vars);
-            console.log("[file-sync] added new module from disk: " + moduleId);
-            try {
-              await manifestWriter(
-                directory,
-                prefix,
-                { [moduleId]: hashSource(diskText) },
-                readFile,
-                writeFile
-              );
-            } catch (e) {
-              console.error(
-                "[file-sync] manifest update for new module failed:",
-                e
-              );
-            }
-          }
-        } finally {
-          window.URL.revokeObjectURL(url);
-        }
-      } catch (e) {
-        console.error("[file-sync] failed to add module " + moduleId + ":", e);
-      }
-    }
-    // REMOVE: modules previously on disk but now gone
-    if (knownDiskModules) {
-      for (const moduleId of knownDiskModules) {
-        if (diskModules.has(moduleId)) continue;
-        if (!nameToModule.has(moduleId)) continue;
+        return current;
+    };
+    const applyModule = (moduleId, defineFn) => {
         const mod = nameToModule.get(moduleId);
-        // Delete all variables in this module
-        for (const v of [...runtime._variables]) {
-          if (v._module === mod) {
-            v.delete();
-          }
+        if (!mod)
+            return;
+        const existingVars = nameToVars.get(moduleId) || new window.Map();
+        const cells = probeDefine(defineFn);
+        let redefinedSelf = false;
+        const seenPids = new Set();
+        for (const cell of cells) {
+            if (cell.type === 'import')
+                continue;
+            if (!cell.pid)
+                continue;
+            seenPids.add(cell.pid);
+            const existing = existingVars.get('__pid__' + cell.pid);
+            if (!existing) {
+                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+                var v = mod.variable();
+                v.define(cell.name, cell.inputs, taggedDefn);
+                v.pid = cell.pid;
+                existingVars.set('__pid__' + cell.pid, v);
+                if (cell.name)
+                    existingVars.set(cell.name, v);
+                console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
+                continue;
+            }
+            if (existing._definition) {
+                const existingInputNames = existing._inputs.map(function (v) {
+                    return typeof v === 'string' ? v : v._name;
+                });
+                const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+                const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+                if (inputsMatch && defnMatch)
+                    continue;
+            }
+            const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+            existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+            if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
+                redefinedSelf = true;
+            }
         }
-        runtime.mains.delete(moduleId);
-        nameToModule.delete(moduleId);
-        nameToVars.delete(moduleId);
-        knownFilePids.delete(moduleId);
-        const idx = syncableModules.indexOf(moduleId);
-        if (idx !== -1) syncableModules.splice(idx, 1);
-        syncableSet.delete(moduleId);
-        console.log("[file-sync] removed module: " + moduleId);
+        const prevKnown = knownFilePids.get(moduleId);
+        if (prevKnown) {
+            for (const pid of prevKnown) {
+                if (seenPids.has(pid))
+                    continue;
+                const v = existingVars.get('__pid__' + pid);
+                if (!v)
+                    continue;
+                console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
+                v.delete();
+                existingVars.delete('__pid__' + pid);
+                if (v._name)
+                    existingVars.delete(v._name);
+            }
+        }
+        knownFilePids.set(moduleId, seenPids);
+        const ordered = [];
+        for (const cell of cells) {
+            if (!cell.pid)
+                continue;
+            const v = existingVars.get('__pid__' + cell.pid);
+            if (v)
+                ordered.push(v);
+        }
+        if (ordered.length) {
+            const orderedSet = new Set(ordered);
+            const others = [];
+            for (const v of runtime._variables) {
+                if (!orderedSet.has(v))
+                    others.push(v);
+            }
+            runtime._variables.clear();
+            for (const v of others)
+                runtime._variables.add(v);
+            for (const v of ordered)
+                runtime._variables.add(v);
+        }
+        if (redefinedSelf) {
+            clearInterval(pollTimer);
+            console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
+        }
+    };
+    const pollModule = async moduleId => {
         try {
-          await manifestWriter(
-            directory,
-            prefix,
-            { [moduleId]: null },
-            readFile,
-            writeFile
-          );
+            let file;
+            try {
+                file = await readFile(directory, prefix + moduleId + '.js');
+            } catch (e) {
+                file = null;
+            }
+            if (file) {
+                const prev = lastSeen.get(moduleId);
+                const changed = !prev || file.lastModified !== prev.lastModified;
+                if (changed) {
+                    lastSeen.set(moduleId, { lastModified: file.lastModified });
+                    const diskText = await file.text();
+                    let needsApply = true;
+                    try {
+                        const runtimeResult = await exportModuleJS(moduleId);
+                        if (runtimeResult.source === diskText)
+                            needsApply = false;
+                    } catch (e) {
+                    }
+                    if (needsApply) {
+                        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+                        const url = window.URL.createObjectURL(blob);
+                        try {
+                            const mod = await import(url);
+                            if (typeof mod.default === 'function') {
+                                applyModule(moduleId, mod.default);
+                                console.log('[file-sync] applied ' + moduleId + ' from disk');
+                                try {
+                                    const after = await exportModuleJS(moduleId);
+                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
+                                } catch (e) {
+                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
+                                }
+                            }
+                        } finally {
+                            window.URL.revokeObjectURL(url);
+                        }
+                    }
+                }
+            }
         } catch (e) {
-          console.error("[file-sync] manifest remove failed:", e);
+            console.error('[file-sync] poll error for ' + moduleId + ':', e);
         }
-      }
-    }
-    knownDiskModules = diskModules;
-  };
-  pollTimer = setInterval(poll, POLL_MS);
-  poll();
-  invalidation.then(() => clearInterval(pollTimer));
-  return (
-    "Polling " + syncableModules.length + " modules every " + POLL_MS + "ms..."
-  );
+        try {
+            const attachDir = await getSubDir(directory, prefix + moduleId);
+            const mod = nameToModule.get(moduleId);
+            const FA = mod ? getModuleFA(mod) : null;
+            const faMap = FA ? getFileAttachmentsMap(FA) : null;
+            if (faMap) {
+                for (const key of [...faMap.keys()]) {
+                    if (key.endsWith('.crswap') || key.startsWith('.'))
+                        faMap.delete(key);
+                }
+            }
+            for await (const [name, handle] of attachDir) {
+                if (handle.kind !== 'file')
+                    continue;
+                if (name.endsWith('.crswap') || name.startsWith('.'))
+                    continue;
+                const file = await handle.getFile();
+                const attKey = '__att__' + moduleId + '/' + name;
+                const prevA = lastSeen.get(attKey);
+                if (prevA && file.lastModified === prevA.lastModified)
+                    continue;
+                lastSeen.set(attKey, { lastModified: file.lastModified });
+                const bytes = new Uint8Array(await file.arrayBuffer());
+                const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
+                const blobUrl = window.URL.createObjectURL(blob);
+                if (faMap) {
+                    faMap.set(name, {
+                        url: blobUrl,
+                        mimeType: file.type || 'application/octet-stream'
+                    });
+                    console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
+                }
+                const scriptId = moduleId + '/' + encodeURIComponent(name);
+                const script = document.getElementById(scriptId);
+                if (script) {
+                    const b64 = btoa(String.fromCharCode.apply(null, bytes));
+                    script.textContent = b64;
+                    script.setAttribute('data-encoding', 'base64');
+                    script.setAttribute('data-mime', file.type || 'application/octet-stream');
+                }
+            }
+        } catch (e) {
+            if (e.name !== 'NotFoundError') {
+                console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
+            }
+        }
+    };
+    const scanDiskModules = async () => {
+        const diskModules = new Set();
+        try {
+            const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
+            for await (const [orgName, orgHandle] of notebookDir) {
+                if (orgHandle.kind !== 'directory')
+                    continue;
+                if (orgName.startsWith('@')) {
+                    for await (const [fname, fhandle] of orgHandle) {
+                        if (fhandle.kind === 'file' && fname.endsWith('.js')) {
+                            diskModules.add(orgName + '/' + fname.slice(0, -3));
+                        }
+                    }
+                } else if (orgName === 'd') {
+                    for await (const [fname, fhandle] of orgHandle) {
+                        if (fhandle.kind === 'file' && fname.endsWith('.js')) {
+                            diskModules.add('d/' + fname.slice(0, -3));
+                        }
+                    }
+                }
+            }
+        } catch (e) {
+        }
+        return diskModules;
+    };
+    const poll = async () => {
+        for (const moduleId of syncableModules) {
+            await pollModule(moduleId);
+        }
+        const diskModules = await scanDiskModules();
+        const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
+        if (newOnDisk.length)
+            console.log('[file-sync] new modules on disk:', newOnDisk);
+        for (const moduleId of diskModules) {
+            if (syncableSet.has(moduleId))
+                continue;
+            if (nameToModule.has(moduleId))
+                continue;
+            try {
+                const file = await readFile(directory, prefix + moduleId + '.js');
+                const diskText = await file.text();
+                const blob = new window.Blob([diskText], { type: 'text/javascript' });
+                const url = window.URL.createObjectURL(blob);
+                try {
+                    const imported = await import(url);
+                    if (typeof imported.default === 'function') {
+                        const newMod = runtime.module(imported.default, () => null);
+                        runtime.mains.set(moduleId, newMod);
+                        nameToModule.set(moduleId, newMod);
+                        syncableModules.push(moduleId);
+                        syncableSet.add(moduleId);
+                        const vars = new window.Map();
+                        for (const v of runtime._variables) {
+                            if (v._module !== newMod)
+                                continue;
+                            if (v._name)
+                                vars.set(v._name, v);
+                            if (v.pid)
+                                vars.set('__pid__' + v.pid, v);
+                        }
+                        nameToVars.set(moduleId, vars);
+                        console.log('[file-sync] added new module from disk: ' + moduleId);
+                        try {
+                            await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
+                        } catch (e) {
+                            console.error('[file-sync] manifest update for new module failed:', e);
+                        }
+                    }
+                } finally {
+                    window.URL.revokeObjectURL(url);
+                }
+            } catch (e) {
+                console.error('[file-sync] failed to add module ' + moduleId + ':', e);
+            }
+        }
+        if (knownDiskModules) {
+            for (const moduleId of knownDiskModules) {
+                if (diskModules.has(moduleId))
+                    continue;
+                if (!nameToModule.has(moduleId))
+                    continue;
+                const mod = nameToModule.get(moduleId);
+                for (const v of [...runtime._variables]) {
+                    if (v._module === mod) {
+                        v.delete();
+                    }
+                }
+                runtime.mains.delete(moduleId);
+                nameToModule.delete(moduleId);
+                nameToVars.delete(moduleId);
+                knownFilePids.delete(moduleId);
+                const idx = syncableModules.indexOf(moduleId);
+                if (idx !== -1)
+                    syncableModules.splice(idx, 1);
+                syncableSet.delete(moduleId);
+                console.log('[file-sync] removed module: ' + moduleId);
+                try {
+                    await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+                } catch (e) {
+                    console.error('[file-sync] manifest remove failed:', e);
+                }
+            }
+        }
+        knownDiskModules = diskModules;
+    };
+    pollTimer = setInterval(poll, POLL_MS);
+    poll();
+    invalidation.then(() => clearInterval(pollTimer));
+    return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
 };
 const _1b4kluo = function _21(md){return(
 md`## How It Works
@@ -9494,20 +9436,20 @@ const _1aloau2 = (G, _) => G.input(_);
 const _7s1qq7 = function _6($0,sqrt){return(
 $0.resolve(Math.sqrt(sqrt))
 )};
-const _x7qi6y = async function _testing(flowQueue)
-{
-  flowQueue; // load after implementation
-  const [{ Runtime }, { default: define }] = await Promise.all([
-    importShim("https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js"
-    , 'https://api.observablehq.com/@tomlarkworthy/flow-queue.js?v=4'),
-    importShim(`https://api.observablehq.com/@tomlarkworthy/testing.js?v=3`, 'https://api.observablehq.com/@tomlarkworthy/flow-queue.js?v=4')
-  ]);
-  const module = new Runtime().module(define);
-  return Object.fromEntries(
-    await Promise.all(
-      ["expect", "createSuite"].map((n) => module.value(n).then((v) => [n, v]))
-    )
-  );
+const _x7qi6y = async function _testing(flowQueue) {
+    flowQueue;
+    const [{Runtime}, {default: define}] = await Promise.all([
+        import('https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js'),
+        import(`https://api.observablehq.com/@tomlarkworthy/testing.js?v=3`)
+    ]);
+    const module = new Runtime().module(define);
+    return Object.fromEntries(await Promise.all([
+        'expect',
+        'createSuite'
+    ].map(n => module.value(n).then(v => [
+        n,
+        v
+    ]))));
 };
 const _8ggfj7 = function _suite(testing){return(
 testing.createSuite({
@@ -10135,18 +10077,14 @@ FileAttachment("lm_popin_black.png").url()
 const _18kpe1x = function _lm_popout_black(FileAttachment){return(
 FileAttachment("lm_popout_black.png").url()
 )};
-const _1p7i538 = async function _gl(unzip,FileAttachment)
-{
-  const blob = await unzip(FileAttachment("golden-layout-2.6.0.js.gz"));
-
-  const objectURL = URL.createObjectURL(
-    new Blob([blob], { type: "application/javascript" })
-  );
-  try {
-    return await importShim(objectURL, 'https://api.observablehq.com/@tomlarkworthy/golden-layout-2-6-0.js?v=4');
-  } finally {
-    URL.revokeObjectURL(objectURL); // Ensure URL is revoked after import
-  }
+const _1p7i538 = async function _gl(unzip, FileAttachment) {
+    const blob = await unzip(FileAttachment('golden-layout-2.6.0.js.gz'));
+    const objectURL = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
+    try {
+        return await import(objectURL);
+    } finally {
+        URL.revokeObjectURL(objectURL);
+    }
 };
 const _17n6uge = function _unzip(Response,DecompressionStream){return(
 async (attachment) =>
@@ -10405,35 +10343,23 @@ import {git, http} from "@tomlarkworthy/isomorphic-git-1-30-1"
 import {FS} from "@tomlarkworthy/lightning-fs-4-6-0"
 ~~~`
 )};
-const _vz8us1 = async function _git(unzip,FileAttachment)
-{
-  const blob = await unzip(
-    FileAttachment("isomorphic-git-1@1.30.1.bundle.js.gz")
-  );
-
-  const objectURL = URL.createObjectURL(
-    new Blob([blob], { type: "application/javascript" })
-  );
-  try {
-    return await importShim(objectURL, 'https://api.observablehq.com/@tomlarkworthy/isomorphic-git-1-30-1.js?v=4');
-  } finally {
-    URL.revokeObjectURL(objectURL);
-  }
+const _vz8us1 = async function _git(unzip, FileAttachment) {
+    const blob = await unzip(FileAttachment('isomorphic-git-1@1.30.1.bundle.js.gz'));
+    const objectURL = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
+    try {
+        return await import(objectURL);
+    } finally {
+        URL.revokeObjectURL(objectURL);
+    }
 };
-const _2acekr = async function _http(unzip,FileAttachment)
-{
-  const blob = await unzip(
-    FileAttachment("isomorphic-git-http-1.0.0-beta.36.js.gz")
-  );
-
-  const objectURL = URL.createObjectURL(
-    new Blob([blob], { type: "application/javascript" })
-  );
-  try {
-    return await importShim(objectURL, 'https://api.observablehq.com/@tomlarkworthy/isomorphic-git-1-30-1.js?v=4');
-  } finally {
-    URL.revokeObjectURL(objectURL);
-  }
+const _2acekr = async function _http(unzip, FileAttachment) {
+    const blob = await unzip(FileAttachment('isomorphic-git-http-1.0.0-beta.36.js.gz'));
+    const objectURL = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
+    try {
+        return await import(objectURL);
+    } finally {
+        URL.revokeObjectURL(objectURL);
+    }
 };
 const _1emihnv = function _4(md){return(
 md`
@@ -10507,21 +10433,15 @@ md`# jest-expect-standalone@24.0.2
 import {expect} from "@tomlarkworthy/jest-expect-standalone"
 ~~~`
 )};
-const _mh1f13 = async function _expect(unzip,FileAttachment)
-{
-  const blob = await unzip(
-    FileAttachment("jest-expect-standalone-24.0.2.js.gz")
-  );
-
-  const objectURL = URL.createObjectURL(
-    new Blob([blob], { type: "application/javascript" })
-  );
-  try {
-    await importShim(objectURL, 'https://api.observablehq.com/@tomlarkworthy/jest-expect-standalone.js?v=4');
-    return window.expect;
-  } finally {
-    URL.revokeObjectURL(objectURL);
-  }
+const _mh1f13 = async function _expect(unzip, FileAttachment) {
+    const blob = await unzip(FileAttachment('jest-expect-standalone-24.0.2.js.gz'));
+    const objectURL = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
+    try {
+        await import(objectURL);
+        return window.expect;
+    } finally {
+        URL.revokeObjectURL(objectURL);
+    }
 };
 const _17n6uge = function _unzip(Response,DecompressionStream){return(
 async (attachment) =>
@@ -10566,18 +10486,14 @@ md`# [jszip@3.10.1](https://stuk.github.io/jszip/)
 import {JSZip} from "@tomlarkworthy/jszip-3-10-1"
 ~~~`
 )};
-const _umavbe = async function _JSZip(unzip,FileAttachment)
-{
-  const blob = await unzip(FileAttachment("jszip-3.10.1.min.js.gz"));
-
-  const objectURL = URL.createObjectURL(
-    new Blob([blob], { type: "application/javascript" })
-  );
-  try {
-    return (await importShim(objectURL, 'https://api.observablehq.com/@tomlarkworthy/jszip-3-10-1.js?v=4')).default;
-  } finally {
-    URL.revokeObjectURL(objectURL); // Ensure URL is revoked after import
-  }
+const _umavbe = async function _JSZip(unzip, FileAttachment) {
+    const blob = await unzip(FileAttachment('jszip-3.10.1.min.js.gz'));
+    const objectURL = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
+    try {
+        return (await import(objectURL)).default;
+    } finally {
+        URL.revokeObjectURL(objectURL);
+    }
 };
 const _g5fwfs = function _unzip(Response,DecompressionStream){return(
 async (attachment) => {
@@ -10629,18 +10545,14 @@ import {FS} from "@tomlarkworthy/lightning-fs-4-6-0"
 import {git, http} from "@tomlarkworthy/isomorphic-git-1-30-1" 
 ~~~`
 )};
-const _1tds3ro = async function _FS(unzip,FileAttachment)
-{
-  const blob = await unzip(FileAttachment("lightning-fs-4.6.0.js.gz"));
-
-  const objectURL = URL.createObjectURL(
-    new Blob([blob], { type: "application/javascript" })
-  );
-  try {
-    return (await importShim(objectURL, 'https://api.observablehq.com/@tomlarkworthy/lightning-fs-4-6-0.js?v=4')).default;
-  } finally {
-    URL.revokeObjectURL(objectURL);
-  }
+const _1tds3ro = async function _FS(unzip, FileAttachment) {
+    const blob = await unzip(FileAttachment('lightning-fs-4.6.0.js.gz'));
+    const objectURL = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
+    try {
+        return (await import(objectURL)).default;
+    } finally {
+        URL.revokeObjectURL(objectURL);
+    }
 };
 const _dqri64 = function _3(md){return(
 md`
@@ -14117,7 +14029,7 @@ export default function define(runtime, observer) {
   return main;
 }</script>
 
-<script id="@tomlarkworthy/lopepage-urls"
+<script id="@tomlarkworthy/lopepage-urls" 
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -14658,8 +14570,7 @@ export default function define(runtime, observer) {
   $def("_1xxtf0r", "updateNotebookImports", ["vars","extractNotebookAndCell","linkTo"], _1xxtf0r);  
   main.define("tests", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("tests", _));
   return main;
-}
-</script>
+}</script>
 
 <script id="@tomlarkworthy/module-map" 
   type="text/plain"
@@ -15737,18 +15648,14 @@ observable.Library
 const _1iyzb44 = function _RuntimeError(observable){return(
 observable.RuntimeError
 )};
-const _b2ba5g = async function _observable(unzip,FileAttachment)
-{
-  const blob = await unzip(FileAttachment("runtime.js.gz"));
-
-  const objectURL = URL.createObjectURL(
-    new Blob([blob], { type: "application/javascript" })
-  );
-  try {
-    return await importShim(objectURL, 'https://api.observablehq.com/@tomlarkworthy/observable-runtime.js?v=4');
-  } finally {
-    URL.revokeObjectURL(objectURL);
-  }
+const _b2ba5g = async function _observable(unzip, FileAttachment) {
+    const blob = await unzip(FileAttachment('runtime.js.gz'));
+    const objectURL = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
+    try {
+        return await import(objectURL);
+    } finally {
+        URL.revokeObjectURL(objectURL);
+    }
 };
 const _17n6uge = function _unzip(Response,DecompressionStream){return(
 async (attachment) =>
@@ -15799,13 +15706,10 @@ runtime.Runtime
 const _bfntg8 = function _RuntimeError(runtime){return(
 runtime.RuntimeError
 )};
-const _axblun = async function _runtime(gunzipBase64ToBlob,source_gz)
-{
-  const blob = await gunzipBase64ToBlob(source_gz);
-  const url = URL.createObjectURL(
-    new Blob([blob], { type: "application/javascript" })
-  );
-  return importShim(url, 'https://api.observablehq.com/@tomlarkworthy/observable-runtime-v6.js?v=4');
+const _axblun = async function _runtime(gunzipBase64ToBlob, source_gz) {
+    const blob = await gunzipBase64ToBlob(source_gz);
+    const url = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
+    return import(url);
 };
 const _1ljam5l = function _gunzipBase64ToBlob(DecompressionStream,Response){return(
 async (b64) => {
@@ -16474,10 +16378,9 @@ notebook_semantics_document.nodes.map((s) => ({
 const _1oevsow = function _28(md){return(
 md`### Runtime Representation (v4)`
 )};
-const _11lfflk = function _notebook_semantics_module(){return(
-importShim("https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4"
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _11lfflk = function _notebook_semantics_module() {
+    return import('https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4');
+};
 const _gjten6 = function _31(md){return(
 md`### Imports`
 )};
@@ -17464,65 +17367,44 @@ parser.parseCell(
   'import {runtime, viewof main as foo} from "@mootari/access-runtime"'
 )
 )};
-const _1n7gw17 = function _findModuleName(extractModuleInfo){return(
-(scope, module, { unknown_id = Math.random() } = {}) => {
-  try {
-    const scopedVariables = [...scope.values()];
-
-    // Prefer variables that *define* a module and have a real module-loader name.
-    const candidates = scopedVariables.filter(
-      (v) =>
-        v &&
-        v._value === module &&
-        typeof v._name === "string" &&
-        v._name.startsWith("module ") &&
-        !v._name.startsWith("module <unknown")
-    );
-
-    const pickBestInfo = (dfn) => {
-      // Avoid the parentUrl (2nd arg) confusing module identification.
-      // Typical patterns:
-      //   importShim("/d/<id>@<ver>.js?v=4", "https://api.observablehq.com/@ns/name.js?v=4")
-      //   import("/d/<id>@<ver>.js?v=4")
-      // Prefer the *first argument* inside importShim(...) / import(...) when present.
-      const s = String(dfn ?? "");
-
-      // Try to capture the first string literal argument to importShim(...) or import(...)
-      // Tolerates quotes ", ', ` and both importShim and plain import.
-      const m = s.match(
-        /\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/
-      );
-      const firstArg = m?.[2];
-
-      const info1 = firstArg ? extractModuleInfo(firstArg) : {};
-      if (info1?.id || info1?.notebook) return info1;
-
-      // Fallback: parse the whole definition string.
-      return extractModuleInfo(s);
+const _1n7gw17 = function _findModuleName(extractModuleInfo) {
+    return (scope, module, {
+        unknown_id = Math.random()
+    } = {}) => {
+        try {
+            const scopedVariables = [...scope.values()];
+            const candidates = scopedVariables.filter(v => v && v._value === module && typeof v._name === 'string' && v._name.startsWith('module ') && !v._name.startsWith('module <unknown'));
+            const pickBestInfo = dfn => {
+                const s = String(dfn ?? '');
+                const m = s.match(/\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/);
+                const firstArg = m?.[2];
+                const info1 = firstArg ? extractModuleInfo(firstArg) : {};
+                if (info1?.id || info1?.notebook)
+                    return info1;
+                return extractModuleInfo(s);
+            };
+            for (const v of candidates) {
+                const info = pickBestInfo(v._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            const any = scopedVariables.find(v => v && v._value === module);
+            if (any) {
+                const info = pickBestInfo(any._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            return `<unknown ${ unknown_id }>`;
+        } catch (e) {
+            debugger;
+            return 'error';
+        }
     };
-
-    // Try module loader cells first.
-    for (const v of candidates) {
-      const info = pickBestInfo(v._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    // Fallback: any scoped variable with _value==module.
-    const any = scopedVariables.find((v) => v && v._value === module);
-    if (any) {
-      const info = pickBestInfo(any._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    return `<unknown ${unknown_id}>`;
-  } catch (e) {
-    debugger;
-    return "error";
-  }
-}
-)};
+};
 const _i47chb = function _findImportedName(){return(
 async (v) => {
   if (v._inputs.length == 1 && v._inputs[0]._name === "@variable") {
@@ -18424,228 +18306,206 @@ JSON.stringify(
 const _1lt3kl6 = function _157(compile,test_case){return(
 compile(test_case.value)
 )};
-const _lpzjrv = function _compile(parser,globalThis,observableToJs){return(
-function compile(source, { anonymousName = "_anonymous" } = {}) {
-  const comments = [],
-    tokens = [];
-  let cell;
-  try {
-    cell = parser.parseCell(source, {
-      ranges: true,
-      onComment: comments,
-      onToken: tokens
-    });
-  } catch (e) {
-    if (e instanceof SyntaxError) {
-      const nameMatch = source.match(
-        /^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/
-      );
-      let _name = null;
-      let funcName = anonymousName;
-      if (nameMatch) {
-        const prefix = nameMatch[1] ? nameMatch[1] + " " : "";
-        _name = prefix + nameMatch[2];
-        funcName = "_" + nameMatch[2];
-      }
-      const escapedMsg = JSON.stringify(e.message);
-      const escapedSource = JSON.stringify(source);
-      return [
-        {
-          _name,
-          _inputs: [],
-          _definition: `function ${funcName}() { throw Object.assign(new SyntaxError(${escapedMsg}), {_sourceExpression: ${escapedSource}}); }`
+const _x1d0wm = function _compile(parser,observableToJs){return(
+function compile(source, {
+    anonymousName = '_anonymous'
+} = {}) {
+    const comments = [], tokens = [];
+    let cell;
+    try {
+        cell = parser.parseCell(source, {
+            ranges: true,
+            onComment: comments,
+            onToken: tokens
+        });
+    } catch (e) {
+        if (e instanceof SyntaxError) {
+            const nameMatch = source.match(/^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/);
+            let _name = null;
+            let funcName = anonymousName;
+            if (nameMatch) {
+                const prefix = nameMatch[1] ? nameMatch[1] + ' ' : '';
+                _name = prefix + nameMatch[2];
+                funcName = '_' + nameMatch[2];
+            }
+            const escapedMsg = JSON.stringify(e.message);
+            const escapedSource = JSON.stringify(source);
+            return [{
+                    _name,
+                    _inputs: [],
+                    _definition: `function ${ funcName }() { throw Object.assign(new SyntaxError(${ escapedMsg }), {_sourceExpression: ${ escapedSource }}); }`
+                }];
         }
-      ];
+        throw e;
     }
-    throw e;
-  }
-  if (!cell) throw new Error("Unable to parse cell");
-  const parseImportSpecifierText = (text) => {
-    const t = String(text ?? "")
-      .trim()
-      .replace(/,$/, "")
-      .trim();
-    if (!t) throw new Error("Empty import specifier");
-    const parts = t.split(/\s+as\s+/);
-    const left = parts[0].trim();
-    const right = parts[1]?.trim();
-    const parseSide = (side, { defaultPrefix = "" } = {}) => {
-      const s = String(side ?? "").trim();
-      const m = s.match(/^(viewof|mutable)\s+(.+)$/);
-      if (m)
-        return {
-          prefix: `${m[1]} `,
-          name: m[2].trim()
+    if (!cell)
+        throw new Error('Unable to parse cell');
+    const parseImportSpecifierText = text => {
+        const t = String(text ?? '').trim().replace(/,$/, '').trim();
+        if (!t)
+            throw new Error('Empty import specifier');
+        const parts = t.split(/\s+as\s+/);
+        const left = parts[0].trim();
+        const right = parts[1]?.trim();
+        const parseSide = (side, {
+            defaultPrefix = ''
+        } = {}) => {
+            const s = String(side ?? '').trim();
+            const m = s.match(/^(viewof|mutable)\s+(.+)$/);
+            if (m)
+                return {
+                    prefix: `${ m[1] } `,
+                    name: m[2].trim()
+                };
+            return {
+                prefix: defaultPrefix,
+                name: s
+            };
         };
-      return {
-        prefix: defaultPrefix,
-        name: s
-      };
+        const L = parseSide(left);
+        const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
+        const importedName = `${ L.prefix }${ L.name }`.trim();
+        const localName = `${ R.prefix }${ R.name }`.trim();
+        if (!importedName)
+            throw new Error(`Could not parse imported name from: ${ t }`);
+        if (!localName)
+            throw new Error(`Could not parse local name from: ${ t }`);
+        return {
+            importedName,
+            localName
+        };
     };
-    const L = parseSide(left);
-    const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
-    const importedName = `${L.prefix}${L.name}`.trim();
-    const localName = `${R.prefix}${R.name}`.trim();
-    if (!importedName)
-      throw new Error(`Could not parse imported name from: ${t}`);
-    if (!localName) throw new Error(`Could not parse local name from: ${t}`);
-    return {
-      importedName,
-      localName
-    };
-  };
-  if (!cell.id && cell.body?.type === "ImportDeclaration") {
-    const module_name = cell.body.source.value;
-    const cell_variables = [
-      {
-        _name: `module ${module_name}`,
-        _inputs: [],
-        _definition: `async () => runtime.module((await import("${module_name}")).default)`
-      }
-    ];
-    for (const specifier of cell.body.specifiers ?? []) {
-      const specText =
-        typeof specifier?.start === "number" &&
-        typeof specifier?.end === "number"
-          ? source.slice(specifier.start, specifier.end)
-          : (() => {
-              if (specifier?.imported?.name && specifier?.local?.name) {
-                return specifier.imported.name === specifier.local.name
-                  ? specifier.local.name
-                  : `${specifier.imported.name} as ${specifier.local.name}`;
-              }
-              throw new Error("Import specifier missing range information");
+    if (!cell.id && cell.body?.type === 'ImportDeclaration') {
+        const module_name = cell.body.source.value;
+        const cell_variables = [{
+                _name: `module ${ module_name }`,
+                _inputs: [],
+                _definition: `async () => runtime.module((await import("${ module_name }")).default)`
+            }];
+        for (const specifier of cell.body.specifiers ?? []) {
+            const specText = typeof specifier?.start === 'number' && typeof specifier?.end === 'number' ? source.slice(specifier.start, specifier.end) : (() => {
+                if (specifier?.imported?.name && specifier?.local?.name) {
+                    return specifier.imported.name === specifier.local.name ? specifier.local.name : `${ specifier.imported.name } as ${ specifier.local.name }`;
+                }
+                throw new Error('Import specifier missing range information');
             })();
-      const { importedName, localName } = parseImportSpecifierText(specText);
-      cell_variables.push({
-        _name: localName,
-        _inputs: [`module ${module_name}`, "@variable"],
-        _definition:
-          importedName === localName
-            ? `(_, v) => v.import("${importedName}", _)`
-            : `(_, v) => v.import("${importedName}", "${localName}", _)`
-      });
+            const {importedName, localName} = parseImportSpecifierText(specText);
+            cell_variables.push({
+                _name: localName,
+                _inputs: [
+                    `module ${ module_name }`,
+                    '@variable'
+                ],
+                _definition: importedName === localName ? `(_, v) => v.import("${ importedName }", _)` : `(_, v) => v.import("${ importedName }", "${ localName }", _)`
+            });
+        }
+        return cell_variables;
     }
-    return cell_variables;
-  }
-  let dollarIdx = 0;
-  const inputToArgMap = {};
-  const dollarToMacro = {};
-  const seen = new Set();
-  const inputs = Array.from(cell.references || []).flatMap((i) => {
-    if (i.name) {
-      if (seen.has(i.name)) return [];
-      seen.add(i.name);
-      return i.name;
+    let dollarIdx = 0;
+    const inputToArgMap = {};
+    const dollarToMacro = {};
+    const seen = new Set();
+    const inputs = Array.from(cell.references || []).flatMap(i => {
+        if (i.name) {
+            if (seen.has(i.name))
+                return [];
+            seen.add(i.name);
+            return i.name;
+        } else {
+            const dedupKey = i.type + ':' + i.id.name;
+            if (seen.has(dedupKey))
+                return [];
+            seen.add(dedupKey);
+            const dollarName = '$' + dollarIdx;
+            inputToArgMap[i.id.name] = dollarName;
+            dollarToMacro[dollarName] = i.type == 'ViewExpression' ? 'viewof ' + i.id.name : 'mutable ' + i.id.name;
+            dollarIdx++;
+            return dollarName;
+        }
+    });
+    let variables;
+    if (cell.id) {
+        if (cell.id.type === 'Identifier') {
+            variables = [{
+                    functionName: '_' + cell.id.name,
+                    name: cell.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                }];
+        } else if (cell.id.type === 'ViewExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'viewof ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '(G, _) => G.input(_)',
+                    inputs: [
+                        'Generators',
+                        'viewof ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                }
+            ];
+        } else if (cell.id.type === 'MutableExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'initial ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'mutable ' + cell.id.id.name,
+                    _definition: '(M, _) => new M(_)',
+                    inputs: [
+                        'Mutable',
+                        'initial ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '_ => _.generator',
+                    inputs: ['mutable ' + cell.id.id.name],
+                    params: inputs.join(',')
+                }
+            ];
+        } else {
+            throw new Error(`Unsupported cell id type: ${ cell.id.type }`);
+        }
     } else {
-      const dedupKey = i.type + ":" + i.id.name;
-      if (seen.has(dedupKey)) return [];
-      seen.add(dedupKey);
-      const dollarName = "$" + dollarIdx;
-      inputToArgMap[i.id.name] = dollarName;
-      dollarToMacro[dollarName] =
-        i.type == "ViewExpression"
-          ? "viewof " + i.id.name
-          : "mutable " + i.id.name;
-      dollarIdx++;
-      return dollarName;
+        variables = [{
+                functionName: anonymousName,
+                name: null,
+                inputs,
+                params: inputs.join(',')
+            }];
     }
-  });
-  let variables;
-  if (cell.id) {
-    if (cell.id.type === "Identifier") {
-      variables = [
-        {
-          functionName: "_" + cell.id.name,
-          name: cell.id.name,
-          inputs,
-          params: inputs.join(",")
+    return variables.map(v => {
+        let _definition = v._definition;
+        if (!_definition) {
+            let functionBody;
+            if (cell.body.type === 'BlockStatement') {
+                functionBody = observableToJs(cell.body, inputToArgMap, comments, tokens);
+            } else {
+                const bodyCode = observableToJs(cell.body, inputToArgMap, comments, tokens);
+                functionBody = `{return (${ bodyCode });}`;
+            }
+            _definition = `${ cell.async ? 'async ' : '' }function${ cell.generator ? '*' : '' } ${ v.functionName }(${ v.inputs.join(',') }) ${ functionBody }`;
         }
-      ];
-    } else if (cell.id.type === "ViewExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "viewof " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "(G, _) => G.input(_)",
-          inputs: ["Generators", "viewof " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else if (cell.id.type === "MutableExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "initial " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "mutable " + cell.id.id.name,
-          _definition: "(M, _) => new M(_)",
-          inputs: ["Mutable", "initial " + cell.id.id.name],
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "_ => _.generator",
-          inputs: ["mutable " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else {
-      throw new Error(`Unsupported cell id type: ${cell.id.type}`);
-    }
-  } else {
-    variables = [
-      {
-        functionName: anonymousName,
-        name: null,
-        inputs,
-        params: inputs.join(",")
-      }
-    ];
-  }
-  return variables.map((v) => {
-    let _definition = v._definition;
-    if (!_definition) {
-      let functionBody;
-      if (cell.body.type === "BlockStatement") {
-        functionBody = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-      } else {
-        const bodyCode = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-        functionBody = `{return (${bodyCode});}`;
-      }
-      _definition = `${cell.async ? "async " : ""}function${
-        cell.generator ? "*" : ""
-      } ${v.functionName}(${v.inputs.join(",")}) ${functionBody}`;
-    }
-    return {
-      _name: v.name,
-      _inputs: v.inputs.map(
-        (i) => dollarToMacro[i] || (i === "$variable" ? "@variable" : i)
-      ),
-      _definition
-    };
-  });
+        return {
+            _name: v.name,
+            _inputs: v.inputs.map(i => dollarToMacro[i] || (i === '$variable' ? '@variable' : i)),
+            _definition
+        };
+    });
 }
 )};
 const _1v1i7wl = function _observableToJs(acorn_walk,parser,escodegen){return(
@@ -18712,16 +18572,15 @@ async (attachment, overrides) => {
   return URL.createObjectURL(blob);
 }
 )};
-const _s9w7ha = async function _parser(decompress_url,FileAttachment,acorn_url,acorn_walk_url){return(
-importShim(await decompress_url(FileAttachment("parser-6.1.0.js.gz"), {
-    "/npm/acorn@8.11.3/+esm": acorn_url,
-    "/npm/acorn-walk@8.3.2/+esm": acorn_walk_url
-  })
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
-const _1hiclbb = function _acorn_walk(acorn_walk_url){return(
-importShim(acorn_walk_url, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _s9w7ha = async function _parser(decompress_url, FileAttachment, acorn_url, acorn_walk_url) {
+    return import(await decompress_url(FileAttachment('parser-6.1.0.js.gz'), {
+        '/npm/acorn@8.11.3/+esm': acorn_url,
+        '/npm/acorn-walk@8.3.2/+esm': acorn_walk_url
+    }));
+};
+const _1hiclbb = function _acorn_walk(acorn_walk_url) {
+    return import(acorn_walk_url);
+};
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
@@ -18909,7 +18768,7 @@ export default function define(runtime, observer) {
   $def("_1dmmuaf", "compiled_selector", ["Generators","viewof compiled_selector"], _1dmmuaf);  
   $def("_u7t3vu", null, ["compiled_selector","normalizeJavascriptSource"], _u7t3vu);  
   $def("_1lt3kl6", null, ["compile","test_case"], _1lt3kl6);  
-  $def("_lpzjrv", "compile", ["parser","globalThis","observableToJs"], _lpzjrv);  
+  $def("_x1d0wm", "compile", ["parser","observableToJs"], _x1d0wm);  
   $def("_1v1i7wl", "observableToJs", ["acorn_walk","parser","escodegen"], _1v1i7wl);  
   $def("_19lv24l", null, ["md"], _19lv24l);  
   $def("_xhj6b8", "decompress_url", ["DecompressionStream","TextDecoderStream","TransformStream","TextEncoderStream","Response"], _xhj6b8);  
@@ -19972,10 +19831,10 @@ md`### \`importShim\` polyfill
 
 Lopecode uses importShim which is not availible on Observablehq`
 )};
-const _12odeih = function _importShim()
-{
-  if (window.importShim) return window.importShim;
-  return (url, options) => importShim(url, 'https://api.observablehq.com/@tomlarkworthy/runtime-sdk.js?v=4');
+const _12odeih = function _importShim() {
+    if (window.importShim)
+        return window.importShim;
+    return (url, options) => import(url);
 };
 const _1nrqtih = function _65(md){return(
 md`---`
@@ -23644,20 +23503,21 @@ md`## [Optional] Tests`
 const _11gtx14 = function _RUN_TESTS(){return(
 true
 )};
-const _46icxz = async function _testing(RUN_TESTS,invalidation)
-{
-  if (!RUN_TESTS) return invalidation;
-  const [{ Runtime }, { default: define }] = await Promise.all([
-    importShim("https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js"
-    , 'https://api.observablehq.com/@tomlarkworthy/view.js?v=4'),
-    importShim(`https://api.observablehq.com/@tomlarkworthy/testing.js?v=3`, 'https://api.observablehq.com/@tomlarkworthy/view.js?v=4')
-  ]);
-  const module = new Runtime().module(define);
-  return Object.fromEntries(
-    await Promise.all(
-      ["expect", "createSuite"].map((n) => module.value(n).then((v) => [n, v]))
-    )
-  );
+const _46icxz = async function _testing(RUN_TESTS, invalidation) {
+    if (!RUN_TESTS)
+        return invalidation;
+    const [{Runtime}, {default: define}] = await Promise.all([
+        import('https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js'),
+        import(`https://api.observablehq.com/@tomlarkworthy/testing.js?v=3`)
+    ]);
+    const module = new Runtime().module(define);
+    return Object.fromEntries(await Promise.all([
+        'expect',
+        'createSuite'
+    ].map(n => module.value(n).then(v => [
+        n,
+        v
+    ]))));
 };
 const _lf943y = function _suite(testing){return(
 testing.createSuite({
@@ -23893,15 +23753,13 @@ suite.test("Collection object creates matching keys", async () => {
   expect(v.value).toHaveProperty("a");
 })
 )};
-const _1qdb7yp = async function _toc()
-{
-  const [{ Runtime }, { default: define }] = await Promise.all([
-    importShim("https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js"
-    , 'https://api.observablehq.com/@tomlarkworthy/view.js?v=4'),
-    importShim(`https://api.observablehq.com/@nebrius/indented-toc.js?v=3`, 'https://api.observablehq.com/@tomlarkworthy/view.js?v=4')
-  ]);
-  const module = new Runtime().module(define);
-  return module.value("toc");
+const _1qdb7yp = async function _toc() {
+    const [{Runtime}, {default: define}] = await Promise.all([
+        import('https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js'),
+        import(`https://api.observablehq.com/@nebrius/indented-toc.js?v=3`)
+    ]);
+    const module = new Runtime().module(define);
+    return module.value('toc');
 };
 
 export default function define(runtime, observer) {
@@ -24620,9 +24478,8 @@ export default function define(runtime, observer) {
   return main;
 }</script>
 
-
 <!-- Bootloader -->
-<script id="bootconf.json" 
+<script id="bootconf.json"
         type="text/plain"
         data-mime="application/json"
 >
@@ -24878,7 +24735,7 @@ export default function define(runtime, observer) {
   const style7 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/syntax-light.css", { with: { type: 'css' } });
   const style8 = await importShim("file://syntax.css", { with: { type: 'css' } });
   document.adoptedStyleSheets = [style0.default,style1.default,style2.default,style3.default,style4.default,style5.default,style6.default,style7.default,style8.default];
-  
+
   const { Runtime } = await importShim("@observablehq/runtime@6.0.0");
   const { Inspector } = await importShim("@observablehq/inspector@5.0.1");
   const notebook = document.querySelector("notebook");

--- a/notebooks/@tomlarkworthy_editor-5.html
+++ b/notebooks/@tomlarkworthy_editor-5.html
@@ -5421,7 +5421,7 @@ const _geoudp = async function _command_processor(command,$0,compile_and_update,
   let result = undefined;
   if (command.command == "createCell") {
     $0.value = true;
-    result = compile_and_update("{}", [], command.args.cell);
+    result = await compile_and_update("{}", [], command.args.cell);
     // For the new one to get focus
     // setTimeout(() => {
     //   debugger;
@@ -5856,9 +5856,9 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+const _nzhbow = function _compile_and_update(compile,realize,runtime,repositionSetElement)
 {
-    return (source, variables = [], cell) => {
+    return async (source, variables = [], cell) => {
         try {
             debugger;
             let reposition = false, insertionIndex = -1;
@@ -5878,10 +5878,10 @@ const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElemen
             if (reposition) {
                 insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
+            const fns = await realize(newVariables.map(v => v._definition), runtime);
             newVariables.forEach((v, i) => {
                 const variable = variables[i];
-                let _fn;
-                eval('_fn = ' + v._definition);
+                const _fn = fns[i];
                 if (v._name) {
                     variable.define(v._name, v._inputs, _fn);
                 } else {
@@ -5930,12 +5930,11 @@ Inputs.textarea({
 })
 )};
 const _b4rsn5 = (G, _) => G.input(_);
-const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
+const _t68yvv = function _98(Inputs,definition,variable,inputs,realize,runtime){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
-  reduce: () => {
-    let _fn;
-    eval("_fn = " + definition);
+  reduce: async () => {
+    const [_fn] = await realize([definition], runtime);
     variable.define(variable._name, inputs, _fn);
   }
 })
@@ -6086,7 +6085,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
+  $def("_nzhbow", "compile_and_update", ["compile","realize","runtime","repositionSetElement"], _nzhbow);
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -6096,7 +6095,7 @@ export default function define(runtime, observer) {
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
   $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
-  $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
+  $def("_t68yvv", null, ["Inputs","definition","variable","inputs","realize","runtime"], _t68yvv);
   $def("_1q557s", null, ["md"], _1q557s);  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
@@ -6106,8 +6105,9 @@ export default function define(runtime, observer) {
   main.define("keepalive", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("keepalive", _));  
   main.define("toObject", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("toObject", _));  
   main.define("isnode", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("isnode", _));  
-  main.define("repositionSetElement", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("repositionSetElement", _));  
-  main.define("onCodeChange", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("onCodeChange", _));  
+  main.define("repositionSetElement", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("repositionSetElement", _));
+  main.define("realize", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("realize", _));
+  main.define("onCodeChange", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("onCodeChange", _));
   main.define("EditorState", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("EditorState", _));  
   main.define("EditorView", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("EditorView", _));  
   main.define("codemirror", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("codemirror", _));  
@@ -18496,12 +18496,11 @@ function compile(source, { anonymousName = "_anonymous" } = {}) {
   };
   if (!cell.id && cell.body?.type === "ImportDeclaration") {
     const module_name = cell.body.source.value;
-    const importKeyword = globalThis?.importShim ? "importShim" : "import";
     const cell_variables = [
       {
         _name: `module ${module_name}`,
         _inputs: [],
-        _definition: `async () => runtime.module((await ${importKeyword}("${module_name}")).default)`
+        _definition: `async () => runtime.module((await import("${module_name}")).default)`
       }
     ];
     for (const specifier of cell.body.specifiers ?? []) {

--- a/notebooks/@tomlarkworthy_editor-5.json
+++ b/notebooks/@tomlarkworthy_editor-5.json
@@ -35,7 +35,7 @@
       ]
     },
     "@tomlarkworthy/acorn-8-11-3": {
-      "hash": "e483cbde82225efd3b3224d603903164",
+      "hash": "cfbb603f9923f42e480bcc24ea214eb4",
       "files": [
         "acorn-8.11.3.js.gz"
       ],
@@ -84,7 +84,7 @@
       ]
     },
     "@tomlarkworthy/codemirror-6-v2": {
-      "hash": "b79a37cf1dd24fd22fc89bbde24edd7a",
+      "hash": "18836087c3003723f4abbea3eaa0993a",
       "files": [
         "codemirror_javascript%405.js.gz"
       ],
@@ -112,7 +112,7 @@
       ]
     },
     "@tomlarkworthy/editor-5": {
-      "hash": "7ed352ac85a30cf1540040cb29aa88b7",
+      "hash": "aeb7deb7c09b934e8ad21cc137e29834",
       "files": [
         "cell_options.json"
       ],
@@ -145,7 +145,7 @@
       ]
     },
     "@tomlarkworthy/exporter-3": {
-      "hash": "12548ff77d201dd107f24d26dd2165e6",
+      "hash": "5778e38fbc2889783f252eba282b6474",
       "dependsOn": [
         "@tomlarkworthy/observable-runtime-v6",
         "@tomlarkworthy/flow-queue",
@@ -168,7 +168,7 @@
       ]
     },
     "@tomlarkworthy/file-sync": {
-      "hash": "e379596265cd3030c6f98d97aa807b75",
+      "hash": "5ce42c89e483aba06e2434b6834d8da6",
       "dependsOn": [
         "@tomlarkworthy/module-map",
         "@tomlarkworthy/exporter-3",
@@ -192,7 +192,7 @@
       ]
     },
     "@tomlarkworthy/flow-queue": {
-      "hash": "e6efc6ff2c5841e59bf5f22a2e4fd309",
+      "hash": "5e3c76c417d8ab3c246fd99d61d398be",
       "files": [
         "flowQuery%401.svg"
       ],
@@ -203,7 +203,7 @@
       ]
     },
     "@tomlarkworthy/golden-layout-2-6-0": {
-      "hash": "17b1cfc092e7aa851102ce64ebd95314",
+      "hash": "24f5fad01bd508dd1bc3a49a99002770",
       "files": [
         "golden-layout-2.6.0.js.gz",
         "lm_popout_black.png",
@@ -239,7 +239,7 @@
       ]
     },
     "@tomlarkworthy/isomorphic-git-1-30-1": {
-      "hash": "cc5644744fc51b6badd823767165b905",
+      "hash": "16fa79b79fb4e9e1a2d03cfc9221147c",
       "files": [
         "isomorphic-git-1%401.30.1.bundle.js.gz",
         "isomorphic-git-http-1.0.0-beta.36.js.gz"
@@ -249,7 +249,7 @@
       ]
     },
     "@tomlarkworthy/jest-expect-standalone": {
-      "hash": "5cd12f98a08cd6144369d970a42e41c9",
+      "hash": "418ef3328580c7b2416be5b9fc940db4",
       "files": [
         "jest-expect-standalone-24.0.2.js.gz"
       ],
@@ -260,7 +260,7 @@
       ]
     },
     "@tomlarkworthy/jszip-3-10-1": {
-      "hash": "104d2a3fa76149964a5ec2e78291b7fa",
+      "hash": "2b119c57e9c2ce093b3a9c7d2932d010",
       "files": [
         "jszip-3.10.1.min.js.gz"
       ],
@@ -269,7 +269,7 @@
       ]
     },
     "@tomlarkworthy/lightning-fs-4-6-0": {
-      "hash": "9f29cd8f7d08a51eca9962323ede7620",
+      "hash": "1f60955582df75104615d8061957d237",
       "files": [
         "lightning-fs-4.6.0.js.gz"
       ],
@@ -318,7 +318,7 @@
       ]
     },
     "@tomlarkworthy/lopepage-urls": {
-      "hash": "a41f679233630d379c881e39e3b914e7",
+      "hash": "eee5c7951f9edd92f8fd1dba8442609b",
       "dependsOn": [
         "@tomlarkworthy/runtime-sdk",
         "@tomlarkworthy/tests"
@@ -369,7 +369,7 @@
       ]
     },
     "@tomlarkworthy/observable-runtime": {
-      "hash": "015af244c77d1c0a73fb2aad51c8da83",
+      "hash": "4b60a23333fcadbc20650feae24d4039",
       "files": [
         "runtime.js.gz"
       ],
@@ -378,13 +378,13 @@
       ]
     },
     "@tomlarkworthy/observable-runtime-v6": {
-      "hash": "060835989c27d5cd2f82d358975a0328",
+      "hash": "6bc9db7b1881559c4d30c39f692e3969",
       "dependedBy": [
         "@tomlarkworthy/exporter-3"
       ]
     },
     "@tomlarkworthy/observablejs-toolchain": {
-      "hash": "4fef8e87ae193330ccb6af2ac955aa86",
+      "hash": "bb6dde010924d34011b212a6aba3ccac",
       "files": [
         "acorn-walk-8.3.2.js.gz",
         "parser-6.1.0.js.gz"
@@ -417,7 +417,7 @@
       ]
     },
     "@tomlarkworthy/runtime-sdk": {
-      "hash": "4d565b1b67254742111f1ef9d9aa8220",
+      "hash": "d6da0322104cb2ad8a836559a8e6cf15",
       "dependsOn": [
         "@mootari/access-runtime"
       ],
@@ -485,7 +485,7 @@
       ]
     },
     "@tomlarkworthy/view": {
-      "hash": "16b8cf235bb51d57792ff44ac408e74a",
+      "hash": "970bf1f386002336660773d1215dd61f",
       "dependedBy": [
         "@tomlarkworthy/exporter-3",
         "@tomlarkworthy/reversible-attachment"

--- a/notebooks/@tomlarkworthy_exporter-2.html
+++ b/notebooks/@tomlarkworthy_exporter-2.html
@@ -5437,58 +5437,41 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _geoudp = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
-  if (command.processed) return;
-
-  let result = undefined;
-  if (command.command == "createCell") {
-    $0.value = true;
-    result = compile_and_update("{}", [], command.args.cell);
-    // For the new one to get focus
-    // setTimeout(() => {
-    //   debugger;
-    //   setOption(result[0], "pinned", true);
-    // }, 100);
-  } else if (command.command == "deleteCell") {
-    remove_variables(command.args.cell.variables);
-    result = true;
-  } else if (command.command == "moveCell") {
-    const cellIndex = findCellIndex(
-      command.args.cell.variables,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const targetCellIndex = cellIndex + command.args.amount;
-    const targetCell = lookupCellByIndex(
-      targetCellIndex,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const currentFirstVariableIndex = findVariableIndex(
-      command.args.cell.variables[0]
-    );
-    const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-    const change = targetFirstVariableIndex - currentFirstVariableIndex;
-    console.log(
-      "moveCell",
-      cellIndex,
-      targetCellIndex,
-      targetCell,
-      currentFirstVariableIndex,
-      targetFirstVariableIndex,
-      change
-    );
-    command.args.cell.variables.forEach((v) => {
-      const currentIndex = findVariableIndex(v);
-      repositionSetElement(runtime._variables, v, currentIndex + change);
-    });
-    // recompute
-    await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
-    result = true;
-  }
-  if (result) {
-    command.processed = true;
-    $2.resolve(result);
-  }
+    if (command.processed)
+        return;
+    let result = undefined;
+    if (command.command == 'createCell') {
+        $0.value = true;
+        result = await compile_and_update('{}', [], command.args.cell);    // For the new one to get focus
+                                                                           // setTimeout(() => {
+                                                                           //   debugger;
+                                                                           //   setOption(result[0], "pinned", true);
+                                                                           // }, 100);
+    } else if (command.command == 'deleteCell') {
+        remove_variables(command.args.cell.variables);
+        result = true;
+    } else if (command.command == 'moveCell') {
+        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const targetCellIndex = cellIndex + command.args.amount;
+        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
+        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+        const change = targetFirstVariableIndex - currentFirstVariableIndex;
+        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
+        command.args.cell.variables.forEach(v => {
+            const currentIndex = findVariableIndex(v);
+            repositionSetElement(runtime._variables, v, currentIndex + change);
+        });
+        // recompute
+        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        result = true;
+    }
+    if (result) {
+        command.processed = true;
+        $2.resolve(result);
+    }
 };
 const _1jadxoe = function _60(md){return(
 md`### UI Action`
@@ -5879,9 +5862,9 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
-    return (source, variables = [], cell) => {
+    return async (source, variables = [], cell) => {
         try {
             debugger;
             let reposition = false, insertionIndex = -1;
@@ -5901,10 +5884,10 @@ const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElemen
             if (reposition) {
                 insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
+            const fns = await realize(newVariables.map(v => v._definition), runtime);
             newVariables.forEach((v, i) => {
                 const variable = variables[i];
-                let _fn;
-                eval('_fn = ' + v._definition);
+                const _fn = fns[i];
                 if (v._name) {
                     variable.define(v._name, v._inputs, _fn);
                 } else {
@@ -5953,12 +5936,11 @@ Inputs.textarea({
 })
 )};
 const _b4rsn5 = (G, _) => G.input(_);
-const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
+const _ga6kci = function _98(Inputs,definition,variable,realize,runtime,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
-  reduce: () => {
-    let _fn;
-    eval("_fn = " + definition);
+  reduce: async () => {
+    const [_fn] = await realize([definition], runtime);
     variable.define(variable._name, inputs, _fn);
   }
 })
@@ -6071,7 +6053,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_geoudp", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _geoudp);  
+  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6109,7 +6091,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
+  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -6119,8 +6101,9 @@ export default function define(runtime, observer) {
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
   $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
-  $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
+  $def("_ga6kci", null, ["Inputs","definition","variable","realize","runtime","inputs"], _ga6kci);  
   $def("_1q557s", null, ["md"], _1q557s);  
+  main.define("realize", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("realize", _));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -18584,10 +18567,9 @@ notebook_semantics_document.nodes.map((s) => ({
 const _1oevsow = function _28(md){return(
 md`### Runtime Representation (v4)`
 )};
-const _11lfflk = function _notebook_semantics_module(){return(
-importShim("https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4"
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _11lfflk = function _notebook_semantics_module() {
+    return import('https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4');
+};
 const _gjten6 = function _31(md){return(
 md`### Imports`
 )};
@@ -19574,65 +19556,44 @@ parser.parseCell(
   'import {runtime, viewof main as foo} from "@mootari/access-runtime"'
 )
 )};
-const _1n7gw17 = function _findModuleName(extractModuleInfo){return(
-(scope, module, { unknown_id = Math.random() } = {}) => {
-  try {
-    const scopedVariables = [...scope.values()];
-
-    // Prefer variables that *define* a module and have a real module-loader name.
-    const candidates = scopedVariables.filter(
-      (v) =>
-        v &&
-        v._value === module &&
-        typeof v._name === "string" &&
-        v._name.startsWith("module ") &&
-        !v._name.startsWith("module <unknown")
-    );
-
-    const pickBestInfo = (dfn) => {
-      // Avoid the parentUrl (2nd arg) confusing module identification.
-      // Typical patterns:
-      //   importShim("/d/<id>@<ver>.js?v=4", "https://api.observablehq.com/@ns/name.js?v=4")
-      //   import("/d/<id>@<ver>.js?v=4")
-      // Prefer the *first argument* inside importShim(...) / import(...) when present.
-      const s = String(dfn ?? "");
-
-      // Try to capture the first string literal argument to importShim(...) or import(...)
-      // Tolerates quotes ", ', ` and both importShim and plain import.
-      const m = s.match(
-        /\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/
-      );
-      const firstArg = m?.[2];
-
-      const info1 = firstArg ? extractModuleInfo(firstArg) : {};
-      if (info1?.id || info1?.notebook) return info1;
-
-      // Fallback: parse the whole definition string.
-      return extractModuleInfo(s);
+const _1n7gw17 = function _findModuleName(extractModuleInfo) {
+    return (scope, module, {
+        unknown_id = Math.random()
+    } = {}) => {
+        try {
+            const scopedVariables = [...scope.values()];
+            const candidates = scopedVariables.filter(v => v && v._value === module && typeof v._name === 'string' && v._name.startsWith('module ') && !v._name.startsWith('module <unknown'));
+            const pickBestInfo = dfn => {
+                const s = String(dfn ?? '');
+                const m = s.match(/\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/);
+                const firstArg = m?.[2];
+                const info1 = firstArg ? extractModuleInfo(firstArg) : {};
+                if (info1?.id || info1?.notebook)
+                    return info1;
+                return extractModuleInfo(s);
+            };
+            for (const v of candidates) {
+                const info = pickBestInfo(v._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            const any = scopedVariables.find(v => v && v._value === module);
+            if (any) {
+                const info = pickBestInfo(any._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            return `<unknown ${ unknown_id }>`;
+        } catch (e) {
+            debugger;
+            return 'error';
+        }
     };
-
-    // Try module loader cells first.
-    for (const v of candidates) {
-      const info = pickBestInfo(v._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    // Fallback: any scoped variable with _value==module.
-    const any = scopedVariables.find((v) => v && v._value === module);
-    if (any) {
-      const info = pickBestInfo(any._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    return `<unknown ${unknown_id}>`;
-  } catch (e) {
-    debugger;
-    return "error";
-  }
-}
-)};
+};
 const _i47chb = function _findImportedName(){return(
 async (v) => {
   if (v._inputs.length == 1 && v._inputs[0]._name === "@variable") {
@@ -20534,229 +20495,206 @@ JSON.stringify(
 const _1lt3kl6 = function _157(compile,test_case){return(
 compile(test_case.value)
 )};
-const _lpzjrv = function _compile(parser,globalThis,observableToJs){return(
-function compile(source, { anonymousName = "_anonymous" } = {}) {
-  const comments = [],
-    tokens = [];
-  let cell;
-  try {
-    cell = parser.parseCell(source, {
-      ranges: true,
-      onComment: comments,
-      onToken: tokens
-    });
-  } catch (e) {
-    if (e instanceof SyntaxError) {
-      const nameMatch = source.match(
-        /^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/
-      );
-      let _name = null;
-      let funcName = anonymousName;
-      if (nameMatch) {
-        const prefix = nameMatch[1] ? nameMatch[1] + " " : "";
-        _name = prefix + nameMatch[2];
-        funcName = "_" + nameMatch[2];
-      }
-      const escapedMsg = JSON.stringify(e.message);
-      const escapedSource = JSON.stringify(source);
-      return [
-        {
-          _name,
-          _inputs: [],
-          _definition: `function ${funcName}() { throw Object.assign(new SyntaxError(${escapedMsg}), {_sourceExpression: ${escapedSource}}); }`
+const _x1d0wm = function _compile(parser,observableToJs){return(
+function compile(source, {
+    anonymousName = '_anonymous'
+} = {}) {
+    const comments = [], tokens = [];
+    let cell;
+    try {
+        cell = parser.parseCell(source, {
+            ranges: true,
+            onComment: comments,
+            onToken: tokens
+        });
+    } catch (e) {
+        if (e instanceof SyntaxError) {
+            const nameMatch = source.match(/^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/);
+            let _name = null;
+            let funcName = anonymousName;
+            if (nameMatch) {
+                const prefix = nameMatch[1] ? nameMatch[1] + ' ' : '';
+                _name = prefix + nameMatch[2];
+                funcName = '_' + nameMatch[2];
+            }
+            const escapedMsg = JSON.stringify(e.message);
+            const escapedSource = JSON.stringify(source);
+            return [{
+                    _name,
+                    _inputs: [],
+                    _definition: `function ${ funcName }() { throw Object.assign(new SyntaxError(${ escapedMsg }), {_sourceExpression: ${ escapedSource }}); }`
+                }];
         }
-      ];
+        throw e;
     }
-    throw e;
-  }
-  if (!cell) throw new Error("Unable to parse cell");
-  const parseImportSpecifierText = (text) => {
-    const t = String(text ?? "")
-      .trim()
-      .replace(/,$/, "")
-      .trim();
-    if (!t) throw new Error("Empty import specifier");
-    const parts = t.split(/\s+as\s+/);
-    const left = parts[0].trim();
-    const right = parts[1]?.trim();
-    const parseSide = (side, { defaultPrefix = "" } = {}) => {
-      const s = String(side ?? "").trim();
-      const m = s.match(/^(viewof|mutable)\s+(.+)$/);
-      if (m)
-        return {
-          prefix: `${m[1]} `,
-          name: m[2].trim()
+    if (!cell)
+        throw new Error('Unable to parse cell');
+    const parseImportSpecifierText = text => {
+        const t = String(text ?? '').trim().replace(/,$/, '').trim();
+        if (!t)
+            throw new Error('Empty import specifier');
+        const parts = t.split(/\s+as\s+/);
+        const left = parts[0].trim();
+        const right = parts[1]?.trim();
+        const parseSide = (side, {
+            defaultPrefix = ''
+        } = {}) => {
+            const s = String(side ?? '').trim();
+            const m = s.match(/^(viewof|mutable)\s+(.+)$/);
+            if (m)
+                return {
+                    prefix: `${ m[1] } `,
+                    name: m[2].trim()
+                };
+            return {
+                prefix: defaultPrefix,
+                name: s
+            };
         };
-      return {
-        prefix: defaultPrefix,
-        name: s
-      };
+        const L = parseSide(left);
+        const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
+        const importedName = `${ L.prefix }${ L.name }`.trim();
+        const localName = `${ R.prefix }${ R.name }`.trim();
+        if (!importedName)
+            throw new Error(`Could not parse imported name from: ${ t }`);
+        if (!localName)
+            throw new Error(`Could not parse local name from: ${ t }`);
+        return {
+            importedName,
+            localName
+        };
     };
-    const L = parseSide(left);
-    const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
-    const importedName = `${L.prefix}${L.name}`.trim();
-    const localName = `${R.prefix}${R.name}`.trim();
-    if (!importedName)
-      throw new Error(`Could not parse imported name from: ${t}`);
-    if (!localName) throw new Error(`Could not parse local name from: ${t}`);
-    return {
-      importedName,
-      localName
-    };
-  };
-  if (!cell.id && cell.body?.type === "ImportDeclaration") {
-    const module_name = cell.body.source.value;
-    const importKeyword = globalThis?.importShim ? "importShim" : "import";
-    const cell_variables = [
-      {
-        _name: `module ${module_name}`,
-        _inputs: [],
-        _definition: `async () => runtime.module((await ${importKeyword}("${module_name}")).default)`
-      }
-    ];
-    for (const specifier of cell.body.specifiers ?? []) {
-      const specText =
-        typeof specifier?.start === "number" &&
-        typeof specifier?.end === "number"
-          ? source.slice(specifier.start, specifier.end)
-          : (() => {
-              if (specifier?.imported?.name && specifier?.local?.name) {
-                return specifier.imported.name === specifier.local.name
-                  ? specifier.local.name
-                  : `${specifier.imported.name} as ${specifier.local.name}`;
-              }
-              throw new Error("Import specifier missing range information");
+    if (!cell.id && cell.body?.type === 'ImportDeclaration') {
+        const module_name = cell.body.source.value;
+        const cell_variables = [{
+                _name: `module ${ module_name }`,
+                _inputs: [],
+                _definition: `async () => runtime.module((await import("${ module_name }")).default)`
+            }];
+        for (const specifier of cell.body.specifiers ?? []) {
+            const specText = typeof specifier?.start === 'number' && typeof specifier?.end === 'number' ? source.slice(specifier.start, specifier.end) : (() => {
+                if (specifier?.imported?.name && specifier?.local?.name) {
+                    return specifier.imported.name === specifier.local.name ? specifier.local.name : `${ specifier.imported.name } as ${ specifier.local.name }`;
+                }
+                throw new Error('Import specifier missing range information');
             })();
-      const { importedName, localName } = parseImportSpecifierText(specText);
-      cell_variables.push({
-        _name: localName,
-        _inputs: [`module ${module_name}`, "@variable"],
-        _definition:
-          importedName === localName
-            ? `(_, v) => v.import("${importedName}", _)`
-            : `(_, v) => v.import("${importedName}", "${localName}", _)`
-      });
+            const {importedName, localName} = parseImportSpecifierText(specText);
+            cell_variables.push({
+                _name: localName,
+                _inputs: [
+                    `module ${ module_name }`,
+                    '@variable'
+                ],
+                _definition: importedName === localName ? `(_, v) => v.import("${ importedName }", _)` : `(_, v) => v.import("${ importedName }", "${ localName }", _)`
+            });
+        }
+        return cell_variables;
     }
-    return cell_variables;
-  }
-  let dollarIdx = 0;
-  const inputToArgMap = {};
-  const dollarToMacro = {};
-  const seen = new Set();
-  const inputs = Array.from(cell.references || []).flatMap((i) => {
-    if (i.name) {
-      if (seen.has(i.name)) return [];
-      seen.add(i.name);
-      return i.name;
+    let dollarIdx = 0;
+    const inputToArgMap = {};
+    const dollarToMacro = {};
+    const seen = new Set();
+    const inputs = Array.from(cell.references || []).flatMap(i => {
+        if (i.name) {
+            if (seen.has(i.name))
+                return [];
+            seen.add(i.name);
+            return i.name;
+        } else {
+            const dedupKey = i.type + ':' + i.id.name;
+            if (seen.has(dedupKey))
+                return [];
+            seen.add(dedupKey);
+            const dollarName = '$' + dollarIdx;
+            inputToArgMap[i.id.name] = dollarName;
+            dollarToMacro[dollarName] = i.type == 'ViewExpression' ? 'viewof ' + i.id.name : 'mutable ' + i.id.name;
+            dollarIdx++;
+            return dollarName;
+        }
+    });
+    let variables;
+    if (cell.id) {
+        if (cell.id.type === 'Identifier') {
+            variables = [{
+                    functionName: '_' + cell.id.name,
+                    name: cell.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                }];
+        } else if (cell.id.type === 'ViewExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'viewof ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '(G, _) => G.input(_)',
+                    inputs: [
+                        'Generators',
+                        'viewof ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                }
+            ];
+        } else if (cell.id.type === 'MutableExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'initial ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'mutable ' + cell.id.id.name,
+                    _definition: '(M, _) => new M(_)',
+                    inputs: [
+                        'Mutable',
+                        'initial ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '_ => _.generator',
+                    inputs: ['mutable ' + cell.id.id.name],
+                    params: inputs.join(',')
+                }
+            ];
+        } else {
+            throw new Error(`Unsupported cell id type: ${ cell.id.type }`);
+        }
     } else {
-      const dedupKey = i.type + ":" + i.id.name;
-      if (seen.has(dedupKey)) return [];
-      seen.add(dedupKey);
-      const dollarName = "$" + dollarIdx;
-      inputToArgMap[i.id.name] = dollarName;
-      dollarToMacro[dollarName] =
-        i.type == "ViewExpression"
-          ? "viewof " + i.id.name
-          : "mutable " + i.id.name;
-      dollarIdx++;
-      return dollarName;
+        variables = [{
+                functionName: anonymousName,
+                name: null,
+                inputs,
+                params: inputs.join(',')
+            }];
     }
-  });
-  let variables;
-  if (cell.id) {
-    if (cell.id.type === "Identifier") {
-      variables = [
-        {
-          functionName: "_" + cell.id.name,
-          name: cell.id.name,
-          inputs,
-          params: inputs.join(",")
+    return variables.map(v => {
+        let _definition = v._definition;
+        if (!_definition) {
+            let functionBody;
+            if (cell.body.type === 'BlockStatement') {
+                functionBody = observableToJs(cell.body, inputToArgMap, comments, tokens);
+            } else {
+                const bodyCode = observableToJs(cell.body, inputToArgMap, comments, tokens);
+                functionBody = `{return (${ bodyCode });}`;
+            }
+            _definition = `${ cell.async ? 'async ' : '' }function${ cell.generator ? '*' : '' } ${ v.functionName }(${ v.inputs.join(',') }) ${ functionBody }`;
         }
-      ];
-    } else if (cell.id.type === "ViewExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "viewof " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "(G, _) => G.input(_)",
-          inputs: ["Generators", "viewof " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else if (cell.id.type === "MutableExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "initial " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "mutable " + cell.id.id.name,
-          _definition: "(M, _) => new M(_)",
-          inputs: ["Mutable", "initial " + cell.id.id.name],
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "_ => _.generator",
-          inputs: ["mutable " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else {
-      throw new Error(`Unsupported cell id type: ${cell.id.type}`);
-    }
-  } else {
-    variables = [
-      {
-        functionName: anonymousName,
-        name: null,
-        inputs,
-        params: inputs.join(",")
-      }
-    ];
-  }
-  return variables.map((v) => {
-    let _definition = v._definition;
-    if (!_definition) {
-      let functionBody;
-      if (cell.body.type === "BlockStatement") {
-        functionBody = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-      } else {
-        const bodyCode = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-        functionBody = `{return (${bodyCode});}`;
-      }
-      _definition = `${cell.async ? "async " : ""}function${
-        cell.generator ? "*" : ""
-      } ${v.functionName}(${v.inputs.join(",")}) ${functionBody}`;
-    }
-    return {
-      _name: v.name,
-      _inputs: v.inputs.map(
-        (i) => dollarToMacro[i] || (i === "$variable" ? "@variable" : i)
-      ),
-      _definition
-    };
-  });
+        return {
+            _name: v.name,
+            _inputs: v.inputs.map(i => dollarToMacro[i] || (i === '$variable' ? '@variable' : i)),
+            _definition
+        };
+    });
 }
 )};
 const _1v1i7wl = function _observableToJs(acorn_walk,parser,escodegen){return(
@@ -20823,16 +20761,15 @@ async (attachment, overrides) => {
   return URL.createObjectURL(blob);
 }
 )};
-const _s9w7ha = async function _parser(decompress_url,FileAttachment,acorn_url,acorn_walk_url){return(
-importShim(await decompress_url(FileAttachment("parser-6.1.0.js.gz"), {
-    "/npm/acorn@8.11.3/+esm": acorn_url,
-    "/npm/acorn-walk@8.3.2/+esm": acorn_walk_url
-  })
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
-const _1hiclbb = function _acorn_walk(acorn_walk_url){return(
-importShim(acorn_walk_url, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _s9w7ha = async function _parser(decompress_url, FileAttachment, acorn_url, acorn_walk_url) {
+    return import(await decompress_url(FileAttachment('parser-6.1.0.js.gz'), {
+        '/npm/acorn@8.11.3/+esm': acorn_url,
+        '/npm/acorn-walk@8.3.2/+esm': acorn_walk_url
+    }));
+};
+const _1hiclbb = function _acorn_walk(acorn_walk_url) {
+    return import(acorn_walk_url);
+};
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
@@ -21020,7 +20957,7 @@ export default function define(runtime, observer) {
   $def("_1dmmuaf", "compiled_selector", ["Generators","viewof compiled_selector"], _1dmmuaf);  
   $def("_u7t3vu", null, ["compiled_selector","normalizeJavascriptSource"], _u7t3vu);  
   $def("_1lt3kl6", null, ["compile","test_case"], _1lt3kl6);  
-  $def("_lpzjrv", "compile", ["parser","globalThis","observableToJs"], _lpzjrv);  
+  $def("_x1d0wm", "compile", ["parser","observableToJs"], _x1d0wm);  
   $def("_1v1i7wl", "observableToJs", ["acorn_walk","parser","escodegen"], _1v1i7wl);  
   $def("_19lv24l", null, ["md"], _19lv24l);  
   $def("_xhj6b8", "decompress_url", ["DecompressionStream","TextDecoderStream","TransformStream","TextEncoderStream","Response"], _xhj6b8);  

--- a/notebooks/@tomlarkworthy_exporter-3.html
+++ b/notebooks/@tomlarkworthy_exporter-3.html
@@ -5414,58 +5414,41 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _geoudp = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
-  if (command.processed) return;
-
-  let result = undefined;
-  if (command.command == "createCell") {
-    $0.value = true;
-    result = compile_and_update("{}", [], command.args.cell);
-    // For the new one to get focus
-    // setTimeout(() => {
-    //   debugger;
-    //   setOption(result[0], "pinned", true);
-    // }, 100);
-  } else if (command.command == "deleteCell") {
-    remove_variables(command.args.cell.variables);
-    result = true;
-  } else if (command.command == "moveCell") {
-    const cellIndex = findCellIndex(
-      command.args.cell.variables,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const targetCellIndex = cellIndex + command.args.amount;
-    const targetCell = lookupCellByIndex(
-      targetCellIndex,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const currentFirstVariableIndex = findVariableIndex(
-      command.args.cell.variables[0]
-    );
-    const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-    const change = targetFirstVariableIndex - currentFirstVariableIndex;
-    console.log(
-      "moveCell",
-      cellIndex,
-      targetCellIndex,
-      targetCell,
-      currentFirstVariableIndex,
-      targetFirstVariableIndex,
-      change
-    );
-    command.args.cell.variables.forEach((v) => {
-      const currentIndex = findVariableIndex(v);
-      repositionSetElement(runtime._variables, v, currentIndex + change);
-    });
-    // recompute
-    await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
-    result = true;
-  }
-  if (result) {
-    command.processed = true;
-    $2.resolve(result);
-  }
+    if (command.processed)
+        return;
+    let result = undefined;
+    if (command.command == 'createCell') {
+        $0.value = true;
+        result = await compile_and_update('{}', [], command.args.cell);    // For the new one to get focus
+                                                                           // setTimeout(() => {
+                                                                           //   debugger;
+                                                                           //   setOption(result[0], "pinned", true);
+                                                                           // }, 100);
+    } else if (command.command == 'deleteCell') {
+        remove_variables(command.args.cell.variables);
+        result = true;
+    } else if (command.command == 'moveCell') {
+        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const targetCellIndex = cellIndex + command.args.amount;
+        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
+        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+        const change = targetFirstVariableIndex - currentFirstVariableIndex;
+        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
+        command.args.cell.variables.forEach(v => {
+            const currentIndex = findVariableIndex(v);
+            repositionSetElement(runtime._variables, v, currentIndex + change);
+        });
+        // recompute
+        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        result = true;
+    }
+    if (result) {
+        command.processed = true;
+        $2.resolve(result);
+    }
 };
 const _1jadxoe = function _60(md){return(
 md`### UI Action`
@@ -5856,9 +5839,9 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
-    return (source, variables = [], cell) => {
+    return async (source, variables = [], cell) => {
         try {
             debugger;
             let reposition = false, insertionIndex = -1;
@@ -5878,10 +5861,10 @@ const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElemen
             if (reposition) {
                 insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
+            const fns = await realize(newVariables.map(v => v._definition), runtime);
             newVariables.forEach((v, i) => {
                 const variable = variables[i];
-                let _fn;
-                eval('_fn = ' + v._definition);
+                const _fn = fns[i];
                 if (v._name) {
                     variable.define(v._name, v._inputs, _fn);
                 } else {
@@ -5930,12 +5913,11 @@ Inputs.textarea({
 })
 )};
 const _b4rsn5 = (G, _) => G.input(_);
-const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
+const _ga6kci = function _98(Inputs,definition,variable,realize,runtime,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
-  reduce: () => {
-    let _fn;
-    eval("_fn = " + definition);
+  reduce: async () => {
+    const [_fn] = await realize([definition], runtime);
     variable.define(variable._name, inputs, _fn);
   }
 })
@@ -6048,7 +6030,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_geoudp", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _geoudp);  
+  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6086,7 +6068,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
+  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -6096,8 +6078,9 @@ export default function define(runtime, observer) {
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
   $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
-  $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
+  $def("_ga6kci", null, ["Inputs","definition","variable","realize","runtime","inputs"], _ga6kci);  
   $def("_1q557s", null, ["md"], _1q557s);  
+  main.define("realize", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("realize", _));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -15850,7 +15833,7 @@ H4sICB8jLWcCA2Fjb3JuLXdhbGtAOC4zLjIuanMApVlbU+O4En6fX2E4VZQza5wAs8yC8XK47FZRNbcC
 >
 H4sICOAiLWcCA3BhcnNlckA2LjEuMC5qcwDtOmtz20aS3/MrIF6KAWIIFKX4ETCwYstKnW4V2yfJSW2ptKsh0KQmAgF6MJTEpfDfr3sewICknNzdbu1+2CqVOK/u6el3z2Dw7bdfed96bxdFlkPmjZfeb9U7yPmd8BYVL6beWZnni7l3tx+9/D4aeqzIvAsQFQjv7nk0/D7ajwj+g+BTXrDcm/AcYm9QzGeDH8sxLrtj4xxuPg/mjIB+fBENo71BJdIBLzJ4iH6rEJwwvCu99x8ucFPwzs9OvHsub7xsWbAZT1meL70pFCCYRBppi2rH+7kU4PFiUooZk7wsYu9GynkVDwb39/eIN1OniNJyNlAn2a0E3yW0uwbtrkKEew++4rN5KeTqorw9KgsJD9JjlQehLG8vlnOoqCfDj+oE1BbhFOQpL+AEt6eBop6IctZTx2ZpKYofX0XDYXQweAbVrDcy6GfsFmh1FbIihUqWChkPK5zP1Qxbx7N7z/JbRHYQ7Rtcd0x4ZVLAvXcO0r/svRGCLXuh/n27mExAYI/JckyDi4yX5kjYfZur0bdlmQMrqMWnJwXNjGXJ8CfFcYEjJLbc9i/4DMoFrUrLokJQaonlXJbYOFrgOWbHd6DQvGOS/cLhXjdpYQZpmcGnsxO3fVQiQwoNksEdT+Ejf4D8jORIQ2W6mOlZKFrwpu2CHwtR0oGhStmcNgRN+QRkeoO/P3FFL/2c8kqa5hmwTPHpp7xk8mDfMlF1X3zXdBdFSqqFzf9UEBW2TmZsCvaXDkztYsILLpeqKYcvLALstMix88ppE5W8+ongQDXfs/f4+1/nH+jnZzZX/yUdQs+8X8zGiuiC3fEpSpjaH8a/QUrHUval6LcdLdk5CGUiqHHY+4gI999RA/WMV6BbD0TSGSumYNl5BqhHyHB3INcbncH0+IGISwln/qbg2v5+EmxG+AR8XqByb4yjuuL/CqSjX9hrtetcCjRTaixn4zJXjUKyB0vCBSrxO6VCtndc2J684SQbsla7/BN3JUG9VhTUe9XpHOVsNofMjqE7BBQpZKrdKBcqX4P+7BT//wrsVouKWvqIv8L4vExvdbsUt4rAe3R35X3vKgjTpPJXJ8oj+MGqDslekKECqgq55aPXCUWwEj5EPMN27yRDTecTjmiCOvx5Icmh/mGAOhhNjBZ7cx9wHciFKBrVbhH1kiSBSCIHHx+baeR3zoSSY2ce+VTe/w4OVKwpyr4dqxtKcocSdErp7blEd6FsvkNFic7oyakPkyentk7Q8VsSFn8nZrQYb0gUwYqcpPREsqLZuOFCOC6zZXwJEf1e1WGhfDjqTohUGGOr4qpOYKSp8pgvwtURBr+WrBiS13qDFUVFgFiETEyVt6xiTsB84rsasJMkwpxDRBj2AAfk42MVqfD7YeKL4Ie9QO9IsEOc51EOxVTePD7u+L1TdE8CjRUPzC/3rhSufn/wl8tveleDSKKl+2pcsPsAeXUBGMuQ+dvB9mwXmiNVZrMgkDeoU552aBHDyWnhqzjXegH/+uuVrD1yMVxQXPYosmPszPV2XqV8iGd5ch2EqwJdRAxoB4pvl+wq4WGZuOdiirpDFqFTWkDMos8LVvGK6FQjmEOUt5Ch5a4qyYTEFeo3hCLDNv6vR0V0wyq/DA6LCHMDbETzRXXjp0FcRBUNhJfpFZpjmAZh0erMBHVmJdk0Rhtm9yjNKYZolldxEUZRhNqwqoNVDtLjJJxikec7iez3UXV5soyUm0cMlTmcx5KxGZQ0OPUZOoQiCO+pEYQ8wq0Shr+4WbKzI2rIMd/iSeaiMuo39XkIGhgbCFyj9leVl3noefHMmAZpVRSLFGMRwiLFqP/VAkOO3xXjCtIZ+wXjJ+nw8KAmfGp1DRQMztNyDq09evt91JVnz8ipRx/+apkVKsxRB6KGBy51x4FWgOlCoFHZyWiSs2nV7+/uPoG1xVPrUEq+R1u0wTtEVVkDRklE7J5xFIlvpli1LNJkZy8wiNeQaeRvCMb/MuYvIjQINLY/c8gzh31fRGfy6FKso7RYNE4ToFqkCrxA0ftBCFE1h1Q5mErv5MCcN1O4Uk2SdRFJ0V8p/bakNLh4QapCruCLuAwy9By42uS0C5b7PZUyK6LKhUgh6e6pPcJhi5m86RvMWf0gVoMY3hVKyCy9lMtVN+/Rb6DIepoS1/d3WOSSaHw/JJdXobA5+ojMt0BujzAP850z+DIaC5bCaTDa0cOsGTsLRmjiaPEBQg5H2kwna9BY2syYoZlN0CouBOM5nvaIJlpUwVhgcmJchGGycmDqiMGoiu4wB0ksDS5vaaKcIHeraKYzj2RHL+/3t603ixSArnogc6VKgcmyOb2B9PZTgX4c00HkfgvhLjgtMdJtzq3ty6pecIirclr9xzdUy7ftpieC2GJs93cX/8Lyc1W7WYiwh8LGwwsVDcygCruB4RdKqGqWmzBy3cZr75uvVy5Y/Y13Q3VhjhLMlt4YoPAypYqQXdM+LMu6+6AdqMizrsmV1eRGYXtBUBvjhrprGmtmryZ/Zssx/AmW96XInPTTqkjY6yayPcwGfh/Y6guWOuuJLSFw3JNDW63YdgR5jia35uiSvbDrN4fhpuMzY+QaUomWaVSqDSzD7zBTVLxTu9gUW7NEGFE6CiOUH8sSEer8LsHcINIEuNTgYEvFOlnWvTVxaJszInKs/zGkCet2dEaZ+VhTKEhezBcybK09UJ6oSlSGcoEZTYF78ISSipCpn5ErdIfJoevDtSH0+y4aNU2ZJckKitNDvuHK/XW3Q8bVgEE56fedfgUzjoHC2ZeUG0esuuGqSmdn/X6jRe3g46O/dlAHuUZVdDw/Lti2Xm0Nn3FjlvxzTWHTp60R3I0N8DkIOofQoaYjGFV5YRj03UGHJMxUVcKZMKcIcqhSpYJO7HtHlBtum0NJMGzyLLARnGSblrnawNpSS3c56Si+UXIeMqP1F+X8FO4g3+qjzGrMbGpZvlG5J3Gya8Bb+NtUc4cQa5+zBbx2DB6s0cmEDP/xEUZ+qZy+Vi8qhZrCrNcocDcKyO3+X1rPzzHFNrHq2uzuRK+2fG1NAoxuuxahx4wC6Y3BbvypsQDvVmskEQCGgGubH25uXa8HwK6LdMCcNV9mPLIxNox2DBOMh9eEa30kKbXeZC3HRAU67DnnwkrFKyeecoa92J2RZDjWmT5hlSr/t4kXr5yUA4I23dvIqLbmzPzJTKjj47FGqGuNeaY8OjLuuoc6TX8+JK8fIqr9iQAs+1RJtmxKsqxTkmGJBbYgU22HV+gRWHr734tSQuM6xJs8L+8xY9sZ1nQvyVluTtzUKpezKzf6GOm4sWJDHDbhV4456fVssSq28M29GMAs2uTOLdvs9cJxrq53/BWvLth0ClmMZ6Yin3JsYQr45LK4GjXk2DgzCroeJytzTKfe6kw87FDgZFIbvnHd4ZpcO7Sba9j/De2N2hRYpvO8yUuMAq1rigg3Lls2gsB2ZyqUX0c1a64hHlC+EBPvNL/mZfVDm0OYG5pm6tmzoMJKLjWs0WvSGyaOkK43JtLjOrIQhoXL9/vx01h3h02pj/MjU6oQ2MGLmC6k9g9sOfvkRs+GQWul2LcASrWMy200kheoiDyzvAs6QQRxJfsuy3R0XdMSTSVmzbUL3AVY28ZJyaIq5yn46x5MMczcsYz/33cs+/++Y/mXv2N5KpX5B1QzTV2yPc8DrZmOmf0D6xd0ej3X+Ux18pCUyoY1oYG6xt64eVHpAs0rcw4gaq/O7UR7m3S4MRLN2NynEArtdUIQY5hR9ytSLFcdjJbC/+O9ftW80soACyzcpjly2UWp74zBBoCdHUyL9RWCDJ58X2iBDvU1gEkxzYUzhM0bsZ64CoLOvTN6fNIENkMZleKYoTv3ZfIa8YSUWqiEpd+nTanlwGaaDhMCdPqmPb378BDfKESOQzdvlR+ZRM0sejFuL1BRhOTgkABEAm0QdGDVw5wDCjqIdgHRo22D/ai3WfZinNVpCK5xV5xBJU1Y1ots7r62TtcENNGQQqtzmDgrM5iwRS5j/Z5BUtBvFz3KoNNyWvC/YfY51wg8pU1e75nho2MX6hrmxqc7BX0d1U4ttQgoOxImwVcPP+2zJb37BCuK6CaFsuF2f1S8TvZGu7uFMrdulYJ6t/Alpk2B8yRUqhHMy+3YenlLrhBXmFLQF8m1rki8r1coFYUONUgXFVhTbC8D1jCYAmY7ihqp2qmUgYhg2zH+0FtSC0OVVlFKj+n0t+e+GjGdyJFk3HzJFgYQ/J4dqIFfmOB0nkZtSDLGkqk8kYFiNMlaGbHD/qfY1UpU882C/KFntFaRsQzyFCEM23eGTK8pArsvaJuWuHaO1jCDBzyNtC5tqwPYgG39wTbo1oxNsLwreUaiaE1605jXlzqG7chzrOX50Nqyzew4PcJa6TmhKFYQyWtjg+r2bIu1DZW19fs0T4qp7M7vIZ91LLvlRXY41yYX58b0lAWo5giirN1zw0vSgz8aQFCHW56ov0QhuP4A1imEgCjCgGEIwdZI+yGMAyHpfLthPAnV1c/fYWPY3f3SxrXeKG6jMkWwbowKjxjaIq5bVLC2UIU6FR90M6RT2AxDOezmYjyehWtX5c3Ie7SJao5FgDOl3nQ7emI0PF6GrSOIl+261vqcp/1xuBFdcOzTPKOSsV3WTUrWVTrsfheBCLrfUMRjRQWr1cVxnTLlukziRXbu5BcUv9WYvT6GCA9fsSk8S649/+uViHKMNXVMrbTMF7OiDq7p/aGkbKyF1AEsEWGGzkGCp+dq7ahAv0F3Ei9MlZqHicZG71ufq3Ktfn9LgrjTTRB1Skff+b2REg1HeaaE9EV9BtYOqvdD5DQbowc5ynm77l1nUL8zQorkmflz1VHjGEJQ1KmipIPj/cZE71+L9+scsinsJk/aGcuFdmTb+c1sK099xONEf+Tl9xSVyL7zZmRWZuZ9KjxpBq0a4OBtM0gRqud84HRH7FQeGJPv4xFJv40xnGIMXexifY4ZGBXT3ZJ5WAdNVluZq4tjFb69c7qJ4N3HCCU4umo4dp4l6PsW+wLRXMJ2BlUh5QzRnsk5XYlJXiygrpJbrCF4O9DduSkNHx/dUXVtQJhOWkDnKuV2jX74HDR3TYoK997lZG0xSSiwWEebjOj3OX0D8wPYL3ls6NSoTSStW4W3A/CgPovN6MtXKgz1B7bhkvr23sQZn9B4c/cY3qkuwO1JFqbUpk9l65FG6pkk3FPR56vB4D88/XUA6uKcF9NPZ6fJoJoNMjaewKv0OYwnr9hzdrB3MMmeP987eAUwefny1ffsJUvHL4bfPX+ZpbA3hvH4VXbwcnLA9sfP0zGkVFH+D3KMR1ZDLQAA
 </script>
-<script id="@tomlarkworthy/observablejs-toolchain" 
+<script id="@tomlarkworthy/observablejs-toolchain"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -16476,10 +16459,9 @@ notebook_semantics_document.nodes.map((s) => ({
 const _1oevsow = function _28(md){return(
 md`### Runtime Representation (v4)`
 )};
-const _11lfflk = function _notebook_semantics_module(){return(
-importShim("https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4"
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _11lfflk = function _notebook_semantics_module() {
+    return import('https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4');
+};
 const _gjten6 = function _31(md){return(
 md`### Imports`
 )};
@@ -17466,65 +17448,44 @@ parser.parseCell(
   'import {runtime, viewof main as foo} from "@mootari/access-runtime"'
 )
 )};
-const _1n7gw17 = function _findModuleName(extractModuleInfo){return(
-(scope, module, { unknown_id = Math.random() } = {}) => {
-  try {
-    const scopedVariables = [...scope.values()];
-
-    // Prefer variables that *define* a module and have a real module-loader name.
-    const candidates = scopedVariables.filter(
-      (v) =>
-        v &&
-        v._value === module &&
-        typeof v._name === "string" &&
-        v._name.startsWith("module ") &&
-        !v._name.startsWith("module <unknown")
-    );
-
-    const pickBestInfo = (dfn) => {
-      // Avoid the parentUrl (2nd arg) confusing module identification.
-      // Typical patterns:
-      //   importShim("/d/<id>@<ver>.js?v=4", "https://api.observablehq.com/@ns/name.js?v=4")
-      //   import("/d/<id>@<ver>.js?v=4")
-      // Prefer the *first argument* inside importShim(...) / import(...) when present.
-      const s = String(dfn ?? "");
-
-      // Try to capture the first string literal argument to importShim(...) or import(...)
-      // Tolerates quotes ", ', ` and both importShim and plain import.
-      const m = s.match(
-        /\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/
-      );
-      const firstArg = m?.[2];
-
-      const info1 = firstArg ? extractModuleInfo(firstArg) : {};
-      if (info1?.id || info1?.notebook) return info1;
-
-      // Fallback: parse the whole definition string.
-      return extractModuleInfo(s);
+const _1n7gw17 = function _findModuleName(extractModuleInfo) {
+    return (scope, module, {
+        unknown_id = Math.random()
+    } = {}) => {
+        try {
+            const scopedVariables = [...scope.values()];
+            const candidates = scopedVariables.filter(v => v && v._value === module && typeof v._name === 'string' && v._name.startsWith('module ') && !v._name.startsWith('module <unknown'));
+            const pickBestInfo = dfn => {
+                const s = String(dfn ?? '');
+                const m = s.match(/\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/);
+                const firstArg = m?.[2];
+                const info1 = firstArg ? extractModuleInfo(firstArg) : {};
+                if (info1?.id || info1?.notebook)
+                    return info1;
+                return extractModuleInfo(s);
+            };
+            for (const v of candidates) {
+                const info = pickBestInfo(v._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            const any = scopedVariables.find(v => v && v._value === module);
+            if (any) {
+                const info = pickBestInfo(any._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            return `<unknown ${ unknown_id }>`;
+        } catch (e) {
+            debugger;
+            return 'error';
+        }
     };
-
-    // Try module loader cells first.
-    for (const v of candidates) {
-      const info = pickBestInfo(v._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    // Fallback: any scoped variable with _value==module.
-    const any = scopedVariables.find((v) => v && v._value === module);
-    if (any) {
-      const info = pickBestInfo(any._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    return `<unknown ${unknown_id}>`;
-  } catch (e) {
-    debugger;
-    return "error";
-  }
-}
-)};
+};
 const _i47chb = function _findImportedName(){return(
 async (v) => {
   if (v._inputs.length == 1 && v._inputs[0]._name === "@variable") {
@@ -18426,229 +18387,206 @@ JSON.stringify(
 const _1lt3kl6 = function _157(compile,test_case){return(
 compile(test_case.value)
 )};
-const _lpzjrv = function _compile(parser,globalThis,observableToJs){return(
-function compile(source, { anonymousName = "_anonymous" } = {}) {
-  const comments = [],
-    tokens = [];
-  let cell;
-  try {
-    cell = parser.parseCell(source, {
-      ranges: true,
-      onComment: comments,
-      onToken: tokens
-    });
-  } catch (e) {
-    if (e instanceof SyntaxError) {
-      const nameMatch = source.match(
-        /^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/
-      );
-      let _name = null;
-      let funcName = anonymousName;
-      if (nameMatch) {
-        const prefix = nameMatch[1] ? nameMatch[1] + " " : "";
-        _name = prefix + nameMatch[2];
-        funcName = "_" + nameMatch[2];
-      }
-      const escapedMsg = JSON.stringify(e.message);
-      const escapedSource = JSON.stringify(source);
-      return [
-        {
-          _name,
-          _inputs: [],
-          _definition: `function ${funcName}() { throw Object.assign(new SyntaxError(${escapedMsg}), {_sourceExpression: ${escapedSource}}); }`
+const _x1d0wm = function _compile(parser,observableToJs){return(
+function compile(source, {
+    anonymousName = '_anonymous'
+} = {}) {
+    const comments = [], tokens = [];
+    let cell;
+    try {
+        cell = parser.parseCell(source, {
+            ranges: true,
+            onComment: comments,
+            onToken: tokens
+        });
+    } catch (e) {
+        if (e instanceof SyntaxError) {
+            const nameMatch = source.match(/^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/);
+            let _name = null;
+            let funcName = anonymousName;
+            if (nameMatch) {
+                const prefix = nameMatch[1] ? nameMatch[1] + ' ' : '';
+                _name = prefix + nameMatch[2];
+                funcName = '_' + nameMatch[2];
+            }
+            const escapedMsg = JSON.stringify(e.message);
+            const escapedSource = JSON.stringify(source);
+            return [{
+                    _name,
+                    _inputs: [],
+                    _definition: `function ${ funcName }() { throw Object.assign(new SyntaxError(${ escapedMsg }), {_sourceExpression: ${ escapedSource }}); }`
+                }];
         }
-      ];
+        throw e;
     }
-    throw e;
-  }
-  if (!cell) throw new Error("Unable to parse cell");
-  const parseImportSpecifierText = (text) => {
-    const t = String(text ?? "")
-      .trim()
-      .replace(/,$/, "")
-      .trim();
-    if (!t) throw new Error("Empty import specifier");
-    const parts = t.split(/\s+as\s+/);
-    const left = parts[0].trim();
-    const right = parts[1]?.trim();
-    const parseSide = (side, { defaultPrefix = "" } = {}) => {
-      const s = String(side ?? "").trim();
-      const m = s.match(/^(viewof|mutable)\s+(.+)$/);
-      if (m)
-        return {
-          prefix: `${m[1]} `,
-          name: m[2].trim()
+    if (!cell)
+        throw new Error('Unable to parse cell');
+    const parseImportSpecifierText = text => {
+        const t = String(text ?? '').trim().replace(/,$/, '').trim();
+        if (!t)
+            throw new Error('Empty import specifier');
+        const parts = t.split(/\s+as\s+/);
+        const left = parts[0].trim();
+        const right = parts[1]?.trim();
+        const parseSide = (side, {
+            defaultPrefix = ''
+        } = {}) => {
+            const s = String(side ?? '').trim();
+            const m = s.match(/^(viewof|mutable)\s+(.+)$/);
+            if (m)
+                return {
+                    prefix: `${ m[1] } `,
+                    name: m[2].trim()
+                };
+            return {
+                prefix: defaultPrefix,
+                name: s
+            };
         };
-      return {
-        prefix: defaultPrefix,
-        name: s
-      };
+        const L = parseSide(left);
+        const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
+        const importedName = `${ L.prefix }${ L.name }`.trim();
+        const localName = `${ R.prefix }${ R.name }`.trim();
+        if (!importedName)
+            throw new Error(`Could not parse imported name from: ${ t }`);
+        if (!localName)
+            throw new Error(`Could not parse local name from: ${ t }`);
+        return {
+            importedName,
+            localName
+        };
     };
-    const L = parseSide(left);
-    const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
-    const importedName = `${L.prefix}${L.name}`.trim();
-    const localName = `${R.prefix}${R.name}`.trim();
-    if (!importedName)
-      throw new Error(`Could not parse imported name from: ${t}`);
-    if (!localName) throw new Error(`Could not parse local name from: ${t}`);
-    return {
-      importedName,
-      localName
-    };
-  };
-  if (!cell.id && cell.body?.type === "ImportDeclaration") {
-    const module_name = cell.body.source.value;
-    const importKeyword = globalThis?.importShim ? "importShim" : "import";
-    const cell_variables = [
-      {
-        _name: `module ${module_name}`,
-        _inputs: [],
-        _definition: `async () => runtime.module((await ${importKeyword}("${module_name}")).default)`
-      }
-    ];
-    for (const specifier of cell.body.specifiers ?? []) {
-      const specText =
-        typeof specifier?.start === "number" &&
-        typeof specifier?.end === "number"
-          ? source.slice(specifier.start, specifier.end)
-          : (() => {
-              if (specifier?.imported?.name && specifier?.local?.name) {
-                return specifier.imported.name === specifier.local.name
-                  ? specifier.local.name
-                  : `${specifier.imported.name} as ${specifier.local.name}`;
-              }
-              throw new Error("Import specifier missing range information");
+    if (!cell.id && cell.body?.type === 'ImportDeclaration') {
+        const module_name = cell.body.source.value;
+        const cell_variables = [{
+                _name: `module ${ module_name }`,
+                _inputs: [],
+                _definition: `async () => runtime.module((await import("${ module_name }")).default)`
+            }];
+        for (const specifier of cell.body.specifiers ?? []) {
+            const specText = typeof specifier?.start === 'number' && typeof specifier?.end === 'number' ? source.slice(specifier.start, specifier.end) : (() => {
+                if (specifier?.imported?.name && specifier?.local?.name) {
+                    return specifier.imported.name === specifier.local.name ? specifier.local.name : `${ specifier.imported.name } as ${ specifier.local.name }`;
+                }
+                throw new Error('Import specifier missing range information');
             })();
-      const { importedName, localName } = parseImportSpecifierText(specText);
-      cell_variables.push({
-        _name: localName,
-        _inputs: [`module ${module_name}`, "@variable"],
-        _definition:
-          importedName === localName
-            ? `(_, v) => v.import("${importedName}", _)`
-            : `(_, v) => v.import("${importedName}", "${localName}", _)`
-      });
+            const {importedName, localName} = parseImportSpecifierText(specText);
+            cell_variables.push({
+                _name: localName,
+                _inputs: [
+                    `module ${ module_name }`,
+                    '@variable'
+                ],
+                _definition: importedName === localName ? `(_, v) => v.import("${ importedName }", _)` : `(_, v) => v.import("${ importedName }", "${ localName }", _)`
+            });
+        }
+        return cell_variables;
     }
-    return cell_variables;
-  }
-  let dollarIdx = 0;
-  const inputToArgMap = {};
-  const dollarToMacro = {};
-  const seen = new Set();
-  const inputs = Array.from(cell.references || []).flatMap((i) => {
-    if (i.name) {
-      if (seen.has(i.name)) return [];
-      seen.add(i.name);
-      return i.name;
+    let dollarIdx = 0;
+    const inputToArgMap = {};
+    const dollarToMacro = {};
+    const seen = new Set();
+    const inputs = Array.from(cell.references || []).flatMap(i => {
+        if (i.name) {
+            if (seen.has(i.name))
+                return [];
+            seen.add(i.name);
+            return i.name;
+        } else {
+            const dedupKey = i.type + ':' + i.id.name;
+            if (seen.has(dedupKey))
+                return [];
+            seen.add(dedupKey);
+            const dollarName = '$' + dollarIdx;
+            inputToArgMap[i.id.name] = dollarName;
+            dollarToMacro[dollarName] = i.type == 'ViewExpression' ? 'viewof ' + i.id.name : 'mutable ' + i.id.name;
+            dollarIdx++;
+            return dollarName;
+        }
+    });
+    let variables;
+    if (cell.id) {
+        if (cell.id.type === 'Identifier') {
+            variables = [{
+                    functionName: '_' + cell.id.name,
+                    name: cell.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                }];
+        } else if (cell.id.type === 'ViewExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'viewof ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '(G, _) => G.input(_)',
+                    inputs: [
+                        'Generators',
+                        'viewof ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                }
+            ];
+        } else if (cell.id.type === 'MutableExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'initial ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'mutable ' + cell.id.id.name,
+                    _definition: '(M, _) => new M(_)',
+                    inputs: [
+                        'Mutable',
+                        'initial ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '_ => _.generator',
+                    inputs: ['mutable ' + cell.id.id.name],
+                    params: inputs.join(',')
+                }
+            ];
+        } else {
+            throw new Error(`Unsupported cell id type: ${ cell.id.type }`);
+        }
     } else {
-      const dedupKey = i.type + ":" + i.id.name;
-      if (seen.has(dedupKey)) return [];
-      seen.add(dedupKey);
-      const dollarName = "$" + dollarIdx;
-      inputToArgMap[i.id.name] = dollarName;
-      dollarToMacro[dollarName] =
-        i.type == "ViewExpression"
-          ? "viewof " + i.id.name
-          : "mutable " + i.id.name;
-      dollarIdx++;
-      return dollarName;
+        variables = [{
+                functionName: anonymousName,
+                name: null,
+                inputs,
+                params: inputs.join(',')
+            }];
     }
-  });
-  let variables;
-  if (cell.id) {
-    if (cell.id.type === "Identifier") {
-      variables = [
-        {
-          functionName: "_" + cell.id.name,
-          name: cell.id.name,
-          inputs,
-          params: inputs.join(",")
+    return variables.map(v => {
+        let _definition = v._definition;
+        if (!_definition) {
+            let functionBody;
+            if (cell.body.type === 'BlockStatement') {
+                functionBody = observableToJs(cell.body, inputToArgMap, comments, tokens);
+            } else {
+                const bodyCode = observableToJs(cell.body, inputToArgMap, comments, tokens);
+                functionBody = `{return (${ bodyCode });}`;
+            }
+            _definition = `${ cell.async ? 'async ' : '' }function${ cell.generator ? '*' : '' } ${ v.functionName }(${ v.inputs.join(',') }) ${ functionBody }`;
         }
-      ];
-    } else if (cell.id.type === "ViewExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "viewof " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "(G, _) => G.input(_)",
-          inputs: ["Generators", "viewof " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else if (cell.id.type === "MutableExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "initial " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "mutable " + cell.id.id.name,
-          _definition: "(M, _) => new M(_)",
-          inputs: ["Mutable", "initial " + cell.id.id.name],
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "_ => _.generator",
-          inputs: ["mutable " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else {
-      throw new Error(`Unsupported cell id type: ${cell.id.type}`);
-    }
-  } else {
-    variables = [
-      {
-        functionName: anonymousName,
-        name: null,
-        inputs,
-        params: inputs.join(",")
-      }
-    ];
-  }
-  return variables.map((v) => {
-    let _definition = v._definition;
-    if (!_definition) {
-      let functionBody;
-      if (cell.body.type === "BlockStatement") {
-        functionBody = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-      } else {
-        const bodyCode = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-        functionBody = `{return (${bodyCode});}`;
-      }
-      _definition = `${cell.async ? "async " : ""}function${
-        cell.generator ? "*" : ""
-      } ${v.functionName}(${v.inputs.join(",")}) ${functionBody}`;
-    }
-    return {
-      _name: v.name,
-      _inputs: v.inputs.map(
-        (i) => dollarToMacro[i] || (i === "$variable" ? "@variable" : i)
-      ),
-      _definition
-    };
-  });
+        return {
+            _name: v.name,
+            _inputs: v.inputs.map(i => dollarToMacro[i] || (i === '$variable' ? '@variable' : i)),
+            _definition
+        };
+    });
 }
 )};
 const _1v1i7wl = function _observableToJs(acorn_walk,parser,escodegen){return(
@@ -18715,16 +18653,15 @@ async (attachment, overrides) => {
   return URL.createObjectURL(blob);
 }
 )};
-const _s9w7ha = async function _parser(decompress_url,FileAttachment,acorn_url,acorn_walk_url){return(
-importShim(await decompress_url(FileAttachment("parser-6.1.0.js.gz"), {
-    "/npm/acorn@8.11.3/+esm": acorn_url,
-    "/npm/acorn-walk@8.3.2/+esm": acorn_walk_url
-  })
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
-const _1hiclbb = function _acorn_walk(acorn_walk_url){return(
-importShim(acorn_walk_url, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _s9w7ha = async function _parser(decompress_url, FileAttachment, acorn_url, acorn_walk_url) {
+    return import(await decompress_url(FileAttachment('parser-6.1.0.js.gz'), {
+        '/npm/acorn@8.11.3/+esm': acorn_url,
+        '/npm/acorn-walk@8.3.2/+esm': acorn_walk_url
+    }));
+};
+const _1hiclbb = function _acorn_walk(acorn_walk_url) {
+    return import(acorn_walk_url);
+};
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
@@ -18912,7 +18849,7 @@ export default function define(runtime, observer) {
   $def("_1dmmuaf", "compiled_selector", ["Generators","viewof compiled_selector"], _1dmmuaf);  
   $def("_u7t3vu", null, ["compiled_selector","normalizeJavascriptSource"], _u7t3vu);  
   $def("_1lt3kl6", null, ["compile","test_case"], _1lt3kl6);  
-  $def("_lpzjrv", "compile", ["parser","globalThis","observableToJs"], _lpzjrv);  
+  $def("_x1d0wm", "compile", ["parser","observableToJs"], _x1d0wm);  
   $def("_1v1i7wl", "observableToJs", ["acorn_walk","parser","escodegen"], _1v1i7wl);  
   $def("_19lv24l", null, ["md"], _19lv24l);  
   $def("_xhj6b8", "decompress_url", ["DecompressionStream","TextDecoderStream","TransformStream","TextEncoderStream","Response"], _xhj6b8);  
@@ -18927,7 +18864,8 @@ export default function define(runtime, observer) {
   main.define("Library", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Library", _));  
   main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));
   return main;
-}</script>
+}
+</script>
 
 <script id="@tomlarkworthy/reversible-attachment" 
   type="text/plain"

--- a/notebooks/@tomlarkworthy_fileattachments.html
+++ b/notebooks/@tomlarkworthy_fileattachments.html
@@ -5414,58 +5414,41 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _geoudp = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
-  if (command.processed) return;
-
-  let result = undefined;
-  if (command.command == "createCell") {
-    $0.value = true;
-    result = compile_and_update("{}", [], command.args.cell);
-    // For the new one to get focus
-    // setTimeout(() => {
-    //   debugger;
-    //   setOption(result[0], "pinned", true);
-    // }, 100);
-  } else if (command.command == "deleteCell") {
-    remove_variables(command.args.cell.variables);
-    result = true;
-  } else if (command.command == "moveCell") {
-    const cellIndex = findCellIndex(
-      command.args.cell.variables,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const targetCellIndex = cellIndex + command.args.amount;
-    const targetCell = lookupCellByIndex(
-      targetCellIndex,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const currentFirstVariableIndex = findVariableIndex(
-      command.args.cell.variables[0]
-    );
-    const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-    const change = targetFirstVariableIndex - currentFirstVariableIndex;
-    console.log(
-      "moveCell",
-      cellIndex,
-      targetCellIndex,
-      targetCell,
-      currentFirstVariableIndex,
-      targetFirstVariableIndex,
-      change
-    );
-    command.args.cell.variables.forEach((v) => {
-      const currentIndex = findVariableIndex(v);
-      repositionSetElement(runtime._variables, v, currentIndex + change);
-    });
-    // recompute
-    await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
-    result = true;
-  }
-  if (result) {
-    command.processed = true;
-    $2.resolve(result);
-  }
+    if (command.processed)
+        return;
+    let result = undefined;
+    if (command.command == 'createCell') {
+        $0.value = true;
+        result = await compile_and_update('{}', [], command.args.cell);    // For the new one to get focus
+                                                                           // setTimeout(() => {
+                                                                           //   debugger;
+                                                                           //   setOption(result[0], "pinned", true);
+                                                                           // }, 100);
+    } else if (command.command == 'deleteCell') {
+        remove_variables(command.args.cell.variables);
+        result = true;
+    } else if (command.command == 'moveCell') {
+        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const targetCellIndex = cellIndex + command.args.amount;
+        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
+        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+        const change = targetFirstVariableIndex - currentFirstVariableIndex;
+        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
+        command.args.cell.variables.forEach(v => {
+            const currentIndex = findVariableIndex(v);
+            repositionSetElement(runtime._variables, v, currentIndex + change);
+        });
+        // recompute
+        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        result = true;
+    }
+    if (result) {
+        command.processed = true;
+        $2.resolve(result);
+    }
 };
 const _1jadxoe = function _60(md){return(
 md`### UI Action`
@@ -5856,9 +5839,9 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
-    return (source, variables = [], cell) => {
+    return async (source, variables = [], cell) => {
         try {
             debugger;
             let reposition = false, insertionIndex = -1;
@@ -5878,10 +5861,10 @@ const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElemen
             if (reposition) {
                 insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
+            const fns = await realize(newVariables.map(v => v._definition), runtime);
             newVariables.forEach((v, i) => {
                 const variable = variables[i];
-                let _fn;
-                eval('_fn = ' + v._definition);
+                const _fn = fns[i];
                 if (v._name) {
                     variable.define(v._name, v._inputs, _fn);
                 } else {
@@ -5930,12 +5913,11 @@ Inputs.textarea({
 })
 )};
 const _b4rsn5 = (G, _) => G.input(_);
-const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
+const _ga6kci = function _98(Inputs,definition,variable,realize,runtime,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
-  reduce: () => {
-    let _fn;
-    eval("_fn = " + definition);
+  reduce: async () => {
+    const [_fn] = await realize([definition], runtime);
     variable.define(variable._name, inputs, _fn);
   }
 })
@@ -6048,7 +6030,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_geoudp", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _geoudp);  
+  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6086,7 +6068,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
+  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -6096,8 +6078,9 @@ export default function define(runtime, observer) {
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
   $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
-  $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
+  $def("_ga6kci", null, ["Inputs","definition","variable","realize","runtime","inputs"], _ga6kci);  
   $def("_1q557s", null, ["md"], _1q557s);  
+  main.define("realize", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("realize", _));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -15849,7 +15832,7 @@ H4sICB8jLWcCA2Fjb3JuLXdhbGtAOC4zLjIuanMApVlbU+O4En6fX2E4VZQza5wAs8yC8XK47FZRNbcC
 >
 H4sICOAiLWcCA3BhcnNlckA2LjEuMC5qcwDtOmtz20aS3/MrIF6KAWIIFKX4ETCwYstKnW4V2yfJSW2ptKsh0KQmAgF6MJTEpfDfr3sewICknNzdbu1+2CqVOK/u6el3z2Dw7bdfed96bxdFlkPmjZfeb9U7yPmd8BYVL6beWZnni7l3tx+9/D4aeqzIvAsQFQjv7nk0/D7ajwj+g+BTXrDcm/AcYm9QzGeDH8sxLrtj4xxuPg/mjIB+fBENo71BJdIBLzJ4iH6rEJwwvCu99x8ucFPwzs9OvHsub7xsWbAZT1meL70pFCCYRBppi2rH+7kU4PFiUooZk7wsYu9GynkVDwb39/eIN1OniNJyNlAn2a0E3yW0uwbtrkKEew++4rN5KeTqorw9KgsJD9JjlQehLG8vlnOoqCfDj+oE1BbhFOQpL+AEt6eBop6IctZTx2ZpKYofX0XDYXQweAbVrDcy6GfsFmh1FbIihUqWChkPK5zP1Qxbx7N7z/JbRHYQ7Rtcd0x4ZVLAvXcO0r/svRGCLXuh/n27mExAYI/JckyDi4yX5kjYfZur0bdlmQMrqMWnJwXNjGXJ8CfFcYEjJLbc9i/4DMoFrUrLokJQaonlXJbYOFrgOWbHd6DQvGOS/cLhXjdpYQZpmcGnsxO3fVQiQwoNksEdT+Ejf4D8jORIQ2W6mOlZKFrwpu2CHwtR0oGhStmcNgRN+QRkeoO/P3FFL/2c8kqa5hmwTPHpp7xk8mDfMlF1X3zXdBdFSqqFzf9UEBW2TmZsCvaXDkztYsILLpeqKYcvLALstMix88ppE5W8+ongQDXfs/f4+1/nH+jnZzZX/yUdQs+8X8zGiuiC3fEpSpjaH8a/QUrHUval6LcdLdk5CGUiqHHY+4gI999RA/WMV6BbD0TSGSumYNl5BqhHyHB3INcbncH0+IGISwln/qbg2v5+EmxG+AR8XqByb4yjuuL/CqSjX9hrtetcCjRTaixn4zJXjUKyB0vCBSrxO6VCtndc2J684SQbsla7/BN3JUG9VhTUe9XpHOVsNofMjqE7BBQpZKrdKBcqX4P+7BT//wrsVouKWvqIv8L4vExvdbsUt4rAe3R35X3vKgjTpPJXJ8oj+MGqDslekKECqgq55aPXCUWwEj5EPMN27yRDTecTjmiCOvx5Icmh/mGAOhhNjBZ7cx9wHciFKBrVbhH1kiSBSCIHHx+baeR3zoSSY2ce+VTe/w4OVKwpyr4dqxtKcocSdErp7blEd6FsvkNFic7oyakPkyentk7Q8VsSFn8nZrQYb0gUwYqcpPREsqLZuOFCOC6zZXwJEf1e1WGhfDjqTohUGGOr4qpOYKSp8pgvwtURBr+WrBiS13qDFUVFgFiETEyVt6xiTsB84rsasJMkwpxDRBj2AAfk42MVqfD7YeKL4Ie9QO9IsEOc51EOxVTePD7u+L1TdE8CjRUPzC/3rhSufn/wl8tveleDSKKl+2pcsPsAeXUBGMuQ+dvB9mwXmiNVZrMgkDeoU552aBHDyWnhqzjXegH/+uuVrD1yMVxQXPYosmPszPV2XqV8iGd5ch2EqwJdRAxoB4pvl+wq4WGZuOdiirpDFqFTWkDMos8LVvGK6FQjmEOUt5Ch5a4qyYTEFeo3hCLDNv6vR0V0wyq/DA6LCHMDbETzRXXjp0FcRBUNhJfpFZpjmAZh0erMBHVmJdk0Rhtm9yjNKYZolldxEUZRhNqwqoNVDtLjJJxikec7iez3UXV5soyUm0cMlTmcx5KxGZQ0OPUZOoQiCO+pEYQ8wq0Shr+4WbKzI2rIMd/iSeaiMuo39XkIGhgbCFyj9leVl3noefHMmAZpVRSLFGMRwiLFqP/VAkOO3xXjCtIZ+wXjJ+nw8KAmfGp1DRQMztNyDq09evt91JVnz8ipRx/+apkVKsxRB6KGBy51x4FWgOlCoFHZyWiSs2nV7+/uPoG1xVPrUEq+R1u0wTtEVVkDRklE7J5xFIlvpli1LNJkZy8wiNeQaeRvCMb/MuYvIjQINLY/c8gzh31fRGfy6FKso7RYNE4ToFqkCrxA0ftBCFE1h1Q5mErv5MCcN1O4Uk2SdRFJ0V8p/bakNLh4QapCruCLuAwy9By42uS0C5b7PZUyK6LKhUgh6e6pPcJhi5m86RvMWf0gVoMY3hVKyCy9lMtVN+/Rb6DIepoS1/d3WOSSaHw/JJdXobA5+ojMt0BujzAP850z+DIaC5bCaTDa0cOsGTsLRmjiaPEBQg5H2kwna9BY2syYoZlN0CouBOM5nvaIJlpUwVhgcmJchGGycmDqiMGoiu4wB0ksDS5vaaKcIHeraKYzj2RHL+/3t603ixSArnogc6VKgcmyOb2B9PZTgX4c00HkfgvhLjgtMdJtzq3ty6pecIirclr9xzdUy7ftpieC2GJs93cX/8Lyc1W7WYiwh8LGwwsVDcygCruB4RdKqGqWmzBy3cZr75uvVy5Y/Y13Q3VhjhLMlt4YoPAypYqQXdM+LMu6+6AdqMizrsmV1eRGYXtBUBvjhrprGmtmryZ/Zssx/AmW96XInPTTqkjY6yayPcwGfh/Y6guWOuuJLSFw3JNDW63YdgR5jia35uiSvbDrN4fhpuMzY+QaUomWaVSqDSzD7zBTVLxTu9gUW7NEGFE6CiOUH8sSEer8LsHcINIEuNTgYEvFOlnWvTVxaJszInKs/zGkCet2dEaZ+VhTKEhezBcybK09UJ6oSlSGcoEZTYF78ISSipCpn5ErdIfJoevDtSH0+y4aNU2ZJckKitNDvuHK/XW3Q8bVgEE56fedfgUzjoHC2ZeUG0esuuGqSmdn/X6jRe3g46O/dlAHuUZVdDw/Lti2Xm0Nn3FjlvxzTWHTp60R3I0N8DkIOofQoaYjGFV5YRj03UGHJMxUVcKZMKcIcqhSpYJO7HtHlBtum0NJMGzyLLARnGSblrnawNpSS3c56Si+UXIeMqP1F+X8FO4g3+qjzGrMbGpZvlG5J3Gya8Bb+NtUc4cQa5+zBbx2DB6s0cmEDP/xEUZ+qZy+Vi8qhZrCrNcocDcKyO3+X1rPzzHFNrHq2uzuRK+2fG1NAoxuuxahx4wC6Y3BbvypsQDvVmskEQCGgGubH25uXa8HwK6LdMCcNV9mPLIxNox2DBOMh9eEa30kKbXeZC3HRAU67DnnwkrFKyeecoa92J2RZDjWmT5hlSr/t4kXr5yUA4I23dvIqLbmzPzJTKjj47FGqGuNeaY8OjLuuoc6TX8+JK8fIqr9iQAs+1RJtmxKsqxTkmGJBbYgU22HV+gRWHr734tSQuM6xJs8L+8xY9sZ1nQvyVluTtzUKpezKzf6GOm4sWJDHDbhV4456fVssSq28M29GMAs2uTOLdvs9cJxrq53/BWvLth0ClmMZ6Yin3JsYQr45LK4GjXk2DgzCroeJytzTKfe6kw87FDgZFIbvnHd4ZpcO7Sba9j/De2N2hRYpvO8yUuMAq1rigg3Lls2gsB2ZyqUX0c1a64hHlC+EBPvNL/mZfVDm0OYG5pm6tmzoMJKLjWs0WvSGyaOkK43JtLjOrIQhoXL9/vx01h3h02pj/MjU6oQ2MGLmC6k9g9sOfvkRs+GQWul2LcASrWMy200kheoiDyzvAs6QQRxJfsuy3R0XdMSTSVmzbUL3AVY28ZJyaIq5yn46x5MMczcsYz/33cs+/++Y/mXv2N5KpX5B1QzTV2yPc8DrZmOmf0D6xd0ej3X+Ux18pCUyoY1oYG6xt64eVHpAs0rcw4gaq/O7UR7m3S4MRLN2NynEArtdUIQY5hR9ytSLFcdjJbC/+O9ftW80soACyzcpjly2UWp74zBBoCdHUyL9RWCDJ58X2iBDvU1gEkxzYUzhM0bsZ64CoLOvTN6fNIENkMZleKYoTv3ZfIa8YSUWqiEpd+nTanlwGaaDhMCdPqmPb378BDfKESOQzdvlR+ZRM0sejFuL1BRhOTgkABEAm0QdGDVw5wDCjqIdgHRo22D/ai3WfZinNVpCK5xV5xBJU1Y1ots7r62TtcENNGQQqtzmDgrM5iwRS5j/Z5BUtBvFz3KoNNyWvC/YfY51wg8pU1e75nho2MX6hrmxqc7BX0d1U4ttQgoOxImwVcPP+2zJb37BCuK6CaFsuF2f1S8TvZGu7uFMrdulYJ6t/Alpk2B8yRUqhHMy+3YenlLrhBXmFLQF8m1rki8r1coFYUONUgXFVhTbC8D1jCYAmY7ihqp2qmUgYhg2zH+0FtSC0OVVlFKj+n0t+e+GjGdyJFk3HzJFgYQ/J4dqIFfmOB0nkZtSDLGkqk8kYFiNMlaGbHD/qfY1UpU882C/KFntFaRsQzyFCEM23eGTK8pArsvaJuWuHaO1jCDBzyNtC5tqwPYgG39wTbo1oxNsLwreUaiaE1605jXlzqG7chzrOX50Nqyzew4PcJa6TmhKFYQyWtjg+r2bIu1DZW19fs0T4qp7M7vIZ91LLvlRXY41yYX58b0lAWo5giirN1zw0vSgz8aQFCHW56ov0QhuP4A1imEgCjCgGEIwdZI+yGMAyHpfLthPAnV1c/fYWPY3f3SxrXeKG6jMkWwbowKjxjaIq5bVLC2UIU6FR90M6RT2AxDOezmYjyehWtX5c3Ie7SJao5FgDOl3nQ7emI0PF6GrSOIl+261vqcp/1xuBFdcOzTPKOSsV3WTUrWVTrsfheBCLrfUMRjRQWr1cVxnTLlukziRXbu5BcUv9WYvT6GCA9fsSk8S649/+uViHKMNXVMrbTMF7OiDq7p/aGkbKyF1AEsEWGGzkGCp+dq7ahAv0F3Ei9MlZqHicZG71ufq3Ktfn9LgrjTTRB1Skff+b2REg1HeaaE9EV9BtYOqvdD5DQbowc5ynm77l1nUL8zQorkmflz1VHjGEJQ1KmipIPj/cZE71+L9+scsinsJk/aGcuFdmTb+c1sK099xONEf+Tl9xSVyL7zZmRWZuZ9KjxpBq0a4OBtM0gRqud84HRH7FQeGJPv4xFJv40xnGIMXexifY4ZGBXT3ZJ5WAdNVluZq4tjFb69c7qJ4N3HCCU4umo4dp4l6PsW+wLRXMJ2BlUh5QzRnsk5XYlJXiygrpJbrCF4O9DduSkNHx/dUXVtQJhOWkDnKuV2jX74HDR3TYoK997lZG0xSSiwWEebjOj3OX0D8wPYL3ls6NSoTSStW4W3A/CgPovN6MtXKgz1B7bhkvr23sQZn9B4c/cY3qkuwO1JFqbUpk9l65FG6pkk3FPR56vB4D88/XUA6uKcF9NPZ6fJoJoNMjaewKv0OYwnr9hzdrB3MMmeP987eAUwefny1ffsJUvHL4bfPX+ZpbA3hvH4VXbwcnLA9sfP0zGkVFH+D3KMR1ZDLQAA
 </script>
-<script id="@tomlarkworthy/observablejs-toolchain" 
+<script id="@tomlarkworthy/observablejs-toolchain"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -16475,10 +16458,9 @@ notebook_semantics_document.nodes.map((s) => ({
 const _1oevsow = function _28(md){return(
 md`### Runtime Representation (v4)`
 )};
-const _11lfflk = function _notebook_semantics_module(){return(
-importShim("https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4"
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _11lfflk = function _notebook_semantics_module() {
+    return import('https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4');
+};
 const _gjten6 = function _31(md){return(
 md`### Imports`
 )};
@@ -17465,65 +17447,44 @@ parser.parseCell(
   'import {runtime, viewof main as foo} from "@mootari/access-runtime"'
 )
 )};
-const _1n7gw17 = function _findModuleName(extractModuleInfo){return(
-(scope, module, { unknown_id = Math.random() } = {}) => {
-  try {
-    const scopedVariables = [...scope.values()];
-
-    // Prefer variables that *define* a module and have a real module-loader name.
-    const candidates = scopedVariables.filter(
-      (v) =>
-        v &&
-        v._value === module &&
-        typeof v._name === "string" &&
-        v._name.startsWith("module ") &&
-        !v._name.startsWith("module <unknown")
-    );
-
-    const pickBestInfo = (dfn) => {
-      // Avoid the parentUrl (2nd arg) confusing module identification.
-      // Typical patterns:
-      //   importShim("/d/<id>@<ver>.js?v=4", "https://api.observablehq.com/@ns/name.js?v=4")
-      //   import("/d/<id>@<ver>.js?v=4")
-      // Prefer the *first argument* inside importShim(...) / import(...) when present.
-      const s = String(dfn ?? "");
-
-      // Try to capture the first string literal argument to importShim(...) or import(...)
-      // Tolerates quotes ", ', ` and both importShim and plain import.
-      const m = s.match(
-        /\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/
-      );
-      const firstArg = m?.[2];
-
-      const info1 = firstArg ? extractModuleInfo(firstArg) : {};
-      if (info1?.id || info1?.notebook) return info1;
-
-      // Fallback: parse the whole definition string.
-      return extractModuleInfo(s);
+const _1n7gw17 = function _findModuleName(extractModuleInfo) {
+    return (scope, module, {
+        unknown_id = Math.random()
+    } = {}) => {
+        try {
+            const scopedVariables = [...scope.values()];
+            const candidates = scopedVariables.filter(v => v && v._value === module && typeof v._name === 'string' && v._name.startsWith('module ') && !v._name.startsWith('module <unknown'));
+            const pickBestInfo = dfn => {
+                const s = String(dfn ?? '');
+                const m = s.match(/\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/);
+                const firstArg = m?.[2];
+                const info1 = firstArg ? extractModuleInfo(firstArg) : {};
+                if (info1?.id || info1?.notebook)
+                    return info1;
+                return extractModuleInfo(s);
+            };
+            for (const v of candidates) {
+                const info = pickBestInfo(v._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            const any = scopedVariables.find(v => v && v._value === module);
+            if (any) {
+                const info = pickBestInfo(any._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            return `<unknown ${ unknown_id }>`;
+        } catch (e) {
+            debugger;
+            return 'error';
+        }
     };
-
-    // Try module loader cells first.
-    for (const v of candidates) {
-      const info = pickBestInfo(v._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    // Fallback: any scoped variable with _value==module.
-    const any = scopedVariables.find((v) => v && v._value === module);
-    if (any) {
-      const info = pickBestInfo(any._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    return `<unknown ${unknown_id}>`;
-  } catch (e) {
-    debugger;
-    return "error";
-  }
-}
-)};
+};
 const _i47chb = function _findImportedName(){return(
 async (v) => {
   if (v._inputs.length == 1 && v._inputs[0]._name === "@variable") {
@@ -18425,229 +18386,206 @@ JSON.stringify(
 const _1lt3kl6 = function _157(compile,test_case){return(
 compile(test_case.value)
 )};
-const _lpzjrv = function _compile(parser,globalThis,observableToJs){return(
-function compile(source, { anonymousName = "_anonymous" } = {}) {
-  const comments = [],
-    tokens = [];
-  let cell;
-  try {
-    cell = parser.parseCell(source, {
-      ranges: true,
-      onComment: comments,
-      onToken: tokens
-    });
-  } catch (e) {
-    if (e instanceof SyntaxError) {
-      const nameMatch = source.match(
-        /^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/
-      );
-      let _name = null;
-      let funcName = anonymousName;
-      if (nameMatch) {
-        const prefix = nameMatch[1] ? nameMatch[1] + " " : "";
-        _name = prefix + nameMatch[2];
-        funcName = "_" + nameMatch[2];
-      }
-      const escapedMsg = JSON.stringify(e.message);
-      const escapedSource = JSON.stringify(source);
-      return [
-        {
-          _name,
-          _inputs: [],
-          _definition: `function ${funcName}() { throw Object.assign(new SyntaxError(${escapedMsg}), {_sourceExpression: ${escapedSource}}); }`
+const _x1d0wm = function _compile(parser,observableToJs){return(
+function compile(source, {
+    anonymousName = '_anonymous'
+} = {}) {
+    const comments = [], tokens = [];
+    let cell;
+    try {
+        cell = parser.parseCell(source, {
+            ranges: true,
+            onComment: comments,
+            onToken: tokens
+        });
+    } catch (e) {
+        if (e instanceof SyntaxError) {
+            const nameMatch = source.match(/^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/);
+            let _name = null;
+            let funcName = anonymousName;
+            if (nameMatch) {
+                const prefix = nameMatch[1] ? nameMatch[1] + ' ' : '';
+                _name = prefix + nameMatch[2];
+                funcName = '_' + nameMatch[2];
+            }
+            const escapedMsg = JSON.stringify(e.message);
+            const escapedSource = JSON.stringify(source);
+            return [{
+                    _name,
+                    _inputs: [],
+                    _definition: `function ${ funcName }() { throw Object.assign(new SyntaxError(${ escapedMsg }), {_sourceExpression: ${ escapedSource }}); }`
+                }];
         }
-      ];
+        throw e;
     }
-    throw e;
-  }
-  if (!cell) throw new Error("Unable to parse cell");
-  const parseImportSpecifierText = (text) => {
-    const t = String(text ?? "")
-      .trim()
-      .replace(/,$/, "")
-      .trim();
-    if (!t) throw new Error("Empty import specifier");
-    const parts = t.split(/\s+as\s+/);
-    const left = parts[0].trim();
-    const right = parts[1]?.trim();
-    const parseSide = (side, { defaultPrefix = "" } = {}) => {
-      const s = String(side ?? "").trim();
-      const m = s.match(/^(viewof|mutable)\s+(.+)$/);
-      if (m)
-        return {
-          prefix: `${m[1]} `,
-          name: m[2].trim()
+    if (!cell)
+        throw new Error('Unable to parse cell');
+    const parseImportSpecifierText = text => {
+        const t = String(text ?? '').trim().replace(/,$/, '').trim();
+        if (!t)
+            throw new Error('Empty import specifier');
+        const parts = t.split(/\s+as\s+/);
+        const left = parts[0].trim();
+        const right = parts[1]?.trim();
+        const parseSide = (side, {
+            defaultPrefix = ''
+        } = {}) => {
+            const s = String(side ?? '').trim();
+            const m = s.match(/^(viewof|mutable)\s+(.+)$/);
+            if (m)
+                return {
+                    prefix: `${ m[1] } `,
+                    name: m[2].trim()
+                };
+            return {
+                prefix: defaultPrefix,
+                name: s
+            };
         };
-      return {
-        prefix: defaultPrefix,
-        name: s
-      };
+        const L = parseSide(left);
+        const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
+        const importedName = `${ L.prefix }${ L.name }`.trim();
+        const localName = `${ R.prefix }${ R.name }`.trim();
+        if (!importedName)
+            throw new Error(`Could not parse imported name from: ${ t }`);
+        if (!localName)
+            throw new Error(`Could not parse local name from: ${ t }`);
+        return {
+            importedName,
+            localName
+        };
     };
-    const L = parseSide(left);
-    const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
-    const importedName = `${L.prefix}${L.name}`.trim();
-    const localName = `${R.prefix}${R.name}`.trim();
-    if (!importedName)
-      throw new Error(`Could not parse imported name from: ${t}`);
-    if (!localName) throw new Error(`Could not parse local name from: ${t}`);
-    return {
-      importedName,
-      localName
-    };
-  };
-  if (!cell.id && cell.body?.type === "ImportDeclaration") {
-    const module_name = cell.body.source.value;
-    const importKeyword = globalThis?.importShim ? "importShim" : "import";
-    const cell_variables = [
-      {
-        _name: `module ${module_name}`,
-        _inputs: [],
-        _definition: `async () => runtime.module((await ${importKeyword}("${module_name}")).default)`
-      }
-    ];
-    for (const specifier of cell.body.specifiers ?? []) {
-      const specText =
-        typeof specifier?.start === "number" &&
-        typeof specifier?.end === "number"
-          ? source.slice(specifier.start, specifier.end)
-          : (() => {
-              if (specifier?.imported?.name && specifier?.local?.name) {
-                return specifier.imported.name === specifier.local.name
-                  ? specifier.local.name
-                  : `${specifier.imported.name} as ${specifier.local.name}`;
-              }
-              throw new Error("Import specifier missing range information");
+    if (!cell.id && cell.body?.type === 'ImportDeclaration') {
+        const module_name = cell.body.source.value;
+        const cell_variables = [{
+                _name: `module ${ module_name }`,
+                _inputs: [],
+                _definition: `async () => runtime.module((await import("${ module_name }")).default)`
+            }];
+        for (const specifier of cell.body.specifiers ?? []) {
+            const specText = typeof specifier?.start === 'number' && typeof specifier?.end === 'number' ? source.slice(specifier.start, specifier.end) : (() => {
+                if (specifier?.imported?.name && specifier?.local?.name) {
+                    return specifier.imported.name === specifier.local.name ? specifier.local.name : `${ specifier.imported.name } as ${ specifier.local.name }`;
+                }
+                throw new Error('Import specifier missing range information');
             })();
-      const { importedName, localName } = parseImportSpecifierText(specText);
-      cell_variables.push({
-        _name: localName,
-        _inputs: [`module ${module_name}`, "@variable"],
-        _definition:
-          importedName === localName
-            ? `(_, v) => v.import("${importedName}", _)`
-            : `(_, v) => v.import("${importedName}", "${localName}", _)`
-      });
+            const {importedName, localName} = parseImportSpecifierText(specText);
+            cell_variables.push({
+                _name: localName,
+                _inputs: [
+                    `module ${ module_name }`,
+                    '@variable'
+                ],
+                _definition: importedName === localName ? `(_, v) => v.import("${ importedName }", _)` : `(_, v) => v.import("${ importedName }", "${ localName }", _)`
+            });
+        }
+        return cell_variables;
     }
-    return cell_variables;
-  }
-  let dollarIdx = 0;
-  const inputToArgMap = {};
-  const dollarToMacro = {};
-  const seen = new Set();
-  const inputs = Array.from(cell.references || []).flatMap((i) => {
-    if (i.name) {
-      if (seen.has(i.name)) return [];
-      seen.add(i.name);
-      return i.name;
+    let dollarIdx = 0;
+    const inputToArgMap = {};
+    const dollarToMacro = {};
+    const seen = new Set();
+    const inputs = Array.from(cell.references || []).flatMap(i => {
+        if (i.name) {
+            if (seen.has(i.name))
+                return [];
+            seen.add(i.name);
+            return i.name;
+        } else {
+            const dedupKey = i.type + ':' + i.id.name;
+            if (seen.has(dedupKey))
+                return [];
+            seen.add(dedupKey);
+            const dollarName = '$' + dollarIdx;
+            inputToArgMap[i.id.name] = dollarName;
+            dollarToMacro[dollarName] = i.type == 'ViewExpression' ? 'viewof ' + i.id.name : 'mutable ' + i.id.name;
+            dollarIdx++;
+            return dollarName;
+        }
+    });
+    let variables;
+    if (cell.id) {
+        if (cell.id.type === 'Identifier') {
+            variables = [{
+                    functionName: '_' + cell.id.name,
+                    name: cell.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                }];
+        } else if (cell.id.type === 'ViewExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'viewof ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '(G, _) => G.input(_)',
+                    inputs: [
+                        'Generators',
+                        'viewof ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                }
+            ];
+        } else if (cell.id.type === 'MutableExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'initial ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'mutable ' + cell.id.id.name,
+                    _definition: '(M, _) => new M(_)',
+                    inputs: [
+                        'Mutable',
+                        'initial ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '_ => _.generator',
+                    inputs: ['mutable ' + cell.id.id.name],
+                    params: inputs.join(',')
+                }
+            ];
+        } else {
+            throw new Error(`Unsupported cell id type: ${ cell.id.type }`);
+        }
     } else {
-      const dedupKey = i.type + ":" + i.id.name;
-      if (seen.has(dedupKey)) return [];
-      seen.add(dedupKey);
-      const dollarName = "$" + dollarIdx;
-      inputToArgMap[i.id.name] = dollarName;
-      dollarToMacro[dollarName] =
-        i.type == "ViewExpression"
-          ? "viewof " + i.id.name
-          : "mutable " + i.id.name;
-      dollarIdx++;
-      return dollarName;
+        variables = [{
+                functionName: anonymousName,
+                name: null,
+                inputs,
+                params: inputs.join(',')
+            }];
     }
-  });
-  let variables;
-  if (cell.id) {
-    if (cell.id.type === "Identifier") {
-      variables = [
-        {
-          functionName: "_" + cell.id.name,
-          name: cell.id.name,
-          inputs,
-          params: inputs.join(",")
+    return variables.map(v => {
+        let _definition = v._definition;
+        if (!_definition) {
+            let functionBody;
+            if (cell.body.type === 'BlockStatement') {
+                functionBody = observableToJs(cell.body, inputToArgMap, comments, tokens);
+            } else {
+                const bodyCode = observableToJs(cell.body, inputToArgMap, comments, tokens);
+                functionBody = `{return (${ bodyCode });}`;
+            }
+            _definition = `${ cell.async ? 'async ' : '' }function${ cell.generator ? '*' : '' } ${ v.functionName }(${ v.inputs.join(',') }) ${ functionBody }`;
         }
-      ];
-    } else if (cell.id.type === "ViewExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "viewof " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "(G, _) => G.input(_)",
-          inputs: ["Generators", "viewof " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else if (cell.id.type === "MutableExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "initial " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "mutable " + cell.id.id.name,
-          _definition: "(M, _) => new M(_)",
-          inputs: ["Mutable", "initial " + cell.id.id.name],
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "_ => _.generator",
-          inputs: ["mutable " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else {
-      throw new Error(`Unsupported cell id type: ${cell.id.type}`);
-    }
-  } else {
-    variables = [
-      {
-        functionName: anonymousName,
-        name: null,
-        inputs,
-        params: inputs.join(",")
-      }
-    ];
-  }
-  return variables.map((v) => {
-    let _definition = v._definition;
-    if (!_definition) {
-      let functionBody;
-      if (cell.body.type === "BlockStatement") {
-        functionBody = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-      } else {
-        const bodyCode = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-        functionBody = `{return (${bodyCode});}`;
-      }
-      _definition = `${cell.async ? "async " : ""}function${
-        cell.generator ? "*" : ""
-      } ${v.functionName}(${v.inputs.join(",")}) ${functionBody}`;
-    }
-    return {
-      _name: v.name,
-      _inputs: v.inputs.map(
-        (i) => dollarToMacro[i] || (i === "$variable" ? "@variable" : i)
-      ),
-      _definition
-    };
-  });
+        return {
+            _name: v.name,
+            _inputs: v.inputs.map(i => dollarToMacro[i] || (i === '$variable' ? '@variable' : i)),
+            _definition
+        };
+    });
 }
 )};
 const _1v1i7wl = function _observableToJs(acorn_walk,parser,escodegen){return(
@@ -18714,16 +18652,15 @@ async (attachment, overrides) => {
   return URL.createObjectURL(blob);
 }
 )};
-const _s9w7ha = async function _parser(decompress_url,FileAttachment,acorn_url,acorn_walk_url){return(
-importShim(await decompress_url(FileAttachment("parser-6.1.0.js.gz"), {
-    "/npm/acorn@8.11.3/+esm": acorn_url,
-    "/npm/acorn-walk@8.3.2/+esm": acorn_walk_url
-  })
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
-const _1hiclbb = function _acorn_walk(acorn_walk_url){return(
-importShim(acorn_walk_url, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _s9w7ha = async function _parser(decompress_url, FileAttachment, acorn_url, acorn_walk_url) {
+    return import(await decompress_url(FileAttachment('parser-6.1.0.js.gz'), {
+        '/npm/acorn@8.11.3/+esm': acorn_url,
+        '/npm/acorn-walk@8.3.2/+esm': acorn_walk_url
+    }));
+};
+const _1hiclbb = function _acorn_walk(acorn_walk_url) {
+    return import(acorn_walk_url);
+};
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
@@ -18911,7 +18848,7 @@ export default function define(runtime, observer) {
   $def("_1dmmuaf", "compiled_selector", ["Generators","viewof compiled_selector"], _1dmmuaf);  
   $def("_u7t3vu", null, ["compiled_selector","normalizeJavascriptSource"], _u7t3vu);  
   $def("_1lt3kl6", null, ["compile","test_case"], _1lt3kl6);  
-  $def("_lpzjrv", "compile", ["parser","globalThis","observableToJs"], _lpzjrv);  
+  $def("_x1d0wm", "compile", ["parser","observableToJs"], _x1d0wm);  
   $def("_1v1i7wl", "observableToJs", ["acorn_walk","parser","escodegen"], _1v1i7wl);  
   $def("_19lv24l", null, ["md"], _19lv24l);  
   $def("_xhj6b8", "decompress_url", ["DecompressionStream","TextDecoderStream","TransformStream","TextEncoderStream","Response"], _xhj6b8);  
@@ -18926,7 +18863,8 @@ export default function define(runtime, observer) {
   main.define("Library", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Library", _));  
   main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));
   return main;
-}</script>
+}
+</script>
 
 <script id="@tomlarkworthy/reversible-attachment" 
   type="text/plain"

--- a/notebooks/@tomlarkworthy_flow-queue.html
+++ b/notebooks/@tomlarkworthy_flow-queue.html
@@ -5437,58 +5437,41 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _geoudp = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
-  if (command.processed) return;
-
-  let result = undefined;
-  if (command.command == "createCell") {
-    $0.value = true;
-    result = compile_and_update("{}", [], command.args.cell);
-    // For the new one to get focus
-    // setTimeout(() => {
-    //   debugger;
-    //   setOption(result[0], "pinned", true);
-    // }, 100);
-  } else if (command.command == "deleteCell") {
-    remove_variables(command.args.cell.variables);
-    result = true;
-  } else if (command.command == "moveCell") {
-    const cellIndex = findCellIndex(
-      command.args.cell.variables,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const targetCellIndex = cellIndex + command.args.amount;
-    const targetCell = lookupCellByIndex(
-      targetCellIndex,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const currentFirstVariableIndex = findVariableIndex(
-      command.args.cell.variables[0]
-    );
-    const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-    const change = targetFirstVariableIndex - currentFirstVariableIndex;
-    console.log(
-      "moveCell",
-      cellIndex,
-      targetCellIndex,
-      targetCell,
-      currentFirstVariableIndex,
-      targetFirstVariableIndex,
-      change
-    );
-    command.args.cell.variables.forEach((v) => {
-      const currentIndex = findVariableIndex(v);
-      repositionSetElement(runtime._variables, v, currentIndex + change);
-    });
-    // recompute
-    await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
-    result = true;
-  }
-  if (result) {
-    command.processed = true;
-    $2.resolve(result);
-  }
+    if (command.processed)
+        return;
+    let result = undefined;
+    if (command.command == 'createCell') {
+        $0.value = true;
+        result = await compile_and_update('{}', [], command.args.cell);    // For the new one to get focus
+                                                                           // setTimeout(() => {
+                                                                           //   debugger;
+                                                                           //   setOption(result[0], "pinned", true);
+                                                                           // }, 100);
+    } else if (command.command == 'deleteCell') {
+        remove_variables(command.args.cell.variables);
+        result = true;
+    } else if (command.command == 'moveCell') {
+        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const targetCellIndex = cellIndex + command.args.amount;
+        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
+        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+        const change = targetFirstVariableIndex - currentFirstVariableIndex;
+        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
+        command.args.cell.variables.forEach(v => {
+            const currentIndex = findVariableIndex(v);
+            repositionSetElement(runtime._variables, v, currentIndex + change);
+        });
+        // recompute
+        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        result = true;
+    }
+    if (result) {
+        command.processed = true;
+        $2.resolve(result);
+    }
 };
 const _1jadxoe = function _60(md){return(
 md`### UI Action`
@@ -5879,9 +5862,9 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
-    return (source, variables = [], cell) => {
+    return async (source, variables = [], cell) => {
         try {
             debugger;
             let reposition = false, insertionIndex = -1;
@@ -5901,10 +5884,10 @@ const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElemen
             if (reposition) {
                 insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
+            const fns = await realize(newVariables.map(v => v._definition), runtime);
             newVariables.forEach((v, i) => {
                 const variable = variables[i];
-                let _fn;
-                eval('_fn = ' + v._definition);
+                const _fn = fns[i];
                 if (v._name) {
                     variable.define(v._name, v._inputs, _fn);
                 } else {
@@ -5953,12 +5936,11 @@ Inputs.textarea({
 })
 )};
 const _b4rsn5 = (G, _) => G.input(_);
-const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
+const _ga6kci = function _98(Inputs,definition,variable,realize,runtime,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
-  reduce: () => {
-    let _fn;
-    eval("_fn = " + definition);
+  reduce: async () => {
+    const [_fn] = await realize([definition], runtime);
     variable.define(variable._name, inputs, _fn);
   }
 })
@@ -6071,7 +6053,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_geoudp", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _geoudp);  
+  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6109,7 +6091,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
+  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -6119,8 +6101,9 @@ export default function define(runtime, observer) {
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
   $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
-  $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
+  $def("_ga6kci", null, ["Inputs","definition","variable","realize","runtime","inputs"], _ga6kci);  
   $def("_1q557s", null, ["md"], _1q557s);  
+  main.define("realize", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("realize", _));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -16490,10 +16473,9 @@ notebook_semantics_document.nodes.map((s) => ({
 const _1oevsow = function _28(md){return(
 md`### Runtime Representation (v4)`
 )};
-const _11lfflk = function _notebook_semantics_module(){return(
-importShim("https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4"
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _11lfflk = function _notebook_semantics_module() {
+    return import('https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4');
+};
 const _gjten6 = function _31(md){return(
 md`### Imports`
 )};
@@ -17480,65 +17462,44 @@ parser.parseCell(
   'import {runtime, viewof main as foo} from "@mootari/access-runtime"'
 )
 )};
-const _1n7gw17 = function _findModuleName(extractModuleInfo){return(
-(scope, module, { unknown_id = Math.random() } = {}) => {
-  try {
-    const scopedVariables = [...scope.values()];
-
-    // Prefer variables that *define* a module and have a real module-loader name.
-    const candidates = scopedVariables.filter(
-      (v) =>
-        v &&
-        v._value === module &&
-        typeof v._name === "string" &&
-        v._name.startsWith("module ") &&
-        !v._name.startsWith("module <unknown")
-    );
-
-    const pickBestInfo = (dfn) => {
-      // Avoid the parentUrl (2nd arg) confusing module identification.
-      // Typical patterns:
-      //   importShim("/d/<id>@<ver>.js?v=4", "https://api.observablehq.com/@ns/name.js?v=4")
-      //   import("/d/<id>@<ver>.js?v=4")
-      // Prefer the *first argument* inside importShim(...) / import(...) when present.
-      const s = String(dfn ?? "");
-
-      // Try to capture the first string literal argument to importShim(...) or import(...)
-      // Tolerates quotes ", ', ` and both importShim and plain import.
-      const m = s.match(
-        /\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/
-      );
-      const firstArg = m?.[2];
-
-      const info1 = firstArg ? extractModuleInfo(firstArg) : {};
-      if (info1?.id || info1?.notebook) return info1;
-
-      // Fallback: parse the whole definition string.
-      return extractModuleInfo(s);
+const _1n7gw17 = function _findModuleName(extractModuleInfo) {
+    return (scope, module, {
+        unknown_id = Math.random()
+    } = {}) => {
+        try {
+            const scopedVariables = [...scope.values()];
+            const candidates = scopedVariables.filter(v => v && v._value === module && typeof v._name === 'string' && v._name.startsWith('module ') && !v._name.startsWith('module <unknown'));
+            const pickBestInfo = dfn => {
+                const s = String(dfn ?? '');
+                const m = s.match(/\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/);
+                const firstArg = m?.[2];
+                const info1 = firstArg ? extractModuleInfo(firstArg) : {};
+                if (info1?.id || info1?.notebook)
+                    return info1;
+                return extractModuleInfo(s);
+            };
+            for (const v of candidates) {
+                const info = pickBestInfo(v._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            const any = scopedVariables.find(v => v && v._value === module);
+            if (any) {
+                const info = pickBestInfo(any._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            return `<unknown ${ unknown_id }>`;
+        } catch (e) {
+            debugger;
+            return 'error';
+        }
     };
-
-    // Try module loader cells first.
-    for (const v of candidates) {
-      const info = pickBestInfo(v._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    // Fallback: any scoped variable with _value==module.
-    const any = scopedVariables.find((v) => v && v._value === module);
-    if (any) {
-      const info = pickBestInfo(any._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    return `<unknown ${unknown_id}>`;
-  } catch (e) {
-    debugger;
-    return "error";
-  }
-}
-)};
+};
 const _i47chb = function _findImportedName(){return(
 async (v) => {
   if (v._inputs.length == 1 && v._inputs[0]._name === "@variable") {
@@ -18440,229 +18401,206 @@ JSON.stringify(
 const _1lt3kl6 = function _157(compile,test_case){return(
 compile(test_case.value)
 )};
-const _lpzjrv = function _compile(parser,globalThis,observableToJs){return(
-function compile(source, { anonymousName = "_anonymous" } = {}) {
-  const comments = [],
-    tokens = [];
-  let cell;
-  try {
-    cell = parser.parseCell(source, {
-      ranges: true,
-      onComment: comments,
-      onToken: tokens
-    });
-  } catch (e) {
-    if (e instanceof SyntaxError) {
-      const nameMatch = source.match(
-        /^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/
-      );
-      let _name = null;
-      let funcName = anonymousName;
-      if (nameMatch) {
-        const prefix = nameMatch[1] ? nameMatch[1] + " " : "";
-        _name = prefix + nameMatch[2];
-        funcName = "_" + nameMatch[2];
-      }
-      const escapedMsg = JSON.stringify(e.message);
-      const escapedSource = JSON.stringify(source);
-      return [
-        {
-          _name,
-          _inputs: [],
-          _definition: `function ${funcName}() { throw Object.assign(new SyntaxError(${escapedMsg}), {_sourceExpression: ${escapedSource}}); }`
+const _x1d0wm = function _compile(parser,observableToJs){return(
+function compile(source, {
+    anonymousName = '_anonymous'
+} = {}) {
+    const comments = [], tokens = [];
+    let cell;
+    try {
+        cell = parser.parseCell(source, {
+            ranges: true,
+            onComment: comments,
+            onToken: tokens
+        });
+    } catch (e) {
+        if (e instanceof SyntaxError) {
+            const nameMatch = source.match(/^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/);
+            let _name = null;
+            let funcName = anonymousName;
+            if (nameMatch) {
+                const prefix = nameMatch[1] ? nameMatch[1] + ' ' : '';
+                _name = prefix + nameMatch[2];
+                funcName = '_' + nameMatch[2];
+            }
+            const escapedMsg = JSON.stringify(e.message);
+            const escapedSource = JSON.stringify(source);
+            return [{
+                    _name,
+                    _inputs: [],
+                    _definition: `function ${ funcName }() { throw Object.assign(new SyntaxError(${ escapedMsg }), {_sourceExpression: ${ escapedSource }}); }`
+                }];
         }
-      ];
+        throw e;
     }
-    throw e;
-  }
-  if (!cell) throw new Error("Unable to parse cell");
-  const parseImportSpecifierText = (text) => {
-    const t = String(text ?? "")
-      .trim()
-      .replace(/,$/, "")
-      .trim();
-    if (!t) throw new Error("Empty import specifier");
-    const parts = t.split(/\s+as\s+/);
-    const left = parts[0].trim();
-    const right = parts[1]?.trim();
-    const parseSide = (side, { defaultPrefix = "" } = {}) => {
-      const s = String(side ?? "").trim();
-      const m = s.match(/^(viewof|mutable)\s+(.+)$/);
-      if (m)
-        return {
-          prefix: `${m[1]} `,
-          name: m[2].trim()
+    if (!cell)
+        throw new Error('Unable to parse cell');
+    const parseImportSpecifierText = text => {
+        const t = String(text ?? '').trim().replace(/,$/, '').trim();
+        if (!t)
+            throw new Error('Empty import specifier');
+        const parts = t.split(/\s+as\s+/);
+        const left = parts[0].trim();
+        const right = parts[1]?.trim();
+        const parseSide = (side, {
+            defaultPrefix = ''
+        } = {}) => {
+            const s = String(side ?? '').trim();
+            const m = s.match(/^(viewof|mutable)\s+(.+)$/);
+            if (m)
+                return {
+                    prefix: `${ m[1] } `,
+                    name: m[2].trim()
+                };
+            return {
+                prefix: defaultPrefix,
+                name: s
+            };
         };
-      return {
-        prefix: defaultPrefix,
-        name: s
-      };
+        const L = parseSide(left);
+        const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
+        const importedName = `${ L.prefix }${ L.name }`.trim();
+        const localName = `${ R.prefix }${ R.name }`.trim();
+        if (!importedName)
+            throw new Error(`Could not parse imported name from: ${ t }`);
+        if (!localName)
+            throw new Error(`Could not parse local name from: ${ t }`);
+        return {
+            importedName,
+            localName
+        };
     };
-    const L = parseSide(left);
-    const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
-    const importedName = `${L.prefix}${L.name}`.trim();
-    const localName = `${R.prefix}${R.name}`.trim();
-    if (!importedName)
-      throw new Error(`Could not parse imported name from: ${t}`);
-    if (!localName) throw new Error(`Could not parse local name from: ${t}`);
-    return {
-      importedName,
-      localName
-    };
-  };
-  if (!cell.id && cell.body?.type === "ImportDeclaration") {
-    const module_name = cell.body.source.value;
-    const importKeyword = globalThis?.importShim ? "importShim" : "import";
-    const cell_variables = [
-      {
-        _name: `module ${module_name}`,
-        _inputs: [],
-        _definition: `async () => runtime.module((await ${importKeyword}("${module_name}")).default)`
-      }
-    ];
-    for (const specifier of cell.body.specifiers ?? []) {
-      const specText =
-        typeof specifier?.start === "number" &&
-        typeof specifier?.end === "number"
-          ? source.slice(specifier.start, specifier.end)
-          : (() => {
-              if (specifier?.imported?.name && specifier?.local?.name) {
-                return specifier.imported.name === specifier.local.name
-                  ? specifier.local.name
-                  : `${specifier.imported.name} as ${specifier.local.name}`;
-              }
-              throw new Error("Import specifier missing range information");
+    if (!cell.id && cell.body?.type === 'ImportDeclaration') {
+        const module_name = cell.body.source.value;
+        const cell_variables = [{
+                _name: `module ${ module_name }`,
+                _inputs: [],
+                _definition: `async () => runtime.module((await import("${ module_name }")).default)`
+            }];
+        for (const specifier of cell.body.specifiers ?? []) {
+            const specText = typeof specifier?.start === 'number' && typeof specifier?.end === 'number' ? source.slice(specifier.start, specifier.end) : (() => {
+                if (specifier?.imported?.name && specifier?.local?.name) {
+                    return specifier.imported.name === specifier.local.name ? specifier.local.name : `${ specifier.imported.name } as ${ specifier.local.name }`;
+                }
+                throw new Error('Import specifier missing range information');
             })();
-      const { importedName, localName } = parseImportSpecifierText(specText);
-      cell_variables.push({
-        _name: localName,
-        _inputs: [`module ${module_name}`, "@variable"],
-        _definition:
-          importedName === localName
-            ? `(_, v) => v.import("${importedName}", _)`
-            : `(_, v) => v.import("${importedName}", "${localName}", _)`
-      });
+            const {importedName, localName} = parseImportSpecifierText(specText);
+            cell_variables.push({
+                _name: localName,
+                _inputs: [
+                    `module ${ module_name }`,
+                    '@variable'
+                ],
+                _definition: importedName === localName ? `(_, v) => v.import("${ importedName }", _)` : `(_, v) => v.import("${ importedName }", "${ localName }", _)`
+            });
+        }
+        return cell_variables;
     }
-    return cell_variables;
-  }
-  let dollarIdx = 0;
-  const inputToArgMap = {};
-  const dollarToMacro = {};
-  const seen = new Set();
-  const inputs = Array.from(cell.references || []).flatMap((i) => {
-    if (i.name) {
-      if (seen.has(i.name)) return [];
-      seen.add(i.name);
-      return i.name;
+    let dollarIdx = 0;
+    const inputToArgMap = {};
+    const dollarToMacro = {};
+    const seen = new Set();
+    const inputs = Array.from(cell.references || []).flatMap(i => {
+        if (i.name) {
+            if (seen.has(i.name))
+                return [];
+            seen.add(i.name);
+            return i.name;
+        } else {
+            const dedupKey = i.type + ':' + i.id.name;
+            if (seen.has(dedupKey))
+                return [];
+            seen.add(dedupKey);
+            const dollarName = '$' + dollarIdx;
+            inputToArgMap[i.id.name] = dollarName;
+            dollarToMacro[dollarName] = i.type == 'ViewExpression' ? 'viewof ' + i.id.name : 'mutable ' + i.id.name;
+            dollarIdx++;
+            return dollarName;
+        }
+    });
+    let variables;
+    if (cell.id) {
+        if (cell.id.type === 'Identifier') {
+            variables = [{
+                    functionName: '_' + cell.id.name,
+                    name: cell.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                }];
+        } else if (cell.id.type === 'ViewExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'viewof ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '(G, _) => G.input(_)',
+                    inputs: [
+                        'Generators',
+                        'viewof ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                }
+            ];
+        } else if (cell.id.type === 'MutableExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'initial ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'mutable ' + cell.id.id.name,
+                    _definition: '(M, _) => new M(_)',
+                    inputs: [
+                        'Mutable',
+                        'initial ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '_ => _.generator',
+                    inputs: ['mutable ' + cell.id.id.name],
+                    params: inputs.join(',')
+                }
+            ];
+        } else {
+            throw new Error(`Unsupported cell id type: ${ cell.id.type }`);
+        }
     } else {
-      const dedupKey = i.type + ":" + i.id.name;
-      if (seen.has(dedupKey)) return [];
-      seen.add(dedupKey);
-      const dollarName = "$" + dollarIdx;
-      inputToArgMap[i.id.name] = dollarName;
-      dollarToMacro[dollarName] =
-        i.type == "ViewExpression"
-          ? "viewof " + i.id.name
-          : "mutable " + i.id.name;
-      dollarIdx++;
-      return dollarName;
+        variables = [{
+                functionName: anonymousName,
+                name: null,
+                inputs,
+                params: inputs.join(',')
+            }];
     }
-  });
-  let variables;
-  if (cell.id) {
-    if (cell.id.type === "Identifier") {
-      variables = [
-        {
-          functionName: "_" + cell.id.name,
-          name: cell.id.name,
-          inputs,
-          params: inputs.join(",")
+    return variables.map(v => {
+        let _definition = v._definition;
+        if (!_definition) {
+            let functionBody;
+            if (cell.body.type === 'BlockStatement') {
+                functionBody = observableToJs(cell.body, inputToArgMap, comments, tokens);
+            } else {
+                const bodyCode = observableToJs(cell.body, inputToArgMap, comments, tokens);
+                functionBody = `{return (${ bodyCode });}`;
+            }
+            _definition = `${ cell.async ? 'async ' : '' }function${ cell.generator ? '*' : '' } ${ v.functionName }(${ v.inputs.join(',') }) ${ functionBody }`;
         }
-      ];
-    } else if (cell.id.type === "ViewExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "viewof " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "(G, _) => G.input(_)",
-          inputs: ["Generators", "viewof " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else if (cell.id.type === "MutableExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "initial " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "mutable " + cell.id.id.name,
-          _definition: "(M, _) => new M(_)",
-          inputs: ["Mutable", "initial " + cell.id.id.name],
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "_ => _.generator",
-          inputs: ["mutable " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else {
-      throw new Error(`Unsupported cell id type: ${cell.id.type}`);
-    }
-  } else {
-    variables = [
-      {
-        functionName: anonymousName,
-        name: null,
-        inputs,
-        params: inputs.join(",")
-      }
-    ];
-  }
-  return variables.map((v) => {
-    let _definition = v._definition;
-    if (!_definition) {
-      let functionBody;
-      if (cell.body.type === "BlockStatement") {
-        functionBody = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-      } else {
-        const bodyCode = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-        functionBody = `{return (${bodyCode});}`;
-      }
-      _definition = `${cell.async ? "async " : ""}function${
-        cell.generator ? "*" : ""
-      } ${v.functionName}(${v.inputs.join(",")}) ${functionBody}`;
-    }
-    return {
-      _name: v.name,
-      _inputs: v.inputs.map(
-        (i) => dollarToMacro[i] || (i === "$variable" ? "@variable" : i)
-      ),
-      _definition
-    };
-  });
+        return {
+            _name: v.name,
+            _inputs: v.inputs.map(i => dollarToMacro[i] || (i === '$variable' ? '@variable' : i)),
+            _definition
+        };
+    });
 }
 )};
 const _1v1i7wl = function _observableToJs(acorn_walk,parser,escodegen){return(
@@ -18729,16 +18667,15 @@ async (attachment, overrides) => {
   return URL.createObjectURL(blob);
 }
 )};
-const _s9w7ha = async function _parser(decompress_url,FileAttachment,acorn_url,acorn_walk_url){return(
-importShim(await decompress_url(FileAttachment("parser-6.1.0.js.gz"), {
-    "/npm/acorn@8.11.3/+esm": acorn_url,
-    "/npm/acorn-walk@8.3.2/+esm": acorn_walk_url
-  })
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
-const _1hiclbb = function _acorn_walk(acorn_walk_url){return(
-importShim(acorn_walk_url, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _s9w7ha = async function _parser(decompress_url, FileAttachment, acorn_url, acorn_walk_url) {
+    return import(await decompress_url(FileAttachment('parser-6.1.0.js.gz'), {
+        '/npm/acorn@8.11.3/+esm': acorn_url,
+        '/npm/acorn-walk@8.3.2/+esm': acorn_walk_url
+    }));
+};
+const _1hiclbb = function _acorn_walk(acorn_walk_url) {
+    return import(acorn_walk_url);
+};
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
@@ -18926,7 +18863,7 @@ export default function define(runtime, observer) {
   $def("_1dmmuaf", "compiled_selector", ["Generators","viewof compiled_selector"], _1dmmuaf);  
   $def("_u7t3vu", null, ["compiled_selector","normalizeJavascriptSource"], _u7t3vu);  
   $def("_1lt3kl6", null, ["compile","test_case"], _1lt3kl6);  
-  $def("_lpzjrv", "compile", ["parser","globalThis","observableToJs"], _lpzjrv);  
+  $def("_x1d0wm", "compile", ["parser","observableToJs"], _x1d0wm);  
   $def("_1v1i7wl", "observableToJs", ["acorn_walk","parser","escodegen"], _1v1i7wl);  
   $def("_19lv24l", null, ["md"], _19lv24l);  
   $def("_xhj6b8", "decompress_url", ["DecompressionStream","TextDecoderStream","TransformStream","TextEncoderStream","Response"], _xhj6b8);  

--- a/notebooks/@tomlarkworthy_global-search.html
+++ b/notebooks/@tomlarkworthy_global-search.html
@@ -4713,58 +4713,41 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _geoudp = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
-  if (command.processed) return;
-
-  let result = undefined;
-  if (command.command == "createCell") {
-    $0.value = true;
-    result = compile_and_update("{}", [], command.args.cell);
-    // For the new one to get focus
-    // setTimeout(() => {
-    //   debugger;
-    //   setOption(result[0], "pinned", true);
-    // }, 100);
-  } else if (command.command == "deleteCell") {
-    remove_variables(command.args.cell.variables);
-    result = true;
-  } else if (command.command == "moveCell") {
-    const cellIndex = findCellIndex(
-      command.args.cell.variables,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const targetCellIndex = cellIndex + command.args.amount;
-    const targetCell = lookupCellByIndex(
-      targetCellIndex,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const currentFirstVariableIndex = findVariableIndex(
-      command.args.cell.variables[0]
-    );
-    const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-    const change = targetFirstVariableIndex - currentFirstVariableIndex;
-    console.log(
-      "moveCell",
-      cellIndex,
-      targetCellIndex,
-      targetCell,
-      currentFirstVariableIndex,
-      targetFirstVariableIndex,
-      change
-    );
-    command.args.cell.variables.forEach((v) => {
-      const currentIndex = findVariableIndex(v);
-      repositionSetElement(runtime._variables, v, currentIndex + change);
-    });
-    // recompute
-    await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
-    result = true;
-  }
-  if (result) {
-    command.processed = true;
-    $2.resolve(result);
-  }
+    if (command.processed)
+        return;
+    let result = undefined;
+    if (command.command == 'createCell') {
+        $0.value = true;
+        result = await compile_and_update('{}', [], command.args.cell);    // For the new one to get focus
+                                                                           // setTimeout(() => {
+                                                                           //   debugger;
+                                                                           //   setOption(result[0], "pinned", true);
+                                                                           // }, 100);
+    } else if (command.command == 'deleteCell') {
+        remove_variables(command.args.cell.variables);
+        result = true;
+    } else if (command.command == 'moveCell') {
+        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const targetCellIndex = cellIndex + command.args.amount;
+        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
+        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+        const change = targetFirstVariableIndex - currentFirstVariableIndex;
+        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
+        command.args.cell.variables.forEach(v => {
+            const currentIndex = findVariableIndex(v);
+            repositionSetElement(runtime._variables, v, currentIndex + change);
+        });
+        // recompute
+        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        result = true;
+    }
+    if (result) {
+        command.processed = true;
+        $2.resolve(result);
+    }
 };
 const _1jadxoe = function _60(md){return(
 md`### UI Action`
@@ -5155,9 +5138,9 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
-    return (source, variables = [], cell) => {
+    return async (source, variables = [], cell) => {
         try {
             debugger;
             let reposition = false, insertionIndex = -1;
@@ -5177,10 +5160,10 @@ const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElemen
             if (reposition) {
                 insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
+            const fns = await realize(newVariables.map(v => v._definition), runtime);
             newVariables.forEach((v, i) => {
                 const variable = variables[i];
-                let _fn;
-                eval('_fn = ' + v._definition);
+                const _fn = fns[i];
                 if (v._name) {
                     variable.define(v._name, v._inputs, _fn);
                 } else {
@@ -5229,12 +5212,11 @@ Inputs.textarea({
 })
 )};
 const _b4rsn5 = (G, _) => G.input(_);
-const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
+const _ga6kci = function _98(Inputs,definition,variable,realize,runtime,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
-  reduce: () => {
-    let _fn;
-    eval("_fn = " + definition);
+  reduce: async () => {
+    const [_fn] = await realize([definition], runtime);
     variable.define(variable._name, inputs, _fn);
   }
 })
@@ -5347,7 +5329,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_geoudp", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _geoudp);  
+  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -5385,7 +5367,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
+  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -5395,8 +5377,9 @@ export default function define(runtime, observer) {
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
   $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
-  $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
+  $def("_ga6kci", null, ["Inputs","definition","variable","realize","runtime","inputs"], _ga6kci);  
   $def("_1q557s", null, ["md"], _1q557s);  
+  main.define("realize", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("realize", _));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -15034,10 +15017,9 @@ notebook_semantics_document.nodes.map((s) => ({
 const _1oevsow = function _28(md){return(
 md`### Runtime Representation (v4)`
 )};
-const _11lfflk = function _notebook_semantics_module(){return(
-importShim("https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4"
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _11lfflk = function _notebook_semantics_module() {
+    return import('https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4');
+};
 const _gjten6 = function _31(md){return(
 md`### Imports`
 )};
@@ -16024,65 +16006,44 @@ parser.parseCell(
   'import {runtime, viewof main as foo} from "@mootari/access-runtime"'
 )
 )};
-const _1n7gw17 = function _findModuleName(extractModuleInfo){return(
-(scope, module, { unknown_id = Math.random() } = {}) => {
-  try {
-    const scopedVariables = [...scope.values()];
-
-    // Prefer variables that *define* a module and have a real module-loader name.
-    const candidates = scopedVariables.filter(
-      (v) =>
-        v &&
-        v._value === module &&
-        typeof v._name === "string" &&
-        v._name.startsWith("module ") &&
-        !v._name.startsWith("module <unknown")
-    );
-
-    const pickBestInfo = (dfn) => {
-      // Avoid the parentUrl (2nd arg) confusing module identification.
-      // Typical patterns:
-      //   importShim("/d/<id>@<ver>.js?v=4", "https://api.observablehq.com/@ns/name.js?v=4")
-      //   import("/d/<id>@<ver>.js?v=4")
-      // Prefer the *first argument* inside importShim(...) / import(...) when present.
-      const s = String(dfn ?? "");
-
-      // Try to capture the first string literal argument to importShim(...) or import(...)
-      // Tolerates quotes ", ', ` and both importShim and plain import.
-      const m = s.match(
-        /\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/
-      );
-      const firstArg = m?.[2];
-
-      const info1 = firstArg ? extractModuleInfo(firstArg) : {};
-      if (info1?.id || info1?.notebook) return info1;
-
-      // Fallback: parse the whole definition string.
-      return extractModuleInfo(s);
+const _1n7gw17 = function _findModuleName(extractModuleInfo) {
+    return (scope, module, {
+        unknown_id = Math.random()
+    } = {}) => {
+        try {
+            const scopedVariables = [...scope.values()];
+            const candidates = scopedVariables.filter(v => v && v._value === module && typeof v._name === 'string' && v._name.startsWith('module ') && !v._name.startsWith('module <unknown'));
+            const pickBestInfo = dfn => {
+                const s = String(dfn ?? '');
+                const m = s.match(/\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/);
+                const firstArg = m?.[2];
+                const info1 = firstArg ? extractModuleInfo(firstArg) : {};
+                if (info1?.id || info1?.notebook)
+                    return info1;
+                return extractModuleInfo(s);
+            };
+            for (const v of candidates) {
+                const info = pickBestInfo(v._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            const any = scopedVariables.find(v => v && v._value === module);
+            if (any) {
+                const info = pickBestInfo(any._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            return `<unknown ${ unknown_id }>`;
+        } catch (e) {
+            debugger;
+            return 'error';
+        }
     };
-
-    // Try module loader cells first.
-    for (const v of candidates) {
-      const info = pickBestInfo(v._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    // Fallback: any scoped variable with _value==module.
-    const any = scopedVariables.find((v) => v && v._value === module);
-    if (any) {
-      const info = pickBestInfo(any._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    return `<unknown ${unknown_id}>`;
-  } catch (e) {
-    debugger;
-    return "error";
-  }
-}
-)};
+};
 const _i47chb = function _findImportedName(){return(
 async (v) => {
   if (v._inputs.length == 1 && v._inputs[0]._name === "@variable") {
@@ -16984,229 +16945,206 @@ JSON.stringify(
 const _1lt3kl6 = function _157(compile,test_case){return(
 compile(test_case.value)
 )};
-const _lpzjrv = function _compile(parser,globalThis,observableToJs){return(
-function compile(source, { anonymousName = "_anonymous" } = {}) {
-  const comments = [],
-    tokens = [];
-  let cell;
-  try {
-    cell = parser.parseCell(source, {
-      ranges: true,
-      onComment: comments,
-      onToken: tokens
-    });
-  } catch (e) {
-    if (e instanceof SyntaxError) {
-      const nameMatch = source.match(
-        /^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/
-      );
-      let _name = null;
-      let funcName = anonymousName;
-      if (nameMatch) {
-        const prefix = nameMatch[1] ? nameMatch[1] + " " : "";
-        _name = prefix + nameMatch[2];
-        funcName = "_" + nameMatch[2];
-      }
-      const escapedMsg = JSON.stringify(e.message);
-      const escapedSource = JSON.stringify(source);
-      return [
-        {
-          _name,
-          _inputs: [],
-          _definition: `function ${funcName}() { throw Object.assign(new SyntaxError(${escapedMsg}), {_sourceExpression: ${escapedSource}}); }`
+const _x1d0wm = function _compile(parser,observableToJs){return(
+function compile(source, {
+    anonymousName = '_anonymous'
+} = {}) {
+    const comments = [], tokens = [];
+    let cell;
+    try {
+        cell = parser.parseCell(source, {
+            ranges: true,
+            onComment: comments,
+            onToken: tokens
+        });
+    } catch (e) {
+        if (e instanceof SyntaxError) {
+            const nameMatch = source.match(/^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/);
+            let _name = null;
+            let funcName = anonymousName;
+            if (nameMatch) {
+                const prefix = nameMatch[1] ? nameMatch[1] + ' ' : '';
+                _name = prefix + nameMatch[2];
+                funcName = '_' + nameMatch[2];
+            }
+            const escapedMsg = JSON.stringify(e.message);
+            const escapedSource = JSON.stringify(source);
+            return [{
+                    _name,
+                    _inputs: [],
+                    _definition: `function ${ funcName }() { throw Object.assign(new SyntaxError(${ escapedMsg }), {_sourceExpression: ${ escapedSource }}); }`
+                }];
         }
-      ];
+        throw e;
     }
-    throw e;
-  }
-  if (!cell) throw new Error("Unable to parse cell");
-  const parseImportSpecifierText = (text) => {
-    const t = String(text ?? "")
-      .trim()
-      .replace(/,$/, "")
-      .trim();
-    if (!t) throw new Error("Empty import specifier");
-    const parts = t.split(/\s+as\s+/);
-    const left = parts[0].trim();
-    const right = parts[1]?.trim();
-    const parseSide = (side, { defaultPrefix = "" } = {}) => {
-      const s = String(side ?? "").trim();
-      const m = s.match(/^(viewof|mutable)\s+(.+)$/);
-      if (m)
-        return {
-          prefix: `${m[1]} `,
-          name: m[2].trim()
+    if (!cell)
+        throw new Error('Unable to parse cell');
+    const parseImportSpecifierText = text => {
+        const t = String(text ?? '').trim().replace(/,$/, '').trim();
+        if (!t)
+            throw new Error('Empty import specifier');
+        const parts = t.split(/\s+as\s+/);
+        const left = parts[0].trim();
+        const right = parts[1]?.trim();
+        const parseSide = (side, {
+            defaultPrefix = ''
+        } = {}) => {
+            const s = String(side ?? '').trim();
+            const m = s.match(/^(viewof|mutable)\s+(.+)$/);
+            if (m)
+                return {
+                    prefix: `${ m[1] } `,
+                    name: m[2].trim()
+                };
+            return {
+                prefix: defaultPrefix,
+                name: s
+            };
         };
-      return {
-        prefix: defaultPrefix,
-        name: s
-      };
+        const L = parseSide(left);
+        const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
+        const importedName = `${ L.prefix }${ L.name }`.trim();
+        const localName = `${ R.prefix }${ R.name }`.trim();
+        if (!importedName)
+            throw new Error(`Could not parse imported name from: ${ t }`);
+        if (!localName)
+            throw new Error(`Could not parse local name from: ${ t }`);
+        return {
+            importedName,
+            localName
+        };
     };
-    const L = parseSide(left);
-    const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
-    const importedName = `${L.prefix}${L.name}`.trim();
-    const localName = `${R.prefix}${R.name}`.trim();
-    if (!importedName)
-      throw new Error(`Could not parse imported name from: ${t}`);
-    if (!localName) throw new Error(`Could not parse local name from: ${t}`);
-    return {
-      importedName,
-      localName
-    };
-  };
-  if (!cell.id && cell.body?.type === "ImportDeclaration") {
-    const module_name = cell.body.source.value;
-    const importKeyword = globalThis?.importShim ? "importShim" : "import";
-    const cell_variables = [
-      {
-        _name: `module ${module_name}`,
-        _inputs: [],
-        _definition: `async () => runtime.module((await ${importKeyword}("${module_name}")).default)`
-      }
-    ];
-    for (const specifier of cell.body.specifiers ?? []) {
-      const specText =
-        typeof specifier?.start === "number" &&
-        typeof specifier?.end === "number"
-          ? source.slice(specifier.start, specifier.end)
-          : (() => {
-              if (specifier?.imported?.name && specifier?.local?.name) {
-                return specifier.imported.name === specifier.local.name
-                  ? specifier.local.name
-                  : `${specifier.imported.name} as ${specifier.local.name}`;
-              }
-              throw new Error("Import specifier missing range information");
+    if (!cell.id && cell.body?.type === 'ImportDeclaration') {
+        const module_name = cell.body.source.value;
+        const cell_variables = [{
+                _name: `module ${ module_name }`,
+                _inputs: [],
+                _definition: `async () => runtime.module((await import("${ module_name }")).default)`
+            }];
+        for (const specifier of cell.body.specifiers ?? []) {
+            const specText = typeof specifier?.start === 'number' && typeof specifier?.end === 'number' ? source.slice(specifier.start, specifier.end) : (() => {
+                if (specifier?.imported?.name && specifier?.local?.name) {
+                    return specifier.imported.name === specifier.local.name ? specifier.local.name : `${ specifier.imported.name } as ${ specifier.local.name }`;
+                }
+                throw new Error('Import specifier missing range information');
             })();
-      const { importedName, localName } = parseImportSpecifierText(specText);
-      cell_variables.push({
-        _name: localName,
-        _inputs: [`module ${module_name}`, "@variable"],
-        _definition:
-          importedName === localName
-            ? `(_, v) => v.import("${importedName}", _)`
-            : `(_, v) => v.import("${importedName}", "${localName}", _)`
-      });
+            const {importedName, localName} = parseImportSpecifierText(specText);
+            cell_variables.push({
+                _name: localName,
+                _inputs: [
+                    `module ${ module_name }`,
+                    '@variable'
+                ],
+                _definition: importedName === localName ? `(_, v) => v.import("${ importedName }", _)` : `(_, v) => v.import("${ importedName }", "${ localName }", _)`
+            });
+        }
+        return cell_variables;
     }
-    return cell_variables;
-  }
-  let dollarIdx = 0;
-  const inputToArgMap = {};
-  const dollarToMacro = {};
-  const seen = new Set();
-  const inputs = Array.from(cell.references || []).flatMap((i) => {
-    if (i.name) {
-      if (seen.has(i.name)) return [];
-      seen.add(i.name);
-      return i.name;
+    let dollarIdx = 0;
+    const inputToArgMap = {};
+    const dollarToMacro = {};
+    const seen = new Set();
+    const inputs = Array.from(cell.references || []).flatMap(i => {
+        if (i.name) {
+            if (seen.has(i.name))
+                return [];
+            seen.add(i.name);
+            return i.name;
+        } else {
+            const dedupKey = i.type + ':' + i.id.name;
+            if (seen.has(dedupKey))
+                return [];
+            seen.add(dedupKey);
+            const dollarName = '$' + dollarIdx;
+            inputToArgMap[i.id.name] = dollarName;
+            dollarToMacro[dollarName] = i.type == 'ViewExpression' ? 'viewof ' + i.id.name : 'mutable ' + i.id.name;
+            dollarIdx++;
+            return dollarName;
+        }
+    });
+    let variables;
+    if (cell.id) {
+        if (cell.id.type === 'Identifier') {
+            variables = [{
+                    functionName: '_' + cell.id.name,
+                    name: cell.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                }];
+        } else if (cell.id.type === 'ViewExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'viewof ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '(G, _) => G.input(_)',
+                    inputs: [
+                        'Generators',
+                        'viewof ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                }
+            ];
+        } else if (cell.id.type === 'MutableExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'initial ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'mutable ' + cell.id.id.name,
+                    _definition: '(M, _) => new M(_)',
+                    inputs: [
+                        'Mutable',
+                        'initial ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '_ => _.generator',
+                    inputs: ['mutable ' + cell.id.id.name],
+                    params: inputs.join(',')
+                }
+            ];
+        } else {
+            throw new Error(`Unsupported cell id type: ${ cell.id.type }`);
+        }
     } else {
-      const dedupKey = i.type + ":" + i.id.name;
-      if (seen.has(dedupKey)) return [];
-      seen.add(dedupKey);
-      const dollarName = "$" + dollarIdx;
-      inputToArgMap[i.id.name] = dollarName;
-      dollarToMacro[dollarName] =
-        i.type == "ViewExpression"
-          ? "viewof " + i.id.name
-          : "mutable " + i.id.name;
-      dollarIdx++;
-      return dollarName;
+        variables = [{
+                functionName: anonymousName,
+                name: null,
+                inputs,
+                params: inputs.join(',')
+            }];
     }
-  });
-  let variables;
-  if (cell.id) {
-    if (cell.id.type === "Identifier") {
-      variables = [
-        {
-          functionName: "_" + cell.id.name,
-          name: cell.id.name,
-          inputs,
-          params: inputs.join(",")
+    return variables.map(v => {
+        let _definition = v._definition;
+        if (!_definition) {
+            let functionBody;
+            if (cell.body.type === 'BlockStatement') {
+                functionBody = observableToJs(cell.body, inputToArgMap, comments, tokens);
+            } else {
+                const bodyCode = observableToJs(cell.body, inputToArgMap, comments, tokens);
+                functionBody = `{return (${ bodyCode });}`;
+            }
+            _definition = `${ cell.async ? 'async ' : '' }function${ cell.generator ? '*' : '' } ${ v.functionName }(${ v.inputs.join(',') }) ${ functionBody }`;
         }
-      ];
-    } else if (cell.id.type === "ViewExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "viewof " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "(G, _) => G.input(_)",
-          inputs: ["Generators", "viewof " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else if (cell.id.type === "MutableExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "initial " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "mutable " + cell.id.id.name,
-          _definition: "(M, _) => new M(_)",
-          inputs: ["Mutable", "initial " + cell.id.id.name],
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "_ => _.generator",
-          inputs: ["mutable " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else {
-      throw new Error(`Unsupported cell id type: ${cell.id.type}`);
-    }
-  } else {
-    variables = [
-      {
-        functionName: anonymousName,
-        name: null,
-        inputs,
-        params: inputs.join(",")
-      }
-    ];
-  }
-  return variables.map((v) => {
-    let _definition = v._definition;
-    if (!_definition) {
-      let functionBody;
-      if (cell.body.type === "BlockStatement") {
-        functionBody = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-      } else {
-        const bodyCode = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-        functionBody = `{return (${bodyCode});}`;
-      }
-      _definition = `${cell.async ? "async " : ""}function${
-        cell.generator ? "*" : ""
-      } ${v.functionName}(${v.inputs.join(",")}) ${functionBody}`;
-    }
-    return {
-      _name: v.name,
-      _inputs: v.inputs.map(
-        (i) => dollarToMacro[i] || (i === "$variable" ? "@variable" : i)
-      ),
-      _definition
-    };
-  });
+        return {
+            _name: v.name,
+            _inputs: v.inputs.map(i => dollarToMacro[i] || (i === '$variable' ? '@variable' : i)),
+            _definition
+        };
+    });
 }
 )};
 const _1v1i7wl = function _observableToJs(acorn_walk,parser,escodegen){return(
@@ -17273,16 +17211,15 @@ async (attachment, overrides) => {
   return URL.createObjectURL(blob);
 }
 )};
-const _s9w7ha = async function _parser(decompress_url,FileAttachment,acorn_url,acorn_walk_url){return(
-importShim(await decompress_url(FileAttachment("parser-6.1.0.js.gz"), {
-    "/npm/acorn@8.11.3/+esm": acorn_url,
-    "/npm/acorn-walk@8.3.2/+esm": acorn_walk_url
-  })
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
-const _1hiclbb = function _acorn_walk(acorn_walk_url){return(
-importShim(acorn_walk_url, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _s9w7ha = async function _parser(decompress_url, FileAttachment, acorn_url, acorn_walk_url) {
+    return import(await decompress_url(FileAttachment('parser-6.1.0.js.gz'), {
+        '/npm/acorn@8.11.3/+esm': acorn_url,
+        '/npm/acorn-walk@8.3.2/+esm': acorn_walk_url
+    }));
+};
+const _1hiclbb = function _acorn_walk(acorn_walk_url) {
+    return import(acorn_walk_url);
+};
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
@@ -17470,7 +17407,7 @@ export default function define(runtime, observer) {
   $def("_1dmmuaf", "compiled_selector", ["Generators","viewof compiled_selector"], _1dmmuaf);  
   $def("_u7t3vu", null, ["compiled_selector","normalizeJavascriptSource"], _u7t3vu);  
   $def("_1lt3kl6", null, ["compile","test_case"], _1lt3kl6);  
-  $def("_lpzjrv", "compile", ["parser","globalThis","observableToJs"], _lpzjrv);  
+  $def("_x1d0wm", "compile", ["parser","observableToJs"], _x1d0wm);  
   $def("_1v1i7wl", "observableToJs", ["acorn_walk","parser","escodegen"], _1v1i7wl);  
   $def("_19lv24l", null, ["md"], _19lv24l);  
   $def("_xhj6b8", "decompress_url", ["DecompressionStream","TextDecoderStream","TransformStream","TextEncoderStream","Response"], _xhj6b8);  

--- a/notebooks/@tomlarkworthy_golden-layout-2-6-0.html
+++ b/notebooks/@tomlarkworthy_golden-layout-2-6-0.html
@@ -5437,58 +5437,41 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _geoudp = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
-  if (command.processed) return;
-
-  let result = undefined;
-  if (command.command == "createCell") {
-    $0.value = true;
-    result = compile_and_update("{}", [], command.args.cell);
-    // For the new one to get focus
-    // setTimeout(() => {
-    //   debugger;
-    //   setOption(result[0], "pinned", true);
-    // }, 100);
-  } else if (command.command == "deleteCell") {
-    remove_variables(command.args.cell.variables);
-    result = true;
-  } else if (command.command == "moveCell") {
-    const cellIndex = findCellIndex(
-      command.args.cell.variables,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const targetCellIndex = cellIndex + command.args.amount;
-    const targetCell = lookupCellByIndex(
-      targetCellIndex,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const currentFirstVariableIndex = findVariableIndex(
-      command.args.cell.variables[0]
-    );
-    const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-    const change = targetFirstVariableIndex - currentFirstVariableIndex;
-    console.log(
-      "moveCell",
-      cellIndex,
-      targetCellIndex,
-      targetCell,
-      currentFirstVariableIndex,
-      targetFirstVariableIndex,
-      change
-    );
-    command.args.cell.variables.forEach((v) => {
-      const currentIndex = findVariableIndex(v);
-      repositionSetElement(runtime._variables, v, currentIndex + change);
-    });
-    // recompute
-    await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
-    result = true;
-  }
-  if (result) {
-    command.processed = true;
-    $2.resolve(result);
-  }
+    if (command.processed)
+        return;
+    let result = undefined;
+    if (command.command == 'createCell') {
+        $0.value = true;
+        result = await compile_and_update('{}', [], command.args.cell);    // For the new one to get focus
+                                                                           // setTimeout(() => {
+                                                                           //   debugger;
+                                                                           //   setOption(result[0], "pinned", true);
+                                                                           // }, 100);
+    } else if (command.command == 'deleteCell') {
+        remove_variables(command.args.cell.variables);
+        result = true;
+    } else if (command.command == 'moveCell') {
+        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const targetCellIndex = cellIndex + command.args.amount;
+        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
+        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+        const change = targetFirstVariableIndex - currentFirstVariableIndex;
+        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
+        command.args.cell.variables.forEach(v => {
+            const currentIndex = findVariableIndex(v);
+            repositionSetElement(runtime._variables, v, currentIndex + change);
+        });
+        // recompute
+        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        result = true;
+    }
+    if (result) {
+        command.processed = true;
+        $2.resolve(result);
+    }
 };
 const _1jadxoe = function _60(md){return(
 md`### UI Action`
@@ -5879,9 +5862,9 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
-    return (source, variables = [], cell) => {
+    return async (source, variables = [], cell) => {
         try {
             debugger;
             let reposition = false, insertionIndex = -1;
@@ -5901,10 +5884,10 @@ const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElemen
             if (reposition) {
                 insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
+            const fns = await realize(newVariables.map(v => v._definition), runtime);
             newVariables.forEach((v, i) => {
                 const variable = variables[i];
-                let _fn;
-                eval('_fn = ' + v._definition);
+                const _fn = fns[i];
                 if (v._name) {
                     variable.define(v._name, v._inputs, _fn);
                 } else {
@@ -5953,12 +5936,11 @@ Inputs.textarea({
 })
 )};
 const _b4rsn5 = (G, _) => G.input(_);
-const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
+const _ga6kci = function _98(Inputs,definition,variable,realize,runtime,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
-  reduce: () => {
-    let _fn;
-    eval("_fn = " + definition);
+  reduce: async () => {
+    const [_fn] = await realize([definition], runtime);
     variable.define(variable._name, inputs, _fn);
   }
 })
@@ -6071,7 +6053,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_geoudp", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _geoudp);  
+  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6109,7 +6091,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
+  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -6119,8 +6101,9 @@ export default function define(runtime, observer) {
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
   $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
-  $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
+  $def("_ga6kci", null, ["Inputs","definition","variable","realize","runtime","inputs"], _ga6kci);  
   $def("_1q557s", null, ["md"], _1q557s);  
+  main.define("realize", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("realize", _));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -16490,10 +16473,9 @@ notebook_semantics_document.nodes.map((s) => ({
 const _1oevsow = function _28(md){return(
 md`### Runtime Representation (v4)`
 )};
-const _11lfflk = function _notebook_semantics_module(){return(
-importShim("https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4"
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _11lfflk = function _notebook_semantics_module() {
+    return import('https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4');
+};
 const _gjten6 = function _31(md){return(
 md`### Imports`
 )};
@@ -17480,65 +17462,44 @@ parser.parseCell(
   'import {runtime, viewof main as foo} from "@mootari/access-runtime"'
 )
 )};
-const _1n7gw17 = function _findModuleName(extractModuleInfo){return(
-(scope, module, { unknown_id = Math.random() } = {}) => {
-  try {
-    const scopedVariables = [...scope.values()];
-
-    // Prefer variables that *define* a module and have a real module-loader name.
-    const candidates = scopedVariables.filter(
-      (v) =>
-        v &&
-        v._value === module &&
-        typeof v._name === "string" &&
-        v._name.startsWith("module ") &&
-        !v._name.startsWith("module <unknown")
-    );
-
-    const pickBestInfo = (dfn) => {
-      // Avoid the parentUrl (2nd arg) confusing module identification.
-      // Typical patterns:
-      //   importShim("/d/<id>@<ver>.js?v=4", "https://api.observablehq.com/@ns/name.js?v=4")
-      //   import("/d/<id>@<ver>.js?v=4")
-      // Prefer the *first argument* inside importShim(...) / import(...) when present.
-      const s = String(dfn ?? "");
-
-      // Try to capture the first string literal argument to importShim(...) or import(...)
-      // Tolerates quotes ", ', ` and both importShim and plain import.
-      const m = s.match(
-        /\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/
-      );
-      const firstArg = m?.[2];
-
-      const info1 = firstArg ? extractModuleInfo(firstArg) : {};
-      if (info1?.id || info1?.notebook) return info1;
-
-      // Fallback: parse the whole definition string.
-      return extractModuleInfo(s);
+const _1n7gw17 = function _findModuleName(extractModuleInfo) {
+    return (scope, module, {
+        unknown_id = Math.random()
+    } = {}) => {
+        try {
+            const scopedVariables = [...scope.values()];
+            const candidates = scopedVariables.filter(v => v && v._value === module && typeof v._name === 'string' && v._name.startsWith('module ') && !v._name.startsWith('module <unknown'));
+            const pickBestInfo = dfn => {
+                const s = String(dfn ?? '');
+                const m = s.match(/\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/);
+                const firstArg = m?.[2];
+                const info1 = firstArg ? extractModuleInfo(firstArg) : {};
+                if (info1?.id || info1?.notebook)
+                    return info1;
+                return extractModuleInfo(s);
+            };
+            for (const v of candidates) {
+                const info = pickBestInfo(v._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            const any = scopedVariables.find(v => v && v._value === module);
+            if (any) {
+                const info = pickBestInfo(any._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            return `<unknown ${ unknown_id }>`;
+        } catch (e) {
+            debugger;
+            return 'error';
+        }
     };
-
-    // Try module loader cells first.
-    for (const v of candidates) {
-      const info = pickBestInfo(v._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    // Fallback: any scoped variable with _value==module.
-    const any = scopedVariables.find((v) => v && v._value === module);
-    if (any) {
-      const info = pickBestInfo(any._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    return `<unknown ${unknown_id}>`;
-  } catch (e) {
-    debugger;
-    return "error";
-  }
-}
-)};
+};
 const _i47chb = function _findImportedName(){return(
 async (v) => {
   if (v._inputs.length == 1 && v._inputs[0]._name === "@variable") {
@@ -18440,229 +18401,206 @@ JSON.stringify(
 const _1lt3kl6 = function _157(compile,test_case){return(
 compile(test_case.value)
 )};
-const _lpzjrv = function _compile(parser,globalThis,observableToJs){return(
-function compile(source, { anonymousName = "_anonymous" } = {}) {
-  const comments = [],
-    tokens = [];
-  let cell;
-  try {
-    cell = parser.parseCell(source, {
-      ranges: true,
-      onComment: comments,
-      onToken: tokens
-    });
-  } catch (e) {
-    if (e instanceof SyntaxError) {
-      const nameMatch = source.match(
-        /^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/
-      );
-      let _name = null;
-      let funcName = anonymousName;
-      if (nameMatch) {
-        const prefix = nameMatch[1] ? nameMatch[1] + " " : "";
-        _name = prefix + nameMatch[2];
-        funcName = "_" + nameMatch[2];
-      }
-      const escapedMsg = JSON.stringify(e.message);
-      const escapedSource = JSON.stringify(source);
-      return [
-        {
-          _name,
-          _inputs: [],
-          _definition: `function ${funcName}() { throw Object.assign(new SyntaxError(${escapedMsg}), {_sourceExpression: ${escapedSource}}); }`
+const _x1d0wm = function _compile(parser,observableToJs){return(
+function compile(source, {
+    anonymousName = '_anonymous'
+} = {}) {
+    const comments = [], tokens = [];
+    let cell;
+    try {
+        cell = parser.parseCell(source, {
+            ranges: true,
+            onComment: comments,
+            onToken: tokens
+        });
+    } catch (e) {
+        if (e instanceof SyntaxError) {
+            const nameMatch = source.match(/^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/);
+            let _name = null;
+            let funcName = anonymousName;
+            if (nameMatch) {
+                const prefix = nameMatch[1] ? nameMatch[1] + ' ' : '';
+                _name = prefix + nameMatch[2];
+                funcName = '_' + nameMatch[2];
+            }
+            const escapedMsg = JSON.stringify(e.message);
+            const escapedSource = JSON.stringify(source);
+            return [{
+                    _name,
+                    _inputs: [],
+                    _definition: `function ${ funcName }() { throw Object.assign(new SyntaxError(${ escapedMsg }), {_sourceExpression: ${ escapedSource }}); }`
+                }];
         }
-      ];
+        throw e;
     }
-    throw e;
-  }
-  if (!cell) throw new Error("Unable to parse cell");
-  const parseImportSpecifierText = (text) => {
-    const t = String(text ?? "")
-      .trim()
-      .replace(/,$/, "")
-      .trim();
-    if (!t) throw new Error("Empty import specifier");
-    const parts = t.split(/\s+as\s+/);
-    const left = parts[0].trim();
-    const right = parts[1]?.trim();
-    const parseSide = (side, { defaultPrefix = "" } = {}) => {
-      const s = String(side ?? "").trim();
-      const m = s.match(/^(viewof|mutable)\s+(.+)$/);
-      if (m)
-        return {
-          prefix: `${m[1]} `,
-          name: m[2].trim()
+    if (!cell)
+        throw new Error('Unable to parse cell');
+    const parseImportSpecifierText = text => {
+        const t = String(text ?? '').trim().replace(/,$/, '').trim();
+        if (!t)
+            throw new Error('Empty import specifier');
+        const parts = t.split(/\s+as\s+/);
+        const left = parts[0].trim();
+        const right = parts[1]?.trim();
+        const parseSide = (side, {
+            defaultPrefix = ''
+        } = {}) => {
+            const s = String(side ?? '').trim();
+            const m = s.match(/^(viewof|mutable)\s+(.+)$/);
+            if (m)
+                return {
+                    prefix: `${ m[1] } `,
+                    name: m[2].trim()
+                };
+            return {
+                prefix: defaultPrefix,
+                name: s
+            };
         };
-      return {
-        prefix: defaultPrefix,
-        name: s
-      };
+        const L = parseSide(left);
+        const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
+        const importedName = `${ L.prefix }${ L.name }`.trim();
+        const localName = `${ R.prefix }${ R.name }`.trim();
+        if (!importedName)
+            throw new Error(`Could not parse imported name from: ${ t }`);
+        if (!localName)
+            throw new Error(`Could not parse local name from: ${ t }`);
+        return {
+            importedName,
+            localName
+        };
     };
-    const L = parseSide(left);
-    const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
-    const importedName = `${L.prefix}${L.name}`.trim();
-    const localName = `${R.prefix}${R.name}`.trim();
-    if (!importedName)
-      throw new Error(`Could not parse imported name from: ${t}`);
-    if (!localName) throw new Error(`Could not parse local name from: ${t}`);
-    return {
-      importedName,
-      localName
-    };
-  };
-  if (!cell.id && cell.body?.type === "ImportDeclaration") {
-    const module_name = cell.body.source.value;
-    const importKeyword = globalThis?.importShim ? "importShim" : "import";
-    const cell_variables = [
-      {
-        _name: `module ${module_name}`,
-        _inputs: [],
-        _definition: `async () => runtime.module((await ${importKeyword}("${module_name}")).default)`
-      }
-    ];
-    for (const specifier of cell.body.specifiers ?? []) {
-      const specText =
-        typeof specifier?.start === "number" &&
-        typeof specifier?.end === "number"
-          ? source.slice(specifier.start, specifier.end)
-          : (() => {
-              if (specifier?.imported?.name && specifier?.local?.name) {
-                return specifier.imported.name === specifier.local.name
-                  ? specifier.local.name
-                  : `${specifier.imported.name} as ${specifier.local.name}`;
-              }
-              throw new Error("Import specifier missing range information");
+    if (!cell.id && cell.body?.type === 'ImportDeclaration') {
+        const module_name = cell.body.source.value;
+        const cell_variables = [{
+                _name: `module ${ module_name }`,
+                _inputs: [],
+                _definition: `async () => runtime.module((await import("${ module_name }")).default)`
+            }];
+        for (const specifier of cell.body.specifiers ?? []) {
+            const specText = typeof specifier?.start === 'number' && typeof specifier?.end === 'number' ? source.slice(specifier.start, specifier.end) : (() => {
+                if (specifier?.imported?.name && specifier?.local?.name) {
+                    return specifier.imported.name === specifier.local.name ? specifier.local.name : `${ specifier.imported.name } as ${ specifier.local.name }`;
+                }
+                throw new Error('Import specifier missing range information');
             })();
-      const { importedName, localName } = parseImportSpecifierText(specText);
-      cell_variables.push({
-        _name: localName,
-        _inputs: [`module ${module_name}`, "@variable"],
-        _definition:
-          importedName === localName
-            ? `(_, v) => v.import("${importedName}", _)`
-            : `(_, v) => v.import("${importedName}", "${localName}", _)`
-      });
+            const {importedName, localName} = parseImportSpecifierText(specText);
+            cell_variables.push({
+                _name: localName,
+                _inputs: [
+                    `module ${ module_name }`,
+                    '@variable'
+                ],
+                _definition: importedName === localName ? `(_, v) => v.import("${ importedName }", _)` : `(_, v) => v.import("${ importedName }", "${ localName }", _)`
+            });
+        }
+        return cell_variables;
     }
-    return cell_variables;
-  }
-  let dollarIdx = 0;
-  const inputToArgMap = {};
-  const dollarToMacro = {};
-  const seen = new Set();
-  const inputs = Array.from(cell.references || []).flatMap((i) => {
-    if (i.name) {
-      if (seen.has(i.name)) return [];
-      seen.add(i.name);
-      return i.name;
+    let dollarIdx = 0;
+    const inputToArgMap = {};
+    const dollarToMacro = {};
+    const seen = new Set();
+    const inputs = Array.from(cell.references || []).flatMap(i => {
+        if (i.name) {
+            if (seen.has(i.name))
+                return [];
+            seen.add(i.name);
+            return i.name;
+        } else {
+            const dedupKey = i.type + ':' + i.id.name;
+            if (seen.has(dedupKey))
+                return [];
+            seen.add(dedupKey);
+            const dollarName = '$' + dollarIdx;
+            inputToArgMap[i.id.name] = dollarName;
+            dollarToMacro[dollarName] = i.type == 'ViewExpression' ? 'viewof ' + i.id.name : 'mutable ' + i.id.name;
+            dollarIdx++;
+            return dollarName;
+        }
+    });
+    let variables;
+    if (cell.id) {
+        if (cell.id.type === 'Identifier') {
+            variables = [{
+                    functionName: '_' + cell.id.name,
+                    name: cell.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                }];
+        } else if (cell.id.type === 'ViewExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'viewof ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '(G, _) => G.input(_)',
+                    inputs: [
+                        'Generators',
+                        'viewof ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                }
+            ];
+        } else if (cell.id.type === 'MutableExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'initial ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'mutable ' + cell.id.id.name,
+                    _definition: '(M, _) => new M(_)',
+                    inputs: [
+                        'Mutable',
+                        'initial ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '_ => _.generator',
+                    inputs: ['mutable ' + cell.id.id.name],
+                    params: inputs.join(',')
+                }
+            ];
+        } else {
+            throw new Error(`Unsupported cell id type: ${ cell.id.type }`);
+        }
     } else {
-      const dedupKey = i.type + ":" + i.id.name;
-      if (seen.has(dedupKey)) return [];
-      seen.add(dedupKey);
-      const dollarName = "$" + dollarIdx;
-      inputToArgMap[i.id.name] = dollarName;
-      dollarToMacro[dollarName] =
-        i.type == "ViewExpression"
-          ? "viewof " + i.id.name
-          : "mutable " + i.id.name;
-      dollarIdx++;
-      return dollarName;
+        variables = [{
+                functionName: anonymousName,
+                name: null,
+                inputs,
+                params: inputs.join(',')
+            }];
     }
-  });
-  let variables;
-  if (cell.id) {
-    if (cell.id.type === "Identifier") {
-      variables = [
-        {
-          functionName: "_" + cell.id.name,
-          name: cell.id.name,
-          inputs,
-          params: inputs.join(",")
+    return variables.map(v => {
+        let _definition = v._definition;
+        if (!_definition) {
+            let functionBody;
+            if (cell.body.type === 'BlockStatement') {
+                functionBody = observableToJs(cell.body, inputToArgMap, comments, tokens);
+            } else {
+                const bodyCode = observableToJs(cell.body, inputToArgMap, comments, tokens);
+                functionBody = `{return (${ bodyCode });}`;
+            }
+            _definition = `${ cell.async ? 'async ' : '' }function${ cell.generator ? '*' : '' } ${ v.functionName }(${ v.inputs.join(',') }) ${ functionBody }`;
         }
-      ];
-    } else if (cell.id.type === "ViewExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "viewof " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "(G, _) => G.input(_)",
-          inputs: ["Generators", "viewof " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else if (cell.id.type === "MutableExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "initial " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "mutable " + cell.id.id.name,
-          _definition: "(M, _) => new M(_)",
-          inputs: ["Mutable", "initial " + cell.id.id.name],
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "_ => _.generator",
-          inputs: ["mutable " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else {
-      throw new Error(`Unsupported cell id type: ${cell.id.type}`);
-    }
-  } else {
-    variables = [
-      {
-        functionName: anonymousName,
-        name: null,
-        inputs,
-        params: inputs.join(",")
-      }
-    ];
-  }
-  return variables.map((v) => {
-    let _definition = v._definition;
-    if (!_definition) {
-      let functionBody;
-      if (cell.body.type === "BlockStatement") {
-        functionBody = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-      } else {
-        const bodyCode = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-        functionBody = `{return (${bodyCode});}`;
-      }
-      _definition = `${cell.async ? "async " : ""}function${
-        cell.generator ? "*" : ""
-      } ${v.functionName}(${v.inputs.join(",")}) ${functionBody}`;
-    }
-    return {
-      _name: v.name,
-      _inputs: v.inputs.map(
-        (i) => dollarToMacro[i] || (i === "$variable" ? "@variable" : i)
-      ),
-      _definition
-    };
-  });
+        return {
+            _name: v.name,
+            _inputs: v.inputs.map(i => dollarToMacro[i] || (i === '$variable' ? '@variable' : i)),
+            _definition
+        };
+    });
 }
 )};
 const _1v1i7wl = function _observableToJs(acorn_walk,parser,escodegen){return(
@@ -18729,16 +18667,15 @@ async (attachment, overrides) => {
   return URL.createObjectURL(blob);
 }
 )};
-const _s9w7ha = async function _parser(decompress_url,FileAttachment,acorn_url,acorn_walk_url){return(
-importShim(await decompress_url(FileAttachment("parser-6.1.0.js.gz"), {
-    "/npm/acorn@8.11.3/+esm": acorn_url,
-    "/npm/acorn-walk@8.3.2/+esm": acorn_walk_url
-  })
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
-const _1hiclbb = function _acorn_walk(acorn_walk_url){return(
-importShim(acorn_walk_url, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _s9w7ha = async function _parser(decompress_url, FileAttachment, acorn_url, acorn_walk_url) {
+    return import(await decompress_url(FileAttachment('parser-6.1.0.js.gz'), {
+        '/npm/acorn@8.11.3/+esm': acorn_url,
+        '/npm/acorn-walk@8.3.2/+esm': acorn_walk_url
+    }));
+};
+const _1hiclbb = function _acorn_walk(acorn_walk_url) {
+    return import(acorn_walk_url);
+};
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
@@ -18926,7 +18863,7 @@ export default function define(runtime, observer) {
   $def("_1dmmuaf", "compiled_selector", ["Generators","viewof compiled_selector"], _1dmmuaf);  
   $def("_u7t3vu", null, ["compiled_selector","normalizeJavascriptSource"], _u7t3vu);  
   $def("_1lt3kl6", null, ["compile","test_case"], _1lt3kl6);  
-  $def("_lpzjrv", "compile", ["parser","globalThis","observableToJs"], _lpzjrv);  
+  $def("_x1d0wm", "compile", ["parser","observableToJs"], _x1d0wm);  
   $def("_1v1i7wl", "observableToJs", ["acorn_walk","parser","escodegen"], _1v1i7wl);  
   $def("_19lv24l", null, ["md"], _19lv24l);  
   $def("_xhj6b8", "decompress_url", ["DecompressionStream","TextDecoderStream","TransformStream","TextEncoderStream","Response"], _xhj6b8);  

--- a/notebooks/@tomlarkworthy_import-notebook.html
+++ b/notebooks/@tomlarkworthy_import-notebook.html
@@ -5437,58 +5437,41 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _geoudp = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
-  if (command.processed) return;
-
-  let result = undefined;
-  if (command.command == "createCell") {
-    $0.value = true;
-    result = compile_and_update("{}", [], command.args.cell);
-    // For the new one to get focus
-    // setTimeout(() => {
-    //   debugger;
-    //   setOption(result[0], "pinned", true);
-    // }, 100);
-  } else if (command.command == "deleteCell") {
-    remove_variables(command.args.cell.variables);
-    result = true;
-  } else if (command.command == "moveCell") {
-    const cellIndex = findCellIndex(
-      command.args.cell.variables,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const targetCellIndex = cellIndex + command.args.amount;
-    const targetCell = lookupCellByIndex(
-      targetCellIndex,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const currentFirstVariableIndex = findVariableIndex(
-      command.args.cell.variables[0]
-    );
-    const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-    const change = targetFirstVariableIndex - currentFirstVariableIndex;
-    console.log(
-      "moveCell",
-      cellIndex,
-      targetCellIndex,
-      targetCell,
-      currentFirstVariableIndex,
-      targetFirstVariableIndex,
-      change
-    );
-    command.args.cell.variables.forEach((v) => {
-      const currentIndex = findVariableIndex(v);
-      repositionSetElement(runtime._variables, v, currentIndex + change);
-    });
-    // recompute
-    await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
-    result = true;
-  }
-  if (result) {
-    command.processed = true;
-    $2.resolve(result);
-  }
+    if (command.processed)
+        return;
+    let result = undefined;
+    if (command.command == 'createCell') {
+        $0.value = true;
+        result = await compile_and_update('{}', [], command.args.cell);    // For the new one to get focus
+                                                                           // setTimeout(() => {
+                                                                           //   debugger;
+                                                                           //   setOption(result[0], "pinned", true);
+                                                                           // }, 100);
+    } else if (command.command == 'deleteCell') {
+        remove_variables(command.args.cell.variables);
+        result = true;
+    } else if (command.command == 'moveCell') {
+        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const targetCellIndex = cellIndex + command.args.amount;
+        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
+        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+        const change = targetFirstVariableIndex - currentFirstVariableIndex;
+        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
+        command.args.cell.variables.forEach(v => {
+            const currentIndex = findVariableIndex(v);
+            repositionSetElement(runtime._variables, v, currentIndex + change);
+        });
+        // recompute
+        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        result = true;
+    }
+    if (result) {
+        command.processed = true;
+        $2.resolve(result);
+    }
 };
 const _1jadxoe = function _60(md){return(
 md`### UI Action`
@@ -5879,9 +5862,9 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
-    return (source, variables = [], cell) => {
+    return async (source, variables = [], cell) => {
         try {
             debugger;
             let reposition = false, insertionIndex = -1;
@@ -5901,10 +5884,10 @@ const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElemen
             if (reposition) {
                 insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
+            const fns = await realize(newVariables.map(v => v._definition), runtime);
             newVariables.forEach((v, i) => {
                 const variable = variables[i];
-                let _fn;
-                eval('_fn = ' + v._definition);
+                const _fn = fns[i];
                 if (v._name) {
                     variable.define(v._name, v._inputs, _fn);
                 } else {
@@ -5953,12 +5936,11 @@ Inputs.textarea({
 })
 )};
 const _b4rsn5 = (G, _) => G.input(_);
-const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
+const _ga6kci = function _98(Inputs,definition,variable,realize,runtime,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
-  reduce: () => {
-    let _fn;
-    eval("_fn = " + definition);
+  reduce: async () => {
+    const [_fn] = await realize([definition], runtime);
     variable.define(variable._name, inputs, _fn);
   }
 })
@@ -6071,7 +6053,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_geoudp", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _geoudp);  
+  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6109,7 +6091,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
+  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -6119,8 +6101,9 @@ export default function define(runtime, observer) {
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
   $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
-  $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
+  $def("_ga6kci", null, ["Inputs","definition","variable","realize","runtime","inputs"], _ga6kci);  
   $def("_1q557s", null, ["md"], _1q557s);  
+  main.define("realize", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("realize", _));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -16490,10 +16473,9 @@ notebook_semantics_document.nodes.map((s) => ({
 const _1oevsow = function _28(md){return(
 md`### Runtime Representation (v4)`
 )};
-const _11lfflk = function _notebook_semantics_module(){return(
-importShim("https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4"
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _11lfflk = function _notebook_semantics_module() {
+    return import('https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4');
+};
 const _gjten6 = function _31(md){return(
 md`### Imports`
 )};
@@ -17480,65 +17462,44 @@ parser.parseCell(
   'import {runtime, viewof main as foo} from "@mootari/access-runtime"'
 )
 )};
-const _1n7gw17 = function _findModuleName(extractModuleInfo){return(
-(scope, module, { unknown_id = Math.random() } = {}) => {
-  try {
-    const scopedVariables = [...scope.values()];
-
-    // Prefer variables that *define* a module and have a real module-loader name.
-    const candidates = scopedVariables.filter(
-      (v) =>
-        v &&
-        v._value === module &&
-        typeof v._name === "string" &&
-        v._name.startsWith("module ") &&
-        !v._name.startsWith("module <unknown")
-    );
-
-    const pickBestInfo = (dfn) => {
-      // Avoid the parentUrl (2nd arg) confusing module identification.
-      // Typical patterns:
-      //   importShim("/d/<id>@<ver>.js?v=4", "https://api.observablehq.com/@ns/name.js?v=4")
-      //   import("/d/<id>@<ver>.js?v=4")
-      // Prefer the *first argument* inside importShim(...) / import(...) when present.
-      const s = String(dfn ?? "");
-
-      // Try to capture the first string literal argument to importShim(...) or import(...)
-      // Tolerates quotes ", ', ` and both importShim and plain import.
-      const m = s.match(
-        /\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/
-      );
-      const firstArg = m?.[2];
-
-      const info1 = firstArg ? extractModuleInfo(firstArg) : {};
-      if (info1?.id || info1?.notebook) return info1;
-
-      // Fallback: parse the whole definition string.
-      return extractModuleInfo(s);
+const _1n7gw17 = function _findModuleName(extractModuleInfo) {
+    return (scope, module, {
+        unknown_id = Math.random()
+    } = {}) => {
+        try {
+            const scopedVariables = [...scope.values()];
+            const candidates = scopedVariables.filter(v => v && v._value === module && typeof v._name === 'string' && v._name.startsWith('module ') && !v._name.startsWith('module <unknown'));
+            const pickBestInfo = dfn => {
+                const s = String(dfn ?? '');
+                const m = s.match(/\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/);
+                const firstArg = m?.[2];
+                const info1 = firstArg ? extractModuleInfo(firstArg) : {};
+                if (info1?.id || info1?.notebook)
+                    return info1;
+                return extractModuleInfo(s);
+            };
+            for (const v of candidates) {
+                const info = pickBestInfo(v._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            const any = scopedVariables.find(v => v && v._value === module);
+            if (any) {
+                const info = pickBestInfo(any._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            return `<unknown ${ unknown_id }>`;
+        } catch (e) {
+            debugger;
+            return 'error';
+        }
     };
-
-    // Try module loader cells first.
-    for (const v of candidates) {
-      const info = pickBestInfo(v._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    // Fallback: any scoped variable with _value==module.
-    const any = scopedVariables.find((v) => v && v._value === module);
-    if (any) {
-      const info = pickBestInfo(any._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    return `<unknown ${unknown_id}>`;
-  } catch (e) {
-    debugger;
-    return "error";
-  }
-}
-)};
+};
 const _i47chb = function _findImportedName(){return(
 async (v) => {
   if (v._inputs.length == 1 && v._inputs[0]._name === "@variable") {
@@ -18440,229 +18401,206 @@ JSON.stringify(
 const _1lt3kl6 = function _157(compile,test_case){return(
 compile(test_case.value)
 )};
-const _lpzjrv = function _compile(parser,globalThis,observableToJs){return(
-function compile(source, { anonymousName = "_anonymous" } = {}) {
-  const comments = [],
-    tokens = [];
-  let cell;
-  try {
-    cell = parser.parseCell(source, {
-      ranges: true,
-      onComment: comments,
-      onToken: tokens
-    });
-  } catch (e) {
-    if (e instanceof SyntaxError) {
-      const nameMatch = source.match(
-        /^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/
-      );
-      let _name = null;
-      let funcName = anonymousName;
-      if (nameMatch) {
-        const prefix = nameMatch[1] ? nameMatch[1] + " " : "";
-        _name = prefix + nameMatch[2];
-        funcName = "_" + nameMatch[2];
-      }
-      const escapedMsg = JSON.stringify(e.message);
-      const escapedSource = JSON.stringify(source);
-      return [
-        {
-          _name,
-          _inputs: [],
-          _definition: `function ${funcName}() { throw Object.assign(new SyntaxError(${escapedMsg}), {_sourceExpression: ${escapedSource}}); }`
+const _x1d0wm = function _compile(parser,observableToJs){return(
+function compile(source, {
+    anonymousName = '_anonymous'
+} = {}) {
+    const comments = [], tokens = [];
+    let cell;
+    try {
+        cell = parser.parseCell(source, {
+            ranges: true,
+            onComment: comments,
+            onToken: tokens
+        });
+    } catch (e) {
+        if (e instanceof SyntaxError) {
+            const nameMatch = source.match(/^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/);
+            let _name = null;
+            let funcName = anonymousName;
+            if (nameMatch) {
+                const prefix = nameMatch[1] ? nameMatch[1] + ' ' : '';
+                _name = prefix + nameMatch[2];
+                funcName = '_' + nameMatch[2];
+            }
+            const escapedMsg = JSON.stringify(e.message);
+            const escapedSource = JSON.stringify(source);
+            return [{
+                    _name,
+                    _inputs: [],
+                    _definition: `function ${ funcName }() { throw Object.assign(new SyntaxError(${ escapedMsg }), {_sourceExpression: ${ escapedSource }}); }`
+                }];
         }
-      ];
+        throw e;
     }
-    throw e;
-  }
-  if (!cell) throw new Error("Unable to parse cell");
-  const parseImportSpecifierText = (text) => {
-    const t = String(text ?? "")
-      .trim()
-      .replace(/,$/, "")
-      .trim();
-    if (!t) throw new Error("Empty import specifier");
-    const parts = t.split(/\s+as\s+/);
-    const left = parts[0].trim();
-    const right = parts[1]?.trim();
-    const parseSide = (side, { defaultPrefix = "" } = {}) => {
-      const s = String(side ?? "").trim();
-      const m = s.match(/^(viewof|mutable)\s+(.+)$/);
-      if (m)
-        return {
-          prefix: `${m[1]} `,
-          name: m[2].trim()
+    if (!cell)
+        throw new Error('Unable to parse cell');
+    const parseImportSpecifierText = text => {
+        const t = String(text ?? '').trim().replace(/,$/, '').trim();
+        if (!t)
+            throw new Error('Empty import specifier');
+        const parts = t.split(/\s+as\s+/);
+        const left = parts[0].trim();
+        const right = parts[1]?.trim();
+        const parseSide = (side, {
+            defaultPrefix = ''
+        } = {}) => {
+            const s = String(side ?? '').trim();
+            const m = s.match(/^(viewof|mutable)\s+(.+)$/);
+            if (m)
+                return {
+                    prefix: `${ m[1] } `,
+                    name: m[2].trim()
+                };
+            return {
+                prefix: defaultPrefix,
+                name: s
+            };
         };
-      return {
-        prefix: defaultPrefix,
-        name: s
-      };
+        const L = parseSide(left);
+        const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
+        const importedName = `${ L.prefix }${ L.name }`.trim();
+        const localName = `${ R.prefix }${ R.name }`.trim();
+        if (!importedName)
+            throw new Error(`Could not parse imported name from: ${ t }`);
+        if (!localName)
+            throw new Error(`Could not parse local name from: ${ t }`);
+        return {
+            importedName,
+            localName
+        };
     };
-    const L = parseSide(left);
-    const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
-    const importedName = `${L.prefix}${L.name}`.trim();
-    const localName = `${R.prefix}${R.name}`.trim();
-    if (!importedName)
-      throw new Error(`Could not parse imported name from: ${t}`);
-    if (!localName) throw new Error(`Could not parse local name from: ${t}`);
-    return {
-      importedName,
-      localName
-    };
-  };
-  if (!cell.id && cell.body?.type === "ImportDeclaration") {
-    const module_name = cell.body.source.value;
-    const importKeyword = globalThis?.importShim ? "importShim" : "import";
-    const cell_variables = [
-      {
-        _name: `module ${module_name}`,
-        _inputs: [],
-        _definition: `async () => runtime.module((await ${importKeyword}("${module_name}")).default)`
-      }
-    ];
-    for (const specifier of cell.body.specifiers ?? []) {
-      const specText =
-        typeof specifier?.start === "number" &&
-        typeof specifier?.end === "number"
-          ? source.slice(specifier.start, specifier.end)
-          : (() => {
-              if (specifier?.imported?.name && specifier?.local?.name) {
-                return specifier.imported.name === specifier.local.name
-                  ? specifier.local.name
-                  : `${specifier.imported.name} as ${specifier.local.name}`;
-              }
-              throw new Error("Import specifier missing range information");
+    if (!cell.id && cell.body?.type === 'ImportDeclaration') {
+        const module_name = cell.body.source.value;
+        const cell_variables = [{
+                _name: `module ${ module_name }`,
+                _inputs: [],
+                _definition: `async () => runtime.module((await import("${ module_name }")).default)`
+            }];
+        for (const specifier of cell.body.specifiers ?? []) {
+            const specText = typeof specifier?.start === 'number' && typeof specifier?.end === 'number' ? source.slice(specifier.start, specifier.end) : (() => {
+                if (specifier?.imported?.name && specifier?.local?.name) {
+                    return specifier.imported.name === specifier.local.name ? specifier.local.name : `${ specifier.imported.name } as ${ specifier.local.name }`;
+                }
+                throw new Error('Import specifier missing range information');
             })();
-      const { importedName, localName } = parseImportSpecifierText(specText);
-      cell_variables.push({
-        _name: localName,
-        _inputs: [`module ${module_name}`, "@variable"],
-        _definition:
-          importedName === localName
-            ? `(_, v) => v.import("${importedName}", _)`
-            : `(_, v) => v.import("${importedName}", "${localName}", _)`
-      });
+            const {importedName, localName} = parseImportSpecifierText(specText);
+            cell_variables.push({
+                _name: localName,
+                _inputs: [
+                    `module ${ module_name }`,
+                    '@variable'
+                ],
+                _definition: importedName === localName ? `(_, v) => v.import("${ importedName }", _)` : `(_, v) => v.import("${ importedName }", "${ localName }", _)`
+            });
+        }
+        return cell_variables;
     }
-    return cell_variables;
-  }
-  let dollarIdx = 0;
-  const inputToArgMap = {};
-  const dollarToMacro = {};
-  const seen = new Set();
-  const inputs = Array.from(cell.references || []).flatMap((i) => {
-    if (i.name) {
-      if (seen.has(i.name)) return [];
-      seen.add(i.name);
-      return i.name;
+    let dollarIdx = 0;
+    const inputToArgMap = {};
+    const dollarToMacro = {};
+    const seen = new Set();
+    const inputs = Array.from(cell.references || []).flatMap(i => {
+        if (i.name) {
+            if (seen.has(i.name))
+                return [];
+            seen.add(i.name);
+            return i.name;
+        } else {
+            const dedupKey = i.type + ':' + i.id.name;
+            if (seen.has(dedupKey))
+                return [];
+            seen.add(dedupKey);
+            const dollarName = '$' + dollarIdx;
+            inputToArgMap[i.id.name] = dollarName;
+            dollarToMacro[dollarName] = i.type == 'ViewExpression' ? 'viewof ' + i.id.name : 'mutable ' + i.id.name;
+            dollarIdx++;
+            return dollarName;
+        }
+    });
+    let variables;
+    if (cell.id) {
+        if (cell.id.type === 'Identifier') {
+            variables = [{
+                    functionName: '_' + cell.id.name,
+                    name: cell.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                }];
+        } else if (cell.id.type === 'ViewExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'viewof ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '(G, _) => G.input(_)',
+                    inputs: [
+                        'Generators',
+                        'viewof ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                }
+            ];
+        } else if (cell.id.type === 'MutableExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'initial ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'mutable ' + cell.id.id.name,
+                    _definition: '(M, _) => new M(_)',
+                    inputs: [
+                        'Mutable',
+                        'initial ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '_ => _.generator',
+                    inputs: ['mutable ' + cell.id.id.name],
+                    params: inputs.join(',')
+                }
+            ];
+        } else {
+            throw new Error(`Unsupported cell id type: ${ cell.id.type }`);
+        }
     } else {
-      const dedupKey = i.type + ":" + i.id.name;
-      if (seen.has(dedupKey)) return [];
-      seen.add(dedupKey);
-      const dollarName = "$" + dollarIdx;
-      inputToArgMap[i.id.name] = dollarName;
-      dollarToMacro[dollarName] =
-        i.type == "ViewExpression"
-          ? "viewof " + i.id.name
-          : "mutable " + i.id.name;
-      dollarIdx++;
-      return dollarName;
+        variables = [{
+                functionName: anonymousName,
+                name: null,
+                inputs,
+                params: inputs.join(',')
+            }];
     }
-  });
-  let variables;
-  if (cell.id) {
-    if (cell.id.type === "Identifier") {
-      variables = [
-        {
-          functionName: "_" + cell.id.name,
-          name: cell.id.name,
-          inputs,
-          params: inputs.join(",")
+    return variables.map(v => {
+        let _definition = v._definition;
+        if (!_definition) {
+            let functionBody;
+            if (cell.body.type === 'BlockStatement') {
+                functionBody = observableToJs(cell.body, inputToArgMap, comments, tokens);
+            } else {
+                const bodyCode = observableToJs(cell.body, inputToArgMap, comments, tokens);
+                functionBody = `{return (${ bodyCode });}`;
+            }
+            _definition = `${ cell.async ? 'async ' : '' }function${ cell.generator ? '*' : '' } ${ v.functionName }(${ v.inputs.join(',') }) ${ functionBody }`;
         }
-      ];
-    } else if (cell.id.type === "ViewExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "viewof " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "(G, _) => G.input(_)",
-          inputs: ["Generators", "viewof " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else if (cell.id.type === "MutableExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "initial " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "mutable " + cell.id.id.name,
-          _definition: "(M, _) => new M(_)",
-          inputs: ["Mutable", "initial " + cell.id.id.name],
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "_ => _.generator",
-          inputs: ["mutable " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else {
-      throw new Error(`Unsupported cell id type: ${cell.id.type}`);
-    }
-  } else {
-    variables = [
-      {
-        functionName: anonymousName,
-        name: null,
-        inputs,
-        params: inputs.join(",")
-      }
-    ];
-  }
-  return variables.map((v) => {
-    let _definition = v._definition;
-    if (!_definition) {
-      let functionBody;
-      if (cell.body.type === "BlockStatement") {
-        functionBody = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-      } else {
-        const bodyCode = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-        functionBody = `{return (${bodyCode});}`;
-      }
-      _definition = `${cell.async ? "async " : ""}function${
-        cell.generator ? "*" : ""
-      } ${v.functionName}(${v.inputs.join(",")}) ${functionBody}`;
-    }
-    return {
-      _name: v.name,
-      _inputs: v.inputs.map(
-        (i) => dollarToMacro[i] || (i === "$variable" ? "@variable" : i)
-      ),
-      _definition
-    };
-  });
+        return {
+            _name: v.name,
+            _inputs: v.inputs.map(i => dollarToMacro[i] || (i === '$variable' ? '@variable' : i)),
+            _definition
+        };
+    });
 }
 )};
 const _1v1i7wl = function _observableToJs(acorn_walk,parser,escodegen){return(
@@ -18729,16 +18667,15 @@ async (attachment, overrides) => {
   return URL.createObjectURL(blob);
 }
 )};
-const _s9w7ha = async function _parser(decompress_url,FileAttachment,acorn_url,acorn_walk_url){return(
-importShim(await decompress_url(FileAttachment("parser-6.1.0.js.gz"), {
-    "/npm/acorn@8.11.3/+esm": acorn_url,
-    "/npm/acorn-walk@8.3.2/+esm": acorn_walk_url
-  })
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
-const _1hiclbb = function _acorn_walk(acorn_walk_url){return(
-importShim(acorn_walk_url, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _s9w7ha = async function _parser(decompress_url, FileAttachment, acorn_url, acorn_walk_url) {
+    return import(await decompress_url(FileAttachment('parser-6.1.0.js.gz'), {
+        '/npm/acorn@8.11.3/+esm': acorn_url,
+        '/npm/acorn-walk@8.3.2/+esm': acorn_walk_url
+    }));
+};
+const _1hiclbb = function _acorn_walk(acorn_walk_url) {
+    return import(acorn_walk_url);
+};
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
@@ -18926,7 +18863,7 @@ export default function define(runtime, observer) {
   $def("_1dmmuaf", "compiled_selector", ["Generators","viewof compiled_selector"], _1dmmuaf);  
   $def("_u7t3vu", null, ["compiled_selector","normalizeJavascriptSource"], _u7t3vu);  
   $def("_1lt3kl6", null, ["compile","test_case"], _1lt3kl6);  
-  $def("_lpzjrv", "compile", ["parser","globalThis","observableToJs"], _lpzjrv);  
+  $def("_x1d0wm", "compile", ["parser","observableToJs"], _x1d0wm);  
   $def("_1v1i7wl", "observableToJs", ["acorn_walk","parser","escodegen"], _1v1i7wl);  
   $def("_19lv24l", null, ["md"], _19lv24l);  
   $def("_xhj6b8", "decompress_url", ["DecompressionStream","TextDecoderStream","TransformStream","TextEncoderStream","Response"], _xhj6b8);  

--- a/notebooks/@tomlarkworthy_jest-expect-standalone.html
+++ b/notebooks/@tomlarkworthy_jest-expect-standalone.html
@@ -5437,58 +5437,41 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _geoudp = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
-  if (command.processed) return;
-
-  let result = undefined;
-  if (command.command == "createCell") {
-    $0.value = true;
-    result = compile_and_update("{}", [], command.args.cell);
-    // For the new one to get focus
-    // setTimeout(() => {
-    //   debugger;
-    //   setOption(result[0], "pinned", true);
-    // }, 100);
-  } else if (command.command == "deleteCell") {
-    remove_variables(command.args.cell.variables);
-    result = true;
-  } else if (command.command == "moveCell") {
-    const cellIndex = findCellIndex(
-      command.args.cell.variables,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const targetCellIndex = cellIndex + command.args.amount;
-    const targetCell = lookupCellByIndex(
-      targetCellIndex,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const currentFirstVariableIndex = findVariableIndex(
-      command.args.cell.variables[0]
-    );
-    const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-    const change = targetFirstVariableIndex - currentFirstVariableIndex;
-    console.log(
-      "moveCell",
-      cellIndex,
-      targetCellIndex,
-      targetCell,
-      currentFirstVariableIndex,
-      targetFirstVariableIndex,
-      change
-    );
-    command.args.cell.variables.forEach((v) => {
-      const currentIndex = findVariableIndex(v);
-      repositionSetElement(runtime._variables, v, currentIndex + change);
-    });
-    // recompute
-    await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
-    result = true;
-  }
-  if (result) {
-    command.processed = true;
-    $2.resolve(result);
-  }
+    if (command.processed)
+        return;
+    let result = undefined;
+    if (command.command == 'createCell') {
+        $0.value = true;
+        result = await compile_and_update('{}', [], command.args.cell);    // For the new one to get focus
+                                                                           // setTimeout(() => {
+                                                                           //   debugger;
+                                                                           //   setOption(result[0], "pinned", true);
+                                                                           // }, 100);
+    } else if (command.command == 'deleteCell') {
+        remove_variables(command.args.cell.variables);
+        result = true;
+    } else if (command.command == 'moveCell') {
+        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const targetCellIndex = cellIndex + command.args.amount;
+        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
+        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+        const change = targetFirstVariableIndex - currentFirstVariableIndex;
+        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
+        command.args.cell.variables.forEach(v => {
+            const currentIndex = findVariableIndex(v);
+            repositionSetElement(runtime._variables, v, currentIndex + change);
+        });
+        // recompute
+        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        result = true;
+    }
+    if (result) {
+        command.processed = true;
+        $2.resolve(result);
+    }
 };
 const _1jadxoe = function _60(md){return(
 md`### UI Action`
@@ -5879,9 +5862,9 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
-    return (source, variables = [], cell) => {
+    return async (source, variables = [], cell) => {
         try {
             debugger;
             let reposition = false, insertionIndex = -1;
@@ -5901,10 +5884,10 @@ const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElemen
             if (reposition) {
                 insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
+            const fns = await realize(newVariables.map(v => v._definition), runtime);
             newVariables.forEach((v, i) => {
                 const variable = variables[i];
-                let _fn;
-                eval('_fn = ' + v._definition);
+                const _fn = fns[i];
                 if (v._name) {
                     variable.define(v._name, v._inputs, _fn);
                 } else {
@@ -5953,12 +5936,11 @@ Inputs.textarea({
 })
 )};
 const _b4rsn5 = (G, _) => G.input(_);
-const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
+const _ga6kci = function _98(Inputs,definition,variable,realize,runtime,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
-  reduce: () => {
-    let _fn;
-    eval("_fn = " + definition);
+  reduce: async () => {
+    const [_fn] = await realize([definition], runtime);
     variable.define(variable._name, inputs, _fn);
   }
 })
@@ -6071,7 +6053,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_geoudp", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _geoudp);  
+  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6109,7 +6091,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
+  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -6119,8 +6101,9 @@ export default function define(runtime, observer) {
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
   $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
-  $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
+  $def("_ga6kci", null, ["Inputs","definition","variable","realize","runtime","inputs"], _ga6kci);  
   $def("_1q557s", null, ["md"], _1q557s);  
+  main.define("realize", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("realize", _));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -16490,10 +16473,9 @@ notebook_semantics_document.nodes.map((s) => ({
 const _1oevsow = function _28(md){return(
 md`### Runtime Representation (v4)`
 )};
-const _11lfflk = function _notebook_semantics_module(){return(
-importShim("https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4"
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _11lfflk = function _notebook_semantics_module() {
+    return import('https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4');
+};
 const _gjten6 = function _31(md){return(
 md`### Imports`
 )};
@@ -17480,65 +17462,44 @@ parser.parseCell(
   'import {runtime, viewof main as foo} from "@mootari/access-runtime"'
 )
 )};
-const _1n7gw17 = function _findModuleName(extractModuleInfo){return(
-(scope, module, { unknown_id = Math.random() } = {}) => {
-  try {
-    const scopedVariables = [...scope.values()];
-
-    // Prefer variables that *define* a module and have a real module-loader name.
-    const candidates = scopedVariables.filter(
-      (v) =>
-        v &&
-        v._value === module &&
-        typeof v._name === "string" &&
-        v._name.startsWith("module ") &&
-        !v._name.startsWith("module <unknown")
-    );
-
-    const pickBestInfo = (dfn) => {
-      // Avoid the parentUrl (2nd arg) confusing module identification.
-      // Typical patterns:
-      //   importShim("/d/<id>@<ver>.js?v=4", "https://api.observablehq.com/@ns/name.js?v=4")
-      //   import("/d/<id>@<ver>.js?v=4")
-      // Prefer the *first argument* inside importShim(...) / import(...) when present.
-      const s = String(dfn ?? "");
-
-      // Try to capture the first string literal argument to importShim(...) or import(...)
-      // Tolerates quotes ", ', ` and both importShim and plain import.
-      const m = s.match(
-        /\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/
-      );
-      const firstArg = m?.[2];
-
-      const info1 = firstArg ? extractModuleInfo(firstArg) : {};
-      if (info1?.id || info1?.notebook) return info1;
-
-      // Fallback: parse the whole definition string.
-      return extractModuleInfo(s);
+const _1n7gw17 = function _findModuleName(extractModuleInfo) {
+    return (scope, module, {
+        unknown_id = Math.random()
+    } = {}) => {
+        try {
+            const scopedVariables = [...scope.values()];
+            const candidates = scopedVariables.filter(v => v && v._value === module && typeof v._name === 'string' && v._name.startsWith('module ') && !v._name.startsWith('module <unknown'));
+            const pickBestInfo = dfn => {
+                const s = String(dfn ?? '');
+                const m = s.match(/\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/);
+                const firstArg = m?.[2];
+                const info1 = firstArg ? extractModuleInfo(firstArg) : {};
+                if (info1?.id || info1?.notebook)
+                    return info1;
+                return extractModuleInfo(s);
+            };
+            for (const v of candidates) {
+                const info = pickBestInfo(v._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            const any = scopedVariables.find(v => v && v._value === module);
+            if (any) {
+                const info = pickBestInfo(any._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            return `<unknown ${ unknown_id }>`;
+        } catch (e) {
+            debugger;
+            return 'error';
+        }
     };
-
-    // Try module loader cells first.
-    for (const v of candidates) {
-      const info = pickBestInfo(v._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    // Fallback: any scoped variable with _value==module.
-    const any = scopedVariables.find((v) => v && v._value === module);
-    if (any) {
-      const info = pickBestInfo(any._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    return `<unknown ${unknown_id}>`;
-  } catch (e) {
-    debugger;
-    return "error";
-  }
-}
-)};
+};
 const _i47chb = function _findImportedName(){return(
 async (v) => {
   if (v._inputs.length == 1 && v._inputs[0]._name === "@variable") {
@@ -18440,229 +18401,206 @@ JSON.stringify(
 const _1lt3kl6 = function _157(compile,test_case){return(
 compile(test_case.value)
 )};
-const _lpzjrv = function _compile(parser,globalThis,observableToJs){return(
-function compile(source, { anonymousName = "_anonymous" } = {}) {
-  const comments = [],
-    tokens = [];
-  let cell;
-  try {
-    cell = parser.parseCell(source, {
-      ranges: true,
-      onComment: comments,
-      onToken: tokens
-    });
-  } catch (e) {
-    if (e instanceof SyntaxError) {
-      const nameMatch = source.match(
-        /^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/
-      );
-      let _name = null;
-      let funcName = anonymousName;
-      if (nameMatch) {
-        const prefix = nameMatch[1] ? nameMatch[1] + " " : "";
-        _name = prefix + nameMatch[2];
-        funcName = "_" + nameMatch[2];
-      }
-      const escapedMsg = JSON.stringify(e.message);
-      const escapedSource = JSON.stringify(source);
-      return [
-        {
-          _name,
-          _inputs: [],
-          _definition: `function ${funcName}() { throw Object.assign(new SyntaxError(${escapedMsg}), {_sourceExpression: ${escapedSource}}); }`
+const _x1d0wm = function _compile(parser,observableToJs){return(
+function compile(source, {
+    anonymousName = '_anonymous'
+} = {}) {
+    const comments = [], tokens = [];
+    let cell;
+    try {
+        cell = parser.parseCell(source, {
+            ranges: true,
+            onComment: comments,
+            onToken: tokens
+        });
+    } catch (e) {
+        if (e instanceof SyntaxError) {
+            const nameMatch = source.match(/^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/);
+            let _name = null;
+            let funcName = anonymousName;
+            if (nameMatch) {
+                const prefix = nameMatch[1] ? nameMatch[1] + ' ' : '';
+                _name = prefix + nameMatch[2];
+                funcName = '_' + nameMatch[2];
+            }
+            const escapedMsg = JSON.stringify(e.message);
+            const escapedSource = JSON.stringify(source);
+            return [{
+                    _name,
+                    _inputs: [],
+                    _definition: `function ${ funcName }() { throw Object.assign(new SyntaxError(${ escapedMsg }), {_sourceExpression: ${ escapedSource }}); }`
+                }];
         }
-      ];
+        throw e;
     }
-    throw e;
-  }
-  if (!cell) throw new Error("Unable to parse cell");
-  const parseImportSpecifierText = (text) => {
-    const t = String(text ?? "")
-      .trim()
-      .replace(/,$/, "")
-      .trim();
-    if (!t) throw new Error("Empty import specifier");
-    const parts = t.split(/\s+as\s+/);
-    const left = parts[0].trim();
-    const right = parts[1]?.trim();
-    const parseSide = (side, { defaultPrefix = "" } = {}) => {
-      const s = String(side ?? "").trim();
-      const m = s.match(/^(viewof|mutable)\s+(.+)$/);
-      if (m)
-        return {
-          prefix: `${m[1]} `,
-          name: m[2].trim()
+    if (!cell)
+        throw new Error('Unable to parse cell');
+    const parseImportSpecifierText = text => {
+        const t = String(text ?? '').trim().replace(/,$/, '').trim();
+        if (!t)
+            throw new Error('Empty import specifier');
+        const parts = t.split(/\s+as\s+/);
+        const left = parts[0].trim();
+        const right = parts[1]?.trim();
+        const parseSide = (side, {
+            defaultPrefix = ''
+        } = {}) => {
+            const s = String(side ?? '').trim();
+            const m = s.match(/^(viewof|mutable)\s+(.+)$/);
+            if (m)
+                return {
+                    prefix: `${ m[1] } `,
+                    name: m[2].trim()
+                };
+            return {
+                prefix: defaultPrefix,
+                name: s
+            };
         };
-      return {
-        prefix: defaultPrefix,
-        name: s
-      };
+        const L = parseSide(left);
+        const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
+        const importedName = `${ L.prefix }${ L.name }`.trim();
+        const localName = `${ R.prefix }${ R.name }`.trim();
+        if (!importedName)
+            throw new Error(`Could not parse imported name from: ${ t }`);
+        if (!localName)
+            throw new Error(`Could not parse local name from: ${ t }`);
+        return {
+            importedName,
+            localName
+        };
     };
-    const L = parseSide(left);
-    const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
-    const importedName = `${L.prefix}${L.name}`.trim();
-    const localName = `${R.prefix}${R.name}`.trim();
-    if (!importedName)
-      throw new Error(`Could not parse imported name from: ${t}`);
-    if (!localName) throw new Error(`Could not parse local name from: ${t}`);
-    return {
-      importedName,
-      localName
-    };
-  };
-  if (!cell.id && cell.body?.type === "ImportDeclaration") {
-    const module_name = cell.body.source.value;
-    const importKeyword = globalThis?.importShim ? "importShim" : "import";
-    const cell_variables = [
-      {
-        _name: `module ${module_name}`,
-        _inputs: [],
-        _definition: `async () => runtime.module((await ${importKeyword}("${module_name}")).default)`
-      }
-    ];
-    for (const specifier of cell.body.specifiers ?? []) {
-      const specText =
-        typeof specifier?.start === "number" &&
-        typeof specifier?.end === "number"
-          ? source.slice(specifier.start, specifier.end)
-          : (() => {
-              if (specifier?.imported?.name && specifier?.local?.name) {
-                return specifier.imported.name === specifier.local.name
-                  ? specifier.local.name
-                  : `${specifier.imported.name} as ${specifier.local.name}`;
-              }
-              throw new Error("Import specifier missing range information");
+    if (!cell.id && cell.body?.type === 'ImportDeclaration') {
+        const module_name = cell.body.source.value;
+        const cell_variables = [{
+                _name: `module ${ module_name }`,
+                _inputs: [],
+                _definition: `async () => runtime.module((await import("${ module_name }")).default)`
+            }];
+        for (const specifier of cell.body.specifiers ?? []) {
+            const specText = typeof specifier?.start === 'number' && typeof specifier?.end === 'number' ? source.slice(specifier.start, specifier.end) : (() => {
+                if (specifier?.imported?.name && specifier?.local?.name) {
+                    return specifier.imported.name === specifier.local.name ? specifier.local.name : `${ specifier.imported.name } as ${ specifier.local.name }`;
+                }
+                throw new Error('Import specifier missing range information');
             })();
-      const { importedName, localName } = parseImportSpecifierText(specText);
-      cell_variables.push({
-        _name: localName,
-        _inputs: [`module ${module_name}`, "@variable"],
-        _definition:
-          importedName === localName
-            ? `(_, v) => v.import("${importedName}", _)`
-            : `(_, v) => v.import("${importedName}", "${localName}", _)`
-      });
+            const {importedName, localName} = parseImportSpecifierText(specText);
+            cell_variables.push({
+                _name: localName,
+                _inputs: [
+                    `module ${ module_name }`,
+                    '@variable'
+                ],
+                _definition: importedName === localName ? `(_, v) => v.import("${ importedName }", _)` : `(_, v) => v.import("${ importedName }", "${ localName }", _)`
+            });
+        }
+        return cell_variables;
     }
-    return cell_variables;
-  }
-  let dollarIdx = 0;
-  const inputToArgMap = {};
-  const dollarToMacro = {};
-  const seen = new Set();
-  const inputs = Array.from(cell.references || []).flatMap((i) => {
-    if (i.name) {
-      if (seen.has(i.name)) return [];
-      seen.add(i.name);
-      return i.name;
+    let dollarIdx = 0;
+    const inputToArgMap = {};
+    const dollarToMacro = {};
+    const seen = new Set();
+    const inputs = Array.from(cell.references || []).flatMap(i => {
+        if (i.name) {
+            if (seen.has(i.name))
+                return [];
+            seen.add(i.name);
+            return i.name;
+        } else {
+            const dedupKey = i.type + ':' + i.id.name;
+            if (seen.has(dedupKey))
+                return [];
+            seen.add(dedupKey);
+            const dollarName = '$' + dollarIdx;
+            inputToArgMap[i.id.name] = dollarName;
+            dollarToMacro[dollarName] = i.type == 'ViewExpression' ? 'viewof ' + i.id.name : 'mutable ' + i.id.name;
+            dollarIdx++;
+            return dollarName;
+        }
+    });
+    let variables;
+    if (cell.id) {
+        if (cell.id.type === 'Identifier') {
+            variables = [{
+                    functionName: '_' + cell.id.name,
+                    name: cell.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                }];
+        } else if (cell.id.type === 'ViewExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'viewof ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '(G, _) => G.input(_)',
+                    inputs: [
+                        'Generators',
+                        'viewof ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                }
+            ];
+        } else if (cell.id.type === 'MutableExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'initial ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'mutable ' + cell.id.id.name,
+                    _definition: '(M, _) => new M(_)',
+                    inputs: [
+                        'Mutable',
+                        'initial ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '_ => _.generator',
+                    inputs: ['mutable ' + cell.id.id.name],
+                    params: inputs.join(',')
+                }
+            ];
+        } else {
+            throw new Error(`Unsupported cell id type: ${ cell.id.type }`);
+        }
     } else {
-      const dedupKey = i.type + ":" + i.id.name;
-      if (seen.has(dedupKey)) return [];
-      seen.add(dedupKey);
-      const dollarName = "$" + dollarIdx;
-      inputToArgMap[i.id.name] = dollarName;
-      dollarToMacro[dollarName] =
-        i.type == "ViewExpression"
-          ? "viewof " + i.id.name
-          : "mutable " + i.id.name;
-      dollarIdx++;
-      return dollarName;
+        variables = [{
+                functionName: anonymousName,
+                name: null,
+                inputs,
+                params: inputs.join(',')
+            }];
     }
-  });
-  let variables;
-  if (cell.id) {
-    if (cell.id.type === "Identifier") {
-      variables = [
-        {
-          functionName: "_" + cell.id.name,
-          name: cell.id.name,
-          inputs,
-          params: inputs.join(",")
+    return variables.map(v => {
+        let _definition = v._definition;
+        if (!_definition) {
+            let functionBody;
+            if (cell.body.type === 'BlockStatement') {
+                functionBody = observableToJs(cell.body, inputToArgMap, comments, tokens);
+            } else {
+                const bodyCode = observableToJs(cell.body, inputToArgMap, comments, tokens);
+                functionBody = `{return (${ bodyCode });}`;
+            }
+            _definition = `${ cell.async ? 'async ' : '' }function${ cell.generator ? '*' : '' } ${ v.functionName }(${ v.inputs.join(',') }) ${ functionBody }`;
         }
-      ];
-    } else if (cell.id.type === "ViewExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "viewof " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "(G, _) => G.input(_)",
-          inputs: ["Generators", "viewof " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else if (cell.id.type === "MutableExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "initial " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "mutable " + cell.id.id.name,
-          _definition: "(M, _) => new M(_)",
-          inputs: ["Mutable", "initial " + cell.id.id.name],
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "_ => _.generator",
-          inputs: ["mutable " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else {
-      throw new Error(`Unsupported cell id type: ${cell.id.type}`);
-    }
-  } else {
-    variables = [
-      {
-        functionName: anonymousName,
-        name: null,
-        inputs,
-        params: inputs.join(",")
-      }
-    ];
-  }
-  return variables.map((v) => {
-    let _definition = v._definition;
-    if (!_definition) {
-      let functionBody;
-      if (cell.body.type === "BlockStatement") {
-        functionBody = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-      } else {
-        const bodyCode = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-        functionBody = `{return (${bodyCode});}`;
-      }
-      _definition = `${cell.async ? "async " : ""}function${
-        cell.generator ? "*" : ""
-      } ${v.functionName}(${v.inputs.join(",")}) ${functionBody}`;
-    }
-    return {
-      _name: v.name,
-      _inputs: v.inputs.map(
-        (i) => dollarToMacro[i] || (i === "$variable" ? "@variable" : i)
-      ),
-      _definition
-    };
-  });
+        return {
+            _name: v.name,
+            _inputs: v.inputs.map(i => dollarToMacro[i] || (i === '$variable' ? '@variable' : i)),
+            _definition
+        };
+    });
 }
 )};
 const _1v1i7wl = function _observableToJs(acorn_walk,parser,escodegen){return(
@@ -18729,16 +18667,15 @@ async (attachment, overrides) => {
   return URL.createObjectURL(blob);
 }
 )};
-const _s9w7ha = async function _parser(decompress_url,FileAttachment,acorn_url,acorn_walk_url){return(
-importShim(await decompress_url(FileAttachment("parser-6.1.0.js.gz"), {
-    "/npm/acorn@8.11.3/+esm": acorn_url,
-    "/npm/acorn-walk@8.3.2/+esm": acorn_walk_url
-  })
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
-const _1hiclbb = function _acorn_walk(acorn_walk_url){return(
-importShim(acorn_walk_url, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _s9w7ha = async function _parser(decompress_url, FileAttachment, acorn_url, acorn_walk_url) {
+    return import(await decompress_url(FileAttachment('parser-6.1.0.js.gz'), {
+        '/npm/acorn@8.11.3/+esm': acorn_url,
+        '/npm/acorn-walk@8.3.2/+esm': acorn_walk_url
+    }));
+};
+const _1hiclbb = function _acorn_walk(acorn_walk_url) {
+    return import(acorn_walk_url);
+};
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
@@ -18926,7 +18863,7 @@ export default function define(runtime, observer) {
   $def("_1dmmuaf", "compiled_selector", ["Generators","viewof compiled_selector"], _1dmmuaf);  
   $def("_u7t3vu", null, ["compiled_selector","normalizeJavascriptSource"], _u7t3vu);  
   $def("_1lt3kl6", null, ["compile","test_case"], _1lt3kl6);  
-  $def("_lpzjrv", "compile", ["parser","globalThis","observableToJs"], _lpzjrv);  
+  $def("_x1d0wm", "compile", ["parser","observableToJs"], _x1d0wm);  
   $def("_1v1i7wl", "observableToJs", ["acorn_walk","parser","escodegen"], _1v1i7wl);  
   $def("_19lv24l", null, ["md"], _19lv24l);  
   $def("_xhj6b8", "decompress_url", ["DecompressionStream","TextDecoderStream","TransformStream","TextEncoderStream","Response"], _xhj6b8);  

--- a/notebooks/@tomlarkworthy_jumpgate.html
+++ b/notebooks/@tomlarkworthy_jumpgate.html
@@ -5415,58 +5415,41 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _geoudp = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
-  if (command.processed) return;
-
-  let result = undefined;
-  if (command.command == "createCell") {
-    $0.value = true;
-    result = compile_and_update("{}", [], command.args.cell);
-    // For the new one to get focus
-    // setTimeout(() => {
-    //   debugger;
-    //   setOption(result[0], "pinned", true);
-    // }, 100);
-  } else if (command.command == "deleteCell") {
-    remove_variables(command.args.cell.variables);
-    result = true;
-  } else if (command.command == "moveCell") {
-    const cellIndex = findCellIndex(
-      command.args.cell.variables,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const targetCellIndex = cellIndex + command.args.amount;
-    const targetCell = lookupCellByIndex(
-      targetCellIndex,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const currentFirstVariableIndex = findVariableIndex(
-      command.args.cell.variables[0]
-    );
-    const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-    const change = targetFirstVariableIndex - currentFirstVariableIndex;
-    console.log(
-      "moveCell",
-      cellIndex,
-      targetCellIndex,
-      targetCell,
-      currentFirstVariableIndex,
-      targetFirstVariableIndex,
-      change
-    );
-    command.args.cell.variables.forEach((v) => {
-      const currentIndex = findVariableIndex(v);
-      repositionSetElement(runtime._variables, v, currentIndex + change);
-    });
-    // recompute
-    await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
-    result = true;
-  }
-  if (result) {
-    command.processed = true;
-    $2.resolve(result);
-  }
+    if (command.processed)
+        return;
+    let result = undefined;
+    if (command.command == 'createCell') {
+        $0.value = true;
+        result = await compile_and_update('{}', [], command.args.cell);    // For the new one to get focus
+                                                                           // setTimeout(() => {
+                                                                           //   debugger;
+                                                                           //   setOption(result[0], "pinned", true);
+                                                                           // }, 100);
+    } else if (command.command == 'deleteCell') {
+        remove_variables(command.args.cell.variables);
+        result = true;
+    } else if (command.command == 'moveCell') {
+        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const targetCellIndex = cellIndex + command.args.amount;
+        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
+        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+        const change = targetFirstVariableIndex - currentFirstVariableIndex;
+        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
+        command.args.cell.variables.forEach(v => {
+            const currentIndex = findVariableIndex(v);
+            repositionSetElement(runtime._variables, v, currentIndex + change);
+        });
+        // recompute
+        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        result = true;
+    }
+    if (result) {
+        command.processed = true;
+        $2.resolve(result);
+    }
 };
 const _1jadxoe = function _60(md){return(
 md`### UI Action`
@@ -5857,9 +5840,9 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
-    return (source, variables = [], cell) => {
+    return async (source, variables = [], cell) => {
         try {
             debugger;
             let reposition = false, insertionIndex = -1;
@@ -5879,10 +5862,10 @@ const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElemen
             if (reposition) {
                 insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
+            const fns = await realize(newVariables.map(v => v._definition), runtime);
             newVariables.forEach((v, i) => {
                 const variable = variables[i];
-                let _fn;
-                eval('_fn = ' + v._definition);
+                const _fn = fns[i];
                 if (v._name) {
                     variable.define(v._name, v._inputs, _fn);
                 } else {
@@ -5931,12 +5914,11 @@ Inputs.textarea({
 })
 )};
 const _b4rsn5 = (G, _) => G.input(_);
-const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
+const _ga6kci = function _98(Inputs,definition,variable,realize,runtime,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
-  reduce: () => {
-    let _fn;
-    eval("_fn = " + definition);
+  reduce: async () => {
+    const [_fn] = await realize([definition], runtime);
     variable.define(variable._name, inputs, _fn);
   }
 })
@@ -6049,7 +6031,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_geoudp", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _geoudp);  
+  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6087,7 +6069,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
+  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -6097,8 +6079,9 @@ export default function define(runtime, observer) {
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
   $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
-  $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
+  $def("_ga6kci", null, ["Inputs","definition","variable","realize","runtime","inputs"], _ga6kci);  
   $def("_1q557s", null, ["md"], _1q557s);  
+  main.define("realize", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("realize", _));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -15884,10 +15867,9 @@ notebook_semantics_document.nodes.map((s) => ({
 const _1oevsow = function _28(md){return(
 md`### Runtime Representation (v4)`
 )};
-const _11lfflk = function _notebook_semantics_module(){return(
-importShim("https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4"
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _11lfflk = function _notebook_semantics_module() {
+    return import('https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4');
+};
 const _gjten6 = function _31(md){return(
 md`### Imports`
 )};
@@ -16874,65 +16856,44 @@ parser.parseCell(
   'import {runtime, viewof main as foo} from "@mootari/access-runtime"'
 )
 )};
-const _1n7gw17 = function _findModuleName(extractModuleInfo){return(
-(scope, module, { unknown_id = Math.random() } = {}) => {
-  try {
-    const scopedVariables = [...scope.values()];
-
-    // Prefer variables that *define* a module and have a real module-loader name.
-    const candidates = scopedVariables.filter(
-      (v) =>
-        v &&
-        v._value === module &&
-        typeof v._name === "string" &&
-        v._name.startsWith("module ") &&
-        !v._name.startsWith("module <unknown")
-    );
-
-    const pickBestInfo = (dfn) => {
-      // Avoid the parentUrl (2nd arg) confusing module identification.
-      // Typical patterns:
-      //   importShim("/d/<id>@<ver>.js?v=4", "https://api.observablehq.com/@ns/name.js?v=4")
-      //   import("/d/<id>@<ver>.js?v=4")
-      // Prefer the *first argument* inside importShim(...) / import(...) when present.
-      const s = String(dfn ?? "");
-
-      // Try to capture the first string literal argument to importShim(...) or import(...)
-      // Tolerates quotes ", ', ` and both importShim and plain import.
-      const m = s.match(
-        /\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/
-      );
-      const firstArg = m?.[2];
-
-      const info1 = firstArg ? extractModuleInfo(firstArg) : {};
-      if (info1?.id || info1?.notebook) return info1;
-
-      // Fallback: parse the whole definition string.
-      return extractModuleInfo(s);
+const _1n7gw17 = function _findModuleName(extractModuleInfo) {
+    return (scope, module, {
+        unknown_id = Math.random()
+    } = {}) => {
+        try {
+            const scopedVariables = [...scope.values()];
+            const candidates = scopedVariables.filter(v => v && v._value === module && typeof v._name === 'string' && v._name.startsWith('module ') && !v._name.startsWith('module <unknown'));
+            const pickBestInfo = dfn => {
+                const s = String(dfn ?? '');
+                const m = s.match(/\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/);
+                const firstArg = m?.[2];
+                const info1 = firstArg ? extractModuleInfo(firstArg) : {};
+                if (info1?.id || info1?.notebook)
+                    return info1;
+                return extractModuleInfo(s);
+            };
+            for (const v of candidates) {
+                const info = pickBestInfo(v._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            const any = scopedVariables.find(v => v && v._value === module);
+            if (any) {
+                const info = pickBestInfo(any._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            return `<unknown ${ unknown_id }>`;
+        } catch (e) {
+            debugger;
+            return 'error';
+        }
     };
-
-    // Try module loader cells first.
-    for (const v of candidates) {
-      const info = pickBestInfo(v._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    // Fallback: any scoped variable with _value==module.
-    const any = scopedVariables.find((v) => v && v._value === module);
-    if (any) {
-      const info = pickBestInfo(any._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    return `<unknown ${unknown_id}>`;
-  } catch (e) {
-    debugger;
-    return "error";
-  }
-}
-)};
+};
 const _i47chb = function _findImportedName(){return(
 async (v) => {
   if (v._inputs.length == 1 && v._inputs[0]._name === "@variable") {
@@ -17834,229 +17795,206 @@ JSON.stringify(
 const _1lt3kl6 = function _157(compile,test_case){return(
 compile(test_case.value)
 )};
-const _lpzjrv = function _compile(parser,globalThis,observableToJs){return(
-function compile(source, { anonymousName = "_anonymous" } = {}) {
-  const comments = [],
-    tokens = [];
-  let cell;
-  try {
-    cell = parser.parseCell(source, {
-      ranges: true,
-      onComment: comments,
-      onToken: tokens
-    });
-  } catch (e) {
-    if (e instanceof SyntaxError) {
-      const nameMatch = source.match(
-        /^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/
-      );
-      let _name = null;
-      let funcName = anonymousName;
-      if (nameMatch) {
-        const prefix = nameMatch[1] ? nameMatch[1] + " " : "";
-        _name = prefix + nameMatch[2];
-        funcName = "_" + nameMatch[2];
-      }
-      const escapedMsg = JSON.stringify(e.message);
-      const escapedSource = JSON.stringify(source);
-      return [
-        {
-          _name,
-          _inputs: [],
-          _definition: `function ${funcName}() { throw Object.assign(new SyntaxError(${escapedMsg}), {_sourceExpression: ${escapedSource}}); }`
+const _x1d0wm = function _compile(parser,observableToJs){return(
+function compile(source, {
+    anonymousName = '_anonymous'
+} = {}) {
+    const comments = [], tokens = [];
+    let cell;
+    try {
+        cell = parser.parseCell(source, {
+            ranges: true,
+            onComment: comments,
+            onToken: tokens
+        });
+    } catch (e) {
+        if (e instanceof SyntaxError) {
+            const nameMatch = source.match(/^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/);
+            let _name = null;
+            let funcName = anonymousName;
+            if (nameMatch) {
+                const prefix = nameMatch[1] ? nameMatch[1] + ' ' : '';
+                _name = prefix + nameMatch[2];
+                funcName = '_' + nameMatch[2];
+            }
+            const escapedMsg = JSON.stringify(e.message);
+            const escapedSource = JSON.stringify(source);
+            return [{
+                    _name,
+                    _inputs: [],
+                    _definition: `function ${ funcName }() { throw Object.assign(new SyntaxError(${ escapedMsg }), {_sourceExpression: ${ escapedSource }}); }`
+                }];
         }
-      ];
+        throw e;
     }
-    throw e;
-  }
-  if (!cell) throw new Error("Unable to parse cell");
-  const parseImportSpecifierText = (text) => {
-    const t = String(text ?? "")
-      .trim()
-      .replace(/,$/, "")
-      .trim();
-    if (!t) throw new Error("Empty import specifier");
-    const parts = t.split(/\s+as\s+/);
-    const left = parts[0].trim();
-    const right = parts[1]?.trim();
-    const parseSide = (side, { defaultPrefix = "" } = {}) => {
-      const s = String(side ?? "").trim();
-      const m = s.match(/^(viewof|mutable)\s+(.+)$/);
-      if (m)
-        return {
-          prefix: `${m[1]} `,
-          name: m[2].trim()
+    if (!cell)
+        throw new Error('Unable to parse cell');
+    const parseImportSpecifierText = text => {
+        const t = String(text ?? '').trim().replace(/,$/, '').trim();
+        if (!t)
+            throw new Error('Empty import specifier');
+        const parts = t.split(/\s+as\s+/);
+        const left = parts[0].trim();
+        const right = parts[1]?.trim();
+        const parseSide = (side, {
+            defaultPrefix = ''
+        } = {}) => {
+            const s = String(side ?? '').trim();
+            const m = s.match(/^(viewof|mutable)\s+(.+)$/);
+            if (m)
+                return {
+                    prefix: `${ m[1] } `,
+                    name: m[2].trim()
+                };
+            return {
+                prefix: defaultPrefix,
+                name: s
+            };
         };
-      return {
-        prefix: defaultPrefix,
-        name: s
-      };
+        const L = parseSide(left);
+        const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
+        const importedName = `${ L.prefix }${ L.name }`.trim();
+        const localName = `${ R.prefix }${ R.name }`.trim();
+        if (!importedName)
+            throw new Error(`Could not parse imported name from: ${ t }`);
+        if (!localName)
+            throw new Error(`Could not parse local name from: ${ t }`);
+        return {
+            importedName,
+            localName
+        };
     };
-    const L = parseSide(left);
-    const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
-    const importedName = `${L.prefix}${L.name}`.trim();
-    const localName = `${R.prefix}${R.name}`.trim();
-    if (!importedName)
-      throw new Error(`Could not parse imported name from: ${t}`);
-    if (!localName) throw new Error(`Could not parse local name from: ${t}`);
-    return {
-      importedName,
-      localName
-    };
-  };
-  if (!cell.id && cell.body?.type === "ImportDeclaration") {
-    const module_name = cell.body.source.value;
-    const importKeyword = globalThis?.importShim ? "importShim" : "import";
-    const cell_variables = [
-      {
-        _name: `module ${module_name}`,
-        _inputs: [],
-        _definition: `async () => runtime.module((await ${importKeyword}("${module_name}")).default)`
-      }
-    ];
-    for (const specifier of cell.body.specifiers ?? []) {
-      const specText =
-        typeof specifier?.start === "number" &&
-        typeof specifier?.end === "number"
-          ? source.slice(specifier.start, specifier.end)
-          : (() => {
-              if (specifier?.imported?.name && specifier?.local?.name) {
-                return specifier.imported.name === specifier.local.name
-                  ? specifier.local.name
-                  : `${specifier.imported.name} as ${specifier.local.name}`;
-              }
-              throw new Error("Import specifier missing range information");
+    if (!cell.id && cell.body?.type === 'ImportDeclaration') {
+        const module_name = cell.body.source.value;
+        const cell_variables = [{
+                _name: `module ${ module_name }`,
+                _inputs: [],
+                _definition: `async () => runtime.module((await import("${ module_name }")).default)`
+            }];
+        for (const specifier of cell.body.specifiers ?? []) {
+            const specText = typeof specifier?.start === 'number' && typeof specifier?.end === 'number' ? source.slice(specifier.start, specifier.end) : (() => {
+                if (specifier?.imported?.name && specifier?.local?.name) {
+                    return specifier.imported.name === specifier.local.name ? specifier.local.name : `${ specifier.imported.name } as ${ specifier.local.name }`;
+                }
+                throw new Error('Import specifier missing range information');
             })();
-      const { importedName, localName } = parseImportSpecifierText(specText);
-      cell_variables.push({
-        _name: localName,
-        _inputs: [`module ${module_name}`, "@variable"],
-        _definition:
-          importedName === localName
-            ? `(_, v) => v.import("${importedName}", _)`
-            : `(_, v) => v.import("${importedName}", "${localName}", _)`
-      });
+            const {importedName, localName} = parseImportSpecifierText(specText);
+            cell_variables.push({
+                _name: localName,
+                _inputs: [
+                    `module ${ module_name }`,
+                    '@variable'
+                ],
+                _definition: importedName === localName ? `(_, v) => v.import("${ importedName }", _)` : `(_, v) => v.import("${ importedName }", "${ localName }", _)`
+            });
+        }
+        return cell_variables;
     }
-    return cell_variables;
-  }
-  let dollarIdx = 0;
-  const inputToArgMap = {};
-  const dollarToMacro = {};
-  const seen = new Set();
-  const inputs = Array.from(cell.references || []).flatMap((i) => {
-    if (i.name) {
-      if (seen.has(i.name)) return [];
-      seen.add(i.name);
-      return i.name;
+    let dollarIdx = 0;
+    const inputToArgMap = {};
+    const dollarToMacro = {};
+    const seen = new Set();
+    const inputs = Array.from(cell.references || []).flatMap(i => {
+        if (i.name) {
+            if (seen.has(i.name))
+                return [];
+            seen.add(i.name);
+            return i.name;
+        } else {
+            const dedupKey = i.type + ':' + i.id.name;
+            if (seen.has(dedupKey))
+                return [];
+            seen.add(dedupKey);
+            const dollarName = '$' + dollarIdx;
+            inputToArgMap[i.id.name] = dollarName;
+            dollarToMacro[dollarName] = i.type == 'ViewExpression' ? 'viewof ' + i.id.name : 'mutable ' + i.id.name;
+            dollarIdx++;
+            return dollarName;
+        }
+    });
+    let variables;
+    if (cell.id) {
+        if (cell.id.type === 'Identifier') {
+            variables = [{
+                    functionName: '_' + cell.id.name,
+                    name: cell.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                }];
+        } else if (cell.id.type === 'ViewExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'viewof ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '(G, _) => G.input(_)',
+                    inputs: [
+                        'Generators',
+                        'viewof ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                }
+            ];
+        } else if (cell.id.type === 'MutableExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'initial ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'mutable ' + cell.id.id.name,
+                    _definition: '(M, _) => new M(_)',
+                    inputs: [
+                        'Mutable',
+                        'initial ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '_ => _.generator',
+                    inputs: ['mutable ' + cell.id.id.name],
+                    params: inputs.join(',')
+                }
+            ];
+        } else {
+            throw new Error(`Unsupported cell id type: ${ cell.id.type }`);
+        }
     } else {
-      const dedupKey = i.type + ":" + i.id.name;
-      if (seen.has(dedupKey)) return [];
-      seen.add(dedupKey);
-      const dollarName = "$" + dollarIdx;
-      inputToArgMap[i.id.name] = dollarName;
-      dollarToMacro[dollarName] =
-        i.type == "ViewExpression"
-          ? "viewof " + i.id.name
-          : "mutable " + i.id.name;
-      dollarIdx++;
-      return dollarName;
+        variables = [{
+                functionName: anonymousName,
+                name: null,
+                inputs,
+                params: inputs.join(',')
+            }];
     }
-  });
-  let variables;
-  if (cell.id) {
-    if (cell.id.type === "Identifier") {
-      variables = [
-        {
-          functionName: "_" + cell.id.name,
-          name: cell.id.name,
-          inputs,
-          params: inputs.join(",")
+    return variables.map(v => {
+        let _definition = v._definition;
+        if (!_definition) {
+            let functionBody;
+            if (cell.body.type === 'BlockStatement') {
+                functionBody = observableToJs(cell.body, inputToArgMap, comments, tokens);
+            } else {
+                const bodyCode = observableToJs(cell.body, inputToArgMap, comments, tokens);
+                functionBody = `{return (${ bodyCode });}`;
+            }
+            _definition = `${ cell.async ? 'async ' : '' }function${ cell.generator ? '*' : '' } ${ v.functionName }(${ v.inputs.join(',') }) ${ functionBody }`;
         }
-      ];
-    } else if (cell.id.type === "ViewExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "viewof " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "(G, _) => G.input(_)",
-          inputs: ["Generators", "viewof " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else if (cell.id.type === "MutableExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "initial " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "mutable " + cell.id.id.name,
-          _definition: "(M, _) => new M(_)",
-          inputs: ["Mutable", "initial " + cell.id.id.name],
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "_ => _.generator",
-          inputs: ["mutable " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else {
-      throw new Error(`Unsupported cell id type: ${cell.id.type}`);
-    }
-  } else {
-    variables = [
-      {
-        functionName: anonymousName,
-        name: null,
-        inputs,
-        params: inputs.join(",")
-      }
-    ];
-  }
-  return variables.map((v) => {
-    let _definition = v._definition;
-    if (!_definition) {
-      let functionBody;
-      if (cell.body.type === "BlockStatement") {
-        functionBody = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-      } else {
-        const bodyCode = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-        functionBody = `{return (${bodyCode});}`;
-      }
-      _definition = `${cell.async ? "async " : ""}function${
-        cell.generator ? "*" : ""
-      } ${v.functionName}(${v.inputs.join(",")}) ${functionBody}`;
-    }
-    return {
-      _name: v.name,
-      _inputs: v.inputs.map(
-        (i) => dollarToMacro[i] || (i === "$variable" ? "@variable" : i)
-      ),
-      _definition
-    };
-  });
+        return {
+            _name: v.name,
+            _inputs: v.inputs.map(i => dollarToMacro[i] || (i === '$variable' ? '@variable' : i)),
+            _definition
+        };
+    });
 }
 )};
 const _1v1i7wl = function _observableToJs(acorn_walk,parser,escodegen){return(
@@ -18123,16 +18061,15 @@ async (attachment, overrides) => {
   return URL.createObjectURL(blob);
 }
 )};
-const _s9w7ha = async function _parser(decompress_url,FileAttachment,acorn_url,acorn_walk_url){return(
-importShim(await decompress_url(FileAttachment("parser-6.1.0.js.gz"), {
-    "/npm/acorn@8.11.3/+esm": acorn_url,
-    "/npm/acorn-walk@8.3.2/+esm": acorn_walk_url
-  })
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
-const _1hiclbb = function _acorn_walk(acorn_walk_url){return(
-importShim(acorn_walk_url, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _s9w7ha = async function _parser(decompress_url, FileAttachment, acorn_url, acorn_walk_url) {
+    return import(await decompress_url(FileAttachment('parser-6.1.0.js.gz'), {
+        '/npm/acorn@8.11.3/+esm': acorn_url,
+        '/npm/acorn-walk@8.3.2/+esm': acorn_walk_url
+    }));
+};
+const _1hiclbb = function _acorn_walk(acorn_walk_url) {
+    return import(acorn_walk_url);
+};
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
@@ -18320,7 +18257,7 @@ export default function define(runtime, observer) {
   $def("_1dmmuaf", "compiled_selector", ["Generators","viewof compiled_selector"], _1dmmuaf);  
   $def("_u7t3vu", null, ["compiled_selector","normalizeJavascriptSource"], _u7t3vu);  
   $def("_1lt3kl6", null, ["compile","test_case"], _1lt3kl6);  
-  $def("_lpzjrv", "compile", ["parser","globalThis","observableToJs"], _lpzjrv);  
+  $def("_x1d0wm", "compile", ["parser","observableToJs"], _x1d0wm);  
   $def("_1v1i7wl", "observableToJs", ["acorn_walk","parser","escodegen"], _1v1i7wl);  
   $def("_19lv24l", null, ["md"], _19lv24l);  
   $def("_xhj6b8", "decompress_url", ["DecompressionStream","TextDecoderStream","TransformStream","TextEncoderStream","Response"], _xhj6b8);  

--- a/notebooks/@tomlarkworthy_local-change-history.html
+++ b/notebooks/@tomlarkworthy_local-change-history.html
@@ -5415,58 +5415,41 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _geoudp = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
-  if (command.processed) return;
-
-  let result = undefined;
-  if (command.command == "createCell") {
-    $0.value = true;
-    result = compile_and_update("{}", [], command.args.cell);
-    // For the new one to get focus
-    // setTimeout(() => {
-    //   debugger;
-    //   setOption(result[0], "pinned", true);
-    // }, 100);
-  } else if (command.command == "deleteCell") {
-    remove_variables(command.args.cell.variables);
-    result = true;
-  } else if (command.command == "moveCell") {
-    const cellIndex = findCellIndex(
-      command.args.cell.variables,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const targetCellIndex = cellIndex + command.args.amount;
-    const targetCell = lookupCellByIndex(
-      targetCellIndex,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const currentFirstVariableIndex = findVariableIndex(
-      command.args.cell.variables[0]
-    );
-    const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-    const change = targetFirstVariableIndex - currentFirstVariableIndex;
-    console.log(
-      "moveCell",
-      cellIndex,
-      targetCellIndex,
-      targetCell,
-      currentFirstVariableIndex,
-      targetFirstVariableIndex,
-      change
-    );
-    command.args.cell.variables.forEach((v) => {
-      const currentIndex = findVariableIndex(v);
-      repositionSetElement(runtime._variables, v, currentIndex + change);
-    });
-    // recompute
-    await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
-    result = true;
-  }
-  if (result) {
-    command.processed = true;
-    $2.resolve(result);
-  }
+    if (command.processed)
+        return;
+    let result = undefined;
+    if (command.command == 'createCell') {
+        $0.value = true;
+        result = await compile_and_update('{}', [], command.args.cell);    // For the new one to get focus
+                                                                           // setTimeout(() => {
+                                                                           //   debugger;
+                                                                           //   setOption(result[0], "pinned", true);
+                                                                           // }, 100);
+    } else if (command.command == 'deleteCell') {
+        remove_variables(command.args.cell.variables);
+        result = true;
+    } else if (command.command == 'moveCell') {
+        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const targetCellIndex = cellIndex + command.args.amount;
+        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
+        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+        const change = targetFirstVariableIndex - currentFirstVariableIndex;
+        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
+        command.args.cell.variables.forEach(v => {
+            const currentIndex = findVariableIndex(v);
+            repositionSetElement(runtime._variables, v, currentIndex + change);
+        });
+        // recompute
+        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        result = true;
+    }
+    if (result) {
+        command.processed = true;
+        $2.resolve(result);
+    }
 };
 const _1jadxoe = function _60(md){return(
 md`### UI Action`
@@ -5857,9 +5840,9 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
-    return (source, variables = [], cell) => {
+    return async (source, variables = [], cell) => {
         try {
             debugger;
             let reposition = false, insertionIndex = -1;
@@ -5879,10 +5862,10 @@ const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElemen
             if (reposition) {
                 insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
+            const fns = await realize(newVariables.map(v => v._definition), runtime);
             newVariables.forEach((v, i) => {
                 const variable = variables[i];
-                let _fn;
-                eval('_fn = ' + v._definition);
+                const _fn = fns[i];
                 if (v._name) {
                     variable.define(v._name, v._inputs, _fn);
                 } else {
@@ -5931,12 +5914,11 @@ Inputs.textarea({
 })
 )};
 const _b4rsn5 = (G, _) => G.input(_);
-const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
+const _ga6kci = function _98(Inputs,definition,variable,realize,runtime,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
-  reduce: () => {
-    let _fn;
-    eval("_fn = " + definition);
+  reduce: async () => {
+    const [_fn] = await realize([definition], runtime);
     variable.define(variable._name, inputs, _fn);
   }
 })
@@ -6049,7 +6031,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_geoudp", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _geoudp);  
+  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6087,7 +6069,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
+  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -6097,8 +6079,9 @@ export default function define(runtime, observer) {
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
   $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
-  $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
+  $def("_ga6kci", null, ["Inputs","definition","variable","realize","runtime","inputs"], _ga6kci);  
   $def("_1q557s", null, ["md"], _1q557s);  
+  main.define("realize", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("realize", _));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -15258,10 +15241,9 @@ notebook_semantics_document.nodes.map((s) => ({
 const _1oevsow = function _28(md){return(
 md`### Runtime Representation (v4)`
 )};
-const _11lfflk = function _notebook_semantics_module(){return(
-importShim("https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4"
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _11lfflk = function _notebook_semantics_module() {
+    return import('https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4');
+};
 const _gjten6 = function _31(md){return(
 md`### Imports`
 )};
@@ -16248,65 +16230,44 @@ parser.parseCell(
   'import {runtime, viewof main as foo} from "@mootari/access-runtime"'
 )
 )};
-const _1n7gw17 = function _findModuleName(extractModuleInfo){return(
-(scope, module, { unknown_id = Math.random() } = {}) => {
-  try {
-    const scopedVariables = [...scope.values()];
-
-    // Prefer variables that *define* a module and have a real module-loader name.
-    const candidates = scopedVariables.filter(
-      (v) =>
-        v &&
-        v._value === module &&
-        typeof v._name === "string" &&
-        v._name.startsWith("module ") &&
-        !v._name.startsWith("module <unknown")
-    );
-
-    const pickBestInfo = (dfn) => {
-      // Avoid the parentUrl (2nd arg) confusing module identification.
-      // Typical patterns:
-      //   importShim("/d/<id>@<ver>.js?v=4", "https://api.observablehq.com/@ns/name.js?v=4")
-      //   import("/d/<id>@<ver>.js?v=4")
-      // Prefer the *first argument* inside importShim(...) / import(...) when present.
-      const s = String(dfn ?? "");
-
-      // Try to capture the first string literal argument to importShim(...) or import(...)
-      // Tolerates quotes ", ', ` and both importShim and plain import.
-      const m = s.match(
-        /\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/
-      );
-      const firstArg = m?.[2];
-
-      const info1 = firstArg ? extractModuleInfo(firstArg) : {};
-      if (info1?.id || info1?.notebook) return info1;
-
-      // Fallback: parse the whole definition string.
-      return extractModuleInfo(s);
+const _1n7gw17 = function _findModuleName(extractModuleInfo) {
+    return (scope, module, {
+        unknown_id = Math.random()
+    } = {}) => {
+        try {
+            const scopedVariables = [...scope.values()];
+            const candidates = scopedVariables.filter(v => v && v._value === module && typeof v._name === 'string' && v._name.startsWith('module ') && !v._name.startsWith('module <unknown'));
+            const pickBestInfo = dfn => {
+                const s = String(dfn ?? '');
+                const m = s.match(/\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/);
+                const firstArg = m?.[2];
+                const info1 = firstArg ? extractModuleInfo(firstArg) : {};
+                if (info1?.id || info1?.notebook)
+                    return info1;
+                return extractModuleInfo(s);
+            };
+            for (const v of candidates) {
+                const info = pickBestInfo(v._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            const any = scopedVariables.find(v => v && v._value === module);
+            if (any) {
+                const info = pickBestInfo(any._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            return `<unknown ${ unknown_id }>`;
+        } catch (e) {
+            debugger;
+            return 'error';
+        }
     };
-
-    // Try module loader cells first.
-    for (const v of candidates) {
-      const info = pickBestInfo(v._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    // Fallback: any scoped variable with _value==module.
-    const any = scopedVariables.find((v) => v && v._value === module);
-    if (any) {
-      const info = pickBestInfo(any._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    return `<unknown ${unknown_id}>`;
-  } catch (e) {
-    debugger;
-    return "error";
-  }
-}
-)};
+};
 const _i47chb = function _findImportedName(){return(
 async (v) => {
   if (v._inputs.length == 1 && v._inputs[0]._name === "@variable") {
@@ -17208,229 +17169,206 @@ JSON.stringify(
 const _1lt3kl6 = function _157(compile,test_case){return(
 compile(test_case.value)
 )};
-const _lpzjrv = function _compile(parser,globalThis,observableToJs){return(
-function compile(source, { anonymousName = "_anonymous" } = {}) {
-  const comments = [],
-    tokens = [];
-  let cell;
-  try {
-    cell = parser.parseCell(source, {
-      ranges: true,
-      onComment: comments,
-      onToken: tokens
-    });
-  } catch (e) {
-    if (e instanceof SyntaxError) {
-      const nameMatch = source.match(
-        /^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/
-      );
-      let _name = null;
-      let funcName = anonymousName;
-      if (nameMatch) {
-        const prefix = nameMatch[1] ? nameMatch[1] + " " : "";
-        _name = prefix + nameMatch[2];
-        funcName = "_" + nameMatch[2];
-      }
-      const escapedMsg = JSON.stringify(e.message);
-      const escapedSource = JSON.stringify(source);
-      return [
-        {
-          _name,
-          _inputs: [],
-          _definition: `function ${funcName}() { throw Object.assign(new SyntaxError(${escapedMsg}), {_sourceExpression: ${escapedSource}}); }`
+const _x1d0wm = function _compile(parser,observableToJs){return(
+function compile(source, {
+    anonymousName = '_anonymous'
+} = {}) {
+    const comments = [], tokens = [];
+    let cell;
+    try {
+        cell = parser.parseCell(source, {
+            ranges: true,
+            onComment: comments,
+            onToken: tokens
+        });
+    } catch (e) {
+        if (e instanceof SyntaxError) {
+            const nameMatch = source.match(/^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/);
+            let _name = null;
+            let funcName = anonymousName;
+            if (nameMatch) {
+                const prefix = nameMatch[1] ? nameMatch[1] + ' ' : '';
+                _name = prefix + nameMatch[2];
+                funcName = '_' + nameMatch[2];
+            }
+            const escapedMsg = JSON.stringify(e.message);
+            const escapedSource = JSON.stringify(source);
+            return [{
+                    _name,
+                    _inputs: [],
+                    _definition: `function ${ funcName }() { throw Object.assign(new SyntaxError(${ escapedMsg }), {_sourceExpression: ${ escapedSource }}); }`
+                }];
         }
-      ];
+        throw e;
     }
-    throw e;
-  }
-  if (!cell) throw new Error("Unable to parse cell");
-  const parseImportSpecifierText = (text) => {
-    const t = String(text ?? "")
-      .trim()
-      .replace(/,$/, "")
-      .trim();
-    if (!t) throw new Error("Empty import specifier");
-    const parts = t.split(/\s+as\s+/);
-    const left = parts[0].trim();
-    const right = parts[1]?.trim();
-    const parseSide = (side, { defaultPrefix = "" } = {}) => {
-      const s = String(side ?? "").trim();
-      const m = s.match(/^(viewof|mutable)\s+(.+)$/);
-      if (m)
-        return {
-          prefix: `${m[1]} `,
-          name: m[2].trim()
+    if (!cell)
+        throw new Error('Unable to parse cell');
+    const parseImportSpecifierText = text => {
+        const t = String(text ?? '').trim().replace(/,$/, '').trim();
+        if (!t)
+            throw new Error('Empty import specifier');
+        const parts = t.split(/\s+as\s+/);
+        const left = parts[0].trim();
+        const right = parts[1]?.trim();
+        const parseSide = (side, {
+            defaultPrefix = ''
+        } = {}) => {
+            const s = String(side ?? '').trim();
+            const m = s.match(/^(viewof|mutable)\s+(.+)$/);
+            if (m)
+                return {
+                    prefix: `${ m[1] } `,
+                    name: m[2].trim()
+                };
+            return {
+                prefix: defaultPrefix,
+                name: s
+            };
         };
-      return {
-        prefix: defaultPrefix,
-        name: s
-      };
+        const L = parseSide(left);
+        const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
+        const importedName = `${ L.prefix }${ L.name }`.trim();
+        const localName = `${ R.prefix }${ R.name }`.trim();
+        if (!importedName)
+            throw new Error(`Could not parse imported name from: ${ t }`);
+        if (!localName)
+            throw new Error(`Could not parse local name from: ${ t }`);
+        return {
+            importedName,
+            localName
+        };
     };
-    const L = parseSide(left);
-    const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
-    const importedName = `${L.prefix}${L.name}`.trim();
-    const localName = `${R.prefix}${R.name}`.trim();
-    if (!importedName)
-      throw new Error(`Could not parse imported name from: ${t}`);
-    if (!localName) throw new Error(`Could not parse local name from: ${t}`);
-    return {
-      importedName,
-      localName
-    };
-  };
-  if (!cell.id && cell.body?.type === "ImportDeclaration") {
-    const module_name = cell.body.source.value;
-    const importKeyword = globalThis?.importShim ? "importShim" : "import";
-    const cell_variables = [
-      {
-        _name: `module ${module_name}`,
-        _inputs: [],
-        _definition: `async () => runtime.module((await ${importKeyword}("${module_name}")).default)`
-      }
-    ];
-    for (const specifier of cell.body.specifiers ?? []) {
-      const specText =
-        typeof specifier?.start === "number" &&
-        typeof specifier?.end === "number"
-          ? source.slice(specifier.start, specifier.end)
-          : (() => {
-              if (specifier?.imported?.name && specifier?.local?.name) {
-                return specifier.imported.name === specifier.local.name
-                  ? specifier.local.name
-                  : `${specifier.imported.name} as ${specifier.local.name}`;
-              }
-              throw new Error("Import specifier missing range information");
+    if (!cell.id && cell.body?.type === 'ImportDeclaration') {
+        const module_name = cell.body.source.value;
+        const cell_variables = [{
+                _name: `module ${ module_name }`,
+                _inputs: [],
+                _definition: `async () => runtime.module((await import("${ module_name }")).default)`
+            }];
+        for (const specifier of cell.body.specifiers ?? []) {
+            const specText = typeof specifier?.start === 'number' && typeof specifier?.end === 'number' ? source.slice(specifier.start, specifier.end) : (() => {
+                if (specifier?.imported?.name && specifier?.local?.name) {
+                    return specifier.imported.name === specifier.local.name ? specifier.local.name : `${ specifier.imported.name } as ${ specifier.local.name }`;
+                }
+                throw new Error('Import specifier missing range information');
             })();
-      const { importedName, localName } = parseImportSpecifierText(specText);
-      cell_variables.push({
-        _name: localName,
-        _inputs: [`module ${module_name}`, "@variable"],
-        _definition:
-          importedName === localName
-            ? `(_, v) => v.import("${importedName}", _)`
-            : `(_, v) => v.import("${importedName}", "${localName}", _)`
-      });
+            const {importedName, localName} = parseImportSpecifierText(specText);
+            cell_variables.push({
+                _name: localName,
+                _inputs: [
+                    `module ${ module_name }`,
+                    '@variable'
+                ],
+                _definition: importedName === localName ? `(_, v) => v.import("${ importedName }", _)` : `(_, v) => v.import("${ importedName }", "${ localName }", _)`
+            });
+        }
+        return cell_variables;
     }
-    return cell_variables;
-  }
-  let dollarIdx = 0;
-  const inputToArgMap = {};
-  const dollarToMacro = {};
-  const seen = new Set();
-  const inputs = Array.from(cell.references || []).flatMap((i) => {
-    if (i.name) {
-      if (seen.has(i.name)) return [];
-      seen.add(i.name);
-      return i.name;
+    let dollarIdx = 0;
+    const inputToArgMap = {};
+    const dollarToMacro = {};
+    const seen = new Set();
+    const inputs = Array.from(cell.references || []).flatMap(i => {
+        if (i.name) {
+            if (seen.has(i.name))
+                return [];
+            seen.add(i.name);
+            return i.name;
+        } else {
+            const dedupKey = i.type + ':' + i.id.name;
+            if (seen.has(dedupKey))
+                return [];
+            seen.add(dedupKey);
+            const dollarName = '$' + dollarIdx;
+            inputToArgMap[i.id.name] = dollarName;
+            dollarToMacro[dollarName] = i.type == 'ViewExpression' ? 'viewof ' + i.id.name : 'mutable ' + i.id.name;
+            dollarIdx++;
+            return dollarName;
+        }
+    });
+    let variables;
+    if (cell.id) {
+        if (cell.id.type === 'Identifier') {
+            variables = [{
+                    functionName: '_' + cell.id.name,
+                    name: cell.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                }];
+        } else if (cell.id.type === 'ViewExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'viewof ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '(G, _) => G.input(_)',
+                    inputs: [
+                        'Generators',
+                        'viewof ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                }
+            ];
+        } else if (cell.id.type === 'MutableExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'initial ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'mutable ' + cell.id.id.name,
+                    _definition: '(M, _) => new M(_)',
+                    inputs: [
+                        'Mutable',
+                        'initial ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '_ => _.generator',
+                    inputs: ['mutable ' + cell.id.id.name],
+                    params: inputs.join(',')
+                }
+            ];
+        } else {
+            throw new Error(`Unsupported cell id type: ${ cell.id.type }`);
+        }
     } else {
-      const dedupKey = i.type + ":" + i.id.name;
-      if (seen.has(dedupKey)) return [];
-      seen.add(dedupKey);
-      const dollarName = "$" + dollarIdx;
-      inputToArgMap[i.id.name] = dollarName;
-      dollarToMacro[dollarName] =
-        i.type == "ViewExpression"
-          ? "viewof " + i.id.name
-          : "mutable " + i.id.name;
-      dollarIdx++;
-      return dollarName;
+        variables = [{
+                functionName: anonymousName,
+                name: null,
+                inputs,
+                params: inputs.join(',')
+            }];
     }
-  });
-  let variables;
-  if (cell.id) {
-    if (cell.id.type === "Identifier") {
-      variables = [
-        {
-          functionName: "_" + cell.id.name,
-          name: cell.id.name,
-          inputs,
-          params: inputs.join(",")
+    return variables.map(v => {
+        let _definition = v._definition;
+        if (!_definition) {
+            let functionBody;
+            if (cell.body.type === 'BlockStatement') {
+                functionBody = observableToJs(cell.body, inputToArgMap, comments, tokens);
+            } else {
+                const bodyCode = observableToJs(cell.body, inputToArgMap, comments, tokens);
+                functionBody = `{return (${ bodyCode });}`;
+            }
+            _definition = `${ cell.async ? 'async ' : '' }function${ cell.generator ? '*' : '' } ${ v.functionName }(${ v.inputs.join(',') }) ${ functionBody }`;
         }
-      ];
-    } else if (cell.id.type === "ViewExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "viewof " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "(G, _) => G.input(_)",
-          inputs: ["Generators", "viewof " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else if (cell.id.type === "MutableExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "initial " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "mutable " + cell.id.id.name,
-          _definition: "(M, _) => new M(_)",
-          inputs: ["Mutable", "initial " + cell.id.id.name],
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "_ => _.generator",
-          inputs: ["mutable " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else {
-      throw new Error(`Unsupported cell id type: ${cell.id.type}`);
-    }
-  } else {
-    variables = [
-      {
-        functionName: anonymousName,
-        name: null,
-        inputs,
-        params: inputs.join(",")
-      }
-    ];
-  }
-  return variables.map((v) => {
-    let _definition = v._definition;
-    if (!_definition) {
-      let functionBody;
-      if (cell.body.type === "BlockStatement") {
-        functionBody = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-      } else {
-        const bodyCode = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-        functionBody = `{return (${bodyCode});}`;
-      }
-      _definition = `${cell.async ? "async " : ""}function${
-        cell.generator ? "*" : ""
-      } ${v.functionName}(${v.inputs.join(",")}) ${functionBody}`;
-    }
-    return {
-      _name: v.name,
-      _inputs: v.inputs.map(
-        (i) => dollarToMacro[i] || (i === "$variable" ? "@variable" : i)
-      ),
-      _definition
-    };
-  });
+        return {
+            _name: v.name,
+            _inputs: v.inputs.map(i => dollarToMacro[i] || (i === '$variable' ? '@variable' : i)),
+            _definition
+        };
+    });
 }
 )};
 const _1v1i7wl = function _observableToJs(acorn_walk,parser,escodegen){return(
@@ -17497,16 +17435,15 @@ async (attachment, overrides) => {
   return URL.createObjectURL(blob);
 }
 )};
-const _s9w7ha = async function _parser(decompress_url,FileAttachment,acorn_url,acorn_walk_url){return(
-importShim(await decompress_url(FileAttachment("parser-6.1.0.js.gz"), {
-    "/npm/acorn@8.11.3/+esm": acorn_url,
-    "/npm/acorn-walk@8.3.2/+esm": acorn_walk_url
-  })
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
-const _1hiclbb = function _acorn_walk(acorn_walk_url){return(
-importShim(acorn_walk_url, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _s9w7ha = async function _parser(decompress_url, FileAttachment, acorn_url, acorn_walk_url) {
+    return import(await decompress_url(FileAttachment('parser-6.1.0.js.gz'), {
+        '/npm/acorn@8.11.3/+esm': acorn_url,
+        '/npm/acorn-walk@8.3.2/+esm': acorn_walk_url
+    }));
+};
+const _1hiclbb = function _acorn_walk(acorn_walk_url) {
+    return import(acorn_walk_url);
+};
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
@@ -17694,7 +17631,7 @@ export default function define(runtime, observer) {
   $def("_1dmmuaf", "compiled_selector", ["Generators","viewof compiled_selector"], _1dmmuaf);  
   $def("_u7t3vu", null, ["compiled_selector","normalizeJavascriptSource"], _u7t3vu);  
   $def("_1lt3kl6", null, ["compile","test_case"], _1lt3kl6);  
-  $def("_lpzjrv", "compile", ["parser","globalThis","observableToJs"], _lpzjrv);  
+  $def("_x1d0wm", "compile", ["parser","observableToJs"], _x1d0wm);  
   $def("_1v1i7wl", "observableToJs", ["acorn_walk","parser","escodegen"], _1v1i7wl);  
   $def("_19lv24l", null, ["md"], _19lv24l);  
   $def("_xhj6b8", "decompress_url", ["DecompressionStream","TextDecoderStream","TransformStream","TextEncoderStream","Response"], _xhj6b8);  

--- a/notebooks/@tomlarkworthy_local-storage-view.html
+++ b/notebooks/@tomlarkworthy_local-storage-view.html
@@ -5437,58 +5437,41 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _geoudp = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
-  if (command.processed) return;
-
-  let result = undefined;
-  if (command.command == "createCell") {
-    $0.value = true;
-    result = compile_and_update("{}", [], command.args.cell);
-    // For the new one to get focus
-    // setTimeout(() => {
-    //   debugger;
-    //   setOption(result[0], "pinned", true);
-    // }, 100);
-  } else if (command.command == "deleteCell") {
-    remove_variables(command.args.cell.variables);
-    result = true;
-  } else if (command.command == "moveCell") {
-    const cellIndex = findCellIndex(
-      command.args.cell.variables,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const targetCellIndex = cellIndex + command.args.amount;
-    const targetCell = lookupCellByIndex(
-      targetCellIndex,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const currentFirstVariableIndex = findVariableIndex(
-      command.args.cell.variables[0]
-    );
-    const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-    const change = targetFirstVariableIndex - currentFirstVariableIndex;
-    console.log(
-      "moveCell",
-      cellIndex,
-      targetCellIndex,
-      targetCell,
-      currentFirstVariableIndex,
-      targetFirstVariableIndex,
-      change
-    );
-    command.args.cell.variables.forEach((v) => {
-      const currentIndex = findVariableIndex(v);
-      repositionSetElement(runtime._variables, v, currentIndex + change);
-    });
-    // recompute
-    await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
-    result = true;
-  }
-  if (result) {
-    command.processed = true;
-    $2.resolve(result);
-  }
+    if (command.processed)
+        return;
+    let result = undefined;
+    if (command.command == 'createCell') {
+        $0.value = true;
+        result = await compile_and_update('{}', [], command.args.cell);    // For the new one to get focus
+                                                                           // setTimeout(() => {
+                                                                           //   debugger;
+                                                                           //   setOption(result[0], "pinned", true);
+                                                                           // }, 100);
+    } else if (command.command == 'deleteCell') {
+        remove_variables(command.args.cell.variables);
+        result = true;
+    } else if (command.command == 'moveCell') {
+        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const targetCellIndex = cellIndex + command.args.amount;
+        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
+        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+        const change = targetFirstVariableIndex - currentFirstVariableIndex;
+        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
+        command.args.cell.variables.forEach(v => {
+            const currentIndex = findVariableIndex(v);
+            repositionSetElement(runtime._variables, v, currentIndex + change);
+        });
+        // recompute
+        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        result = true;
+    }
+    if (result) {
+        command.processed = true;
+        $2.resolve(result);
+    }
 };
 const _1jadxoe = function _60(md){return(
 md`### UI Action`
@@ -5879,9 +5862,9 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
-    return (source, variables = [], cell) => {
+    return async (source, variables = [], cell) => {
         try {
             debugger;
             let reposition = false, insertionIndex = -1;
@@ -5901,10 +5884,10 @@ const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElemen
             if (reposition) {
                 insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
+            const fns = await realize(newVariables.map(v => v._definition), runtime);
             newVariables.forEach((v, i) => {
                 const variable = variables[i];
-                let _fn;
-                eval('_fn = ' + v._definition);
+                const _fn = fns[i];
                 if (v._name) {
                     variable.define(v._name, v._inputs, _fn);
                 } else {
@@ -5953,12 +5936,11 @@ Inputs.textarea({
 })
 )};
 const _b4rsn5 = (G, _) => G.input(_);
-const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
+const _ga6kci = function _98(Inputs,definition,variable,realize,runtime,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
-  reduce: () => {
-    let _fn;
-    eval("_fn = " + definition);
+  reduce: async () => {
+    const [_fn] = await realize([definition], runtime);
     variable.define(variable._name, inputs, _fn);
   }
 })
@@ -6071,7 +6053,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_geoudp", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _geoudp);  
+  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6109,7 +6091,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
+  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -6119,8 +6101,9 @@ export default function define(runtime, observer) {
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
   $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
-  $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
+  $def("_ga6kci", null, ["Inputs","definition","variable","realize","runtime","inputs"], _ga6kci);  
   $def("_1q557s", null, ["md"], _1q557s);  
+  main.define("realize", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("realize", _));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -16490,10 +16473,9 @@ notebook_semantics_document.nodes.map((s) => ({
 const _1oevsow = function _28(md){return(
 md`### Runtime Representation (v4)`
 )};
-const _11lfflk = function _notebook_semantics_module(){return(
-importShim("https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4"
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _11lfflk = function _notebook_semantics_module() {
+    return import('https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4');
+};
 const _gjten6 = function _31(md){return(
 md`### Imports`
 )};
@@ -17480,65 +17462,44 @@ parser.parseCell(
   'import {runtime, viewof main as foo} from "@mootari/access-runtime"'
 )
 )};
-const _1n7gw17 = function _findModuleName(extractModuleInfo){return(
-(scope, module, { unknown_id = Math.random() } = {}) => {
-  try {
-    const scopedVariables = [...scope.values()];
-
-    // Prefer variables that *define* a module and have a real module-loader name.
-    const candidates = scopedVariables.filter(
-      (v) =>
-        v &&
-        v._value === module &&
-        typeof v._name === "string" &&
-        v._name.startsWith("module ") &&
-        !v._name.startsWith("module <unknown")
-    );
-
-    const pickBestInfo = (dfn) => {
-      // Avoid the parentUrl (2nd arg) confusing module identification.
-      // Typical patterns:
-      //   importShim("/d/<id>@<ver>.js?v=4", "https://api.observablehq.com/@ns/name.js?v=4")
-      //   import("/d/<id>@<ver>.js?v=4")
-      // Prefer the *first argument* inside importShim(...) / import(...) when present.
-      const s = String(dfn ?? "");
-
-      // Try to capture the first string literal argument to importShim(...) or import(...)
-      // Tolerates quotes ", ', ` and both importShim and plain import.
-      const m = s.match(
-        /\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/
-      );
-      const firstArg = m?.[2];
-
-      const info1 = firstArg ? extractModuleInfo(firstArg) : {};
-      if (info1?.id || info1?.notebook) return info1;
-
-      // Fallback: parse the whole definition string.
-      return extractModuleInfo(s);
+const _1n7gw17 = function _findModuleName(extractModuleInfo) {
+    return (scope, module, {
+        unknown_id = Math.random()
+    } = {}) => {
+        try {
+            const scopedVariables = [...scope.values()];
+            const candidates = scopedVariables.filter(v => v && v._value === module && typeof v._name === 'string' && v._name.startsWith('module ') && !v._name.startsWith('module <unknown'));
+            const pickBestInfo = dfn => {
+                const s = String(dfn ?? '');
+                const m = s.match(/\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/);
+                const firstArg = m?.[2];
+                const info1 = firstArg ? extractModuleInfo(firstArg) : {};
+                if (info1?.id || info1?.notebook)
+                    return info1;
+                return extractModuleInfo(s);
+            };
+            for (const v of candidates) {
+                const info = pickBestInfo(v._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            const any = scopedVariables.find(v => v && v._value === module);
+            if (any) {
+                const info = pickBestInfo(any._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            return `<unknown ${ unknown_id }>`;
+        } catch (e) {
+            debugger;
+            return 'error';
+        }
     };
-
-    // Try module loader cells first.
-    for (const v of candidates) {
-      const info = pickBestInfo(v._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    // Fallback: any scoped variable with _value==module.
-    const any = scopedVariables.find((v) => v && v._value === module);
-    if (any) {
-      const info = pickBestInfo(any._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    return `<unknown ${unknown_id}>`;
-  } catch (e) {
-    debugger;
-    return "error";
-  }
-}
-)};
+};
 const _i47chb = function _findImportedName(){return(
 async (v) => {
   if (v._inputs.length == 1 && v._inputs[0]._name === "@variable") {
@@ -18440,229 +18401,206 @@ JSON.stringify(
 const _1lt3kl6 = function _157(compile,test_case){return(
 compile(test_case.value)
 )};
-const _lpzjrv = function _compile(parser,globalThis,observableToJs){return(
-function compile(source, { anonymousName = "_anonymous" } = {}) {
-  const comments = [],
-    tokens = [];
-  let cell;
-  try {
-    cell = parser.parseCell(source, {
-      ranges: true,
-      onComment: comments,
-      onToken: tokens
-    });
-  } catch (e) {
-    if (e instanceof SyntaxError) {
-      const nameMatch = source.match(
-        /^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/
-      );
-      let _name = null;
-      let funcName = anonymousName;
-      if (nameMatch) {
-        const prefix = nameMatch[1] ? nameMatch[1] + " " : "";
-        _name = prefix + nameMatch[2];
-        funcName = "_" + nameMatch[2];
-      }
-      const escapedMsg = JSON.stringify(e.message);
-      const escapedSource = JSON.stringify(source);
-      return [
-        {
-          _name,
-          _inputs: [],
-          _definition: `function ${funcName}() { throw Object.assign(new SyntaxError(${escapedMsg}), {_sourceExpression: ${escapedSource}}); }`
+const _x1d0wm = function _compile(parser,observableToJs){return(
+function compile(source, {
+    anonymousName = '_anonymous'
+} = {}) {
+    const comments = [], tokens = [];
+    let cell;
+    try {
+        cell = parser.parseCell(source, {
+            ranges: true,
+            onComment: comments,
+            onToken: tokens
+        });
+    } catch (e) {
+        if (e instanceof SyntaxError) {
+            const nameMatch = source.match(/^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/);
+            let _name = null;
+            let funcName = anonymousName;
+            if (nameMatch) {
+                const prefix = nameMatch[1] ? nameMatch[1] + ' ' : '';
+                _name = prefix + nameMatch[2];
+                funcName = '_' + nameMatch[2];
+            }
+            const escapedMsg = JSON.stringify(e.message);
+            const escapedSource = JSON.stringify(source);
+            return [{
+                    _name,
+                    _inputs: [],
+                    _definition: `function ${ funcName }() { throw Object.assign(new SyntaxError(${ escapedMsg }), {_sourceExpression: ${ escapedSource }}); }`
+                }];
         }
-      ];
+        throw e;
     }
-    throw e;
-  }
-  if (!cell) throw new Error("Unable to parse cell");
-  const parseImportSpecifierText = (text) => {
-    const t = String(text ?? "")
-      .trim()
-      .replace(/,$/, "")
-      .trim();
-    if (!t) throw new Error("Empty import specifier");
-    const parts = t.split(/\s+as\s+/);
-    const left = parts[0].trim();
-    const right = parts[1]?.trim();
-    const parseSide = (side, { defaultPrefix = "" } = {}) => {
-      const s = String(side ?? "").trim();
-      const m = s.match(/^(viewof|mutable)\s+(.+)$/);
-      if (m)
-        return {
-          prefix: `${m[1]} `,
-          name: m[2].trim()
+    if (!cell)
+        throw new Error('Unable to parse cell');
+    const parseImportSpecifierText = text => {
+        const t = String(text ?? '').trim().replace(/,$/, '').trim();
+        if (!t)
+            throw new Error('Empty import specifier');
+        const parts = t.split(/\s+as\s+/);
+        const left = parts[0].trim();
+        const right = parts[1]?.trim();
+        const parseSide = (side, {
+            defaultPrefix = ''
+        } = {}) => {
+            const s = String(side ?? '').trim();
+            const m = s.match(/^(viewof|mutable)\s+(.+)$/);
+            if (m)
+                return {
+                    prefix: `${ m[1] } `,
+                    name: m[2].trim()
+                };
+            return {
+                prefix: defaultPrefix,
+                name: s
+            };
         };
-      return {
-        prefix: defaultPrefix,
-        name: s
-      };
+        const L = parseSide(left);
+        const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
+        const importedName = `${ L.prefix }${ L.name }`.trim();
+        const localName = `${ R.prefix }${ R.name }`.trim();
+        if (!importedName)
+            throw new Error(`Could not parse imported name from: ${ t }`);
+        if (!localName)
+            throw new Error(`Could not parse local name from: ${ t }`);
+        return {
+            importedName,
+            localName
+        };
     };
-    const L = parseSide(left);
-    const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
-    const importedName = `${L.prefix}${L.name}`.trim();
-    const localName = `${R.prefix}${R.name}`.trim();
-    if (!importedName)
-      throw new Error(`Could not parse imported name from: ${t}`);
-    if (!localName) throw new Error(`Could not parse local name from: ${t}`);
-    return {
-      importedName,
-      localName
-    };
-  };
-  if (!cell.id && cell.body?.type === "ImportDeclaration") {
-    const module_name = cell.body.source.value;
-    const importKeyword = globalThis?.importShim ? "importShim" : "import";
-    const cell_variables = [
-      {
-        _name: `module ${module_name}`,
-        _inputs: [],
-        _definition: `async () => runtime.module((await ${importKeyword}("${module_name}")).default)`
-      }
-    ];
-    for (const specifier of cell.body.specifiers ?? []) {
-      const specText =
-        typeof specifier?.start === "number" &&
-        typeof specifier?.end === "number"
-          ? source.slice(specifier.start, specifier.end)
-          : (() => {
-              if (specifier?.imported?.name && specifier?.local?.name) {
-                return specifier.imported.name === specifier.local.name
-                  ? specifier.local.name
-                  : `${specifier.imported.name} as ${specifier.local.name}`;
-              }
-              throw new Error("Import specifier missing range information");
+    if (!cell.id && cell.body?.type === 'ImportDeclaration') {
+        const module_name = cell.body.source.value;
+        const cell_variables = [{
+                _name: `module ${ module_name }`,
+                _inputs: [],
+                _definition: `async () => runtime.module((await import("${ module_name }")).default)`
+            }];
+        for (const specifier of cell.body.specifiers ?? []) {
+            const specText = typeof specifier?.start === 'number' && typeof specifier?.end === 'number' ? source.slice(specifier.start, specifier.end) : (() => {
+                if (specifier?.imported?.name && specifier?.local?.name) {
+                    return specifier.imported.name === specifier.local.name ? specifier.local.name : `${ specifier.imported.name } as ${ specifier.local.name }`;
+                }
+                throw new Error('Import specifier missing range information');
             })();
-      const { importedName, localName } = parseImportSpecifierText(specText);
-      cell_variables.push({
-        _name: localName,
-        _inputs: [`module ${module_name}`, "@variable"],
-        _definition:
-          importedName === localName
-            ? `(_, v) => v.import("${importedName}", _)`
-            : `(_, v) => v.import("${importedName}", "${localName}", _)`
-      });
+            const {importedName, localName} = parseImportSpecifierText(specText);
+            cell_variables.push({
+                _name: localName,
+                _inputs: [
+                    `module ${ module_name }`,
+                    '@variable'
+                ],
+                _definition: importedName === localName ? `(_, v) => v.import("${ importedName }", _)` : `(_, v) => v.import("${ importedName }", "${ localName }", _)`
+            });
+        }
+        return cell_variables;
     }
-    return cell_variables;
-  }
-  let dollarIdx = 0;
-  const inputToArgMap = {};
-  const dollarToMacro = {};
-  const seen = new Set();
-  const inputs = Array.from(cell.references || []).flatMap((i) => {
-    if (i.name) {
-      if (seen.has(i.name)) return [];
-      seen.add(i.name);
-      return i.name;
+    let dollarIdx = 0;
+    const inputToArgMap = {};
+    const dollarToMacro = {};
+    const seen = new Set();
+    const inputs = Array.from(cell.references || []).flatMap(i => {
+        if (i.name) {
+            if (seen.has(i.name))
+                return [];
+            seen.add(i.name);
+            return i.name;
+        } else {
+            const dedupKey = i.type + ':' + i.id.name;
+            if (seen.has(dedupKey))
+                return [];
+            seen.add(dedupKey);
+            const dollarName = '$' + dollarIdx;
+            inputToArgMap[i.id.name] = dollarName;
+            dollarToMacro[dollarName] = i.type == 'ViewExpression' ? 'viewof ' + i.id.name : 'mutable ' + i.id.name;
+            dollarIdx++;
+            return dollarName;
+        }
+    });
+    let variables;
+    if (cell.id) {
+        if (cell.id.type === 'Identifier') {
+            variables = [{
+                    functionName: '_' + cell.id.name,
+                    name: cell.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                }];
+        } else if (cell.id.type === 'ViewExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'viewof ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '(G, _) => G.input(_)',
+                    inputs: [
+                        'Generators',
+                        'viewof ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                }
+            ];
+        } else if (cell.id.type === 'MutableExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'initial ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'mutable ' + cell.id.id.name,
+                    _definition: '(M, _) => new M(_)',
+                    inputs: [
+                        'Mutable',
+                        'initial ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '_ => _.generator',
+                    inputs: ['mutable ' + cell.id.id.name],
+                    params: inputs.join(',')
+                }
+            ];
+        } else {
+            throw new Error(`Unsupported cell id type: ${ cell.id.type }`);
+        }
     } else {
-      const dedupKey = i.type + ":" + i.id.name;
-      if (seen.has(dedupKey)) return [];
-      seen.add(dedupKey);
-      const dollarName = "$" + dollarIdx;
-      inputToArgMap[i.id.name] = dollarName;
-      dollarToMacro[dollarName] =
-        i.type == "ViewExpression"
-          ? "viewof " + i.id.name
-          : "mutable " + i.id.name;
-      dollarIdx++;
-      return dollarName;
+        variables = [{
+                functionName: anonymousName,
+                name: null,
+                inputs,
+                params: inputs.join(',')
+            }];
     }
-  });
-  let variables;
-  if (cell.id) {
-    if (cell.id.type === "Identifier") {
-      variables = [
-        {
-          functionName: "_" + cell.id.name,
-          name: cell.id.name,
-          inputs,
-          params: inputs.join(",")
+    return variables.map(v => {
+        let _definition = v._definition;
+        if (!_definition) {
+            let functionBody;
+            if (cell.body.type === 'BlockStatement') {
+                functionBody = observableToJs(cell.body, inputToArgMap, comments, tokens);
+            } else {
+                const bodyCode = observableToJs(cell.body, inputToArgMap, comments, tokens);
+                functionBody = `{return (${ bodyCode });}`;
+            }
+            _definition = `${ cell.async ? 'async ' : '' }function${ cell.generator ? '*' : '' } ${ v.functionName }(${ v.inputs.join(',') }) ${ functionBody }`;
         }
-      ];
-    } else if (cell.id.type === "ViewExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "viewof " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "(G, _) => G.input(_)",
-          inputs: ["Generators", "viewof " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else if (cell.id.type === "MutableExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "initial " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "mutable " + cell.id.id.name,
-          _definition: "(M, _) => new M(_)",
-          inputs: ["Mutable", "initial " + cell.id.id.name],
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "_ => _.generator",
-          inputs: ["mutable " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else {
-      throw new Error(`Unsupported cell id type: ${cell.id.type}`);
-    }
-  } else {
-    variables = [
-      {
-        functionName: anonymousName,
-        name: null,
-        inputs,
-        params: inputs.join(",")
-      }
-    ];
-  }
-  return variables.map((v) => {
-    let _definition = v._definition;
-    if (!_definition) {
-      let functionBody;
-      if (cell.body.type === "BlockStatement") {
-        functionBody = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-      } else {
-        const bodyCode = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-        functionBody = `{return (${bodyCode});}`;
-      }
-      _definition = `${cell.async ? "async " : ""}function${
-        cell.generator ? "*" : ""
-      } ${v.functionName}(${v.inputs.join(",")}) ${functionBody}`;
-    }
-    return {
-      _name: v.name,
-      _inputs: v.inputs.map(
-        (i) => dollarToMacro[i] || (i === "$variable" ? "@variable" : i)
-      ),
-      _definition
-    };
-  });
+        return {
+            _name: v.name,
+            _inputs: v.inputs.map(i => dollarToMacro[i] || (i === '$variable' ? '@variable' : i)),
+            _definition
+        };
+    });
 }
 )};
 const _1v1i7wl = function _observableToJs(acorn_walk,parser,escodegen){return(
@@ -18729,16 +18667,15 @@ async (attachment, overrides) => {
   return URL.createObjectURL(blob);
 }
 )};
-const _s9w7ha = async function _parser(decompress_url,FileAttachment,acorn_url,acorn_walk_url){return(
-importShim(await decompress_url(FileAttachment("parser-6.1.0.js.gz"), {
-    "/npm/acorn@8.11.3/+esm": acorn_url,
-    "/npm/acorn-walk@8.3.2/+esm": acorn_walk_url
-  })
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
-const _1hiclbb = function _acorn_walk(acorn_walk_url){return(
-importShim(acorn_walk_url, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _s9w7ha = async function _parser(decompress_url, FileAttachment, acorn_url, acorn_walk_url) {
+    return import(await decompress_url(FileAttachment('parser-6.1.0.js.gz'), {
+        '/npm/acorn@8.11.3/+esm': acorn_url,
+        '/npm/acorn-walk@8.3.2/+esm': acorn_walk_url
+    }));
+};
+const _1hiclbb = function _acorn_walk(acorn_walk_url) {
+    return import(acorn_walk_url);
+};
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
@@ -18926,7 +18863,7 @@ export default function define(runtime, observer) {
   $def("_1dmmuaf", "compiled_selector", ["Generators","viewof compiled_selector"], _1dmmuaf);  
   $def("_u7t3vu", null, ["compiled_selector","normalizeJavascriptSource"], _u7t3vu);  
   $def("_1lt3kl6", null, ["compile","test_case"], _1lt3kl6);  
-  $def("_lpzjrv", "compile", ["parser","globalThis","observableToJs"], _lpzjrv);  
+  $def("_x1d0wm", "compile", ["parser","observableToJs"], _x1d0wm);  
   $def("_1v1i7wl", "observableToJs", ["acorn_walk","parser","escodegen"], _1v1i7wl);  
   $def("_19lv24l", null, ["md"], _19lv24l);  
   $def("_xhj6b8", "decompress_url", ["DecompressionStream","TextDecoderStream","TransformStream","TextEncoderStream","Response"], _xhj6b8);  

--- a/notebooks/@tomlarkworthy_lopecode-tour.html
+++ b/notebooks/@tomlarkworthy_lopecode-tour.html
@@ -6258,58 +6258,41 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _geoudp = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
-  if (command.processed) return;
-
-  let result = undefined;
-  if (command.command == "createCell") {
-    $0.value = true;
-    result = compile_and_update("{}", [], command.args.cell);
-    // For the new one to get focus
-    // setTimeout(() => {
-    //   debugger;
-    //   setOption(result[0], "pinned", true);
-    // }, 100);
-  } else if (command.command == "deleteCell") {
-    remove_variables(command.args.cell.variables);
-    result = true;
-  } else if (command.command == "moveCell") {
-    const cellIndex = findCellIndex(
-      command.args.cell.variables,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const targetCellIndex = cellIndex + command.args.amount;
-    const targetCell = lookupCellByIndex(
-      targetCellIndex,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const currentFirstVariableIndex = findVariableIndex(
-      command.args.cell.variables[0]
-    );
-    const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-    const change = targetFirstVariableIndex - currentFirstVariableIndex;
-    console.log(
-      "moveCell",
-      cellIndex,
-      targetCellIndex,
-      targetCell,
-      currentFirstVariableIndex,
-      targetFirstVariableIndex,
-      change
-    );
-    command.args.cell.variables.forEach((v) => {
-      const currentIndex = findVariableIndex(v);
-      repositionSetElement(runtime._variables, v, currentIndex + change);
-    });
-    // recompute
-    await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
-    result = true;
-  }
-  if (result) {
-    command.processed = true;
-    $2.resolve(result);
-  }
+    if (command.processed)
+        return;
+    let result = undefined;
+    if (command.command == 'createCell') {
+        $0.value = true;
+        result = await compile_and_update('{}', [], command.args.cell);    // For the new one to get focus
+                                                                           // setTimeout(() => {
+                                                                           //   debugger;
+                                                                           //   setOption(result[0], "pinned", true);
+                                                                           // }, 100);
+    } else if (command.command == 'deleteCell') {
+        remove_variables(command.args.cell.variables);
+        result = true;
+    } else if (command.command == 'moveCell') {
+        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const targetCellIndex = cellIndex + command.args.amount;
+        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
+        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+        const change = targetFirstVariableIndex - currentFirstVariableIndex;
+        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
+        command.args.cell.variables.forEach(v => {
+            const currentIndex = findVariableIndex(v);
+            repositionSetElement(runtime._variables, v, currentIndex + change);
+        });
+        // recompute
+        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        result = true;
+    }
+    if (result) {
+        command.processed = true;
+        $2.resolve(result);
+    }
 };
 const _1jadxoe = function _60(md){return(
 md`### UI Action`
@@ -6700,9 +6683,9 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
-    return (source, variables = [], cell) => {
+    return async (source, variables = [], cell) => {
         try {
             debugger;
             let reposition = false, insertionIndex = -1;
@@ -6722,10 +6705,10 @@ const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElemen
             if (reposition) {
                 insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
+            const fns = await realize(newVariables.map(v => v._definition), runtime);
             newVariables.forEach((v, i) => {
                 const variable = variables[i];
-                let _fn;
-                eval('_fn = ' + v._definition);
+                const _fn = fns[i];
                 if (v._name) {
                     variable.define(v._name, v._inputs, _fn);
                 } else {
@@ -6774,12 +6757,11 @@ Inputs.textarea({
 })
 )};
 const _b4rsn5 = (G, _) => G.input(_);
-const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
+const _ga6kci = function _98(Inputs,definition,variable,realize,runtime,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
-  reduce: () => {
-    let _fn;
-    eval("_fn = " + definition);
+  reduce: async () => {
+    const [_fn] = await realize([definition], runtime);
     variable.define(variable._name, inputs, _fn);
   }
 })
@@ -6892,7 +6874,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_geoudp", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _geoudp);  
+  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6930,7 +6912,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
+  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -6940,8 +6922,9 @@ export default function define(runtime, observer) {
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
   $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
-  $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
+  $def("_ga6kci", null, ["Inputs","definition","variable","realize","runtime","inputs"], _ga6kci);  
   $def("_1q557s", null, ["md"], _1q557s);  
+  main.define("realize", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("realize", _));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -20072,10 +20055,9 @@ notebook_semantics_document.nodes.map((s) => ({
 const _1oevsow = function _28(md){return(
 md`### Runtime Representation (v4)`
 )};
-const _11lfflk = function _notebook_semantics_module(){return(
-importShim("https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4"
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _11lfflk = function _notebook_semantics_module() {
+    return import('https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4');
+};
 const _gjten6 = function _31(md){return(
 md`### Imports`
 )};
@@ -21062,65 +21044,44 @@ parser.parseCell(
   'import {runtime, viewof main as foo} from "@mootari/access-runtime"'
 )
 )};
-const _1n7gw17 = function _findModuleName(extractModuleInfo){return(
-(scope, module, { unknown_id = Math.random() } = {}) => {
-  try {
-    const scopedVariables = [...scope.values()];
-
-    // Prefer variables that *define* a module and have a real module-loader name.
-    const candidates = scopedVariables.filter(
-      (v) =>
-        v &&
-        v._value === module &&
-        typeof v._name === "string" &&
-        v._name.startsWith("module ") &&
-        !v._name.startsWith("module <unknown")
-    );
-
-    const pickBestInfo = (dfn) => {
-      // Avoid the parentUrl (2nd arg) confusing module identification.
-      // Typical patterns:
-      //   importShim("/d/<id>@<ver>.js?v=4", "https://api.observablehq.com/@ns/name.js?v=4")
-      //   import("/d/<id>@<ver>.js?v=4")
-      // Prefer the *first argument* inside importShim(...) / import(...) when present.
-      const s = String(dfn ?? "");
-
-      // Try to capture the first string literal argument to importShim(...) or import(...)
-      // Tolerates quotes ", ', ` and both importShim and plain import.
-      const m = s.match(
-        /\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/
-      );
-      const firstArg = m?.[2];
-
-      const info1 = firstArg ? extractModuleInfo(firstArg) : {};
-      if (info1?.id || info1?.notebook) return info1;
-
-      // Fallback: parse the whole definition string.
-      return extractModuleInfo(s);
+const _1n7gw17 = function _findModuleName(extractModuleInfo) {
+    return (scope, module, {
+        unknown_id = Math.random()
+    } = {}) => {
+        try {
+            const scopedVariables = [...scope.values()];
+            const candidates = scopedVariables.filter(v => v && v._value === module && typeof v._name === 'string' && v._name.startsWith('module ') && !v._name.startsWith('module <unknown'));
+            const pickBestInfo = dfn => {
+                const s = String(dfn ?? '');
+                const m = s.match(/\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/);
+                const firstArg = m?.[2];
+                const info1 = firstArg ? extractModuleInfo(firstArg) : {};
+                if (info1?.id || info1?.notebook)
+                    return info1;
+                return extractModuleInfo(s);
+            };
+            for (const v of candidates) {
+                const info = pickBestInfo(v._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            const any = scopedVariables.find(v => v && v._value === module);
+            if (any) {
+                const info = pickBestInfo(any._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            return `<unknown ${ unknown_id }>`;
+        } catch (e) {
+            debugger;
+            return 'error';
+        }
     };
-
-    // Try module loader cells first.
-    for (const v of candidates) {
-      const info = pickBestInfo(v._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    // Fallback: any scoped variable with _value==module.
-    const any = scopedVariables.find((v) => v && v._value === module);
-    if (any) {
-      const info = pickBestInfo(any._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    return `<unknown ${unknown_id}>`;
-  } catch (e) {
-    debugger;
-    return "error";
-  }
-}
-)};
+};
 const _i47chb = function _findImportedName(){return(
 async (v) => {
   if (v._inputs.length == 1 && v._inputs[0]._name === "@variable") {
@@ -22022,229 +21983,206 @@ JSON.stringify(
 const _1lt3kl6 = function _157(compile,test_case){return(
 compile(test_case.value)
 )};
-const _lpzjrv = function _compile(parser,globalThis,observableToJs){return(
-function compile(source, { anonymousName = "_anonymous" } = {}) {
-  const comments = [],
-    tokens = [];
-  let cell;
-  try {
-    cell = parser.parseCell(source, {
-      ranges: true,
-      onComment: comments,
-      onToken: tokens
-    });
-  } catch (e) {
-    if (e instanceof SyntaxError) {
-      const nameMatch = source.match(
-        /^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/
-      );
-      let _name = null;
-      let funcName = anonymousName;
-      if (nameMatch) {
-        const prefix = nameMatch[1] ? nameMatch[1] + " " : "";
-        _name = prefix + nameMatch[2];
-        funcName = "_" + nameMatch[2];
-      }
-      const escapedMsg = JSON.stringify(e.message);
-      const escapedSource = JSON.stringify(source);
-      return [
-        {
-          _name,
-          _inputs: [],
-          _definition: `function ${funcName}() { throw Object.assign(new SyntaxError(${escapedMsg}), {_sourceExpression: ${escapedSource}}); }`
+const _x1d0wm = function _compile(parser,observableToJs){return(
+function compile(source, {
+    anonymousName = '_anonymous'
+} = {}) {
+    const comments = [], tokens = [];
+    let cell;
+    try {
+        cell = parser.parseCell(source, {
+            ranges: true,
+            onComment: comments,
+            onToken: tokens
+        });
+    } catch (e) {
+        if (e instanceof SyntaxError) {
+            const nameMatch = source.match(/^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/);
+            let _name = null;
+            let funcName = anonymousName;
+            if (nameMatch) {
+                const prefix = nameMatch[1] ? nameMatch[1] + ' ' : '';
+                _name = prefix + nameMatch[2];
+                funcName = '_' + nameMatch[2];
+            }
+            const escapedMsg = JSON.stringify(e.message);
+            const escapedSource = JSON.stringify(source);
+            return [{
+                    _name,
+                    _inputs: [],
+                    _definition: `function ${ funcName }() { throw Object.assign(new SyntaxError(${ escapedMsg }), {_sourceExpression: ${ escapedSource }}); }`
+                }];
         }
-      ];
+        throw e;
     }
-    throw e;
-  }
-  if (!cell) throw new Error("Unable to parse cell");
-  const parseImportSpecifierText = (text) => {
-    const t = String(text ?? "")
-      .trim()
-      .replace(/,$/, "")
-      .trim();
-    if (!t) throw new Error("Empty import specifier");
-    const parts = t.split(/\s+as\s+/);
-    const left = parts[0].trim();
-    const right = parts[1]?.trim();
-    const parseSide = (side, { defaultPrefix = "" } = {}) => {
-      const s = String(side ?? "").trim();
-      const m = s.match(/^(viewof|mutable)\s+(.+)$/);
-      if (m)
-        return {
-          prefix: `${m[1]} `,
-          name: m[2].trim()
+    if (!cell)
+        throw new Error('Unable to parse cell');
+    const parseImportSpecifierText = text => {
+        const t = String(text ?? '').trim().replace(/,$/, '').trim();
+        if (!t)
+            throw new Error('Empty import specifier');
+        const parts = t.split(/\s+as\s+/);
+        const left = parts[0].trim();
+        const right = parts[1]?.trim();
+        const parseSide = (side, {
+            defaultPrefix = ''
+        } = {}) => {
+            const s = String(side ?? '').trim();
+            const m = s.match(/^(viewof|mutable)\s+(.+)$/);
+            if (m)
+                return {
+                    prefix: `${ m[1] } `,
+                    name: m[2].trim()
+                };
+            return {
+                prefix: defaultPrefix,
+                name: s
+            };
         };
-      return {
-        prefix: defaultPrefix,
-        name: s
-      };
+        const L = parseSide(left);
+        const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
+        const importedName = `${ L.prefix }${ L.name }`.trim();
+        const localName = `${ R.prefix }${ R.name }`.trim();
+        if (!importedName)
+            throw new Error(`Could not parse imported name from: ${ t }`);
+        if (!localName)
+            throw new Error(`Could not parse local name from: ${ t }`);
+        return {
+            importedName,
+            localName
+        };
     };
-    const L = parseSide(left);
-    const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
-    const importedName = `${L.prefix}${L.name}`.trim();
-    const localName = `${R.prefix}${R.name}`.trim();
-    if (!importedName)
-      throw new Error(`Could not parse imported name from: ${t}`);
-    if (!localName) throw new Error(`Could not parse local name from: ${t}`);
-    return {
-      importedName,
-      localName
-    };
-  };
-  if (!cell.id && cell.body?.type === "ImportDeclaration") {
-    const module_name = cell.body.source.value;
-    const importKeyword = globalThis?.importShim ? "importShim" : "import";
-    const cell_variables = [
-      {
-        _name: `module ${module_name}`,
-        _inputs: [],
-        _definition: `async () => runtime.module((await ${importKeyword}("${module_name}")).default)`
-      }
-    ];
-    for (const specifier of cell.body.specifiers ?? []) {
-      const specText =
-        typeof specifier?.start === "number" &&
-        typeof specifier?.end === "number"
-          ? source.slice(specifier.start, specifier.end)
-          : (() => {
-              if (specifier?.imported?.name && specifier?.local?.name) {
-                return specifier.imported.name === specifier.local.name
-                  ? specifier.local.name
-                  : `${specifier.imported.name} as ${specifier.local.name}`;
-              }
-              throw new Error("Import specifier missing range information");
+    if (!cell.id && cell.body?.type === 'ImportDeclaration') {
+        const module_name = cell.body.source.value;
+        const cell_variables = [{
+                _name: `module ${ module_name }`,
+                _inputs: [],
+                _definition: `async () => runtime.module((await import("${ module_name }")).default)`
+            }];
+        for (const specifier of cell.body.specifiers ?? []) {
+            const specText = typeof specifier?.start === 'number' && typeof specifier?.end === 'number' ? source.slice(specifier.start, specifier.end) : (() => {
+                if (specifier?.imported?.name && specifier?.local?.name) {
+                    return specifier.imported.name === specifier.local.name ? specifier.local.name : `${ specifier.imported.name } as ${ specifier.local.name }`;
+                }
+                throw new Error('Import specifier missing range information');
             })();
-      const { importedName, localName } = parseImportSpecifierText(specText);
-      cell_variables.push({
-        _name: localName,
-        _inputs: [`module ${module_name}`, "@variable"],
-        _definition:
-          importedName === localName
-            ? `(_, v) => v.import("${importedName}", _)`
-            : `(_, v) => v.import("${importedName}", "${localName}", _)`
-      });
+            const {importedName, localName} = parseImportSpecifierText(specText);
+            cell_variables.push({
+                _name: localName,
+                _inputs: [
+                    `module ${ module_name }`,
+                    '@variable'
+                ],
+                _definition: importedName === localName ? `(_, v) => v.import("${ importedName }", _)` : `(_, v) => v.import("${ importedName }", "${ localName }", _)`
+            });
+        }
+        return cell_variables;
     }
-    return cell_variables;
-  }
-  let dollarIdx = 0;
-  const inputToArgMap = {};
-  const dollarToMacro = {};
-  const seen = new Set();
-  const inputs = Array.from(cell.references || []).flatMap((i) => {
-    if (i.name) {
-      if (seen.has(i.name)) return [];
-      seen.add(i.name);
-      return i.name;
+    let dollarIdx = 0;
+    const inputToArgMap = {};
+    const dollarToMacro = {};
+    const seen = new Set();
+    const inputs = Array.from(cell.references || []).flatMap(i => {
+        if (i.name) {
+            if (seen.has(i.name))
+                return [];
+            seen.add(i.name);
+            return i.name;
+        } else {
+            const dedupKey = i.type + ':' + i.id.name;
+            if (seen.has(dedupKey))
+                return [];
+            seen.add(dedupKey);
+            const dollarName = '$' + dollarIdx;
+            inputToArgMap[i.id.name] = dollarName;
+            dollarToMacro[dollarName] = i.type == 'ViewExpression' ? 'viewof ' + i.id.name : 'mutable ' + i.id.name;
+            dollarIdx++;
+            return dollarName;
+        }
+    });
+    let variables;
+    if (cell.id) {
+        if (cell.id.type === 'Identifier') {
+            variables = [{
+                    functionName: '_' + cell.id.name,
+                    name: cell.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                }];
+        } else if (cell.id.type === 'ViewExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'viewof ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '(G, _) => G.input(_)',
+                    inputs: [
+                        'Generators',
+                        'viewof ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                }
+            ];
+        } else if (cell.id.type === 'MutableExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'initial ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'mutable ' + cell.id.id.name,
+                    _definition: '(M, _) => new M(_)',
+                    inputs: [
+                        'Mutable',
+                        'initial ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '_ => _.generator',
+                    inputs: ['mutable ' + cell.id.id.name],
+                    params: inputs.join(',')
+                }
+            ];
+        } else {
+            throw new Error(`Unsupported cell id type: ${ cell.id.type }`);
+        }
     } else {
-      const dedupKey = i.type + ":" + i.id.name;
-      if (seen.has(dedupKey)) return [];
-      seen.add(dedupKey);
-      const dollarName = "$" + dollarIdx;
-      inputToArgMap[i.id.name] = dollarName;
-      dollarToMacro[dollarName] =
-        i.type == "ViewExpression"
-          ? "viewof " + i.id.name
-          : "mutable " + i.id.name;
-      dollarIdx++;
-      return dollarName;
+        variables = [{
+                functionName: anonymousName,
+                name: null,
+                inputs,
+                params: inputs.join(',')
+            }];
     }
-  });
-  let variables;
-  if (cell.id) {
-    if (cell.id.type === "Identifier") {
-      variables = [
-        {
-          functionName: "_" + cell.id.name,
-          name: cell.id.name,
-          inputs,
-          params: inputs.join(",")
+    return variables.map(v => {
+        let _definition = v._definition;
+        if (!_definition) {
+            let functionBody;
+            if (cell.body.type === 'BlockStatement') {
+                functionBody = observableToJs(cell.body, inputToArgMap, comments, tokens);
+            } else {
+                const bodyCode = observableToJs(cell.body, inputToArgMap, comments, tokens);
+                functionBody = `{return (${ bodyCode });}`;
+            }
+            _definition = `${ cell.async ? 'async ' : '' }function${ cell.generator ? '*' : '' } ${ v.functionName }(${ v.inputs.join(',') }) ${ functionBody }`;
         }
-      ];
-    } else if (cell.id.type === "ViewExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "viewof " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "(G, _) => G.input(_)",
-          inputs: ["Generators", "viewof " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else if (cell.id.type === "MutableExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "initial " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "mutable " + cell.id.id.name,
-          _definition: "(M, _) => new M(_)",
-          inputs: ["Mutable", "initial " + cell.id.id.name],
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "_ => _.generator",
-          inputs: ["mutable " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else {
-      throw new Error(`Unsupported cell id type: ${cell.id.type}`);
-    }
-  } else {
-    variables = [
-      {
-        functionName: anonymousName,
-        name: null,
-        inputs,
-        params: inputs.join(",")
-      }
-    ];
-  }
-  return variables.map((v) => {
-    let _definition = v._definition;
-    if (!_definition) {
-      let functionBody;
-      if (cell.body.type === "BlockStatement") {
-        functionBody = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-      } else {
-        const bodyCode = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-        functionBody = `{return (${bodyCode});}`;
-      }
-      _definition = `${cell.async ? "async " : ""}function${
-        cell.generator ? "*" : ""
-      } ${v.functionName}(${v.inputs.join(",")}) ${functionBody}`;
-    }
-    return {
-      _name: v.name,
-      _inputs: v.inputs.map(
-        (i) => dollarToMacro[i] || (i === "$variable" ? "@variable" : i)
-      ),
-      _definition
-    };
-  });
+        return {
+            _name: v.name,
+            _inputs: v.inputs.map(i => dollarToMacro[i] || (i === '$variable' ? '@variable' : i)),
+            _definition
+        };
+    });
 }
 )};
 const _1v1i7wl = function _observableToJs(acorn_walk,parser,escodegen){return(
@@ -22311,16 +22249,15 @@ async (attachment, overrides) => {
   return URL.createObjectURL(blob);
 }
 )};
-const _s9w7ha = async function _parser(decompress_url,FileAttachment,acorn_url,acorn_walk_url){return(
-importShim(await decompress_url(FileAttachment("parser-6.1.0.js.gz"), {
-    "/npm/acorn@8.11.3/+esm": acorn_url,
-    "/npm/acorn-walk@8.3.2/+esm": acorn_walk_url
-  })
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
-const _1hiclbb = function _acorn_walk(acorn_walk_url){return(
-importShim(acorn_walk_url, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _s9w7ha = async function _parser(decompress_url, FileAttachment, acorn_url, acorn_walk_url) {
+    return import(await decompress_url(FileAttachment('parser-6.1.0.js.gz'), {
+        '/npm/acorn@8.11.3/+esm': acorn_url,
+        '/npm/acorn-walk@8.3.2/+esm': acorn_walk_url
+    }));
+};
+const _1hiclbb = function _acorn_walk(acorn_walk_url) {
+    return import(acorn_walk_url);
+};
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
@@ -22508,7 +22445,7 @@ export default function define(runtime, observer) {
   $def("_1dmmuaf", "compiled_selector", ["Generators","viewof compiled_selector"], _1dmmuaf);  
   $def("_u7t3vu", null, ["compiled_selector","normalizeJavascriptSource"], _u7t3vu);  
   $def("_1lt3kl6", null, ["compile","test_case"], _1lt3kl6);  
-  $def("_lpzjrv", "compile", ["parser","globalThis","observableToJs"], _lpzjrv);  
+  $def("_x1d0wm", "compile", ["parser","observableToJs"], _x1d0wm);  
   $def("_1v1i7wl", "observableToJs", ["acorn_walk","parser","escodegen"], _1v1i7wl);  
   $def("_19lv24l", null, ["md"], _19lv24l);  
   $def("_xhj6b8", "decompress_url", ["DecompressionStream","TextDecoderStream","TransformStream","TextEncoderStream","Response"], _xhj6b8);  

--- a/notebooks/@tomlarkworthy_lopecode-vision.html
+++ b/notebooks/@tomlarkworthy_lopecode-vision.html
@@ -6258,58 +6258,41 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _geoudp = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
-  if (command.processed) return;
-
-  let result = undefined;
-  if (command.command == "createCell") {
-    $0.value = true;
-    result = compile_and_update("{}", [], command.args.cell);
-    // For the new one to get focus
-    // setTimeout(() => {
-    //   debugger;
-    //   setOption(result[0], "pinned", true);
-    // }, 100);
-  } else if (command.command == "deleteCell") {
-    remove_variables(command.args.cell.variables);
-    result = true;
-  } else if (command.command == "moveCell") {
-    const cellIndex = findCellIndex(
-      command.args.cell.variables,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const targetCellIndex = cellIndex + command.args.amount;
-    const targetCell = lookupCellByIndex(
-      targetCellIndex,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const currentFirstVariableIndex = findVariableIndex(
-      command.args.cell.variables[0]
-    );
-    const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-    const change = targetFirstVariableIndex - currentFirstVariableIndex;
-    console.log(
-      "moveCell",
-      cellIndex,
-      targetCellIndex,
-      targetCell,
-      currentFirstVariableIndex,
-      targetFirstVariableIndex,
-      change
-    );
-    command.args.cell.variables.forEach((v) => {
-      const currentIndex = findVariableIndex(v);
-      repositionSetElement(runtime._variables, v, currentIndex + change);
-    });
-    // recompute
-    await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
-    result = true;
-  }
-  if (result) {
-    command.processed = true;
-    $2.resolve(result);
-  }
+    if (command.processed)
+        return;
+    let result = undefined;
+    if (command.command == 'createCell') {
+        $0.value = true;
+        result = await compile_and_update('{}', [], command.args.cell);    // For the new one to get focus
+                                                                           // setTimeout(() => {
+                                                                           //   debugger;
+                                                                           //   setOption(result[0], "pinned", true);
+                                                                           // }, 100);
+    } else if (command.command == 'deleteCell') {
+        remove_variables(command.args.cell.variables);
+        result = true;
+    } else if (command.command == 'moveCell') {
+        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const targetCellIndex = cellIndex + command.args.amount;
+        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
+        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+        const change = targetFirstVariableIndex - currentFirstVariableIndex;
+        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
+        command.args.cell.variables.forEach(v => {
+            const currentIndex = findVariableIndex(v);
+            repositionSetElement(runtime._variables, v, currentIndex + change);
+        });
+        // recompute
+        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        result = true;
+    }
+    if (result) {
+        command.processed = true;
+        $2.resolve(result);
+    }
 };
 const _1jadxoe = function _60(md){return(
 md`### UI Action`
@@ -6700,9 +6683,9 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
-    return (source, variables = [], cell) => {
+    return async (source, variables = [], cell) => {
         try {
             debugger;
             let reposition = false, insertionIndex = -1;
@@ -6722,10 +6705,10 @@ const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElemen
             if (reposition) {
                 insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
+            const fns = await realize(newVariables.map(v => v._definition), runtime);
             newVariables.forEach((v, i) => {
                 const variable = variables[i];
-                let _fn;
-                eval('_fn = ' + v._definition);
+                const _fn = fns[i];
                 if (v._name) {
                     variable.define(v._name, v._inputs, _fn);
                 } else {
@@ -6774,12 +6757,11 @@ Inputs.textarea({
 })
 )};
 const _b4rsn5 = (G, _) => G.input(_);
-const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
+const _ga6kci = function _98(Inputs,definition,variable,realize,runtime,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
-  reduce: () => {
-    let _fn;
-    eval("_fn = " + definition);
+  reduce: async () => {
+    const [_fn] = await realize([definition], runtime);
     variable.define(variable._name, inputs, _fn);
   }
 })
@@ -6892,7 +6874,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_geoudp", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _geoudp);  
+  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6930,7 +6912,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
+  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -6940,8 +6922,9 @@ export default function define(runtime, observer) {
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
   $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
-  $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
+  $def("_ga6kci", null, ["Inputs","definition","variable","realize","runtime","inputs"], _ga6kci);  
   $def("_1q557s", null, ["md"], _1q557s);  
+  main.define("realize", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("realize", _));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -17609,10 +17592,9 @@ notebook_semantics_document.nodes.map((s) => ({
 const _1oevsow = function _28(md){return(
 md`### Runtime Representation (v4)`
 )};
-const _11lfflk = function _notebook_semantics_module(){return(
-importShim("https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4"
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _11lfflk = function _notebook_semantics_module() {
+    return import('https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4');
+};
 const _gjten6 = function _31(md){return(
 md`### Imports`
 )};
@@ -18599,65 +18581,44 @@ parser.parseCell(
   'import {runtime, viewof main as foo} from "@mootari/access-runtime"'
 )
 )};
-const _1n7gw17 = function _findModuleName(extractModuleInfo){return(
-(scope, module, { unknown_id = Math.random() } = {}) => {
-  try {
-    const scopedVariables = [...scope.values()];
-
-    // Prefer variables that *define* a module and have a real module-loader name.
-    const candidates = scopedVariables.filter(
-      (v) =>
-        v &&
-        v._value === module &&
-        typeof v._name === "string" &&
-        v._name.startsWith("module ") &&
-        !v._name.startsWith("module <unknown")
-    );
-
-    const pickBestInfo = (dfn) => {
-      // Avoid the parentUrl (2nd arg) confusing module identification.
-      // Typical patterns:
-      //   importShim("/d/<id>@<ver>.js?v=4", "https://api.observablehq.com/@ns/name.js?v=4")
-      //   import("/d/<id>@<ver>.js?v=4")
-      // Prefer the *first argument* inside importShim(...) / import(...) when present.
-      const s = String(dfn ?? "");
-
-      // Try to capture the first string literal argument to importShim(...) or import(...)
-      // Tolerates quotes ", ', ` and both importShim and plain import.
-      const m = s.match(
-        /\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/
-      );
-      const firstArg = m?.[2];
-
-      const info1 = firstArg ? extractModuleInfo(firstArg) : {};
-      if (info1?.id || info1?.notebook) return info1;
-
-      // Fallback: parse the whole definition string.
-      return extractModuleInfo(s);
+const _1n7gw17 = function _findModuleName(extractModuleInfo) {
+    return (scope, module, {
+        unknown_id = Math.random()
+    } = {}) => {
+        try {
+            const scopedVariables = [...scope.values()];
+            const candidates = scopedVariables.filter(v => v && v._value === module && typeof v._name === 'string' && v._name.startsWith('module ') && !v._name.startsWith('module <unknown'));
+            const pickBestInfo = dfn => {
+                const s = String(dfn ?? '');
+                const m = s.match(/\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/);
+                const firstArg = m?.[2];
+                const info1 = firstArg ? extractModuleInfo(firstArg) : {};
+                if (info1?.id || info1?.notebook)
+                    return info1;
+                return extractModuleInfo(s);
+            };
+            for (const v of candidates) {
+                const info = pickBestInfo(v._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            const any = scopedVariables.find(v => v && v._value === module);
+            if (any) {
+                const info = pickBestInfo(any._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            return `<unknown ${ unknown_id }>`;
+        } catch (e) {
+            debugger;
+            return 'error';
+        }
     };
-
-    // Try module loader cells first.
-    for (const v of candidates) {
-      const info = pickBestInfo(v._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    // Fallback: any scoped variable with _value==module.
-    const any = scopedVariables.find((v) => v && v._value === module);
-    if (any) {
-      const info = pickBestInfo(any._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    return `<unknown ${unknown_id}>`;
-  } catch (e) {
-    debugger;
-    return "error";
-  }
-}
-)};
+};
 const _i47chb = function _findImportedName(){return(
 async (v) => {
   if (v._inputs.length == 1 && v._inputs[0]._name === "@variable") {
@@ -19559,229 +19520,206 @@ JSON.stringify(
 const _1lt3kl6 = function _157(compile,test_case){return(
 compile(test_case.value)
 )};
-const _lpzjrv = function _compile(parser,globalThis,observableToJs){return(
-function compile(source, { anonymousName = "_anonymous" } = {}) {
-  const comments = [],
-    tokens = [];
-  let cell;
-  try {
-    cell = parser.parseCell(source, {
-      ranges: true,
-      onComment: comments,
-      onToken: tokens
-    });
-  } catch (e) {
-    if (e instanceof SyntaxError) {
-      const nameMatch = source.match(
-        /^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/
-      );
-      let _name = null;
-      let funcName = anonymousName;
-      if (nameMatch) {
-        const prefix = nameMatch[1] ? nameMatch[1] + " " : "";
-        _name = prefix + nameMatch[2];
-        funcName = "_" + nameMatch[2];
-      }
-      const escapedMsg = JSON.stringify(e.message);
-      const escapedSource = JSON.stringify(source);
-      return [
-        {
-          _name,
-          _inputs: [],
-          _definition: `function ${funcName}() { throw Object.assign(new SyntaxError(${escapedMsg}), {_sourceExpression: ${escapedSource}}); }`
+const _x1d0wm = function _compile(parser,observableToJs){return(
+function compile(source, {
+    anonymousName = '_anonymous'
+} = {}) {
+    const comments = [], tokens = [];
+    let cell;
+    try {
+        cell = parser.parseCell(source, {
+            ranges: true,
+            onComment: comments,
+            onToken: tokens
+        });
+    } catch (e) {
+        if (e instanceof SyntaxError) {
+            const nameMatch = source.match(/^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/);
+            let _name = null;
+            let funcName = anonymousName;
+            if (nameMatch) {
+                const prefix = nameMatch[1] ? nameMatch[1] + ' ' : '';
+                _name = prefix + nameMatch[2];
+                funcName = '_' + nameMatch[2];
+            }
+            const escapedMsg = JSON.stringify(e.message);
+            const escapedSource = JSON.stringify(source);
+            return [{
+                    _name,
+                    _inputs: [],
+                    _definition: `function ${ funcName }() { throw Object.assign(new SyntaxError(${ escapedMsg }), {_sourceExpression: ${ escapedSource }}); }`
+                }];
         }
-      ];
+        throw e;
     }
-    throw e;
-  }
-  if (!cell) throw new Error("Unable to parse cell");
-  const parseImportSpecifierText = (text) => {
-    const t = String(text ?? "")
-      .trim()
-      .replace(/,$/, "")
-      .trim();
-    if (!t) throw new Error("Empty import specifier");
-    const parts = t.split(/\s+as\s+/);
-    const left = parts[0].trim();
-    const right = parts[1]?.trim();
-    const parseSide = (side, { defaultPrefix = "" } = {}) => {
-      const s = String(side ?? "").trim();
-      const m = s.match(/^(viewof|mutable)\s+(.+)$/);
-      if (m)
-        return {
-          prefix: `${m[1]} `,
-          name: m[2].trim()
+    if (!cell)
+        throw new Error('Unable to parse cell');
+    const parseImportSpecifierText = text => {
+        const t = String(text ?? '').trim().replace(/,$/, '').trim();
+        if (!t)
+            throw new Error('Empty import specifier');
+        const parts = t.split(/\s+as\s+/);
+        const left = parts[0].trim();
+        const right = parts[1]?.trim();
+        const parseSide = (side, {
+            defaultPrefix = ''
+        } = {}) => {
+            const s = String(side ?? '').trim();
+            const m = s.match(/^(viewof|mutable)\s+(.+)$/);
+            if (m)
+                return {
+                    prefix: `${ m[1] } `,
+                    name: m[2].trim()
+                };
+            return {
+                prefix: defaultPrefix,
+                name: s
+            };
         };
-      return {
-        prefix: defaultPrefix,
-        name: s
-      };
+        const L = parseSide(left);
+        const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
+        const importedName = `${ L.prefix }${ L.name }`.trim();
+        const localName = `${ R.prefix }${ R.name }`.trim();
+        if (!importedName)
+            throw new Error(`Could not parse imported name from: ${ t }`);
+        if (!localName)
+            throw new Error(`Could not parse local name from: ${ t }`);
+        return {
+            importedName,
+            localName
+        };
     };
-    const L = parseSide(left);
-    const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
-    const importedName = `${L.prefix}${L.name}`.trim();
-    const localName = `${R.prefix}${R.name}`.trim();
-    if (!importedName)
-      throw new Error(`Could not parse imported name from: ${t}`);
-    if (!localName) throw new Error(`Could not parse local name from: ${t}`);
-    return {
-      importedName,
-      localName
-    };
-  };
-  if (!cell.id && cell.body?.type === "ImportDeclaration") {
-    const module_name = cell.body.source.value;
-    const importKeyword = globalThis?.importShim ? "importShim" : "import";
-    const cell_variables = [
-      {
-        _name: `module ${module_name}`,
-        _inputs: [],
-        _definition: `async () => runtime.module((await ${importKeyword}("${module_name}")).default)`
-      }
-    ];
-    for (const specifier of cell.body.specifiers ?? []) {
-      const specText =
-        typeof specifier?.start === "number" &&
-        typeof specifier?.end === "number"
-          ? source.slice(specifier.start, specifier.end)
-          : (() => {
-              if (specifier?.imported?.name && specifier?.local?.name) {
-                return specifier.imported.name === specifier.local.name
-                  ? specifier.local.name
-                  : `${specifier.imported.name} as ${specifier.local.name}`;
-              }
-              throw new Error("Import specifier missing range information");
+    if (!cell.id && cell.body?.type === 'ImportDeclaration') {
+        const module_name = cell.body.source.value;
+        const cell_variables = [{
+                _name: `module ${ module_name }`,
+                _inputs: [],
+                _definition: `async () => runtime.module((await import("${ module_name }")).default)`
+            }];
+        for (const specifier of cell.body.specifiers ?? []) {
+            const specText = typeof specifier?.start === 'number' && typeof specifier?.end === 'number' ? source.slice(specifier.start, specifier.end) : (() => {
+                if (specifier?.imported?.name && specifier?.local?.name) {
+                    return specifier.imported.name === specifier.local.name ? specifier.local.name : `${ specifier.imported.name } as ${ specifier.local.name }`;
+                }
+                throw new Error('Import specifier missing range information');
             })();
-      const { importedName, localName } = parseImportSpecifierText(specText);
-      cell_variables.push({
-        _name: localName,
-        _inputs: [`module ${module_name}`, "@variable"],
-        _definition:
-          importedName === localName
-            ? `(_, v) => v.import("${importedName}", _)`
-            : `(_, v) => v.import("${importedName}", "${localName}", _)`
-      });
+            const {importedName, localName} = parseImportSpecifierText(specText);
+            cell_variables.push({
+                _name: localName,
+                _inputs: [
+                    `module ${ module_name }`,
+                    '@variable'
+                ],
+                _definition: importedName === localName ? `(_, v) => v.import("${ importedName }", _)` : `(_, v) => v.import("${ importedName }", "${ localName }", _)`
+            });
+        }
+        return cell_variables;
     }
-    return cell_variables;
-  }
-  let dollarIdx = 0;
-  const inputToArgMap = {};
-  const dollarToMacro = {};
-  const seen = new Set();
-  const inputs = Array.from(cell.references || []).flatMap((i) => {
-    if (i.name) {
-      if (seen.has(i.name)) return [];
-      seen.add(i.name);
-      return i.name;
+    let dollarIdx = 0;
+    const inputToArgMap = {};
+    const dollarToMacro = {};
+    const seen = new Set();
+    const inputs = Array.from(cell.references || []).flatMap(i => {
+        if (i.name) {
+            if (seen.has(i.name))
+                return [];
+            seen.add(i.name);
+            return i.name;
+        } else {
+            const dedupKey = i.type + ':' + i.id.name;
+            if (seen.has(dedupKey))
+                return [];
+            seen.add(dedupKey);
+            const dollarName = '$' + dollarIdx;
+            inputToArgMap[i.id.name] = dollarName;
+            dollarToMacro[dollarName] = i.type == 'ViewExpression' ? 'viewof ' + i.id.name : 'mutable ' + i.id.name;
+            dollarIdx++;
+            return dollarName;
+        }
+    });
+    let variables;
+    if (cell.id) {
+        if (cell.id.type === 'Identifier') {
+            variables = [{
+                    functionName: '_' + cell.id.name,
+                    name: cell.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                }];
+        } else if (cell.id.type === 'ViewExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'viewof ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '(G, _) => G.input(_)',
+                    inputs: [
+                        'Generators',
+                        'viewof ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                }
+            ];
+        } else if (cell.id.type === 'MutableExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'initial ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'mutable ' + cell.id.id.name,
+                    _definition: '(M, _) => new M(_)',
+                    inputs: [
+                        'Mutable',
+                        'initial ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '_ => _.generator',
+                    inputs: ['mutable ' + cell.id.id.name],
+                    params: inputs.join(',')
+                }
+            ];
+        } else {
+            throw new Error(`Unsupported cell id type: ${ cell.id.type }`);
+        }
     } else {
-      const dedupKey = i.type + ":" + i.id.name;
-      if (seen.has(dedupKey)) return [];
-      seen.add(dedupKey);
-      const dollarName = "$" + dollarIdx;
-      inputToArgMap[i.id.name] = dollarName;
-      dollarToMacro[dollarName] =
-        i.type == "ViewExpression"
-          ? "viewof " + i.id.name
-          : "mutable " + i.id.name;
-      dollarIdx++;
-      return dollarName;
+        variables = [{
+                functionName: anonymousName,
+                name: null,
+                inputs,
+                params: inputs.join(',')
+            }];
     }
-  });
-  let variables;
-  if (cell.id) {
-    if (cell.id.type === "Identifier") {
-      variables = [
-        {
-          functionName: "_" + cell.id.name,
-          name: cell.id.name,
-          inputs,
-          params: inputs.join(",")
+    return variables.map(v => {
+        let _definition = v._definition;
+        if (!_definition) {
+            let functionBody;
+            if (cell.body.type === 'BlockStatement') {
+                functionBody = observableToJs(cell.body, inputToArgMap, comments, tokens);
+            } else {
+                const bodyCode = observableToJs(cell.body, inputToArgMap, comments, tokens);
+                functionBody = `{return (${ bodyCode });}`;
+            }
+            _definition = `${ cell.async ? 'async ' : '' }function${ cell.generator ? '*' : '' } ${ v.functionName }(${ v.inputs.join(',') }) ${ functionBody }`;
         }
-      ];
-    } else if (cell.id.type === "ViewExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "viewof " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "(G, _) => G.input(_)",
-          inputs: ["Generators", "viewof " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else if (cell.id.type === "MutableExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "initial " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "mutable " + cell.id.id.name,
-          _definition: "(M, _) => new M(_)",
-          inputs: ["Mutable", "initial " + cell.id.id.name],
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "_ => _.generator",
-          inputs: ["mutable " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else {
-      throw new Error(`Unsupported cell id type: ${cell.id.type}`);
-    }
-  } else {
-    variables = [
-      {
-        functionName: anonymousName,
-        name: null,
-        inputs,
-        params: inputs.join(",")
-      }
-    ];
-  }
-  return variables.map((v) => {
-    let _definition = v._definition;
-    if (!_definition) {
-      let functionBody;
-      if (cell.body.type === "BlockStatement") {
-        functionBody = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-      } else {
-        const bodyCode = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-        functionBody = `{return (${bodyCode});}`;
-      }
-      _definition = `${cell.async ? "async " : ""}function${
-        cell.generator ? "*" : ""
-      } ${v.functionName}(${v.inputs.join(",")}) ${functionBody}`;
-    }
-    return {
-      _name: v.name,
-      _inputs: v.inputs.map(
-        (i) => dollarToMacro[i] || (i === "$variable" ? "@variable" : i)
-      ),
-      _definition
-    };
-  });
+        return {
+            _name: v.name,
+            _inputs: v.inputs.map(i => dollarToMacro[i] || (i === '$variable' ? '@variable' : i)),
+            _definition
+        };
+    });
 }
 )};
 const _1v1i7wl = function _observableToJs(acorn_walk,parser,escodegen){return(
@@ -19848,16 +19786,15 @@ async (attachment, overrides) => {
   return URL.createObjectURL(blob);
 }
 )};
-const _s9w7ha = async function _parser(decompress_url,FileAttachment,acorn_url,acorn_walk_url){return(
-importShim(await decompress_url(FileAttachment("parser-6.1.0.js.gz"), {
-    "/npm/acorn@8.11.3/+esm": acorn_url,
-    "/npm/acorn-walk@8.3.2/+esm": acorn_walk_url
-  })
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
-const _1hiclbb = function _acorn_walk(acorn_walk_url){return(
-importShim(acorn_walk_url, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _s9w7ha = async function _parser(decompress_url, FileAttachment, acorn_url, acorn_walk_url) {
+    return import(await decompress_url(FileAttachment('parser-6.1.0.js.gz'), {
+        '/npm/acorn@8.11.3/+esm': acorn_url,
+        '/npm/acorn-walk@8.3.2/+esm': acorn_walk_url
+    }));
+};
+const _1hiclbb = function _acorn_walk(acorn_walk_url) {
+    return import(acorn_walk_url);
+};
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
@@ -20045,7 +19982,7 @@ export default function define(runtime, observer) {
   $def("_1dmmuaf", "compiled_selector", ["Generators","viewof compiled_selector"], _1dmmuaf);  
   $def("_u7t3vu", null, ["compiled_selector","normalizeJavascriptSource"], _u7t3vu);  
   $def("_1lt3kl6", null, ["compile","test_case"], _1lt3kl6);  
-  $def("_lpzjrv", "compile", ["parser","globalThis","observableToJs"], _lpzjrv);  
+  $def("_x1d0wm", "compile", ["parser","observableToJs"], _x1d0wm);  
   $def("_1v1i7wl", "observableToJs", ["acorn_walk","parser","escodegen"], _1v1i7wl);  
   $def("_19lv24l", null, ["md"], _19lv24l);  
   $def("_xhj6b8", "decompress_url", ["DecompressionStream","TextDecoderStream","TransformStream","TextEncoderStream","Response"], _xhj6b8);  

--- a/notebooks/@tomlarkworthy_lopepage-urls.html
+++ b/notebooks/@tomlarkworthy_lopepage-urls.html
@@ -4667,7 +4667,7 @@ export default function define(runtime, observer) {
 >
 e30K
 </script>
-<script id="@tomlarkworthy/editor-5" 
+<script id="@tomlarkworthy/editor-5"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -5414,58 +5414,41 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _geoudp = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
-  if (command.processed) return;
-
-  let result = undefined;
-  if (command.command == "createCell") {
-    $0.value = true;
-    result = compile_and_update("{}", [], command.args.cell);
-    // For the new one to get focus
-    // setTimeout(() => {
-    //   debugger;
-    //   setOption(result[0], "pinned", true);
-    // }, 100);
-  } else if (command.command == "deleteCell") {
-    remove_variables(command.args.cell.variables);
-    result = true;
-  } else if (command.command == "moveCell") {
-    const cellIndex = findCellIndex(
-      command.args.cell.variables,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const targetCellIndex = cellIndex + command.args.amount;
-    const targetCell = lookupCellByIndex(
-      targetCellIndex,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const currentFirstVariableIndex = findVariableIndex(
-      command.args.cell.variables[0]
-    );
-    const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-    const change = targetFirstVariableIndex - currentFirstVariableIndex;
-    console.log(
-      "moveCell",
-      cellIndex,
-      targetCellIndex,
-      targetCell,
-      currentFirstVariableIndex,
-      targetFirstVariableIndex,
-      change
-    );
-    command.args.cell.variables.forEach((v) => {
-      const currentIndex = findVariableIndex(v);
-      repositionSetElement(runtime._variables, v, currentIndex + change);
-    });
-    // recompute
-    await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
-    result = true;
-  }
-  if (result) {
-    command.processed = true;
-    $2.resolve(result);
-  }
+    if (command.processed)
+        return;
+    let result = undefined;
+    if (command.command == 'createCell') {
+        $0.value = true;
+        result = await compile_and_update('{}', [], command.args.cell);    // For the new one to get focus
+                                                                           // setTimeout(() => {
+                                                                           //   debugger;
+                                                                           //   setOption(result[0], "pinned", true);
+                                                                           // }, 100);
+    } else if (command.command == 'deleteCell') {
+        remove_variables(command.args.cell.variables);
+        result = true;
+    } else if (command.command == 'moveCell') {
+        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const targetCellIndex = cellIndex + command.args.amount;
+        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
+        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+        const change = targetFirstVariableIndex - currentFirstVariableIndex;
+        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
+        command.args.cell.variables.forEach(v => {
+            const currentIndex = findVariableIndex(v);
+            repositionSetElement(runtime._variables, v, currentIndex + change);
+        });
+        // recompute
+        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        result = true;
+    }
+    if (result) {
+        command.processed = true;
+        $2.resolve(result);
+    }
 };
 const _1jadxoe = function _60(md){return(
 md`### UI Action`
@@ -5856,9 +5839,9 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
-    return (source, variables = [], cell) => {
+    return async (source, variables = [], cell) => {
         try {
             debugger;
             let reposition = false, insertionIndex = -1;
@@ -5878,10 +5861,10 @@ const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElemen
             if (reposition) {
                 insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
+            const fns = await realize(newVariables.map(v => v._definition), runtime);
             newVariables.forEach((v, i) => {
                 const variable = variables[i];
-                let _fn;
-                eval('_fn = ' + v._definition);
+                const _fn = fns[i];
                 if (v._name) {
                     variable.define(v._name, v._inputs, _fn);
                 } else {
@@ -5930,12 +5913,11 @@ Inputs.textarea({
 })
 )};
 const _b4rsn5 = (G, _) => G.input(_);
-const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
+const _ga6kci = function _98(Inputs,definition,variable,realize,runtime,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
-  reduce: () => {
-    let _fn;
-    eval("_fn = " + definition);
+  reduce: async () => {
+    const [_fn] = await realize([definition], runtime);
     variable.define(variable._name, inputs, _fn);
   }
 })
@@ -6048,7 +6030,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_geoudp", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _geoudp);  
+  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6086,7 +6068,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
+  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -6096,8 +6078,9 @@ export default function define(runtime, observer) {
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
   $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
-  $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
+  $def("_ga6kci", null, ["Inputs","definition","variable","realize","runtime","inputs"], _ga6kci);  
   $def("_1q557s", null, ["md"], _1q557s);  
+  main.define("realize", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("realize", _));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -6133,7 +6116,8 @@ export default function define(runtime, observer) {
   main.define("navHref", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("navHref", _));  
   main.define("cellsToClipboard", ["module @tomlarkworthy/cells-to-clipboard", "@variable"], (_, v) => v.import("cellsToClipboard", _));
   return main;
-}</script>
+}
+</script>
 <script id="@tomlarkworthy/escodegen/escodegen.browser.min.js.gz" 
   type="text/plain"
   data-encoding="base64"
@@ -15847,7 +15831,7 @@ H4sICB8jLWcCA2Fjb3JuLXdhbGtAOC4zLjIuanMApVlbU+O4En6fX2E4VZQza5wAs8yC8XK47FZRNbcC
 >
 H4sICOAiLWcCA3BhcnNlckA2LjEuMC5qcwDtOmtz20aS3/MrIF6KAWIIFKX4ETCwYstKnW4V2yfJSW2ptKsh0KQmAgF6MJTEpfDfr3sewICknNzdbu1+2CqVOK/u6el3z2Dw7bdfed96bxdFlkPmjZfeb9U7yPmd8BYVL6beWZnni7l3tx+9/D4aeqzIvAsQFQjv7nk0/D7ajwj+g+BTXrDcm/AcYm9QzGeDH8sxLrtj4xxuPg/mjIB+fBENo71BJdIBLzJ4iH6rEJwwvCu99x8ucFPwzs9OvHsub7xsWbAZT1meL70pFCCYRBppi2rH+7kU4PFiUooZk7wsYu9GynkVDwb39/eIN1OniNJyNlAn2a0E3yW0uwbtrkKEew++4rN5KeTqorw9KgsJD9JjlQehLG8vlnOoqCfDj+oE1BbhFOQpL+AEt6eBop6IctZTx2ZpKYofX0XDYXQweAbVrDcy6GfsFmh1FbIihUqWChkPK5zP1Qxbx7N7z/JbRHYQ7Rtcd0x4ZVLAvXcO0r/svRGCLXuh/n27mExAYI/JckyDi4yX5kjYfZur0bdlmQMrqMWnJwXNjGXJ8CfFcYEjJLbc9i/4DMoFrUrLokJQaonlXJbYOFrgOWbHd6DQvGOS/cLhXjdpYQZpmcGnsxO3fVQiQwoNksEdT+Ejf4D8jORIQ2W6mOlZKFrwpu2CHwtR0oGhStmcNgRN+QRkeoO/P3FFL/2c8kqa5hmwTPHpp7xk8mDfMlF1X3zXdBdFSqqFzf9UEBW2TmZsCvaXDkztYsILLpeqKYcvLALstMix88ppE5W8+ongQDXfs/f4+1/nH+jnZzZX/yUdQs+8X8zGiuiC3fEpSpjaH8a/QUrHUval6LcdLdk5CGUiqHHY+4gI999RA/WMV6BbD0TSGSumYNl5BqhHyHB3INcbncH0+IGISwln/qbg2v5+EmxG+AR8XqByb4yjuuL/CqSjX9hrtetcCjRTaixn4zJXjUKyB0vCBSrxO6VCtndc2J684SQbsla7/BN3JUG9VhTUe9XpHOVsNofMjqE7BBQpZKrdKBcqX4P+7BT//wrsVouKWvqIv8L4vExvdbsUt4rAe3R35X3vKgjTpPJXJ8oj+MGqDslekKECqgq55aPXCUWwEj5EPMN27yRDTecTjmiCOvx5Icmh/mGAOhhNjBZ7cx9wHciFKBrVbhH1kiSBSCIHHx+baeR3zoSSY2ce+VTe/w4OVKwpyr4dqxtKcocSdErp7blEd6FsvkNFic7oyakPkyentk7Q8VsSFn8nZrQYb0gUwYqcpPREsqLZuOFCOC6zZXwJEf1e1WGhfDjqTohUGGOr4qpOYKSp8pgvwtURBr+WrBiS13qDFUVFgFiETEyVt6xiTsB84rsasJMkwpxDRBj2AAfk42MVqfD7YeKL4Ie9QO9IsEOc51EOxVTePD7u+L1TdE8CjRUPzC/3rhSufn/wl8tveleDSKKl+2pcsPsAeXUBGMuQ+dvB9mwXmiNVZrMgkDeoU552aBHDyWnhqzjXegH/+uuVrD1yMVxQXPYosmPszPV2XqV8iGd5ch2EqwJdRAxoB4pvl+wq4WGZuOdiirpDFqFTWkDMos8LVvGK6FQjmEOUt5Ch5a4qyYTEFeo3hCLDNv6vR0V0wyq/DA6LCHMDbETzRXXjp0FcRBUNhJfpFZpjmAZh0erMBHVmJdk0Rhtm9yjNKYZolldxEUZRhNqwqoNVDtLjJJxikec7iez3UXV5soyUm0cMlTmcx5KxGZQ0OPUZOoQiCO+pEYQ8wq0Shr+4WbKzI2rIMd/iSeaiMuo39XkIGhgbCFyj9leVl3noefHMmAZpVRSLFGMRwiLFqP/VAkOO3xXjCtIZ+wXjJ+nw8KAmfGp1DRQMztNyDq09evt91JVnz8ipRx/+apkVKsxRB6KGBy51x4FWgOlCoFHZyWiSs2nV7+/uPoG1xVPrUEq+R1u0wTtEVVkDRklE7J5xFIlvpli1LNJkZy8wiNeQaeRvCMb/MuYvIjQINLY/c8gzh31fRGfy6FKso7RYNE4ToFqkCrxA0ftBCFE1h1Q5mErv5MCcN1O4Uk2SdRFJ0V8p/bakNLh4QapCruCLuAwy9By42uS0C5b7PZUyK6LKhUgh6e6pPcJhi5m86RvMWf0gVoMY3hVKyCy9lMtVN+/Rb6DIepoS1/d3WOSSaHw/JJdXobA5+ojMt0BujzAP850z+DIaC5bCaTDa0cOsGTsLRmjiaPEBQg5H2kwna9BY2syYoZlN0CouBOM5nvaIJlpUwVhgcmJchGGycmDqiMGoiu4wB0ksDS5vaaKcIHeraKYzj2RHL+/3t603ixSArnogc6VKgcmyOb2B9PZTgX4c00HkfgvhLjgtMdJtzq3ty6pecIirclr9xzdUy7ftpieC2GJs93cX/8Lyc1W7WYiwh8LGwwsVDcygCruB4RdKqGqWmzBy3cZr75uvVy5Y/Y13Q3VhjhLMlt4YoPAypYqQXdM+LMu6+6AdqMizrsmV1eRGYXtBUBvjhrprGmtmryZ/Zssx/AmW96XInPTTqkjY6yayPcwGfh/Y6guWOuuJLSFw3JNDW63YdgR5jia35uiSvbDrN4fhpuMzY+QaUomWaVSqDSzD7zBTVLxTu9gUW7NEGFE6CiOUH8sSEer8LsHcINIEuNTgYEvFOlnWvTVxaJszInKs/zGkCet2dEaZ+VhTKEhezBcybK09UJ6oSlSGcoEZTYF78ISSipCpn5ErdIfJoevDtSH0+y4aNU2ZJckKitNDvuHK/XW3Q8bVgEE56fedfgUzjoHC2ZeUG0esuuGqSmdn/X6jRe3g46O/dlAHuUZVdDw/Lti2Xm0Nn3FjlvxzTWHTp60R3I0N8DkIOofQoaYjGFV5YRj03UGHJMxUVcKZMKcIcqhSpYJO7HtHlBtum0NJMGzyLLARnGSblrnawNpSS3c56Si+UXIeMqP1F+X8FO4g3+qjzGrMbGpZvlG5J3Gya8Bb+NtUc4cQa5+zBbx2DB6s0cmEDP/xEUZ+qZy+Vi8qhZrCrNcocDcKyO3+X1rPzzHFNrHq2uzuRK+2fG1NAoxuuxahx4wC6Y3BbvypsQDvVmskEQCGgGubH25uXa8HwK6LdMCcNV9mPLIxNox2DBOMh9eEa30kKbXeZC3HRAU67DnnwkrFKyeecoa92J2RZDjWmT5hlSr/t4kXr5yUA4I23dvIqLbmzPzJTKjj47FGqGuNeaY8OjLuuoc6TX8+JK8fIqr9iQAs+1RJtmxKsqxTkmGJBbYgU22HV+gRWHr734tSQuM6xJs8L+8xY9sZ1nQvyVluTtzUKpezKzf6GOm4sWJDHDbhV4456fVssSq28M29GMAs2uTOLdvs9cJxrq53/BWvLth0ClmMZ6Yin3JsYQr45LK4GjXk2DgzCroeJytzTKfe6kw87FDgZFIbvnHd4ZpcO7Sba9j/De2N2hRYpvO8yUuMAq1rigg3Lls2gsB2ZyqUX0c1a64hHlC+EBPvNL/mZfVDm0OYG5pm6tmzoMJKLjWs0WvSGyaOkK43JtLjOrIQhoXL9/vx01h3h02pj/MjU6oQ2MGLmC6k9g9sOfvkRs+GQWul2LcASrWMy200kheoiDyzvAs6QQRxJfsuy3R0XdMSTSVmzbUL3AVY28ZJyaIq5yn46x5MMczcsYz/33cs+/++Y/mXv2N5KpX5B1QzTV2yPc8DrZmOmf0D6xd0ej3X+Ux18pCUyoY1oYG6xt64eVHpAs0rcw4gaq/O7UR7m3S4MRLN2NynEArtdUIQY5hR9ytSLFcdjJbC/+O9ftW80soACyzcpjly2UWp74zBBoCdHUyL9RWCDJ58X2iBDvU1gEkxzYUzhM0bsZ64CoLOvTN6fNIENkMZleKYoTv3ZfIa8YSUWqiEpd+nTanlwGaaDhMCdPqmPb378BDfKESOQzdvlR+ZRM0sejFuL1BRhOTgkABEAm0QdGDVw5wDCjqIdgHRo22D/ai3WfZinNVpCK5xV5xBJU1Y1ots7r62TtcENNGQQqtzmDgrM5iwRS5j/Z5BUtBvFz3KoNNyWvC/YfY51wg8pU1e75nho2MX6hrmxqc7BX0d1U4ttQgoOxImwVcPP+2zJb37BCuK6CaFsuF2f1S8TvZGu7uFMrdulYJ6t/Alpk2B8yRUqhHMy+3YenlLrhBXmFLQF8m1rki8r1coFYUONUgXFVhTbC8D1jCYAmY7ihqp2qmUgYhg2zH+0FtSC0OVVlFKj+n0t+e+GjGdyJFk3HzJFgYQ/J4dqIFfmOB0nkZtSDLGkqk8kYFiNMlaGbHD/qfY1UpU882C/KFntFaRsQzyFCEM23eGTK8pArsvaJuWuHaO1jCDBzyNtC5tqwPYgG39wTbo1oxNsLwreUaiaE1605jXlzqG7chzrOX50Nqyzew4PcJa6TmhKFYQyWtjg+r2bIu1DZW19fs0T4qp7M7vIZ91LLvlRXY41yYX58b0lAWo5giirN1zw0vSgz8aQFCHW56ov0QhuP4A1imEgCjCgGEIwdZI+yGMAyHpfLthPAnV1c/fYWPY3f3SxrXeKG6jMkWwbowKjxjaIq5bVLC2UIU6FR90M6RT2AxDOezmYjyehWtX5c3Ie7SJao5FgDOl3nQ7emI0PF6GrSOIl+261vqcp/1xuBFdcOzTPKOSsV3WTUrWVTrsfheBCLrfUMRjRQWr1cVxnTLlukziRXbu5BcUv9WYvT6GCA9fsSk8S649/+uViHKMNXVMrbTMF7OiDq7p/aGkbKyF1AEsEWGGzkGCp+dq7ahAv0F3Ei9MlZqHicZG71ufq3Ktfn9LgrjTTRB1Skff+b2REg1HeaaE9EV9BtYOqvdD5DQbowc5ynm77l1nUL8zQorkmflz1VHjGEJQ1KmipIPj/cZE71+L9+scsinsJk/aGcuFdmTb+c1sK099xONEf+Tl9xSVyL7zZmRWZuZ9KjxpBq0a4OBtM0gRqud84HRH7FQeGJPv4xFJv40xnGIMXexifY4ZGBXT3ZJ5WAdNVluZq4tjFb69c7qJ4N3HCCU4umo4dp4l6PsW+wLRXMJ2BlUh5QzRnsk5XYlJXiygrpJbrCF4O9DduSkNHx/dUXVtQJhOWkDnKuV2jX74HDR3TYoK997lZG0xSSiwWEebjOj3OX0D8wPYL3ls6NSoTSStW4W3A/CgPovN6MtXKgz1B7bhkvr23sQZn9B4c/cY3qkuwO1JFqbUpk9l65FG6pkk3FPR56vB4D88/XUA6uKcF9NPZ6fJoJoNMjaewKv0OYwnr9hzdrB3MMmeP987eAUwefny1ffsJUvHL4bfPX+ZpbA3hvH4VXbwcnLA9sfP0zGkVFH+D3KMR1ZDLQAA
 </script>
-<script id="@tomlarkworthy/observablejs-toolchain" 
+<script id="@tomlarkworthy/observablejs-toolchain"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -16473,10 +16457,9 @@ notebook_semantics_document.nodes.map((s) => ({
 const _1oevsow = function _28(md){return(
 md`### Runtime Representation (v4)`
 )};
-const _11lfflk = function _notebook_semantics_module(){return(
-importShim("https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4"
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _11lfflk = function _notebook_semantics_module() {
+    return import('https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4');
+};
 const _gjten6 = function _31(md){return(
 md`### Imports`
 )};
@@ -17463,65 +17446,44 @@ parser.parseCell(
   'import {runtime, viewof main as foo} from "@mootari/access-runtime"'
 )
 )};
-const _1n7gw17 = function _findModuleName(extractModuleInfo){return(
-(scope, module, { unknown_id = Math.random() } = {}) => {
-  try {
-    const scopedVariables = [...scope.values()];
-
-    // Prefer variables that *define* a module and have a real module-loader name.
-    const candidates = scopedVariables.filter(
-      (v) =>
-        v &&
-        v._value === module &&
-        typeof v._name === "string" &&
-        v._name.startsWith("module ") &&
-        !v._name.startsWith("module <unknown")
-    );
-
-    const pickBestInfo = (dfn) => {
-      // Avoid the parentUrl (2nd arg) confusing module identification.
-      // Typical patterns:
-      //   importShim("/d/<id>@<ver>.js?v=4", "https://api.observablehq.com/@ns/name.js?v=4")
-      //   import("/d/<id>@<ver>.js?v=4")
-      // Prefer the *first argument* inside importShim(...) / import(...) when present.
-      const s = String(dfn ?? "");
-
-      // Try to capture the first string literal argument to importShim(...) or import(...)
-      // Tolerates quotes ", ', ` and both importShim and plain import.
-      const m = s.match(
-        /\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/
-      );
-      const firstArg = m?.[2];
-
-      const info1 = firstArg ? extractModuleInfo(firstArg) : {};
-      if (info1?.id || info1?.notebook) return info1;
-
-      // Fallback: parse the whole definition string.
-      return extractModuleInfo(s);
+const _1n7gw17 = function _findModuleName(extractModuleInfo) {
+    return (scope, module, {
+        unknown_id = Math.random()
+    } = {}) => {
+        try {
+            const scopedVariables = [...scope.values()];
+            const candidates = scopedVariables.filter(v => v && v._value === module && typeof v._name === 'string' && v._name.startsWith('module ') && !v._name.startsWith('module <unknown'));
+            const pickBestInfo = dfn => {
+                const s = String(dfn ?? '');
+                const m = s.match(/\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/);
+                const firstArg = m?.[2];
+                const info1 = firstArg ? extractModuleInfo(firstArg) : {};
+                if (info1?.id || info1?.notebook)
+                    return info1;
+                return extractModuleInfo(s);
+            };
+            for (const v of candidates) {
+                const info = pickBestInfo(v._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            const any = scopedVariables.find(v => v && v._value === module);
+            if (any) {
+                const info = pickBestInfo(any._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            return `<unknown ${ unknown_id }>`;
+        } catch (e) {
+            debugger;
+            return 'error';
+        }
     };
-
-    // Try module loader cells first.
-    for (const v of candidates) {
-      const info = pickBestInfo(v._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    // Fallback: any scoped variable with _value==module.
-    const any = scopedVariables.find((v) => v && v._value === module);
-    if (any) {
-      const info = pickBestInfo(any._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    return `<unknown ${unknown_id}>`;
-  } catch (e) {
-    debugger;
-    return "error";
-  }
-}
-)};
+};
 const _i47chb = function _findImportedName(){return(
 async (v) => {
   if (v._inputs.length == 1 && v._inputs[0]._name === "@variable") {
@@ -18423,229 +18385,206 @@ JSON.stringify(
 const _1lt3kl6 = function _157(compile,test_case){return(
 compile(test_case.value)
 )};
-const _lpzjrv = function _compile(parser,globalThis,observableToJs){return(
-function compile(source, { anonymousName = "_anonymous" } = {}) {
-  const comments = [],
-    tokens = [];
-  let cell;
-  try {
-    cell = parser.parseCell(source, {
-      ranges: true,
-      onComment: comments,
-      onToken: tokens
-    });
-  } catch (e) {
-    if (e instanceof SyntaxError) {
-      const nameMatch = source.match(
-        /^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/
-      );
-      let _name = null;
-      let funcName = anonymousName;
-      if (nameMatch) {
-        const prefix = nameMatch[1] ? nameMatch[1] + " " : "";
-        _name = prefix + nameMatch[2];
-        funcName = "_" + nameMatch[2];
-      }
-      const escapedMsg = JSON.stringify(e.message);
-      const escapedSource = JSON.stringify(source);
-      return [
-        {
-          _name,
-          _inputs: [],
-          _definition: `function ${funcName}() { throw Object.assign(new SyntaxError(${escapedMsg}), {_sourceExpression: ${escapedSource}}); }`
+const _x1d0wm = function _compile(parser,observableToJs){return(
+function compile(source, {
+    anonymousName = '_anonymous'
+} = {}) {
+    const comments = [], tokens = [];
+    let cell;
+    try {
+        cell = parser.parseCell(source, {
+            ranges: true,
+            onComment: comments,
+            onToken: tokens
+        });
+    } catch (e) {
+        if (e instanceof SyntaxError) {
+            const nameMatch = source.match(/^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/);
+            let _name = null;
+            let funcName = anonymousName;
+            if (nameMatch) {
+                const prefix = nameMatch[1] ? nameMatch[1] + ' ' : '';
+                _name = prefix + nameMatch[2];
+                funcName = '_' + nameMatch[2];
+            }
+            const escapedMsg = JSON.stringify(e.message);
+            const escapedSource = JSON.stringify(source);
+            return [{
+                    _name,
+                    _inputs: [],
+                    _definition: `function ${ funcName }() { throw Object.assign(new SyntaxError(${ escapedMsg }), {_sourceExpression: ${ escapedSource }}); }`
+                }];
         }
-      ];
+        throw e;
     }
-    throw e;
-  }
-  if (!cell) throw new Error("Unable to parse cell");
-  const parseImportSpecifierText = (text) => {
-    const t = String(text ?? "")
-      .trim()
-      .replace(/,$/, "")
-      .trim();
-    if (!t) throw new Error("Empty import specifier");
-    const parts = t.split(/\s+as\s+/);
-    const left = parts[0].trim();
-    const right = parts[1]?.trim();
-    const parseSide = (side, { defaultPrefix = "" } = {}) => {
-      const s = String(side ?? "").trim();
-      const m = s.match(/^(viewof|mutable)\s+(.+)$/);
-      if (m)
-        return {
-          prefix: `${m[1]} `,
-          name: m[2].trim()
+    if (!cell)
+        throw new Error('Unable to parse cell');
+    const parseImportSpecifierText = text => {
+        const t = String(text ?? '').trim().replace(/,$/, '').trim();
+        if (!t)
+            throw new Error('Empty import specifier');
+        const parts = t.split(/\s+as\s+/);
+        const left = parts[0].trim();
+        const right = parts[1]?.trim();
+        const parseSide = (side, {
+            defaultPrefix = ''
+        } = {}) => {
+            const s = String(side ?? '').trim();
+            const m = s.match(/^(viewof|mutable)\s+(.+)$/);
+            if (m)
+                return {
+                    prefix: `${ m[1] } `,
+                    name: m[2].trim()
+                };
+            return {
+                prefix: defaultPrefix,
+                name: s
+            };
         };
-      return {
-        prefix: defaultPrefix,
-        name: s
-      };
+        const L = parseSide(left);
+        const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
+        const importedName = `${ L.prefix }${ L.name }`.trim();
+        const localName = `${ R.prefix }${ R.name }`.trim();
+        if (!importedName)
+            throw new Error(`Could not parse imported name from: ${ t }`);
+        if (!localName)
+            throw new Error(`Could not parse local name from: ${ t }`);
+        return {
+            importedName,
+            localName
+        };
     };
-    const L = parseSide(left);
-    const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
-    const importedName = `${L.prefix}${L.name}`.trim();
-    const localName = `${R.prefix}${R.name}`.trim();
-    if (!importedName)
-      throw new Error(`Could not parse imported name from: ${t}`);
-    if (!localName) throw new Error(`Could not parse local name from: ${t}`);
-    return {
-      importedName,
-      localName
-    };
-  };
-  if (!cell.id && cell.body?.type === "ImportDeclaration") {
-    const module_name = cell.body.source.value;
-    const importKeyword = globalThis?.importShim ? "importShim" : "import";
-    const cell_variables = [
-      {
-        _name: `module ${module_name}`,
-        _inputs: [],
-        _definition: `async () => runtime.module((await ${importKeyword}("${module_name}")).default)`
-      }
-    ];
-    for (const specifier of cell.body.specifiers ?? []) {
-      const specText =
-        typeof specifier?.start === "number" &&
-        typeof specifier?.end === "number"
-          ? source.slice(specifier.start, specifier.end)
-          : (() => {
-              if (specifier?.imported?.name && specifier?.local?.name) {
-                return specifier.imported.name === specifier.local.name
-                  ? specifier.local.name
-                  : `${specifier.imported.name} as ${specifier.local.name}`;
-              }
-              throw new Error("Import specifier missing range information");
+    if (!cell.id && cell.body?.type === 'ImportDeclaration') {
+        const module_name = cell.body.source.value;
+        const cell_variables = [{
+                _name: `module ${ module_name }`,
+                _inputs: [],
+                _definition: `async () => runtime.module((await import("${ module_name }")).default)`
+            }];
+        for (const specifier of cell.body.specifiers ?? []) {
+            const specText = typeof specifier?.start === 'number' && typeof specifier?.end === 'number' ? source.slice(specifier.start, specifier.end) : (() => {
+                if (specifier?.imported?.name && specifier?.local?.name) {
+                    return specifier.imported.name === specifier.local.name ? specifier.local.name : `${ specifier.imported.name } as ${ specifier.local.name }`;
+                }
+                throw new Error('Import specifier missing range information');
             })();
-      const { importedName, localName } = parseImportSpecifierText(specText);
-      cell_variables.push({
-        _name: localName,
-        _inputs: [`module ${module_name}`, "@variable"],
-        _definition:
-          importedName === localName
-            ? `(_, v) => v.import("${importedName}", _)`
-            : `(_, v) => v.import("${importedName}", "${localName}", _)`
-      });
+            const {importedName, localName} = parseImportSpecifierText(specText);
+            cell_variables.push({
+                _name: localName,
+                _inputs: [
+                    `module ${ module_name }`,
+                    '@variable'
+                ],
+                _definition: importedName === localName ? `(_, v) => v.import("${ importedName }", _)` : `(_, v) => v.import("${ importedName }", "${ localName }", _)`
+            });
+        }
+        return cell_variables;
     }
-    return cell_variables;
-  }
-  let dollarIdx = 0;
-  const inputToArgMap = {};
-  const dollarToMacro = {};
-  const seen = new Set();
-  const inputs = Array.from(cell.references || []).flatMap((i) => {
-    if (i.name) {
-      if (seen.has(i.name)) return [];
-      seen.add(i.name);
-      return i.name;
+    let dollarIdx = 0;
+    const inputToArgMap = {};
+    const dollarToMacro = {};
+    const seen = new Set();
+    const inputs = Array.from(cell.references || []).flatMap(i => {
+        if (i.name) {
+            if (seen.has(i.name))
+                return [];
+            seen.add(i.name);
+            return i.name;
+        } else {
+            const dedupKey = i.type + ':' + i.id.name;
+            if (seen.has(dedupKey))
+                return [];
+            seen.add(dedupKey);
+            const dollarName = '$' + dollarIdx;
+            inputToArgMap[i.id.name] = dollarName;
+            dollarToMacro[dollarName] = i.type == 'ViewExpression' ? 'viewof ' + i.id.name : 'mutable ' + i.id.name;
+            dollarIdx++;
+            return dollarName;
+        }
+    });
+    let variables;
+    if (cell.id) {
+        if (cell.id.type === 'Identifier') {
+            variables = [{
+                    functionName: '_' + cell.id.name,
+                    name: cell.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                }];
+        } else if (cell.id.type === 'ViewExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'viewof ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '(G, _) => G.input(_)',
+                    inputs: [
+                        'Generators',
+                        'viewof ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                }
+            ];
+        } else if (cell.id.type === 'MutableExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'initial ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'mutable ' + cell.id.id.name,
+                    _definition: '(M, _) => new M(_)',
+                    inputs: [
+                        'Mutable',
+                        'initial ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '_ => _.generator',
+                    inputs: ['mutable ' + cell.id.id.name],
+                    params: inputs.join(',')
+                }
+            ];
+        } else {
+            throw new Error(`Unsupported cell id type: ${ cell.id.type }`);
+        }
     } else {
-      const dedupKey = i.type + ":" + i.id.name;
-      if (seen.has(dedupKey)) return [];
-      seen.add(dedupKey);
-      const dollarName = "$" + dollarIdx;
-      inputToArgMap[i.id.name] = dollarName;
-      dollarToMacro[dollarName] =
-        i.type == "ViewExpression"
-          ? "viewof " + i.id.name
-          : "mutable " + i.id.name;
-      dollarIdx++;
-      return dollarName;
+        variables = [{
+                functionName: anonymousName,
+                name: null,
+                inputs,
+                params: inputs.join(',')
+            }];
     }
-  });
-  let variables;
-  if (cell.id) {
-    if (cell.id.type === "Identifier") {
-      variables = [
-        {
-          functionName: "_" + cell.id.name,
-          name: cell.id.name,
-          inputs,
-          params: inputs.join(",")
+    return variables.map(v => {
+        let _definition = v._definition;
+        if (!_definition) {
+            let functionBody;
+            if (cell.body.type === 'BlockStatement') {
+                functionBody = observableToJs(cell.body, inputToArgMap, comments, tokens);
+            } else {
+                const bodyCode = observableToJs(cell.body, inputToArgMap, comments, tokens);
+                functionBody = `{return (${ bodyCode });}`;
+            }
+            _definition = `${ cell.async ? 'async ' : '' }function${ cell.generator ? '*' : '' } ${ v.functionName }(${ v.inputs.join(',') }) ${ functionBody }`;
         }
-      ];
-    } else if (cell.id.type === "ViewExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "viewof " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "(G, _) => G.input(_)",
-          inputs: ["Generators", "viewof " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else if (cell.id.type === "MutableExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "initial " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "mutable " + cell.id.id.name,
-          _definition: "(M, _) => new M(_)",
-          inputs: ["Mutable", "initial " + cell.id.id.name],
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "_ => _.generator",
-          inputs: ["mutable " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else {
-      throw new Error(`Unsupported cell id type: ${cell.id.type}`);
-    }
-  } else {
-    variables = [
-      {
-        functionName: anonymousName,
-        name: null,
-        inputs,
-        params: inputs.join(",")
-      }
-    ];
-  }
-  return variables.map((v) => {
-    let _definition = v._definition;
-    if (!_definition) {
-      let functionBody;
-      if (cell.body.type === "BlockStatement") {
-        functionBody = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-      } else {
-        const bodyCode = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-        functionBody = `{return (${bodyCode});}`;
-      }
-      _definition = `${cell.async ? "async " : ""}function${
-        cell.generator ? "*" : ""
-      } ${v.functionName}(${v.inputs.join(",")}) ${functionBody}`;
-    }
-    return {
-      _name: v.name,
-      _inputs: v.inputs.map(
-        (i) => dollarToMacro[i] || (i === "$variable" ? "@variable" : i)
-      ),
-      _definition
-    };
-  });
+        return {
+            _name: v.name,
+            _inputs: v.inputs.map(i => dollarToMacro[i] || (i === '$variable' ? '@variable' : i)),
+            _definition
+        };
+    });
 }
 )};
 const _1v1i7wl = function _observableToJs(acorn_walk,parser,escodegen){return(
@@ -18712,16 +18651,15 @@ async (attachment, overrides) => {
   return URL.createObjectURL(blob);
 }
 )};
-const _s9w7ha = async function _parser(decompress_url,FileAttachment,acorn_url,acorn_walk_url){return(
-importShim(await decompress_url(FileAttachment("parser-6.1.0.js.gz"), {
-    "/npm/acorn@8.11.3/+esm": acorn_url,
-    "/npm/acorn-walk@8.3.2/+esm": acorn_walk_url
-  })
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
-const _1hiclbb = function _acorn_walk(acorn_walk_url){return(
-importShim(acorn_walk_url, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _s9w7ha = async function _parser(decompress_url, FileAttachment, acorn_url, acorn_walk_url) {
+    return import(await decompress_url(FileAttachment('parser-6.1.0.js.gz'), {
+        '/npm/acorn@8.11.3/+esm': acorn_url,
+        '/npm/acorn-walk@8.3.2/+esm': acorn_walk_url
+    }));
+};
+const _1hiclbb = function _acorn_walk(acorn_walk_url) {
+    return import(acorn_walk_url);
+};
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
@@ -18909,7 +18847,7 @@ export default function define(runtime, observer) {
   $def("_1dmmuaf", "compiled_selector", ["Generators","viewof compiled_selector"], _1dmmuaf);  
   $def("_u7t3vu", null, ["compiled_selector","normalizeJavascriptSource"], _u7t3vu);  
   $def("_1lt3kl6", null, ["compile","test_case"], _1lt3kl6);  
-  $def("_lpzjrv", "compile", ["parser","globalThis","observableToJs"], _lpzjrv);  
+  $def("_x1d0wm", "compile", ["parser","observableToJs"], _x1d0wm);  
   $def("_1v1i7wl", "observableToJs", ["acorn_walk","parser","escodegen"], _1v1i7wl);  
   $def("_19lv24l", null, ["md"], _19lv24l);  
   $def("_xhj6b8", "decompress_url", ["DecompressionStream","TextDecoderStream","TransformStream","TextEncoderStream","Response"], _xhj6b8);  
@@ -18924,7 +18862,8 @@ export default function define(runtime, observer) {
   main.define("Library", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Library", _));  
   main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));
   return main;
-}</script>
+}
+</script>
 
 <script id="@tomlarkworthy/reversible-attachment" 
   type="text/plain"

--- a/notebooks/@tomlarkworthy_lopepage.html
+++ b/notebooks/@tomlarkworthy_lopepage.html
@@ -5415,58 +5415,41 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _geoudp = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
-  if (command.processed) return;
-
-  let result = undefined;
-  if (command.command == "createCell") {
-    $0.value = true;
-    result = compile_and_update("{}", [], command.args.cell);
-    // For the new one to get focus
-    // setTimeout(() => {
-    //   debugger;
-    //   setOption(result[0], "pinned", true);
-    // }, 100);
-  } else if (command.command == "deleteCell") {
-    remove_variables(command.args.cell.variables);
-    result = true;
-  } else if (command.command == "moveCell") {
-    const cellIndex = findCellIndex(
-      command.args.cell.variables,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const targetCellIndex = cellIndex + command.args.amount;
-    const targetCell = lookupCellByIndex(
-      targetCellIndex,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const currentFirstVariableIndex = findVariableIndex(
-      command.args.cell.variables[0]
-    );
-    const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-    const change = targetFirstVariableIndex - currentFirstVariableIndex;
-    console.log(
-      "moveCell",
-      cellIndex,
-      targetCellIndex,
-      targetCell,
-      currentFirstVariableIndex,
-      targetFirstVariableIndex,
-      change
-    );
-    command.args.cell.variables.forEach((v) => {
-      const currentIndex = findVariableIndex(v);
-      repositionSetElement(runtime._variables, v, currentIndex + change);
-    });
-    // recompute
-    await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
-    result = true;
-  }
-  if (result) {
-    command.processed = true;
-    $2.resolve(result);
-  }
+    if (command.processed)
+        return;
+    let result = undefined;
+    if (command.command == 'createCell') {
+        $0.value = true;
+        result = await compile_and_update('{}', [], command.args.cell);    // For the new one to get focus
+                                                                           // setTimeout(() => {
+                                                                           //   debugger;
+                                                                           //   setOption(result[0], "pinned", true);
+                                                                           // }, 100);
+    } else if (command.command == 'deleteCell') {
+        remove_variables(command.args.cell.variables);
+        result = true;
+    } else if (command.command == 'moveCell') {
+        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const targetCellIndex = cellIndex + command.args.amount;
+        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
+        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+        const change = targetFirstVariableIndex - currentFirstVariableIndex;
+        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
+        command.args.cell.variables.forEach(v => {
+            const currentIndex = findVariableIndex(v);
+            repositionSetElement(runtime._variables, v, currentIndex + change);
+        });
+        // recompute
+        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        result = true;
+    }
+    if (result) {
+        command.processed = true;
+        $2.resolve(result);
+    }
 };
 const _1jadxoe = function _60(md){return(
 md`### UI Action`
@@ -5857,9 +5840,9 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
-    return (source, variables = [], cell) => {
+    return async (source, variables = [], cell) => {
         try {
             debugger;
             let reposition = false, insertionIndex = -1;
@@ -5879,10 +5862,10 @@ const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElemen
             if (reposition) {
                 insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
+            const fns = await realize(newVariables.map(v => v._definition), runtime);
             newVariables.forEach((v, i) => {
                 const variable = variables[i];
-                let _fn;
-                eval('_fn = ' + v._definition);
+                const _fn = fns[i];
                 if (v._name) {
                     variable.define(v._name, v._inputs, _fn);
                 } else {
@@ -5931,12 +5914,11 @@ Inputs.textarea({
 })
 )};
 const _b4rsn5 = (G, _) => G.input(_);
-const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
+const _ga6kci = function _98(Inputs,definition,variable,realize,runtime,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
-  reduce: () => {
-    let _fn;
-    eval("_fn = " + definition);
+  reduce: async () => {
+    const [_fn] = await realize([definition], runtime);
     variable.define(variable._name, inputs, _fn);
   }
 })
@@ -6049,7 +6031,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_geoudp", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _geoudp);  
+  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6087,7 +6069,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
+  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -6097,8 +6079,9 @@ export default function define(runtime, observer) {
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
   $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
-  $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
+  $def("_ga6kci", null, ["Inputs","definition","variable","realize","runtime","inputs"], _ga6kci);  
   $def("_1q557s", null, ["md"], _1q557s);  
+  main.define("realize", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("realize", _));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -15258,10 +15241,9 @@ notebook_semantics_document.nodes.map((s) => ({
 const _1oevsow = function _28(md){return(
 md`### Runtime Representation (v4)`
 )};
-const _11lfflk = function _notebook_semantics_module(){return(
-importShim("https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4"
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _11lfflk = function _notebook_semantics_module() {
+    return import('https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4');
+};
 const _gjten6 = function _31(md){return(
 md`### Imports`
 )};
@@ -16248,65 +16230,44 @@ parser.parseCell(
   'import {runtime, viewof main as foo} from "@mootari/access-runtime"'
 )
 )};
-const _1n7gw17 = function _findModuleName(extractModuleInfo){return(
-(scope, module, { unknown_id = Math.random() } = {}) => {
-  try {
-    const scopedVariables = [...scope.values()];
-
-    // Prefer variables that *define* a module and have a real module-loader name.
-    const candidates = scopedVariables.filter(
-      (v) =>
-        v &&
-        v._value === module &&
-        typeof v._name === "string" &&
-        v._name.startsWith("module ") &&
-        !v._name.startsWith("module <unknown")
-    );
-
-    const pickBestInfo = (dfn) => {
-      // Avoid the parentUrl (2nd arg) confusing module identification.
-      // Typical patterns:
-      //   importShim("/d/<id>@<ver>.js?v=4", "https://api.observablehq.com/@ns/name.js?v=4")
-      //   import("/d/<id>@<ver>.js?v=4")
-      // Prefer the *first argument* inside importShim(...) / import(...) when present.
-      const s = String(dfn ?? "");
-
-      // Try to capture the first string literal argument to importShim(...) or import(...)
-      // Tolerates quotes ", ', ` and both importShim and plain import.
-      const m = s.match(
-        /\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/
-      );
-      const firstArg = m?.[2];
-
-      const info1 = firstArg ? extractModuleInfo(firstArg) : {};
-      if (info1?.id || info1?.notebook) return info1;
-
-      // Fallback: parse the whole definition string.
-      return extractModuleInfo(s);
+const _1n7gw17 = function _findModuleName(extractModuleInfo) {
+    return (scope, module, {
+        unknown_id = Math.random()
+    } = {}) => {
+        try {
+            const scopedVariables = [...scope.values()];
+            const candidates = scopedVariables.filter(v => v && v._value === module && typeof v._name === 'string' && v._name.startsWith('module ') && !v._name.startsWith('module <unknown'));
+            const pickBestInfo = dfn => {
+                const s = String(dfn ?? '');
+                const m = s.match(/\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/);
+                const firstArg = m?.[2];
+                const info1 = firstArg ? extractModuleInfo(firstArg) : {};
+                if (info1?.id || info1?.notebook)
+                    return info1;
+                return extractModuleInfo(s);
+            };
+            for (const v of candidates) {
+                const info = pickBestInfo(v._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            const any = scopedVariables.find(v => v && v._value === module);
+            if (any) {
+                const info = pickBestInfo(any._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            return `<unknown ${ unknown_id }>`;
+        } catch (e) {
+            debugger;
+            return 'error';
+        }
     };
-
-    // Try module loader cells first.
-    for (const v of candidates) {
-      const info = pickBestInfo(v._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    // Fallback: any scoped variable with _value==module.
-    const any = scopedVariables.find((v) => v && v._value === module);
-    if (any) {
-      const info = pickBestInfo(any._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    return `<unknown ${unknown_id}>`;
-  } catch (e) {
-    debugger;
-    return "error";
-  }
-}
-)};
+};
 const _i47chb = function _findImportedName(){return(
 async (v) => {
   if (v._inputs.length == 1 && v._inputs[0]._name === "@variable") {
@@ -17208,229 +17169,206 @@ JSON.stringify(
 const _1lt3kl6 = function _157(compile,test_case){return(
 compile(test_case.value)
 )};
-const _lpzjrv = function _compile(parser,globalThis,observableToJs){return(
-function compile(source, { anonymousName = "_anonymous" } = {}) {
-  const comments = [],
-    tokens = [];
-  let cell;
-  try {
-    cell = parser.parseCell(source, {
-      ranges: true,
-      onComment: comments,
-      onToken: tokens
-    });
-  } catch (e) {
-    if (e instanceof SyntaxError) {
-      const nameMatch = source.match(
-        /^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/
-      );
-      let _name = null;
-      let funcName = anonymousName;
-      if (nameMatch) {
-        const prefix = nameMatch[1] ? nameMatch[1] + " " : "";
-        _name = prefix + nameMatch[2];
-        funcName = "_" + nameMatch[2];
-      }
-      const escapedMsg = JSON.stringify(e.message);
-      const escapedSource = JSON.stringify(source);
-      return [
-        {
-          _name,
-          _inputs: [],
-          _definition: `function ${funcName}() { throw Object.assign(new SyntaxError(${escapedMsg}), {_sourceExpression: ${escapedSource}}); }`
+const _x1d0wm = function _compile(parser,observableToJs){return(
+function compile(source, {
+    anonymousName = '_anonymous'
+} = {}) {
+    const comments = [], tokens = [];
+    let cell;
+    try {
+        cell = parser.parseCell(source, {
+            ranges: true,
+            onComment: comments,
+            onToken: tokens
+        });
+    } catch (e) {
+        if (e instanceof SyntaxError) {
+            const nameMatch = source.match(/^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/);
+            let _name = null;
+            let funcName = anonymousName;
+            if (nameMatch) {
+                const prefix = nameMatch[1] ? nameMatch[1] + ' ' : '';
+                _name = prefix + nameMatch[2];
+                funcName = '_' + nameMatch[2];
+            }
+            const escapedMsg = JSON.stringify(e.message);
+            const escapedSource = JSON.stringify(source);
+            return [{
+                    _name,
+                    _inputs: [],
+                    _definition: `function ${ funcName }() { throw Object.assign(new SyntaxError(${ escapedMsg }), {_sourceExpression: ${ escapedSource }}); }`
+                }];
         }
-      ];
+        throw e;
     }
-    throw e;
-  }
-  if (!cell) throw new Error("Unable to parse cell");
-  const parseImportSpecifierText = (text) => {
-    const t = String(text ?? "")
-      .trim()
-      .replace(/,$/, "")
-      .trim();
-    if (!t) throw new Error("Empty import specifier");
-    const parts = t.split(/\s+as\s+/);
-    const left = parts[0].trim();
-    const right = parts[1]?.trim();
-    const parseSide = (side, { defaultPrefix = "" } = {}) => {
-      const s = String(side ?? "").trim();
-      const m = s.match(/^(viewof|mutable)\s+(.+)$/);
-      if (m)
-        return {
-          prefix: `${m[1]} `,
-          name: m[2].trim()
+    if (!cell)
+        throw new Error('Unable to parse cell');
+    const parseImportSpecifierText = text => {
+        const t = String(text ?? '').trim().replace(/,$/, '').trim();
+        if (!t)
+            throw new Error('Empty import specifier');
+        const parts = t.split(/\s+as\s+/);
+        const left = parts[0].trim();
+        const right = parts[1]?.trim();
+        const parseSide = (side, {
+            defaultPrefix = ''
+        } = {}) => {
+            const s = String(side ?? '').trim();
+            const m = s.match(/^(viewof|mutable)\s+(.+)$/);
+            if (m)
+                return {
+                    prefix: `${ m[1] } `,
+                    name: m[2].trim()
+                };
+            return {
+                prefix: defaultPrefix,
+                name: s
+            };
         };
-      return {
-        prefix: defaultPrefix,
-        name: s
-      };
+        const L = parseSide(left);
+        const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
+        const importedName = `${ L.prefix }${ L.name }`.trim();
+        const localName = `${ R.prefix }${ R.name }`.trim();
+        if (!importedName)
+            throw new Error(`Could not parse imported name from: ${ t }`);
+        if (!localName)
+            throw new Error(`Could not parse local name from: ${ t }`);
+        return {
+            importedName,
+            localName
+        };
     };
-    const L = parseSide(left);
-    const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
-    const importedName = `${L.prefix}${L.name}`.trim();
-    const localName = `${R.prefix}${R.name}`.trim();
-    if (!importedName)
-      throw new Error(`Could not parse imported name from: ${t}`);
-    if (!localName) throw new Error(`Could not parse local name from: ${t}`);
-    return {
-      importedName,
-      localName
-    };
-  };
-  if (!cell.id && cell.body?.type === "ImportDeclaration") {
-    const module_name = cell.body.source.value;
-    const importKeyword = globalThis?.importShim ? "importShim" : "import";
-    const cell_variables = [
-      {
-        _name: `module ${module_name}`,
-        _inputs: [],
-        _definition: `async () => runtime.module((await ${importKeyword}("${module_name}")).default)`
-      }
-    ];
-    for (const specifier of cell.body.specifiers ?? []) {
-      const specText =
-        typeof specifier?.start === "number" &&
-        typeof specifier?.end === "number"
-          ? source.slice(specifier.start, specifier.end)
-          : (() => {
-              if (specifier?.imported?.name && specifier?.local?.name) {
-                return specifier.imported.name === specifier.local.name
-                  ? specifier.local.name
-                  : `${specifier.imported.name} as ${specifier.local.name}`;
-              }
-              throw new Error("Import specifier missing range information");
+    if (!cell.id && cell.body?.type === 'ImportDeclaration') {
+        const module_name = cell.body.source.value;
+        const cell_variables = [{
+                _name: `module ${ module_name }`,
+                _inputs: [],
+                _definition: `async () => runtime.module((await import("${ module_name }")).default)`
+            }];
+        for (const specifier of cell.body.specifiers ?? []) {
+            const specText = typeof specifier?.start === 'number' && typeof specifier?.end === 'number' ? source.slice(specifier.start, specifier.end) : (() => {
+                if (specifier?.imported?.name && specifier?.local?.name) {
+                    return specifier.imported.name === specifier.local.name ? specifier.local.name : `${ specifier.imported.name } as ${ specifier.local.name }`;
+                }
+                throw new Error('Import specifier missing range information');
             })();
-      const { importedName, localName } = parseImportSpecifierText(specText);
-      cell_variables.push({
-        _name: localName,
-        _inputs: [`module ${module_name}`, "@variable"],
-        _definition:
-          importedName === localName
-            ? `(_, v) => v.import("${importedName}", _)`
-            : `(_, v) => v.import("${importedName}", "${localName}", _)`
-      });
+            const {importedName, localName} = parseImportSpecifierText(specText);
+            cell_variables.push({
+                _name: localName,
+                _inputs: [
+                    `module ${ module_name }`,
+                    '@variable'
+                ],
+                _definition: importedName === localName ? `(_, v) => v.import("${ importedName }", _)` : `(_, v) => v.import("${ importedName }", "${ localName }", _)`
+            });
+        }
+        return cell_variables;
     }
-    return cell_variables;
-  }
-  let dollarIdx = 0;
-  const inputToArgMap = {};
-  const dollarToMacro = {};
-  const seen = new Set();
-  const inputs = Array.from(cell.references || []).flatMap((i) => {
-    if (i.name) {
-      if (seen.has(i.name)) return [];
-      seen.add(i.name);
-      return i.name;
+    let dollarIdx = 0;
+    const inputToArgMap = {};
+    const dollarToMacro = {};
+    const seen = new Set();
+    const inputs = Array.from(cell.references || []).flatMap(i => {
+        if (i.name) {
+            if (seen.has(i.name))
+                return [];
+            seen.add(i.name);
+            return i.name;
+        } else {
+            const dedupKey = i.type + ':' + i.id.name;
+            if (seen.has(dedupKey))
+                return [];
+            seen.add(dedupKey);
+            const dollarName = '$' + dollarIdx;
+            inputToArgMap[i.id.name] = dollarName;
+            dollarToMacro[dollarName] = i.type == 'ViewExpression' ? 'viewof ' + i.id.name : 'mutable ' + i.id.name;
+            dollarIdx++;
+            return dollarName;
+        }
+    });
+    let variables;
+    if (cell.id) {
+        if (cell.id.type === 'Identifier') {
+            variables = [{
+                    functionName: '_' + cell.id.name,
+                    name: cell.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                }];
+        } else if (cell.id.type === 'ViewExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'viewof ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '(G, _) => G.input(_)',
+                    inputs: [
+                        'Generators',
+                        'viewof ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                }
+            ];
+        } else if (cell.id.type === 'MutableExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'initial ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'mutable ' + cell.id.id.name,
+                    _definition: '(M, _) => new M(_)',
+                    inputs: [
+                        'Mutable',
+                        'initial ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '_ => _.generator',
+                    inputs: ['mutable ' + cell.id.id.name],
+                    params: inputs.join(',')
+                }
+            ];
+        } else {
+            throw new Error(`Unsupported cell id type: ${ cell.id.type }`);
+        }
     } else {
-      const dedupKey = i.type + ":" + i.id.name;
-      if (seen.has(dedupKey)) return [];
-      seen.add(dedupKey);
-      const dollarName = "$" + dollarIdx;
-      inputToArgMap[i.id.name] = dollarName;
-      dollarToMacro[dollarName] =
-        i.type == "ViewExpression"
-          ? "viewof " + i.id.name
-          : "mutable " + i.id.name;
-      dollarIdx++;
-      return dollarName;
+        variables = [{
+                functionName: anonymousName,
+                name: null,
+                inputs,
+                params: inputs.join(',')
+            }];
     }
-  });
-  let variables;
-  if (cell.id) {
-    if (cell.id.type === "Identifier") {
-      variables = [
-        {
-          functionName: "_" + cell.id.name,
-          name: cell.id.name,
-          inputs,
-          params: inputs.join(",")
+    return variables.map(v => {
+        let _definition = v._definition;
+        if (!_definition) {
+            let functionBody;
+            if (cell.body.type === 'BlockStatement') {
+                functionBody = observableToJs(cell.body, inputToArgMap, comments, tokens);
+            } else {
+                const bodyCode = observableToJs(cell.body, inputToArgMap, comments, tokens);
+                functionBody = `{return (${ bodyCode });}`;
+            }
+            _definition = `${ cell.async ? 'async ' : '' }function${ cell.generator ? '*' : '' } ${ v.functionName }(${ v.inputs.join(',') }) ${ functionBody }`;
         }
-      ];
-    } else if (cell.id.type === "ViewExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "viewof " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "(G, _) => G.input(_)",
-          inputs: ["Generators", "viewof " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else if (cell.id.type === "MutableExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "initial " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "mutable " + cell.id.id.name,
-          _definition: "(M, _) => new M(_)",
-          inputs: ["Mutable", "initial " + cell.id.id.name],
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "_ => _.generator",
-          inputs: ["mutable " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else {
-      throw new Error(`Unsupported cell id type: ${cell.id.type}`);
-    }
-  } else {
-    variables = [
-      {
-        functionName: anonymousName,
-        name: null,
-        inputs,
-        params: inputs.join(",")
-      }
-    ];
-  }
-  return variables.map((v) => {
-    let _definition = v._definition;
-    if (!_definition) {
-      let functionBody;
-      if (cell.body.type === "BlockStatement") {
-        functionBody = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-      } else {
-        const bodyCode = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-        functionBody = `{return (${bodyCode});}`;
-      }
-      _definition = `${cell.async ? "async " : ""}function${
-        cell.generator ? "*" : ""
-      } ${v.functionName}(${v.inputs.join(",")}) ${functionBody}`;
-    }
-    return {
-      _name: v.name,
-      _inputs: v.inputs.map(
-        (i) => dollarToMacro[i] || (i === "$variable" ? "@variable" : i)
-      ),
-      _definition
-    };
-  });
+        return {
+            _name: v.name,
+            _inputs: v.inputs.map(i => dollarToMacro[i] || (i === '$variable' ? '@variable' : i)),
+            _definition
+        };
+    });
 }
 )};
 const _1v1i7wl = function _observableToJs(acorn_walk,parser,escodegen){return(
@@ -17497,16 +17435,15 @@ async (attachment, overrides) => {
   return URL.createObjectURL(blob);
 }
 )};
-const _s9w7ha = async function _parser(decompress_url,FileAttachment,acorn_url,acorn_walk_url){return(
-importShim(await decompress_url(FileAttachment("parser-6.1.0.js.gz"), {
-    "/npm/acorn@8.11.3/+esm": acorn_url,
-    "/npm/acorn-walk@8.3.2/+esm": acorn_walk_url
-  })
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
-const _1hiclbb = function _acorn_walk(acorn_walk_url){return(
-importShim(acorn_walk_url, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _s9w7ha = async function _parser(decompress_url, FileAttachment, acorn_url, acorn_walk_url) {
+    return import(await decompress_url(FileAttachment('parser-6.1.0.js.gz'), {
+        '/npm/acorn@8.11.3/+esm': acorn_url,
+        '/npm/acorn-walk@8.3.2/+esm': acorn_walk_url
+    }));
+};
+const _1hiclbb = function _acorn_walk(acorn_walk_url) {
+    return import(acorn_walk_url);
+};
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
@@ -17694,7 +17631,7 @@ export default function define(runtime, observer) {
   $def("_1dmmuaf", "compiled_selector", ["Generators","viewof compiled_selector"], _1dmmuaf);  
   $def("_u7t3vu", null, ["compiled_selector","normalizeJavascriptSource"], _u7t3vu);  
   $def("_1lt3kl6", null, ["compile","test_case"], _1lt3kl6);  
-  $def("_lpzjrv", "compile", ["parser","globalThis","observableToJs"], _lpzjrv);  
+  $def("_x1d0wm", "compile", ["parser","observableToJs"], _x1d0wm);  
   $def("_1v1i7wl", "observableToJs", ["acorn_walk","parser","escodegen"], _1v1i7wl);  
   $def("_19lv24l", null, ["md"], _19lv24l);  
   $def("_xhj6b8", "decompress_url", ["DecompressionStream","TextDecoderStream","TransformStream","TextEncoderStream","Response"], _xhj6b8);  

--- a/notebooks/@tomlarkworthy_modern-screenshot.html
+++ b/notebooks/@tomlarkworthy_modern-screenshot.html
@@ -5437,58 +5437,41 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _geoudp = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
-  if (command.processed) return;
-
-  let result = undefined;
-  if (command.command == "createCell") {
-    $0.value = true;
-    result = compile_and_update("{}", [], command.args.cell);
-    // For the new one to get focus
-    // setTimeout(() => {
-    //   debugger;
-    //   setOption(result[0], "pinned", true);
-    // }, 100);
-  } else if (command.command == "deleteCell") {
-    remove_variables(command.args.cell.variables);
-    result = true;
-  } else if (command.command == "moveCell") {
-    const cellIndex = findCellIndex(
-      command.args.cell.variables,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const targetCellIndex = cellIndex + command.args.amount;
-    const targetCell = lookupCellByIndex(
-      targetCellIndex,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const currentFirstVariableIndex = findVariableIndex(
-      command.args.cell.variables[0]
-    );
-    const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-    const change = targetFirstVariableIndex - currentFirstVariableIndex;
-    console.log(
-      "moveCell",
-      cellIndex,
-      targetCellIndex,
-      targetCell,
-      currentFirstVariableIndex,
-      targetFirstVariableIndex,
-      change
-    );
-    command.args.cell.variables.forEach((v) => {
-      const currentIndex = findVariableIndex(v);
-      repositionSetElement(runtime._variables, v, currentIndex + change);
-    });
-    // recompute
-    await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
-    result = true;
-  }
-  if (result) {
-    command.processed = true;
-    $2.resolve(result);
-  }
+    if (command.processed)
+        return;
+    let result = undefined;
+    if (command.command == 'createCell') {
+        $0.value = true;
+        result = await compile_and_update('{}', [], command.args.cell);    // For the new one to get focus
+                                                                           // setTimeout(() => {
+                                                                           //   debugger;
+                                                                           //   setOption(result[0], "pinned", true);
+                                                                           // }, 100);
+    } else if (command.command == 'deleteCell') {
+        remove_variables(command.args.cell.variables);
+        result = true;
+    } else if (command.command == 'moveCell') {
+        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const targetCellIndex = cellIndex + command.args.amount;
+        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
+        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+        const change = targetFirstVariableIndex - currentFirstVariableIndex;
+        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
+        command.args.cell.variables.forEach(v => {
+            const currentIndex = findVariableIndex(v);
+            repositionSetElement(runtime._variables, v, currentIndex + change);
+        });
+        // recompute
+        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        result = true;
+    }
+    if (result) {
+        command.processed = true;
+        $2.resolve(result);
+    }
 };
 const _1jadxoe = function _60(md){return(
 md`### UI Action`
@@ -5879,9 +5862,9 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
-    return (source, variables = [], cell) => {
+    return async (source, variables = [], cell) => {
         try {
             debugger;
             let reposition = false, insertionIndex = -1;
@@ -5901,10 +5884,10 @@ const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElemen
             if (reposition) {
                 insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
+            const fns = await realize(newVariables.map(v => v._definition), runtime);
             newVariables.forEach((v, i) => {
                 const variable = variables[i];
-                let _fn;
-                eval('_fn = ' + v._definition);
+                const _fn = fns[i];
                 if (v._name) {
                     variable.define(v._name, v._inputs, _fn);
                 } else {
@@ -5953,12 +5936,11 @@ Inputs.textarea({
 })
 )};
 const _b4rsn5 = (G, _) => G.input(_);
-const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
+const _ga6kci = function _98(Inputs,definition,variable,realize,runtime,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
-  reduce: () => {
-    let _fn;
-    eval("_fn = " + definition);
+  reduce: async () => {
+    const [_fn] = await realize([definition], runtime);
     variable.define(variable._name, inputs, _fn);
   }
 })
@@ -6071,7 +6053,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_geoudp", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _geoudp);  
+  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6109,7 +6091,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
+  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -6119,8 +6101,9 @@ export default function define(runtime, observer) {
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
   $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
-  $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
+  $def("_ga6kci", null, ["Inputs","definition","variable","realize","runtime","inputs"], _ga6kci);  
   $def("_1q557s", null, ["md"], _1q557s);  
+  main.define("realize", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("realize", _));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -16545,10 +16528,9 @@ notebook_semantics_document.nodes.map((s) => ({
 const _1oevsow = function _28(md){return(
 md`### Runtime Representation (v4)`
 )};
-const _11lfflk = function _notebook_semantics_module(){return(
-importShim("https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4"
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _11lfflk = function _notebook_semantics_module() {
+    return import('https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4');
+};
 const _gjten6 = function _31(md){return(
 md`### Imports`
 )};
@@ -17535,65 +17517,44 @@ parser.parseCell(
   'import {runtime, viewof main as foo} from "@mootari/access-runtime"'
 )
 )};
-const _1n7gw17 = function _findModuleName(extractModuleInfo){return(
-(scope, module, { unknown_id = Math.random() } = {}) => {
-  try {
-    const scopedVariables = [...scope.values()];
-
-    // Prefer variables that *define* a module and have a real module-loader name.
-    const candidates = scopedVariables.filter(
-      (v) =>
-        v &&
-        v._value === module &&
-        typeof v._name === "string" &&
-        v._name.startsWith("module ") &&
-        !v._name.startsWith("module <unknown")
-    );
-
-    const pickBestInfo = (dfn) => {
-      // Avoid the parentUrl (2nd arg) confusing module identification.
-      // Typical patterns:
-      //   importShim("/d/<id>@<ver>.js?v=4", "https://api.observablehq.com/@ns/name.js?v=4")
-      //   import("/d/<id>@<ver>.js?v=4")
-      // Prefer the *first argument* inside importShim(...) / import(...) when present.
-      const s = String(dfn ?? "");
-
-      // Try to capture the first string literal argument to importShim(...) or import(...)
-      // Tolerates quotes ", ', ` and both importShim and plain import.
-      const m = s.match(
-        /\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/
-      );
-      const firstArg = m?.[2];
-
-      const info1 = firstArg ? extractModuleInfo(firstArg) : {};
-      if (info1?.id || info1?.notebook) return info1;
-
-      // Fallback: parse the whole definition string.
-      return extractModuleInfo(s);
+const _1n7gw17 = function _findModuleName(extractModuleInfo) {
+    return (scope, module, {
+        unknown_id = Math.random()
+    } = {}) => {
+        try {
+            const scopedVariables = [...scope.values()];
+            const candidates = scopedVariables.filter(v => v && v._value === module && typeof v._name === 'string' && v._name.startsWith('module ') && !v._name.startsWith('module <unknown'));
+            const pickBestInfo = dfn => {
+                const s = String(dfn ?? '');
+                const m = s.match(/\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/);
+                const firstArg = m?.[2];
+                const info1 = firstArg ? extractModuleInfo(firstArg) : {};
+                if (info1?.id || info1?.notebook)
+                    return info1;
+                return extractModuleInfo(s);
+            };
+            for (const v of candidates) {
+                const info = pickBestInfo(v._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            const any = scopedVariables.find(v => v && v._value === module);
+            if (any) {
+                const info = pickBestInfo(any._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            return `<unknown ${ unknown_id }>`;
+        } catch (e) {
+            debugger;
+            return 'error';
+        }
     };
-
-    // Try module loader cells first.
-    for (const v of candidates) {
-      const info = pickBestInfo(v._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    // Fallback: any scoped variable with _value==module.
-    const any = scopedVariables.find((v) => v && v._value === module);
-    if (any) {
-      const info = pickBestInfo(any._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    return `<unknown ${unknown_id}>`;
-  } catch (e) {
-    debugger;
-    return "error";
-  }
-}
-)};
+};
 const _i47chb = function _findImportedName(){return(
 async (v) => {
   if (v._inputs.length == 1 && v._inputs[0]._name === "@variable") {
@@ -18495,229 +18456,206 @@ JSON.stringify(
 const _1lt3kl6 = function _157(compile,test_case){return(
 compile(test_case.value)
 )};
-const _lpzjrv = function _compile(parser,globalThis,observableToJs){return(
-function compile(source, { anonymousName = "_anonymous" } = {}) {
-  const comments = [],
-    tokens = [];
-  let cell;
-  try {
-    cell = parser.parseCell(source, {
-      ranges: true,
-      onComment: comments,
-      onToken: tokens
-    });
-  } catch (e) {
-    if (e instanceof SyntaxError) {
-      const nameMatch = source.match(
-        /^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/
-      );
-      let _name = null;
-      let funcName = anonymousName;
-      if (nameMatch) {
-        const prefix = nameMatch[1] ? nameMatch[1] + " " : "";
-        _name = prefix + nameMatch[2];
-        funcName = "_" + nameMatch[2];
-      }
-      const escapedMsg = JSON.stringify(e.message);
-      const escapedSource = JSON.stringify(source);
-      return [
-        {
-          _name,
-          _inputs: [],
-          _definition: `function ${funcName}() { throw Object.assign(new SyntaxError(${escapedMsg}), {_sourceExpression: ${escapedSource}}); }`
+const _x1d0wm = function _compile(parser,observableToJs){return(
+function compile(source, {
+    anonymousName = '_anonymous'
+} = {}) {
+    const comments = [], tokens = [];
+    let cell;
+    try {
+        cell = parser.parseCell(source, {
+            ranges: true,
+            onComment: comments,
+            onToken: tokens
+        });
+    } catch (e) {
+        if (e instanceof SyntaxError) {
+            const nameMatch = source.match(/^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/);
+            let _name = null;
+            let funcName = anonymousName;
+            if (nameMatch) {
+                const prefix = nameMatch[1] ? nameMatch[1] + ' ' : '';
+                _name = prefix + nameMatch[2];
+                funcName = '_' + nameMatch[2];
+            }
+            const escapedMsg = JSON.stringify(e.message);
+            const escapedSource = JSON.stringify(source);
+            return [{
+                    _name,
+                    _inputs: [],
+                    _definition: `function ${ funcName }() { throw Object.assign(new SyntaxError(${ escapedMsg }), {_sourceExpression: ${ escapedSource }}); }`
+                }];
         }
-      ];
+        throw e;
     }
-    throw e;
-  }
-  if (!cell) throw new Error("Unable to parse cell");
-  const parseImportSpecifierText = (text) => {
-    const t = String(text ?? "")
-      .trim()
-      .replace(/,$/, "")
-      .trim();
-    if (!t) throw new Error("Empty import specifier");
-    const parts = t.split(/\s+as\s+/);
-    const left = parts[0].trim();
-    const right = parts[1]?.trim();
-    const parseSide = (side, { defaultPrefix = "" } = {}) => {
-      const s = String(side ?? "").trim();
-      const m = s.match(/^(viewof|mutable)\s+(.+)$/);
-      if (m)
-        return {
-          prefix: `${m[1]} `,
-          name: m[2].trim()
+    if (!cell)
+        throw new Error('Unable to parse cell');
+    const parseImportSpecifierText = text => {
+        const t = String(text ?? '').trim().replace(/,$/, '').trim();
+        if (!t)
+            throw new Error('Empty import specifier');
+        const parts = t.split(/\s+as\s+/);
+        const left = parts[0].trim();
+        const right = parts[1]?.trim();
+        const parseSide = (side, {
+            defaultPrefix = ''
+        } = {}) => {
+            const s = String(side ?? '').trim();
+            const m = s.match(/^(viewof|mutable)\s+(.+)$/);
+            if (m)
+                return {
+                    prefix: `${ m[1] } `,
+                    name: m[2].trim()
+                };
+            return {
+                prefix: defaultPrefix,
+                name: s
+            };
         };
-      return {
-        prefix: defaultPrefix,
-        name: s
-      };
+        const L = parseSide(left);
+        const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
+        const importedName = `${ L.prefix }${ L.name }`.trim();
+        const localName = `${ R.prefix }${ R.name }`.trim();
+        if (!importedName)
+            throw new Error(`Could not parse imported name from: ${ t }`);
+        if (!localName)
+            throw new Error(`Could not parse local name from: ${ t }`);
+        return {
+            importedName,
+            localName
+        };
     };
-    const L = parseSide(left);
-    const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
-    const importedName = `${L.prefix}${L.name}`.trim();
-    const localName = `${R.prefix}${R.name}`.trim();
-    if (!importedName)
-      throw new Error(`Could not parse imported name from: ${t}`);
-    if (!localName) throw new Error(`Could not parse local name from: ${t}`);
-    return {
-      importedName,
-      localName
-    };
-  };
-  if (!cell.id && cell.body?.type === "ImportDeclaration") {
-    const module_name = cell.body.source.value;
-    const importKeyword = globalThis?.importShim ? "importShim" : "import";
-    const cell_variables = [
-      {
-        _name: `module ${module_name}`,
-        _inputs: [],
-        _definition: `async () => runtime.module((await ${importKeyword}("${module_name}")).default)`
-      }
-    ];
-    for (const specifier of cell.body.specifiers ?? []) {
-      const specText =
-        typeof specifier?.start === "number" &&
-        typeof specifier?.end === "number"
-          ? source.slice(specifier.start, specifier.end)
-          : (() => {
-              if (specifier?.imported?.name && specifier?.local?.name) {
-                return specifier.imported.name === specifier.local.name
-                  ? specifier.local.name
-                  : `${specifier.imported.name} as ${specifier.local.name}`;
-              }
-              throw new Error("Import specifier missing range information");
+    if (!cell.id && cell.body?.type === 'ImportDeclaration') {
+        const module_name = cell.body.source.value;
+        const cell_variables = [{
+                _name: `module ${ module_name }`,
+                _inputs: [],
+                _definition: `async () => runtime.module((await import("${ module_name }")).default)`
+            }];
+        for (const specifier of cell.body.specifiers ?? []) {
+            const specText = typeof specifier?.start === 'number' && typeof specifier?.end === 'number' ? source.slice(specifier.start, specifier.end) : (() => {
+                if (specifier?.imported?.name && specifier?.local?.name) {
+                    return specifier.imported.name === specifier.local.name ? specifier.local.name : `${ specifier.imported.name } as ${ specifier.local.name }`;
+                }
+                throw new Error('Import specifier missing range information');
             })();
-      const { importedName, localName } = parseImportSpecifierText(specText);
-      cell_variables.push({
-        _name: localName,
-        _inputs: [`module ${module_name}`, "@variable"],
-        _definition:
-          importedName === localName
-            ? `(_, v) => v.import("${importedName}", _)`
-            : `(_, v) => v.import("${importedName}", "${localName}", _)`
-      });
+            const {importedName, localName} = parseImportSpecifierText(specText);
+            cell_variables.push({
+                _name: localName,
+                _inputs: [
+                    `module ${ module_name }`,
+                    '@variable'
+                ],
+                _definition: importedName === localName ? `(_, v) => v.import("${ importedName }", _)` : `(_, v) => v.import("${ importedName }", "${ localName }", _)`
+            });
+        }
+        return cell_variables;
     }
-    return cell_variables;
-  }
-  let dollarIdx = 0;
-  const inputToArgMap = {};
-  const dollarToMacro = {};
-  const seen = new Set();
-  const inputs = Array.from(cell.references || []).flatMap((i) => {
-    if (i.name) {
-      if (seen.has(i.name)) return [];
-      seen.add(i.name);
-      return i.name;
+    let dollarIdx = 0;
+    const inputToArgMap = {};
+    const dollarToMacro = {};
+    const seen = new Set();
+    const inputs = Array.from(cell.references || []).flatMap(i => {
+        if (i.name) {
+            if (seen.has(i.name))
+                return [];
+            seen.add(i.name);
+            return i.name;
+        } else {
+            const dedupKey = i.type + ':' + i.id.name;
+            if (seen.has(dedupKey))
+                return [];
+            seen.add(dedupKey);
+            const dollarName = '$' + dollarIdx;
+            inputToArgMap[i.id.name] = dollarName;
+            dollarToMacro[dollarName] = i.type == 'ViewExpression' ? 'viewof ' + i.id.name : 'mutable ' + i.id.name;
+            dollarIdx++;
+            return dollarName;
+        }
+    });
+    let variables;
+    if (cell.id) {
+        if (cell.id.type === 'Identifier') {
+            variables = [{
+                    functionName: '_' + cell.id.name,
+                    name: cell.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                }];
+        } else if (cell.id.type === 'ViewExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'viewof ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '(G, _) => G.input(_)',
+                    inputs: [
+                        'Generators',
+                        'viewof ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                }
+            ];
+        } else if (cell.id.type === 'MutableExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'initial ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'mutable ' + cell.id.id.name,
+                    _definition: '(M, _) => new M(_)',
+                    inputs: [
+                        'Mutable',
+                        'initial ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '_ => _.generator',
+                    inputs: ['mutable ' + cell.id.id.name],
+                    params: inputs.join(',')
+                }
+            ];
+        } else {
+            throw new Error(`Unsupported cell id type: ${ cell.id.type }`);
+        }
     } else {
-      const dedupKey = i.type + ":" + i.id.name;
-      if (seen.has(dedupKey)) return [];
-      seen.add(dedupKey);
-      const dollarName = "$" + dollarIdx;
-      inputToArgMap[i.id.name] = dollarName;
-      dollarToMacro[dollarName] =
-        i.type == "ViewExpression"
-          ? "viewof " + i.id.name
-          : "mutable " + i.id.name;
-      dollarIdx++;
-      return dollarName;
+        variables = [{
+                functionName: anonymousName,
+                name: null,
+                inputs,
+                params: inputs.join(',')
+            }];
     }
-  });
-  let variables;
-  if (cell.id) {
-    if (cell.id.type === "Identifier") {
-      variables = [
-        {
-          functionName: "_" + cell.id.name,
-          name: cell.id.name,
-          inputs,
-          params: inputs.join(",")
+    return variables.map(v => {
+        let _definition = v._definition;
+        if (!_definition) {
+            let functionBody;
+            if (cell.body.type === 'BlockStatement') {
+                functionBody = observableToJs(cell.body, inputToArgMap, comments, tokens);
+            } else {
+                const bodyCode = observableToJs(cell.body, inputToArgMap, comments, tokens);
+                functionBody = `{return (${ bodyCode });}`;
+            }
+            _definition = `${ cell.async ? 'async ' : '' }function${ cell.generator ? '*' : '' } ${ v.functionName }(${ v.inputs.join(',') }) ${ functionBody }`;
         }
-      ];
-    } else if (cell.id.type === "ViewExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "viewof " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "(G, _) => G.input(_)",
-          inputs: ["Generators", "viewof " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else if (cell.id.type === "MutableExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "initial " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "mutable " + cell.id.id.name,
-          _definition: "(M, _) => new M(_)",
-          inputs: ["Mutable", "initial " + cell.id.id.name],
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "_ => _.generator",
-          inputs: ["mutable " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else {
-      throw new Error(`Unsupported cell id type: ${cell.id.type}`);
-    }
-  } else {
-    variables = [
-      {
-        functionName: anonymousName,
-        name: null,
-        inputs,
-        params: inputs.join(",")
-      }
-    ];
-  }
-  return variables.map((v) => {
-    let _definition = v._definition;
-    if (!_definition) {
-      let functionBody;
-      if (cell.body.type === "BlockStatement") {
-        functionBody = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-      } else {
-        const bodyCode = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-        functionBody = `{return (${bodyCode});}`;
-      }
-      _definition = `${cell.async ? "async " : ""}function${
-        cell.generator ? "*" : ""
-      } ${v.functionName}(${v.inputs.join(",")}) ${functionBody}`;
-    }
-    return {
-      _name: v.name,
-      _inputs: v.inputs.map(
-        (i) => dollarToMacro[i] || (i === "$variable" ? "@variable" : i)
-      ),
-      _definition
-    };
-  });
+        return {
+            _name: v.name,
+            _inputs: v.inputs.map(i => dollarToMacro[i] || (i === '$variable' ? '@variable' : i)),
+            _definition
+        };
+    });
 }
 )};
 const _1v1i7wl = function _observableToJs(acorn_walk,parser,escodegen){return(
@@ -18784,16 +18722,15 @@ async (attachment, overrides) => {
   return URL.createObjectURL(blob);
 }
 )};
-const _s9w7ha = async function _parser(decompress_url,FileAttachment,acorn_url,acorn_walk_url){return(
-importShim(await decompress_url(FileAttachment("parser-6.1.0.js.gz"), {
-    "/npm/acorn@8.11.3/+esm": acorn_url,
-    "/npm/acorn-walk@8.3.2/+esm": acorn_walk_url
-  })
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
-const _1hiclbb = function _acorn_walk(acorn_walk_url){return(
-importShim(acorn_walk_url, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _s9w7ha = async function _parser(decompress_url, FileAttachment, acorn_url, acorn_walk_url) {
+    return import(await decompress_url(FileAttachment('parser-6.1.0.js.gz'), {
+        '/npm/acorn@8.11.3/+esm': acorn_url,
+        '/npm/acorn-walk@8.3.2/+esm': acorn_walk_url
+    }));
+};
+const _1hiclbb = function _acorn_walk(acorn_walk_url) {
+    return import(acorn_walk_url);
+};
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
@@ -18981,7 +18918,7 @@ export default function define(runtime, observer) {
   $def("_1dmmuaf", "compiled_selector", ["Generators","viewof compiled_selector"], _1dmmuaf);  
   $def("_u7t3vu", null, ["compiled_selector","normalizeJavascriptSource"], _u7t3vu);  
   $def("_1lt3kl6", null, ["compile","test_case"], _1lt3kl6);  
-  $def("_lpzjrv", "compile", ["parser","globalThis","observableToJs"], _lpzjrv);  
+  $def("_x1d0wm", "compile", ["parser","observableToJs"], _x1d0wm);  
   $def("_1v1i7wl", "observableToJs", ["acorn_walk","parser","escodegen"], _1v1i7wl);  
   $def("_19lv24l", null, ["md"], _19lv24l);  
   $def("_xhj6b8", "decompress_url", ["DecompressionStream","TextDecoderStream","TransformStream","TextEncoderStream","Response"], _xhj6b8);  

--- a/notebooks/@tomlarkworthy_module-selection.html
+++ b/notebooks/@tomlarkworthy_module-selection.html
@@ -5415,58 +5415,41 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _geoudp = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
-  if (command.processed) return;
-
-  let result = undefined;
-  if (command.command == "createCell") {
-    $0.value = true;
-    result = compile_and_update("{}", [], command.args.cell);
-    // For the new one to get focus
-    // setTimeout(() => {
-    //   debugger;
-    //   setOption(result[0], "pinned", true);
-    // }, 100);
-  } else if (command.command == "deleteCell") {
-    remove_variables(command.args.cell.variables);
-    result = true;
-  } else if (command.command == "moveCell") {
-    const cellIndex = findCellIndex(
-      command.args.cell.variables,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const targetCellIndex = cellIndex + command.args.amount;
-    const targetCell = lookupCellByIndex(
-      targetCellIndex,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const currentFirstVariableIndex = findVariableIndex(
-      command.args.cell.variables[0]
-    );
-    const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-    const change = targetFirstVariableIndex - currentFirstVariableIndex;
-    console.log(
-      "moveCell",
-      cellIndex,
-      targetCellIndex,
-      targetCell,
-      currentFirstVariableIndex,
-      targetFirstVariableIndex,
-      change
-    );
-    command.args.cell.variables.forEach((v) => {
-      const currentIndex = findVariableIndex(v);
-      repositionSetElement(runtime._variables, v, currentIndex + change);
-    });
-    // recompute
-    await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
-    result = true;
-  }
-  if (result) {
-    command.processed = true;
-    $2.resolve(result);
-  }
+    if (command.processed)
+        return;
+    let result = undefined;
+    if (command.command == 'createCell') {
+        $0.value = true;
+        result = await compile_and_update('{}', [], command.args.cell);    // For the new one to get focus
+                                                                           // setTimeout(() => {
+                                                                           //   debugger;
+                                                                           //   setOption(result[0], "pinned", true);
+                                                                           // }, 100);
+    } else if (command.command == 'deleteCell') {
+        remove_variables(command.args.cell.variables);
+        result = true;
+    } else if (command.command == 'moveCell') {
+        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const targetCellIndex = cellIndex + command.args.amount;
+        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
+        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+        const change = targetFirstVariableIndex - currentFirstVariableIndex;
+        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
+        command.args.cell.variables.forEach(v => {
+            const currentIndex = findVariableIndex(v);
+            repositionSetElement(runtime._variables, v, currentIndex + change);
+        });
+        // recompute
+        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        result = true;
+    }
+    if (result) {
+        command.processed = true;
+        $2.resolve(result);
+    }
 };
 const _1jadxoe = function _60(md){return(
 md`### UI Action`
@@ -5857,9 +5840,9 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
-    return (source, variables = [], cell) => {
+    return async (source, variables = [], cell) => {
         try {
             debugger;
             let reposition = false, insertionIndex = -1;
@@ -5879,10 +5862,10 @@ const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElemen
             if (reposition) {
                 insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
+            const fns = await realize(newVariables.map(v => v._definition), runtime);
             newVariables.forEach((v, i) => {
                 const variable = variables[i];
-                let _fn;
-                eval('_fn = ' + v._definition);
+                const _fn = fns[i];
                 if (v._name) {
                     variable.define(v._name, v._inputs, _fn);
                 } else {
@@ -5931,12 +5914,11 @@ Inputs.textarea({
 })
 )};
 const _b4rsn5 = (G, _) => G.input(_);
-const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
+const _ga6kci = function _98(Inputs,definition,variable,realize,runtime,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
-  reduce: () => {
-    let _fn;
-    eval("_fn = " + definition);
+  reduce: async () => {
+    const [_fn] = await realize([definition], runtime);
     variable.define(variable._name, inputs, _fn);
   }
 })
@@ -6049,7 +6031,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_geoudp", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _geoudp);  
+  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6087,7 +6069,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
+  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -6097,8 +6079,9 @@ export default function define(runtime, observer) {
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
   $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
-  $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
+  $def("_ga6kci", null, ["Inputs","definition","variable","realize","runtime","inputs"], _ga6kci);  
   $def("_1q557s", null, ["md"], _1q557s);  
+  main.define("realize", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("realize", _));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -15258,10 +15241,9 @@ notebook_semantics_document.nodes.map((s) => ({
 const _1oevsow = function _28(md){return(
 md`### Runtime Representation (v4)`
 )};
-const _11lfflk = function _notebook_semantics_module(){return(
-importShim("https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4"
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _11lfflk = function _notebook_semantics_module() {
+    return import('https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4');
+};
 const _gjten6 = function _31(md){return(
 md`### Imports`
 )};
@@ -16248,65 +16230,44 @@ parser.parseCell(
   'import {runtime, viewof main as foo} from "@mootari/access-runtime"'
 )
 )};
-const _1n7gw17 = function _findModuleName(extractModuleInfo){return(
-(scope, module, { unknown_id = Math.random() } = {}) => {
-  try {
-    const scopedVariables = [...scope.values()];
-
-    // Prefer variables that *define* a module and have a real module-loader name.
-    const candidates = scopedVariables.filter(
-      (v) =>
-        v &&
-        v._value === module &&
-        typeof v._name === "string" &&
-        v._name.startsWith("module ") &&
-        !v._name.startsWith("module <unknown")
-    );
-
-    const pickBestInfo = (dfn) => {
-      // Avoid the parentUrl (2nd arg) confusing module identification.
-      // Typical patterns:
-      //   importShim("/d/<id>@<ver>.js?v=4", "https://api.observablehq.com/@ns/name.js?v=4")
-      //   import("/d/<id>@<ver>.js?v=4")
-      // Prefer the *first argument* inside importShim(...) / import(...) when present.
-      const s = String(dfn ?? "");
-
-      // Try to capture the first string literal argument to importShim(...) or import(...)
-      // Tolerates quotes ", ', ` and both importShim and plain import.
-      const m = s.match(
-        /\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/
-      );
-      const firstArg = m?.[2];
-
-      const info1 = firstArg ? extractModuleInfo(firstArg) : {};
-      if (info1?.id || info1?.notebook) return info1;
-
-      // Fallback: parse the whole definition string.
-      return extractModuleInfo(s);
+const _1n7gw17 = function _findModuleName(extractModuleInfo) {
+    return (scope, module, {
+        unknown_id = Math.random()
+    } = {}) => {
+        try {
+            const scopedVariables = [...scope.values()];
+            const candidates = scopedVariables.filter(v => v && v._value === module && typeof v._name === 'string' && v._name.startsWith('module ') && !v._name.startsWith('module <unknown'));
+            const pickBestInfo = dfn => {
+                const s = String(dfn ?? '');
+                const m = s.match(/\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/);
+                const firstArg = m?.[2];
+                const info1 = firstArg ? extractModuleInfo(firstArg) : {};
+                if (info1?.id || info1?.notebook)
+                    return info1;
+                return extractModuleInfo(s);
+            };
+            for (const v of candidates) {
+                const info = pickBestInfo(v._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            const any = scopedVariables.find(v => v && v._value === module);
+            if (any) {
+                const info = pickBestInfo(any._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            return `<unknown ${ unknown_id }>`;
+        } catch (e) {
+            debugger;
+            return 'error';
+        }
     };
-
-    // Try module loader cells first.
-    for (const v of candidates) {
-      const info = pickBestInfo(v._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    // Fallback: any scoped variable with _value==module.
-    const any = scopedVariables.find((v) => v && v._value === module);
-    if (any) {
-      const info = pickBestInfo(any._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    return `<unknown ${unknown_id}>`;
-  } catch (e) {
-    debugger;
-    return "error";
-  }
-}
-)};
+};
 const _i47chb = function _findImportedName(){return(
 async (v) => {
   if (v._inputs.length == 1 && v._inputs[0]._name === "@variable") {
@@ -17208,229 +17169,206 @@ JSON.stringify(
 const _1lt3kl6 = function _157(compile,test_case){return(
 compile(test_case.value)
 )};
-const _lpzjrv = function _compile(parser,globalThis,observableToJs){return(
-function compile(source, { anonymousName = "_anonymous" } = {}) {
-  const comments = [],
-    tokens = [];
-  let cell;
-  try {
-    cell = parser.parseCell(source, {
-      ranges: true,
-      onComment: comments,
-      onToken: tokens
-    });
-  } catch (e) {
-    if (e instanceof SyntaxError) {
-      const nameMatch = source.match(
-        /^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/
-      );
-      let _name = null;
-      let funcName = anonymousName;
-      if (nameMatch) {
-        const prefix = nameMatch[1] ? nameMatch[1] + " " : "";
-        _name = prefix + nameMatch[2];
-        funcName = "_" + nameMatch[2];
-      }
-      const escapedMsg = JSON.stringify(e.message);
-      const escapedSource = JSON.stringify(source);
-      return [
-        {
-          _name,
-          _inputs: [],
-          _definition: `function ${funcName}() { throw Object.assign(new SyntaxError(${escapedMsg}), {_sourceExpression: ${escapedSource}}); }`
+const _x1d0wm = function _compile(parser,observableToJs){return(
+function compile(source, {
+    anonymousName = '_anonymous'
+} = {}) {
+    const comments = [], tokens = [];
+    let cell;
+    try {
+        cell = parser.parseCell(source, {
+            ranges: true,
+            onComment: comments,
+            onToken: tokens
+        });
+    } catch (e) {
+        if (e instanceof SyntaxError) {
+            const nameMatch = source.match(/^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/);
+            let _name = null;
+            let funcName = anonymousName;
+            if (nameMatch) {
+                const prefix = nameMatch[1] ? nameMatch[1] + ' ' : '';
+                _name = prefix + nameMatch[2];
+                funcName = '_' + nameMatch[2];
+            }
+            const escapedMsg = JSON.stringify(e.message);
+            const escapedSource = JSON.stringify(source);
+            return [{
+                    _name,
+                    _inputs: [],
+                    _definition: `function ${ funcName }() { throw Object.assign(new SyntaxError(${ escapedMsg }), {_sourceExpression: ${ escapedSource }}); }`
+                }];
         }
-      ];
+        throw e;
     }
-    throw e;
-  }
-  if (!cell) throw new Error("Unable to parse cell");
-  const parseImportSpecifierText = (text) => {
-    const t = String(text ?? "")
-      .trim()
-      .replace(/,$/, "")
-      .trim();
-    if (!t) throw new Error("Empty import specifier");
-    const parts = t.split(/\s+as\s+/);
-    const left = parts[0].trim();
-    const right = parts[1]?.trim();
-    const parseSide = (side, { defaultPrefix = "" } = {}) => {
-      const s = String(side ?? "").trim();
-      const m = s.match(/^(viewof|mutable)\s+(.+)$/);
-      if (m)
-        return {
-          prefix: `${m[1]} `,
-          name: m[2].trim()
+    if (!cell)
+        throw new Error('Unable to parse cell');
+    const parseImportSpecifierText = text => {
+        const t = String(text ?? '').trim().replace(/,$/, '').trim();
+        if (!t)
+            throw new Error('Empty import specifier');
+        const parts = t.split(/\s+as\s+/);
+        const left = parts[0].trim();
+        const right = parts[1]?.trim();
+        const parseSide = (side, {
+            defaultPrefix = ''
+        } = {}) => {
+            const s = String(side ?? '').trim();
+            const m = s.match(/^(viewof|mutable)\s+(.+)$/);
+            if (m)
+                return {
+                    prefix: `${ m[1] } `,
+                    name: m[2].trim()
+                };
+            return {
+                prefix: defaultPrefix,
+                name: s
+            };
         };
-      return {
-        prefix: defaultPrefix,
-        name: s
-      };
+        const L = parseSide(left);
+        const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
+        const importedName = `${ L.prefix }${ L.name }`.trim();
+        const localName = `${ R.prefix }${ R.name }`.trim();
+        if (!importedName)
+            throw new Error(`Could not parse imported name from: ${ t }`);
+        if (!localName)
+            throw new Error(`Could not parse local name from: ${ t }`);
+        return {
+            importedName,
+            localName
+        };
     };
-    const L = parseSide(left);
-    const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
-    const importedName = `${L.prefix}${L.name}`.trim();
-    const localName = `${R.prefix}${R.name}`.trim();
-    if (!importedName)
-      throw new Error(`Could not parse imported name from: ${t}`);
-    if (!localName) throw new Error(`Could not parse local name from: ${t}`);
-    return {
-      importedName,
-      localName
-    };
-  };
-  if (!cell.id && cell.body?.type === "ImportDeclaration") {
-    const module_name = cell.body.source.value;
-    const importKeyword = globalThis?.importShim ? "importShim" : "import";
-    const cell_variables = [
-      {
-        _name: `module ${module_name}`,
-        _inputs: [],
-        _definition: `async () => runtime.module((await ${importKeyword}("${module_name}")).default)`
-      }
-    ];
-    for (const specifier of cell.body.specifiers ?? []) {
-      const specText =
-        typeof specifier?.start === "number" &&
-        typeof specifier?.end === "number"
-          ? source.slice(specifier.start, specifier.end)
-          : (() => {
-              if (specifier?.imported?.name && specifier?.local?.name) {
-                return specifier.imported.name === specifier.local.name
-                  ? specifier.local.name
-                  : `${specifier.imported.name} as ${specifier.local.name}`;
-              }
-              throw new Error("Import specifier missing range information");
+    if (!cell.id && cell.body?.type === 'ImportDeclaration') {
+        const module_name = cell.body.source.value;
+        const cell_variables = [{
+                _name: `module ${ module_name }`,
+                _inputs: [],
+                _definition: `async () => runtime.module((await import("${ module_name }")).default)`
+            }];
+        for (const specifier of cell.body.specifiers ?? []) {
+            const specText = typeof specifier?.start === 'number' && typeof specifier?.end === 'number' ? source.slice(specifier.start, specifier.end) : (() => {
+                if (specifier?.imported?.name && specifier?.local?.name) {
+                    return specifier.imported.name === specifier.local.name ? specifier.local.name : `${ specifier.imported.name } as ${ specifier.local.name }`;
+                }
+                throw new Error('Import specifier missing range information');
             })();
-      const { importedName, localName } = parseImportSpecifierText(specText);
-      cell_variables.push({
-        _name: localName,
-        _inputs: [`module ${module_name}`, "@variable"],
-        _definition:
-          importedName === localName
-            ? `(_, v) => v.import("${importedName}", _)`
-            : `(_, v) => v.import("${importedName}", "${localName}", _)`
-      });
+            const {importedName, localName} = parseImportSpecifierText(specText);
+            cell_variables.push({
+                _name: localName,
+                _inputs: [
+                    `module ${ module_name }`,
+                    '@variable'
+                ],
+                _definition: importedName === localName ? `(_, v) => v.import("${ importedName }", _)` : `(_, v) => v.import("${ importedName }", "${ localName }", _)`
+            });
+        }
+        return cell_variables;
     }
-    return cell_variables;
-  }
-  let dollarIdx = 0;
-  const inputToArgMap = {};
-  const dollarToMacro = {};
-  const seen = new Set();
-  const inputs = Array.from(cell.references || []).flatMap((i) => {
-    if (i.name) {
-      if (seen.has(i.name)) return [];
-      seen.add(i.name);
-      return i.name;
+    let dollarIdx = 0;
+    const inputToArgMap = {};
+    const dollarToMacro = {};
+    const seen = new Set();
+    const inputs = Array.from(cell.references || []).flatMap(i => {
+        if (i.name) {
+            if (seen.has(i.name))
+                return [];
+            seen.add(i.name);
+            return i.name;
+        } else {
+            const dedupKey = i.type + ':' + i.id.name;
+            if (seen.has(dedupKey))
+                return [];
+            seen.add(dedupKey);
+            const dollarName = '$' + dollarIdx;
+            inputToArgMap[i.id.name] = dollarName;
+            dollarToMacro[dollarName] = i.type == 'ViewExpression' ? 'viewof ' + i.id.name : 'mutable ' + i.id.name;
+            dollarIdx++;
+            return dollarName;
+        }
+    });
+    let variables;
+    if (cell.id) {
+        if (cell.id.type === 'Identifier') {
+            variables = [{
+                    functionName: '_' + cell.id.name,
+                    name: cell.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                }];
+        } else if (cell.id.type === 'ViewExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'viewof ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '(G, _) => G.input(_)',
+                    inputs: [
+                        'Generators',
+                        'viewof ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                }
+            ];
+        } else if (cell.id.type === 'MutableExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'initial ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'mutable ' + cell.id.id.name,
+                    _definition: '(M, _) => new M(_)',
+                    inputs: [
+                        'Mutable',
+                        'initial ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '_ => _.generator',
+                    inputs: ['mutable ' + cell.id.id.name],
+                    params: inputs.join(',')
+                }
+            ];
+        } else {
+            throw new Error(`Unsupported cell id type: ${ cell.id.type }`);
+        }
     } else {
-      const dedupKey = i.type + ":" + i.id.name;
-      if (seen.has(dedupKey)) return [];
-      seen.add(dedupKey);
-      const dollarName = "$" + dollarIdx;
-      inputToArgMap[i.id.name] = dollarName;
-      dollarToMacro[dollarName] =
-        i.type == "ViewExpression"
-          ? "viewof " + i.id.name
-          : "mutable " + i.id.name;
-      dollarIdx++;
-      return dollarName;
+        variables = [{
+                functionName: anonymousName,
+                name: null,
+                inputs,
+                params: inputs.join(',')
+            }];
     }
-  });
-  let variables;
-  if (cell.id) {
-    if (cell.id.type === "Identifier") {
-      variables = [
-        {
-          functionName: "_" + cell.id.name,
-          name: cell.id.name,
-          inputs,
-          params: inputs.join(",")
+    return variables.map(v => {
+        let _definition = v._definition;
+        if (!_definition) {
+            let functionBody;
+            if (cell.body.type === 'BlockStatement') {
+                functionBody = observableToJs(cell.body, inputToArgMap, comments, tokens);
+            } else {
+                const bodyCode = observableToJs(cell.body, inputToArgMap, comments, tokens);
+                functionBody = `{return (${ bodyCode });}`;
+            }
+            _definition = `${ cell.async ? 'async ' : '' }function${ cell.generator ? '*' : '' } ${ v.functionName }(${ v.inputs.join(',') }) ${ functionBody }`;
         }
-      ];
-    } else if (cell.id.type === "ViewExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "viewof " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "(G, _) => G.input(_)",
-          inputs: ["Generators", "viewof " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else if (cell.id.type === "MutableExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "initial " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "mutable " + cell.id.id.name,
-          _definition: "(M, _) => new M(_)",
-          inputs: ["Mutable", "initial " + cell.id.id.name],
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "_ => _.generator",
-          inputs: ["mutable " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else {
-      throw new Error(`Unsupported cell id type: ${cell.id.type}`);
-    }
-  } else {
-    variables = [
-      {
-        functionName: anonymousName,
-        name: null,
-        inputs,
-        params: inputs.join(",")
-      }
-    ];
-  }
-  return variables.map((v) => {
-    let _definition = v._definition;
-    if (!_definition) {
-      let functionBody;
-      if (cell.body.type === "BlockStatement") {
-        functionBody = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-      } else {
-        const bodyCode = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-        functionBody = `{return (${bodyCode});}`;
-      }
-      _definition = `${cell.async ? "async " : ""}function${
-        cell.generator ? "*" : ""
-      } ${v.functionName}(${v.inputs.join(",")}) ${functionBody}`;
-    }
-    return {
-      _name: v.name,
-      _inputs: v.inputs.map(
-        (i) => dollarToMacro[i] || (i === "$variable" ? "@variable" : i)
-      ),
-      _definition
-    };
-  });
+        return {
+            _name: v.name,
+            _inputs: v.inputs.map(i => dollarToMacro[i] || (i === '$variable' ? '@variable' : i)),
+            _definition
+        };
+    });
 }
 )};
 const _1v1i7wl = function _observableToJs(acorn_walk,parser,escodegen){return(
@@ -17497,16 +17435,15 @@ async (attachment, overrides) => {
   return URL.createObjectURL(blob);
 }
 )};
-const _s9w7ha = async function _parser(decompress_url,FileAttachment,acorn_url,acorn_walk_url){return(
-importShim(await decompress_url(FileAttachment("parser-6.1.0.js.gz"), {
-    "/npm/acorn@8.11.3/+esm": acorn_url,
-    "/npm/acorn-walk@8.3.2/+esm": acorn_walk_url
-  })
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
-const _1hiclbb = function _acorn_walk(acorn_walk_url){return(
-importShim(acorn_walk_url, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _s9w7ha = async function _parser(decompress_url, FileAttachment, acorn_url, acorn_walk_url) {
+    return import(await decompress_url(FileAttachment('parser-6.1.0.js.gz'), {
+        '/npm/acorn@8.11.3/+esm': acorn_url,
+        '/npm/acorn-walk@8.3.2/+esm': acorn_walk_url
+    }));
+};
+const _1hiclbb = function _acorn_walk(acorn_walk_url) {
+    return import(acorn_walk_url);
+};
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
@@ -17694,7 +17631,7 @@ export default function define(runtime, observer) {
   $def("_1dmmuaf", "compiled_selector", ["Generators","viewof compiled_selector"], _1dmmuaf);  
   $def("_u7t3vu", null, ["compiled_selector","normalizeJavascriptSource"], _u7t3vu);  
   $def("_1lt3kl6", null, ["compile","test_case"], _1lt3kl6);  
-  $def("_lpzjrv", "compile", ["parser","globalThis","observableToJs"], _lpzjrv);  
+  $def("_x1d0wm", "compile", ["parser","observableToJs"], _x1d0wm);  
   $def("_1v1i7wl", "observableToJs", ["acorn_walk","parser","escodegen"], _1v1i7wl);  
   $def("_19lv24l", null, ["md"], _19lv24l);  
   $def("_xhj6b8", "decompress_url", ["DecompressionStream","TextDecoderStream","TransformStream","TextEncoderStream","Response"], _xhj6b8);  

--- a/notebooks/@tomlarkworthy_notes.html
+++ b/notebooks/@tomlarkworthy_notes.html
@@ -5464,58 +5464,41 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _geoudp = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
-  if (command.processed) return;
-
-  let result = undefined;
-  if (command.command == "createCell") {
-    $0.value = true;
-    result = compile_and_update("{}", [], command.args.cell);
-    // For the new one to get focus
-    // setTimeout(() => {
-    //   debugger;
-    //   setOption(result[0], "pinned", true);
-    // }, 100);
-  } else if (command.command == "deleteCell") {
-    remove_variables(command.args.cell.variables);
-    result = true;
-  } else if (command.command == "moveCell") {
-    const cellIndex = findCellIndex(
-      command.args.cell.variables,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const targetCellIndex = cellIndex + command.args.amount;
-    const targetCell = lookupCellByIndex(
-      targetCellIndex,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const currentFirstVariableIndex = findVariableIndex(
-      command.args.cell.variables[0]
-    );
-    const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-    const change = targetFirstVariableIndex - currentFirstVariableIndex;
-    console.log(
-      "moveCell",
-      cellIndex,
-      targetCellIndex,
-      targetCell,
-      currentFirstVariableIndex,
-      targetFirstVariableIndex,
-      change
-    );
-    command.args.cell.variables.forEach((v) => {
-      const currentIndex = findVariableIndex(v);
-      repositionSetElement(runtime._variables, v, currentIndex + change);
-    });
-    // recompute
-    await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
-    result = true;
-  }
-  if (result) {
-    command.processed = true;
-    $2.resolve(result);
-  }
+    if (command.processed)
+        return;
+    let result = undefined;
+    if (command.command == 'createCell') {
+        $0.value = true;
+        result = await compile_and_update('{}', [], command.args.cell);    // For the new one to get focus
+                                                                           // setTimeout(() => {
+                                                                           //   debugger;
+                                                                           //   setOption(result[0], "pinned", true);
+                                                                           // }, 100);
+    } else if (command.command == 'deleteCell') {
+        remove_variables(command.args.cell.variables);
+        result = true;
+    } else if (command.command == 'moveCell') {
+        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const targetCellIndex = cellIndex + command.args.amount;
+        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
+        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+        const change = targetFirstVariableIndex - currentFirstVariableIndex;
+        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
+        command.args.cell.variables.forEach(v => {
+            const currentIndex = findVariableIndex(v);
+            repositionSetElement(runtime._variables, v, currentIndex + change);
+        });
+        // recompute
+        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        result = true;
+    }
+    if (result) {
+        command.processed = true;
+        $2.resolve(result);
+    }
 };
 const _1jadxoe = function _60(md){return(
 md`### UI Action`
@@ -5906,9 +5889,9 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
-    return (source, variables = [], cell) => {
+    return async (source, variables = [], cell) => {
         try {
             debugger;
             let reposition = false, insertionIndex = -1;
@@ -5928,10 +5911,10 @@ const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElemen
             if (reposition) {
                 insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
+            const fns = await realize(newVariables.map(v => v._definition), runtime);
             newVariables.forEach((v, i) => {
                 const variable = variables[i];
-                let _fn;
-                eval('_fn = ' + v._definition);
+                const _fn = fns[i];
                 if (v._name) {
                     variable.define(v._name, v._inputs, _fn);
                 } else {
@@ -5980,12 +5963,11 @@ Inputs.textarea({
 })
 )};
 const _b4rsn5 = (G, _) => G.input(_);
-const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
+const _ga6kci = function _98(Inputs,definition,variable,realize,runtime,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
-  reduce: () => {
-    let _fn;
-    eval("_fn = " + definition);
+  reduce: async () => {
+    const [_fn] = await realize([definition], runtime);
     variable.define(variable._name, inputs, _fn);
   }
 })
@@ -6098,7 +6080,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_geoudp", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _geoudp);  
+  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6136,7 +6118,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
+  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -6146,8 +6128,9 @@ export default function define(runtime, observer) {
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
   $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
-  $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
+  $def("_ga6kci", null, ["Inputs","definition","variable","realize","runtime","inputs"], _ga6kci);  
   $def("_1q557s", null, ["md"], _1q557s);  
+  main.define("realize", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("realize", _));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -16983,10 +16966,9 @@ notebook_semantics_document.nodes.map((s) => ({
 const _1oevsow = function _28(md){return(
 md`### Runtime Representation (v4)`
 )};
-const _11lfflk = function _notebook_semantics_module(){return(
-importShim("https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4"
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _11lfflk = function _notebook_semantics_module() {
+    return import('https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4');
+};
 const _gjten6 = function _31(md){return(
 md`### Imports`
 )};
@@ -17973,65 +17955,44 @@ parser.parseCell(
   'import {runtime, viewof main as foo} from "@mootari/access-runtime"'
 )
 )};
-const _1n7gw17 = function _findModuleName(extractModuleInfo){return(
-(scope, module, { unknown_id = Math.random() } = {}) => {
-  try {
-    const scopedVariables = [...scope.values()];
-
-    // Prefer variables that *define* a module and have a real module-loader name.
-    const candidates = scopedVariables.filter(
-      (v) =>
-        v &&
-        v._value === module &&
-        typeof v._name === "string" &&
-        v._name.startsWith("module ") &&
-        !v._name.startsWith("module <unknown")
-    );
-
-    const pickBestInfo = (dfn) => {
-      // Avoid the parentUrl (2nd arg) confusing module identification.
-      // Typical patterns:
-      //   importShim("/d/<id>@<ver>.js?v=4", "https://api.observablehq.com/@ns/name.js?v=4")
-      //   import("/d/<id>@<ver>.js?v=4")
-      // Prefer the *first argument* inside importShim(...) / import(...) when present.
-      const s = String(dfn ?? "");
-
-      // Try to capture the first string literal argument to importShim(...) or import(...)
-      // Tolerates quotes ", ', ` and both importShim and plain import.
-      const m = s.match(
-        /\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/
-      );
-      const firstArg = m?.[2];
-
-      const info1 = firstArg ? extractModuleInfo(firstArg) : {};
-      if (info1?.id || info1?.notebook) return info1;
-
-      // Fallback: parse the whole definition string.
-      return extractModuleInfo(s);
+const _1n7gw17 = function _findModuleName(extractModuleInfo) {
+    return (scope, module, {
+        unknown_id = Math.random()
+    } = {}) => {
+        try {
+            const scopedVariables = [...scope.values()];
+            const candidates = scopedVariables.filter(v => v && v._value === module && typeof v._name === 'string' && v._name.startsWith('module ') && !v._name.startsWith('module <unknown'));
+            const pickBestInfo = dfn => {
+                const s = String(dfn ?? '');
+                const m = s.match(/\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/);
+                const firstArg = m?.[2];
+                const info1 = firstArg ? extractModuleInfo(firstArg) : {};
+                if (info1?.id || info1?.notebook)
+                    return info1;
+                return extractModuleInfo(s);
+            };
+            for (const v of candidates) {
+                const info = pickBestInfo(v._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            const any = scopedVariables.find(v => v && v._value === module);
+            if (any) {
+                const info = pickBestInfo(any._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            return `<unknown ${ unknown_id }>`;
+        } catch (e) {
+            debugger;
+            return 'error';
+        }
     };
-
-    // Try module loader cells first.
-    for (const v of candidates) {
-      const info = pickBestInfo(v._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    // Fallback: any scoped variable with _value==module.
-    const any = scopedVariables.find((v) => v && v._value === module);
-    if (any) {
-      const info = pickBestInfo(any._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    return `<unknown ${unknown_id}>`;
-  } catch (e) {
-    debugger;
-    return "error";
-  }
-}
-)};
+};
 const _i47chb = function _findImportedName(){return(
 async (v) => {
   if (v._inputs.length == 1 && v._inputs[0]._name === "@variable") {
@@ -18933,229 +18894,206 @@ JSON.stringify(
 const _1lt3kl6 = function _157(compile,test_case){return(
 compile(test_case.value)
 )};
-const _lpzjrv = function _compile(parser,globalThis,observableToJs){return(
-function compile(source, { anonymousName = "_anonymous" } = {}) {
-  const comments = [],
-    tokens = [];
-  let cell;
-  try {
-    cell = parser.parseCell(source, {
-      ranges: true,
-      onComment: comments,
-      onToken: tokens
-    });
-  } catch (e) {
-    if (e instanceof SyntaxError) {
-      const nameMatch = source.match(
-        /^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/
-      );
-      let _name = null;
-      let funcName = anonymousName;
-      if (nameMatch) {
-        const prefix = nameMatch[1] ? nameMatch[1] + " " : "";
-        _name = prefix + nameMatch[2];
-        funcName = "_" + nameMatch[2];
-      }
-      const escapedMsg = JSON.stringify(e.message);
-      const escapedSource = JSON.stringify(source);
-      return [
-        {
-          _name,
-          _inputs: [],
-          _definition: `function ${funcName}() { throw Object.assign(new SyntaxError(${escapedMsg}), {_sourceExpression: ${escapedSource}}); }`
+const _x1d0wm = function _compile(parser,observableToJs){return(
+function compile(source, {
+    anonymousName = '_anonymous'
+} = {}) {
+    const comments = [], tokens = [];
+    let cell;
+    try {
+        cell = parser.parseCell(source, {
+            ranges: true,
+            onComment: comments,
+            onToken: tokens
+        });
+    } catch (e) {
+        if (e instanceof SyntaxError) {
+            const nameMatch = source.match(/^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/);
+            let _name = null;
+            let funcName = anonymousName;
+            if (nameMatch) {
+                const prefix = nameMatch[1] ? nameMatch[1] + ' ' : '';
+                _name = prefix + nameMatch[2];
+                funcName = '_' + nameMatch[2];
+            }
+            const escapedMsg = JSON.stringify(e.message);
+            const escapedSource = JSON.stringify(source);
+            return [{
+                    _name,
+                    _inputs: [],
+                    _definition: `function ${ funcName }() { throw Object.assign(new SyntaxError(${ escapedMsg }), {_sourceExpression: ${ escapedSource }}); }`
+                }];
         }
-      ];
+        throw e;
     }
-    throw e;
-  }
-  if (!cell) throw new Error("Unable to parse cell");
-  const parseImportSpecifierText = (text) => {
-    const t = String(text ?? "")
-      .trim()
-      .replace(/,$/, "")
-      .trim();
-    if (!t) throw new Error("Empty import specifier");
-    const parts = t.split(/\s+as\s+/);
-    const left = parts[0].trim();
-    const right = parts[1]?.trim();
-    const parseSide = (side, { defaultPrefix = "" } = {}) => {
-      const s = String(side ?? "").trim();
-      const m = s.match(/^(viewof|mutable)\s+(.+)$/);
-      if (m)
-        return {
-          prefix: `${m[1]} `,
-          name: m[2].trim()
+    if (!cell)
+        throw new Error('Unable to parse cell');
+    const parseImportSpecifierText = text => {
+        const t = String(text ?? '').trim().replace(/,$/, '').trim();
+        if (!t)
+            throw new Error('Empty import specifier');
+        const parts = t.split(/\s+as\s+/);
+        const left = parts[0].trim();
+        const right = parts[1]?.trim();
+        const parseSide = (side, {
+            defaultPrefix = ''
+        } = {}) => {
+            const s = String(side ?? '').trim();
+            const m = s.match(/^(viewof|mutable)\s+(.+)$/);
+            if (m)
+                return {
+                    prefix: `${ m[1] } `,
+                    name: m[2].trim()
+                };
+            return {
+                prefix: defaultPrefix,
+                name: s
+            };
         };
-      return {
-        prefix: defaultPrefix,
-        name: s
-      };
+        const L = parseSide(left);
+        const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
+        const importedName = `${ L.prefix }${ L.name }`.trim();
+        const localName = `${ R.prefix }${ R.name }`.trim();
+        if (!importedName)
+            throw new Error(`Could not parse imported name from: ${ t }`);
+        if (!localName)
+            throw new Error(`Could not parse local name from: ${ t }`);
+        return {
+            importedName,
+            localName
+        };
     };
-    const L = parseSide(left);
-    const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
-    const importedName = `${L.prefix}${L.name}`.trim();
-    const localName = `${R.prefix}${R.name}`.trim();
-    if (!importedName)
-      throw new Error(`Could not parse imported name from: ${t}`);
-    if (!localName) throw new Error(`Could not parse local name from: ${t}`);
-    return {
-      importedName,
-      localName
-    };
-  };
-  if (!cell.id && cell.body?.type === "ImportDeclaration") {
-    const module_name = cell.body.source.value;
-    const importKeyword = globalThis?.importShim ? "importShim" : "import";
-    const cell_variables = [
-      {
-        _name: `module ${module_name}`,
-        _inputs: [],
-        _definition: `async () => runtime.module((await ${importKeyword}("${module_name}")).default)`
-      }
-    ];
-    for (const specifier of cell.body.specifiers ?? []) {
-      const specText =
-        typeof specifier?.start === "number" &&
-        typeof specifier?.end === "number"
-          ? source.slice(specifier.start, specifier.end)
-          : (() => {
-              if (specifier?.imported?.name && specifier?.local?.name) {
-                return specifier.imported.name === specifier.local.name
-                  ? specifier.local.name
-                  : `${specifier.imported.name} as ${specifier.local.name}`;
-              }
-              throw new Error("Import specifier missing range information");
+    if (!cell.id && cell.body?.type === 'ImportDeclaration') {
+        const module_name = cell.body.source.value;
+        const cell_variables = [{
+                _name: `module ${ module_name }`,
+                _inputs: [],
+                _definition: `async () => runtime.module((await import("${ module_name }")).default)`
+            }];
+        for (const specifier of cell.body.specifiers ?? []) {
+            const specText = typeof specifier?.start === 'number' && typeof specifier?.end === 'number' ? source.slice(specifier.start, specifier.end) : (() => {
+                if (specifier?.imported?.name && specifier?.local?.name) {
+                    return specifier.imported.name === specifier.local.name ? specifier.local.name : `${ specifier.imported.name } as ${ specifier.local.name }`;
+                }
+                throw new Error('Import specifier missing range information');
             })();
-      const { importedName, localName } = parseImportSpecifierText(specText);
-      cell_variables.push({
-        _name: localName,
-        _inputs: [`module ${module_name}`, "@variable"],
-        _definition:
-          importedName === localName
-            ? `(_, v) => v.import("${importedName}", _)`
-            : `(_, v) => v.import("${importedName}", "${localName}", _)`
-      });
+            const {importedName, localName} = parseImportSpecifierText(specText);
+            cell_variables.push({
+                _name: localName,
+                _inputs: [
+                    `module ${ module_name }`,
+                    '@variable'
+                ],
+                _definition: importedName === localName ? `(_, v) => v.import("${ importedName }", _)` : `(_, v) => v.import("${ importedName }", "${ localName }", _)`
+            });
+        }
+        return cell_variables;
     }
-    return cell_variables;
-  }
-  let dollarIdx = 0;
-  const inputToArgMap = {};
-  const dollarToMacro = {};
-  const seen = new Set();
-  const inputs = Array.from(cell.references || []).flatMap((i) => {
-    if (i.name) {
-      if (seen.has(i.name)) return [];
-      seen.add(i.name);
-      return i.name;
+    let dollarIdx = 0;
+    const inputToArgMap = {};
+    const dollarToMacro = {};
+    const seen = new Set();
+    const inputs = Array.from(cell.references || []).flatMap(i => {
+        if (i.name) {
+            if (seen.has(i.name))
+                return [];
+            seen.add(i.name);
+            return i.name;
+        } else {
+            const dedupKey = i.type + ':' + i.id.name;
+            if (seen.has(dedupKey))
+                return [];
+            seen.add(dedupKey);
+            const dollarName = '$' + dollarIdx;
+            inputToArgMap[i.id.name] = dollarName;
+            dollarToMacro[dollarName] = i.type == 'ViewExpression' ? 'viewof ' + i.id.name : 'mutable ' + i.id.name;
+            dollarIdx++;
+            return dollarName;
+        }
+    });
+    let variables;
+    if (cell.id) {
+        if (cell.id.type === 'Identifier') {
+            variables = [{
+                    functionName: '_' + cell.id.name,
+                    name: cell.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                }];
+        } else if (cell.id.type === 'ViewExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'viewof ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '(G, _) => G.input(_)',
+                    inputs: [
+                        'Generators',
+                        'viewof ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                }
+            ];
+        } else if (cell.id.type === 'MutableExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'initial ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'mutable ' + cell.id.id.name,
+                    _definition: '(M, _) => new M(_)',
+                    inputs: [
+                        'Mutable',
+                        'initial ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '_ => _.generator',
+                    inputs: ['mutable ' + cell.id.id.name],
+                    params: inputs.join(',')
+                }
+            ];
+        } else {
+            throw new Error(`Unsupported cell id type: ${ cell.id.type }`);
+        }
     } else {
-      const dedupKey = i.type + ":" + i.id.name;
-      if (seen.has(dedupKey)) return [];
-      seen.add(dedupKey);
-      const dollarName = "$" + dollarIdx;
-      inputToArgMap[i.id.name] = dollarName;
-      dollarToMacro[dollarName] =
-        i.type == "ViewExpression"
-          ? "viewof " + i.id.name
-          : "mutable " + i.id.name;
-      dollarIdx++;
-      return dollarName;
+        variables = [{
+                functionName: anonymousName,
+                name: null,
+                inputs,
+                params: inputs.join(',')
+            }];
     }
-  });
-  let variables;
-  if (cell.id) {
-    if (cell.id.type === "Identifier") {
-      variables = [
-        {
-          functionName: "_" + cell.id.name,
-          name: cell.id.name,
-          inputs,
-          params: inputs.join(",")
+    return variables.map(v => {
+        let _definition = v._definition;
+        if (!_definition) {
+            let functionBody;
+            if (cell.body.type === 'BlockStatement') {
+                functionBody = observableToJs(cell.body, inputToArgMap, comments, tokens);
+            } else {
+                const bodyCode = observableToJs(cell.body, inputToArgMap, comments, tokens);
+                functionBody = `{return (${ bodyCode });}`;
+            }
+            _definition = `${ cell.async ? 'async ' : '' }function${ cell.generator ? '*' : '' } ${ v.functionName }(${ v.inputs.join(',') }) ${ functionBody }`;
         }
-      ];
-    } else if (cell.id.type === "ViewExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "viewof " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "(G, _) => G.input(_)",
-          inputs: ["Generators", "viewof " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else if (cell.id.type === "MutableExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "initial " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "mutable " + cell.id.id.name,
-          _definition: "(M, _) => new M(_)",
-          inputs: ["Mutable", "initial " + cell.id.id.name],
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "_ => _.generator",
-          inputs: ["mutable " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else {
-      throw new Error(`Unsupported cell id type: ${cell.id.type}`);
-    }
-  } else {
-    variables = [
-      {
-        functionName: anonymousName,
-        name: null,
-        inputs,
-        params: inputs.join(",")
-      }
-    ];
-  }
-  return variables.map((v) => {
-    let _definition = v._definition;
-    if (!_definition) {
-      let functionBody;
-      if (cell.body.type === "BlockStatement") {
-        functionBody = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-      } else {
-        const bodyCode = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-        functionBody = `{return (${bodyCode});}`;
-      }
-      _definition = `${cell.async ? "async " : ""}function${
-        cell.generator ? "*" : ""
-      } ${v.functionName}(${v.inputs.join(",")}) ${functionBody}`;
-    }
-    return {
-      _name: v.name,
-      _inputs: v.inputs.map(
-        (i) => dollarToMacro[i] || (i === "$variable" ? "@variable" : i)
-      ),
-      _definition
-    };
-  });
+        return {
+            _name: v.name,
+            _inputs: v.inputs.map(i => dollarToMacro[i] || (i === '$variable' ? '@variable' : i)),
+            _definition
+        };
+    });
 }
 )};
 const _1v1i7wl = function _observableToJs(acorn_walk,parser,escodegen){return(
@@ -19222,16 +19160,15 @@ async (attachment, overrides) => {
   return URL.createObjectURL(blob);
 }
 )};
-const _s9w7ha = async function _parser(decompress_url,FileAttachment,acorn_url,acorn_walk_url){return(
-importShim(await decompress_url(FileAttachment("parser-6.1.0.js.gz"), {
-    "/npm/acorn@8.11.3/+esm": acorn_url,
-    "/npm/acorn-walk@8.3.2/+esm": acorn_walk_url
-  })
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
-const _1hiclbb = function _acorn_walk(acorn_walk_url){return(
-importShim(acorn_walk_url, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _s9w7ha = async function _parser(decompress_url, FileAttachment, acorn_url, acorn_walk_url) {
+    return import(await decompress_url(FileAttachment('parser-6.1.0.js.gz'), {
+        '/npm/acorn@8.11.3/+esm': acorn_url,
+        '/npm/acorn-walk@8.3.2/+esm': acorn_walk_url
+    }));
+};
+const _1hiclbb = function _acorn_walk(acorn_walk_url) {
+    return import(acorn_walk_url);
+};
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
@@ -19419,7 +19356,7 @@ export default function define(runtime, observer) {
   $def("_1dmmuaf", "compiled_selector", ["Generators","viewof compiled_selector"], _1dmmuaf);  
   $def("_u7t3vu", null, ["compiled_selector","normalizeJavascriptSource"], _u7t3vu);  
   $def("_1lt3kl6", null, ["compile","test_case"], _1lt3kl6);  
-  $def("_lpzjrv", "compile", ["parser","globalThis","observableToJs"], _lpzjrv);  
+  $def("_x1d0wm", "compile", ["parser","observableToJs"], _x1d0wm);  
   $def("_1v1i7wl", "observableToJs", ["acorn_walk","parser","escodegen"], _1v1i7wl);  
   $def("_19lv24l", null, ["md"], _19lv24l);  
   $def("_xhj6b8", "decompress_url", ["DecompressionStream","TextDecoderStream","TransformStream","TextEncoderStream","Response"], _xhj6b8);  

--- a/notebooks/@tomlarkworthy_observablejs-toolchain.html
+++ b/notebooks/@tomlarkworthy_observablejs-toolchain.html
@@ -7,7 +7,6 @@
   <link rel="icon" href="data:image/svg+xml;base64,PHN2ZyBmaWxsPSJ3aGl0ZSIgd2lkdGg9IjUwcHgiIGhlaWdodD0iNTBweCIgdmlld0JveD0iMCAwIDY0IDY0IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxyZWN0IGhlaWdodD0iNCIgd2lkdGg9IjQiIHg9IjIwIiB5PSI1MCI+PC9yZWN0PjxyZWN0IGhlaWdodD0iNCIgd2lkdGg9IjE2IiB4PSIyOCIgeT0iNTAiPjwvcmVjdD48cGF0aCBkPSJNMzIsMzhhOCw4LDAsMSwwLTgtOEE4LjAwOSw4LjAwOSwwLDAsMCwzMiwzOFptMC0xMmE0LDQsMCwxLDEtNCw0QTQsNCwwLDAsMSwzMiwyNloiPjwvcGF0aD48cGF0aCBkPSJNNiw2Mkg1OGEyLDIsMCwwLDAsMi0yVjE1YTIsMiwwLDAsMC0uNTg2LTEuNDE0bC0xMS0xMUEyLDIsMCwwLDAsNDcsMkg2QTIsMiwwLDAsMCw0LDRWNjBBMiwyLDAsMCwwLDYsNjJabTQyLTRIMTZWNDZINDhaTTE2LDZIMzF2NGg0VjZoNHY4SDE2Wk04LDZoNFYxNmEyLDIsMCwwLDAsMiwySDQxYTIsMiwwLDAsMCwyLTJWNmgzLjE3Mkw1NiwxNS44MjlWNThINTJWNDRhMiwyLDAsMCwwLTItMkgxNGEyLDIsMCwwLDAtMiwyVjU4SDhaIj48L3BhdGg+PC9zdmc+">
 </head>
 <body>
-<!-- Networking -->
 <script id="networking_script">
   const normalize = url => url.replace(/^(?:https:\/\/api\.observablehq\.com)?\/(.*?)\.js(?:\?.*)?$/, '$1').replace(/^(d\/[a-f0-9]{16})@\d+$/, '$1');
   const isNotebook = id => /^(@[^/]+\/[^/]+|d\/[a-f0-9]{16})$/.test(id);
@@ -238,21 +237,6 @@
 </script>
 
 <!-- CSS -->
-<!-- Style sheets from https://github.com/observablehq/notebook-kit
-Copyright 2025 Observable, Inc.
-
-Permission to use, copy, modify, and/or distribute this software for any purpose
-with or without fee is hereby granted, provided that the above copyright notice
-and this permission notice appear in all copies.
-
-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
-REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
-FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
-INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
-OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
-TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
-THIS SOFTWARE.
--->
 <script id="https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/global.css" 
   type="text/plain"
   data-mime="text/css"
@@ -817,7 +801,6 @@ body .inputs-3a86ea-table thead th {
   background: var(--theme-foreground-faintest);
 }
 </style>
-
 <!-- System Modules -->
 <script id="es-module-shims@2.6.2" 
   type="text/plain"
@@ -837,7 +820,6 @@ H4sIAK6D82gAA7Uca2/cNvK7fwVjHAqpUTep+83bNC3uckCAJimatMDBMFx5V7bV7kp7ktaOz93/fiTn
   data-mime="application/javascript">
 H4sIAGWI82gAA+08/XfbOI6/969QdXlbuXHs2O112qRpm0ncndzko69J566X5BLFomNNZckryfnY1P/7AQRJkfqwZW96s7Pv+l5jiQRBEAABECTVblth5LGLUeRNApa0P0RXCYtv3KuADf/W9sNkzPppFLeTuN/2/GTspv1h6/fkyWAS9lM/Ci1Z6CCappXej+Gvx1LXDxrWwxNLPFtb8uH7d+thugkVN25seVF/MmJh2oV6RNCKbkMW74rSpsVu4AfbSriWxwbuJEh/89lta2eSpNGohzCI0B9YDvYfDWS7rS3LlpTaRI6lcIbslp4dIvpBUjhtILapxYKE5dpkdPRj5qaM9+3Y/MfmzQRsyw/9tKdhH7iATfwYgDn+8K7hP+eGZC4h4vDQdvrkSXsBsblx7N4bMvMTXubcuMGEEVtilk7i0NrmsH6yrdeDxPiTBXhTN+wjg/fC9DUHqqrtvJpZ/aJbXf3Fn4mcV+8E7mjMvNlQs2jA+llEfAwidz7Aq5ccAGWicdcPPXbnfGP3Bm/hnWskVljfrfWGtWrZ9sLiFG+H7oiZQs3KnRD+UN/9CCi2Qk11peYGbMR1FzQsJNUNW/3ATRLEAPC2TsPaWp8FAaK1CTJld+lOFKY0LS5XHrBuio+b2YjDhQc3iOKRmx7fj66iAEeHNiLhbyfRcRr74TV0IarHcZRGOLlaqajbzLihI3IIgyEME2mr7wYKbGGio6vf4UWS+2Bds/ToNvwUR2MWp/dEQ9K0FL0bADN0Ew0GjA3y7ogj2hRo5KhO3GteS4io9uPR55/3dnd7h1CO1jTjUwKquVVOwqauo2BoHSK8aeU11SSOmKPDGuqeutfRQFQbWKjoVBvGOU4kwS2umPEEmWj95S8lpS3UKGxgE1tso1c+HVW/2hDS+F7YbFJ9mrdbkhqAOyfri95CGDj+o/dNEGIcvJY8Qh+NseX412EUM+lPBJgSCVnwRWf1aDRJsUaq0fHXg5+P9o+B8lPA9yCku2HZHz5cXOwdHHw52f55v3exd7jb+6/e7sXFhw9200KWAcge2h/mQQF07Q98Fm8AX4AN0+YsXL/2vuYx/cruF8ezv3d8YqLZ95MU3rjX8ZNhLSwH259MJAfu2BZtON8r2h193u19luPggKL9UeyxGEfDC80RUdk4ZgP/jkpQiDPp+9zbga5MEj+zfhR7dag87p0UKTxmqSgwOUVlCUtVyVzqjk+2d341iTtO3f63Eik8OdcNg9RD7kdg0uRnVcBSaWnQJpGWtgZ+kLLYcSQ9EENZW+9w0p1SwTl3fdhhI5t+TwWiVsDC63TYEFNpU5u+ITkjCTgA1+o4CUf+NGlJITb0JiRFDPDQRRICDAS5/oCpKcOVoeIQLcJhoJVs06hJIuCRwiABjFYktMo2VN0w7A3xWSoFuFYxoPdiZDQkEKg9JbfLC6aXTdFO9CRfM3GrEcAQn1LPqg1/4y9Tw9TlrVw4CYKlDBy7gzjDY57hJj9Jl3g0aOZ81i5L+rE/huZJwTeSLVeNyd9puJwHDOHzkVFPUKB8xgVNDeGZaaCo3pqkZaQs3NumgACfB6G8zwIP/HoIoVDTCuUKhED1SBEUT3KxHKDo/BpKC6ArjKoAh7PyIAAT/+9s2rjcFCBECFILcxBCO4ClKmMJI1HhPHAadlVjyWfePlsGlRMOBusfHhngqD0ygJ01MkS11MjU1BUYBWmKrHxYMs0oJtOlaM53KpYHRm8YjRfsLKpXrvs9FRPAPKd+5QNZNOlu3oMtAINwWeDjVFClaXSo7FSO4KwC8Anq90a0/tmAWmHJtDpgN9So14y/2li1qSXHZQSM5Vzjc7mwCK/dXKNELYFwmVNrFYRPsxZC0pDZcsJniy3R2B2PWejtDP3AcwqrsoZJlouuId+oikjXpuZuyw9DFv9ycrCPevI2ubm2bn0vHW69tobMvx6m8MCHsPUst4pzwY4/e8dpfTt206HlbT07eGn9tL9udYav//4MeBkEW8/6kziGLneiIIqfWW1s8LYN3by7pP5nUHsC5vAQvIID0wdkBSqr6ZVtnaKm2taDPb2Ug3E9jyc4MEpkMC7HHkWThE3GEKxIIy6SH3o6ppWk0RjdhXvtchDlRseB22cOsrUpjT+MJHDHiWb90ZOZDoBEw/8qjaIHXd1gZWk56AR8qF7ftJ466AAUaAvfnEaj5UUhQ0/rW2+tLsCtrvqVWoJtWrQYkerB4yNejogaxprG7S6jNcDq7izF5vTbCjJJ7wPKQAVgAQD6KoggflT1tVTAss4m3fXuKwi3Y3ap0bG4zOdIXXAVxA3Rw88MpMQ0tjapFgafcooxwLvxocdj/yqAxalCsox0O28M6T4aLVPxy41Mpgm8dcxG0Q0j7tdEpzK1NDHsIHI9mbOcKr2bp1ZKtvqsPueTeioUTaZYAJO+Zn+uxSfOSMZEnOGk1rg4b9Jy+9yC4GGUxU33yH2R1IHmH/HVycAV9RzuuekHeF+lhGC8kMgQRiOEcgZAQZLFNzoF0I4oqNE5oijtnPvPx+u+pAdK4nI5aX0o5W7ytCBlhymK2eTqHBrajMrngxW1NDx5gogav6myMhwWbG+jmTcyPDWqtE4wThs75kbznXFTaGRVceLxDJboCAtnkZZpSkYctimQB4UziBNrW5SMzLUJ9paJibrO7EohHykXXznCcrU5CqnW5pXVoheBmy58LvcOt2rmqDItwKhxE4GkEnSqx+V3RCahBWsveANeqtV9KUk8pjPyhEWxVy4B8xHyHBHrWcFqGdeQ7txuFxCvJGph+WaJDeBgcbGrxSYq4sYZQg9Pt7by6+Wy0ahKEbFXilGYtdly1GuFCSkknGvP13rCrD1h/1+kRWMxW6h5v2xKd5b0Zs29aX6zJqNX25ckCoDQ0YzFm+ffEFZjqYeNagXItPYjbmObWjHyvGWi2u3hY1YtcvtmuAqTgLS2mke1ir9siLg0oksWnY6QwU3ke+ju87/cXusRGyLaLAqmKFU17j+bkNRztUBWHmCk0x8jizrcLgtvl+ByfSbVH6U1d5TcsC+IdOvd4zEvFxr/afhWPcCFkux9meUwTgYM3eSYBUysqWHEOl8ShmdPbiG4jm4xlMsgjbUcC1qUaud5Rze8ZnwvxcEKQJS6QAgfLOIXpgU3b/FVAXBoN+wPoxhhKwAGwEaOq2FuNFdmcpKhGwTR7b9uNr87K+ldJ50vETz558vnzxxbnYR++dh+cEa/m0tz/+lS+t3qnH63mNTXh7tULr6rpzXFfDVzmuiMu7US9OS4Z6YyRQ9Cc/JJeolgfp5e5uCK8FW2HjjSMKhcJtGJBBtGm6NqmPvjc/Oheh68W5kIVwM1N6F5I3Ot8mg7KMpL/QttofxkvdzvWK9/W/8jtlBo9AsrWqma5bRs8Z2WwjZ71UaLljD6sdstlMJ8hycua2e3gWm2PpEX3a5ZpCPaIrF1Wf7o/Hv3MRLw3boZ+O7MFHx3wSR4bnWrZR2rep+dg3+8/qsTsd1CJnYdVHit01w+Jcu1ugNqDahWLSjWRdQbjdN7rF7D6jWo3iwZQVX+1iLy/I6u3Qv1VbUbsTQf1AZFNSeKexRLsahUzNqeRo5TBq+yJOQSXf/oXZDuH7gN0nVK06lVWx8VGdR5Wenuj01Ld//QvPQ8FuZz0QvzUAX7j5QH7i6bCKbpYWRvHu/0DuKuSsfSGqyDHpXgcAXGn6yzu92frJUHNtXvN+Q9bPXoSxOmg9i9Hpn3isTA5AWojwLCKSZOZeNFk6cLp0RhGNw61eivJB9a2qzMg+qRi2w0IzvarUiPLsrTmfTxLjLqFmOBltf8h5lQSAKC3SJ+aLdmjJwfFTkekMQvnQVXbv8bMYo7El6jZ3Z24R2MDy/estrPrQ8XF5++fO5dXFjP2/yuHEI4qwigNqZ8UJxDjkotGyxxA0/2mbuEB3NL1lA7mGKyINPxYTSJcTmAEBiffDnZ+QWL9Hkw8sNJynJQB1RozBcGv14O7pgKTXxB4JcCH2g1RlYUlmfE56/MjR2txUdY8vAyMMMvG9O1lYex6+kABzC9hg7eAIPQp1sGwbnd4JUrD8SP79/VoOFRkspLNdLfW5cnhI234hg2qEC0FkhnIBDwokTA54FaEmlW3LReNKaXaDUv5c9/y9eSycxZdA9/jHtDWABB3jr2IfiyhmVN6xUh5wDvrDfwD2FWCcYAyQpemklkrBAzji/3jZ5BnrxuetkCuOPUjVOHQ4H7WrcXvxhGo0RJlsxNLmCaAhoJxry190Kgx/f41Fu6/14cR7E8ds/wRbtLR5U1rtJxwJIbo3R3KsG7JTydr+Onm2NyfbgU8Z/Zde9uLKmP+ZtGvqiuQT9BlgzAxPkIJAtEguTD3n/u7x3ipaiDvROguLtevKXIGzgJ/9G2M+RJY0qeZMZbAHDLSveJtYi2H03At0lc7VP7LDxvXzest+DpzarL72crD1CVRbxZgPGiZiZWT9/xdrWSqrInDDR+Q1a/ECm8F4tGMzwVrbDMTAnzYdsljcxw5z+Ojw5bBOwP7gW3tJyqCvxe6AliGk/gh9whUaNWMg58IPdMcQt5xWHEchaMmKkeeDFHSj0vFs+/qbN/acoEipeXSL7xHyIP+9IGL5lCFB64KUqEGJgEfp85602TgY3W75EfEstzI+PCgIXO8uMSHIph8gKUt4OzCbAZAl0z6ZFNZef50wbHQ5jGKw8mzmnWB0eerwet4UuUxKZLYJeFXuayXVxisAstl9mtmLsRkSWKgfMqT1y0d/yqo2Wq5TQ/9QBFceItsnlkGqx6u0C5ySGP38/cEipXowyHIaXLMinBclPYAp72r7iGYiiBhn7ONBKGDb9BcGk/2taPydwavM1xdpGtHI2vqn1Ni5PB1zD+mbHurPOgFEJnYeClEfr39caUsvi5urWXbygg1fxIVfKgRDhamCLQypnUPj07uzy7W19fgz9v4P8VPHTenJNPb2rIdoZu3KjoCOuc/lAG4Biv9CHYwawAFLbwzw68b6fOOiUPbn1+K7TPT2+QAei7CbNeb5iz1D47uxJaxevfFOtTvb7TKQLcGADdIsDAAHhRBIhtqcaijA/urdV5hRPqDLiGkwILVdzodF7hklQAvugKwCo4qONVwCiDxWaoJb8VgPwNZZr7FpSbWU7MWuyO9aXIYUKuhpqWLP4JDfH2UZAi49A0C5pVVVnYjLAnXz/1LraPvx7uAPSDuhZvu8l92LfOJuudN13bmuaBL/7aO+x93j45+lzd7LnZbmd/+/jYhOYz2IT6+OVw52Tv6NAELKOjggK97/x5IskNZ6DH2Zxl/MM9eJoJjzoYC4SBMR0G+a9ZDArnS4zZYm8jR2THtlRccZc5Y6h0fVdg+L5t5tv/FR20Cx3MR5TxpRJlPWyz8IgvM+Watf+HC/Tsqg22NkkdCBze67LfMEVcwCs3U9Tps6xt7mq6SL5KcZL0bPH9A2OjdsTpct5vcM08S5433jtnt6sNeNp616b5mGXiZ6J3cPqPTjvn6EgbNTs7c+AHe4RSeGrCf+wea+CpsRAFvO/3GiGZixCo0R3w7WwiEa2WU5dSFfNxQs+QUfQE5HJi//lGMltc5KW1RsXsvdnEja+TpiW/fpQZh0fbkVCpURk/mX3NORCjgNX4JXEnNP+WCadk81lkf2P3t3hSzYA3oynuWcgGK0bUO9lwnZSeZFjGD2bfmzC+vyTN+YZ66uY+wpT3EzJtmEvPVJw6FdZPJMPVJ4Skx9DvbJD9vYqigLnS6lLZBAL8AawAPXtDrbboXMLqFv90WMEGT7XW4WR0xeJC0y35C7Z0HZ1Vx2qLIkq62mvrOLVER/P7ufKv/TCt7AcwhPNQiL3JIgpjy1MIQM32GQjVpMpQynPVOa9fRGoQRmuGAhYjcTdLMQyc0kMaBxQyaeBBKX1ZLXSIzk9Jjtj4qvhpMMC8MVz4YN2uyjUb6G3MNdvNHMt5drqM4XN7xJGob2GV9QcdXPmex0KtU/tUlZ7PG5yaQ3Li6jlbvUMS4ak4xUwJ4HNNljpRMbsGsRXYoGeNC4zI0ZdRmO+a587PVUBlWWDHhmk6Tjba7Ws/HU6uIF4ctYPIc5Oh/LkKoqv2yE1SFrf9RCbx/22/+6qil92jg95dn41RrauGydPzhVFquf1FBpkL+PCfmB4OTQE8WGweCsSjxblzqI3C/NENal74ufn+f5eiCJf0peGsPM/KAwqGkjf5fXflM6ryBfrpy6PAo88KHLJbbaOAaogCTOllFy0K17L5yIFmiUVr5HpeJbx07NjN2MUDr+jCZeSWfZ8AMDYlIG9kfI2A16oPEizs6D12J938/tHONq4jLg62T3Z+wYD2LFmFKNVb3YD/Z42V9oiWi3sShzwCkR0ioGUb/6CtcfiKCtJhHN3yDXGaNrYvNumwWiYZ06GftC5CyqXgDxXzj7rOYGx2Lxl1DH2LeUj+wSKcGKdgF4T1IoeWvg2RFxlN/UZ5kxIRx5MwRN+nSBpMAjzZzDzDUtSgT5xcw5r8J2U1ncFQpFCGV10vdEFkoUEuLBPf16WBDfxYfA0DsebLsnHPrq2cLSr32siZy5ssB1lr5ki7Vk+CUiKFw1SGaJHbBS4gH7Wtzyo43XuK/BSBqK+LZBIxmlGJ/lGSXDvNo0hYzUIIGRbwKutv3g6SOHRTnJ1Cztgqoi5paS7oE9X2ZOyJ/XS5YkT/CXrN+VhfrxeTWv2ZZ4izXAz1Oc6/sl136xB3xmas+aTu5jdS6u4yztl4UwtAEgRfezRUEsC07JjZaTQMnhqY/RvVZ076MgR6oLMK6tM3080nyie0YEGD1/JV+kNYAhZnzlUs7VQNHXQSCwZNfWRtxv+/TVh8T7cuwH9kqDO26kjFsqDgdjKYMEohkIPFoq7StEyR9Oe/4gho1GCz3mrFNlxdRLph84mRUDVMvLZ3UVyLCGylH9ZGNWgob6DXlHynd/oEjHEUp7w7NSQk638B7sve5NpeAAA=
 </script>
-
 
 <script id="@mbostock/safe-local-storage" 
   type="text/plain"
@@ -1203,9 +1185,9 @@ md`# [Acorn@8.11.3](https://github.com/acornjs/acorn)
 import { acorn } from "@tomlarkworthy/acorn-8-11-3"
 \`\`\``
 )};
-const _1xdqqxo = function _acorn(acorn_url){return(
-importShim(acorn_url, 'https://api.observablehq.com/@tomlarkworthy/acorn-8-11-3.js?v=4')
-)};
+const _1xdqqxo = function _acorn(acorn_url) {
+    return import(acorn_url);
+};
 const _jdtsxp = async function _acorn_url(unzip,FileAttachment)
 {
   const blob = await unzip(FileAttachment("acorn-8.11.3.js.gz"));
@@ -2326,7 +2308,7 @@ export default function define(runtime, observer) {
   return main;
 }</script>
 
-<script id="@tomlarkworthy/claude-code-pairing"
+<script id="@tomlarkworthy/claude-code-pairing" 
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -4042,8 +4024,7 @@ export default function define(runtime, observer) {
   main.define("syncEnabled", ["module @tomlarkworthy/file-sync", "@variable"], (_, v) => v.import("syncEnabled", _));  
   main.define("syncStatus", ["module @tomlarkworthy/file-sync", "@variable"], (_, v) => v.import("syncStatus", _));
   return main;
-}
-</script>
+}</script>
 <script id="@tomlarkworthy/codemirror-6-v2/codemirror_javascript%405.js.gz" 
   type="text/plain"
   data-encoding="base64"
@@ -4120,19 +4101,15 @@ codemirror.EditorView.theme({
 const _12m5h41 = function _9(md){return(
 md`---`
 )};
-const _1d6o6ga = async function _codemirror(unzip,FileAttachment)
-{
-  const blob = await unzip(FileAttachment("codemirror_javascript@5.js.gz"));
-
-  const objectURL = URL.createObjectURL(
-    new Blob([blob], { type: "application/javascript" })
-  );
-  try {
-    console.log("Loading codemirror from", objectURL);
-    return await importShim(objectURL, 'https://api.observablehq.com/@tomlarkworthy/codemirror-6-v2.js?v=4');
-  } finally {
-    URL.revokeObjectURL(objectURL); // Ensure URL is revoked after import
-  }
+const _1d6o6ga = async function _codemirror(unzip, FileAttachment) {
+    const blob = await unzip(FileAttachment('codemirror_javascript@5.js.gz'));
+    const objectURL = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
+    try {
+        console.log('Loading codemirror from', objectURL);
+        return await import(objectURL);
+    } finally {
+        URL.revokeObjectURL(objectURL);
+    }
 };
 const _g5fwfs = function _unzip(Response,DecompressionStream){return(
 async (attachment) => {
@@ -4668,7 +4645,7 @@ export default function define(runtime, observer) {
 >
 e30K
 </script>
-<script id="@tomlarkworthy/editor-5"
+<script id="@tomlarkworthy/editor-5" 
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -5415,58 +5392,41 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _geoudp = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
-  if (command.processed) return;
-
-  let result = undefined;
-  if (command.command == "createCell") {
-    $0.value = true;
-    result = compile_and_update("{}", [], command.args.cell);
-    // For the new one to get focus
-    // setTimeout(() => {
-    //   debugger;
-    //   setOption(result[0], "pinned", true);
-    // }, 100);
-  } else if (command.command == "deleteCell") {
-    remove_variables(command.args.cell.variables);
-    result = true;
-  } else if (command.command == "moveCell") {
-    const cellIndex = findCellIndex(
-      command.args.cell.variables,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const targetCellIndex = cellIndex + command.args.amount;
-    const targetCell = lookupCellByIndex(
-      targetCellIndex,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const currentFirstVariableIndex = findVariableIndex(
-      command.args.cell.variables[0]
-    );
-    const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-    const change = targetFirstVariableIndex - currentFirstVariableIndex;
-    console.log(
-      "moveCell",
-      cellIndex,
-      targetCellIndex,
-      targetCell,
-      currentFirstVariableIndex,
-      targetFirstVariableIndex,
-      change
-    );
-    command.args.cell.variables.forEach((v) => {
-      const currentIndex = findVariableIndex(v);
-      repositionSetElement(runtime._variables, v, currentIndex + change);
-    });
-    // recompute
-    await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
-    result = true;
-  }
-  if (result) {
-    command.processed = true;
-    $2.resolve(result);
-  }
+    if (command.processed)
+        return;
+    let result = undefined;
+    if (command.command == 'createCell') {
+        $0.value = true;
+        result = await compile_and_update('{}', [], command.args.cell);    // For the new one to get focus
+                                                                           // setTimeout(() => {
+                                                                           //   debugger;
+                                                                           //   setOption(result[0], "pinned", true);
+                                                                           // }, 100);
+    } else if (command.command == 'deleteCell') {
+        remove_variables(command.args.cell.variables);
+        result = true;
+    } else if (command.command == 'moveCell') {
+        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const targetCellIndex = cellIndex + command.args.amount;
+        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
+        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+        const change = targetFirstVariableIndex - currentFirstVariableIndex;
+        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
+        command.args.cell.variables.forEach(v => {
+            const currentIndex = findVariableIndex(v);
+            repositionSetElement(runtime._variables, v, currentIndex + change);
+        });
+        // recompute
+        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        result = true;
+    }
+    if (result) {
+        command.processed = true;
+        $2.resolve(result);
+    }
 };
 const _1jadxoe = function _60(md){return(
 md`### UI Action`
@@ -5857,9 +5817,9 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
-    return (source, variables = [], cell) => {
+    return async (source, variables = [], cell) => {
         try {
             debugger;
             let reposition = false, insertionIndex = -1;
@@ -5879,10 +5839,10 @@ const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElemen
             if (reposition) {
                 insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
+            const fns = await realize(newVariables.map(v => v._definition), runtime);
             newVariables.forEach((v, i) => {
                 const variable = variables[i];
-                let _fn;
-                eval('_fn = ' + v._definition);
+                const _fn = fns[i];
                 if (v._name) {
                     variable.define(v._name, v._inputs, _fn);
                 } else {
@@ -5931,12 +5891,11 @@ Inputs.textarea({
 })
 )};
 const _b4rsn5 = (G, _) => G.input(_);
-const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
+const _ga6kci = function _98(Inputs,definition,variable,realize,runtime,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
-  reduce: () => {
-    let _fn;
-    eval("_fn = " + definition);
+  reduce: async () => {
+    const [_fn] = await realize([definition], runtime);
     variable.define(variable._name, inputs, _fn);
   }
 })
@@ -6049,7 +6008,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_geoudp", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _geoudp);  
+  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6087,7 +6046,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
+  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -6097,8 +6056,9 @@ export default function define(runtime, observer) {
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
   $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
-  $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
+  $def("_ga6kci", null, ["Inputs","definition","variable","realize","runtime","inputs"], _ga6kci);  
   $def("_1q557s", null, ["md"], _1q557s);  
+  main.define("realize", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("realize", _));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -6134,8 +6094,7 @@ export default function define(runtime, observer) {
   main.define("navHref", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("navHref", _));  
   main.define("cellsToClipboard", ["module @tomlarkworthy/cells-to-clipboard", "@variable"], (_, v) => v.import("cellsToClipboard", _));
   return main;
-}
-</script>
+}</script>
 <script id="@tomlarkworthy/escodegen/escodegen.browser.min.js.gz" 
   type="text/plain"
   data-encoding="base64"
@@ -6707,15 +6666,11 @@ async (action, state, options, feedback_callback) => {
     }
 }
 )};
-const _1i2b0pi = function _exportToHTML(_runtime,importShim,cssForTheme,css,location,keepalive,exporter_module,$0)
-{
-    return async function exportToHTML({mains = new Map(), // (name -> module) Map of main modules
-        runtime = _runtime, options = {}    // Object, export options, e.g. head, title, theme
-} = {}) {
-        // defaults if conf not found
+const _1i2b0pi = function _exportToHTML(_runtime, importShim, cssForTheme, css, location, keepalive, exporter_module, $0) {
+    return async function exportToHTML({mains = new Map(), runtime = _runtime, options = {}} = {}) {
         let conf = { headless: false };
         try {
-            conf = (await importShim('file://bootconf.json', 'file://@tomlarkworthy/exporter-3')).default;
+            conf = (await import('file://bootconf.json')).default;
         } catch (_) {
         }
         if (runtime.module_names) {
@@ -6736,7 +6691,6 @@ const _1i2b0pi = function _exportToHTML(_runtime,importShim,cssForTheme,css,loca
         if (!options.hash) {
             options.hash = location.hash;
         }
-        // Force observation of response
         keepalive(exporter_module, 'tomlarkworthy_exporter_task');
         const response = await $0.send({
             mains,
@@ -6746,28 +6700,28 @@ const _1i2b0pi = function _exportToHTML(_runtime,importShim,cssForTheme,css,loca
         return response;
     };
 };
-const _17k9v19 = function _getSourceModule(notebook_name,main,_runtime,importShim){return(
-async state => {
-    if (state.source == 'this notebook')
+const _17k9v19 = function _getSourceModule(notebook_name, main, _runtime, importShim) {
+    return async state => {
+        if (state.source == 'this notebook')
+            return {
+                notebook: notebook_name,
+                module: main,
+                runtime: _runtime
+            };
+        const url = state.source == 'a notebook url' ? state.notebook_url.child : state.top_100.child;
+        const notebook = url.trim().replace('', '');
+        const [{Runtime, Inspector}, {default: define}] = await Promise.all([
+            import('https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js'),
+            import(`https://api.observablehq.com/${ notebook }.js?v=4`)
+        ]);
+        const runtime = new Runtime();
         return {
-            notebook: notebook_name,
-            module: main,
-            runtime: _runtime
+            notebook,
+            module: runtime.module(define),
+            runtime
         };
-    const url = state.source == 'a notebook url' ? state.notebook_url.child : state.top_100.child;
-    const notebook = url.trim().replace('', '');
-    const [{Runtime, Inspector}, {default: define}] = await Promise.all([
-        importShim('https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js', 'file://@tomlarkworthy/exporter-3'),
-        importShim(`https://api.observablehq.com/${ notebook }.js?v=4`, 'file://@tomlarkworthy/exporter-3')
-    ]);
-    const runtime = new Runtime();
-    return {
-        notebook,
-        module: runtime.module(define),
-        runtime
     };
-}
-)};
+};
 const _6vlf2p = function _createShowable(variable,view)
 {
     return function createShowable(child, {
@@ -7158,15 +7112,52 @@ module => {
     return fileMap;
 }
 )};
-const _pvnegh = async function _book(lopebook,task,module_specs)
+const _1x463u7 = function _book(task,inlineModule,inlineGzipModule,es_module_shims,runtime_gz,inspector_gz,module_specs,lopemodule,lopebook){return(
+(async () => {
+    const cssBlocks = task.options.style.map(([url, content]) => inlineModule(url, content, { mime: 'text/css' })).join('\n');
+    const cssUrls = task.options.style.map(([url]) => url);
+    const systemBlocks = [
+        inlineGzipModule('es-module-shims@2.6.2', es_module_shims),
+        inlineGzipModule('@observablehq/runtime@6.0.0', runtime_gz),
+        inlineGzipModule('@observablehq/inspector@5.0.1', inspector_gz)
+    ].join('\n');
+    const userBlocks = (await Promise.all([...module_specs.values()].sort((a, b) => a.url.localeCompare(b.url)).map(m => lopemodule(m)))).join('');
+    const bootloader = task.options.bootloader || '@tomlarkworthy/bootloader';
+    const bootconfBlock = `<script id="bootconf.json"
+        type="text/plain"
+        data-mime="application/json"
+>
 {
-    const book = await lopebook({
-        url: task.notebook,
-        modules: module_specs
-    }, { ...task.options });
-    console.log('book', book);
-    return book;
-};
+  "mains": ${ JSON.stringify([...task.mains.keys()]) },
+  "hash": "${ task.options.hash || '' }",
+  "headless": ${ !!task.options.headless }
+}
+</scr` + `ipt>`;
+    const bootloaderBlock = inlineModule(bootloader, await (await fetch(`https://api.observablehq.com/${ bootloader }.js?v=4`)).text());
+    const blocks = [
+        '<!-- CSS -->',
+        cssBlocks,
+        `<style>
+body .inputs-3a86ea-table thead th {
+  background: var(--theme-foreground-faintest);
+}
+</style>`,
+        '<!-- System Modules -->',
+        systemBlocks,
+        userBlocks,
+        '<!-- Bootloader -->',
+        bootconfBlock,
+        bootloaderBlock
+    ].join('\n');
+    return lopebook({
+        blocks,
+        cssUrls,
+        bootloader,
+        title: task.options.title || 'Lopecode notebook',
+        head: task.options.head
+    });
+})()
+)};
 const _18javdl = function _47(Inputs,module_specs){return(
 Inputs.table([...module_specs.entries().map(([name, spec]) => ({
         name,
@@ -7285,8 +7276,7 @@ ${ await generate_define(spec, variables, fileAttachments, { moduleNames }) }`
 const _19ft5zb = function _generate_definitions(variableToDefinition){return(
 variables => variables.map(v => variableToDefinition(v)).join('')
 )};
-const _7nr512 = function _generate_define(variableToDefine)
-{
+const _7nr512 = function _generate_define(variableToDefine) {
     return async (spec, variables, fileAttachments, {moduleNames} = {}) => {
         const fileAttachmentExpression = fileAttachments?.size ? `  const fileAttachments = new Map(${ JSON.stringify([...fileAttachments.keys()]) }.map((name) => {
     const module_name = "${ spec.name }";
@@ -7296,9 +7286,6 @@ const _7nr512 = function _generate_define(variableToDefine)
   }));
   main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));\n` : '';
         const varLines = (await Promise.all(variables.map(v => variableToDefine(v, { moduleNames })))).flat();
-        // Collect module names referenced by import-bridged variables but not defined by isModuleVar variables.
-        // On Observable, module reference variables ("module X") don't exist in the task_runtime,
-        // so we need to synthesize them from the import bridge patterns.
         const definedModules = new Set(varLines.filter(l => l.includes('runtime.module(')).map(l => {
             const m = l.match(/main\.define\("module ([^"]+)"/);
             return m ? m[1] : null;
@@ -7323,7 +7310,7 @@ ${ varLines.join('  \n') }
 const _1hslsmt = function _isLiveImport(){return(
 v => !v._name && v._definition?.toString().includes('observablehq' + '--inspect ' + 'observablehq--import')
 )};
-const _18sa1aj = function _variableToDefinition(isModuleVar,isImportBridged,isLiveImport,isDynamicVar,pid){return(
+const _g39v22 = function _variableToDefinition(isModuleVar,isImportBridged,isLiveImport,isDynamicVar,pid,restoreCanonicalImports){return(
 function variableToDefinition(v) {
     if (isModuleVar(v))
         return '';
@@ -7333,7 +7320,46 @@ function variableToDefinition(v) {
         return '';
     if (isDynamicVar(v))
         return '';
-    return `const ${ pid(v) } = ${ v._definition.toString() };\n`;
+    return `const ${ pid(v) } = ${ restoreCanonicalImports(v._definition.toString()) };\n`;
+}
+)};
+const _5zomoj = function _restoreCanonicalImports(acorn,escodegen){return(
+source => {
+    if (!/\bimportShim\s*\(/.test(source))
+        return source;
+    let ast;
+    try {
+        ast = acorn.Parser.parse(source, {
+            ecmaVersion: 'latest',
+            sourceType: 'script',
+            allowAwaitOutsideFunction: true,
+            allowReturnOutsideFunction: true,
+            allowImportExportEverywhere: true
+        });
+    } catch (e) {
+        console.warn('[exporter-3] importShim AST parse failed; leaving cell unchanged:', e.message);
+        return source;
+    }
+    const visit = node => {
+        if (!node || typeof node !== 'object')
+            return;
+        if (node.type === 'CallExpression' && node.callee && node.callee.type === 'Identifier' && node.callee.name === 'importShim' && node.arguments.length >= 1) {
+            const spec = node.arguments[0];
+            for (const k of Object.keys(node))
+                delete node[k];
+            node.type = 'ImportExpression';
+            node.source = spec;
+        }
+        for (const k of Object.keys(node)) {
+            const v = node[k];
+            if (Array.isArray(v))
+                v.forEach(visit);
+            else if (v && typeof v === 'object' && v.type)
+                visit(v);
+        }
+    };
+    visit(ast);
+    return escodegen.generate(ast);
 }
 )};
 const _1g36je3 = function _variableToDefine(isLiveImport,isDynamicVar,isModuleVar,isImportBridged,findImportedName3,pid)
@@ -7400,7 +7426,7 @@ const _1g36je3 = function _variableToDefine(isLiveImport,isDynamicVar,isModuleVa
         return [`  $def("${ pid(v) }", ${ name_literal }, ${ deps }, ${ pid(v) });`];
     };
 };
-const _1bux505 = function _60(md){return(
+const _dxkjia = function _61(md){return(
 md`## Assemble `
 )};
 const _g33g3u = function _es_module_shims(){return(
@@ -7670,8 +7696,11 @@ const _1pcnq22 = function _networking_script(normalize,isNotebook){return(
     }
   })();`
 )};
-const _13sd8x8 = function _lopebook(diskDataUrl,networking_script,task,inlineModule,inlineGzipModule,es_module_shims,runtime_gz,inspector_gz,lopemodule){return(
-async (bundle, {title, head, bootloader, headless = false, hash} = {}) => `<!DOCTYPE html>
+const _1crzwh0 = function _lopebook(diskDataUrl, networking_script) {
+    return ({blocks = '', cssUrls = [], bootloader = '@tomlarkworthy/bootloader', title = 'Lopecode notebook', head} = {}) => {
+        const styleImports = cssUrls.map((url, i) => `  const style${ i } = await importShim(${ JSON.stringify(url) }, { with: { type: 'css' } });`).join('\n');
+        const styleAdopt = cssUrls.map((_, i) => `style${ i }.default`).join(',');
+        return `<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
@@ -7680,52 +7709,10 @@ async (bundle, {title, head, bootloader, headless = false, hash} = {}) => `<!DOC
   ${ head ? head : `<link rel="icon" href="${ diskDataUrl }">` }
 </head>
 <body>
-<!-- Networking -->
 <script id="networking_script">${ networking_script }
 </scr\ipt>
 
-<!-- CSS -->
-<!-- Style sheets from https://github.com/observablehq/notebook-kit
-Copyright 2025 Observable, Inc.
-
-Permission to use, copy, modify, and/or distribute this software for any purpose
-with or without fee is hereby granted, provided that the above copyright notice
-and this permission notice appear in all copies.
-
-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
-REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
-FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
-INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
-OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
-TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
-THIS SOFTWARE.
--->
-${ task.options.style.map(([url, content]) => inlineModule(url, content, { mime: 'text/css' })).join('\n') }
-<style>
-body .inputs-3a86ea-table thead th {
-  background: var(--theme-foreground-faintest);
-}
-</style>
-
-<!-- System Modules -->
-${ inlineGzipModule('es-module-shims@2.6.2', es_module_shims) }
-${ inlineGzipModule('@observablehq/runtime@6.0.0', runtime_gz) }
-${ inlineGzipModule('@observablehq/inspector@5.0.1', inspector_gz) }
-
-${ (await Promise.all([...bundle.modules.values()].sort((a, b) => a.url.localeCompare(b.url)).map(module => lopemodule(module)))).join('') }
-
-<!-- Bootloader -->
-<script id="bootconf.json" 
-        type="text/plain"
-        data-mime="application/json"
->
-{
-  "mains": ${ JSON.stringify([...task.mains.keys()]) },
-  "hash": "${ hash }",
-  "headless": ${ headless }
-}
-</scr\ipt>
-${ inlineModule(bootloader, await (await fetch(`https://api.observablehq.com/${ bootloader }.js?v=4`)).text()) }
+${ blocks }
 
 <script type="module" id="main">
   await window.esmsInitOptions.fetch("file://es-module-shims@2.6.2").text().then(src => {
@@ -7734,20 +7721,21 @@ ${ inlineModule(bootloader, await (await fetch(`https://api.observablehq.com/${ 
     document.head.appendChild(script);
   });
 
-${ task.options.style.map(([url, content], i) => `  const style${ i } = await importShim("${ url }", { with: { type: 'css' } });`).join('\n') }
-  document.adoptedStyleSheets = [${ task.options.style.map(([url, content], i) => `style${ i }.default`) }];
-  
+${ styleImports }
+  document.adoptedStyleSheets = [${ styleAdopt }];
+
   const { Runtime } = await importShim("@observablehq/runtime@6.0.0");
   const { Inspector } = await importShim("@observablehq/inspector@5.0.1");
   const notebook = document.querySelector("notebook");
   const runtime = new Runtime({__ojs_runtime: () => runtime, __ojs_observer: () => observer});
   const observer = Inspector.into(document.body);
-  const {default: define} = await importShim("${ bootloader }");
+  const {default: define} = await importShim(${ JSON.stringify(bootloader) });
   runtime.bootloader = runtime.module(define, () => ({}));
 </scr\ipt>
 </body>
-</html>`
-)};
+</html>`;
+    };
+};
 const _1tiwgkp = function _lopemodule(TRACE_MODULE,CSS,arrayBufferToBase64,inlineModule,escapeScriptTags)
 {
     return async module => {
@@ -7793,10 +7781,10 @@ async function arrayBufferToBase64(buffer) {
     return btoa(binary);
 }
 )};
-const _1p6pb2e = function _73(md){return(
+const _am38ex = function _74(md){return(
 md`### Global Output`
 )};
-const _1yismpd = function _74(md){return(
+const _kx1h0y = function _75(md){return(
 md`## Utils`
 )};
 const _t237wb = function _getCompactISODate(){return(
@@ -7811,7 +7799,7 @@ function getCompactISODate() {
     return `${ year }${ month }${ day }T${ hours }${ minutes }${ seconds }Z`;
 }
 )};
-const _4t2ire = function _76(md){return(
+const _1nku2br = function _77(md){return(
 md`## Additional Tests`
 )};
 const _8765p8 = function _diskDataUrl(disk_svg){return(
@@ -7893,7 +7881,7 @@ export default function define(runtime, observer) {
   $def("_1y5e5x8", "module_specs", ["task","included_modules","TRACE_MODULE","task_runtime","isModuleVar","isDynamicVar","getFileAttachments","main","generate_module_source","moduleNames"], _1y5e5x8);  
   $def("_1r3eg9r", "findImports", [], _1r3eg9r);  
   $def("_ipv4ft", "getFileAttachments", [], _ipv4ft);  
-  $def("_pvnegh", "book", ["lopebook","task","module_specs"], _pvnegh);  
+  $def("_1x463u7", "book", ["task","inlineModule","inlineGzipModule","es_module_shims","runtime_gz","inspector_gz","module_specs","lopemodule","lopebook"], _1x463u7);  
   $def("_18javdl", null, ["Inputs","module_specs"], _18javdl);  
   $def("_1gb47v", null, ["md"], _1gb47v);  
   $def("_5m8hbe", "report", ["DOMParser","book"], _5m8hbe);  
@@ -7905,9 +7893,10 @@ export default function define(runtime, observer) {
   $def("_19ft5zb", "generate_definitions", ["variableToDefinition"], _19ft5zb);  
   $def("_7nr512", "generate_define", ["variableToDefine"], _7nr512);  
   $def("_1hslsmt", "isLiveImport", [], _1hslsmt);  
-  $def("_18sa1aj", "variableToDefinition", ["isModuleVar","isImportBridged","isLiveImport","isDynamicVar","pid"], _18sa1aj);  
+  $def("_g39v22", "variableToDefinition", ["isModuleVar","isImportBridged","isLiveImport","isDynamicVar","pid","restoreCanonicalImports"], _g39v22);  
+  $def("_5zomoj", "restoreCanonicalImports", ["acorn","escodegen"], _5zomoj);  
   $def("_1g36je3", "variableToDefine", ["isLiveImport","isDynamicVar","isModuleVar","isImportBridged","findImportedName3","pid"], _1g36je3);  
-  $def("_1bux505", null, ["md"], _1bux505);  
+  $def("_dxkjia", null, ["md"], _dxkjia);  
   $def("_g33g3u", "es_module_shims", [], _g33g3u);  
   $def("_1na8qih", "inspector_gz", [], _1na8qih);  
   $def("_3naqgd", "inlineModule", [], _3naqgd);  
@@ -7916,14 +7905,14 @@ export default function define(runtime, observer) {
   $def("_eoywzy", "test_normalize", ["expect","normalize"], _eoywzy);  
   $def("_1vgrzwk", "isNotebook", [], _1vgrzwk);  
   $def("_1pcnq22", "networking_script", ["normalize","isNotebook"], _1pcnq22);  
-  $def("_13sd8x8", "lopebook", ["diskDataUrl","networking_script","task","inlineModule","inlineGzipModule","es_module_shims","runtime_gz","inspector_gz","lopemodule"], _13sd8x8);  
+  $def("_1crzwh0", "lopebook", ["diskDataUrl","networking_script"], _1crzwh0);  
   $def("_1tiwgkp", "lopemodule", ["TRACE_MODULE","CSS","arrayBufferToBase64","inlineModule","escapeScriptTags"], _1tiwgkp);  
   $def("_19l1umr", "escapeScriptTags", [], _19l1umr);  
   $def("_1hwkszj", "arrayBufferToBase64", [], _1hwkszj);  
-  $def("_1p6pb2e", null, ["md"], _1p6pb2e);  
-  $def("_1yismpd", null, ["md"], _1yismpd);  
+  $def("_am38ex", null, ["md"], _am38ex);  
+  $def("_kx1h0y", null, ["md"], _kx1h0y);  
   $def("_t237wb", "getCompactISODate", [], _t237wb);  
-  $def("_4t2ire", null, ["md"], _4t2ire);  
+  $def("_1nku2br", null, ["md"], _1nku2br);  
   $def("_8765p8", "diskDataUrl", ["disk_svg"], _8765p8);  
   $def("_z4k2or", "viewof task", ["flowQueue"], _z4k2or);  
   $def("_ngmf1x", "task", ["Generators","viewof task"], _ngmf1x);  
@@ -7940,6 +7929,8 @@ export default function define(runtime, observer) {
   main.define("variableToObject", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("variableToObject", _));  
   main.define("parser", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("parser", _));  
   main.define("decompress_url", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("decompress_url", _));  
+  main.define("acorn", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("acorn", _));  
+  main.define("escodegen", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("escodegen", _));  
   main.define("view", ["module @tomlarkworthy/view", "@variable"], (_, v) => v.import("view", _));  
   main.define("variable", ["module @tomlarkworthy/view", "@variable"], (_, v) => v.import("variable", _));  
   main.define("bindOneWay", ["module @tomlarkworthy/view", "@variable"], (_, v) => v.import("bindOneWay", _));  
@@ -8538,397 +8529,345 @@ const _1bf1rb4 = function _fileSyncLastSeen(directory)
     void directory;
     return new window.Map();
 };
-const _1srrp0d = function _filesToNotebook(directory,syncArmed,currentModules,fileSyncLastSeen,notebookId,runtime,probeDefine,tag,readFile,exportModuleJS,manifestWriter,hashSource,writeFile,getFileAttachmentsMap,invalidation)
-{
-  if (!directory) return "Waiting for directory...";
-  if (!syncArmed || !syncArmed.armed)
-    return "Sync inactive: " + ((syncArmed && syncArmed.reason) || "unknown");
-  // Compute syncable modules inline — avoid depending on syncableModules/SKIP_MODULES reactively,
-  // which would restart this cell every time SKIP_MODULES changes.
-  const SKIP = new Set(["bootloader", "builtin"]);
-  const syncableModules = [];
-  for (const [mod, info] of currentModules) {
-    if (SKIP.has(info.name)) continue;
-    if (!info.name.includes("/") && !info.name.startsWith("d/")) continue;
-    syncableModules.push(info.name);
-  }
-  const syncableSet = new Set(syncableModules);
-  // Use stable lastSeen map that survives restarts — only resets when directory changes
-  const lastSeen = fileSyncLastSeen;
-  const POLL_MS = 1000;
-  const prefix = notebookId + "/";
-  // Build lookup: module name → module object (the Observable Module instance)
-  const nameToModule = new window.Map();
-  // Build lookup: module name → Map of pid key → variable
-  const nameToVars = new window.Map();
-  for (const [mod, info] of currentModules) {
-    if (!syncableSet.has(info.name)) continue;
-    nameToModule.set(info.name, info.module);
-    const vars = new window.Map();
-    for (const v of runtime._variables) {
-      if (v._module !== info.module) continue;
-      if (v._name) vars.set(v._name, v);
-      if (v.pid) vars.set("__pid__" + v.pid, v);
+const _1srrp0d = function _filesToNotebook(directory, syncArmed, currentModules, fileSyncLastSeen, notebookId, runtime, probeDefine, tag, readFile, exportModuleJS, manifestWriter, hashSource, writeFile, getFileAttachmentsMap, invalidation) {
+    if (!directory)
+        return 'Waiting for directory...';
+    if (!syncArmed || !syncArmed.armed)
+        return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
+    const SKIP = new Set([
+        'bootloader',
+        'builtin'
+    ]);
+    const syncableModules = [];
+    for (const [mod, info] of currentModules) {
+        if (SKIP.has(info.name))
+            continue;
+        if (!info.name.includes('/') && !info.name.startsWith('d/'))
+            continue;
+        syncableModules.push(info.name);
     }
-    nameToVars.set(info.name, vars);
-  }
-  let pollTimer;
-  // Track pids seen from .js files — only delete pids we've previously seen
-  const knownFilePids = new window.Map();
-  // Track modules found on disk — for detecting additions and removals
-  let knownDiskModules = null;
-  // null = first scan (no deletions)
-  // FileAttachment helpers
-  const getModuleFA = (mod) => {
-    for (const v of runtime._variables) {
-      if (v._module === mod && v._name === "FileAttachment" && v._value)
-        return v._value;
-    }
-    return null;
-  };
-  const getSubDir = async (dirHandle, path) => {
-    let current = dirHandle;
-    for (const part of path.split("/").filter(Boolean)) {
-      current = await current.getDirectoryHandle(part);
-    }
-    return current;
-  };
-  const applyModule = (moduleId, defineFn) => {
-    const mod = nameToModule.get(moduleId);
-    if (!mod) return;
-    const existingVars = nameToVars.get(moduleId) || new window.Map();
-    const cells = probeDefine(defineFn);
-    let redefinedSelf = false;
-    const seenPids = new Set();
-    for (const cell of cells) {
-      if (cell.type === "import") continue;
-      if (!cell.pid) continue;
-      seenPids.add(cell.pid);
-      const existing = existingVars.get("__pid__" + cell.pid);
-      if (!existing) {
-        // CREATE new cell — always unobserved; lopepage visualizer will pick it up
-        const taggedDefn = cell.definition
-          ? tag(cell.definition, { source: "file-sync" })
-          : cell.definition;
-        var v = mod.variable();
-        v.define(cell.name, cell.inputs, taggedDefn);
-        v.pid = cell.pid;
-        existingVars.set("__pid__" + cell.pid, v);
-        if (cell.name) existingVars.set(cell.name, v);
-        console.log(
-          "[file-sync] created cell",
-          cell.pid,
-          cell.name || "(anonymous)"
-        );
-        continue;
-      }
-      // UPDATE existing cell — skip if definition and inputs are unchanged
-      if (existing._definition) {
-        const existingInputNames = existing._inputs.map(function (v) {
-          return typeof v === "string" ? v : v._name;
-        });
-        const inputsMatch =
-          JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-        const defnMatch =
-          existing._definition.toString() ===
-          (cell.definition ? cell.definition.toString() : "");
-        if (inputsMatch && defnMatch) continue;
-      }
-      const taggedDefn = cell.definition
-        ? tag(cell.definition, { source: "file-sync" })
-        : cell.definition;
-      existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-      if (
-        moduleId === "@tomlarkworthy/file-sync" &&
-        cell.name === "filesToNotebook"
-      ) {
-        redefinedSelf = true;
-      }
-    }
-    // DELETE: only remove pids that were in a PREVIOUS probeDefine but are now absent.
-    // This ensures we never touch variables we didn't create (implicits, import bridges, etc.)
-    const prevKnown = knownFilePids.get(moduleId);
-    if (prevKnown) {
-      for (const pid of prevKnown) {
-        if (seenPids.has(pid)) continue;
-        const v = existingVars.get("__pid__" + pid);
-        if (!v) continue;
-        console.log("[file-sync] deleting cell", pid, v._name || "(anonymous)");
-        v.delete();
-        existingVars.delete("__pid__" + pid);
-        if (v._name) existingVars.delete(v._name);
-      }
-    }
-    knownFilePids.set(moduleId, seenPids);
-    const ordered = [];
-    for (const cell of cells) {
-      if (!cell.pid) continue;
-      const v = existingVars.get("__pid__" + cell.pid);
-      if (v) ordered.push(v);
-    }
-    if (ordered.length) {
-      const orderedSet = new Set(ordered);
-      const others = [];
-      for (const v of runtime._variables) {
-        if (!orderedSet.has(v)) others.push(v);
-      }
-      runtime._variables.clear();
-      for (const v of others) runtime._variables.add(v);
-      for (const v of ordered) runtime._variables.add(v);
-    }
-    if (redefinedSelf) {
-      clearInterval(pollTimer);
-      console.log(
-        "[file-sync] filesToNotebook redefined \u2014 stopping old poll timer"
-      );
-    }
-  };
-  const pollModule = async (moduleId) => {
-    // --- Module source (.js) ---
-    try {
-      let file;
-      try {
-        file = await readFile(directory, prefix + moduleId + ".js");
-      } catch (e) {
-        // .js file doesn't exist on disk — skip source sync
-        file = null;
-      }
-      if (file) {
-        const prev = lastSeen.get(moduleId);
-        const changed = !prev || file.lastModified !== prev.lastModified;
-        if (changed) {
-          lastSeen.set(moduleId, { lastModified: file.lastModified });
-          const diskText = await file.text();
-          let needsApply = true;
-          try {
-            const runtimeResult = await exportModuleJS(moduleId);
-            if (runtimeResult.source === diskText) needsApply = false;
-          } catch (e) {}
-          if (needsApply) {
-            const blob = new window.Blob([diskText], {
-              type: "text/javascript"
-            });
-            const url = window.URL.createObjectURL(blob);
-            try {
-              const mod = await importShim(url, 'https://api.observablehq.com/@tomlarkworthy/file-sync.js?v=4');
-              if (typeof mod.default === "function") {
-                applyModule(moduleId, mod.default);
-                console.log("[file-sync] applied " + moduleId + " from disk");
-                try {
-                  const after = await exportModuleJS(moduleId);
-                  await manifestWriter(
-                    directory,
-                    prefix,
-                    { [moduleId]: hashSource(after.source) },
-                    readFile,
-                    writeFile
-                  );
-                } catch (e) {
-                  await manifestWriter(
-                    directory,
-                    prefix,
-                    { [moduleId]: hashSource(diskText) },
-                    readFile,
-                    writeFile
-                  );
-                }
-              }
-            } finally {
-              window.URL.revokeObjectURL(url);
-            }
-          }
+    const syncableSet = new Set(syncableModules);
+    const lastSeen = fileSyncLastSeen;
+    const POLL_MS = 1000;
+    const prefix = notebookId + '/';
+    const nameToModule = new window.Map();
+    const nameToVars = new window.Map();
+    for (const [mod, info] of currentModules) {
+        if (!syncableSet.has(info.name))
+            continue;
+        nameToModule.set(info.name, info.module);
+        const vars = new window.Map();
+        for (const v of runtime._variables) {
+            if (v._module !== info.module)
+                continue;
+            if (v._name)
+                vars.set(v._name, v);
+            if (v.pid)
+                vars.set('__pid__' + v.pid, v);
         }
-      }
-    } catch (e) {
-      console.error("[file-sync] poll error for " + moduleId + ":", e);
+        nameToVars.set(info.name, vars);
     }
-    // --- File attachments ---
-    try {
-      const attachDir = await getSubDir(directory, prefix + moduleId);
-      const mod = nameToModule.get(moduleId);
-      const FA = mod ? getModuleFA(mod) : null;
-      const faMap = FA ? getFileAttachmentsMap(FA) : null;
-      if (faMap) {
-        for (const key of [...faMap.keys()]) {
-          if (key.endsWith(".crswap") || key.startsWith(".")) faMap.delete(key);
+    let pollTimer;
+    const knownFilePids = new window.Map();
+    let knownDiskModules = null;
+    const getModuleFA = mod => {
+        for (const v of runtime._variables) {
+            if (v._module === mod && v._name === 'FileAttachment' && v._value)
+                return v._value;
         }
-      }
-      for await (const [name, handle] of attachDir) {
-        if (handle.kind !== "file") continue;
-        if (name.endsWith(".crswap") || name.startsWith(".")) continue;
-        const file = await handle.getFile();
-        const attKey = "__att__" + moduleId + "/" + name;
-        const prevA = lastSeen.get(attKey);
-        if (prevA && file.lastModified === prevA.lastModified) continue;
-        lastSeen.set(attKey, { lastModified: file.lastModified });
-        // Read file and create blob URL
-        const bytes = new Uint8Array(await file.arrayBuffer());
-        const blob = new window.Blob([bytes], {
-          type: file.type || "application/octet-stream"
-        });
-        const blobUrl = window.URL.createObjectURL(blob);
-        // Update runtime FileAttachment map
-        if (faMap) {
-          faMap.set(name, {
-            url: blobUrl,
-            mimeType: file.type || "application/octet-stream"
-          });
-          console.log(
-            "[file-sync] updated attachment " + moduleId + "/" + name
-          );
+        return null;
+    };
+    const getSubDir = async (dirHandle, path) => {
+        let current = dirHandle;
+        for (const part of path.split('/').filter(Boolean)) {
+            current = await current.getDirectoryHandle(part);
         }
-        // Update DOM script tag so re-exports pick up the change
-        const scriptId = moduleId + "/" + encodeURIComponent(name);
-        const script = document.getElementById(scriptId);
-        if (script) {
-          const b64 = btoa(String.fromCharCode.apply(null, bytes));
-          script.textContent = b64;
-          script.setAttribute("data-encoding", "base64");
-          script.setAttribute(
-            "data-mime",
-            file.type || "application/octet-stream"
-          );
-        }
-      }
-    } catch (e) {
-      if (e.name !== "NotFoundError") {
-        console.error(
-          "[file-sync] attachment scan error for " + moduleId + ":",
-          e
-        );
-      }
-    }
-  };
-  // Scan the notebook directory for all .js module files
-  const scanDiskModules = async () => {
-    const diskModules = new Set();
-    try {
-      const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
-      for await (const [orgName, orgHandle] of notebookDir) {
-        if (orgHandle.kind !== "directory") continue;
-        if (orgName.startsWith("@")) {
-          // Scoped modules: @org/name
-          for await (const [fname, fhandle] of orgHandle) {
-            if (fhandle.kind === "file" && fname.endsWith(".js")) {
-              diskModules.add(orgName + "/" + fname.slice(0, -3));
-            }
-          }
-        } else if (orgName === "d") {
-          // Observable hash modules: d/hash@version
-          for await (const [fname, fhandle] of orgHandle) {
-            if (fhandle.kind === "file" && fname.endsWith(".js")) {
-              diskModules.add("d/" + fname.slice(0, -3));
-            }
-          }
-        }
-      }
-    } catch (e) {}
-    return diskModules;
-  };
-  const poll = async () => {
-    // Poll existing syncable modules
-    for (const moduleId of syncableModules) {
-      await pollModule(moduleId);
-    }
-    // Scan disk for new/removed modules
-    const diskModules = await scanDiskModules();
-    // ADD: new modules on disk not in the runtime
-    const newOnDisk = [...diskModules].filter(
-      (m) => !syncableSet.has(m) && !nameToModule.has(m)
-    );
-    if (newOnDisk.length)
-      console.log("[file-sync] new modules on disk:", newOnDisk);
-    for (const moduleId of diskModules) {
-      if (syncableSet.has(moduleId)) continue;
-      // already known
-      if (nameToModule.has(moduleId)) continue;
-      // already added by a previous scan
-      try {
-        const file = await readFile(directory, prefix + moduleId + ".js");
-        const diskText = await file.text();
-        const blob = new window.Blob([diskText], { type: "text/javascript" });
-        const url = window.URL.createObjectURL(blob);
-        try {
-          const imported = await importShim(url, 'https://api.observablehq.com/@tomlarkworthy/file-sync.js?v=4');
-          if (typeof imported.default === "function") {
-            // Create a new runtime module — unobserved (lopepage visualizer discovers it)
-            const newMod = runtime.module(imported.default, () => null);
-            runtime.mains.set(moduleId, newMod);
-            nameToModule.set(moduleId, newMod);
-            syncableModules.push(moduleId);
-            syncableSet.add(moduleId);
-            // Index its variables for future pid tracking
-            const vars = new window.Map();
-            for (const v of runtime._variables) {
-              if (v._module !== newMod) continue;
-              if (v._name) vars.set(v._name, v);
-              if (v.pid) vars.set("__pid__" + v.pid, v);
-            }
-            nameToVars.set(moduleId, vars);
-            console.log("[file-sync] added new module from disk: " + moduleId);
-            try {
-              await manifestWriter(
-                directory,
-                prefix,
-                { [moduleId]: hashSource(diskText) },
-                readFile,
-                writeFile
-              );
-            } catch (e) {
-              console.error(
-                "[file-sync] manifest update for new module failed:",
-                e
-              );
-            }
-          }
-        } finally {
-          window.URL.revokeObjectURL(url);
-        }
-      } catch (e) {
-        console.error("[file-sync] failed to add module " + moduleId + ":", e);
-      }
-    }
-    // REMOVE: modules previously on disk but now gone
-    if (knownDiskModules) {
-      for (const moduleId of knownDiskModules) {
-        if (diskModules.has(moduleId)) continue;
-        if (!nameToModule.has(moduleId)) continue;
+        return current;
+    };
+    const applyModule = (moduleId, defineFn) => {
         const mod = nameToModule.get(moduleId);
-        // Delete all variables in this module
-        for (const v of [...runtime._variables]) {
-          if (v._module === mod) {
-            v.delete();
-          }
+        if (!mod)
+            return;
+        const existingVars = nameToVars.get(moduleId) || new window.Map();
+        const cells = probeDefine(defineFn);
+        let redefinedSelf = false;
+        const seenPids = new Set();
+        for (const cell of cells) {
+            if (cell.type === 'import')
+                continue;
+            if (!cell.pid)
+                continue;
+            seenPids.add(cell.pid);
+            const existing = existingVars.get('__pid__' + cell.pid);
+            if (!existing) {
+                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+                var v = mod.variable();
+                v.define(cell.name, cell.inputs, taggedDefn);
+                v.pid = cell.pid;
+                existingVars.set('__pid__' + cell.pid, v);
+                if (cell.name)
+                    existingVars.set(cell.name, v);
+                console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
+                continue;
+            }
+            if (existing._definition) {
+                const existingInputNames = existing._inputs.map(function (v) {
+                    return typeof v === 'string' ? v : v._name;
+                });
+                const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+                const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+                if (inputsMatch && defnMatch)
+                    continue;
+            }
+            const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+            existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+            if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
+                redefinedSelf = true;
+            }
         }
-        runtime.mains.delete(moduleId);
-        nameToModule.delete(moduleId);
-        nameToVars.delete(moduleId);
-        knownFilePids.delete(moduleId);
-        const idx = syncableModules.indexOf(moduleId);
-        if (idx !== -1) syncableModules.splice(idx, 1);
-        syncableSet.delete(moduleId);
-        console.log("[file-sync] removed module: " + moduleId);
+        const prevKnown = knownFilePids.get(moduleId);
+        if (prevKnown) {
+            for (const pid of prevKnown) {
+                if (seenPids.has(pid))
+                    continue;
+                const v = existingVars.get('__pid__' + pid);
+                if (!v)
+                    continue;
+                console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
+                v.delete();
+                existingVars.delete('__pid__' + pid);
+                if (v._name)
+                    existingVars.delete(v._name);
+            }
+        }
+        knownFilePids.set(moduleId, seenPids);
+        const ordered = [];
+        for (const cell of cells) {
+            if (!cell.pid)
+                continue;
+            const v = existingVars.get('__pid__' + cell.pid);
+            if (v)
+                ordered.push(v);
+        }
+        if (ordered.length) {
+            const orderedSet = new Set(ordered);
+            const others = [];
+            for (const v of runtime._variables) {
+                if (!orderedSet.has(v))
+                    others.push(v);
+            }
+            runtime._variables.clear();
+            for (const v of others)
+                runtime._variables.add(v);
+            for (const v of ordered)
+                runtime._variables.add(v);
+        }
+        if (redefinedSelf) {
+            clearInterval(pollTimer);
+            console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
+        }
+    };
+    const pollModule = async moduleId => {
         try {
-          await manifestWriter(
-            directory,
-            prefix,
-            { [moduleId]: null },
-            readFile,
-            writeFile
-          );
+            let file;
+            try {
+                file = await readFile(directory, prefix + moduleId + '.js');
+            } catch (e) {
+                file = null;
+            }
+            if (file) {
+                const prev = lastSeen.get(moduleId);
+                const changed = !prev || file.lastModified !== prev.lastModified;
+                if (changed) {
+                    lastSeen.set(moduleId, { lastModified: file.lastModified });
+                    const diskText = await file.text();
+                    let needsApply = true;
+                    try {
+                        const runtimeResult = await exportModuleJS(moduleId);
+                        if (runtimeResult.source === diskText)
+                            needsApply = false;
+                    } catch (e) {
+                    }
+                    if (needsApply) {
+                        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+                        const url = window.URL.createObjectURL(blob);
+                        try {
+                            const mod = await import(url);
+                            if (typeof mod.default === 'function') {
+                                applyModule(moduleId, mod.default);
+                                console.log('[file-sync] applied ' + moduleId + ' from disk');
+                                try {
+                                    const after = await exportModuleJS(moduleId);
+                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
+                                } catch (e) {
+                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
+                                }
+                            }
+                        } finally {
+                            window.URL.revokeObjectURL(url);
+                        }
+                    }
+                }
+            }
         } catch (e) {
-          console.error("[file-sync] manifest remove failed:", e);
+            console.error('[file-sync] poll error for ' + moduleId + ':', e);
         }
-      }
-    }
-    knownDiskModules = diskModules;
-  };
-  pollTimer = setInterval(poll, POLL_MS);
-  poll();
-  invalidation.then(() => clearInterval(pollTimer));
-  return (
-    "Polling " + syncableModules.length + " modules every " + POLL_MS + "ms..."
-  );
+        try {
+            const attachDir = await getSubDir(directory, prefix + moduleId);
+            const mod = nameToModule.get(moduleId);
+            const FA = mod ? getModuleFA(mod) : null;
+            const faMap = FA ? getFileAttachmentsMap(FA) : null;
+            if (faMap) {
+                for (const key of [...faMap.keys()]) {
+                    if (key.endsWith('.crswap') || key.startsWith('.'))
+                        faMap.delete(key);
+                }
+            }
+            for await (const [name, handle] of attachDir) {
+                if (handle.kind !== 'file')
+                    continue;
+                if (name.endsWith('.crswap') || name.startsWith('.'))
+                    continue;
+                const file = await handle.getFile();
+                const attKey = '__att__' + moduleId + '/' + name;
+                const prevA = lastSeen.get(attKey);
+                if (prevA && file.lastModified === prevA.lastModified)
+                    continue;
+                lastSeen.set(attKey, { lastModified: file.lastModified });
+                const bytes = new Uint8Array(await file.arrayBuffer());
+                const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
+                const blobUrl = window.URL.createObjectURL(blob);
+                if (faMap) {
+                    faMap.set(name, {
+                        url: blobUrl,
+                        mimeType: file.type || 'application/octet-stream'
+                    });
+                    console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
+                }
+                const scriptId = moduleId + '/' + encodeURIComponent(name);
+                const script = document.getElementById(scriptId);
+                if (script) {
+                    const b64 = btoa(String.fromCharCode.apply(null, bytes));
+                    script.textContent = b64;
+                    script.setAttribute('data-encoding', 'base64');
+                    script.setAttribute('data-mime', file.type || 'application/octet-stream');
+                }
+            }
+        } catch (e) {
+            if (e.name !== 'NotFoundError') {
+                console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
+            }
+        }
+    };
+    const scanDiskModules = async () => {
+        const diskModules = new Set();
+        try {
+            const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
+            for await (const [orgName, orgHandle] of notebookDir) {
+                if (orgHandle.kind !== 'directory')
+                    continue;
+                if (orgName.startsWith('@')) {
+                    for await (const [fname, fhandle] of orgHandle) {
+                        if (fhandle.kind === 'file' && fname.endsWith('.js')) {
+                            diskModules.add(orgName + '/' + fname.slice(0, -3));
+                        }
+                    }
+                } else if (orgName === 'd') {
+                    for await (const [fname, fhandle] of orgHandle) {
+                        if (fhandle.kind === 'file' && fname.endsWith('.js')) {
+                            diskModules.add('d/' + fname.slice(0, -3));
+                        }
+                    }
+                }
+            }
+        } catch (e) {
+        }
+        return diskModules;
+    };
+    const poll = async () => {
+        for (const moduleId of syncableModules) {
+            await pollModule(moduleId);
+        }
+        const diskModules = await scanDiskModules();
+        const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
+        if (newOnDisk.length)
+            console.log('[file-sync] new modules on disk:', newOnDisk);
+        for (const moduleId of diskModules) {
+            if (syncableSet.has(moduleId))
+                continue;
+            if (nameToModule.has(moduleId))
+                continue;
+            try {
+                const file = await readFile(directory, prefix + moduleId + '.js');
+                const diskText = await file.text();
+                const blob = new window.Blob([diskText], { type: 'text/javascript' });
+                const url = window.URL.createObjectURL(blob);
+                try {
+                    const imported = await import(url);
+                    if (typeof imported.default === 'function') {
+                        const newMod = runtime.module(imported.default, () => null);
+                        runtime.mains.set(moduleId, newMod);
+                        nameToModule.set(moduleId, newMod);
+                        syncableModules.push(moduleId);
+                        syncableSet.add(moduleId);
+                        const vars = new window.Map();
+                        for (const v of runtime._variables) {
+                            if (v._module !== newMod)
+                                continue;
+                            if (v._name)
+                                vars.set(v._name, v);
+                            if (v.pid)
+                                vars.set('__pid__' + v.pid, v);
+                        }
+                        nameToVars.set(moduleId, vars);
+                        console.log('[file-sync] added new module from disk: ' + moduleId);
+                        try {
+                            await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
+                        } catch (e) {
+                            console.error('[file-sync] manifest update for new module failed:', e);
+                        }
+                    }
+                } finally {
+                    window.URL.revokeObjectURL(url);
+                }
+            } catch (e) {
+                console.error('[file-sync] failed to add module ' + moduleId + ':', e);
+            }
+        }
+        if (knownDiskModules) {
+            for (const moduleId of knownDiskModules) {
+                if (diskModules.has(moduleId))
+                    continue;
+                if (!nameToModule.has(moduleId))
+                    continue;
+                const mod = nameToModule.get(moduleId);
+                for (const v of [...runtime._variables]) {
+                    if (v._module === mod) {
+                        v.delete();
+                    }
+                }
+                runtime.mains.delete(moduleId);
+                nameToModule.delete(moduleId);
+                nameToVars.delete(moduleId);
+                knownFilePids.delete(moduleId);
+                const idx = syncableModules.indexOf(moduleId);
+                if (idx !== -1)
+                    syncableModules.splice(idx, 1);
+                syncableSet.delete(moduleId);
+                console.log('[file-sync] removed module: ' + moduleId);
+                try {
+                    await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+                } catch (e) {
+                    console.error('[file-sync] manifest remove failed:', e);
+                }
+            }
+        }
+        knownDiskModules = diskModules;
+    };
+    pollTimer = setInterval(poll, POLL_MS);
+    poll();
+    invalidation.then(() => clearInterval(pollTimer));
+    return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
 };
 const _1b4kluo = function _21(md){return(
 md`## How It Works
@@ -9024,7 +8963,7 @@ export default function define(runtime, observer) {
   return main;
 }</script>
 
-<script id="@tomlarkworthy/fileattachments"
+<script id="@tomlarkworthy/fileattachments" 
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -9331,8 +9270,7 @@ export default function define(runtime, observer) {
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
   main.define("thisModule", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("thisModule", _));
   return main;
-}
-</script>
+}</script>
 <script id="@tomlarkworthy/flow-queue/flowQuery%401.svg" 
   type="text/plain"
   data-encoding="base64"
@@ -9498,20 +9436,20 @@ const _1aloau2 = (G, _) => G.input(_);
 const _7s1qq7 = function _6($0,sqrt){return(
 $0.resolve(Math.sqrt(sqrt))
 )};
-const _x7qi6y = async function _testing(flowQueue)
-{
-  flowQueue; // load after implementation
-  const [{ Runtime }, { default: define }] = await Promise.all([
-    importShim("https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js"
-    , 'https://api.observablehq.com/@tomlarkworthy/flow-queue.js?v=4'),
-    importShim(`https://api.observablehq.com/@tomlarkworthy/testing.js?v=3`, 'https://api.observablehq.com/@tomlarkworthy/flow-queue.js?v=4')
-  ]);
-  const module = new Runtime().module(define);
-  return Object.fromEntries(
-    await Promise.all(
-      ["expect", "createSuite"].map((n) => module.value(n).then((v) => [n, v]))
-    )
-  );
+const _x7qi6y = async function _testing(flowQueue) {
+    flowQueue;
+    const [{Runtime}, {default: define}] = await Promise.all([
+        import('https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js'),
+        import(`https://api.observablehq.com/@tomlarkworthy/testing.js?v=3`)
+    ]);
+    const module = new Runtime().module(define);
+    return Object.fromEntries(await Promise.all([
+        'expect',
+        'createSuite'
+    ].map(n => module.value(n).then(v => [
+        n,
+        v
+    ]))));
 };
 const _8ggfj7 = function _suite(testing){return(
 testing.createSuite({
@@ -10139,18 +10077,14 @@ FileAttachment("lm_popin_black.png").url()
 const _18kpe1x = function _lm_popout_black(FileAttachment){return(
 FileAttachment("lm_popout_black.png").url()
 )};
-const _1p7i538 = async function _gl(unzip,FileAttachment)
-{
-  const blob = await unzip(FileAttachment("golden-layout-2.6.0.js.gz"));
-
-  const objectURL = URL.createObjectURL(
-    new Blob([blob], { type: "application/javascript" })
-  );
-  try {
-    return await importShim(objectURL, 'https://api.observablehq.com/@tomlarkworthy/golden-layout-2-6-0.js?v=4');
-  } finally {
-    URL.revokeObjectURL(objectURL); // Ensure URL is revoked after import
-  }
+const _1p7i538 = async function _gl(unzip, FileAttachment) {
+    const blob = await unzip(FileAttachment('golden-layout-2.6.0.js.gz'));
+    const objectURL = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
+    try {
+        return await import(objectURL);
+    } finally {
+        URL.revokeObjectURL(objectURL);
+    }
 };
 const _17n6uge = function _unzip(Response,DecompressionStream){return(
 async (attachment) =>
@@ -10409,35 +10343,23 @@ import {git, http} from "@tomlarkworthy/isomorphic-git-1-30-1"
 import {FS} from "@tomlarkworthy/lightning-fs-4-6-0"
 ~~~`
 )};
-const _vz8us1 = async function _git(unzip,FileAttachment)
-{
-  const blob = await unzip(
-    FileAttachment("isomorphic-git-1@1.30.1.bundle.js.gz")
-  );
-
-  const objectURL = URL.createObjectURL(
-    new Blob([blob], { type: "application/javascript" })
-  );
-  try {
-    return await importShim(objectURL, 'https://api.observablehq.com/@tomlarkworthy/isomorphic-git-1-30-1.js?v=4');
-  } finally {
-    URL.revokeObjectURL(objectURL);
-  }
+const _vz8us1 = async function _git(unzip, FileAttachment) {
+    const blob = await unzip(FileAttachment('isomorphic-git-1@1.30.1.bundle.js.gz'));
+    const objectURL = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
+    try {
+        return await import(objectURL);
+    } finally {
+        URL.revokeObjectURL(objectURL);
+    }
 };
-const _2acekr = async function _http(unzip,FileAttachment)
-{
-  const blob = await unzip(
-    FileAttachment("isomorphic-git-http-1.0.0-beta.36.js.gz")
-  );
-
-  const objectURL = URL.createObjectURL(
-    new Blob([blob], { type: "application/javascript" })
-  );
-  try {
-    return await importShim(objectURL, 'https://api.observablehq.com/@tomlarkworthy/isomorphic-git-1-30-1.js?v=4');
-  } finally {
-    URL.revokeObjectURL(objectURL);
-  }
+const _2acekr = async function _http(unzip, FileAttachment) {
+    const blob = await unzip(FileAttachment('isomorphic-git-http-1.0.0-beta.36.js.gz'));
+    const objectURL = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
+    try {
+        return await import(objectURL);
+    } finally {
+        URL.revokeObjectURL(objectURL);
+    }
 };
 const _1emihnv = function _4(md){return(
 md`
@@ -10511,21 +10433,15 @@ md`# jest-expect-standalone@24.0.2
 import {expect} from "@tomlarkworthy/jest-expect-standalone"
 ~~~`
 )};
-const _mh1f13 = async function _expect(unzip,FileAttachment)
-{
-  const blob = await unzip(
-    FileAttachment("jest-expect-standalone-24.0.2.js.gz")
-  );
-
-  const objectURL = URL.createObjectURL(
-    new Blob([blob], { type: "application/javascript" })
-  );
-  try {
-    await importShim(objectURL, 'https://api.observablehq.com/@tomlarkworthy/jest-expect-standalone.js?v=4');
-    return window.expect;
-  } finally {
-    URL.revokeObjectURL(objectURL);
-  }
+const _mh1f13 = async function _expect(unzip, FileAttachment) {
+    const blob = await unzip(FileAttachment('jest-expect-standalone-24.0.2.js.gz'));
+    const objectURL = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
+    try {
+        await import(objectURL);
+        return window.expect;
+    } finally {
+        URL.revokeObjectURL(objectURL);
+    }
 };
 const _17n6uge = function _unzip(Response,DecompressionStream){return(
 async (attachment) =>
@@ -10570,18 +10486,14 @@ md`# [jszip@3.10.1](https://stuk.github.io/jszip/)
 import {JSZip} from "@tomlarkworthy/jszip-3-10-1"
 ~~~`
 )};
-const _umavbe = async function _JSZip(unzip,FileAttachment)
-{
-  const blob = await unzip(FileAttachment("jszip-3.10.1.min.js.gz"));
-
-  const objectURL = URL.createObjectURL(
-    new Blob([blob], { type: "application/javascript" })
-  );
-  try {
-    return (await importShim(objectURL, 'https://api.observablehq.com/@tomlarkworthy/jszip-3-10-1.js?v=4')).default;
-  } finally {
-    URL.revokeObjectURL(objectURL); // Ensure URL is revoked after import
-  }
+const _umavbe = async function _JSZip(unzip, FileAttachment) {
+    const blob = await unzip(FileAttachment('jszip-3.10.1.min.js.gz'));
+    const objectURL = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
+    try {
+        return (await import(objectURL)).default;
+    } finally {
+        URL.revokeObjectURL(objectURL);
+    }
 };
 const _g5fwfs = function _unzip(Response,DecompressionStream){return(
 async (attachment) => {
@@ -10633,18 +10545,14 @@ import {FS} from "@tomlarkworthy/lightning-fs-4-6-0"
 import {git, http} from "@tomlarkworthy/isomorphic-git-1-30-1" 
 ~~~`
 )};
-const _1tds3ro = async function _FS(unzip,FileAttachment)
-{
-  const blob = await unzip(FileAttachment("lightning-fs-4.6.0.js.gz"));
-
-  const objectURL = URL.createObjectURL(
-    new Blob([blob], { type: "application/javascript" })
-  );
-  try {
-    return (await importShim(objectURL, 'https://api.observablehq.com/@tomlarkworthy/lightning-fs-4-6-0.js?v=4')).default;
-  } finally {
-    URL.revokeObjectURL(objectURL);
-  }
+const _1tds3ro = async function _FS(unzip, FileAttachment) {
+    const blob = await unzip(FileAttachment('lightning-fs-4.6.0.js.gz'));
+    const objectURL = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
+    try {
+        return (await import(objectURL)).default;
+    } finally {
+        URL.revokeObjectURL(objectURL);
+    }
 };
 const _dqri64 = function _3(md){return(
 md`
@@ -14121,7 +14029,7 @@ export default function define(runtime, observer) {
   return main;
 }</script>
 
-<script id="@tomlarkworthy/lopepage-urls"
+<script id="@tomlarkworthy/lopepage-urls" 
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -14662,8 +14570,7 @@ export default function define(runtime, observer) {
   $def("_1xxtf0r", "updateNotebookImports", ["vars","extractNotebookAndCell","linkTo"], _1xxtf0r);  
   main.define("tests", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("tests", _));
   return main;
-}
-</script>
+}</script>
 
 <script id="@tomlarkworthy/module-map" 
   type="text/plain"
@@ -15741,18 +15648,14 @@ observable.Library
 const _1iyzb44 = function _RuntimeError(observable){return(
 observable.RuntimeError
 )};
-const _b2ba5g = async function _observable(unzip,FileAttachment)
-{
-  const blob = await unzip(FileAttachment("runtime.js.gz"));
-
-  const objectURL = URL.createObjectURL(
-    new Blob([blob], { type: "application/javascript" })
-  );
-  try {
-    return await importShim(objectURL, 'https://api.observablehq.com/@tomlarkworthy/observable-runtime.js?v=4');
-  } finally {
-    URL.revokeObjectURL(objectURL);
-  }
+const _b2ba5g = async function _observable(unzip, FileAttachment) {
+    const blob = await unzip(FileAttachment('runtime.js.gz'));
+    const objectURL = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
+    try {
+        return await import(objectURL);
+    } finally {
+        URL.revokeObjectURL(objectURL);
+    }
 };
 const _17n6uge = function _unzip(Response,DecompressionStream){return(
 async (attachment) =>
@@ -15803,13 +15706,10 @@ runtime.Runtime
 const _bfntg8 = function _RuntimeError(runtime){return(
 runtime.RuntimeError
 )};
-const _axblun = async function _runtime(gunzipBase64ToBlob,source_gz)
-{
-  const blob = await gunzipBase64ToBlob(source_gz);
-  const url = URL.createObjectURL(
-    new Blob([blob], { type: "application/javascript" })
-  );
-  return importShim(url, 'https://api.observablehq.com/@tomlarkworthy/observable-runtime-v6.js?v=4');
+const _axblun = async function _runtime(gunzipBase64ToBlob, source_gz) {
+    const blob = await gunzipBase64ToBlob(source_gz);
+    const url = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
+    return import(url);
 };
 const _1ljam5l = function _gunzipBase64ToBlob(DecompressionStream,Response){return(
 async (b64) => {
@@ -16478,10 +16378,9 @@ notebook_semantics_document.nodes.map((s) => ({
 const _1oevsow = function _28(md){return(
 md`### Runtime Representation (v4)`
 )};
-const _11lfflk = function _notebook_semantics_module(){return(
-importShim("https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4"
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _11lfflk = function _notebook_semantics_module() {
+    return import('https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4');
+};
 const _gjten6 = function _31(md){return(
 md`### Imports`
 )};
@@ -17468,65 +17367,44 @@ parser.parseCell(
   'import {runtime, viewof main as foo} from "@mootari/access-runtime"'
 )
 )};
-const _1n7gw17 = function _findModuleName(extractModuleInfo){return(
-(scope, module, { unknown_id = Math.random() } = {}) => {
-  try {
-    const scopedVariables = [...scope.values()];
-
-    // Prefer variables that *define* a module and have a real module-loader name.
-    const candidates = scopedVariables.filter(
-      (v) =>
-        v &&
-        v._value === module &&
-        typeof v._name === "string" &&
-        v._name.startsWith("module ") &&
-        !v._name.startsWith("module <unknown")
-    );
-
-    const pickBestInfo = (dfn) => {
-      // Avoid the parentUrl (2nd arg) confusing module identification.
-      // Typical patterns:
-      //   importShim("/d/<id>@<ver>.js?v=4", "https://api.observablehq.com/@ns/name.js?v=4")
-      //   import("/d/<id>@<ver>.js?v=4")
-      // Prefer the *first argument* inside importShim(...) / import(...) when present.
-      const s = String(dfn ?? "");
-
-      // Try to capture the first string literal argument to importShim(...) or import(...)
-      // Tolerates quotes ", ', ` and both importShim and plain import.
-      const m = s.match(
-        /\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/
-      );
-      const firstArg = m?.[2];
-
-      const info1 = firstArg ? extractModuleInfo(firstArg) : {};
-      if (info1?.id || info1?.notebook) return info1;
-
-      // Fallback: parse the whole definition string.
-      return extractModuleInfo(s);
+const _1n7gw17 = function _findModuleName(extractModuleInfo) {
+    return (scope, module, {
+        unknown_id = Math.random()
+    } = {}) => {
+        try {
+            const scopedVariables = [...scope.values()];
+            const candidates = scopedVariables.filter(v => v && v._value === module && typeof v._name === 'string' && v._name.startsWith('module ') && !v._name.startsWith('module <unknown'));
+            const pickBestInfo = dfn => {
+                const s = String(dfn ?? '');
+                const m = s.match(/\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/);
+                const firstArg = m?.[2];
+                const info1 = firstArg ? extractModuleInfo(firstArg) : {};
+                if (info1?.id || info1?.notebook)
+                    return info1;
+                return extractModuleInfo(s);
+            };
+            for (const v of candidates) {
+                const info = pickBestInfo(v._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            const any = scopedVariables.find(v => v && v._value === module);
+            if (any) {
+                const info = pickBestInfo(any._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            return `<unknown ${ unknown_id }>`;
+        } catch (e) {
+            debugger;
+            return 'error';
+        }
     };
-
-    // Try module loader cells first.
-    for (const v of candidates) {
-      const info = pickBestInfo(v._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    // Fallback: any scoped variable with _value==module.
-    const any = scopedVariables.find((v) => v && v._value === module);
-    if (any) {
-      const info = pickBestInfo(any._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    return `<unknown ${unknown_id}>`;
-  } catch (e) {
-    debugger;
-    return "error";
-  }
-}
-)};
+};
 const _i47chb = function _findImportedName(){return(
 async (v) => {
   if (v._inputs.length == 1 && v._inputs[0]._name === "@variable") {
@@ -18428,228 +18306,206 @@ JSON.stringify(
 const _1lt3kl6 = function _157(compile,test_case){return(
 compile(test_case.value)
 )};
-const _lpzjrv = function _compile(parser,globalThis,observableToJs){return(
-function compile(source, { anonymousName = "_anonymous" } = {}) {
-  const comments = [],
-    tokens = [];
-  let cell;
-  try {
-    cell = parser.parseCell(source, {
-      ranges: true,
-      onComment: comments,
-      onToken: tokens
-    });
-  } catch (e) {
-    if (e instanceof SyntaxError) {
-      const nameMatch = source.match(
-        /^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/
-      );
-      let _name = null;
-      let funcName = anonymousName;
-      if (nameMatch) {
-        const prefix = nameMatch[1] ? nameMatch[1] + " " : "";
-        _name = prefix + nameMatch[2];
-        funcName = "_" + nameMatch[2];
-      }
-      const escapedMsg = JSON.stringify(e.message);
-      const escapedSource = JSON.stringify(source);
-      return [
-        {
-          _name,
-          _inputs: [],
-          _definition: `function ${funcName}() { throw Object.assign(new SyntaxError(${escapedMsg}), {_sourceExpression: ${escapedSource}}); }`
+const _x1d0wm = function _compile(parser,observableToJs){return(
+function compile(source, {
+    anonymousName = '_anonymous'
+} = {}) {
+    const comments = [], tokens = [];
+    let cell;
+    try {
+        cell = parser.parseCell(source, {
+            ranges: true,
+            onComment: comments,
+            onToken: tokens
+        });
+    } catch (e) {
+        if (e instanceof SyntaxError) {
+            const nameMatch = source.match(/^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/);
+            let _name = null;
+            let funcName = anonymousName;
+            if (nameMatch) {
+                const prefix = nameMatch[1] ? nameMatch[1] + ' ' : '';
+                _name = prefix + nameMatch[2];
+                funcName = '_' + nameMatch[2];
+            }
+            const escapedMsg = JSON.stringify(e.message);
+            const escapedSource = JSON.stringify(source);
+            return [{
+                    _name,
+                    _inputs: [],
+                    _definition: `function ${ funcName }() { throw Object.assign(new SyntaxError(${ escapedMsg }), {_sourceExpression: ${ escapedSource }}); }`
+                }];
         }
-      ];
+        throw e;
     }
-    throw e;
-  }
-  if (!cell) throw new Error("Unable to parse cell");
-  const parseImportSpecifierText = (text) => {
-    const t = String(text ?? "")
-      .trim()
-      .replace(/,$/, "")
-      .trim();
-    if (!t) throw new Error("Empty import specifier");
-    const parts = t.split(/\s+as\s+/);
-    const left = parts[0].trim();
-    const right = parts[1]?.trim();
-    const parseSide = (side, { defaultPrefix = "" } = {}) => {
-      const s = String(side ?? "").trim();
-      const m = s.match(/^(viewof|mutable)\s+(.+)$/);
-      if (m)
-        return {
-          prefix: `${m[1]} `,
-          name: m[2].trim()
+    if (!cell)
+        throw new Error('Unable to parse cell');
+    const parseImportSpecifierText = text => {
+        const t = String(text ?? '').trim().replace(/,$/, '').trim();
+        if (!t)
+            throw new Error('Empty import specifier');
+        const parts = t.split(/\s+as\s+/);
+        const left = parts[0].trim();
+        const right = parts[1]?.trim();
+        const parseSide = (side, {
+            defaultPrefix = ''
+        } = {}) => {
+            const s = String(side ?? '').trim();
+            const m = s.match(/^(viewof|mutable)\s+(.+)$/);
+            if (m)
+                return {
+                    prefix: `${ m[1] } `,
+                    name: m[2].trim()
+                };
+            return {
+                prefix: defaultPrefix,
+                name: s
+            };
         };
-      return {
-        prefix: defaultPrefix,
-        name: s
-      };
+        const L = parseSide(left);
+        const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
+        const importedName = `${ L.prefix }${ L.name }`.trim();
+        const localName = `${ R.prefix }${ R.name }`.trim();
+        if (!importedName)
+            throw new Error(`Could not parse imported name from: ${ t }`);
+        if (!localName)
+            throw new Error(`Could not parse local name from: ${ t }`);
+        return {
+            importedName,
+            localName
+        };
     };
-    const L = parseSide(left);
-    const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
-    const importedName = `${L.prefix}${L.name}`.trim();
-    const localName = `${R.prefix}${R.name}`.trim();
-    if (!importedName)
-      throw new Error(`Could not parse imported name from: ${t}`);
-    if (!localName) throw new Error(`Could not parse local name from: ${t}`);
-    return {
-      importedName,
-      localName
-    };
-  };
-  if (!cell.id && cell.body?.type === "ImportDeclaration") {
-    const module_name = cell.body.source.value;
-    const cell_variables = [
-      {
-        _name: `module ${module_name}`,
-        _inputs: [],
-        _definition: `async () => runtime.module((await import("${module_name}")).default)`
-      }
-    ];
-    for (const specifier of cell.body.specifiers ?? []) {
-      const specText =
-        typeof specifier?.start === "number" &&
-        typeof specifier?.end === "number"
-          ? source.slice(specifier.start, specifier.end)
-          : (() => {
-              if (specifier?.imported?.name && specifier?.local?.name) {
-                return specifier.imported.name === specifier.local.name
-                  ? specifier.local.name
-                  : `${specifier.imported.name} as ${specifier.local.name}`;
-              }
-              throw new Error("Import specifier missing range information");
+    if (!cell.id && cell.body?.type === 'ImportDeclaration') {
+        const module_name = cell.body.source.value;
+        const cell_variables = [{
+                _name: `module ${ module_name }`,
+                _inputs: [],
+                _definition: `async () => runtime.module((await import("${ module_name }")).default)`
+            }];
+        for (const specifier of cell.body.specifiers ?? []) {
+            const specText = typeof specifier?.start === 'number' && typeof specifier?.end === 'number' ? source.slice(specifier.start, specifier.end) : (() => {
+                if (specifier?.imported?.name && specifier?.local?.name) {
+                    return specifier.imported.name === specifier.local.name ? specifier.local.name : `${ specifier.imported.name } as ${ specifier.local.name }`;
+                }
+                throw new Error('Import specifier missing range information');
             })();
-      const { importedName, localName } = parseImportSpecifierText(specText);
-      cell_variables.push({
-        _name: localName,
-        _inputs: [`module ${module_name}`, "@variable"],
-        _definition:
-          importedName === localName
-            ? `(_, v) => v.import("${importedName}", _)`
-            : `(_, v) => v.import("${importedName}", "${localName}", _)`
-      });
+            const {importedName, localName} = parseImportSpecifierText(specText);
+            cell_variables.push({
+                _name: localName,
+                _inputs: [
+                    `module ${ module_name }`,
+                    '@variable'
+                ],
+                _definition: importedName === localName ? `(_, v) => v.import("${ importedName }", _)` : `(_, v) => v.import("${ importedName }", "${ localName }", _)`
+            });
+        }
+        return cell_variables;
     }
-    return cell_variables;
-  }
-  let dollarIdx = 0;
-  const inputToArgMap = {};
-  const dollarToMacro = {};
-  const seen = new Set();
-  const inputs = Array.from(cell.references || []).flatMap((i) => {
-    if (i.name) {
-      if (seen.has(i.name)) return [];
-      seen.add(i.name);
-      return i.name;
+    let dollarIdx = 0;
+    const inputToArgMap = {};
+    const dollarToMacro = {};
+    const seen = new Set();
+    const inputs = Array.from(cell.references || []).flatMap(i => {
+        if (i.name) {
+            if (seen.has(i.name))
+                return [];
+            seen.add(i.name);
+            return i.name;
+        } else {
+            const dedupKey = i.type + ':' + i.id.name;
+            if (seen.has(dedupKey))
+                return [];
+            seen.add(dedupKey);
+            const dollarName = '$' + dollarIdx;
+            inputToArgMap[i.id.name] = dollarName;
+            dollarToMacro[dollarName] = i.type == 'ViewExpression' ? 'viewof ' + i.id.name : 'mutable ' + i.id.name;
+            dollarIdx++;
+            return dollarName;
+        }
+    });
+    let variables;
+    if (cell.id) {
+        if (cell.id.type === 'Identifier') {
+            variables = [{
+                    functionName: '_' + cell.id.name,
+                    name: cell.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                }];
+        } else if (cell.id.type === 'ViewExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'viewof ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '(G, _) => G.input(_)',
+                    inputs: [
+                        'Generators',
+                        'viewof ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                }
+            ];
+        } else if (cell.id.type === 'MutableExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'initial ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'mutable ' + cell.id.id.name,
+                    _definition: '(M, _) => new M(_)',
+                    inputs: [
+                        'Mutable',
+                        'initial ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '_ => _.generator',
+                    inputs: ['mutable ' + cell.id.id.name],
+                    params: inputs.join(',')
+                }
+            ];
+        } else {
+            throw new Error(`Unsupported cell id type: ${ cell.id.type }`);
+        }
     } else {
-      const dedupKey = i.type + ":" + i.id.name;
-      if (seen.has(dedupKey)) return [];
-      seen.add(dedupKey);
-      const dollarName = "$" + dollarIdx;
-      inputToArgMap[i.id.name] = dollarName;
-      dollarToMacro[dollarName] =
-        i.type == "ViewExpression"
-          ? "viewof " + i.id.name
-          : "mutable " + i.id.name;
-      dollarIdx++;
-      return dollarName;
+        variables = [{
+                functionName: anonymousName,
+                name: null,
+                inputs,
+                params: inputs.join(',')
+            }];
     }
-  });
-  let variables;
-  if (cell.id) {
-    if (cell.id.type === "Identifier") {
-      variables = [
-        {
-          functionName: "_" + cell.id.name,
-          name: cell.id.name,
-          inputs,
-          params: inputs.join(",")
+    return variables.map(v => {
+        let _definition = v._definition;
+        if (!_definition) {
+            let functionBody;
+            if (cell.body.type === 'BlockStatement') {
+                functionBody = observableToJs(cell.body, inputToArgMap, comments, tokens);
+            } else {
+                const bodyCode = observableToJs(cell.body, inputToArgMap, comments, tokens);
+                functionBody = `{return (${ bodyCode });}`;
+            }
+            _definition = `${ cell.async ? 'async ' : '' }function${ cell.generator ? '*' : '' } ${ v.functionName }(${ v.inputs.join(',') }) ${ functionBody }`;
         }
-      ];
-    } else if (cell.id.type === "ViewExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "viewof " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "(G, _) => G.input(_)",
-          inputs: ["Generators", "viewof " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else if (cell.id.type === "MutableExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "initial " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "mutable " + cell.id.id.name,
-          _definition: "(M, _) => new M(_)",
-          inputs: ["Mutable", "initial " + cell.id.id.name],
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "_ => _.generator",
-          inputs: ["mutable " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else {
-      throw new Error(`Unsupported cell id type: ${cell.id.type}`);
-    }
-  } else {
-    variables = [
-      {
-        functionName: anonymousName,
-        name: null,
-        inputs,
-        params: inputs.join(",")
-      }
-    ];
-  }
-  return variables.map((v) => {
-    let _definition = v._definition;
-    if (!_definition) {
-      let functionBody;
-      if (cell.body.type === "BlockStatement") {
-        functionBody = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-      } else {
-        const bodyCode = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-        functionBody = `{return (${bodyCode});}`;
-      }
-      _definition = `${cell.async ? "async " : ""}function${
-        cell.generator ? "*" : ""
-      } ${v.functionName}(${v.inputs.join(",")}) ${functionBody}`;
-    }
-    return {
-      _name: v.name,
-      _inputs: v.inputs.map(
-        (i) => dollarToMacro[i] || (i === "$variable" ? "@variable" : i)
-      ),
-      _definition
-    };
-  });
+        return {
+            _name: v.name,
+            _inputs: v.inputs.map(i => dollarToMacro[i] || (i === '$variable' ? '@variable' : i)),
+            _definition
+        };
+    });
 }
 )};
 const _1v1i7wl = function _observableToJs(acorn_walk,parser,escodegen){return(
@@ -18716,16 +18572,15 @@ async (attachment, overrides) => {
   return URL.createObjectURL(blob);
 }
 )};
-const _s9w7ha = async function _parser(decompress_url,FileAttachment,acorn_url,acorn_walk_url){return(
-importShim(await decompress_url(FileAttachment("parser-6.1.0.js.gz"), {
-    "/npm/acorn@8.11.3/+esm": acorn_url,
-    "/npm/acorn-walk@8.3.2/+esm": acorn_walk_url
-  })
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
-const _1hiclbb = function _acorn_walk(acorn_walk_url){return(
-importShim(acorn_walk_url, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _s9w7ha = async function _parser(decompress_url, FileAttachment, acorn_url, acorn_walk_url) {
+    return import(await decompress_url(FileAttachment('parser-6.1.0.js.gz'), {
+        '/npm/acorn@8.11.3/+esm': acorn_url,
+        '/npm/acorn-walk@8.3.2/+esm': acorn_walk_url
+    }));
+};
+const _1hiclbb = function _acorn_walk(acorn_walk_url) {
+    return import(acorn_walk_url);
+};
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
@@ -18913,7 +18768,7 @@ export default function define(runtime, observer) {
   $def("_1dmmuaf", "compiled_selector", ["Generators","viewof compiled_selector"], _1dmmuaf);  
   $def("_u7t3vu", null, ["compiled_selector","normalizeJavascriptSource"], _u7t3vu);  
   $def("_1lt3kl6", null, ["compile","test_case"], _1lt3kl6);  
-  $def("_lpzjrv", "compile", ["parser","globalThis","observableToJs"], _lpzjrv);  
+  $def("_x1d0wm", "compile", ["parser","observableToJs"], _x1d0wm);  
   $def("_1v1i7wl", "observableToJs", ["acorn_walk","parser","escodegen"], _1v1i7wl);  
   $def("_19lv24l", null, ["md"], _19lv24l);  
   $def("_xhj6b8", "decompress_url", ["DecompressionStream","TextDecoderStream","TransformStream","TextEncoderStream","Response"], _xhj6b8);  
@@ -19976,10 +19831,10 @@ md`### \`importShim\` polyfill
 
 Lopecode uses importShim which is not availible on Observablehq`
 )};
-const _12odeih = function _importShim()
-{
-  if (window.importShim) return window.importShim;
-  return (url, options) => importShim(url, 'https://api.observablehq.com/@tomlarkworthy/runtime-sdk.js?v=4');
+const _12odeih = function _importShim() {
+    if (window.importShim)
+        return window.importShim;
+    return (url, options) => import(url);
 };
 const _1nrqtih = function _65(md){return(
 md`---`
@@ -23648,20 +23503,21 @@ md`## [Optional] Tests`
 const _11gtx14 = function _RUN_TESTS(){return(
 true
 )};
-const _46icxz = async function _testing(RUN_TESTS,invalidation)
-{
-  if (!RUN_TESTS) return invalidation;
-  const [{ Runtime }, { default: define }] = await Promise.all([
-    importShim("https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js"
-    , 'https://api.observablehq.com/@tomlarkworthy/view.js?v=4'),
-    importShim(`https://api.observablehq.com/@tomlarkworthy/testing.js?v=3`, 'https://api.observablehq.com/@tomlarkworthy/view.js?v=4')
-  ]);
-  const module = new Runtime().module(define);
-  return Object.fromEntries(
-    await Promise.all(
-      ["expect", "createSuite"].map((n) => module.value(n).then((v) => [n, v]))
-    )
-  );
+const _46icxz = async function _testing(RUN_TESTS, invalidation) {
+    if (!RUN_TESTS)
+        return invalidation;
+    const [{Runtime}, {default: define}] = await Promise.all([
+        import('https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js'),
+        import(`https://api.observablehq.com/@tomlarkworthy/testing.js?v=3`)
+    ]);
+    const module = new Runtime().module(define);
+    return Object.fromEntries(await Promise.all([
+        'expect',
+        'createSuite'
+    ].map(n => module.value(n).then(v => [
+        n,
+        v
+    ]))));
 };
 const _lf943y = function _suite(testing){return(
 testing.createSuite({
@@ -23897,15 +23753,13 @@ suite.test("Collection object creates matching keys", async () => {
   expect(v.value).toHaveProperty("a");
 })
 )};
-const _1qdb7yp = async function _toc()
-{
-  const [{ Runtime }, { default: define }] = await Promise.all([
-    importShim("https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js"
-    , 'https://api.observablehq.com/@tomlarkworthy/view.js?v=4'),
-    importShim(`https://api.observablehq.com/@nebrius/indented-toc.js?v=3`, 'https://api.observablehq.com/@tomlarkworthy/view.js?v=4')
-  ]);
-  const module = new Runtime().module(define);
-  return module.value("toc");
+const _1qdb7yp = async function _toc() {
+    const [{Runtime}, {default: define}] = await Promise.all([
+        import('https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js'),
+        import(`https://api.observablehq.com/@nebrius/indented-toc.js?v=3`)
+    ]);
+    const module = new Runtime().module(define);
+    return module.value('toc');
 };
 
 export default function define(runtime, observer) {
@@ -24624,9 +24478,8 @@ export default function define(runtime, observer) {
   return main;
 }</script>
 
-
 <!-- Bootloader -->
-<script id="bootconf.json" 
+<script id="bootconf.json"
         type="text/plain"
         data-mime="application/json"
 >
@@ -24882,7 +24735,7 @@ export default function define(runtime, observer) {
   const style7 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/syntax-light.css", { with: { type: 'css' } });
   const style8 = await importShim("file://syntax.css", { with: { type: 'css' } });
   document.adoptedStyleSheets = [style0.default,style1.default,style2.default,style3.default,style4.default,style5.default,style6.default,style7.default,style8.default];
-  
+
   const { Runtime } = await importShim("@observablehq/runtime@6.0.0");
   const { Inspector } = await importShim("@observablehq/inspector@5.0.1");
   const notebook = document.querySelector("notebook");

--- a/notebooks/@tomlarkworthy_observablejs-toolchain.html
+++ b/notebooks/@tomlarkworthy_observablejs-toolchain.html
@@ -18500,12 +18500,11 @@ function compile(source, { anonymousName = "_anonymous" } = {}) {
   };
   if (!cell.id && cell.body?.type === "ImportDeclaration") {
     const module_name = cell.body.source.value;
-    const importKeyword = globalThis?.importShim ? "importShim" : "import";
     const cell_variables = [
       {
         _name: `module ${module_name}`,
         _inputs: [],
-        _definition: `async () => runtime.module((await ${importKeyword}("${module_name}")).default)`
+        _definition: `async () => runtime.module((await import("${module_name}")).default)`
       }
     ];
     for (const specifier of cell.body.specifiers ?? []) {

--- a/notebooks/@tomlarkworthy_observablejs-toolchain.json
+++ b/notebooks/@tomlarkworthy_observablejs-toolchain.json
@@ -35,7 +35,7 @@
       ]
     },
     "@tomlarkworthy/acorn-8-11-3": {
-      "hash": "e483cbde82225efd3b3224d603903164",
+      "hash": "cfbb603f9923f42e480bcc24ea214eb4",
       "files": [
         "acorn-8.11.3.js.gz"
       ],
@@ -68,7 +68,7 @@
       ]
     },
     "@tomlarkworthy/claude-code-pairing": {
-      "hash": "566dc503f086b466a90b07a419075dc7",
+      "hash": "e3d2efd40f14f02510af61a5df5b451c",
       "dependsOn": [
         "@tomlarkworthy/module-map",
         "@tomlarkworthy/exporter-3",
@@ -84,7 +84,7 @@
       ]
     },
     "@tomlarkworthy/codemirror-6-v2": {
-      "hash": "b79a37cf1dd24fd22fc89bbde24edd7a",
+      "hash": "18836087c3003723f4abbea3eaa0993a",
       "files": [
         "codemirror_javascript%405.js.gz"
       ],
@@ -112,7 +112,7 @@
       ]
     },
     "@tomlarkworthy/editor-5": {
-      "hash": "c87ba2e3220fa0f518c060503c1f2986",
+      "hash": "aeb7deb7c09b934e8ad21cc137e29834",
       "files": [
         "cell_options.json"
       ],
@@ -145,7 +145,7 @@
       ]
     },
     "@tomlarkworthy/exporter-3": {
-      "hash": "297a85500f06c75afd02cd7c501e0a64",
+      "hash": "5778e38fbc2889783f252eba282b6474",
       "dependsOn": [
         "@tomlarkworthy/observable-runtime-v6",
         "@tomlarkworthy/flow-queue",
@@ -168,7 +168,7 @@
       ]
     },
     "@tomlarkworthy/file-sync": {
-      "hash": "e379596265cd3030c6f98d97aa807b75",
+      "hash": "5ce42c89e483aba06e2434b6834d8da6",
       "dependsOn": [
         "@tomlarkworthy/module-map",
         "@tomlarkworthy/exporter-3",
@@ -181,7 +181,7 @@
       ]
     },
     "@tomlarkworthy/fileattachments": {
-      "hash": "fc07a6c8b39d5fa8495e9b9c8c75edf9",
+      "hash": "fba8f936fac563f937051341f9c4aaf4",
       "dependsOn": [
         "@tomlarkworthy/runtime-sdk"
       ],
@@ -192,7 +192,7 @@
       ]
     },
     "@tomlarkworthy/flow-queue": {
-      "hash": "e6efc6ff2c5841e59bf5f22a2e4fd309",
+      "hash": "5e3c76c417d8ab3c246fd99d61d398be",
       "files": [
         "flowQuery%401.svg"
       ],
@@ -203,7 +203,7 @@
       ]
     },
     "@tomlarkworthy/golden-layout-2-6-0": {
-      "hash": "17b1cfc092e7aa851102ce64ebd95314",
+      "hash": "24f5fad01bd508dd1bc3a49a99002770",
       "files": [
         "golden-layout-2.6.0.js.gz",
         "lm_popout_black.png",
@@ -239,7 +239,7 @@
       ]
     },
     "@tomlarkworthy/isomorphic-git-1-30-1": {
-      "hash": "cc5644744fc51b6badd823767165b905",
+      "hash": "16fa79b79fb4e9e1a2d03cfc9221147c",
       "files": [
         "isomorphic-git-1%401.30.1.bundle.js.gz",
         "isomorphic-git-http-1.0.0-beta.36.js.gz"
@@ -249,7 +249,7 @@
       ]
     },
     "@tomlarkworthy/jest-expect-standalone": {
-      "hash": "5cd12f98a08cd6144369d970a42e41c9",
+      "hash": "418ef3328580c7b2416be5b9fc940db4",
       "files": [
         "jest-expect-standalone-24.0.2.js.gz"
       ],
@@ -260,7 +260,7 @@
       ]
     },
     "@tomlarkworthy/jszip-3-10-1": {
-      "hash": "104d2a3fa76149964a5ec2e78291b7fa",
+      "hash": "2b119c57e9c2ce093b3a9c7d2932d010",
       "files": [
         "jszip-3.10.1.min.js.gz"
       ],
@@ -269,7 +269,7 @@
       ]
     },
     "@tomlarkworthy/lightning-fs-4-6-0": {
-      "hash": "9f29cd8f7d08a51eca9962323ede7620",
+      "hash": "1f60955582df75104615d8061957d237",
       "files": [
         "lightning-fs-4.6.0.js.gz"
       ],
@@ -318,7 +318,7 @@
       ]
     },
     "@tomlarkworthy/lopepage-urls": {
-      "hash": "a41f679233630d379c881e39e3b914e7",
+      "hash": "eee5c7951f9edd92f8fd1dba8442609b",
       "dependsOn": [
         "@tomlarkworthy/runtime-sdk",
         "@tomlarkworthy/tests"
@@ -369,7 +369,7 @@
       ]
     },
     "@tomlarkworthy/observable-runtime": {
-      "hash": "015af244c77d1c0a73fb2aad51c8da83",
+      "hash": "4b60a23333fcadbc20650feae24d4039",
       "files": [
         "runtime.js.gz"
       ],
@@ -378,13 +378,13 @@
       ]
     },
     "@tomlarkworthy/observable-runtime-v6": {
-      "hash": "060835989c27d5cd2f82d358975a0328",
+      "hash": "6bc9db7b1881559c4d30c39f692e3969",
       "dependedBy": [
         "@tomlarkworthy/exporter-3"
       ]
     },
     "@tomlarkworthy/observablejs-toolchain": {
-      "hash": "4fef8e87ae193330ccb6af2ac955aa86",
+      "hash": "bb6dde010924d34011b212a6aba3ccac",
       "files": [
         "acorn-walk-8.3.2.js.gz",
         "parser-6.1.0.js.gz"
@@ -417,7 +417,7 @@
       ]
     },
     "@tomlarkworthy/runtime-sdk": {
-      "hash": "4d565b1b67254742111f1ef9d9aa8220",
+      "hash": "d6da0322104cb2ad8a836559a8e6cf15",
       "dependsOn": [
         "@mootari/access-runtime"
       ],
@@ -485,7 +485,7 @@
       ]
     },
     "@tomlarkworthy/view": {
-      "hash": "16b8cf235bb51d57792ff44ac408e74a",
+      "hash": "970bf1f386002336660773d1215dd61f",
       "dependedBy": [
         "@tomlarkworthy/exporter-3",
         "@tomlarkworthy/reversible-attachment"

--- a/notebooks/@tomlarkworthy_openai-responses-api.html
+++ b/notebooks/@tomlarkworthy_openai-responses-api.html
@@ -5437,58 +5437,41 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _geoudp = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
-  if (command.processed) return;
-
-  let result = undefined;
-  if (command.command == "createCell") {
-    $0.value = true;
-    result = compile_and_update("{}", [], command.args.cell);
-    // For the new one to get focus
-    // setTimeout(() => {
-    //   debugger;
-    //   setOption(result[0], "pinned", true);
-    // }, 100);
-  } else if (command.command == "deleteCell") {
-    remove_variables(command.args.cell.variables);
-    result = true;
-  } else if (command.command == "moveCell") {
-    const cellIndex = findCellIndex(
-      command.args.cell.variables,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const targetCellIndex = cellIndex + command.args.amount;
-    const targetCell = lookupCellByIndex(
-      targetCellIndex,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const currentFirstVariableIndex = findVariableIndex(
-      command.args.cell.variables[0]
-    );
-    const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-    const change = targetFirstVariableIndex - currentFirstVariableIndex;
-    console.log(
-      "moveCell",
-      cellIndex,
-      targetCellIndex,
-      targetCell,
-      currentFirstVariableIndex,
-      targetFirstVariableIndex,
-      change
-    );
-    command.args.cell.variables.forEach((v) => {
-      const currentIndex = findVariableIndex(v);
-      repositionSetElement(runtime._variables, v, currentIndex + change);
-    });
-    // recompute
-    await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
-    result = true;
-  }
-  if (result) {
-    command.processed = true;
-    $2.resolve(result);
-  }
+    if (command.processed)
+        return;
+    let result = undefined;
+    if (command.command == 'createCell') {
+        $0.value = true;
+        result = await compile_and_update('{}', [], command.args.cell);    // For the new one to get focus
+                                                                           // setTimeout(() => {
+                                                                           //   debugger;
+                                                                           //   setOption(result[0], "pinned", true);
+                                                                           // }, 100);
+    } else if (command.command == 'deleteCell') {
+        remove_variables(command.args.cell.variables);
+        result = true;
+    } else if (command.command == 'moveCell') {
+        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const targetCellIndex = cellIndex + command.args.amount;
+        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
+        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+        const change = targetFirstVariableIndex - currentFirstVariableIndex;
+        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
+        command.args.cell.variables.forEach(v => {
+            const currentIndex = findVariableIndex(v);
+            repositionSetElement(runtime._variables, v, currentIndex + change);
+        });
+        // recompute
+        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        result = true;
+    }
+    if (result) {
+        command.processed = true;
+        $2.resolve(result);
+    }
 };
 const _1jadxoe = function _60(md){return(
 md`### UI Action`
@@ -5879,9 +5862,9 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
-    return (source, variables = [], cell) => {
+    return async (source, variables = [], cell) => {
         try {
             debugger;
             let reposition = false, insertionIndex = -1;
@@ -5901,10 +5884,10 @@ const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElemen
             if (reposition) {
                 insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
+            const fns = await realize(newVariables.map(v => v._definition), runtime);
             newVariables.forEach((v, i) => {
                 const variable = variables[i];
-                let _fn;
-                eval('_fn = ' + v._definition);
+                const _fn = fns[i];
                 if (v._name) {
                     variable.define(v._name, v._inputs, _fn);
                 } else {
@@ -5953,12 +5936,11 @@ Inputs.textarea({
 })
 )};
 const _b4rsn5 = (G, _) => G.input(_);
-const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
+const _ga6kci = function _98(Inputs,definition,variable,realize,runtime,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
-  reduce: () => {
-    let _fn;
-    eval("_fn = " + definition);
+  reduce: async () => {
+    const [_fn] = await realize([definition], runtime);
     variable.define(variable._name, inputs, _fn);
   }
 })
@@ -6071,7 +6053,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_geoudp", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _geoudp);  
+  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6109,7 +6091,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
+  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -6119,8 +6101,9 @@ export default function define(runtime, observer) {
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
   $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
-  $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
+  $def("_ga6kci", null, ["Inputs","definition","variable","realize","runtime","inputs"], _ga6kci);  
   $def("_1q557s", null, ["md"], _1q557s);  
+  main.define("realize", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("realize", _));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -16490,10 +16473,9 @@ notebook_semantics_document.nodes.map((s) => ({
 const _1oevsow = function _28(md){return(
 md`### Runtime Representation (v4)`
 )};
-const _11lfflk = function _notebook_semantics_module(){return(
-importShim("https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4"
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _11lfflk = function _notebook_semantics_module() {
+    return import('https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4');
+};
 const _gjten6 = function _31(md){return(
 md`### Imports`
 )};
@@ -17480,65 +17462,44 @@ parser.parseCell(
   'import {runtime, viewof main as foo} from "@mootari/access-runtime"'
 )
 )};
-const _1n7gw17 = function _findModuleName(extractModuleInfo){return(
-(scope, module, { unknown_id = Math.random() } = {}) => {
-  try {
-    const scopedVariables = [...scope.values()];
-
-    // Prefer variables that *define* a module and have a real module-loader name.
-    const candidates = scopedVariables.filter(
-      (v) =>
-        v &&
-        v._value === module &&
-        typeof v._name === "string" &&
-        v._name.startsWith("module ") &&
-        !v._name.startsWith("module <unknown")
-    );
-
-    const pickBestInfo = (dfn) => {
-      // Avoid the parentUrl (2nd arg) confusing module identification.
-      // Typical patterns:
-      //   importShim("/d/<id>@<ver>.js?v=4", "https://api.observablehq.com/@ns/name.js?v=4")
-      //   import("/d/<id>@<ver>.js?v=4")
-      // Prefer the *first argument* inside importShim(...) / import(...) when present.
-      const s = String(dfn ?? "");
-
-      // Try to capture the first string literal argument to importShim(...) or import(...)
-      // Tolerates quotes ", ', ` and both importShim and plain import.
-      const m = s.match(
-        /\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/
-      );
-      const firstArg = m?.[2];
-
-      const info1 = firstArg ? extractModuleInfo(firstArg) : {};
-      if (info1?.id || info1?.notebook) return info1;
-
-      // Fallback: parse the whole definition string.
-      return extractModuleInfo(s);
+const _1n7gw17 = function _findModuleName(extractModuleInfo) {
+    return (scope, module, {
+        unknown_id = Math.random()
+    } = {}) => {
+        try {
+            const scopedVariables = [...scope.values()];
+            const candidates = scopedVariables.filter(v => v && v._value === module && typeof v._name === 'string' && v._name.startsWith('module ') && !v._name.startsWith('module <unknown'));
+            const pickBestInfo = dfn => {
+                const s = String(dfn ?? '');
+                const m = s.match(/\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/);
+                const firstArg = m?.[2];
+                const info1 = firstArg ? extractModuleInfo(firstArg) : {};
+                if (info1?.id || info1?.notebook)
+                    return info1;
+                return extractModuleInfo(s);
+            };
+            for (const v of candidates) {
+                const info = pickBestInfo(v._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            const any = scopedVariables.find(v => v && v._value === module);
+            if (any) {
+                const info = pickBestInfo(any._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            return `<unknown ${ unknown_id }>`;
+        } catch (e) {
+            debugger;
+            return 'error';
+        }
     };
-
-    // Try module loader cells first.
-    for (const v of candidates) {
-      const info = pickBestInfo(v._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    // Fallback: any scoped variable with _value==module.
-    const any = scopedVariables.find((v) => v && v._value === module);
-    if (any) {
-      const info = pickBestInfo(any._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    return `<unknown ${unknown_id}>`;
-  } catch (e) {
-    debugger;
-    return "error";
-  }
-}
-)};
+};
 const _i47chb = function _findImportedName(){return(
 async (v) => {
   if (v._inputs.length == 1 && v._inputs[0]._name === "@variable") {
@@ -18440,229 +18401,206 @@ JSON.stringify(
 const _1lt3kl6 = function _157(compile,test_case){return(
 compile(test_case.value)
 )};
-const _lpzjrv = function _compile(parser,globalThis,observableToJs){return(
-function compile(source, { anonymousName = "_anonymous" } = {}) {
-  const comments = [],
-    tokens = [];
-  let cell;
-  try {
-    cell = parser.parseCell(source, {
-      ranges: true,
-      onComment: comments,
-      onToken: tokens
-    });
-  } catch (e) {
-    if (e instanceof SyntaxError) {
-      const nameMatch = source.match(
-        /^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/
-      );
-      let _name = null;
-      let funcName = anonymousName;
-      if (nameMatch) {
-        const prefix = nameMatch[1] ? nameMatch[1] + " " : "";
-        _name = prefix + nameMatch[2];
-        funcName = "_" + nameMatch[2];
-      }
-      const escapedMsg = JSON.stringify(e.message);
-      const escapedSource = JSON.stringify(source);
-      return [
-        {
-          _name,
-          _inputs: [],
-          _definition: `function ${funcName}() { throw Object.assign(new SyntaxError(${escapedMsg}), {_sourceExpression: ${escapedSource}}); }`
+const _x1d0wm = function _compile(parser,observableToJs){return(
+function compile(source, {
+    anonymousName = '_anonymous'
+} = {}) {
+    const comments = [], tokens = [];
+    let cell;
+    try {
+        cell = parser.parseCell(source, {
+            ranges: true,
+            onComment: comments,
+            onToken: tokens
+        });
+    } catch (e) {
+        if (e instanceof SyntaxError) {
+            const nameMatch = source.match(/^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/);
+            let _name = null;
+            let funcName = anonymousName;
+            if (nameMatch) {
+                const prefix = nameMatch[1] ? nameMatch[1] + ' ' : '';
+                _name = prefix + nameMatch[2];
+                funcName = '_' + nameMatch[2];
+            }
+            const escapedMsg = JSON.stringify(e.message);
+            const escapedSource = JSON.stringify(source);
+            return [{
+                    _name,
+                    _inputs: [],
+                    _definition: `function ${ funcName }() { throw Object.assign(new SyntaxError(${ escapedMsg }), {_sourceExpression: ${ escapedSource }}); }`
+                }];
         }
-      ];
+        throw e;
     }
-    throw e;
-  }
-  if (!cell) throw new Error("Unable to parse cell");
-  const parseImportSpecifierText = (text) => {
-    const t = String(text ?? "")
-      .trim()
-      .replace(/,$/, "")
-      .trim();
-    if (!t) throw new Error("Empty import specifier");
-    const parts = t.split(/\s+as\s+/);
-    const left = parts[0].trim();
-    const right = parts[1]?.trim();
-    const parseSide = (side, { defaultPrefix = "" } = {}) => {
-      const s = String(side ?? "").trim();
-      const m = s.match(/^(viewof|mutable)\s+(.+)$/);
-      if (m)
-        return {
-          prefix: `${m[1]} `,
-          name: m[2].trim()
+    if (!cell)
+        throw new Error('Unable to parse cell');
+    const parseImportSpecifierText = text => {
+        const t = String(text ?? '').trim().replace(/,$/, '').trim();
+        if (!t)
+            throw new Error('Empty import specifier');
+        const parts = t.split(/\s+as\s+/);
+        const left = parts[0].trim();
+        const right = parts[1]?.trim();
+        const parseSide = (side, {
+            defaultPrefix = ''
+        } = {}) => {
+            const s = String(side ?? '').trim();
+            const m = s.match(/^(viewof|mutable)\s+(.+)$/);
+            if (m)
+                return {
+                    prefix: `${ m[1] } `,
+                    name: m[2].trim()
+                };
+            return {
+                prefix: defaultPrefix,
+                name: s
+            };
         };
-      return {
-        prefix: defaultPrefix,
-        name: s
-      };
+        const L = parseSide(left);
+        const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
+        const importedName = `${ L.prefix }${ L.name }`.trim();
+        const localName = `${ R.prefix }${ R.name }`.trim();
+        if (!importedName)
+            throw new Error(`Could not parse imported name from: ${ t }`);
+        if (!localName)
+            throw new Error(`Could not parse local name from: ${ t }`);
+        return {
+            importedName,
+            localName
+        };
     };
-    const L = parseSide(left);
-    const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
-    const importedName = `${L.prefix}${L.name}`.trim();
-    const localName = `${R.prefix}${R.name}`.trim();
-    if (!importedName)
-      throw new Error(`Could not parse imported name from: ${t}`);
-    if (!localName) throw new Error(`Could not parse local name from: ${t}`);
-    return {
-      importedName,
-      localName
-    };
-  };
-  if (!cell.id && cell.body?.type === "ImportDeclaration") {
-    const module_name = cell.body.source.value;
-    const importKeyword = globalThis?.importShim ? "importShim" : "import";
-    const cell_variables = [
-      {
-        _name: `module ${module_name}`,
-        _inputs: [],
-        _definition: `async () => runtime.module((await ${importKeyword}("${module_name}")).default)`
-      }
-    ];
-    for (const specifier of cell.body.specifiers ?? []) {
-      const specText =
-        typeof specifier?.start === "number" &&
-        typeof specifier?.end === "number"
-          ? source.slice(specifier.start, specifier.end)
-          : (() => {
-              if (specifier?.imported?.name && specifier?.local?.name) {
-                return specifier.imported.name === specifier.local.name
-                  ? specifier.local.name
-                  : `${specifier.imported.name} as ${specifier.local.name}`;
-              }
-              throw new Error("Import specifier missing range information");
+    if (!cell.id && cell.body?.type === 'ImportDeclaration') {
+        const module_name = cell.body.source.value;
+        const cell_variables = [{
+                _name: `module ${ module_name }`,
+                _inputs: [],
+                _definition: `async () => runtime.module((await import("${ module_name }")).default)`
+            }];
+        for (const specifier of cell.body.specifiers ?? []) {
+            const specText = typeof specifier?.start === 'number' && typeof specifier?.end === 'number' ? source.slice(specifier.start, specifier.end) : (() => {
+                if (specifier?.imported?.name && specifier?.local?.name) {
+                    return specifier.imported.name === specifier.local.name ? specifier.local.name : `${ specifier.imported.name } as ${ specifier.local.name }`;
+                }
+                throw new Error('Import specifier missing range information');
             })();
-      const { importedName, localName } = parseImportSpecifierText(specText);
-      cell_variables.push({
-        _name: localName,
-        _inputs: [`module ${module_name}`, "@variable"],
-        _definition:
-          importedName === localName
-            ? `(_, v) => v.import("${importedName}", _)`
-            : `(_, v) => v.import("${importedName}", "${localName}", _)`
-      });
+            const {importedName, localName} = parseImportSpecifierText(specText);
+            cell_variables.push({
+                _name: localName,
+                _inputs: [
+                    `module ${ module_name }`,
+                    '@variable'
+                ],
+                _definition: importedName === localName ? `(_, v) => v.import("${ importedName }", _)` : `(_, v) => v.import("${ importedName }", "${ localName }", _)`
+            });
+        }
+        return cell_variables;
     }
-    return cell_variables;
-  }
-  let dollarIdx = 0;
-  const inputToArgMap = {};
-  const dollarToMacro = {};
-  const seen = new Set();
-  const inputs = Array.from(cell.references || []).flatMap((i) => {
-    if (i.name) {
-      if (seen.has(i.name)) return [];
-      seen.add(i.name);
-      return i.name;
+    let dollarIdx = 0;
+    const inputToArgMap = {};
+    const dollarToMacro = {};
+    const seen = new Set();
+    const inputs = Array.from(cell.references || []).flatMap(i => {
+        if (i.name) {
+            if (seen.has(i.name))
+                return [];
+            seen.add(i.name);
+            return i.name;
+        } else {
+            const dedupKey = i.type + ':' + i.id.name;
+            if (seen.has(dedupKey))
+                return [];
+            seen.add(dedupKey);
+            const dollarName = '$' + dollarIdx;
+            inputToArgMap[i.id.name] = dollarName;
+            dollarToMacro[dollarName] = i.type == 'ViewExpression' ? 'viewof ' + i.id.name : 'mutable ' + i.id.name;
+            dollarIdx++;
+            return dollarName;
+        }
+    });
+    let variables;
+    if (cell.id) {
+        if (cell.id.type === 'Identifier') {
+            variables = [{
+                    functionName: '_' + cell.id.name,
+                    name: cell.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                }];
+        } else if (cell.id.type === 'ViewExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'viewof ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '(G, _) => G.input(_)',
+                    inputs: [
+                        'Generators',
+                        'viewof ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                }
+            ];
+        } else if (cell.id.type === 'MutableExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'initial ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'mutable ' + cell.id.id.name,
+                    _definition: '(M, _) => new M(_)',
+                    inputs: [
+                        'Mutable',
+                        'initial ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '_ => _.generator',
+                    inputs: ['mutable ' + cell.id.id.name],
+                    params: inputs.join(',')
+                }
+            ];
+        } else {
+            throw new Error(`Unsupported cell id type: ${ cell.id.type }`);
+        }
     } else {
-      const dedupKey = i.type + ":" + i.id.name;
-      if (seen.has(dedupKey)) return [];
-      seen.add(dedupKey);
-      const dollarName = "$" + dollarIdx;
-      inputToArgMap[i.id.name] = dollarName;
-      dollarToMacro[dollarName] =
-        i.type == "ViewExpression"
-          ? "viewof " + i.id.name
-          : "mutable " + i.id.name;
-      dollarIdx++;
-      return dollarName;
+        variables = [{
+                functionName: anonymousName,
+                name: null,
+                inputs,
+                params: inputs.join(',')
+            }];
     }
-  });
-  let variables;
-  if (cell.id) {
-    if (cell.id.type === "Identifier") {
-      variables = [
-        {
-          functionName: "_" + cell.id.name,
-          name: cell.id.name,
-          inputs,
-          params: inputs.join(",")
+    return variables.map(v => {
+        let _definition = v._definition;
+        if (!_definition) {
+            let functionBody;
+            if (cell.body.type === 'BlockStatement') {
+                functionBody = observableToJs(cell.body, inputToArgMap, comments, tokens);
+            } else {
+                const bodyCode = observableToJs(cell.body, inputToArgMap, comments, tokens);
+                functionBody = `{return (${ bodyCode });}`;
+            }
+            _definition = `${ cell.async ? 'async ' : '' }function${ cell.generator ? '*' : '' } ${ v.functionName }(${ v.inputs.join(',') }) ${ functionBody }`;
         }
-      ];
-    } else if (cell.id.type === "ViewExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "viewof " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "(G, _) => G.input(_)",
-          inputs: ["Generators", "viewof " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else if (cell.id.type === "MutableExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "initial " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "mutable " + cell.id.id.name,
-          _definition: "(M, _) => new M(_)",
-          inputs: ["Mutable", "initial " + cell.id.id.name],
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "_ => _.generator",
-          inputs: ["mutable " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else {
-      throw new Error(`Unsupported cell id type: ${cell.id.type}`);
-    }
-  } else {
-    variables = [
-      {
-        functionName: anonymousName,
-        name: null,
-        inputs,
-        params: inputs.join(",")
-      }
-    ];
-  }
-  return variables.map((v) => {
-    let _definition = v._definition;
-    if (!_definition) {
-      let functionBody;
-      if (cell.body.type === "BlockStatement") {
-        functionBody = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-      } else {
-        const bodyCode = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-        functionBody = `{return (${bodyCode});}`;
-      }
-      _definition = `${cell.async ? "async " : ""}function${
-        cell.generator ? "*" : ""
-      } ${v.functionName}(${v.inputs.join(",")}) ${functionBody}`;
-    }
-    return {
-      _name: v.name,
-      _inputs: v.inputs.map(
-        (i) => dollarToMacro[i] || (i === "$variable" ? "@variable" : i)
-      ),
-      _definition
-    };
-  });
+        return {
+            _name: v.name,
+            _inputs: v.inputs.map(i => dollarToMacro[i] || (i === '$variable' ? '@variable' : i)),
+            _definition
+        };
+    });
 }
 )};
 const _1v1i7wl = function _observableToJs(acorn_walk,parser,escodegen){return(
@@ -18729,16 +18667,15 @@ async (attachment, overrides) => {
   return URL.createObjectURL(blob);
 }
 )};
-const _s9w7ha = async function _parser(decompress_url,FileAttachment,acorn_url,acorn_walk_url){return(
-importShim(await decompress_url(FileAttachment("parser-6.1.0.js.gz"), {
-    "/npm/acorn@8.11.3/+esm": acorn_url,
-    "/npm/acorn-walk@8.3.2/+esm": acorn_walk_url
-  })
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
-const _1hiclbb = function _acorn_walk(acorn_walk_url){return(
-importShim(acorn_walk_url, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _s9w7ha = async function _parser(decompress_url, FileAttachment, acorn_url, acorn_walk_url) {
+    return import(await decompress_url(FileAttachment('parser-6.1.0.js.gz'), {
+        '/npm/acorn@8.11.3/+esm': acorn_url,
+        '/npm/acorn-walk@8.3.2/+esm': acorn_walk_url
+    }));
+};
+const _1hiclbb = function _acorn_walk(acorn_walk_url) {
+    return import(acorn_walk_url);
+};
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
@@ -18926,7 +18863,7 @@ export default function define(runtime, observer) {
   $def("_1dmmuaf", "compiled_selector", ["Generators","viewof compiled_selector"], _1dmmuaf);  
   $def("_u7t3vu", null, ["compiled_selector","normalizeJavascriptSource"], _u7t3vu);  
   $def("_1lt3kl6", null, ["compile","test_case"], _1lt3kl6);  
-  $def("_lpzjrv", "compile", ["parser","globalThis","observableToJs"], _lpzjrv);  
+  $def("_x1d0wm", "compile", ["parser","observableToJs"], _x1d0wm);  
   $def("_1v1i7wl", "observableToJs", ["acorn_walk","parser","escodegen"], _1v1i7wl);  
   $def("_19lv24l", null, ["md"], _19lv24l);  
   $def("_xhj6b8", "decompress_url", ["DecompressionStream","TextDecoderStream","TransformStream","TextEncoderStream","Response"], _xhj6b8);  

--- a/notebooks/@tomlarkworthy_reversible-attachment.html
+++ b/notebooks/@tomlarkworthy_reversible-attachment.html
@@ -5437,58 +5437,41 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _geoudp = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
-  if (command.processed) return;
-
-  let result = undefined;
-  if (command.command == "createCell") {
-    $0.value = true;
-    result = compile_and_update("{}", [], command.args.cell);
-    // For the new one to get focus
-    // setTimeout(() => {
-    //   debugger;
-    //   setOption(result[0], "pinned", true);
-    // }, 100);
-  } else if (command.command == "deleteCell") {
-    remove_variables(command.args.cell.variables);
-    result = true;
-  } else if (command.command == "moveCell") {
-    const cellIndex = findCellIndex(
-      command.args.cell.variables,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const targetCellIndex = cellIndex + command.args.amount;
-    const targetCell = lookupCellByIndex(
-      targetCellIndex,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const currentFirstVariableIndex = findVariableIndex(
-      command.args.cell.variables[0]
-    );
-    const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-    const change = targetFirstVariableIndex - currentFirstVariableIndex;
-    console.log(
-      "moveCell",
-      cellIndex,
-      targetCellIndex,
-      targetCell,
-      currentFirstVariableIndex,
-      targetFirstVariableIndex,
-      change
-    );
-    command.args.cell.variables.forEach((v) => {
-      const currentIndex = findVariableIndex(v);
-      repositionSetElement(runtime._variables, v, currentIndex + change);
-    });
-    // recompute
-    await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
-    result = true;
-  }
-  if (result) {
-    command.processed = true;
-    $2.resolve(result);
-  }
+    if (command.processed)
+        return;
+    let result = undefined;
+    if (command.command == 'createCell') {
+        $0.value = true;
+        result = await compile_and_update('{}', [], command.args.cell);    // For the new one to get focus
+                                                                           // setTimeout(() => {
+                                                                           //   debugger;
+                                                                           //   setOption(result[0], "pinned", true);
+                                                                           // }, 100);
+    } else if (command.command == 'deleteCell') {
+        remove_variables(command.args.cell.variables);
+        result = true;
+    } else if (command.command == 'moveCell') {
+        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const targetCellIndex = cellIndex + command.args.amount;
+        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
+        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+        const change = targetFirstVariableIndex - currentFirstVariableIndex;
+        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
+        command.args.cell.variables.forEach(v => {
+            const currentIndex = findVariableIndex(v);
+            repositionSetElement(runtime._variables, v, currentIndex + change);
+        });
+        // recompute
+        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        result = true;
+    }
+    if (result) {
+        command.processed = true;
+        $2.resolve(result);
+    }
 };
 const _1jadxoe = function _60(md){return(
 md`### UI Action`
@@ -5879,9 +5862,9 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
-    return (source, variables = [], cell) => {
+    return async (source, variables = [], cell) => {
         try {
             debugger;
             let reposition = false, insertionIndex = -1;
@@ -5901,10 +5884,10 @@ const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElemen
             if (reposition) {
                 insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
+            const fns = await realize(newVariables.map(v => v._definition), runtime);
             newVariables.forEach((v, i) => {
                 const variable = variables[i];
-                let _fn;
-                eval('_fn = ' + v._definition);
+                const _fn = fns[i];
                 if (v._name) {
                     variable.define(v._name, v._inputs, _fn);
                 } else {
@@ -5953,12 +5936,11 @@ Inputs.textarea({
 })
 )};
 const _b4rsn5 = (G, _) => G.input(_);
-const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
+const _ga6kci = function _98(Inputs,definition,variable,realize,runtime,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
-  reduce: () => {
-    let _fn;
-    eval("_fn = " + definition);
+  reduce: async () => {
+    const [_fn] = await realize([definition], runtime);
     variable.define(variable._name, inputs, _fn);
   }
 })
@@ -6071,7 +6053,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_geoudp", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _geoudp);  
+  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6109,7 +6091,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
+  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -6119,8 +6101,9 @@ export default function define(runtime, observer) {
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
   $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
-  $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
+  $def("_ga6kci", null, ["Inputs","definition","variable","realize","runtime","inputs"], _ga6kci);  
   $def("_1q557s", null, ["md"], _1q557s);  
+  main.define("realize", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("realize", _));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -16490,10 +16473,9 @@ notebook_semantics_document.nodes.map((s) => ({
 const _1oevsow = function _28(md){return(
 md`### Runtime Representation (v4)`
 )};
-const _11lfflk = function _notebook_semantics_module(){return(
-importShim("https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4"
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _11lfflk = function _notebook_semantics_module() {
+    return import('https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4');
+};
 const _gjten6 = function _31(md){return(
 md`### Imports`
 )};
@@ -17480,65 +17462,44 @@ parser.parseCell(
   'import {runtime, viewof main as foo} from "@mootari/access-runtime"'
 )
 )};
-const _1n7gw17 = function _findModuleName(extractModuleInfo){return(
-(scope, module, { unknown_id = Math.random() } = {}) => {
-  try {
-    const scopedVariables = [...scope.values()];
-
-    // Prefer variables that *define* a module and have a real module-loader name.
-    const candidates = scopedVariables.filter(
-      (v) =>
-        v &&
-        v._value === module &&
-        typeof v._name === "string" &&
-        v._name.startsWith("module ") &&
-        !v._name.startsWith("module <unknown")
-    );
-
-    const pickBestInfo = (dfn) => {
-      // Avoid the parentUrl (2nd arg) confusing module identification.
-      // Typical patterns:
-      //   importShim("/d/<id>@<ver>.js?v=4", "https://api.observablehq.com/@ns/name.js?v=4")
-      //   import("/d/<id>@<ver>.js?v=4")
-      // Prefer the *first argument* inside importShim(...) / import(...) when present.
-      const s = String(dfn ?? "");
-
-      // Try to capture the first string literal argument to importShim(...) or import(...)
-      // Tolerates quotes ", ', ` and both importShim and plain import.
-      const m = s.match(
-        /\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/
-      );
-      const firstArg = m?.[2];
-
-      const info1 = firstArg ? extractModuleInfo(firstArg) : {};
-      if (info1?.id || info1?.notebook) return info1;
-
-      // Fallback: parse the whole definition string.
-      return extractModuleInfo(s);
+const _1n7gw17 = function _findModuleName(extractModuleInfo) {
+    return (scope, module, {
+        unknown_id = Math.random()
+    } = {}) => {
+        try {
+            const scopedVariables = [...scope.values()];
+            const candidates = scopedVariables.filter(v => v && v._value === module && typeof v._name === 'string' && v._name.startsWith('module ') && !v._name.startsWith('module <unknown'));
+            const pickBestInfo = dfn => {
+                const s = String(dfn ?? '');
+                const m = s.match(/\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/);
+                const firstArg = m?.[2];
+                const info1 = firstArg ? extractModuleInfo(firstArg) : {};
+                if (info1?.id || info1?.notebook)
+                    return info1;
+                return extractModuleInfo(s);
+            };
+            for (const v of candidates) {
+                const info = pickBestInfo(v._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            const any = scopedVariables.find(v => v && v._value === module);
+            if (any) {
+                const info = pickBestInfo(any._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            return `<unknown ${ unknown_id }>`;
+        } catch (e) {
+            debugger;
+            return 'error';
+        }
     };
-
-    // Try module loader cells first.
-    for (const v of candidates) {
-      const info = pickBestInfo(v._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    // Fallback: any scoped variable with _value==module.
-    const any = scopedVariables.find((v) => v && v._value === module);
-    if (any) {
-      const info = pickBestInfo(any._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    return `<unknown ${unknown_id}>`;
-  } catch (e) {
-    debugger;
-    return "error";
-  }
-}
-)};
+};
 const _i47chb = function _findImportedName(){return(
 async (v) => {
   if (v._inputs.length == 1 && v._inputs[0]._name === "@variable") {
@@ -18440,229 +18401,206 @@ JSON.stringify(
 const _1lt3kl6 = function _157(compile,test_case){return(
 compile(test_case.value)
 )};
-const _lpzjrv = function _compile(parser,globalThis,observableToJs){return(
-function compile(source, { anonymousName = "_anonymous" } = {}) {
-  const comments = [],
-    tokens = [];
-  let cell;
-  try {
-    cell = parser.parseCell(source, {
-      ranges: true,
-      onComment: comments,
-      onToken: tokens
-    });
-  } catch (e) {
-    if (e instanceof SyntaxError) {
-      const nameMatch = source.match(
-        /^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/
-      );
-      let _name = null;
-      let funcName = anonymousName;
-      if (nameMatch) {
-        const prefix = nameMatch[1] ? nameMatch[1] + " " : "";
-        _name = prefix + nameMatch[2];
-        funcName = "_" + nameMatch[2];
-      }
-      const escapedMsg = JSON.stringify(e.message);
-      const escapedSource = JSON.stringify(source);
-      return [
-        {
-          _name,
-          _inputs: [],
-          _definition: `function ${funcName}() { throw Object.assign(new SyntaxError(${escapedMsg}), {_sourceExpression: ${escapedSource}}); }`
+const _x1d0wm = function _compile(parser,observableToJs){return(
+function compile(source, {
+    anonymousName = '_anonymous'
+} = {}) {
+    const comments = [], tokens = [];
+    let cell;
+    try {
+        cell = parser.parseCell(source, {
+            ranges: true,
+            onComment: comments,
+            onToken: tokens
+        });
+    } catch (e) {
+        if (e instanceof SyntaxError) {
+            const nameMatch = source.match(/^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/);
+            let _name = null;
+            let funcName = anonymousName;
+            if (nameMatch) {
+                const prefix = nameMatch[1] ? nameMatch[1] + ' ' : '';
+                _name = prefix + nameMatch[2];
+                funcName = '_' + nameMatch[2];
+            }
+            const escapedMsg = JSON.stringify(e.message);
+            const escapedSource = JSON.stringify(source);
+            return [{
+                    _name,
+                    _inputs: [],
+                    _definition: `function ${ funcName }() { throw Object.assign(new SyntaxError(${ escapedMsg }), {_sourceExpression: ${ escapedSource }}); }`
+                }];
         }
-      ];
+        throw e;
     }
-    throw e;
-  }
-  if (!cell) throw new Error("Unable to parse cell");
-  const parseImportSpecifierText = (text) => {
-    const t = String(text ?? "")
-      .trim()
-      .replace(/,$/, "")
-      .trim();
-    if (!t) throw new Error("Empty import specifier");
-    const parts = t.split(/\s+as\s+/);
-    const left = parts[0].trim();
-    const right = parts[1]?.trim();
-    const parseSide = (side, { defaultPrefix = "" } = {}) => {
-      const s = String(side ?? "").trim();
-      const m = s.match(/^(viewof|mutable)\s+(.+)$/);
-      if (m)
-        return {
-          prefix: `${m[1]} `,
-          name: m[2].trim()
+    if (!cell)
+        throw new Error('Unable to parse cell');
+    const parseImportSpecifierText = text => {
+        const t = String(text ?? '').trim().replace(/,$/, '').trim();
+        if (!t)
+            throw new Error('Empty import specifier');
+        const parts = t.split(/\s+as\s+/);
+        const left = parts[0].trim();
+        const right = parts[1]?.trim();
+        const parseSide = (side, {
+            defaultPrefix = ''
+        } = {}) => {
+            const s = String(side ?? '').trim();
+            const m = s.match(/^(viewof|mutable)\s+(.+)$/);
+            if (m)
+                return {
+                    prefix: `${ m[1] } `,
+                    name: m[2].trim()
+                };
+            return {
+                prefix: defaultPrefix,
+                name: s
+            };
         };
-      return {
-        prefix: defaultPrefix,
-        name: s
-      };
+        const L = parseSide(left);
+        const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
+        const importedName = `${ L.prefix }${ L.name }`.trim();
+        const localName = `${ R.prefix }${ R.name }`.trim();
+        if (!importedName)
+            throw new Error(`Could not parse imported name from: ${ t }`);
+        if (!localName)
+            throw new Error(`Could not parse local name from: ${ t }`);
+        return {
+            importedName,
+            localName
+        };
     };
-    const L = parseSide(left);
-    const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
-    const importedName = `${L.prefix}${L.name}`.trim();
-    const localName = `${R.prefix}${R.name}`.trim();
-    if (!importedName)
-      throw new Error(`Could not parse imported name from: ${t}`);
-    if (!localName) throw new Error(`Could not parse local name from: ${t}`);
-    return {
-      importedName,
-      localName
-    };
-  };
-  if (!cell.id && cell.body?.type === "ImportDeclaration") {
-    const module_name = cell.body.source.value;
-    const importKeyword = globalThis?.importShim ? "importShim" : "import";
-    const cell_variables = [
-      {
-        _name: `module ${module_name}`,
-        _inputs: [],
-        _definition: `async () => runtime.module((await ${importKeyword}("${module_name}")).default)`
-      }
-    ];
-    for (const specifier of cell.body.specifiers ?? []) {
-      const specText =
-        typeof specifier?.start === "number" &&
-        typeof specifier?.end === "number"
-          ? source.slice(specifier.start, specifier.end)
-          : (() => {
-              if (specifier?.imported?.name && specifier?.local?.name) {
-                return specifier.imported.name === specifier.local.name
-                  ? specifier.local.name
-                  : `${specifier.imported.name} as ${specifier.local.name}`;
-              }
-              throw new Error("Import specifier missing range information");
+    if (!cell.id && cell.body?.type === 'ImportDeclaration') {
+        const module_name = cell.body.source.value;
+        const cell_variables = [{
+                _name: `module ${ module_name }`,
+                _inputs: [],
+                _definition: `async () => runtime.module((await import("${ module_name }")).default)`
+            }];
+        for (const specifier of cell.body.specifiers ?? []) {
+            const specText = typeof specifier?.start === 'number' && typeof specifier?.end === 'number' ? source.slice(specifier.start, specifier.end) : (() => {
+                if (specifier?.imported?.name && specifier?.local?.name) {
+                    return specifier.imported.name === specifier.local.name ? specifier.local.name : `${ specifier.imported.name } as ${ specifier.local.name }`;
+                }
+                throw new Error('Import specifier missing range information');
             })();
-      const { importedName, localName } = parseImportSpecifierText(specText);
-      cell_variables.push({
-        _name: localName,
-        _inputs: [`module ${module_name}`, "@variable"],
-        _definition:
-          importedName === localName
-            ? `(_, v) => v.import("${importedName}", _)`
-            : `(_, v) => v.import("${importedName}", "${localName}", _)`
-      });
+            const {importedName, localName} = parseImportSpecifierText(specText);
+            cell_variables.push({
+                _name: localName,
+                _inputs: [
+                    `module ${ module_name }`,
+                    '@variable'
+                ],
+                _definition: importedName === localName ? `(_, v) => v.import("${ importedName }", _)` : `(_, v) => v.import("${ importedName }", "${ localName }", _)`
+            });
+        }
+        return cell_variables;
     }
-    return cell_variables;
-  }
-  let dollarIdx = 0;
-  const inputToArgMap = {};
-  const dollarToMacro = {};
-  const seen = new Set();
-  const inputs = Array.from(cell.references || []).flatMap((i) => {
-    if (i.name) {
-      if (seen.has(i.name)) return [];
-      seen.add(i.name);
-      return i.name;
+    let dollarIdx = 0;
+    const inputToArgMap = {};
+    const dollarToMacro = {};
+    const seen = new Set();
+    const inputs = Array.from(cell.references || []).flatMap(i => {
+        if (i.name) {
+            if (seen.has(i.name))
+                return [];
+            seen.add(i.name);
+            return i.name;
+        } else {
+            const dedupKey = i.type + ':' + i.id.name;
+            if (seen.has(dedupKey))
+                return [];
+            seen.add(dedupKey);
+            const dollarName = '$' + dollarIdx;
+            inputToArgMap[i.id.name] = dollarName;
+            dollarToMacro[dollarName] = i.type == 'ViewExpression' ? 'viewof ' + i.id.name : 'mutable ' + i.id.name;
+            dollarIdx++;
+            return dollarName;
+        }
+    });
+    let variables;
+    if (cell.id) {
+        if (cell.id.type === 'Identifier') {
+            variables = [{
+                    functionName: '_' + cell.id.name,
+                    name: cell.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                }];
+        } else if (cell.id.type === 'ViewExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'viewof ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '(G, _) => G.input(_)',
+                    inputs: [
+                        'Generators',
+                        'viewof ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                }
+            ];
+        } else if (cell.id.type === 'MutableExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'initial ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'mutable ' + cell.id.id.name,
+                    _definition: '(M, _) => new M(_)',
+                    inputs: [
+                        'Mutable',
+                        'initial ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '_ => _.generator',
+                    inputs: ['mutable ' + cell.id.id.name],
+                    params: inputs.join(',')
+                }
+            ];
+        } else {
+            throw new Error(`Unsupported cell id type: ${ cell.id.type }`);
+        }
     } else {
-      const dedupKey = i.type + ":" + i.id.name;
-      if (seen.has(dedupKey)) return [];
-      seen.add(dedupKey);
-      const dollarName = "$" + dollarIdx;
-      inputToArgMap[i.id.name] = dollarName;
-      dollarToMacro[dollarName] =
-        i.type == "ViewExpression"
-          ? "viewof " + i.id.name
-          : "mutable " + i.id.name;
-      dollarIdx++;
-      return dollarName;
+        variables = [{
+                functionName: anonymousName,
+                name: null,
+                inputs,
+                params: inputs.join(',')
+            }];
     }
-  });
-  let variables;
-  if (cell.id) {
-    if (cell.id.type === "Identifier") {
-      variables = [
-        {
-          functionName: "_" + cell.id.name,
-          name: cell.id.name,
-          inputs,
-          params: inputs.join(",")
+    return variables.map(v => {
+        let _definition = v._definition;
+        if (!_definition) {
+            let functionBody;
+            if (cell.body.type === 'BlockStatement') {
+                functionBody = observableToJs(cell.body, inputToArgMap, comments, tokens);
+            } else {
+                const bodyCode = observableToJs(cell.body, inputToArgMap, comments, tokens);
+                functionBody = `{return (${ bodyCode });}`;
+            }
+            _definition = `${ cell.async ? 'async ' : '' }function${ cell.generator ? '*' : '' } ${ v.functionName }(${ v.inputs.join(',') }) ${ functionBody }`;
         }
-      ];
-    } else if (cell.id.type === "ViewExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "viewof " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "(G, _) => G.input(_)",
-          inputs: ["Generators", "viewof " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else if (cell.id.type === "MutableExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "initial " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "mutable " + cell.id.id.name,
-          _definition: "(M, _) => new M(_)",
-          inputs: ["Mutable", "initial " + cell.id.id.name],
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "_ => _.generator",
-          inputs: ["mutable " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else {
-      throw new Error(`Unsupported cell id type: ${cell.id.type}`);
-    }
-  } else {
-    variables = [
-      {
-        functionName: anonymousName,
-        name: null,
-        inputs,
-        params: inputs.join(",")
-      }
-    ];
-  }
-  return variables.map((v) => {
-    let _definition = v._definition;
-    if (!_definition) {
-      let functionBody;
-      if (cell.body.type === "BlockStatement") {
-        functionBody = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-      } else {
-        const bodyCode = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-        functionBody = `{return (${bodyCode});}`;
-      }
-      _definition = `${cell.async ? "async " : ""}function${
-        cell.generator ? "*" : ""
-      } ${v.functionName}(${v.inputs.join(",")}) ${functionBody}`;
-    }
-    return {
-      _name: v.name,
-      _inputs: v.inputs.map(
-        (i) => dollarToMacro[i] || (i === "$variable" ? "@variable" : i)
-      ),
-      _definition
-    };
-  });
+        return {
+            _name: v.name,
+            _inputs: v.inputs.map(i => dollarToMacro[i] || (i === '$variable' ? '@variable' : i)),
+            _definition
+        };
+    });
 }
 )};
 const _1v1i7wl = function _observableToJs(acorn_walk,parser,escodegen){return(
@@ -18729,16 +18667,15 @@ async (attachment, overrides) => {
   return URL.createObjectURL(blob);
 }
 )};
-const _s9w7ha = async function _parser(decompress_url,FileAttachment,acorn_url,acorn_walk_url){return(
-importShim(await decompress_url(FileAttachment("parser-6.1.0.js.gz"), {
-    "/npm/acorn@8.11.3/+esm": acorn_url,
-    "/npm/acorn-walk@8.3.2/+esm": acorn_walk_url
-  })
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
-const _1hiclbb = function _acorn_walk(acorn_walk_url){return(
-importShim(acorn_walk_url, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _s9w7ha = async function _parser(decompress_url, FileAttachment, acorn_url, acorn_walk_url) {
+    return import(await decompress_url(FileAttachment('parser-6.1.0.js.gz'), {
+        '/npm/acorn@8.11.3/+esm': acorn_url,
+        '/npm/acorn-walk@8.3.2/+esm': acorn_walk_url
+    }));
+};
+const _1hiclbb = function _acorn_walk(acorn_walk_url) {
+    return import(acorn_walk_url);
+};
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
@@ -18926,7 +18863,7 @@ export default function define(runtime, observer) {
   $def("_1dmmuaf", "compiled_selector", ["Generators","viewof compiled_selector"], _1dmmuaf);  
   $def("_u7t3vu", null, ["compiled_selector","normalizeJavascriptSource"], _u7t3vu);  
   $def("_1lt3kl6", null, ["compile","test_case"], _1lt3kl6);  
-  $def("_lpzjrv", "compile", ["parser","globalThis","observableToJs"], _lpzjrv);  
+  $def("_x1d0wm", "compile", ["parser","observableToJs"], _x1d0wm);  
   $def("_1v1i7wl", "observableToJs", ["acorn_walk","parser","escodegen"], _1v1i7wl);  
   $def("_19lv24l", null, ["md"], _19lv24l);  
   $def("_xhj6b8", "decompress_url", ["DecompressionStream","TextDecoderStream","TransformStream","TextEncoderStream","Response"], _xhj6b8);  

--- a/notebooks/@tomlarkworthy_robocoop-2.html
+++ b/notebooks/@tomlarkworthy_robocoop-2.html
@@ -5437,58 +5437,41 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _geoudp = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
-  if (command.processed) return;
-
-  let result = undefined;
-  if (command.command == "createCell") {
-    $0.value = true;
-    result = compile_and_update("{}", [], command.args.cell);
-    // For the new one to get focus
-    // setTimeout(() => {
-    //   debugger;
-    //   setOption(result[0], "pinned", true);
-    // }, 100);
-  } else if (command.command == "deleteCell") {
-    remove_variables(command.args.cell.variables);
-    result = true;
-  } else if (command.command == "moveCell") {
-    const cellIndex = findCellIndex(
-      command.args.cell.variables,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const targetCellIndex = cellIndex + command.args.amount;
-    const targetCell = lookupCellByIndex(
-      targetCellIndex,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const currentFirstVariableIndex = findVariableIndex(
-      command.args.cell.variables[0]
-    );
-    const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-    const change = targetFirstVariableIndex - currentFirstVariableIndex;
-    console.log(
-      "moveCell",
-      cellIndex,
-      targetCellIndex,
-      targetCell,
-      currentFirstVariableIndex,
-      targetFirstVariableIndex,
-      change
-    );
-    command.args.cell.variables.forEach((v) => {
-      const currentIndex = findVariableIndex(v);
-      repositionSetElement(runtime._variables, v, currentIndex + change);
-    });
-    // recompute
-    await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
-    result = true;
-  }
-  if (result) {
-    command.processed = true;
-    $2.resolve(result);
-  }
+    if (command.processed)
+        return;
+    let result = undefined;
+    if (command.command == 'createCell') {
+        $0.value = true;
+        result = await compile_and_update('{}', [], command.args.cell);    // For the new one to get focus
+                                                                           // setTimeout(() => {
+                                                                           //   debugger;
+                                                                           //   setOption(result[0], "pinned", true);
+                                                                           // }, 100);
+    } else if (command.command == 'deleteCell') {
+        remove_variables(command.args.cell.variables);
+        result = true;
+    } else if (command.command == 'moveCell') {
+        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const targetCellIndex = cellIndex + command.args.amount;
+        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
+        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+        const change = targetFirstVariableIndex - currentFirstVariableIndex;
+        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
+        command.args.cell.variables.forEach(v => {
+            const currentIndex = findVariableIndex(v);
+            repositionSetElement(runtime._variables, v, currentIndex + change);
+        });
+        // recompute
+        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        result = true;
+    }
+    if (result) {
+        command.processed = true;
+        $2.resolve(result);
+    }
 };
 const _1jadxoe = function _60(md){return(
 md`### UI Action`
@@ -5879,9 +5862,9 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
-    return (source, variables = [], cell) => {
+    return async (source, variables = [], cell) => {
         try {
             debugger;
             let reposition = false, insertionIndex = -1;
@@ -5901,10 +5884,10 @@ const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElemen
             if (reposition) {
                 insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
+            const fns = await realize(newVariables.map(v => v._definition), runtime);
             newVariables.forEach((v, i) => {
                 const variable = variables[i];
-                let _fn;
-                eval('_fn = ' + v._definition);
+                const _fn = fns[i];
                 if (v._name) {
                     variable.define(v._name, v._inputs, _fn);
                 } else {
@@ -5953,12 +5936,11 @@ Inputs.textarea({
 })
 )};
 const _b4rsn5 = (G, _) => G.input(_);
-const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
+const _ga6kci = function _98(Inputs,definition,variable,realize,runtime,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
-  reduce: () => {
-    let _fn;
-    eval("_fn = " + definition);
+  reduce: async () => {
+    const [_fn] = await realize([definition], runtime);
     variable.define(variable._name, inputs, _fn);
   }
 })
@@ -6071,7 +6053,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_geoudp", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _geoudp);  
+  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6109,7 +6091,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
+  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -6119,8 +6101,9 @@ export default function define(runtime, observer) {
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
   $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
-  $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
+  $def("_ga6kci", null, ["Inputs","definition","variable","realize","runtime","inputs"], _ga6kci);  
   $def("_1q557s", null, ["md"], _1q557s);  
+  main.define("realize", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("realize", _));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -16545,10 +16528,9 @@ notebook_semantics_document.nodes.map((s) => ({
 const _1oevsow = function _28(md){return(
 md`### Runtime Representation (v4)`
 )};
-const _11lfflk = function _notebook_semantics_module(){return(
-importShim("https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4"
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _11lfflk = function _notebook_semantics_module() {
+    return import('https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4');
+};
 const _gjten6 = function _31(md){return(
 md`### Imports`
 )};
@@ -17535,65 +17517,44 @@ parser.parseCell(
   'import {runtime, viewof main as foo} from "@mootari/access-runtime"'
 )
 )};
-const _1n7gw17 = function _findModuleName(extractModuleInfo){return(
-(scope, module, { unknown_id = Math.random() } = {}) => {
-  try {
-    const scopedVariables = [...scope.values()];
-
-    // Prefer variables that *define* a module and have a real module-loader name.
-    const candidates = scopedVariables.filter(
-      (v) =>
-        v &&
-        v._value === module &&
-        typeof v._name === "string" &&
-        v._name.startsWith("module ") &&
-        !v._name.startsWith("module <unknown")
-    );
-
-    const pickBestInfo = (dfn) => {
-      // Avoid the parentUrl (2nd arg) confusing module identification.
-      // Typical patterns:
-      //   importShim("/d/<id>@<ver>.js?v=4", "https://api.observablehq.com/@ns/name.js?v=4")
-      //   import("/d/<id>@<ver>.js?v=4")
-      // Prefer the *first argument* inside importShim(...) / import(...) when present.
-      const s = String(dfn ?? "");
-
-      // Try to capture the first string literal argument to importShim(...) or import(...)
-      // Tolerates quotes ", ', ` and both importShim and plain import.
-      const m = s.match(
-        /\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/
-      );
-      const firstArg = m?.[2];
-
-      const info1 = firstArg ? extractModuleInfo(firstArg) : {};
-      if (info1?.id || info1?.notebook) return info1;
-
-      // Fallback: parse the whole definition string.
-      return extractModuleInfo(s);
+const _1n7gw17 = function _findModuleName(extractModuleInfo) {
+    return (scope, module, {
+        unknown_id = Math.random()
+    } = {}) => {
+        try {
+            const scopedVariables = [...scope.values()];
+            const candidates = scopedVariables.filter(v => v && v._value === module && typeof v._name === 'string' && v._name.startsWith('module ') && !v._name.startsWith('module <unknown'));
+            const pickBestInfo = dfn => {
+                const s = String(dfn ?? '');
+                const m = s.match(/\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/);
+                const firstArg = m?.[2];
+                const info1 = firstArg ? extractModuleInfo(firstArg) : {};
+                if (info1?.id || info1?.notebook)
+                    return info1;
+                return extractModuleInfo(s);
+            };
+            for (const v of candidates) {
+                const info = pickBestInfo(v._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            const any = scopedVariables.find(v => v && v._value === module);
+            if (any) {
+                const info = pickBestInfo(any._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            return `<unknown ${ unknown_id }>`;
+        } catch (e) {
+            debugger;
+            return 'error';
+        }
     };
-
-    // Try module loader cells first.
-    for (const v of candidates) {
-      const info = pickBestInfo(v._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    // Fallback: any scoped variable with _value==module.
-    const any = scopedVariables.find((v) => v && v._value === module);
-    if (any) {
-      const info = pickBestInfo(any._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    return `<unknown ${unknown_id}>`;
-  } catch (e) {
-    debugger;
-    return "error";
-  }
-}
-)};
+};
 const _i47chb = function _findImportedName(){return(
 async (v) => {
   if (v._inputs.length == 1 && v._inputs[0]._name === "@variable") {
@@ -18495,229 +18456,206 @@ JSON.stringify(
 const _1lt3kl6 = function _157(compile,test_case){return(
 compile(test_case.value)
 )};
-const _lpzjrv = function _compile(parser,globalThis,observableToJs){return(
-function compile(source, { anonymousName = "_anonymous" } = {}) {
-  const comments = [],
-    tokens = [];
-  let cell;
-  try {
-    cell = parser.parseCell(source, {
-      ranges: true,
-      onComment: comments,
-      onToken: tokens
-    });
-  } catch (e) {
-    if (e instanceof SyntaxError) {
-      const nameMatch = source.match(
-        /^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/
-      );
-      let _name = null;
-      let funcName = anonymousName;
-      if (nameMatch) {
-        const prefix = nameMatch[1] ? nameMatch[1] + " " : "";
-        _name = prefix + nameMatch[2];
-        funcName = "_" + nameMatch[2];
-      }
-      const escapedMsg = JSON.stringify(e.message);
-      const escapedSource = JSON.stringify(source);
-      return [
-        {
-          _name,
-          _inputs: [],
-          _definition: `function ${funcName}() { throw Object.assign(new SyntaxError(${escapedMsg}), {_sourceExpression: ${escapedSource}}); }`
+const _x1d0wm = function _compile(parser,observableToJs){return(
+function compile(source, {
+    anonymousName = '_anonymous'
+} = {}) {
+    const comments = [], tokens = [];
+    let cell;
+    try {
+        cell = parser.parseCell(source, {
+            ranges: true,
+            onComment: comments,
+            onToken: tokens
+        });
+    } catch (e) {
+        if (e instanceof SyntaxError) {
+            const nameMatch = source.match(/^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/);
+            let _name = null;
+            let funcName = anonymousName;
+            if (nameMatch) {
+                const prefix = nameMatch[1] ? nameMatch[1] + ' ' : '';
+                _name = prefix + nameMatch[2];
+                funcName = '_' + nameMatch[2];
+            }
+            const escapedMsg = JSON.stringify(e.message);
+            const escapedSource = JSON.stringify(source);
+            return [{
+                    _name,
+                    _inputs: [],
+                    _definition: `function ${ funcName }() { throw Object.assign(new SyntaxError(${ escapedMsg }), {_sourceExpression: ${ escapedSource }}); }`
+                }];
         }
-      ];
+        throw e;
     }
-    throw e;
-  }
-  if (!cell) throw new Error("Unable to parse cell");
-  const parseImportSpecifierText = (text) => {
-    const t = String(text ?? "")
-      .trim()
-      .replace(/,$/, "")
-      .trim();
-    if (!t) throw new Error("Empty import specifier");
-    const parts = t.split(/\s+as\s+/);
-    const left = parts[0].trim();
-    const right = parts[1]?.trim();
-    const parseSide = (side, { defaultPrefix = "" } = {}) => {
-      const s = String(side ?? "").trim();
-      const m = s.match(/^(viewof|mutable)\s+(.+)$/);
-      if (m)
-        return {
-          prefix: `${m[1]} `,
-          name: m[2].trim()
+    if (!cell)
+        throw new Error('Unable to parse cell');
+    const parseImportSpecifierText = text => {
+        const t = String(text ?? '').trim().replace(/,$/, '').trim();
+        if (!t)
+            throw new Error('Empty import specifier');
+        const parts = t.split(/\s+as\s+/);
+        const left = parts[0].trim();
+        const right = parts[1]?.trim();
+        const parseSide = (side, {
+            defaultPrefix = ''
+        } = {}) => {
+            const s = String(side ?? '').trim();
+            const m = s.match(/^(viewof|mutable)\s+(.+)$/);
+            if (m)
+                return {
+                    prefix: `${ m[1] } `,
+                    name: m[2].trim()
+                };
+            return {
+                prefix: defaultPrefix,
+                name: s
+            };
         };
-      return {
-        prefix: defaultPrefix,
-        name: s
-      };
+        const L = parseSide(left);
+        const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
+        const importedName = `${ L.prefix }${ L.name }`.trim();
+        const localName = `${ R.prefix }${ R.name }`.trim();
+        if (!importedName)
+            throw new Error(`Could not parse imported name from: ${ t }`);
+        if (!localName)
+            throw new Error(`Could not parse local name from: ${ t }`);
+        return {
+            importedName,
+            localName
+        };
     };
-    const L = parseSide(left);
-    const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
-    const importedName = `${L.prefix}${L.name}`.trim();
-    const localName = `${R.prefix}${R.name}`.trim();
-    if (!importedName)
-      throw new Error(`Could not parse imported name from: ${t}`);
-    if (!localName) throw new Error(`Could not parse local name from: ${t}`);
-    return {
-      importedName,
-      localName
-    };
-  };
-  if (!cell.id && cell.body?.type === "ImportDeclaration") {
-    const module_name = cell.body.source.value;
-    const importKeyword = globalThis?.importShim ? "importShim" : "import";
-    const cell_variables = [
-      {
-        _name: `module ${module_name}`,
-        _inputs: [],
-        _definition: `async () => runtime.module((await ${importKeyword}("${module_name}")).default)`
-      }
-    ];
-    for (const specifier of cell.body.specifiers ?? []) {
-      const specText =
-        typeof specifier?.start === "number" &&
-        typeof specifier?.end === "number"
-          ? source.slice(specifier.start, specifier.end)
-          : (() => {
-              if (specifier?.imported?.name && specifier?.local?.name) {
-                return specifier.imported.name === specifier.local.name
-                  ? specifier.local.name
-                  : `${specifier.imported.name} as ${specifier.local.name}`;
-              }
-              throw new Error("Import specifier missing range information");
+    if (!cell.id && cell.body?.type === 'ImportDeclaration') {
+        const module_name = cell.body.source.value;
+        const cell_variables = [{
+                _name: `module ${ module_name }`,
+                _inputs: [],
+                _definition: `async () => runtime.module((await import("${ module_name }")).default)`
+            }];
+        for (const specifier of cell.body.specifiers ?? []) {
+            const specText = typeof specifier?.start === 'number' && typeof specifier?.end === 'number' ? source.slice(specifier.start, specifier.end) : (() => {
+                if (specifier?.imported?.name && specifier?.local?.name) {
+                    return specifier.imported.name === specifier.local.name ? specifier.local.name : `${ specifier.imported.name } as ${ specifier.local.name }`;
+                }
+                throw new Error('Import specifier missing range information');
             })();
-      const { importedName, localName } = parseImportSpecifierText(specText);
-      cell_variables.push({
-        _name: localName,
-        _inputs: [`module ${module_name}`, "@variable"],
-        _definition:
-          importedName === localName
-            ? `(_, v) => v.import("${importedName}", _)`
-            : `(_, v) => v.import("${importedName}", "${localName}", _)`
-      });
+            const {importedName, localName} = parseImportSpecifierText(specText);
+            cell_variables.push({
+                _name: localName,
+                _inputs: [
+                    `module ${ module_name }`,
+                    '@variable'
+                ],
+                _definition: importedName === localName ? `(_, v) => v.import("${ importedName }", _)` : `(_, v) => v.import("${ importedName }", "${ localName }", _)`
+            });
+        }
+        return cell_variables;
     }
-    return cell_variables;
-  }
-  let dollarIdx = 0;
-  const inputToArgMap = {};
-  const dollarToMacro = {};
-  const seen = new Set();
-  const inputs = Array.from(cell.references || []).flatMap((i) => {
-    if (i.name) {
-      if (seen.has(i.name)) return [];
-      seen.add(i.name);
-      return i.name;
+    let dollarIdx = 0;
+    const inputToArgMap = {};
+    const dollarToMacro = {};
+    const seen = new Set();
+    const inputs = Array.from(cell.references || []).flatMap(i => {
+        if (i.name) {
+            if (seen.has(i.name))
+                return [];
+            seen.add(i.name);
+            return i.name;
+        } else {
+            const dedupKey = i.type + ':' + i.id.name;
+            if (seen.has(dedupKey))
+                return [];
+            seen.add(dedupKey);
+            const dollarName = '$' + dollarIdx;
+            inputToArgMap[i.id.name] = dollarName;
+            dollarToMacro[dollarName] = i.type == 'ViewExpression' ? 'viewof ' + i.id.name : 'mutable ' + i.id.name;
+            dollarIdx++;
+            return dollarName;
+        }
+    });
+    let variables;
+    if (cell.id) {
+        if (cell.id.type === 'Identifier') {
+            variables = [{
+                    functionName: '_' + cell.id.name,
+                    name: cell.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                }];
+        } else if (cell.id.type === 'ViewExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'viewof ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '(G, _) => G.input(_)',
+                    inputs: [
+                        'Generators',
+                        'viewof ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                }
+            ];
+        } else if (cell.id.type === 'MutableExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'initial ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'mutable ' + cell.id.id.name,
+                    _definition: '(M, _) => new M(_)',
+                    inputs: [
+                        'Mutable',
+                        'initial ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '_ => _.generator',
+                    inputs: ['mutable ' + cell.id.id.name],
+                    params: inputs.join(',')
+                }
+            ];
+        } else {
+            throw new Error(`Unsupported cell id type: ${ cell.id.type }`);
+        }
     } else {
-      const dedupKey = i.type + ":" + i.id.name;
-      if (seen.has(dedupKey)) return [];
-      seen.add(dedupKey);
-      const dollarName = "$" + dollarIdx;
-      inputToArgMap[i.id.name] = dollarName;
-      dollarToMacro[dollarName] =
-        i.type == "ViewExpression"
-          ? "viewof " + i.id.name
-          : "mutable " + i.id.name;
-      dollarIdx++;
-      return dollarName;
+        variables = [{
+                functionName: anonymousName,
+                name: null,
+                inputs,
+                params: inputs.join(',')
+            }];
     }
-  });
-  let variables;
-  if (cell.id) {
-    if (cell.id.type === "Identifier") {
-      variables = [
-        {
-          functionName: "_" + cell.id.name,
-          name: cell.id.name,
-          inputs,
-          params: inputs.join(",")
+    return variables.map(v => {
+        let _definition = v._definition;
+        if (!_definition) {
+            let functionBody;
+            if (cell.body.type === 'BlockStatement') {
+                functionBody = observableToJs(cell.body, inputToArgMap, comments, tokens);
+            } else {
+                const bodyCode = observableToJs(cell.body, inputToArgMap, comments, tokens);
+                functionBody = `{return (${ bodyCode });}`;
+            }
+            _definition = `${ cell.async ? 'async ' : '' }function${ cell.generator ? '*' : '' } ${ v.functionName }(${ v.inputs.join(',') }) ${ functionBody }`;
         }
-      ];
-    } else if (cell.id.type === "ViewExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "viewof " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "(G, _) => G.input(_)",
-          inputs: ["Generators", "viewof " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else if (cell.id.type === "MutableExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "initial " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "mutable " + cell.id.id.name,
-          _definition: "(M, _) => new M(_)",
-          inputs: ["Mutable", "initial " + cell.id.id.name],
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "_ => _.generator",
-          inputs: ["mutable " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else {
-      throw new Error(`Unsupported cell id type: ${cell.id.type}`);
-    }
-  } else {
-    variables = [
-      {
-        functionName: anonymousName,
-        name: null,
-        inputs,
-        params: inputs.join(",")
-      }
-    ];
-  }
-  return variables.map((v) => {
-    let _definition = v._definition;
-    if (!_definition) {
-      let functionBody;
-      if (cell.body.type === "BlockStatement") {
-        functionBody = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-      } else {
-        const bodyCode = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-        functionBody = `{return (${bodyCode});}`;
-      }
-      _definition = `${cell.async ? "async " : ""}function${
-        cell.generator ? "*" : ""
-      } ${v.functionName}(${v.inputs.join(",")}) ${functionBody}`;
-    }
-    return {
-      _name: v.name,
-      _inputs: v.inputs.map(
-        (i) => dollarToMacro[i] || (i === "$variable" ? "@variable" : i)
-      ),
-      _definition
-    };
-  });
+        return {
+            _name: v.name,
+            _inputs: v.inputs.map(i => dollarToMacro[i] || (i === '$variable' ? '@variable' : i)),
+            _definition
+        };
+    });
 }
 )};
 const _1v1i7wl = function _observableToJs(acorn_walk,parser,escodegen){return(
@@ -18784,16 +18722,15 @@ async (attachment, overrides) => {
   return URL.createObjectURL(blob);
 }
 )};
-const _s9w7ha = async function _parser(decompress_url,FileAttachment,acorn_url,acorn_walk_url){return(
-importShim(await decompress_url(FileAttachment("parser-6.1.0.js.gz"), {
-    "/npm/acorn@8.11.3/+esm": acorn_url,
-    "/npm/acorn-walk@8.3.2/+esm": acorn_walk_url
-  })
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
-const _1hiclbb = function _acorn_walk(acorn_walk_url){return(
-importShim(acorn_walk_url, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _s9w7ha = async function _parser(decompress_url, FileAttachment, acorn_url, acorn_walk_url) {
+    return import(await decompress_url(FileAttachment('parser-6.1.0.js.gz'), {
+        '/npm/acorn@8.11.3/+esm': acorn_url,
+        '/npm/acorn-walk@8.3.2/+esm': acorn_walk_url
+    }));
+};
+const _1hiclbb = function _acorn_walk(acorn_walk_url) {
+    return import(acorn_walk_url);
+};
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
@@ -18981,7 +18918,7 @@ export default function define(runtime, observer) {
   $def("_1dmmuaf", "compiled_selector", ["Generators","viewof compiled_selector"], _1dmmuaf);  
   $def("_u7t3vu", null, ["compiled_selector","normalizeJavascriptSource"], _u7t3vu);  
   $def("_1lt3kl6", null, ["compile","test_case"], _1lt3kl6);  
-  $def("_lpzjrv", "compile", ["parser","globalThis","observableToJs"], _lpzjrv);  
+  $def("_x1d0wm", "compile", ["parser","observableToJs"], _x1d0wm);  
   $def("_1v1i7wl", "observableToJs", ["acorn_walk","parser","escodegen"], _1v1i7wl);  
   $def("_19lv24l", null, ["md"], _19lv24l);  
   $def("_xhj6b8", "decompress_url", ["DecompressionStream","TextDecoderStream","TransformStream","TextEncoderStream","Response"], _xhj6b8);  

--- a/notebooks/@tomlarkworthy_robocoop-3.html
+++ b/notebooks/@tomlarkworthy_robocoop-3.html
@@ -5437,58 +5437,41 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _geoudp = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
-  if (command.processed) return;
-
-  let result = undefined;
-  if (command.command == "createCell") {
-    $0.value = true;
-    result = compile_and_update("{}", [], command.args.cell);
-    // For the new one to get focus
-    // setTimeout(() => {
-    //   debugger;
-    //   setOption(result[0], "pinned", true);
-    // }, 100);
-  } else if (command.command == "deleteCell") {
-    remove_variables(command.args.cell.variables);
-    result = true;
-  } else if (command.command == "moveCell") {
-    const cellIndex = findCellIndex(
-      command.args.cell.variables,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const targetCellIndex = cellIndex + command.args.amount;
-    const targetCell = lookupCellByIndex(
-      targetCellIndex,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const currentFirstVariableIndex = findVariableIndex(
-      command.args.cell.variables[0]
-    );
-    const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-    const change = targetFirstVariableIndex - currentFirstVariableIndex;
-    console.log(
-      "moveCell",
-      cellIndex,
-      targetCellIndex,
-      targetCell,
-      currentFirstVariableIndex,
-      targetFirstVariableIndex,
-      change
-    );
-    command.args.cell.variables.forEach((v) => {
-      const currentIndex = findVariableIndex(v);
-      repositionSetElement(runtime._variables, v, currentIndex + change);
-    });
-    // recompute
-    await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
-    result = true;
-  }
-  if (result) {
-    command.processed = true;
-    $2.resolve(result);
-  }
+    if (command.processed)
+        return;
+    let result = undefined;
+    if (command.command == 'createCell') {
+        $0.value = true;
+        result = await compile_and_update('{}', [], command.args.cell);    // For the new one to get focus
+                                                                           // setTimeout(() => {
+                                                                           //   debugger;
+                                                                           //   setOption(result[0], "pinned", true);
+                                                                           // }, 100);
+    } else if (command.command == 'deleteCell') {
+        remove_variables(command.args.cell.variables);
+        result = true;
+    } else if (command.command == 'moveCell') {
+        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const targetCellIndex = cellIndex + command.args.amount;
+        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
+        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+        const change = targetFirstVariableIndex - currentFirstVariableIndex;
+        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
+        command.args.cell.variables.forEach(v => {
+            const currentIndex = findVariableIndex(v);
+            repositionSetElement(runtime._variables, v, currentIndex + change);
+        });
+        // recompute
+        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        result = true;
+    }
+    if (result) {
+        command.processed = true;
+        $2.resolve(result);
+    }
 };
 const _1jadxoe = function _60(md){return(
 md`### UI Action`
@@ -5879,9 +5862,9 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
-    return (source, variables = [], cell) => {
+    return async (source, variables = [], cell) => {
         try {
             debugger;
             let reposition = false, insertionIndex = -1;
@@ -5901,10 +5884,10 @@ const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElemen
             if (reposition) {
                 insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
+            const fns = await realize(newVariables.map(v => v._definition), runtime);
             newVariables.forEach((v, i) => {
                 const variable = variables[i];
-                let _fn;
-                eval('_fn = ' + v._definition);
+                const _fn = fns[i];
                 if (v._name) {
                     variable.define(v._name, v._inputs, _fn);
                 } else {
@@ -5953,12 +5936,11 @@ Inputs.textarea({
 })
 )};
 const _b4rsn5 = (G, _) => G.input(_);
-const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
+const _ga6kci = function _98(Inputs,definition,variable,realize,runtime,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
-  reduce: () => {
-    let _fn;
-    eval("_fn = " + definition);
+  reduce: async () => {
+    const [_fn] = await realize([definition], runtime);
     variable.define(variable._name, inputs, _fn);
   }
 })
@@ -6071,7 +6053,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_geoudp", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _geoudp);  
+  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6109,7 +6091,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
+  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -6119,8 +6101,9 @@ export default function define(runtime, observer) {
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
   $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
-  $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
+  $def("_ga6kci", null, ["Inputs","definition","variable","realize","runtime","inputs"], _ga6kci);  
   $def("_1q557s", null, ["md"], _1q557s);  
+  main.define("realize", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("realize", _));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -16545,10 +16528,9 @@ notebook_semantics_document.nodes.map((s) => ({
 const _1oevsow = function _28(md){return(
 md`### Runtime Representation (v4)`
 )};
-const _11lfflk = function _notebook_semantics_module(){return(
-importShim("https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4"
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _11lfflk = function _notebook_semantics_module() {
+    return import('https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4');
+};
 const _gjten6 = function _31(md){return(
 md`### Imports`
 )};
@@ -17535,65 +17517,44 @@ parser.parseCell(
   'import {runtime, viewof main as foo} from "@mootari/access-runtime"'
 )
 )};
-const _1n7gw17 = function _findModuleName(extractModuleInfo){return(
-(scope, module, { unknown_id = Math.random() } = {}) => {
-  try {
-    const scopedVariables = [...scope.values()];
-
-    // Prefer variables that *define* a module and have a real module-loader name.
-    const candidates = scopedVariables.filter(
-      (v) =>
-        v &&
-        v._value === module &&
-        typeof v._name === "string" &&
-        v._name.startsWith("module ") &&
-        !v._name.startsWith("module <unknown")
-    );
-
-    const pickBestInfo = (dfn) => {
-      // Avoid the parentUrl (2nd arg) confusing module identification.
-      // Typical patterns:
-      //   importShim("/d/<id>@<ver>.js?v=4", "https://api.observablehq.com/@ns/name.js?v=4")
-      //   import("/d/<id>@<ver>.js?v=4")
-      // Prefer the *first argument* inside importShim(...) / import(...) when present.
-      const s = String(dfn ?? "");
-
-      // Try to capture the first string literal argument to importShim(...) or import(...)
-      // Tolerates quotes ", ', ` and both importShim and plain import.
-      const m = s.match(
-        /\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/
-      );
-      const firstArg = m?.[2];
-
-      const info1 = firstArg ? extractModuleInfo(firstArg) : {};
-      if (info1?.id || info1?.notebook) return info1;
-
-      // Fallback: parse the whole definition string.
-      return extractModuleInfo(s);
+const _1n7gw17 = function _findModuleName(extractModuleInfo) {
+    return (scope, module, {
+        unknown_id = Math.random()
+    } = {}) => {
+        try {
+            const scopedVariables = [...scope.values()];
+            const candidates = scopedVariables.filter(v => v && v._value === module && typeof v._name === 'string' && v._name.startsWith('module ') && !v._name.startsWith('module <unknown'));
+            const pickBestInfo = dfn => {
+                const s = String(dfn ?? '');
+                const m = s.match(/\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/);
+                const firstArg = m?.[2];
+                const info1 = firstArg ? extractModuleInfo(firstArg) : {};
+                if (info1?.id || info1?.notebook)
+                    return info1;
+                return extractModuleInfo(s);
+            };
+            for (const v of candidates) {
+                const info = pickBestInfo(v._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            const any = scopedVariables.find(v => v && v._value === module);
+            if (any) {
+                const info = pickBestInfo(any._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            return `<unknown ${ unknown_id }>`;
+        } catch (e) {
+            debugger;
+            return 'error';
+        }
     };
-
-    // Try module loader cells first.
-    for (const v of candidates) {
-      const info = pickBestInfo(v._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    // Fallback: any scoped variable with _value==module.
-    const any = scopedVariables.find((v) => v && v._value === module);
-    if (any) {
-      const info = pickBestInfo(any._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    return `<unknown ${unknown_id}>`;
-  } catch (e) {
-    debugger;
-    return "error";
-  }
-}
-)};
+};
 const _i47chb = function _findImportedName(){return(
 async (v) => {
   if (v._inputs.length == 1 && v._inputs[0]._name === "@variable") {
@@ -18495,229 +18456,206 @@ JSON.stringify(
 const _1lt3kl6 = function _157(compile,test_case){return(
 compile(test_case.value)
 )};
-const _lpzjrv = function _compile(parser,globalThis,observableToJs){return(
-function compile(source, { anonymousName = "_anonymous" } = {}) {
-  const comments = [],
-    tokens = [];
-  let cell;
-  try {
-    cell = parser.parseCell(source, {
-      ranges: true,
-      onComment: comments,
-      onToken: tokens
-    });
-  } catch (e) {
-    if (e instanceof SyntaxError) {
-      const nameMatch = source.match(
-        /^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/
-      );
-      let _name = null;
-      let funcName = anonymousName;
-      if (nameMatch) {
-        const prefix = nameMatch[1] ? nameMatch[1] + " " : "";
-        _name = prefix + nameMatch[2];
-        funcName = "_" + nameMatch[2];
-      }
-      const escapedMsg = JSON.stringify(e.message);
-      const escapedSource = JSON.stringify(source);
-      return [
-        {
-          _name,
-          _inputs: [],
-          _definition: `function ${funcName}() { throw Object.assign(new SyntaxError(${escapedMsg}), {_sourceExpression: ${escapedSource}}); }`
+const _x1d0wm = function _compile(parser,observableToJs){return(
+function compile(source, {
+    anonymousName = '_anonymous'
+} = {}) {
+    const comments = [], tokens = [];
+    let cell;
+    try {
+        cell = parser.parseCell(source, {
+            ranges: true,
+            onComment: comments,
+            onToken: tokens
+        });
+    } catch (e) {
+        if (e instanceof SyntaxError) {
+            const nameMatch = source.match(/^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/);
+            let _name = null;
+            let funcName = anonymousName;
+            if (nameMatch) {
+                const prefix = nameMatch[1] ? nameMatch[1] + ' ' : '';
+                _name = prefix + nameMatch[2];
+                funcName = '_' + nameMatch[2];
+            }
+            const escapedMsg = JSON.stringify(e.message);
+            const escapedSource = JSON.stringify(source);
+            return [{
+                    _name,
+                    _inputs: [],
+                    _definition: `function ${ funcName }() { throw Object.assign(new SyntaxError(${ escapedMsg }), {_sourceExpression: ${ escapedSource }}); }`
+                }];
         }
-      ];
+        throw e;
     }
-    throw e;
-  }
-  if (!cell) throw new Error("Unable to parse cell");
-  const parseImportSpecifierText = (text) => {
-    const t = String(text ?? "")
-      .trim()
-      .replace(/,$/, "")
-      .trim();
-    if (!t) throw new Error("Empty import specifier");
-    const parts = t.split(/\s+as\s+/);
-    const left = parts[0].trim();
-    const right = parts[1]?.trim();
-    const parseSide = (side, { defaultPrefix = "" } = {}) => {
-      const s = String(side ?? "").trim();
-      const m = s.match(/^(viewof|mutable)\s+(.+)$/);
-      if (m)
-        return {
-          prefix: `${m[1]} `,
-          name: m[2].trim()
+    if (!cell)
+        throw new Error('Unable to parse cell');
+    const parseImportSpecifierText = text => {
+        const t = String(text ?? '').trim().replace(/,$/, '').trim();
+        if (!t)
+            throw new Error('Empty import specifier');
+        const parts = t.split(/\s+as\s+/);
+        const left = parts[0].trim();
+        const right = parts[1]?.trim();
+        const parseSide = (side, {
+            defaultPrefix = ''
+        } = {}) => {
+            const s = String(side ?? '').trim();
+            const m = s.match(/^(viewof|mutable)\s+(.+)$/);
+            if (m)
+                return {
+                    prefix: `${ m[1] } `,
+                    name: m[2].trim()
+                };
+            return {
+                prefix: defaultPrefix,
+                name: s
+            };
         };
-      return {
-        prefix: defaultPrefix,
-        name: s
-      };
+        const L = parseSide(left);
+        const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
+        const importedName = `${ L.prefix }${ L.name }`.trim();
+        const localName = `${ R.prefix }${ R.name }`.trim();
+        if (!importedName)
+            throw new Error(`Could not parse imported name from: ${ t }`);
+        if (!localName)
+            throw new Error(`Could not parse local name from: ${ t }`);
+        return {
+            importedName,
+            localName
+        };
     };
-    const L = parseSide(left);
-    const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
-    const importedName = `${L.prefix}${L.name}`.trim();
-    const localName = `${R.prefix}${R.name}`.trim();
-    if (!importedName)
-      throw new Error(`Could not parse imported name from: ${t}`);
-    if (!localName) throw new Error(`Could not parse local name from: ${t}`);
-    return {
-      importedName,
-      localName
-    };
-  };
-  if (!cell.id && cell.body?.type === "ImportDeclaration") {
-    const module_name = cell.body.source.value;
-    const importKeyword = globalThis?.importShim ? "importShim" : "import";
-    const cell_variables = [
-      {
-        _name: `module ${module_name}`,
-        _inputs: [],
-        _definition: `async () => runtime.module((await ${importKeyword}("${module_name}")).default)`
-      }
-    ];
-    for (const specifier of cell.body.specifiers ?? []) {
-      const specText =
-        typeof specifier?.start === "number" &&
-        typeof specifier?.end === "number"
-          ? source.slice(specifier.start, specifier.end)
-          : (() => {
-              if (specifier?.imported?.name && specifier?.local?.name) {
-                return specifier.imported.name === specifier.local.name
-                  ? specifier.local.name
-                  : `${specifier.imported.name} as ${specifier.local.name}`;
-              }
-              throw new Error("Import specifier missing range information");
+    if (!cell.id && cell.body?.type === 'ImportDeclaration') {
+        const module_name = cell.body.source.value;
+        const cell_variables = [{
+                _name: `module ${ module_name }`,
+                _inputs: [],
+                _definition: `async () => runtime.module((await import("${ module_name }")).default)`
+            }];
+        for (const specifier of cell.body.specifiers ?? []) {
+            const specText = typeof specifier?.start === 'number' && typeof specifier?.end === 'number' ? source.slice(specifier.start, specifier.end) : (() => {
+                if (specifier?.imported?.name && specifier?.local?.name) {
+                    return specifier.imported.name === specifier.local.name ? specifier.local.name : `${ specifier.imported.name } as ${ specifier.local.name }`;
+                }
+                throw new Error('Import specifier missing range information');
             })();
-      const { importedName, localName } = parseImportSpecifierText(specText);
-      cell_variables.push({
-        _name: localName,
-        _inputs: [`module ${module_name}`, "@variable"],
-        _definition:
-          importedName === localName
-            ? `(_, v) => v.import("${importedName}", _)`
-            : `(_, v) => v.import("${importedName}", "${localName}", _)`
-      });
+            const {importedName, localName} = parseImportSpecifierText(specText);
+            cell_variables.push({
+                _name: localName,
+                _inputs: [
+                    `module ${ module_name }`,
+                    '@variable'
+                ],
+                _definition: importedName === localName ? `(_, v) => v.import("${ importedName }", _)` : `(_, v) => v.import("${ importedName }", "${ localName }", _)`
+            });
+        }
+        return cell_variables;
     }
-    return cell_variables;
-  }
-  let dollarIdx = 0;
-  const inputToArgMap = {};
-  const dollarToMacro = {};
-  const seen = new Set();
-  const inputs = Array.from(cell.references || []).flatMap((i) => {
-    if (i.name) {
-      if (seen.has(i.name)) return [];
-      seen.add(i.name);
-      return i.name;
+    let dollarIdx = 0;
+    const inputToArgMap = {};
+    const dollarToMacro = {};
+    const seen = new Set();
+    const inputs = Array.from(cell.references || []).flatMap(i => {
+        if (i.name) {
+            if (seen.has(i.name))
+                return [];
+            seen.add(i.name);
+            return i.name;
+        } else {
+            const dedupKey = i.type + ':' + i.id.name;
+            if (seen.has(dedupKey))
+                return [];
+            seen.add(dedupKey);
+            const dollarName = '$' + dollarIdx;
+            inputToArgMap[i.id.name] = dollarName;
+            dollarToMacro[dollarName] = i.type == 'ViewExpression' ? 'viewof ' + i.id.name : 'mutable ' + i.id.name;
+            dollarIdx++;
+            return dollarName;
+        }
+    });
+    let variables;
+    if (cell.id) {
+        if (cell.id.type === 'Identifier') {
+            variables = [{
+                    functionName: '_' + cell.id.name,
+                    name: cell.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                }];
+        } else if (cell.id.type === 'ViewExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'viewof ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '(G, _) => G.input(_)',
+                    inputs: [
+                        'Generators',
+                        'viewof ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                }
+            ];
+        } else if (cell.id.type === 'MutableExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'initial ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'mutable ' + cell.id.id.name,
+                    _definition: '(M, _) => new M(_)',
+                    inputs: [
+                        'Mutable',
+                        'initial ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '_ => _.generator',
+                    inputs: ['mutable ' + cell.id.id.name],
+                    params: inputs.join(',')
+                }
+            ];
+        } else {
+            throw new Error(`Unsupported cell id type: ${ cell.id.type }`);
+        }
     } else {
-      const dedupKey = i.type + ":" + i.id.name;
-      if (seen.has(dedupKey)) return [];
-      seen.add(dedupKey);
-      const dollarName = "$" + dollarIdx;
-      inputToArgMap[i.id.name] = dollarName;
-      dollarToMacro[dollarName] =
-        i.type == "ViewExpression"
-          ? "viewof " + i.id.name
-          : "mutable " + i.id.name;
-      dollarIdx++;
-      return dollarName;
+        variables = [{
+                functionName: anonymousName,
+                name: null,
+                inputs,
+                params: inputs.join(',')
+            }];
     }
-  });
-  let variables;
-  if (cell.id) {
-    if (cell.id.type === "Identifier") {
-      variables = [
-        {
-          functionName: "_" + cell.id.name,
-          name: cell.id.name,
-          inputs,
-          params: inputs.join(",")
+    return variables.map(v => {
+        let _definition = v._definition;
+        if (!_definition) {
+            let functionBody;
+            if (cell.body.type === 'BlockStatement') {
+                functionBody = observableToJs(cell.body, inputToArgMap, comments, tokens);
+            } else {
+                const bodyCode = observableToJs(cell.body, inputToArgMap, comments, tokens);
+                functionBody = `{return (${ bodyCode });}`;
+            }
+            _definition = `${ cell.async ? 'async ' : '' }function${ cell.generator ? '*' : '' } ${ v.functionName }(${ v.inputs.join(',') }) ${ functionBody }`;
         }
-      ];
-    } else if (cell.id.type === "ViewExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "viewof " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "(G, _) => G.input(_)",
-          inputs: ["Generators", "viewof " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else if (cell.id.type === "MutableExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "initial " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "mutable " + cell.id.id.name,
-          _definition: "(M, _) => new M(_)",
-          inputs: ["Mutable", "initial " + cell.id.id.name],
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "_ => _.generator",
-          inputs: ["mutable " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else {
-      throw new Error(`Unsupported cell id type: ${cell.id.type}`);
-    }
-  } else {
-    variables = [
-      {
-        functionName: anonymousName,
-        name: null,
-        inputs,
-        params: inputs.join(",")
-      }
-    ];
-  }
-  return variables.map((v) => {
-    let _definition = v._definition;
-    if (!_definition) {
-      let functionBody;
-      if (cell.body.type === "BlockStatement") {
-        functionBody = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-      } else {
-        const bodyCode = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-        functionBody = `{return (${bodyCode});}`;
-      }
-      _definition = `${cell.async ? "async " : ""}function${
-        cell.generator ? "*" : ""
-      } ${v.functionName}(${v.inputs.join(",")}) ${functionBody}`;
-    }
-    return {
-      _name: v.name,
-      _inputs: v.inputs.map(
-        (i) => dollarToMacro[i] || (i === "$variable" ? "@variable" : i)
-      ),
-      _definition
-    };
-  });
+        return {
+            _name: v.name,
+            _inputs: v.inputs.map(i => dollarToMacro[i] || (i === '$variable' ? '@variable' : i)),
+            _definition
+        };
+    });
 }
 )};
 const _1v1i7wl = function _observableToJs(acorn_walk,parser,escodegen){return(
@@ -18784,16 +18722,15 @@ async (attachment, overrides) => {
   return URL.createObjectURL(blob);
 }
 )};
-const _s9w7ha = async function _parser(decompress_url,FileAttachment,acorn_url,acorn_walk_url){return(
-importShim(await decompress_url(FileAttachment("parser-6.1.0.js.gz"), {
-    "/npm/acorn@8.11.3/+esm": acorn_url,
-    "/npm/acorn-walk@8.3.2/+esm": acorn_walk_url
-  })
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
-const _1hiclbb = function _acorn_walk(acorn_walk_url){return(
-importShim(acorn_walk_url, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _s9w7ha = async function _parser(decompress_url, FileAttachment, acorn_url, acorn_walk_url) {
+    return import(await decompress_url(FileAttachment('parser-6.1.0.js.gz'), {
+        '/npm/acorn@8.11.3/+esm': acorn_url,
+        '/npm/acorn-walk@8.3.2/+esm': acorn_walk_url
+    }));
+};
+const _1hiclbb = function _acorn_walk(acorn_walk_url) {
+    return import(acorn_walk_url);
+};
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
@@ -18981,7 +18918,7 @@ export default function define(runtime, observer) {
   $def("_1dmmuaf", "compiled_selector", ["Generators","viewof compiled_selector"], _1dmmuaf);  
   $def("_u7t3vu", null, ["compiled_selector","normalizeJavascriptSource"], _u7t3vu);  
   $def("_1lt3kl6", null, ["compile","test_case"], _1lt3kl6);  
-  $def("_lpzjrv", "compile", ["parser","globalThis","observableToJs"], _lpzjrv);  
+  $def("_x1d0wm", "compile", ["parser","observableToJs"], _x1d0wm);  
   $def("_1v1i7wl", "observableToJs", ["acorn_walk","parser","escodegen"], _1v1i7wl);  
   $def("_19lv24l", null, ["md"], _19lv24l);  
   $def("_xhj6b8", "decompress_url", ["DecompressionStream","TextDecoderStream","TransformStream","TextEncoderStream","Response"], _xhj6b8);  

--- a/notebooks/@tomlarkworthy_runtime-sdk.html
+++ b/notebooks/@tomlarkworthy_runtime-sdk.html
@@ -5437,58 +5437,41 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _geoudp = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
-  if (command.processed) return;
-
-  let result = undefined;
-  if (command.command == "createCell") {
-    $0.value = true;
-    result = compile_and_update("{}", [], command.args.cell);
-    // For the new one to get focus
-    // setTimeout(() => {
-    //   debugger;
-    //   setOption(result[0], "pinned", true);
-    // }, 100);
-  } else if (command.command == "deleteCell") {
-    remove_variables(command.args.cell.variables);
-    result = true;
-  } else if (command.command == "moveCell") {
-    const cellIndex = findCellIndex(
-      command.args.cell.variables,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const targetCellIndex = cellIndex + command.args.amount;
-    const targetCell = lookupCellByIndex(
-      targetCellIndex,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const currentFirstVariableIndex = findVariableIndex(
-      command.args.cell.variables[0]
-    );
-    const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-    const change = targetFirstVariableIndex - currentFirstVariableIndex;
-    console.log(
-      "moveCell",
-      cellIndex,
-      targetCellIndex,
-      targetCell,
-      currentFirstVariableIndex,
-      targetFirstVariableIndex,
-      change
-    );
-    command.args.cell.variables.forEach((v) => {
-      const currentIndex = findVariableIndex(v);
-      repositionSetElement(runtime._variables, v, currentIndex + change);
-    });
-    // recompute
-    await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
-    result = true;
-  }
-  if (result) {
-    command.processed = true;
-    $2.resolve(result);
-  }
+    if (command.processed)
+        return;
+    let result = undefined;
+    if (command.command == 'createCell') {
+        $0.value = true;
+        result = await compile_and_update('{}', [], command.args.cell);    // For the new one to get focus
+                                                                           // setTimeout(() => {
+                                                                           //   debugger;
+                                                                           //   setOption(result[0], "pinned", true);
+                                                                           // }, 100);
+    } else if (command.command == 'deleteCell') {
+        remove_variables(command.args.cell.variables);
+        result = true;
+    } else if (command.command == 'moveCell') {
+        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const targetCellIndex = cellIndex + command.args.amount;
+        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
+        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+        const change = targetFirstVariableIndex - currentFirstVariableIndex;
+        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
+        command.args.cell.variables.forEach(v => {
+            const currentIndex = findVariableIndex(v);
+            repositionSetElement(runtime._variables, v, currentIndex + change);
+        });
+        // recompute
+        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        result = true;
+    }
+    if (result) {
+        command.processed = true;
+        $2.resolve(result);
+    }
 };
 const _1jadxoe = function _60(md){return(
 md`### UI Action`
@@ -5879,9 +5862,9 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
-    return (source, variables = [], cell) => {
+    return async (source, variables = [], cell) => {
         try {
             debugger;
             let reposition = false, insertionIndex = -1;
@@ -5901,10 +5884,10 @@ const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElemen
             if (reposition) {
                 insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
+            const fns = await realize(newVariables.map(v => v._definition), runtime);
             newVariables.forEach((v, i) => {
                 const variable = variables[i];
-                let _fn;
-                eval('_fn = ' + v._definition);
+                const _fn = fns[i];
                 if (v._name) {
                     variable.define(v._name, v._inputs, _fn);
                 } else {
@@ -5953,12 +5936,11 @@ Inputs.textarea({
 })
 )};
 const _b4rsn5 = (G, _) => G.input(_);
-const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
+const _ga6kci = function _98(Inputs,definition,variable,realize,runtime,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
-  reduce: () => {
-    let _fn;
-    eval("_fn = " + definition);
+  reduce: async () => {
+    const [_fn] = await realize([definition], runtime);
     variable.define(variable._name, inputs, _fn);
   }
 })
@@ -6071,7 +6053,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_geoudp", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _geoudp);  
+  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6109,7 +6091,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
+  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -6119,8 +6101,9 @@ export default function define(runtime, observer) {
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
   $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
-  $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
+  $def("_ga6kci", null, ["Inputs","definition","variable","realize","runtime","inputs"], _ga6kci);  
   $def("_1q557s", null, ["md"], _1q557s);  
+  main.define("realize", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("realize", _));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -16490,10 +16473,9 @@ notebook_semantics_document.nodes.map((s) => ({
 const _1oevsow = function _28(md){return(
 md`### Runtime Representation (v4)`
 )};
-const _11lfflk = function _notebook_semantics_module(){return(
-importShim("https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4"
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _11lfflk = function _notebook_semantics_module() {
+    return import('https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4');
+};
 const _gjten6 = function _31(md){return(
 md`### Imports`
 )};
@@ -17480,65 +17462,44 @@ parser.parseCell(
   'import {runtime, viewof main as foo} from "@mootari/access-runtime"'
 )
 )};
-const _1n7gw17 = function _findModuleName(extractModuleInfo){return(
-(scope, module, { unknown_id = Math.random() } = {}) => {
-  try {
-    const scopedVariables = [...scope.values()];
-
-    // Prefer variables that *define* a module and have a real module-loader name.
-    const candidates = scopedVariables.filter(
-      (v) =>
-        v &&
-        v._value === module &&
-        typeof v._name === "string" &&
-        v._name.startsWith("module ") &&
-        !v._name.startsWith("module <unknown")
-    );
-
-    const pickBestInfo = (dfn) => {
-      // Avoid the parentUrl (2nd arg) confusing module identification.
-      // Typical patterns:
-      //   importShim("/d/<id>@<ver>.js?v=4", "https://api.observablehq.com/@ns/name.js?v=4")
-      //   import("/d/<id>@<ver>.js?v=4")
-      // Prefer the *first argument* inside importShim(...) / import(...) when present.
-      const s = String(dfn ?? "");
-
-      // Try to capture the first string literal argument to importShim(...) or import(...)
-      // Tolerates quotes ", ', ` and both importShim and plain import.
-      const m = s.match(
-        /\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/
-      );
-      const firstArg = m?.[2];
-
-      const info1 = firstArg ? extractModuleInfo(firstArg) : {};
-      if (info1?.id || info1?.notebook) return info1;
-
-      // Fallback: parse the whole definition string.
-      return extractModuleInfo(s);
+const _1n7gw17 = function _findModuleName(extractModuleInfo) {
+    return (scope, module, {
+        unknown_id = Math.random()
+    } = {}) => {
+        try {
+            const scopedVariables = [...scope.values()];
+            const candidates = scopedVariables.filter(v => v && v._value === module && typeof v._name === 'string' && v._name.startsWith('module ') && !v._name.startsWith('module <unknown'));
+            const pickBestInfo = dfn => {
+                const s = String(dfn ?? '');
+                const m = s.match(/\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/);
+                const firstArg = m?.[2];
+                const info1 = firstArg ? extractModuleInfo(firstArg) : {};
+                if (info1?.id || info1?.notebook)
+                    return info1;
+                return extractModuleInfo(s);
+            };
+            for (const v of candidates) {
+                const info = pickBestInfo(v._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            const any = scopedVariables.find(v => v && v._value === module);
+            if (any) {
+                const info = pickBestInfo(any._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            return `<unknown ${ unknown_id }>`;
+        } catch (e) {
+            debugger;
+            return 'error';
+        }
     };
-
-    // Try module loader cells first.
-    for (const v of candidates) {
-      const info = pickBestInfo(v._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    // Fallback: any scoped variable with _value==module.
-    const any = scopedVariables.find((v) => v && v._value === module);
-    if (any) {
-      const info = pickBestInfo(any._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    return `<unknown ${unknown_id}>`;
-  } catch (e) {
-    debugger;
-    return "error";
-  }
-}
-)};
+};
 const _i47chb = function _findImportedName(){return(
 async (v) => {
   if (v._inputs.length == 1 && v._inputs[0]._name === "@variable") {
@@ -18440,229 +18401,206 @@ JSON.stringify(
 const _1lt3kl6 = function _157(compile,test_case){return(
 compile(test_case.value)
 )};
-const _lpzjrv = function _compile(parser,globalThis,observableToJs){return(
-function compile(source, { anonymousName = "_anonymous" } = {}) {
-  const comments = [],
-    tokens = [];
-  let cell;
-  try {
-    cell = parser.parseCell(source, {
-      ranges: true,
-      onComment: comments,
-      onToken: tokens
-    });
-  } catch (e) {
-    if (e instanceof SyntaxError) {
-      const nameMatch = source.match(
-        /^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/
-      );
-      let _name = null;
-      let funcName = anonymousName;
-      if (nameMatch) {
-        const prefix = nameMatch[1] ? nameMatch[1] + " " : "";
-        _name = prefix + nameMatch[2];
-        funcName = "_" + nameMatch[2];
-      }
-      const escapedMsg = JSON.stringify(e.message);
-      const escapedSource = JSON.stringify(source);
-      return [
-        {
-          _name,
-          _inputs: [],
-          _definition: `function ${funcName}() { throw Object.assign(new SyntaxError(${escapedMsg}), {_sourceExpression: ${escapedSource}}); }`
+const _x1d0wm = function _compile(parser,observableToJs){return(
+function compile(source, {
+    anonymousName = '_anonymous'
+} = {}) {
+    const comments = [], tokens = [];
+    let cell;
+    try {
+        cell = parser.parseCell(source, {
+            ranges: true,
+            onComment: comments,
+            onToken: tokens
+        });
+    } catch (e) {
+        if (e instanceof SyntaxError) {
+            const nameMatch = source.match(/^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/);
+            let _name = null;
+            let funcName = anonymousName;
+            if (nameMatch) {
+                const prefix = nameMatch[1] ? nameMatch[1] + ' ' : '';
+                _name = prefix + nameMatch[2];
+                funcName = '_' + nameMatch[2];
+            }
+            const escapedMsg = JSON.stringify(e.message);
+            const escapedSource = JSON.stringify(source);
+            return [{
+                    _name,
+                    _inputs: [],
+                    _definition: `function ${ funcName }() { throw Object.assign(new SyntaxError(${ escapedMsg }), {_sourceExpression: ${ escapedSource }}); }`
+                }];
         }
-      ];
+        throw e;
     }
-    throw e;
-  }
-  if (!cell) throw new Error("Unable to parse cell");
-  const parseImportSpecifierText = (text) => {
-    const t = String(text ?? "")
-      .trim()
-      .replace(/,$/, "")
-      .trim();
-    if (!t) throw new Error("Empty import specifier");
-    const parts = t.split(/\s+as\s+/);
-    const left = parts[0].trim();
-    const right = parts[1]?.trim();
-    const parseSide = (side, { defaultPrefix = "" } = {}) => {
-      const s = String(side ?? "").trim();
-      const m = s.match(/^(viewof|mutable)\s+(.+)$/);
-      if (m)
-        return {
-          prefix: `${m[1]} `,
-          name: m[2].trim()
+    if (!cell)
+        throw new Error('Unable to parse cell');
+    const parseImportSpecifierText = text => {
+        const t = String(text ?? '').trim().replace(/,$/, '').trim();
+        if (!t)
+            throw new Error('Empty import specifier');
+        const parts = t.split(/\s+as\s+/);
+        const left = parts[0].trim();
+        const right = parts[1]?.trim();
+        const parseSide = (side, {
+            defaultPrefix = ''
+        } = {}) => {
+            const s = String(side ?? '').trim();
+            const m = s.match(/^(viewof|mutable)\s+(.+)$/);
+            if (m)
+                return {
+                    prefix: `${ m[1] } `,
+                    name: m[2].trim()
+                };
+            return {
+                prefix: defaultPrefix,
+                name: s
+            };
         };
-      return {
-        prefix: defaultPrefix,
-        name: s
-      };
+        const L = parseSide(left);
+        const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
+        const importedName = `${ L.prefix }${ L.name }`.trim();
+        const localName = `${ R.prefix }${ R.name }`.trim();
+        if (!importedName)
+            throw new Error(`Could not parse imported name from: ${ t }`);
+        if (!localName)
+            throw new Error(`Could not parse local name from: ${ t }`);
+        return {
+            importedName,
+            localName
+        };
     };
-    const L = parseSide(left);
-    const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
-    const importedName = `${L.prefix}${L.name}`.trim();
-    const localName = `${R.prefix}${R.name}`.trim();
-    if (!importedName)
-      throw new Error(`Could not parse imported name from: ${t}`);
-    if (!localName) throw new Error(`Could not parse local name from: ${t}`);
-    return {
-      importedName,
-      localName
-    };
-  };
-  if (!cell.id && cell.body?.type === "ImportDeclaration") {
-    const module_name = cell.body.source.value;
-    const importKeyword = globalThis?.importShim ? "importShim" : "import";
-    const cell_variables = [
-      {
-        _name: `module ${module_name}`,
-        _inputs: [],
-        _definition: `async () => runtime.module((await ${importKeyword}("${module_name}")).default)`
-      }
-    ];
-    for (const specifier of cell.body.specifiers ?? []) {
-      const specText =
-        typeof specifier?.start === "number" &&
-        typeof specifier?.end === "number"
-          ? source.slice(specifier.start, specifier.end)
-          : (() => {
-              if (specifier?.imported?.name && specifier?.local?.name) {
-                return specifier.imported.name === specifier.local.name
-                  ? specifier.local.name
-                  : `${specifier.imported.name} as ${specifier.local.name}`;
-              }
-              throw new Error("Import specifier missing range information");
+    if (!cell.id && cell.body?.type === 'ImportDeclaration') {
+        const module_name = cell.body.source.value;
+        const cell_variables = [{
+                _name: `module ${ module_name }`,
+                _inputs: [],
+                _definition: `async () => runtime.module((await import("${ module_name }")).default)`
+            }];
+        for (const specifier of cell.body.specifiers ?? []) {
+            const specText = typeof specifier?.start === 'number' && typeof specifier?.end === 'number' ? source.slice(specifier.start, specifier.end) : (() => {
+                if (specifier?.imported?.name && specifier?.local?.name) {
+                    return specifier.imported.name === specifier.local.name ? specifier.local.name : `${ specifier.imported.name } as ${ specifier.local.name }`;
+                }
+                throw new Error('Import specifier missing range information');
             })();
-      const { importedName, localName } = parseImportSpecifierText(specText);
-      cell_variables.push({
-        _name: localName,
-        _inputs: [`module ${module_name}`, "@variable"],
-        _definition:
-          importedName === localName
-            ? `(_, v) => v.import("${importedName}", _)`
-            : `(_, v) => v.import("${importedName}", "${localName}", _)`
-      });
+            const {importedName, localName} = parseImportSpecifierText(specText);
+            cell_variables.push({
+                _name: localName,
+                _inputs: [
+                    `module ${ module_name }`,
+                    '@variable'
+                ],
+                _definition: importedName === localName ? `(_, v) => v.import("${ importedName }", _)` : `(_, v) => v.import("${ importedName }", "${ localName }", _)`
+            });
+        }
+        return cell_variables;
     }
-    return cell_variables;
-  }
-  let dollarIdx = 0;
-  const inputToArgMap = {};
-  const dollarToMacro = {};
-  const seen = new Set();
-  const inputs = Array.from(cell.references || []).flatMap((i) => {
-    if (i.name) {
-      if (seen.has(i.name)) return [];
-      seen.add(i.name);
-      return i.name;
+    let dollarIdx = 0;
+    const inputToArgMap = {};
+    const dollarToMacro = {};
+    const seen = new Set();
+    const inputs = Array.from(cell.references || []).flatMap(i => {
+        if (i.name) {
+            if (seen.has(i.name))
+                return [];
+            seen.add(i.name);
+            return i.name;
+        } else {
+            const dedupKey = i.type + ':' + i.id.name;
+            if (seen.has(dedupKey))
+                return [];
+            seen.add(dedupKey);
+            const dollarName = '$' + dollarIdx;
+            inputToArgMap[i.id.name] = dollarName;
+            dollarToMacro[dollarName] = i.type == 'ViewExpression' ? 'viewof ' + i.id.name : 'mutable ' + i.id.name;
+            dollarIdx++;
+            return dollarName;
+        }
+    });
+    let variables;
+    if (cell.id) {
+        if (cell.id.type === 'Identifier') {
+            variables = [{
+                    functionName: '_' + cell.id.name,
+                    name: cell.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                }];
+        } else if (cell.id.type === 'ViewExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'viewof ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '(G, _) => G.input(_)',
+                    inputs: [
+                        'Generators',
+                        'viewof ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                }
+            ];
+        } else if (cell.id.type === 'MutableExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'initial ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'mutable ' + cell.id.id.name,
+                    _definition: '(M, _) => new M(_)',
+                    inputs: [
+                        'Mutable',
+                        'initial ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '_ => _.generator',
+                    inputs: ['mutable ' + cell.id.id.name],
+                    params: inputs.join(',')
+                }
+            ];
+        } else {
+            throw new Error(`Unsupported cell id type: ${ cell.id.type }`);
+        }
     } else {
-      const dedupKey = i.type + ":" + i.id.name;
-      if (seen.has(dedupKey)) return [];
-      seen.add(dedupKey);
-      const dollarName = "$" + dollarIdx;
-      inputToArgMap[i.id.name] = dollarName;
-      dollarToMacro[dollarName] =
-        i.type == "ViewExpression"
-          ? "viewof " + i.id.name
-          : "mutable " + i.id.name;
-      dollarIdx++;
-      return dollarName;
+        variables = [{
+                functionName: anonymousName,
+                name: null,
+                inputs,
+                params: inputs.join(',')
+            }];
     }
-  });
-  let variables;
-  if (cell.id) {
-    if (cell.id.type === "Identifier") {
-      variables = [
-        {
-          functionName: "_" + cell.id.name,
-          name: cell.id.name,
-          inputs,
-          params: inputs.join(",")
+    return variables.map(v => {
+        let _definition = v._definition;
+        if (!_definition) {
+            let functionBody;
+            if (cell.body.type === 'BlockStatement') {
+                functionBody = observableToJs(cell.body, inputToArgMap, comments, tokens);
+            } else {
+                const bodyCode = observableToJs(cell.body, inputToArgMap, comments, tokens);
+                functionBody = `{return (${ bodyCode });}`;
+            }
+            _definition = `${ cell.async ? 'async ' : '' }function${ cell.generator ? '*' : '' } ${ v.functionName }(${ v.inputs.join(',') }) ${ functionBody }`;
         }
-      ];
-    } else if (cell.id.type === "ViewExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "viewof " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "(G, _) => G.input(_)",
-          inputs: ["Generators", "viewof " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else if (cell.id.type === "MutableExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "initial " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "mutable " + cell.id.id.name,
-          _definition: "(M, _) => new M(_)",
-          inputs: ["Mutable", "initial " + cell.id.id.name],
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "_ => _.generator",
-          inputs: ["mutable " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else {
-      throw new Error(`Unsupported cell id type: ${cell.id.type}`);
-    }
-  } else {
-    variables = [
-      {
-        functionName: anonymousName,
-        name: null,
-        inputs,
-        params: inputs.join(",")
-      }
-    ];
-  }
-  return variables.map((v) => {
-    let _definition = v._definition;
-    if (!_definition) {
-      let functionBody;
-      if (cell.body.type === "BlockStatement") {
-        functionBody = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-      } else {
-        const bodyCode = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-        functionBody = `{return (${bodyCode});}`;
-      }
-      _definition = `${cell.async ? "async " : ""}function${
-        cell.generator ? "*" : ""
-      } ${v.functionName}(${v.inputs.join(",")}) ${functionBody}`;
-    }
-    return {
-      _name: v.name,
-      _inputs: v.inputs.map(
-        (i) => dollarToMacro[i] || (i === "$variable" ? "@variable" : i)
-      ),
-      _definition
-    };
-  });
+        return {
+            _name: v.name,
+            _inputs: v.inputs.map(i => dollarToMacro[i] || (i === '$variable' ? '@variable' : i)),
+            _definition
+        };
+    });
 }
 )};
 const _1v1i7wl = function _observableToJs(acorn_walk,parser,escodegen){return(
@@ -18729,16 +18667,15 @@ async (attachment, overrides) => {
   return URL.createObjectURL(blob);
 }
 )};
-const _s9w7ha = async function _parser(decompress_url,FileAttachment,acorn_url,acorn_walk_url){return(
-importShim(await decompress_url(FileAttachment("parser-6.1.0.js.gz"), {
-    "/npm/acorn@8.11.3/+esm": acorn_url,
-    "/npm/acorn-walk@8.3.2/+esm": acorn_walk_url
-  })
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
-const _1hiclbb = function _acorn_walk(acorn_walk_url){return(
-importShim(acorn_walk_url, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _s9w7ha = async function _parser(decompress_url, FileAttachment, acorn_url, acorn_walk_url) {
+    return import(await decompress_url(FileAttachment('parser-6.1.0.js.gz'), {
+        '/npm/acorn@8.11.3/+esm': acorn_url,
+        '/npm/acorn-walk@8.3.2/+esm': acorn_walk_url
+    }));
+};
+const _1hiclbb = function _acorn_walk(acorn_walk_url) {
+    return import(acorn_walk_url);
+};
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
@@ -18926,7 +18863,7 @@ export default function define(runtime, observer) {
   $def("_1dmmuaf", "compiled_selector", ["Generators","viewof compiled_selector"], _1dmmuaf);  
   $def("_u7t3vu", null, ["compiled_selector","normalizeJavascriptSource"], _u7t3vu);  
   $def("_1lt3kl6", null, ["compile","test_case"], _1lt3kl6);  
-  $def("_lpzjrv", "compile", ["parser","globalThis","observableToJs"], _lpzjrv);  
+  $def("_x1d0wm", "compile", ["parser","observableToJs"], _x1d0wm);  
   $def("_1v1i7wl", "observableToJs", ["acorn_walk","parser","escodegen"], _1v1i7wl);  
   $def("_19lv24l", null, ["md"], _19lv24l);  
   $def("_xhj6b8", "decompress_url", ["DecompressionStream","TextDecoderStream","TransformStream","TextEncoderStream","Response"], _xhj6b8);  

--- a/notebooks/@tomlarkworthy_secrets.html
+++ b/notebooks/@tomlarkworthy_secrets.html
@@ -5437,58 +5437,41 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _geoudp = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
-  if (command.processed) return;
-
-  let result = undefined;
-  if (command.command == "createCell") {
-    $0.value = true;
-    result = compile_and_update("{}", [], command.args.cell);
-    // For the new one to get focus
-    // setTimeout(() => {
-    //   debugger;
-    //   setOption(result[0], "pinned", true);
-    // }, 100);
-  } else if (command.command == "deleteCell") {
-    remove_variables(command.args.cell.variables);
-    result = true;
-  } else if (command.command == "moveCell") {
-    const cellIndex = findCellIndex(
-      command.args.cell.variables,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const targetCellIndex = cellIndex + command.args.amount;
-    const targetCell = lookupCellByIndex(
-      targetCellIndex,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const currentFirstVariableIndex = findVariableIndex(
-      command.args.cell.variables[0]
-    );
-    const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-    const change = targetFirstVariableIndex - currentFirstVariableIndex;
-    console.log(
-      "moveCell",
-      cellIndex,
-      targetCellIndex,
-      targetCell,
-      currentFirstVariableIndex,
-      targetFirstVariableIndex,
-      change
-    );
-    command.args.cell.variables.forEach((v) => {
-      const currentIndex = findVariableIndex(v);
-      repositionSetElement(runtime._variables, v, currentIndex + change);
-    });
-    // recompute
-    await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
-    result = true;
-  }
-  if (result) {
-    command.processed = true;
-    $2.resolve(result);
-  }
+    if (command.processed)
+        return;
+    let result = undefined;
+    if (command.command == 'createCell') {
+        $0.value = true;
+        result = await compile_and_update('{}', [], command.args.cell);    // For the new one to get focus
+                                                                           // setTimeout(() => {
+                                                                           //   debugger;
+                                                                           //   setOption(result[0], "pinned", true);
+                                                                           // }, 100);
+    } else if (command.command == 'deleteCell') {
+        remove_variables(command.args.cell.variables);
+        result = true;
+    } else if (command.command == 'moveCell') {
+        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const targetCellIndex = cellIndex + command.args.amount;
+        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
+        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+        const change = targetFirstVariableIndex - currentFirstVariableIndex;
+        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
+        command.args.cell.variables.forEach(v => {
+            const currentIndex = findVariableIndex(v);
+            repositionSetElement(runtime._variables, v, currentIndex + change);
+        });
+        // recompute
+        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        result = true;
+    }
+    if (result) {
+        command.processed = true;
+        $2.resolve(result);
+    }
 };
 const _1jadxoe = function _60(md){return(
 md`### UI Action`
@@ -5879,9 +5862,9 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
-    return (source, variables = [], cell) => {
+    return async (source, variables = [], cell) => {
         try {
             debugger;
             let reposition = false, insertionIndex = -1;
@@ -5901,10 +5884,10 @@ const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElemen
             if (reposition) {
                 insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
+            const fns = await realize(newVariables.map(v => v._definition), runtime);
             newVariables.forEach((v, i) => {
                 const variable = variables[i];
-                let _fn;
-                eval('_fn = ' + v._definition);
+                const _fn = fns[i];
                 if (v._name) {
                     variable.define(v._name, v._inputs, _fn);
                 } else {
@@ -5953,12 +5936,11 @@ Inputs.textarea({
 })
 )};
 const _b4rsn5 = (G, _) => G.input(_);
-const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
+const _ga6kci = function _98(Inputs,definition,variable,realize,runtime,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
-  reduce: () => {
-    let _fn;
-    eval("_fn = " + definition);
+  reduce: async () => {
+    const [_fn] = await realize([definition], runtime);
     variable.define(variable._name, inputs, _fn);
   }
 })
@@ -6071,7 +6053,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_geoudp", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _geoudp);  
+  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6109,7 +6091,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
+  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -6119,8 +6101,9 @@ export default function define(runtime, observer) {
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
   $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
-  $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
+  $def("_ga6kci", null, ["Inputs","definition","variable","realize","runtime","inputs"], _ga6kci);  
   $def("_1q557s", null, ["md"], _1q557s);  
+  main.define("realize", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("realize", _));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -16490,10 +16473,9 @@ notebook_semantics_document.nodes.map((s) => ({
 const _1oevsow = function _28(md){return(
 md`### Runtime Representation (v4)`
 )};
-const _11lfflk = function _notebook_semantics_module(){return(
-importShim("https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4"
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _11lfflk = function _notebook_semantics_module() {
+    return import('https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4');
+};
 const _gjten6 = function _31(md){return(
 md`### Imports`
 )};
@@ -17480,65 +17462,44 @@ parser.parseCell(
   'import {runtime, viewof main as foo} from "@mootari/access-runtime"'
 )
 )};
-const _1n7gw17 = function _findModuleName(extractModuleInfo){return(
-(scope, module, { unknown_id = Math.random() } = {}) => {
-  try {
-    const scopedVariables = [...scope.values()];
-
-    // Prefer variables that *define* a module and have a real module-loader name.
-    const candidates = scopedVariables.filter(
-      (v) =>
-        v &&
-        v._value === module &&
-        typeof v._name === "string" &&
-        v._name.startsWith("module ") &&
-        !v._name.startsWith("module <unknown")
-    );
-
-    const pickBestInfo = (dfn) => {
-      // Avoid the parentUrl (2nd arg) confusing module identification.
-      // Typical patterns:
-      //   importShim("/d/<id>@<ver>.js?v=4", "https://api.observablehq.com/@ns/name.js?v=4")
-      //   import("/d/<id>@<ver>.js?v=4")
-      // Prefer the *first argument* inside importShim(...) / import(...) when present.
-      const s = String(dfn ?? "");
-
-      // Try to capture the first string literal argument to importShim(...) or import(...)
-      // Tolerates quotes ", ', ` and both importShim and plain import.
-      const m = s.match(
-        /\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/
-      );
-      const firstArg = m?.[2];
-
-      const info1 = firstArg ? extractModuleInfo(firstArg) : {};
-      if (info1?.id || info1?.notebook) return info1;
-
-      // Fallback: parse the whole definition string.
-      return extractModuleInfo(s);
+const _1n7gw17 = function _findModuleName(extractModuleInfo) {
+    return (scope, module, {
+        unknown_id = Math.random()
+    } = {}) => {
+        try {
+            const scopedVariables = [...scope.values()];
+            const candidates = scopedVariables.filter(v => v && v._value === module && typeof v._name === 'string' && v._name.startsWith('module ') && !v._name.startsWith('module <unknown'));
+            const pickBestInfo = dfn => {
+                const s = String(dfn ?? '');
+                const m = s.match(/\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/);
+                const firstArg = m?.[2];
+                const info1 = firstArg ? extractModuleInfo(firstArg) : {};
+                if (info1?.id || info1?.notebook)
+                    return info1;
+                return extractModuleInfo(s);
+            };
+            for (const v of candidates) {
+                const info = pickBestInfo(v._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            const any = scopedVariables.find(v => v && v._value === module);
+            if (any) {
+                const info = pickBestInfo(any._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            return `<unknown ${ unknown_id }>`;
+        } catch (e) {
+            debugger;
+            return 'error';
+        }
     };
-
-    // Try module loader cells first.
-    for (const v of candidates) {
-      const info = pickBestInfo(v._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    // Fallback: any scoped variable with _value==module.
-    const any = scopedVariables.find((v) => v && v._value === module);
-    if (any) {
-      const info = pickBestInfo(any._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    return `<unknown ${unknown_id}>`;
-  } catch (e) {
-    debugger;
-    return "error";
-  }
-}
-)};
+};
 const _i47chb = function _findImportedName(){return(
 async (v) => {
   if (v._inputs.length == 1 && v._inputs[0]._name === "@variable") {
@@ -18440,229 +18401,206 @@ JSON.stringify(
 const _1lt3kl6 = function _157(compile,test_case){return(
 compile(test_case.value)
 )};
-const _lpzjrv = function _compile(parser,globalThis,observableToJs){return(
-function compile(source, { anonymousName = "_anonymous" } = {}) {
-  const comments = [],
-    tokens = [];
-  let cell;
-  try {
-    cell = parser.parseCell(source, {
-      ranges: true,
-      onComment: comments,
-      onToken: tokens
-    });
-  } catch (e) {
-    if (e instanceof SyntaxError) {
-      const nameMatch = source.match(
-        /^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/
-      );
-      let _name = null;
-      let funcName = anonymousName;
-      if (nameMatch) {
-        const prefix = nameMatch[1] ? nameMatch[1] + " " : "";
-        _name = prefix + nameMatch[2];
-        funcName = "_" + nameMatch[2];
-      }
-      const escapedMsg = JSON.stringify(e.message);
-      const escapedSource = JSON.stringify(source);
-      return [
-        {
-          _name,
-          _inputs: [],
-          _definition: `function ${funcName}() { throw Object.assign(new SyntaxError(${escapedMsg}), {_sourceExpression: ${escapedSource}}); }`
+const _x1d0wm = function _compile(parser,observableToJs){return(
+function compile(source, {
+    anonymousName = '_anonymous'
+} = {}) {
+    const comments = [], tokens = [];
+    let cell;
+    try {
+        cell = parser.parseCell(source, {
+            ranges: true,
+            onComment: comments,
+            onToken: tokens
+        });
+    } catch (e) {
+        if (e instanceof SyntaxError) {
+            const nameMatch = source.match(/^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/);
+            let _name = null;
+            let funcName = anonymousName;
+            if (nameMatch) {
+                const prefix = nameMatch[1] ? nameMatch[1] + ' ' : '';
+                _name = prefix + nameMatch[2];
+                funcName = '_' + nameMatch[2];
+            }
+            const escapedMsg = JSON.stringify(e.message);
+            const escapedSource = JSON.stringify(source);
+            return [{
+                    _name,
+                    _inputs: [],
+                    _definition: `function ${ funcName }() { throw Object.assign(new SyntaxError(${ escapedMsg }), {_sourceExpression: ${ escapedSource }}); }`
+                }];
         }
-      ];
+        throw e;
     }
-    throw e;
-  }
-  if (!cell) throw new Error("Unable to parse cell");
-  const parseImportSpecifierText = (text) => {
-    const t = String(text ?? "")
-      .trim()
-      .replace(/,$/, "")
-      .trim();
-    if (!t) throw new Error("Empty import specifier");
-    const parts = t.split(/\s+as\s+/);
-    const left = parts[0].trim();
-    const right = parts[1]?.trim();
-    const parseSide = (side, { defaultPrefix = "" } = {}) => {
-      const s = String(side ?? "").trim();
-      const m = s.match(/^(viewof|mutable)\s+(.+)$/);
-      if (m)
-        return {
-          prefix: `${m[1]} `,
-          name: m[2].trim()
+    if (!cell)
+        throw new Error('Unable to parse cell');
+    const parseImportSpecifierText = text => {
+        const t = String(text ?? '').trim().replace(/,$/, '').trim();
+        if (!t)
+            throw new Error('Empty import specifier');
+        const parts = t.split(/\s+as\s+/);
+        const left = parts[0].trim();
+        const right = parts[1]?.trim();
+        const parseSide = (side, {
+            defaultPrefix = ''
+        } = {}) => {
+            const s = String(side ?? '').trim();
+            const m = s.match(/^(viewof|mutable)\s+(.+)$/);
+            if (m)
+                return {
+                    prefix: `${ m[1] } `,
+                    name: m[2].trim()
+                };
+            return {
+                prefix: defaultPrefix,
+                name: s
+            };
         };
-      return {
-        prefix: defaultPrefix,
-        name: s
-      };
+        const L = parseSide(left);
+        const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
+        const importedName = `${ L.prefix }${ L.name }`.trim();
+        const localName = `${ R.prefix }${ R.name }`.trim();
+        if (!importedName)
+            throw new Error(`Could not parse imported name from: ${ t }`);
+        if (!localName)
+            throw new Error(`Could not parse local name from: ${ t }`);
+        return {
+            importedName,
+            localName
+        };
     };
-    const L = parseSide(left);
-    const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
-    const importedName = `${L.prefix}${L.name}`.trim();
-    const localName = `${R.prefix}${R.name}`.trim();
-    if (!importedName)
-      throw new Error(`Could not parse imported name from: ${t}`);
-    if (!localName) throw new Error(`Could not parse local name from: ${t}`);
-    return {
-      importedName,
-      localName
-    };
-  };
-  if (!cell.id && cell.body?.type === "ImportDeclaration") {
-    const module_name = cell.body.source.value;
-    const importKeyword = globalThis?.importShim ? "importShim" : "import";
-    const cell_variables = [
-      {
-        _name: `module ${module_name}`,
-        _inputs: [],
-        _definition: `async () => runtime.module((await ${importKeyword}("${module_name}")).default)`
-      }
-    ];
-    for (const specifier of cell.body.specifiers ?? []) {
-      const specText =
-        typeof specifier?.start === "number" &&
-        typeof specifier?.end === "number"
-          ? source.slice(specifier.start, specifier.end)
-          : (() => {
-              if (specifier?.imported?.name && specifier?.local?.name) {
-                return specifier.imported.name === specifier.local.name
-                  ? specifier.local.name
-                  : `${specifier.imported.name} as ${specifier.local.name}`;
-              }
-              throw new Error("Import specifier missing range information");
+    if (!cell.id && cell.body?.type === 'ImportDeclaration') {
+        const module_name = cell.body.source.value;
+        const cell_variables = [{
+                _name: `module ${ module_name }`,
+                _inputs: [],
+                _definition: `async () => runtime.module((await import("${ module_name }")).default)`
+            }];
+        for (const specifier of cell.body.specifiers ?? []) {
+            const specText = typeof specifier?.start === 'number' && typeof specifier?.end === 'number' ? source.slice(specifier.start, specifier.end) : (() => {
+                if (specifier?.imported?.name && specifier?.local?.name) {
+                    return specifier.imported.name === specifier.local.name ? specifier.local.name : `${ specifier.imported.name } as ${ specifier.local.name }`;
+                }
+                throw new Error('Import specifier missing range information');
             })();
-      const { importedName, localName } = parseImportSpecifierText(specText);
-      cell_variables.push({
-        _name: localName,
-        _inputs: [`module ${module_name}`, "@variable"],
-        _definition:
-          importedName === localName
-            ? `(_, v) => v.import("${importedName}", _)`
-            : `(_, v) => v.import("${importedName}", "${localName}", _)`
-      });
+            const {importedName, localName} = parseImportSpecifierText(specText);
+            cell_variables.push({
+                _name: localName,
+                _inputs: [
+                    `module ${ module_name }`,
+                    '@variable'
+                ],
+                _definition: importedName === localName ? `(_, v) => v.import("${ importedName }", _)` : `(_, v) => v.import("${ importedName }", "${ localName }", _)`
+            });
+        }
+        return cell_variables;
     }
-    return cell_variables;
-  }
-  let dollarIdx = 0;
-  const inputToArgMap = {};
-  const dollarToMacro = {};
-  const seen = new Set();
-  const inputs = Array.from(cell.references || []).flatMap((i) => {
-    if (i.name) {
-      if (seen.has(i.name)) return [];
-      seen.add(i.name);
-      return i.name;
+    let dollarIdx = 0;
+    const inputToArgMap = {};
+    const dollarToMacro = {};
+    const seen = new Set();
+    const inputs = Array.from(cell.references || []).flatMap(i => {
+        if (i.name) {
+            if (seen.has(i.name))
+                return [];
+            seen.add(i.name);
+            return i.name;
+        } else {
+            const dedupKey = i.type + ':' + i.id.name;
+            if (seen.has(dedupKey))
+                return [];
+            seen.add(dedupKey);
+            const dollarName = '$' + dollarIdx;
+            inputToArgMap[i.id.name] = dollarName;
+            dollarToMacro[dollarName] = i.type == 'ViewExpression' ? 'viewof ' + i.id.name : 'mutable ' + i.id.name;
+            dollarIdx++;
+            return dollarName;
+        }
+    });
+    let variables;
+    if (cell.id) {
+        if (cell.id.type === 'Identifier') {
+            variables = [{
+                    functionName: '_' + cell.id.name,
+                    name: cell.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                }];
+        } else if (cell.id.type === 'ViewExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'viewof ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '(G, _) => G.input(_)',
+                    inputs: [
+                        'Generators',
+                        'viewof ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                }
+            ];
+        } else if (cell.id.type === 'MutableExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'initial ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'mutable ' + cell.id.id.name,
+                    _definition: '(M, _) => new M(_)',
+                    inputs: [
+                        'Mutable',
+                        'initial ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '_ => _.generator',
+                    inputs: ['mutable ' + cell.id.id.name],
+                    params: inputs.join(',')
+                }
+            ];
+        } else {
+            throw new Error(`Unsupported cell id type: ${ cell.id.type }`);
+        }
     } else {
-      const dedupKey = i.type + ":" + i.id.name;
-      if (seen.has(dedupKey)) return [];
-      seen.add(dedupKey);
-      const dollarName = "$" + dollarIdx;
-      inputToArgMap[i.id.name] = dollarName;
-      dollarToMacro[dollarName] =
-        i.type == "ViewExpression"
-          ? "viewof " + i.id.name
-          : "mutable " + i.id.name;
-      dollarIdx++;
-      return dollarName;
+        variables = [{
+                functionName: anonymousName,
+                name: null,
+                inputs,
+                params: inputs.join(',')
+            }];
     }
-  });
-  let variables;
-  if (cell.id) {
-    if (cell.id.type === "Identifier") {
-      variables = [
-        {
-          functionName: "_" + cell.id.name,
-          name: cell.id.name,
-          inputs,
-          params: inputs.join(",")
+    return variables.map(v => {
+        let _definition = v._definition;
+        if (!_definition) {
+            let functionBody;
+            if (cell.body.type === 'BlockStatement') {
+                functionBody = observableToJs(cell.body, inputToArgMap, comments, tokens);
+            } else {
+                const bodyCode = observableToJs(cell.body, inputToArgMap, comments, tokens);
+                functionBody = `{return (${ bodyCode });}`;
+            }
+            _definition = `${ cell.async ? 'async ' : '' }function${ cell.generator ? '*' : '' } ${ v.functionName }(${ v.inputs.join(',') }) ${ functionBody }`;
         }
-      ];
-    } else if (cell.id.type === "ViewExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "viewof " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "(G, _) => G.input(_)",
-          inputs: ["Generators", "viewof " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else if (cell.id.type === "MutableExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "initial " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "mutable " + cell.id.id.name,
-          _definition: "(M, _) => new M(_)",
-          inputs: ["Mutable", "initial " + cell.id.id.name],
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "_ => _.generator",
-          inputs: ["mutable " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else {
-      throw new Error(`Unsupported cell id type: ${cell.id.type}`);
-    }
-  } else {
-    variables = [
-      {
-        functionName: anonymousName,
-        name: null,
-        inputs,
-        params: inputs.join(",")
-      }
-    ];
-  }
-  return variables.map((v) => {
-    let _definition = v._definition;
-    if (!_definition) {
-      let functionBody;
-      if (cell.body.type === "BlockStatement") {
-        functionBody = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-      } else {
-        const bodyCode = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-        functionBody = `{return (${bodyCode});}`;
-      }
-      _definition = `${cell.async ? "async " : ""}function${
-        cell.generator ? "*" : ""
-      } ${v.functionName}(${v.inputs.join(",")}) ${functionBody}`;
-    }
-    return {
-      _name: v.name,
-      _inputs: v.inputs.map(
-        (i) => dollarToMacro[i] || (i === "$variable" ? "@variable" : i)
-      ),
-      _definition
-    };
-  });
+        return {
+            _name: v.name,
+            _inputs: v.inputs.map(i => dollarToMacro[i] || (i === '$variable' ? '@variable' : i)),
+            _definition
+        };
+    });
 }
 )};
 const _1v1i7wl = function _observableToJs(acorn_walk,parser,escodegen){return(
@@ -18729,16 +18667,15 @@ async (attachment, overrides) => {
   return URL.createObjectURL(blob);
 }
 )};
-const _s9w7ha = async function _parser(decompress_url,FileAttachment,acorn_url,acorn_walk_url){return(
-importShim(await decompress_url(FileAttachment("parser-6.1.0.js.gz"), {
-    "/npm/acorn@8.11.3/+esm": acorn_url,
-    "/npm/acorn-walk@8.3.2/+esm": acorn_walk_url
-  })
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
-const _1hiclbb = function _acorn_walk(acorn_walk_url){return(
-importShim(acorn_walk_url, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _s9w7ha = async function _parser(decompress_url, FileAttachment, acorn_url, acorn_walk_url) {
+    return import(await decompress_url(FileAttachment('parser-6.1.0.js.gz'), {
+        '/npm/acorn@8.11.3/+esm': acorn_url,
+        '/npm/acorn-walk@8.3.2/+esm': acorn_walk_url
+    }));
+};
+const _1hiclbb = function _acorn_walk(acorn_walk_url) {
+    return import(acorn_walk_url);
+};
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
@@ -18926,7 +18863,7 @@ export default function define(runtime, observer) {
   $def("_1dmmuaf", "compiled_selector", ["Generators","viewof compiled_selector"], _1dmmuaf);  
   $def("_u7t3vu", null, ["compiled_selector","normalizeJavascriptSource"], _u7t3vu);  
   $def("_1lt3kl6", null, ["compile","test_case"], _1lt3kl6);  
-  $def("_lpzjrv", "compile", ["parser","globalThis","observableToJs"], _lpzjrv);  
+  $def("_x1d0wm", "compile", ["parser","observableToJs"], _x1d0wm);  
   $def("_1v1i7wl", "observableToJs", ["acorn_walk","parser","escodegen"], _1v1i7wl);  
   $def("_19lv24l", null, ["md"], _19lv24l);  
   $def("_xhj6b8", "decompress_url", ["DecompressionStream","TextDecoderStream","TransformStream","TextEncoderStream","Response"], _xhj6b8);  

--- a/notebooks/@tomlarkworthy_tests.html
+++ b/notebooks/@tomlarkworthy_tests.html
@@ -5437,58 +5437,41 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _geoudp = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
-  if (command.processed) return;
-
-  let result = undefined;
-  if (command.command == "createCell") {
-    $0.value = true;
-    result = compile_and_update("{}", [], command.args.cell);
-    // For the new one to get focus
-    // setTimeout(() => {
-    //   debugger;
-    //   setOption(result[0], "pinned", true);
-    // }, 100);
-  } else if (command.command == "deleteCell") {
-    remove_variables(command.args.cell.variables);
-    result = true;
-  } else if (command.command == "moveCell") {
-    const cellIndex = findCellIndex(
-      command.args.cell.variables,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const targetCellIndex = cellIndex + command.args.amount;
-    const targetCell = lookupCellByIndex(
-      targetCellIndex,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const currentFirstVariableIndex = findVariableIndex(
-      command.args.cell.variables[0]
-    );
-    const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-    const change = targetFirstVariableIndex - currentFirstVariableIndex;
-    console.log(
-      "moveCell",
-      cellIndex,
-      targetCellIndex,
-      targetCell,
-      currentFirstVariableIndex,
-      targetFirstVariableIndex,
-      change
-    );
-    command.args.cell.variables.forEach((v) => {
-      const currentIndex = findVariableIndex(v);
-      repositionSetElement(runtime._variables, v, currentIndex + change);
-    });
-    // recompute
-    await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
-    result = true;
-  }
-  if (result) {
-    command.processed = true;
-    $2.resolve(result);
-  }
+    if (command.processed)
+        return;
+    let result = undefined;
+    if (command.command == 'createCell') {
+        $0.value = true;
+        result = await compile_and_update('{}', [], command.args.cell);    // For the new one to get focus
+                                                                           // setTimeout(() => {
+                                                                           //   debugger;
+                                                                           //   setOption(result[0], "pinned", true);
+                                                                           // }, 100);
+    } else if (command.command == 'deleteCell') {
+        remove_variables(command.args.cell.variables);
+        result = true;
+    } else if (command.command == 'moveCell') {
+        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const targetCellIndex = cellIndex + command.args.amount;
+        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
+        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+        const change = targetFirstVariableIndex - currentFirstVariableIndex;
+        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
+        command.args.cell.variables.forEach(v => {
+            const currentIndex = findVariableIndex(v);
+            repositionSetElement(runtime._variables, v, currentIndex + change);
+        });
+        // recompute
+        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        result = true;
+    }
+    if (result) {
+        command.processed = true;
+        $2.resolve(result);
+    }
 };
 const _1jadxoe = function _60(md){return(
 md`### UI Action`
@@ -5879,9 +5862,9 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
-    return (source, variables = [], cell) => {
+    return async (source, variables = [], cell) => {
         try {
             debugger;
             let reposition = false, insertionIndex = -1;
@@ -5901,10 +5884,10 @@ const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElemen
             if (reposition) {
                 insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
+            const fns = await realize(newVariables.map(v => v._definition), runtime);
             newVariables.forEach((v, i) => {
                 const variable = variables[i];
-                let _fn;
-                eval('_fn = ' + v._definition);
+                const _fn = fns[i];
                 if (v._name) {
                     variable.define(v._name, v._inputs, _fn);
                 } else {
@@ -5953,12 +5936,11 @@ Inputs.textarea({
 })
 )};
 const _b4rsn5 = (G, _) => G.input(_);
-const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
+const _ga6kci = function _98(Inputs,definition,variable,realize,runtime,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
-  reduce: () => {
-    let _fn;
-    eval("_fn = " + definition);
+  reduce: async () => {
+    const [_fn] = await realize([definition], runtime);
     variable.define(variable._name, inputs, _fn);
   }
 })
@@ -6071,7 +6053,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_geoudp", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _geoudp);  
+  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6109,7 +6091,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
+  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -6119,8 +6101,9 @@ export default function define(runtime, observer) {
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
   $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
-  $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
+  $def("_ga6kci", null, ["Inputs","definition","variable","realize","runtime","inputs"], _ga6kci);  
   $def("_1q557s", null, ["md"], _1q557s);  
+  main.define("realize", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("realize", _));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -16490,10 +16473,9 @@ notebook_semantics_document.nodes.map((s) => ({
 const _1oevsow = function _28(md){return(
 md`### Runtime Representation (v4)`
 )};
-const _11lfflk = function _notebook_semantics_module(){return(
-importShim("https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4"
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _11lfflk = function _notebook_semantics_module() {
+    return import('https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4');
+};
 const _gjten6 = function _31(md){return(
 md`### Imports`
 )};
@@ -17480,65 +17462,44 @@ parser.parseCell(
   'import {runtime, viewof main as foo} from "@mootari/access-runtime"'
 )
 )};
-const _1n7gw17 = function _findModuleName(extractModuleInfo){return(
-(scope, module, { unknown_id = Math.random() } = {}) => {
-  try {
-    const scopedVariables = [...scope.values()];
-
-    // Prefer variables that *define* a module and have a real module-loader name.
-    const candidates = scopedVariables.filter(
-      (v) =>
-        v &&
-        v._value === module &&
-        typeof v._name === "string" &&
-        v._name.startsWith("module ") &&
-        !v._name.startsWith("module <unknown")
-    );
-
-    const pickBestInfo = (dfn) => {
-      // Avoid the parentUrl (2nd arg) confusing module identification.
-      // Typical patterns:
-      //   importShim("/d/<id>@<ver>.js?v=4", "https://api.observablehq.com/@ns/name.js?v=4")
-      //   import("/d/<id>@<ver>.js?v=4")
-      // Prefer the *first argument* inside importShim(...) / import(...) when present.
-      const s = String(dfn ?? "");
-
-      // Try to capture the first string literal argument to importShim(...) or import(...)
-      // Tolerates quotes ", ', ` and both importShim and plain import.
-      const m = s.match(
-        /\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/
-      );
-      const firstArg = m?.[2];
-
-      const info1 = firstArg ? extractModuleInfo(firstArg) : {};
-      if (info1?.id || info1?.notebook) return info1;
-
-      // Fallback: parse the whole definition string.
-      return extractModuleInfo(s);
+const _1n7gw17 = function _findModuleName(extractModuleInfo) {
+    return (scope, module, {
+        unknown_id = Math.random()
+    } = {}) => {
+        try {
+            const scopedVariables = [...scope.values()];
+            const candidates = scopedVariables.filter(v => v && v._value === module && typeof v._name === 'string' && v._name.startsWith('module ') && !v._name.startsWith('module <unknown'));
+            const pickBestInfo = dfn => {
+                const s = String(dfn ?? '');
+                const m = s.match(/\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/);
+                const firstArg = m?.[2];
+                const info1 = firstArg ? extractModuleInfo(firstArg) : {};
+                if (info1?.id || info1?.notebook)
+                    return info1;
+                return extractModuleInfo(s);
+            };
+            for (const v of candidates) {
+                const info = pickBestInfo(v._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            const any = scopedVariables.find(v => v && v._value === module);
+            if (any) {
+                const info = pickBestInfo(any._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            return `<unknown ${ unknown_id }>`;
+        } catch (e) {
+            debugger;
+            return 'error';
+        }
     };
-
-    // Try module loader cells first.
-    for (const v of candidates) {
-      const info = pickBestInfo(v._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    // Fallback: any scoped variable with _value==module.
-    const any = scopedVariables.find((v) => v && v._value === module);
-    if (any) {
-      const info = pickBestInfo(any._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    return `<unknown ${unknown_id}>`;
-  } catch (e) {
-    debugger;
-    return "error";
-  }
-}
-)};
+};
 const _i47chb = function _findImportedName(){return(
 async (v) => {
   if (v._inputs.length == 1 && v._inputs[0]._name === "@variable") {
@@ -18440,229 +18401,206 @@ JSON.stringify(
 const _1lt3kl6 = function _157(compile,test_case){return(
 compile(test_case.value)
 )};
-const _lpzjrv = function _compile(parser,globalThis,observableToJs){return(
-function compile(source, { anonymousName = "_anonymous" } = {}) {
-  const comments = [],
-    tokens = [];
-  let cell;
-  try {
-    cell = parser.parseCell(source, {
-      ranges: true,
-      onComment: comments,
-      onToken: tokens
-    });
-  } catch (e) {
-    if (e instanceof SyntaxError) {
-      const nameMatch = source.match(
-        /^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/
-      );
-      let _name = null;
-      let funcName = anonymousName;
-      if (nameMatch) {
-        const prefix = nameMatch[1] ? nameMatch[1] + " " : "";
-        _name = prefix + nameMatch[2];
-        funcName = "_" + nameMatch[2];
-      }
-      const escapedMsg = JSON.stringify(e.message);
-      const escapedSource = JSON.stringify(source);
-      return [
-        {
-          _name,
-          _inputs: [],
-          _definition: `function ${funcName}() { throw Object.assign(new SyntaxError(${escapedMsg}), {_sourceExpression: ${escapedSource}}); }`
+const _x1d0wm = function _compile(parser,observableToJs){return(
+function compile(source, {
+    anonymousName = '_anonymous'
+} = {}) {
+    const comments = [], tokens = [];
+    let cell;
+    try {
+        cell = parser.parseCell(source, {
+            ranges: true,
+            onComment: comments,
+            onToken: tokens
+        });
+    } catch (e) {
+        if (e instanceof SyntaxError) {
+            const nameMatch = source.match(/^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/);
+            let _name = null;
+            let funcName = anonymousName;
+            if (nameMatch) {
+                const prefix = nameMatch[1] ? nameMatch[1] + ' ' : '';
+                _name = prefix + nameMatch[2];
+                funcName = '_' + nameMatch[2];
+            }
+            const escapedMsg = JSON.stringify(e.message);
+            const escapedSource = JSON.stringify(source);
+            return [{
+                    _name,
+                    _inputs: [],
+                    _definition: `function ${ funcName }() { throw Object.assign(new SyntaxError(${ escapedMsg }), {_sourceExpression: ${ escapedSource }}); }`
+                }];
         }
-      ];
+        throw e;
     }
-    throw e;
-  }
-  if (!cell) throw new Error("Unable to parse cell");
-  const parseImportSpecifierText = (text) => {
-    const t = String(text ?? "")
-      .trim()
-      .replace(/,$/, "")
-      .trim();
-    if (!t) throw new Error("Empty import specifier");
-    const parts = t.split(/\s+as\s+/);
-    const left = parts[0].trim();
-    const right = parts[1]?.trim();
-    const parseSide = (side, { defaultPrefix = "" } = {}) => {
-      const s = String(side ?? "").trim();
-      const m = s.match(/^(viewof|mutable)\s+(.+)$/);
-      if (m)
-        return {
-          prefix: `${m[1]} `,
-          name: m[2].trim()
+    if (!cell)
+        throw new Error('Unable to parse cell');
+    const parseImportSpecifierText = text => {
+        const t = String(text ?? '').trim().replace(/,$/, '').trim();
+        if (!t)
+            throw new Error('Empty import specifier');
+        const parts = t.split(/\s+as\s+/);
+        const left = parts[0].trim();
+        const right = parts[1]?.trim();
+        const parseSide = (side, {
+            defaultPrefix = ''
+        } = {}) => {
+            const s = String(side ?? '').trim();
+            const m = s.match(/^(viewof|mutable)\s+(.+)$/);
+            if (m)
+                return {
+                    prefix: `${ m[1] } `,
+                    name: m[2].trim()
+                };
+            return {
+                prefix: defaultPrefix,
+                name: s
+            };
         };
-      return {
-        prefix: defaultPrefix,
-        name: s
-      };
+        const L = parseSide(left);
+        const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
+        const importedName = `${ L.prefix }${ L.name }`.trim();
+        const localName = `${ R.prefix }${ R.name }`.trim();
+        if (!importedName)
+            throw new Error(`Could not parse imported name from: ${ t }`);
+        if (!localName)
+            throw new Error(`Could not parse local name from: ${ t }`);
+        return {
+            importedName,
+            localName
+        };
     };
-    const L = parseSide(left);
-    const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
-    const importedName = `${L.prefix}${L.name}`.trim();
-    const localName = `${R.prefix}${R.name}`.trim();
-    if (!importedName)
-      throw new Error(`Could not parse imported name from: ${t}`);
-    if (!localName) throw new Error(`Could not parse local name from: ${t}`);
-    return {
-      importedName,
-      localName
-    };
-  };
-  if (!cell.id && cell.body?.type === "ImportDeclaration") {
-    const module_name = cell.body.source.value;
-    const importKeyword = globalThis?.importShim ? "importShim" : "import";
-    const cell_variables = [
-      {
-        _name: `module ${module_name}`,
-        _inputs: [],
-        _definition: `async () => runtime.module((await ${importKeyword}("${module_name}")).default)`
-      }
-    ];
-    for (const specifier of cell.body.specifiers ?? []) {
-      const specText =
-        typeof specifier?.start === "number" &&
-        typeof specifier?.end === "number"
-          ? source.slice(specifier.start, specifier.end)
-          : (() => {
-              if (specifier?.imported?.name && specifier?.local?.name) {
-                return specifier.imported.name === specifier.local.name
-                  ? specifier.local.name
-                  : `${specifier.imported.name} as ${specifier.local.name}`;
-              }
-              throw new Error("Import specifier missing range information");
+    if (!cell.id && cell.body?.type === 'ImportDeclaration') {
+        const module_name = cell.body.source.value;
+        const cell_variables = [{
+                _name: `module ${ module_name }`,
+                _inputs: [],
+                _definition: `async () => runtime.module((await import("${ module_name }")).default)`
+            }];
+        for (const specifier of cell.body.specifiers ?? []) {
+            const specText = typeof specifier?.start === 'number' && typeof specifier?.end === 'number' ? source.slice(specifier.start, specifier.end) : (() => {
+                if (specifier?.imported?.name && specifier?.local?.name) {
+                    return specifier.imported.name === specifier.local.name ? specifier.local.name : `${ specifier.imported.name } as ${ specifier.local.name }`;
+                }
+                throw new Error('Import specifier missing range information');
             })();
-      const { importedName, localName } = parseImportSpecifierText(specText);
-      cell_variables.push({
-        _name: localName,
-        _inputs: [`module ${module_name}`, "@variable"],
-        _definition:
-          importedName === localName
-            ? `(_, v) => v.import("${importedName}", _)`
-            : `(_, v) => v.import("${importedName}", "${localName}", _)`
-      });
+            const {importedName, localName} = parseImportSpecifierText(specText);
+            cell_variables.push({
+                _name: localName,
+                _inputs: [
+                    `module ${ module_name }`,
+                    '@variable'
+                ],
+                _definition: importedName === localName ? `(_, v) => v.import("${ importedName }", _)` : `(_, v) => v.import("${ importedName }", "${ localName }", _)`
+            });
+        }
+        return cell_variables;
     }
-    return cell_variables;
-  }
-  let dollarIdx = 0;
-  const inputToArgMap = {};
-  const dollarToMacro = {};
-  const seen = new Set();
-  const inputs = Array.from(cell.references || []).flatMap((i) => {
-    if (i.name) {
-      if (seen.has(i.name)) return [];
-      seen.add(i.name);
-      return i.name;
+    let dollarIdx = 0;
+    const inputToArgMap = {};
+    const dollarToMacro = {};
+    const seen = new Set();
+    const inputs = Array.from(cell.references || []).flatMap(i => {
+        if (i.name) {
+            if (seen.has(i.name))
+                return [];
+            seen.add(i.name);
+            return i.name;
+        } else {
+            const dedupKey = i.type + ':' + i.id.name;
+            if (seen.has(dedupKey))
+                return [];
+            seen.add(dedupKey);
+            const dollarName = '$' + dollarIdx;
+            inputToArgMap[i.id.name] = dollarName;
+            dollarToMacro[dollarName] = i.type == 'ViewExpression' ? 'viewof ' + i.id.name : 'mutable ' + i.id.name;
+            dollarIdx++;
+            return dollarName;
+        }
+    });
+    let variables;
+    if (cell.id) {
+        if (cell.id.type === 'Identifier') {
+            variables = [{
+                    functionName: '_' + cell.id.name,
+                    name: cell.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                }];
+        } else if (cell.id.type === 'ViewExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'viewof ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '(G, _) => G.input(_)',
+                    inputs: [
+                        'Generators',
+                        'viewof ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                }
+            ];
+        } else if (cell.id.type === 'MutableExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'initial ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'mutable ' + cell.id.id.name,
+                    _definition: '(M, _) => new M(_)',
+                    inputs: [
+                        'Mutable',
+                        'initial ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '_ => _.generator',
+                    inputs: ['mutable ' + cell.id.id.name],
+                    params: inputs.join(',')
+                }
+            ];
+        } else {
+            throw new Error(`Unsupported cell id type: ${ cell.id.type }`);
+        }
     } else {
-      const dedupKey = i.type + ":" + i.id.name;
-      if (seen.has(dedupKey)) return [];
-      seen.add(dedupKey);
-      const dollarName = "$" + dollarIdx;
-      inputToArgMap[i.id.name] = dollarName;
-      dollarToMacro[dollarName] =
-        i.type == "ViewExpression"
-          ? "viewof " + i.id.name
-          : "mutable " + i.id.name;
-      dollarIdx++;
-      return dollarName;
+        variables = [{
+                functionName: anonymousName,
+                name: null,
+                inputs,
+                params: inputs.join(',')
+            }];
     }
-  });
-  let variables;
-  if (cell.id) {
-    if (cell.id.type === "Identifier") {
-      variables = [
-        {
-          functionName: "_" + cell.id.name,
-          name: cell.id.name,
-          inputs,
-          params: inputs.join(",")
+    return variables.map(v => {
+        let _definition = v._definition;
+        if (!_definition) {
+            let functionBody;
+            if (cell.body.type === 'BlockStatement') {
+                functionBody = observableToJs(cell.body, inputToArgMap, comments, tokens);
+            } else {
+                const bodyCode = observableToJs(cell.body, inputToArgMap, comments, tokens);
+                functionBody = `{return (${ bodyCode });}`;
+            }
+            _definition = `${ cell.async ? 'async ' : '' }function${ cell.generator ? '*' : '' } ${ v.functionName }(${ v.inputs.join(',') }) ${ functionBody }`;
         }
-      ];
-    } else if (cell.id.type === "ViewExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "viewof " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "(G, _) => G.input(_)",
-          inputs: ["Generators", "viewof " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else if (cell.id.type === "MutableExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "initial " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "mutable " + cell.id.id.name,
-          _definition: "(M, _) => new M(_)",
-          inputs: ["Mutable", "initial " + cell.id.id.name],
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "_ => _.generator",
-          inputs: ["mutable " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else {
-      throw new Error(`Unsupported cell id type: ${cell.id.type}`);
-    }
-  } else {
-    variables = [
-      {
-        functionName: anonymousName,
-        name: null,
-        inputs,
-        params: inputs.join(",")
-      }
-    ];
-  }
-  return variables.map((v) => {
-    let _definition = v._definition;
-    if (!_definition) {
-      let functionBody;
-      if (cell.body.type === "BlockStatement") {
-        functionBody = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-      } else {
-        const bodyCode = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-        functionBody = `{return (${bodyCode});}`;
-      }
-      _definition = `${cell.async ? "async " : ""}function${
-        cell.generator ? "*" : ""
-      } ${v.functionName}(${v.inputs.join(",")}) ${functionBody}`;
-    }
-    return {
-      _name: v.name,
-      _inputs: v.inputs.map(
-        (i) => dollarToMacro[i] || (i === "$variable" ? "@variable" : i)
-      ),
-      _definition
-    };
-  });
+        return {
+            _name: v.name,
+            _inputs: v.inputs.map(i => dollarToMacro[i] || (i === '$variable' ? '@variable' : i)),
+            _definition
+        };
+    });
 }
 )};
 const _1v1i7wl = function _observableToJs(acorn_walk,parser,escodegen){return(
@@ -18729,16 +18667,15 @@ async (attachment, overrides) => {
   return URL.createObjectURL(blob);
 }
 )};
-const _s9w7ha = async function _parser(decompress_url,FileAttachment,acorn_url,acorn_walk_url){return(
-importShim(await decompress_url(FileAttachment("parser-6.1.0.js.gz"), {
-    "/npm/acorn@8.11.3/+esm": acorn_url,
-    "/npm/acorn-walk@8.3.2/+esm": acorn_walk_url
-  })
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
-const _1hiclbb = function _acorn_walk(acorn_walk_url){return(
-importShim(acorn_walk_url, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _s9w7ha = async function _parser(decompress_url, FileAttachment, acorn_url, acorn_walk_url) {
+    return import(await decompress_url(FileAttachment('parser-6.1.0.js.gz'), {
+        '/npm/acorn@8.11.3/+esm': acorn_url,
+        '/npm/acorn-walk@8.3.2/+esm': acorn_walk_url
+    }));
+};
+const _1hiclbb = function _acorn_walk(acorn_walk_url) {
+    return import(acorn_walk_url);
+};
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
@@ -18926,7 +18863,7 @@ export default function define(runtime, observer) {
   $def("_1dmmuaf", "compiled_selector", ["Generators","viewof compiled_selector"], _1dmmuaf);  
   $def("_u7t3vu", null, ["compiled_selector","normalizeJavascriptSource"], _u7t3vu);  
   $def("_1lt3kl6", null, ["compile","test_case"], _1lt3kl6);  
-  $def("_lpzjrv", "compile", ["parser","globalThis","observableToJs"], _lpzjrv);  
+  $def("_x1d0wm", "compile", ["parser","observableToJs"], _x1d0wm);  
   $def("_1v1i7wl", "observableToJs", ["acorn_walk","parser","escodegen"], _1v1i7wl);  
   $def("_19lv24l", null, ["md"], _19lv24l);  
   $def("_xhj6b8", "decompress_url", ["DecompressionStream","TextDecoderStream","TransformStream","TextEncoderStream","Response"], _xhj6b8);  

--- a/notebooks/@tomlarkworthy_themes.html
+++ b/notebooks/@tomlarkworthy_themes.html
@@ -5437,58 +5437,41 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _geoudp = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
-  if (command.processed) return;
-
-  let result = undefined;
-  if (command.command == "createCell") {
-    $0.value = true;
-    result = compile_and_update("{}", [], command.args.cell);
-    // For the new one to get focus
-    // setTimeout(() => {
-    //   debugger;
-    //   setOption(result[0], "pinned", true);
-    // }, 100);
-  } else if (command.command == "deleteCell") {
-    remove_variables(command.args.cell.variables);
-    result = true;
-  } else if (command.command == "moveCell") {
-    const cellIndex = findCellIndex(
-      command.args.cell.variables,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const targetCellIndex = cellIndex + command.args.amount;
-    const targetCell = lookupCellByIndex(
-      targetCellIndex,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const currentFirstVariableIndex = findVariableIndex(
-      command.args.cell.variables[0]
-    );
-    const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-    const change = targetFirstVariableIndex - currentFirstVariableIndex;
-    console.log(
-      "moveCell",
-      cellIndex,
-      targetCellIndex,
-      targetCell,
-      currentFirstVariableIndex,
-      targetFirstVariableIndex,
-      change
-    );
-    command.args.cell.variables.forEach((v) => {
-      const currentIndex = findVariableIndex(v);
-      repositionSetElement(runtime._variables, v, currentIndex + change);
-    });
-    // recompute
-    await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
-    result = true;
-  }
-  if (result) {
-    command.processed = true;
-    $2.resolve(result);
-  }
+    if (command.processed)
+        return;
+    let result = undefined;
+    if (command.command == 'createCell') {
+        $0.value = true;
+        result = await compile_and_update('{}', [], command.args.cell);    // For the new one to get focus
+                                                                           // setTimeout(() => {
+                                                                           //   debugger;
+                                                                           //   setOption(result[0], "pinned", true);
+                                                                           // }, 100);
+    } else if (command.command == 'deleteCell') {
+        remove_variables(command.args.cell.variables);
+        result = true;
+    } else if (command.command == 'moveCell') {
+        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const targetCellIndex = cellIndex + command.args.amount;
+        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
+        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+        const change = targetFirstVariableIndex - currentFirstVariableIndex;
+        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
+        command.args.cell.variables.forEach(v => {
+            const currentIndex = findVariableIndex(v);
+            repositionSetElement(runtime._variables, v, currentIndex + change);
+        });
+        // recompute
+        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        result = true;
+    }
+    if (result) {
+        command.processed = true;
+        $2.resolve(result);
+    }
 };
 const _1jadxoe = function _60(md){return(
 md`### UI Action`
@@ -5879,9 +5862,9 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
-    return (source, variables = [], cell) => {
+    return async (source, variables = [], cell) => {
         try {
             debugger;
             let reposition = false, insertionIndex = -1;
@@ -5901,10 +5884,10 @@ const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElemen
             if (reposition) {
                 insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
+            const fns = await realize(newVariables.map(v => v._definition), runtime);
             newVariables.forEach((v, i) => {
                 const variable = variables[i];
-                let _fn;
-                eval('_fn = ' + v._definition);
+                const _fn = fns[i];
                 if (v._name) {
                     variable.define(v._name, v._inputs, _fn);
                 } else {
@@ -5953,12 +5936,11 @@ Inputs.textarea({
 })
 )};
 const _b4rsn5 = (G, _) => G.input(_);
-const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
+const _ga6kci = function _98(Inputs,definition,variable,realize,runtime,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
-  reduce: () => {
-    let _fn;
-    eval("_fn = " + definition);
+  reduce: async () => {
+    const [_fn] = await realize([definition], runtime);
     variable.define(variable._name, inputs, _fn);
   }
 })
@@ -6071,7 +6053,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_geoudp", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _geoudp);  
+  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6109,7 +6091,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
+  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -6119,8 +6101,9 @@ export default function define(runtime, observer) {
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
   $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
-  $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
+  $def("_ga6kci", null, ["Inputs","definition","variable","realize","runtime","inputs"], _ga6kci);  
   $def("_1q557s", null, ["md"], _1q557s);  
+  main.define("realize", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("realize", _));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -16490,10 +16473,9 @@ notebook_semantics_document.nodes.map((s) => ({
 const _1oevsow = function _28(md){return(
 md`### Runtime Representation (v4)`
 )};
-const _11lfflk = function _notebook_semantics_module(){return(
-importShim("https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4"
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _11lfflk = function _notebook_semantics_module() {
+    return import('https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4');
+};
 const _gjten6 = function _31(md){return(
 md`### Imports`
 )};
@@ -17480,65 +17462,44 @@ parser.parseCell(
   'import {runtime, viewof main as foo} from "@mootari/access-runtime"'
 )
 )};
-const _1n7gw17 = function _findModuleName(extractModuleInfo){return(
-(scope, module, { unknown_id = Math.random() } = {}) => {
-  try {
-    const scopedVariables = [...scope.values()];
-
-    // Prefer variables that *define* a module and have a real module-loader name.
-    const candidates = scopedVariables.filter(
-      (v) =>
-        v &&
-        v._value === module &&
-        typeof v._name === "string" &&
-        v._name.startsWith("module ") &&
-        !v._name.startsWith("module <unknown")
-    );
-
-    const pickBestInfo = (dfn) => {
-      // Avoid the parentUrl (2nd arg) confusing module identification.
-      // Typical patterns:
-      //   importShim("/d/<id>@<ver>.js?v=4", "https://api.observablehq.com/@ns/name.js?v=4")
-      //   import("/d/<id>@<ver>.js?v=4")
-      // Prefer the *first argument* inside importShim(...) / import(...) when present.
-      const s = String(dfn ?? "");
-
-      // Try to capture the first string literal argument to importShim(...) or import(...)
-      // Tolerates quotes ", ', ` and both importShim and plain import.
-      const m = s.match(
-        /\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/
-      );
-      const firstArg = m?.[2];
-
-      const info1 = firstArg ? extractModuleInfo(firstArg) : {};
-      if (info1?.id || info1?.notebook) return info1;
-
-      // Fallback: parse the whole definition string.
-      return extractModuleInfo(s);
+const _1n7gw17 = function _findModuleName(extractModuleInfo) {
+    return (scope, module, {
+        unknown_id = Math.random()
+    } = {}) => {
+        try {
+            const scopedVariables = [...scope.values()];
+            const candidates = scopedVariables.filter(v => v && v._value === module && typeof v._name === 'string' && v._name.startsWith('module ') && !v._name.startsWith('module <unknown'));
+            const pickBestInfo = dfn => {
+                const s = String(dfn ?? '');
+                const m = s.match(/\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/);
+                const firstArg = m?.[2];
+                const info1 = firstArg ? extractModuleInfo(firstArg) : {};
+                if (info1?.id || info1?.notebook)
+                    return info1;
+                return extractModuleInfo(s);
+            };
+            for (const v of candidates) {
+                const info = pickBestInfo(v._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            const any = scopedVariables.find(v => v && v._value === module);
+            if (any) {
+                const info = pickBestInfo(any._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            return `<unknown ${ unknown_id }>`;
+        } catch (e) {
+            debugger;
+            return 'error';
+        }
     };
-
-    // Try module loader cells first.
-    for (const v of candidates) {
-      const info = pickBestInfo(v._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    // Fallback: any scoped variable with _value==module.
-    const any = scopedVariables.find((v) => v && v._value === module);
-    if (any) {
-      const info = pickBestInfo(any._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    return `<unknown ${unknown_id}>`;
-  } catch (e) {
-    debugger;
-    return "error";
-  }
-}
-)};
+};
 const _i47chb = function _findImportedName(){return(
 async (v) => {
   if (v._inputs.length == 1 && v._inputs[0]._name === "@variable") {
@@ -18440,229 +18401,206 @@ JSON.stringify(
 const _1lt3kl6 = function _157(compile,test_case){return(
 compile(test_case.value)
 )};
-const _lpzjrv = function _compile(parser,globalThis,observableToJs){return(
-function compile(source, { anonymousName = "_anonymous" } = {}) {
-  const comments = [],
-    tokens = [];
-  let cell;
-  try {
-    cell = parser.parseCell(source, {
-      ranges: true,
-      onComment: comments,
-      onToken: tokens
-    });
-  } catch (e) {
-    if (e instanceof SyntaxError) {
-      const nameMatch = source.match(
-        /^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/
-      );
-      let _name = null;
-      let funcName = anonymousName;
-      if (nameMatch) {
-        const prefix = nameMatch[1] ? nameMatch[1] + " " : "";
-        _name = prefix + nameMatch[2];
-        funcName = "_" + nameMatch[2];
-      }
-      const escapedMsg = JSON.stringify(e.message);
-      const escapedSource = JSON.stringify(source);
-      return [
-        {
-          _name,
-          _inputs: [],
-          _definition: `function ${funcName}() { throw Object.assign(new SyntaxError(${escapedMsg}), {_sourceExpression: ${escapedSource}}); }`
+const _x1d0wm = function _compile(parser,observableToJs){return(
+function compile(source, {
+    anonymousName = '_anonymous'
+} = {}) {
+    const comments = [], tokens = [];
+    let cell;
+    try {
+        cell = parser.parseCell(source, {
+            ranges: true,
+            onComment: comments,
+            onToken: tokens
+        });
+    } catch (e) {
+        if (e instanceof SyntaxError) {
+            const nameMatch = source.match(/^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/);
+            let _name = null;
+            let funcName = anonymousName;
+            if (nameMatch) {
+                const prefix = nameMatch[1] ? nameMatch[1] + ' ' : '';
+                _name = prefix + nameMatch[2];
+                funcName = '_' + nameMatch[2];
+            }
+            const escapedMsg = JSON.stringify(e.message);
+            const escapedSource = JSON.stringify(source);
+            return [{
+                    _name,
+                    _inputs: [],
+                    _definition: `function ${ funcName }() { throw Object.assign(new SyntaxError(${ escapedMsg }), {_sourceExpression: ${ escapedSource }}); }`
+                }];
         }
-      ];
+        throw e;
     }
-    throw e;
-  }
-  if (!cell) throw new Error("Unable to parse cell");
-  const parseImportSpecifierText = (text) => {
-    const t = String(text ?? "")
-      .trim()
-      .replace(/,$/, "")
-      .trim();
-    if (!t) throw new Error("Empty import specifier");
-    const parts = t.split(/\s+as\s+/);
-    const left = parts[0].trim();
-    const right = parts[1]?.trim();
-    const parseSide = (side, { defaultPrefix = "" } = {}) => {
-      const s = String(side ?? "").trim();
-      const m = s.match(/^(viewof|mutable)\s+(.+)$/);
-      if (m)
-        return {
-          prefix: `${m[1]} `,
-          name: m[2].trim()
+    if (!cell)
+        throw new Error('Unable to parse cell');
+    const parseImportSpecifierText = text => {
+        const t = String(text ?? '').trim().replace(/,$/, '').trim();
+        if (!t)
+            throw new Error('Empty import specifier');
+        const parts = t.split(/\s+as\s+/);
+        const left = parts[0].trim();
+        const right = parts[1]?.trim();
+        const parseSide = (side, {
+            defaultPrefix = ''
+        } = {}) => {
+            const s = String(side ?? '').trim();
+            const m = s.match(/^(viewof|mutable)\s+(.+)$/);
+            if (m)
+                return {
+                    prefix: `${ m[1] } `,
+                    name: m[2].trim()
+                };
+            return {
+                prefix: defaultPrefix,
+                name: s
+            };
         };
-      return {
-        prefix: defaultPrefix,
-        name: s
-      };
+        const L = parseSide(left);
+        const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
+        const importedName = `${ L.prefix }${ L.name }`.trim();
+        const localName = `${ R.prefix }${ R.name }`.trim();
+        if (!importedName)
+            throw new Error(`Could not parse imported name from: ${ t }`);
+        if (!localName)
+            throw new Error(`Could not parse local name from: ${ t }`);
+        return {
+            importedName,
+            localName
+        };
     };
-    const L = parseSide(left);
-    const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
-    const importedName = `${L.prefix}${L.name}`.trim();
-    const localName = `${R.prefix}${R.name}`.trim();
-    if (!importedName)
-      throw new Error(`Could not parse imported name from: ${t}`);
-    if (!localName) throw new Error(`Could not parse local name from: ${t}`);
-    return {
-      importedName,
-      localName
-    };
-  };
-  if (!cell.id && cell.body?.type === "ImportDeclaration") {
-    const module_name = cell.body.source.value;
-    const importKeyword = globalThis?.importShim ? "importShim" : "import";
-    const cell_variables = [
-      {
-        _name: `module ${module_name}`,
-        _inputs: [],
-        _definition: `async () => runtime.module((await ${importKeyword}("${module_name}")).default)`
-      }
-    ];
-    for (const specifier of cell.body.specifiers ?? []) {
-      const specText =
-        typeof specifier?.start === "number" &&
-        typeof specifier?.end === "number"
-          ? source.slice(specifier.start, specifier.end)
-          : (() => {
-              if (specifier?.imported?.name && specifier?.local?.name) {
-                return specifier.imported.name === specifier.local.name
-                  ? specifier.local.name
-                  : `${specifier.imported.name} as ${specifier.local.name}`;
-              }
-              throw new Error("Import specifier missing range information");
+    if (!cell.id && cell.body?.type === 'ImportDeclaration') {
+        const module_name = cell.body.source.value;
+        const cell_variables = [{
+                _name: `module ${ module_name }`,
+                _inputs: [],
+                _definition: `async () => runtime.module((await import("${ module_name }")).default)`
+            }];
+        for (const specifier of cell.body.specifiers ?? []) {
+            const specText = typeof specifier?.start === 'number' && typeof specifier?.end === 'number' ? source.slice(specifier.start, specifier.end) : (() => {
+                if (specifier?.imported?.name && specifier?.local?.name) {
+                    return specifier.imported.name === specifier.local.name ? specifier.local.name : `${ specifier.imported.name } as ${ specifier.local.name }`;
+                }
+                throw new Error('Import specifier missing range information');
             })();
-      const { importedName, localName } = parseImportSpecifierText(specText);
-      cell_variables.push({
-        _name: localName,
-        _inputs: [`module ${module_name}`, "@variable"],
-        _definition:
-          importedName === localName
-            ? `(_, v) => v.import("${importedName}", _)`
-            : `(_, v) => v.import("${importedName}", "${localName}", _)`
-      });
+            const {importedName, localName} = parseImportSpecifierText(specText);
+            cell_variables.push({
+                _name: localName,
+                _inputs: [
+                    `module ${ module_name }`,
+                    '@variable'
+                ],
+                _definition: importedName === localName ? `(_, v) => v.import("${ importedName }", _)` : `(_, v) => v.import("${ importedName }", "${ localName }", _)`
+            });
+        }
+        return cell_variables;
     }
-    return cell_variables;
-  }
-  let dollarIdx = 0;
-  const inputToArgMap = {};
-  const dollarToMacro = {};
-  const seen = new Set();
-  const inputs = Array.from(cell.references || []).flatMap((i) => {
-    if (i.name) {
-      if (seen.has(i.name)) return [];
-      seen.add(i.name);
-      return i.name;
+    let dollarIdx = 0;
+    const inputToArgMap = {};
+    const dollarToMacro = {};
+    const seen = new Set();
+    const inputs = Array.from(cell.references || []).flatMap(i => {
+        if (i.name) {
+            if (seen.has(i.name))
+                return [];
+            seen.add(i.name);
+            return i.name;
+        } else {
+            const dedupKey = i.type + ':' + i.id.name;
+            if (seen.has(dedupKey))
+                return [];
+            seen.add(dedupKey);
+            const dollarName = '$' + dollarIdx;
+            inputToArgMap[i.id.name] = dollarName;
+            dollarToMacro[dollarName] = i.type == 'ViewExpression' ? 'viewof ' + i.id.name : 'mutable ' + i.id.name;
+            dollarIdx++;
+            return dollarName;
+        }
+    });
+    let variables;
+    if (cell.id) {
+        if (cell.id.type === 'Identifier') {
+            variables = [{
+                    functionName: '_' + cell.id.name,
+                    name: cell.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                }];
+        } else if (cell.id.type === 'ViewExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'viewof ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '(G, _) => G.input(_)',
+                    inputs: [
+                        'Generators',
+                        'viewof ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                }
+            ];
+        } else if (cell.id.type === 'MutableExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'initial ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'mutable ' + cell.id.id.name,
+                    _definition: '(M, _) => new M(_)',
+                    inputs: [
+                        'Mutable',
+                        'initial ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '_ => _.generator',
+                    inputs: ['mutable ' + cell.id.id.name],
+                    params: inputs.join(',')
+                }
+            ];
+        } else {
+            throw new Error(`Unsupported cell id type: ${ cell.id.type }`);
+        }
     } else {
-      const dedupKey = i.type + ":" + i.id.name;
-      if (seen.has(dedupKey)) return [];
-      seen.add(dedupKey);
-      const dollarName = "$" + dollarIdx;
-      inputToArgMap[i.id.name] = dollarName;
-      dollarToMacro[dollarName] =
-        i.type == "ViewExpression"
-          ? "viewof " + i.id.name
-          : "mutable " + i.id.name;
-      dollarIdx++;
-      return dollarName;
+        variables = [{
+                functionName: anonymousName,
+                name: null,
+                inputs,
+                params: inputs.join(',')
+            }];
     }
-  });
-  let variables;
-  if (cell.id) {
-    if (cell.id.type === "Identifier") {
-      variables = [
-        {
-          functionName: "_" + cell.id.name,
-          name: cell.id.name,
-          inputs,
-          params: inputs.join(",")
+    return variables.map(v => {
+        let _definition = v._definition;
+        if (!_definition) {
+            let functionBody;
+            if (cell.body.type === 'BlockStatement') {
+                functionBody = observableToJs(cell.body, inputToArgMap, comments, tokens);
+            } else {
+                const bodyCode = observableToJs(cell.body, inputToArgMap, comments, tokens);
+                functionBody = `{return (${ bodyCode });}`;
+            }
+            _definition = `${ cell.async ? 'async ' : '' }function${ cell.generator ? '*' : '' } ${ v.functionName }(${ v.inputs.join(',') }) ${ functionBody }`;
         }
-      ];
-    } else if (cell.id.type === "ViewExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "viewof " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "(G, _) => G.input(_)",
-          inputs: ["Generators", "viewof " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else if (cell.id.type === "MutableExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "initial " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "mutable " + cell.id.id.name,
-          _definition: "(M, _) => new M(_)",
-          inputs: ["Mutable", "initial " + cell.id.id.name],
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "_ => _.generator",
-          inputs: ["mutable " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else {
-      throw new Error(`Unsupported cell id type: ${cell.id.type}`);
-    }
-  } else {
-    variables = [
-      {
-        functionName: anonymousName,
-        name: null,
-        inputs,
-        params: inputs.join(",")
-      }
-    ];
-  }
-  return variables.map((v) => {
-    let _definition = v._definition;
-    if (!_definition) {
-      let functionBody;
-      if (cell.body.type === "BlockStatement") {
-        functionBody = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-      } else {
-        const bodyCode = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-        functionBody = `{return (${bodyCode});}`;
-      }
-      _definition = `${cell.async ? "async " : ""}function${
-        cell.generator ? "*" : ""
-      } ${v.functionName}(${v.inputs.join(",")}) ${functionBody}`;
-    }
-    return {
-      _name: v.name,
-      _inputs: v.inputs.map(
-        (i) => dollarToMacro[i] || (i === "$variable" ? "@variable" : i)
-      ),
-      _definition
-    };
-  });
+        return {
+            _name: v.name,
+            _inputs: v.inputs.map(i => dollarToMacro[i] || (i === '$variable' ? '@variable' : i)),
+            _definition
+        };
+    });
 }
 )};
 const _1v1i7wl = function _observableToJs(acorn_walk,parser,escodegen){return(
@@ -18729,16 +18667,15 @@ async (attachment, overrides) => {
   return URL.createObjectURL(blob);
 }
 )};
-const _s9w7ha = async function _parser(decompress_url,FileAttachment,acorn_url,acorn_walk_url){return(
-importShim(await decompress_url(FileAttachment("parser-6.1.0.js.gz"), {
-    "/npm/acorn@8.11.3/+esm": acorn_url,
-    "/npm/acorn-walk@8.3.2/+esm": acorn_walk_url
-  })
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
-const _1hiclbb = function _acorn_walk(acorn_walk_url){return(
-importShim(acorn_walk_url, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _s9w7ha = async function _parser(decompress_url, FileAttachment, acorn_url, acorn_walk_url) {
+    return import(await decompress_url(FileAttachment('parser-6.1.0.js.gz'), {
+        '/npm/acorn@8.11.3/+esm': acorn_url,
+        '/npm/acorn-walk@8.3.2/+esm': acorn_walk_url
+    }));
+};
+const _1hiclbb = function _acorn_walk(acorn_walk_url) {
+    return import(acorn_walk_url);
+};
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
@@ -18926,7 +18863,7 @@ export default function define(runtime, observer) {
   $def("_1dmmuaf", "compiled_selector", ["Generators","viewof compiled_selector"], _1dmmuaf);  
   $def("_u7t3vu", null, ["compiled_selector","normalizeJavascriptSource"], _u7t3vu);  
   $def("_1lt3kl6", null, ["compile","test_case"], _1lt3kl6);  
-  $def("_lpzjrv", "compile", ["parser","globalThis","observableToJs"], _lpzjrv);  
+  $def("_x1d0wm", "compile", ["parser","observableToJs"], _x1d0wm);  
   $def("_1v1i7wl", "observableToJs", ["acorn_walk","parser","escodegen"], _1v1i7wl);  
   $def("_19lv24l", null, ["md"], _19lv24l);  
   $def("_xhj6b8", "decompress_url", ["DecompressionStream","TextDecoderStream","TransformStream","TextEncoderStream","Response"], _xhj6b8);  

--- a/notebooks/@tomlarkworthy_visualizer.html
+++ b/notebooks/@tomlarkworthy_visualizer.html
@@ -5437,58 +5437,41 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _geoudp = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
-  if (command.processed) return;
-
-  let result = undefined;
-  if (command.command == "createCell") {
-    $0.value = true;
-    result = compile_and_update("{}", [], command.args.cell);
-    // For the new one to get focus
-    // setTimeout(() => {
-    //   debugger;
-    //   setOption(result[0], "pinned", true);
-    // }, 100);
-  } else if (command.command == "deleteCell") {
-    remove_variables(command.args.cell.variables);
-    result = true;
-  } else if (command.command == "moveCell") {
-    const cellIndex = findCellIndex(
-      command.args.cell.variables,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const targetCellIndex = cellIndex + command.args.amount;
-    const targetCell = lookupCellByIndex(
-      targetCellIndex,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const currentFirstVariableIndex = findVariableIndex(
-      command.args.cell.variables[0]
-    );
-    const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-    const change = targetFirstVariableIndex - currentFirstVariableIndex;
-    console.log(
-      "moveCell",
-      cellIndex,
-      targetCellIndex,
-      targetCell,
-      currentFirstVariableIndex,
-      targetFirstVariableIndex,
-      change
-    );
-    command.args.cell.variables.forEach((v) => {
-      const currentIndex = findVariableIndex(v);
-      repositionSetElement(runtime._variables, v, currentIndex + change);
-    });
-    // recompute
-    await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
-    result = true;
-  }
-  if (result) {
-    command.processed = true;
-    $2.resolve(result);
-  }
+    if (command.processed)
+        return;
+    let result = undefined;
+    if (command.command == 'createCell') {
+        $0.value = true;
+        result = await compile_and_update('{}', [], command.args.cell);    // For the new one to get focus
+                                                                           // setTimeout(() => {
+                                                                           //   debugger;
+                                                                           //   setOption(result[0], "pinned", true);
+                                                                           // }, 100);
+    } else if (command.command == 'deleteCell') {
+        remove_variables(command.args.cell.variables);
+        result = true;
+    } else if (command.command == 'moveCell') {
+        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const targetCellIndex = cellIndex + command.args.amount;
+        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
+        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+        const change = targetFirstVariableIndex - currentFirstVariableIndex;
+        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
+        command.args.cell.variables.forEach(v => {
+            const currentIndex = findVariableIndex(v);
+            repositionSetElement(runtime._variables, v, currentIndex + change);
+        });
+        // recompute
+        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        result = true;
+    }
+    if (result) {
+        command.processed = true;
+        $2.resolve(result);
+    }
 };
 const _1jadxoe = function _60(md){return(
 md`### UI Action`
@@ -5879,9 +5862,9 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
-    return (source, variables = [], cell) => {
+    return async (source, variables = [], cell) => {
         try {
             debugger;
             let reposition = false, insertionIndex = -1;
@@ -5901,10 +5884,10 @@ const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElemen
             if (reposition) {
                 insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
+            const fns = await realize(newVariables.map(v => v._definition), runtime);
             newVariables.forEach((v, i) => {
                 const variable = variables[i];
-                let _fn;
-                eval('_fn = ' + v._definition);
+                const _fn = fns[i];
                 if (v._name) {
                     variable.define(v._name, v._inputs, _fn);
                 } else {
@@ -5953,12 +5936,11 @@ Inputs.textarea({
 })
 )};
 const _b4rsn5 = (G, _) => G.input(_);
-const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
+const _ga6kci = function _98(Inputs,definition,variable,realize,runtime,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
-  reduce: () => {
-    let _fn;
-    eval("_fn = " + definition);
+  reduce: async () => {
+    const [_fn] = await realize([definition], runtime);
     variable.define(variable._name, inputs, _fn);
   }
 })
@@ -6071,7 +6053,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_geoudp", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _geoudp);  
+  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6109,7 +6091,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
+  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -6119,8 +6101,9 @@ export default function define(runtime, observer) {
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
   $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
-  $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
+  $def("_ga6kci", null, ["Inputs","definition","variable","realize","runtime","inputs"], _ga6kci);  
   $def("_1q557s", null, ["md"], _1q557s);  
+  main.define("realize", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("realize", _));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -16490,10 +16473,9 @@ notebook_semantics_document.nodes.map((s) => ({
 const _1oevsow = function _28(md){return(
 md`### Runtime Representation (v4)`
 )};
-const _11lfflk = function _notebook_semantics_module(){return(
-importShim("https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4"
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _11lfflk = function _notebook_semantics_module() {
+    return import('https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4');
+};
 const _gjten6 = function _31(md){return(
 md`### Imports`
 )};
@@ -17480,65 +17462,44 @@ parser.parseCell(
   'import {runtime, viewof main as foo} from "@mootari/access-runtime"'
 )
 )};
-const _1n7gw17 = function _findModuleName(extractModuleInfo){return(
-(scope, module, { unknown_id = Math.random() } = {}) => {
-  try {
-    const scopedVariables = [...scope.values()];
-
-    // Prefer variables that *define* a module and have a real module-loader name.
-    const candidates = scopedVariables.filter(
-      (v) =>
-        v &&
-        v._value === module &&
-        typeof v._name === "string" &&
-        v._name.startsWith("module ") &&
-        !v._name.startsWith("module <unknown")
-    );
-
-    const pickBestInfo = (dfn) => {
-      // Avoid the parentUrl (2nd arg) confusing module identification.
-      // Typical patterns:
-      //   importShim("/d/<id>@<ver>.js?v=4", "https://api.observablehq.com/@ns/name.js?v=4")
-      //   import("/d/<id>@<ver>.js?v=4")
-      // Prefer the *first argument* inside importShim(...) / import(...) when present.
-      const s = String(dfn ?? "");
-
-      // Try to capture the first string literal argument to importShim(...) or import(...)
-      // Tolerates quotes ", ', ` and both importShim and plain import.
-      const m = s.match(
-        /\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/
-      );
-      const firstArg = m?.[2];
-
-      const info1 = firstArg ? extractModuleInfo(firstArg) : {};
-      if (info1?.id || info1?.notebook) return info1;
-
-      // Fallback: parse the whole definition string.
-      return extractModuleInfo(s);
+const _1n7gw17 = function _findModuleName(extractModuleInfo) {
+    return (scope, module, {
+        unknown_id = Math.random()
+    } = {}) => {
+        try {
+            const scopedVariables = [...scope.values()];
+            const candidates = scopedVariables.filter(v => v && v._value === module && typeof v._name === 'string' && v._name.startsWith('module ') && !v._name.startsWith('module <unknown'));
+            const pickBestInfo = dfn => {
+                const s = String(dfn ?? '');
+                const m = s.match(/\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/);
+                const firstArg = m?.[2];
+                const info1 = firstArg ? extractModuleInfo(firstArg) : {};
+                if (info1?.id || info1?.notebook)
+                    return info1;
+                return extractModuleInfo(s);
+            };
+            for (const v of candidates) {
+                const info = pickBestInfo(v._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            const any = scopedVariables.find(v => v && v._value === module);
+            if (any) {
+                const info = pickBestInfo(any._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            return `<unknown ${ unknown_id }>`;
+        } catch (e) {
+            debugger;
+            return 'error';
+        }
     };
-
-    // Try module loader cells first.
-    for (const v of candidates) {
-      const info = pickBestInfo(v._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    // Fallback: any scoped variable with _value==module.
-    const any = scopedVariables.find((v) => v && v._value === module);
-    if (any) {
-      const info = pickBestInfo(any._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    return `<unknown ${unknown_id}>`;
-  } catch (e) {
-    debugger;
-    return "error";
-  }
-}
-)};
+};
 const _i47chb = function _findImportedName(){return(
 async (v) => {
   if (v._inputs.length == 1 && v._inputs[0]._name === "@variable") {
@@ -18440,229 +18401,206 @@ JSON.stringify(
 const _1lt3kl6 = function _157(compile,test_case){return(
 compile(test_case.value)
 )};
-const _lpzjrv = function _compile(parser,globalThis,observableToJs){return(
-function compile(source, { anonymousName = "_anonymous" } = {}) {
-  const comments = [],
-    tokens = [];
-  let cell;
-  try {
-    cell = parser.parseCell(source, {
-      ranges: true,
-      onComment: comments,
-      onToken: tokens
-    });
-  } catch (e) {
-    if (e instanceof SyntaxError) {
-      const nameMatch = source.match(
-        /^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/
-      );
-      let _name = null;
-      let funcName = anonymousName;
-      if (nameMatch) {
-        const prefix = nameMatch[1] ? nameMatch[1] + " " : "";
-        _name = prefix + nameMatch[2];
-        funcName = "_" + nameMatch[2];
-      }
-      const escapedMsg = JSON.stringify(e.message);
-      const escapedSource = JSON.stringify(source);
-      return [
-        {
-          _name,
-          _inputs: [],
-          _definition: `function ${funcName}() { throw Object.assign(new SyntaxError(${escapedMsg}), {_sourceExpression: ${escapedSource}}); }`
+const _x1d0wm = function _compile(parser,observableToJs){return(
+function compile(source, {
+    anonymousName = '_anonymous'
+} = {}) {
+    const comments = [], tokens = [];
+    let cell;
+    try {
+        cell = parser.parseCell(source, {
+            ranges: true,
+            onComment: comments,
+            onToken: tokens
+        });
+    } catch (e) {
+        if (e instanceof SyntaxError) {
+            const nameMatch = source.match(/^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/);
+            let _name = null;
+            let funcName = anonymousName;
+            if (nameMatch) {
+                const prefix = nameMatch[1] ? nameMatch[1] + ' ' : '';
+                _name = prefix + nameMatch[2];
+                funcName = '_' + nameMatch[2];
+            }
+            const escapedMsg = JSON.stringify(e.message);
+            const escapedSource = JSON.stringify(source);
+            return [{
+                    _name,
+                    _inputs: [],
+                    _definition: `function ${ funcName }() { throw Object.assign(new SyntaxError(${ escapedMsg }), {_sourceExpression: ${ escapedSource }}); }`
+                }];
         }
-      ];
+        throw e;
     }
-    throw e;
-  }
-  if (!cell) throw new Error("Unable to parse cell");
-  const parseImportSpecifierText = (text) => {
-    const t = String(text ?? "")
-      .trim()
-      .replace(/,$/, "")
-      .trim();
-    if (!t) throw new Error("Empty import specifier");
-    const parts = t.split(/\s+as\s+/);
-    const left = parts[0].trim();
-    const right = parts[1]?.trim();
-    const parseSide = (side, { defaultPrefix = "" } = {}) => {
-      const s = String(side ?? "").trim();
-      const m = s.match(/^(viewof|mutable)\s+(.+)$/);
-      if (m)
-        return {
-          prefix: `${m[1]} `,
-          name: m[2].trim()
+    if (!cell)
+        throw new Error('Unable to parse cell');
+    const parseImportSpecifierText = text => {
+        const t = String(text ?? '').trim().replace(/,$/, '').trim();
+        if (!t)
+            throw new Error('Empty import specifier');
+        const parts = t.split(/\s+as\s+/);
+        const left = parts[0].trim();
+        const right = parts[1]?.trim();
+        const parseSide = (side, {
+            defaultPrefix = ''
+        } = {}) => {
+            const s = String(side ?? '').trim();
+            const m = s.match(/^(viewof|mutable)\s+(.+)$/);
+            if (m)
+                return {
+                    prefix: `${ m[1] } `,
+                    name: m[2].trim()
+                };
+            return {
+                prefix: defaultPrefix,
+                name: s
+            };
         };
-      return {
-        prefix: defaultPrefix,
-        name: s
-      };
+        const L = parseSide(left);
+        const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
+        const importedName = `${ L.prefix }${ L.name }`.trim();
+        const localName = `${ R.prefix }${ R.name }`.trim();
+        if (!importedName)
+            throw new Error(`Could not parse imported name from: ${ t }`);
+        if (!localName)
+            throw new Error(`Could not parse local name from: ${ t }`);
+        return {
+            importedName,
+            localName
+        };
     };
-    const L = parseSide(left);
-    const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
-    const importedName = `${L.prefix}${L.name}`.trim();
-    const localName = `${R.prefix}${R.name}`.trim();
-    if (!importedName)
-      throw new Error(`Could not parse imported name from: ${t}`);
-    if (!localName) throw new Error(`Could not parse local name from: ${t}`);
-    return {
-      importedName,
-      localName
-    };
-  };
-  if (!cell.id && cell.body?.type === "ImportDeclaration") {
-    const module_name = cell.body.source.value;
-    const importKeyword = globalThis?.importShim ? "importShim" : "import";
-    const cell_variables = [
-      {
-        _name: `module ${module_name}`,
-        _inputs: [],
-        _definition: `async () => runtime.module((await ${importKeyword}("${module_name}")).default)`
-      }
-    ];
-    for (const specifier of cell.body.specifiers ?? []) {
-      const specText =
-        typeof specifier?.start === "number" &&
-        typeof specifier?.end === "number"
-          ? source.slice(specifier.start, specifier.end)
-          : (() => {
-              if (specifier?.imported?.name && specifier?.local?.name) {
-                return specifier.imported.name === specifier.local.name
-                  ? specifier.local.name
-                  : `${specifier.imported.name} as ${specifier.local.name}`;
-              }
-              throw new Error("Import specifier missing range information");
+    if (!cell.id && cell.body?.type === 'ImportDeclaration') {
+        const module_name = cell.body.source.value;
+        const cell_variables = [{
+                _name: `module ${ module_name }`,
+                _inputs: [],
+                _definition: `async () => runtime.module((await import("${ module_name }")).default)`
+            }];
+        for (const specifier of cell.body.specifiers ?? []) {
+            const specText = typeof specifier?.start === 'number' && typeof specifier?.end === 'number' ? source.slice(specifier.start, specifier.end) : (() => {
+                if (specifier?.imported?.name && specifier?.local?.name) {
+                    return specifier.imported.name === specifier.local.name ? specifier.local.name : `${ specifier.imported.name } as ${ specifier.local.name }`;
+                }
+                throw new Error('Import specifier missing range information');
             })();
-      const { importedName, localName } = parseImportSpecifierText(specText);
-      cell_variables.push({
-        _name: localName,
-        _inputs: [`module ${module_name}`, "@variable"],
-        _definition:
-          importedName === localName
-            ? `(_, v) => v.import("${importedName}", _)`
-            : `(_, v) => v.import("${importedName}", "${localName}", _)`
-      });
+            const {importedName, localName} = parseImportSpecifierText(specText);
+            cell_variables.push({
+                _name: localName,
+                _inputs: [
+                    `module ${ module_name }`,
+                    '@variable'
+                ],
+                _definition: importedName === localName ? `(_, v) => v.import("${ importedName }", _)` : `(_, v) => v.import("${ importedName }", "${ localName }", _)`
+            });
+        }
+        return cell_variables;
     }
-    return cell_variables;
-  }
-  let dollarIdx = 0;
-  const inputToArgMap = {};
-  const dollarToMacro = {};
-  const seen = new Set();
-  const inputs = Array.from(cell.references || []).flatMap((i) => {
-    if (i.name) {
-      if (seen.has(i.name)) return [];
-      seen.add(i.name);
-      return i.name;
+    let dollarIdx = 0;
+    const inputToArgMap = {};
+    const dollarToMacro = {};
+    const seen = new Set();
+    const inputs = Array.from(cell.references || []).flatMap(i => {
+        if (i.name) {
+            if (seen.has(i.name))
+                return [];
+            seen.add(i.name);
+            return i.name;
+        } else {
+            const dedupKey = i.type + ':' + i.id.name;
+            if (seen.has(dedupKey))
+                return [];
+            seen.add(dedupKey);
+            const dollarName = '$' + dollarIdx;
+            inputToArgMap[i.id.name] = dollarName;
+            dollarToMacro[dollarName] = i.type == 'ViewExpression' ? 'viewof ' + i.id.name : 'mutable ' + i.id.name;
+            dollarIdx++;
+            return dollarName;
+        }
+    });
+    let variables;
+    if (cell.id) {
+        if (cell.id.type === 'Identifier') {
+            variables = [{
+                    functionName: '_' + cell.id.name,
+                    name: cell.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                }];
+        } else if (cell.id.type === 'ViewExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'viewof ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '(G, _) => G.input(_)',
+                    inputs: [
+                        'Generators',
+                        'viewof ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                }
+            ];
+        } else if (cell.id.type === 'MutableExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'initial ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'mutable ' + cell.id.id.name,
+                    _definition: '(M, _) => new M(_)',
+                    inputs: [
+                        'Mutable',
+                        'initial ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '_ => _.generator',
+                    inputs: ['mutable ' + cell.id.id.name],
+                    params: inputs.join(',')
+                }
+            ];
+        } else {
+            throw new Error(`Unsupported cell id type: ${ cell.id.type }`);
+        }
     } else {
-      const dedupKey = i.type + ":" + i.id.name;
-      if (seen.has(dedupKey)) return [];
-      seen.add(dedupKey);
-      const dollarName = "$" + dollarIdx;
-      inputToArgMap[i.id.name] = dollarName;
-      dollarToMacro[dollarName] =
-        i.type == "ViewExpression"
-          ? "viewof " + i.id.name
-          : "mutable " + i.id.name;
-      dollarIdx++;
-      return dollarName;
+        variables = [{
+                functionName: anonymousName,
+                name: null,
+                inputs,
+                params: inputs.join(',')
+            }];
     }
-  });
-  let variables;
-  if (cell.id) {
-    if (cell.id.type === "Identifier") {
-      variables = [
-        {
-          functionName: "_" + cell.id.name,
-          name: cell.id.name,
-          inputs,
-          params: inputs.join(",")
+    return variables.map(v => {
+        let _definition = v._definition;
+        if (!_definition) {
+            let functionBody;
+            if (cell.body.type === 'BlockStatement') {
+                functionBody = observableToJs(cell.body, inputToArgMap, comments, tokens);
+            } else {
+                const bodyCode = observableToJs(cell.body, inputToArgMap, comments, tokens);
+                functionBody = `{return (${ bodyCode });}`;
+            }
+            _definition = `${ cell.async ? 'async ' : '' }function${ cell.generator ? '*' : '' } ${ v.functionName }(${ v.inputs.join(',') }) ${ functionBody }`;
         }
-      ];
-    } else if (cell.id.type === "ViewExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "viewof " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "(G, _) => G.input(_)",
-          inputs: ["Generators", "viewof " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else if (cell.id.type === "MutableExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "initial " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "mutable " + cell.id.id.name,
-          _definition: "(M, _) => new M(_)",
-          inputs: ["Mutable", "initial " + cell.id.id.name],
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "_ => _.generator",
-          inputs: ["mutable " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else {
-      throw new Error(`Unsupported cell id type: ${cell.id.type}`);
-    }
-  } else {
-    variables = [
-      {
-        functionName: anonymousName,
-        name: null,
-        inputs,
-        params: inputs.join(",")
-      }
-    ];
-  }
-  return variables.map((v) => {
-    let _definition = v._definition;
-    if (!_definition) {
-      let functionBody;
-      if (cell.body.type === "BlockStatement") {
-        functionBody = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-      } else {
-        const bodyCode = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-        functionBody = `{return (${bodyCode});}`;
-      }
-      _definition = `${cell.async ? "async " : ""}function${
-        cell.generator ? "*" : ""
-      } ${v.functionName}(${v.inputs.join(",")}) ${functionBody}`;
-    }
-    return {
-      _name: v.name,
-      _inputs: v.inputs.map(
-        (i) => dollarToMacro[i] || (i === "$variable" ? "@variable" : i)
-      ),
-      _definition
-    };
-  });
+        return {
+            _name: v.name,
+            _inputs: v.inputs.map(i => dollarToMacro[i] || (i === '$variable' ? '@variable' : i)),
+            _definition
+        };
+    });
 }
 )};
 const _1v1i7wl = function _observableToJs(acorn_walk,parser,escodegen){return(
@@ -18729,16 +18667,15 @@ async (attachment, overrides) => {
   return URL.createObjectURL(blob);
 }
 )};
-const _s9w7ha = async function _parser(decompress_url,FileAttachment,acorn_url,acorn_walk_url){return(
-importShim(await decompress_url(FileAttachment("parser-6.1.0.js.gz"), {
-    "/npm/acorn@8.11.3/+esm": acorn_url,
-    "/npm/acorn-walk@8.3.2/+esm": acorn_walk_url
-  })
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
-const _1hiclbb = function _acorn_walk(acorn_walk_url){return(
-importShim(acorn_walk_url, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _s9w7ha = async function _parser(decompress_url, FileAttachment, acorn_url, acorn_walk_url) {
+    return import(await decompress_url(FileAttachment('parser-6.1.0.js.gz'), {
+        '/npm/acorn@8.11.3/+esm': acorn_url,
+        '/npm/acorn-walk@8.3.2/+esm': acorn_walk_url
+    }));
+};
+const _1hiclbb = function _acorn_walk(acorn_walk_url) {
+    return import(acorn_walk_url);
+};
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
@@ -18926,7 +18863,7 @@ export default function define(runtime, observer) {
   $def("_1dmmuaf", "compiled_selector", ["Generators","viewof compiled_selector"], _1dmmuaf);  
   $def("_u7t3vu", null, ["compiled_selector","normalizeJavascriptSource"], _u7t3vu);  
   $def("_1lt3kl6", null, ["compile","test_case"], _1lt3kl6);  
-  $def("_lpzjrv", "compile", ["parser","globalThis","observableToJs"], _lpzjrv);  
+  $def("_x1d0wm", "compile", ["parser","observableToJs"], _x1d0wm);  
   $def("_1v1i7wl", "observableToJs", ["acorn_walk","parser","escodegen"], _1v1i7wl);  
   $def("_19lv24l", null, ["md"], _19lv24l);  
   $def("_xhj6b8", "decompress_url", ["DecompressionStream","TextDecoderStream","TransformStream","TextEncoderStream","Response"], _xhj6b8);  

--- a/notebooks/atproto.html
+++ b/notebooks/atproto.html
@@ -5984,7 +5984,7 @@ export default function define(runtime, observer) {
 >
 eyJAdG9tbGFya3dvcnRoeS9ibGFuay1ub3RlYm9vayI6eyJ2aWV3b2YgbG9naW5DbGljayI6eyJwaW5uZWQiOnRydWV9fSwiQHRvbWxhcmt3b3J0aHkvYXQtcmVhZCI6W251bGwseyJwaW5uZWQiOmZhbHNlfV0sIkB0b21sYXJrd29ydGh5L2F0cHJvdG8iOlt7InBpbm5lZCI6dHJ1ZX0seyJwaW5uZWQiOnRydWV9LG51bGwseyJwaW5uZWQiOmZhbHNlfV0sIkB0b21sYXJrd29ydGh5L2F0cHJvdG8tbG9naW4iOltudWxsLHsicGlubmVkIjpmYWxzZX1dLCJAdG9tbGFya3dvcnRoeS9hdC13cml0ZSI6eyJwdWJsaXNoV2lkZ2V0Ijp7InBpbm5lZCI6dHJ1ZX19fQ==
 </script>
-<script id="@tomlarkworthy/editor-5" 
+<script id="@tomlarkworthy/editor-5"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -6731,58 +6731,41 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _geoudp = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
-  if (command.processed) return;
-
-  let result = undefined;
-  if (command.command == "createCell") {
-    $0.value = true;
-    result = compile_and_update("{}", [], command.args.cell);
-    // For the new one to get focus
-    // setTimeout(() => {
-    //   debugger;
-    //   setOption(result[0], "pinned", true);
-    // }, 100);
-  } else if (command.command == "deleteCell") {
-    remove_variables(command.args.cell.variables);
-    result = true;
-  } else if (command.command == "moveCell") {
-    const cellIndex = findCellIndex(
-      command.args.cell.variables,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const targetCellIndex = cellIndex + command.args.amount;
-    const targetCell = lookupCellByIndex(
-      targetCellIndex,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const currentFirstVariableIndex = findVariableIndex(
-      command.args.cell.variables[0]
-    );
-    const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-    const change = targetFirstVariableIndex - currentFirstVariableIndex;
-    console.log(
-      "moveCell",
-      cellIndex,
-      targetCellIndex,
-      targetCell,
-      currentFirstVariableIndex,
-      targetFirstVariableIndex,
-      change
-    );
-    command.args.cell.variables.forEach((v) => {
-      const currentIndex = findVariableIndex(v);
-      repositionSetElement(runtime._variables, v, currentIndex + change);
-    });
-    // recompute
-    await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
-    result = true;
-  }
-  if (result) {
-    command.processed = true;
-    $2.resolve(result);
-  }
+    if (command.processed)
+        return;
+    let result = undefined;
+    if (command.command == 'createCell') {
+        $0.value = true;
+        result = await compile_and_update('{}', [], command.args.cell);    // For the new one to get focus
+                                                                           // setTimeout(() => {
+                                                                           //   debugger;
+                                                                           //   setOption(result[0], "pinned", true);
+                                                                           // }, 100);
+    } else if (command.command == 'deleteCell') {
+        remove_variables(command.args.cell.variables);
+        result = true;
+    } else if (command.command == 'moveCell') {
+        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const targetCellIndex = cellIndex + command.args.amount;
+        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
+        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+        const change = targetFirstVariableIndex - currentFirstVariableIndex;
+        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
+        command.args.cell.variables.forEach(v => {
+            const currentIndex = findVariableIndex(v);
+            repositionSetElement(runtime._variables, v, currentIndex + change);
+        });
+        // recompute
+        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        result = true;
+    }
+    if (result) {
+        command.processed = true;
+        $2.resolve(result);
+    }
 };
 const _1jadxoe = function _60(md){return(
 md`### UI Action`
@@ -7173,9 +7156,9 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
-    return (source, variables = [], cell) => {
+    return async (source, variables = [], cell) => {
         try {
             debugger;
             let reposition = false, insertionIndex = -1;
@@ -7195,10 +7178,10 @@ const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElemen
             if (reposition) {
                 insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
+            const fns = await realize(newVariables.map(v => v._definition), runtime);
             newVariables.forEach((v, i) => {
                 const variable = variables[i];
-                let _fn;
-                eval('_fn = ' + v._definition);
+                const _fn = fns[i];
                 if (v._name) {
                     variable.define(v._name, v._inputs, _fn);
                 } else {
@@ -7247,12 +7230,11 @@ Inputs.textarea({
 })
 )};
 const _b4rsn5 = (G, _) => G.input(_);
-const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
+const _ga6kci = function _98(Inputs,definition,variable,realize,runtime,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
-  reduce: () => {
-    let _fn;
-    eval("_fn = " + definition);
+  reduce: async () => {
+    const [_fn] = await realize([definition], runtime);
     variable.define(variable._name, inputs, _fn);
   }
 })
@@ -7365,7 +7347,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_geoudp", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _geoudp);  
+  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -7403,7 +7385,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
+  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -7413,8 +7395,9 @@ export default function define(runtime, observer) {
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
   $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
-  $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
+  $def("_ga6kci", null, ["Inputs","definition","variable","realize","runtime","inputs"], _ga6kci);  
   $def("_1q557s", null, ["md"], _1q557s);  
+  main.define("realize", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("realize", _));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -7450,7 +7433,8 @@ export default function define(runtime, observer) {
   main.define("navHref", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("navHref", _));  
   main.define("cellsToClipboard", ["module @tomlarkworthy/cells-to-clipboard", "@variable"], (_, v) => v.import("cellsToClipboard", _));
   return main;
-}</script>
+}
+</script>
 <script id="@tomlarkworthy/escodegen/escodegen.browser.min.js.gz" 
   type="text/plain"
   data-encoding="base64"
@@ -17164,7 +17148,7 @@ H4sICB8jLWcCA2Fjb3JuLXdhbGtAOC4zLjIuanMApVlbU+O4En6fX2E4VZQza5wAs8yC8XK47FZRNbcC
 >
 H4sICOAiLWcCA3BhcnNlckA2LjEuMC5qcwDtOmtz20aS3/MrIF6KAWIIFKX4ETCwYstKnW4V2yfJSW2ptKsh0KQmAgF6MJTEpfDfr3sewICknNzdbu1+2CqVOK/u6el3z2Dw7bdfed96bxdFlkPmjZfeb9U7yPmd8BYVL6beWZnni7l3tx+9/D4aeqzIvAsQFQjv7nk0/D7ajwj+g+BTXrDcm/AcYm9QzGeDH8sxLrtj4xxuPg/mjIB+fBENo71BJdIBLzJ4iH6rEJwwvCu99x8ucFPwzs9OvHsub7xsWbAZT1meL70pFCCYRBppi2rH+7kU4PFiUooZk7wsYu9GynkVDwb39/eIN1OniNJyNlAn2a0E3yW0uwbtrkKEew++4rN5KeTqorw9KgsJD9JjlQehLG8vlnOoqCfDj+oE1BbhFOQpL+AEt6eBop6IctZTx2ZpKYofX0XDYXQweAbVrDcy6GfsFmh1FbIihUqWChkPK5zP1Qxbx7N7z/JbRHYQ7Rtcd0x4ZVLAvXcO0r/svRGCLXuh/n27mExAYI/JckyDi4yX5kjYfZur0bdlmQMrqMWnJwXNjGXJ8CfFcYEjJLbc9i/4DMoFrUrLokJQaonlXJbYOFrgOWbHd6DQvGOS/cLhXjdpYQZpmcGnsxO3fVQiQwoNksEdT+Ejf4D8jORIQ2W6mOlZKFrwpu2CHwtR0oGhStmcNgRN+QRkeoO/P3FFL/2c8kqa5hmwTPHpp7xk8mDfMlF1X3zXdBdFSqqFzf9UEBW2TmZsCvaXDkztYsILLpeqKYcvLALstMix88ppE5W8+ongQDXfs/f4+1/nH+jnZzZX/yUdQs+8X8zGiuiC3fEpSpjaH8a/QUrHUval6LcdLdk5CGUiqHHY+4gI999RA/WMV6BbD0TSGSumYNl5BqhHyHB3INcbncH0+IGISwln/qbg2v5+EmxG+AR8XqByb4yjuuL/CqSjX9hrtetcCjRTaixn4zJXjUKyB0vCBSrxO6VCtndc2J684SQbsla7/BN3JUG9VhTUe9XpHOVsNofMjqE7BBQpZKrdKBcqX4P+7BT//wrsVouKWvqIv8L4vExvdbsUt4rAe3R35X3vKgjTpPJXJ8oj+MGqDslekKECqgq55aPXCUWwEj5EPMN27yRDTecTjmiCOvx5Icmh/mGAOhhNjBZ7cx9wHciFKBrVbhH1kiSBSCIHHx+baeR3zoSSY2ce+VTe/w4OVKwpyr4dqxtKcocSdErp7blEd6FsvkNFic7oyakPkyentk7Q8VsSFn8nZrQYb0gUwYqcpPREsqLZuOFCOC6zZXwJEf1e1WGhfDjqTohUGGOr4qpOYKSp8pgvwtURBr+WrBiS13qDFUVFgFiETEyVt6xiTsB84rsasJMkwpxDRBj2AAfk42MVqfD7YeKL4Ie9QO9IsEOc51EOxVTePD7u+L1TdE8CjRUPzC/3rhSufn/wl8tveleDSKKl+2pcsPsAeXUBGMuQ+dvB9mwXmiNVZrMgkDeoU552aBHDyWnhqzjXegH/+uuVrD1yMVxQXPYosmPszPV2XqV8iGd5ch2EqwJdRAxoB4pvl+wq4WGZuOdiirpDFqFTWkDMos8LVvGK6FQjmEOUt5Ch5a4qyYTEFeo3hCLDNv6vR0V0wyq/DA6LCHMDbETzRXXjp0FcRBUNhJfpFZpjmAZh0erMBHVmJdk0Rhtm9yjNKYZolldxEUZRhNqwqoNVDtLjJJxikec7iez3UXV5soyUm0cMlTmcx5KxGZQ0OPUZOoQiCO+pEYQ8wq0Shr+4WbKzI2rIMd/iSeaiMuo39XkIGhgbCFyj9leVl3noefHMmAZpVRSLFGMRwiLFqP/VAkOO3xXjCtIZ+wXjJ+nw8KAmfGp1DRQMztNyDq09evt91JVnz8ipRx/+apkVKsxRB6KGBy51x4FWgOlCoFHZyWiSs2nV7+/uPoG1xVPrUEq+R1u0wTtEVVkDRklE7J5xFIlvpli1LNJkZy8wiNeQaeRvCMb/MuYvIjQINLY/c8gzh31fRGfy6FKso7RYNE4ToFqkCrxA0ftBCFE1h1Q5mErv5MCcN1O4Uk2SdRFJ0V8p/bakNLh4QapCruCLuAwy9By42uS0C5b7PZUyK6LKhUgh6e6pPcJhi5m86RvMWf0gVoMY3hVKyCy9lMtVN+/Rb6DIepoS1/d3WOSSaHw/JJdXobA5+ojMt0BujzAP850z+DIaC5bCaTDa0cOsGTsLRmjiaPEBQg5H2kwna9BY2syYoZlN0CouBOM5nvaIJlpUwVhgcmJchGGycmDqiMGoiu4wB0ksDS5vaaKcIHeraKYzj2RHL+/3t603ixSArnogc6VKgcmyOb2B9PZTgX4c00HkfgvhLjgtMdJtzq3ty6pecIirclr9xzdUy7ftpieC2GJs93cX/8Lyc1W7WYiwh8LGwwsVDcygCruB4RdKqGqWmzBy3cZr75uvVy5Y/Y13Q3VhjhLMlt4YoPAypYqQXdM+LMu6+6AdqMizrsmV1eRGYXtBUBvjhrprGmtmryZ/Zssx/AmW96XInPTTqkjY6yayPcwGfh/Y6guWOuuJLSFw3JNDW63YdgR5jia35uiSvbDrN4fhpuMzY+QaUomWaVSqDSzD7zBTVLxTu9gUW7NEGFE6CiOUH8sSEer8LsHcINIEuNTgYEvFOlnWvTVxaJszInKs/zGkCet2dEaZ+VhTKEhezBcybK09UJ6oSlSGcoEZTYF78ISSipCpn5ErdIfJoevDtSH0+y4aNU2ZJckKitNDvuHK/XW3Q8bVgEE56fedfgUzjoHC2ZeUG0esuuGqSmdn/X6jRe3g46O/dlAHuUZVdDw/Lti2Xm0Nn3FjlvxzTWHTp60R3I0N8DkIOofQoaYjGFV5YRj03UGHJMxUVcKZMKcIcqhSpYJO7HtHlBtum0NJMGzyLLARnGSblrnawNpSS3c56Si+UXIeMqP1F+X8FO4g3+qjzGrMbGpZvlG5J3Gya8Bb+NtUc4cQa5+zBbx2DB6s0cmEDP/xEUZ+qZy+Vi8qhZrCrNcocDcKyO3+X1rPzzHFNrHq2uzuRK+2fG1NAoxuuxahx4wC6Y3BbvypsQDvVmskEQCGgGubH25uXa8HwK6LdMCcNV9mPLIxNox2DBOMh9eEa30kKbXeZC3HRAU67DnnwkrFKyeecoa92J2RZDjWmT5hlSr/t4kXr5yUA4I23dvIqLbmzPzJTKjj47FGqGuNeaY8OjLuuoc6TX8+JK8fIqr9iQAs+1RJtmxKsqxTkmGJBbYgU22HV+gRWHr734tSQuM6xJs8L+8xY9sZ1nQvyVluTtzUKpezKzf6GOm4sWJDHDbhV4456fVssSq28M29GMAs2uTOLdvs9cJxrq53/BWvLth0ClmMZ6Yin3JsYQr45LK4GjXk2DgzCroeJytzTKfe6kw87FDgZFIbvnHd4ZpcO7Sba9j/De2N2hRYpvO8yUuMAq1rigg3Lls2gsB2ZyqUX0c1a64hHlC+EBPvNL/mZfVDm0OYG5pm6tmzoMJKLjWs0WvSGyaOkK43JtLjOrIQhoXL9/vx01h3h02pj/MjU6oQ2MGLmC6k9g9sOfvkRs+GQWul2LcASrWMy200kheoiDyzvAs6QQRxJfsuy3R0XdMSTSVmzbUL3AVY28ZJyaIq5yn46x5MMczcsYz/33cs+/++Y/mXv2N5KpX5B1QzTV2yPc8DrZmOmf0D6xd0ej3X+Ux18pCUyoY1oYG6xt64eVHpAs0rcw4gaq/O7UR7m3S4MRLN2NynEArtdUIQY5hR9ytSLFcdjJbC/+O9ftW80soACyzcpjly2UWp74zBBoCdHUyL9RWCDJ58X2iBDvU1gEkxzYUzhM0bsZ64CoLOvTN6fNIENkMZleKYoTv3ZfIa8YSUWqiEpd+nTanlwGaaDhMCdPqmPb378BDfKESOQzdvlR+ZRM0sejFuL1BRhOTgkABEAm0QdGDVw5wDCjqIdgHRo22D/ai3WfZinNVpCK5xV5xBJU1Y1ots7r62TtcENNGQQqtzmDgrM5iwRS5j/Z5BUtBvFz3KoNNyWvC/YfY51wg8pU1e75nho2MX6hrmxqc7BX0d1U4ttQgoOxImwVcPP+2zJb37BCuK6CaFsuF2f1S8TvZGu7uFMrdulYJ6t/Alpk2B8yRUqhHMy+3YenlLrhBXmFLQF8m1rki8r1coFYUONUgXFVhTbC8D1jCYAmY7ihqp2qmUgYhg2zH+0FtSC0OVVlFKj+n0t+e+GjGdyJFk3HzJFgYQ/J4dqIFfmOB0nkZtSDLGkqk8kYFiNMlaGbHD/qfY1UpU882C/KFntFaRsQzyFCEM23eGTK8pArsvaJuWuHaO1jCDBzyNtC5tqwPYgG39wTbo1oxNsLwreUaiaE1605jXlzqG7chzrOX50Nqyzew4PcJa6TmhKFYQyWtjg+r2bIu1DZW19fs0T4qp7M7vIZ91LLvlRXY41yYX58b0lAWo5giirN1zw0vSgz8aQFCHW56ov0QhuP4A1imEgCjCgGEIwdZI+yGMAyHpfLthPAnV1c/fYWPY3f3SxrXeKG6jMkWwbowKjxjaIq5bVLC2UIU6FR90M6RT2AxDOezmYjyehWtX5c3Ie7SJao5FgDOl3nQ7emI0PF6GrSOIl+261vqcp/1xuBFdcOzTPKOSsV3WTUrWVTrsfheBCLrfUMRjRQWr1cVxnTLlukziRXbu5BcUv9WYvT6GCA9fsSk8S649/+uViHKMNXVMrbTMF7OiDq7p/aGkbKyF1AEsEWGGzkGCp+dq7ahAv0F3Ei9MlZqHicZG71ufq3Ktfn9LgrjTTRB1Skff+b2REg1HeaaE9EV9BtYOqvdD5DQbowc5ynm77l1nUL8zQorkmflz1VHjGEJQ1KmipIPj/cZE71+L9+scsinsJk/aGcuFdmTb+c1sK099xONEf+Tl9xSVyL7zZmRWZuZ9KjxpBq0a4OBtM0gRqud84HRH7FQeGJPv4xFJv40xnGIMXexifY4ZGBXT3ZJ5WAdNVluZq4tjFb69c7qJ4N3HCCU4umo4dp4l6PsW+wLRXMJ2BlUh5QzRnsk5XYlJXiygrpJbrCF4O9DduSkNHx/dUXVtQJhOWkDnKuV2jX74HDR3TYoK997lZG0xSSiwWEebjOj3OX0D8wPYL3ls6NSoTSStW4W3A/CgPovN6MtXKgz1B7bhkvr23sQZn9B4c/cY3qkuwO1JFqbUpk9l65FG6pkk3FPR56vB4D88/XUA6uKcF9NPZ6fJoJoNMjaewKv0OYwnr9hzdrB3MMmeP987eAUwefny1ffsJUvHL4bfPX+ZpbA3hvH4VXbwcnLA9sfP0zGkVFH+D3KMR1ZDLQAA
 </script>
-<script id="@tomlarkworthy/observablejs-toolchain" 
+<script id="@tomlarkworthy/observablejs-toolchain"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -17790,10 +17774,9 @@ notebook_semantics_document.nodes.map((s) => ({
 const _1oevsow = function _28(md){return(
 md`### Runtime Representation (v4)`
 )};
-const _11lfflk = function _notebook_semantics_module(){return(
-importShim("https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4"
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _11lfflk = function _notebook_semantics_module() {
+    return import('https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4');
+};
 const _gjten6 = function _31(md){return(
 md`### Imports`
 )};
@@ -18780,65 +18763,44 @@ parser.parseCell(
   'import {runtime, viewof main as foo} from "@mootari/access-runtime"'
 )
 )};
-const _1n7gw17 = function _findModuleName(extractModuleInfo){return(
-(scope, module, { unknown_id = Math.random() } = {}) => {
-  try {
-    const scopedVariables = [...scope.values()];
-
-    // Prefer variables that *define* a module and have a real module-loader name.
-    const candidates = scopedVariables.filter(
-      (v) =>
-        v &&
-        v._value === module &&
-        typeof v._name === "string" &&
-        v._name.startsWith("module ") &&
-        !v._name.startsWith("module <unknown")
-    );
-
-    const pickBestInfo = (dfn) => {
-      // Avoid the parentUrl (2nd arg) confusing module identification.
-      // Typical patterns:
-      //   importShim("/d/<id>@<ver>.js?v=4", "https://api.observablehq.com/@ns/name.js?v=4")
-      //   import("/d/<id>@<ver>.js?v=4")
-      // Prefer the *first argument* inside importShim(...) / import(...) when present.
-      const s = String(dfn ?? "");
-
-      // Try to capture the first string literal argument to importShim(...) or import(...)
-      // Tolerates quotes ", ', ` and both importShim and plain import.
-      const m = s.match(
-        /\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/
-      );
-      const firstArg = m?.[2];
-
-      const info1 = firstArg ? extractModuleInfo(firstArg) : {};
-      if (info1?.id || info1?.notebook) return info1;
-
-      // Fallback: parse the whole definition string.
-      return extractModuleInfo(s);
+const _1n7gw17 = function _findModuleName(extractModuleInfo) {
+    return (scope, module, {
+        unknown_id = Math.random()
+    } = {}) => {
+        try {
+            const scopedVariables = [...scope.values()];
+            const candidates = scopedVariables.filter(v => v && v._value === module && typeof v._name === 'string' && v._name.startsWith('module ') && !v._name.startsWith('module <unknown'));
+            const pickBestInfo = dfn => {
+                const s = String(dfn ?? '');
+                const m = s.match(/\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/);
+                const firstArg = m?.[2];
+                const info1 = firstArg ? extractModuleInfo(firstArg) : {};
+                if (info1?.id || info1?.notebook)
+                    return info1;
+                return extractModuleInfo(s);
+            };
+            for (const v of candidates) {
+                const info = pickBestInfo(v._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            const any = scopedVariables.find(v => v && v._value === module);
+            if (any) {
+                const info = pickBestInfo(any._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            return `<unknown ${ unknown_id }>`;
+        } catch (e) {
+            debugger;
+            return 'error';
+        }
     };
-
-    // Try module loader cells first.
-    for (const v of candidates) {
-      const info = pickBestInfo(v._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    // Fallback: any scoped variable with _value==module.
-    const any = scopedVariables.find((v) => v && v._value === module);
-    if (any) {
-      const info = pickBestInfo(any._definition?.toString?.());
-      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
-      if (info?.id) return `d/${info.id}@${info.version}`;
-    }
-
-    return `<unknown ${unknown_id}>`;
-  } catch (e) {
-    debugger;
-    return "error";
-  }
-}
-)};
+};
 const _i47chb = function _findImportedName(){return(
 async (v) => {
   if (v._inputs.length == 1 && v._inputs[0]._name === "@variable") {
@@ -19740,229 +19702,206 @@ JSON.stringify(
 const _1lt3kl6 = function _157(compile,test_case){return(
 compile(test_case.value)
 )};
-const _lpzjrv = function _compile(parser,globalThis,observableToJs){return(
-function compile(source, { anonymousName = "_anonymous" } = {}) {
-  const comments = [],
-    tokens = [];
-  let cell;
-  try {
-    cell = parser.parseCell(source, {
-      ranges: true,
-      onComment: comments,
-      onToken: tokens
-    });
-  } catch (e) {
-    if (e instanceof SyntaxError) {
-      const nameMatch = source.match(
-        /^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/
-      );
-      let _name = null;
-      let funcName = anonymousName;
-      if (nameMatch) {
-        const prefix = nameMatch[1] ? nameMatch[1] + " " : "";
-        _name = prefix + nameMatch[2];
-        funcName = "_" + nameMatch[2];
-      }
-      const escapedMsg = JSON.stringify(e.message);
-      const escapedSource = JSON.stringify(source);
-      return [
-        {
-          _name,
-          _inputs: [],
-          _definition: `function ${funcName}() { throw Object.assign(new SyntaxError(${escapedMsg}), {_sourceExpression: ${escapedSource}}); }`
+const _x1d0wm = function _compile(parser,observableToJs){return(
+function compile(source, {
+    anonymousName = '_anonymous'
+} = {}) {
+    const comments = [], tokens = [];
+    let cell;
+    try {
+        cell = parser.parseCell(source, {
+            ranges: true,
+            onComment: comments,
+            onToken: tokens
+        });
+    } catch (e) {
+        if (e instanceof SyntaxError) {
+            const nameMatch = source.match(/^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/);
+            let _name = null;
+            let funcName = anonymousName;
+            if (nameMatch) {
+                const prefix = nameMatch[1] ? nameMatch[1] + ' ' : '';
+                _name = prefix + nameMatch[2];
+                funcName = '_' + nameMatch[2];
+            }
+            const escapedMsg = JSON.stringify(e.message);
+            const escapedSource = JSON.stringify(source);
+            return [{
+                    _name,
+                    _inputs: [],
+                    _definition: `function ${ funcName }() { throw Object.assign(new SyntaxError(${ escapedMsg }), {_sourceExpression: ${ escapedSource }}); }`
+                }];
         }
-      ];
+        throw e;
     }
-    throw e;
-  }
-  if (!cell) throw new Error("Unable to parse cell");
-  const parseImportSpecifierText = (text) => {
-    const t = String(text ?? "")
-      .trim()
-      .replace(/,$/, "")
-      .trim();
-    if (!t) throw new Error("Empty import specifier");
-    const parts = t.split(/\s+as\s+/);
-    const left = parts[0].trim();
-    const right = parts[1]?.trim();
-    const parseSide = (side, { defaultPrefix = "" } = {}) => {
-      const s = String(side ?? "").trim();
-      const m = s.match(/^(viewof|mutable)\s+(.+)$/);
-      if (m)
-        return {
-          prefix: `${m[1]} `,
-          name: m[2].trim()
+    if (!cell)
+        throw new Error('Unable to parse cell');
+    const parseImportSpecifierText = text => {
+        const t = String(text ?? '').trim().replace(/,$/, '').trim();
+        if (!t)
+            throw new Error('Empty import specifier');
+        const parts = t.split(/\s+as\s+/);
+        const left = parts[0].trim();
+        const right = parts[1]?.trim();
+        const parseSide = (side, {
+            defaultPrefix = ''
+        } = {}) => {
+            const s = String(side ?? '').trim();
+            const m = s.match(/^(viewof|mutable)\s+(.+)$/);
+            if (m)
+                return {
+                    prefix: `${ m[1] } `,
+                    name: m[2].trim()
+                };
+            return {
+                prefix: defaultPrefix,
+                name: s
+            };
         };
-      return {
-        prefix: defaultPrefix,
-        name: s
-      };
+        const L = parseSide(left);
+        const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
+        const importedName = `${ L.prefix }${ L.name }`.trim();
+        const localName = `${ R.prefix }${ R.name }`.trim();
+        if (!importedName)
+            throw new Error(`Could not parse imported name from: ${ t }`);
+        if (!localName)
+            throw new Error(`Could not parse local name from: ${ t }`);
+        return {
+            importedName,
+            localName
+        };
     };
-    const L = parseSide(left);
-    const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
-    const importedName = `${L.prefix}${L.name}`.trim();
-    const localName = `${R.prefix}${R.name}`.trim();
-    if (!importedName)
-      throw new Error(`Could not parse imported name from: ${t}`);
-    if (!localName) throw new Error(`Could not parse local name from: ${t}`);
-    return {
-      importedName,
-      localName
-    };
-  };
-  if (!cell.id && cell.body?.type === "ImportDeclaration") {
-    const module_name = cell.body.source.value;
-    const importKeyword = globalThis?.importShim ? "importShim" : "import";
-    const cell_variables = [
-      {
-        _name: `module ${module_name}`,
-        _inputs: [],
-        _definition: `async () => runtime.module((await ${importKeyword}("${module_name}")).default)`
-      }
-    ];
-    for (const specifier of cell.body.specifiers ?? []) {
-      const specText =
-        typeof specifier?.start === "number" &&
-        typeof specifier?.end === "number"
-          ? source.slice(specifier.start, specifier.end)
-          : (() => {
-              if (specifier?.imported?.name && specifier?.local?.name) {
-                return specifier.imported.name === specifier.local.name
-                  ? specifier.local.name
-                  : `${specifier.imported.name} as ${specifier.local.name}`;
-              }
-              throw new Error("Import specifier missing range information");
+    if (!cell.id && cell.body?.type === 'ImportDeclaration') {
+        const module_name = cell.body.source.value;
+        const cell_variables = [{
+                _name: `module ${ module_name }`,
+                _inputs: [],
+                _definition: `async () => runtime.module((await import("${ module_name }")).default)`
+            }];
+        for (const specifier of cell.body.specifiers ?? []) {
+            const specText = typeof specifier?.start === 'number' && typeof specifier?.end === 'number' ? source.slice(specifier.start, specifier.end) : (() => {
+                if (specifier?.imported?.name && specifier?.local?.name) {
+                    return specifier.imported.name === specifier.local.name ? specifier.local.name : `${ specifier.imported.name } as ${ specifier.local.name }`;
+                }
+                throw new Error('Import specifier missing range information');
             })();
-      const { importedName, localName } = parseImportSpecifierText(specText);
-      cell_variables.push({
-        _name: localName,
-        _inputs: [`module ${module_name}`, "@variable"],
-        _definition:
-          importedName === localName
-            ? `(_, v) => v.import("${importedName}", _)`
-            : `(_, v) => v.import("${importedName}", "${localName}", _)`
-      });
+            const {importedName, localName} = parseImportSpecifierText(specText);
+            cell_variables.push({
+                _name: localName,
+                _inputs: [
+                    `module ${ module_name }`,
+                    '@variable'
+                ],
+                _definition: importedName === localName ? `(_, v) => v.import("${ importedName }", _)` : `(_, v) => v.import("${ importedName }", "${ localName }", _)`
+            });
+        }
+        return cell_variables;
     }
-    return cell_variables;
-  }
-  let dollarIdx = 0;
-  const inputToArgMap = {};
-  const dollarToMacro = {};
-  const seen = new Set();
-  const inputs = Array.from(cell.references || []).flatMap((i) => {
-    if (i.name) {
-      if (seen.has(i.name)) return [];
-      seen.add(i.name);
-      return i.name;
+    let dollarIdx = 0;
+    const inputToArgMap = {};
+    const dollarToMacro = {};
+    const seen = new Set();
+    const inputs = Array.from(cell.references || []).flatMap(i => {
+        if (i.name) {
+            if (seen.has(i.name))
+                return [];
+            seen.add(i.name);
+            return i.name;
+        } else {
+            const dedupKey = i.type + ':' + i.id.name;
+            if (seen.has(dedupKey))
+                return [];
+            seen.add(dedupKey);
+            const dollarName = '$' + dollarIdx;
+            inputToArgMap[i.id.name] = dollarName;
+            dollarToMacro[dollarName] = i.type == 'ViewExpression' ? 'viewof ' + i.id.name : 'mutable ' + i.id.name;
+            dollarIdx++;
+            return dollarName;
+        }
+    });
+    let variables;
+    if (cell.id) {
+        if (cell.id.type === 'Identifier') {
+            variables = [{
+                    functionName: '_' + cell.id.name,
+                    name: cell.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                }];
+        } else if (cell.id.type === 'ViewExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'viewof ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '(G, _) => G.input(_)',
+                    inputs: [
+                        'Generators',
+                        'viewof ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                }
+            ];
+        } else if (cell.id.type === 'MutableExpression') {
+            variables = [
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'initial ' + cell.id.id.name,
+                    inputs,
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: 'mutable ' + cell.id.id.name,
+                    _definition: '(M, _) => new M(_)',
+                    inputs: [
+                        'Mutable',
+                        'initial ' + cell.id.id.name
+                    ],
+                    params: inputs.join(',')
+                },
+                {
+                    functionName: '_' + cell.id.id.name,
+                    name: cell.id.id.name,
+                    _definition: '_ => _.generator',
+                    inputs: ['mutable ' + cell.id.id.name],
+                    params: inputs.join(',')
+                }
+            ];
+        } else {
+            throw new Error(`Unsupported cell id type: ${ cell.id.type }`);
+        }
     } else {
-      const dedupKey = i.type + ":" + i.id.name;
-      if (seen.has(dedupKey)) return [];
-      seen.add(dedupKey);
-      const dollarName = "$" + dollarIdx;
-      inputToArgMap[i.id.name] = dollarName;
-      dollarToMacro[dollarName] =
-        i.type == "ViewExpression"
-          ? "viewof " + i.id.name
-          : "mutable " + i.id.name;
-      dollarIdx++;
-      return dollarName;
+        variables = [{
+                functionName: anonymousName,
+                name: null,
+                inputs,
+                params: inputs.join(',')
+            }];
     }
-  });
-  let variables;
-  if (cell.id) {
-    if (cell.id.type === "Identifier") {
-      variables = [
-        {
-          functionName: "_" + cell.id.name,
-          name: cell.id.name,
-          inputs,
-          params: inputs.join(",")
+    return variables.map(v => {
+        let _definition = v._definition;
+        if (!_definition) {
+            let functionBody;
+            if (cell.body.type === 'BlockStatement') {
+                functionBody = observableToJs(cell.body, inputToArgMap, comments, tokens);
+            } else {
+                const bodyCode = observableToJs(cell.body, inputToArgMap, comments, tokens);
+                functionBody = `{return (${ bodyCode });}`;
+            }
+            _definition = `${ cell.async ? 'async ' : '' }function${ cell.generator ? '*' : '' } ${ v.functionName }(${ v.inputs.join(',') }) ${ functionBody }`;
         }
-      ];
-    } else if (cell.id.type === "ViewExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "viewof " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "(G, _) => G.input(_)",
-          inputs: ["Generators", "viewof " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else if (cell.id.type === "MutableExpression") {
-      variables = [
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "initial " + cell.id.id.name,
-          inputs,
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: "mutable " + cell.id.id.name,
-          _definition: "(M, _) => new M(_)",
-          inputs: ["Mutable", "initial " + cell.id.id.name],
-          params: inputs.join(",")
-        },
-        {
-          functionName: "_" + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: "_ => _.generator",
-          inputs: ["mutable " + cell.id.id.name],
-          params: inputs.join(",")
-        }
-      ];
-    } else {
-      throw new Error(`Unsupported cell id type: ${cell.id.type}`);
-    }
-  } else {
-    variables = [
-      {
-        functionName: anonymousName,
-        name: null,
-        inputs,
-        params: inputs.join(",")
-      }
-    ];
-  }
-  return variables.map((v) => {
-    let _definition = v._definition;
-    if (!_definition) {
-      let functionBody;
-      if (cell.body.type === "BlockStatement") {
-        functionBody = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-      } else {
-        const bodyCode = observableToJs(
-          cell.body,
-          inputToArgMap,
-          comments,
-          tokens
-        );
-        functionBody = `{return (${bodyCode});}`;
-      }
-      _definition = `${cell.async ? "async " : ""}function${
-        cell.generator ? "*" : ""
-      } ${v.functionName}(${v.inputs.join(",")}) ${functionBody}`;
-    }
-    return {
-      _name: v.name,
-      _inputs: v.inputs.map(
-        (i) => dollarToMacro[i] || (i === "$variable" ? "@variable" : i)
-      ),
-      _definition
-    };
-  });
+        return {
+            _name: v.name,
+            _inputs: v.inputs.map(i => dollarToMacro[i] || (i === '$variable' ? '@variable' : i)),
+            _definition
+        };
+    });
 }
 )};
 const _1v1i7wl = function _observableToJs(acorn_walk,parser,escodegen){return(
@@ -20029,16 +19968,15 @@ async (attachment, overrides) => {
   return URL.createObjectURL(blob);
 }
 )};
-const _s9w7ha = async function _parser(decompress_url,FileAttachment,acorn_url,acorn_walk_url){return(
-importShim(await decompress_url(FileAttachment("parser-6.1.0.js.gz"), {
-    "/npm/acorn@8.11.3/+esm": acorn_url,
-    "/npm/acorn-walk@8.3.2/+esm": acorn_walk_url
-  })
-, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
-const _1hiclbb = function _acorn_walk(acorn_walk_url){return(
-importShim(acorn_walk_url, 'https://api.observablehq.com/@tomlarkworthy/observablejs-toolchain.js?v=4')
-)};
+const _s9w7ha = async function _parser(decompress_url, FileAttachment, acorn_url, acorn_walk_url) {
+    return import(await decompress_url(FileAttachment('parser-6.1.0.js.gz'), {
+        '/npm/acorn@8.11.3/+esm': acorn_url,
+        '/npm/acorn-walk@8.3.2/+esm': acorn_walk_url
+    }));
+};
+const _1hiclbb = function _acorn_walk(acorn_walk_url) {
+    return import(acorn_walk_url);
+};
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
@@ -20226,7 +20164,7 @@ export default function define(runtime, observer) {
   $def("_1dmmuaf", "compiled_selector", ["Generators","viewof compiled_selector"], _1dmmuaf);  
   $def("_u7t3vu", null, ["compiled_selector","normalizeJavascriptSource"], _u7t3vu);  
   $def("_1lt3kl6", null, ["compile","test_case"], _1lt3kl6);  
-  $def("_lpzjrv", "compile", ["parser","globalThis","observableToJs"], _lpzjrv);  
+  $def("_x1d0wm", "compile", ["parser","observableToJs"], _x1d0wm);  
   $def("_1v1i7wl", "observableToJs", ["acorn_walk","parser","escodegen"], _1v1i7wl);  
   $def("_19lv24l", null, ["md"], _19lv24l);  
   $def("_xhj6b8", "decompress_url", ["DecompressionStream","TextDecoderStream","TransformStream","TextEncoderStream","Response"], _xhj6b8);  
@@ -20241,7 +20179,8 @@ export default function define(runtime, observer) {
   main.define("Library", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Library", _));  
   main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));
   return main;
-}</script>
+}
+</script>
 
 <script id="@tomlarkworthy/reversible-attachment" 
   type="text/plain"


### PR DESCRIPTION
Fixes tomlarkworthy/lopecode#153.

**This PR is a proposal** — only the canonical worktree HTMLs were updated. ObservableHQ has not been pushed and consumer notebooks have not been re-synced yet. After approval, those steps will run as additional commits to this branch.

## Root cause

`observablejs-toolchain.compile` emitted `importShim(...)` when `globalThis.importShim` was present and `import(...)` otherwise — non-deterministic output that depended on whether es-module-shims was loaded.

The conditional existed because `editor-5.compile_and_update` materialized the compiled `_definition` strings via raw `eval()`, which resolves dynamic `import()` through the native browser importmap and therefore can't see lopecode's es-module-shims importmap. With `importShim()` baked into the source, the eval'd function reaches the right importmap.

`@tomlarkworthy/runtime-sdk.realize()` already solves this cleanly: it evaluates the source inside a `<script type="module-shim">`, so canonical `import(...)` *is* rewritten by es-module-shims and resolves the right importmap. Once editor-5 routes through `realize`, the toolchain doesn't need the conditional.

## Fix

`@tomlarkworthy/observablejs-toolchain` — `compile()`:
```diff
   if (!cell.id && cell.body?.type === "ImportDeclaration") {
     const module_name = cell.body.source.value;
-    const importKeyword = globalThis?.importShim ? "importShim" : "import";
     const cell_variables = [
       {
         _name: `module ${module_name}`,
         _inputs: [],
-        _definition: `async () => runtime.module((await ${importKeyword}("${module_name}")).default)`
+        _definition: `async () => runtime.module((await import("${module_name}")).default)`
       }
     ];
```

`@tomlarkworthy/editor-5`:
- `compile_and_update` → async, uses `realize(definitions, runtime)` instead of `eval('_fn = ' + …)`. `realize` added to deps.
- `_t68yvv` (update-variable button) → same swap.
- `command_processor` → `await`s the now-async `compile_and_update("{}", …)`.
- Module footer adds `main.define("realize", …)` so the import is in scope.

## Targeted QA (live runtime, post-fix)

- ✅ `compile('import {chart} from "@user/foo"')` returns canonical `import(...)` regardless of `globalThis.importShim`.
- ✅ `realize` correctly resolves bare specifiers like `@observablehq/runtime@6.0.0` through es-module-shims (verified directly).
- ✅ Direct `eval` of the same source fails with `Failed to resolve module specifier '@observablehq/runtime@6.0.0'` — confirms `realize` is necessary.
- ✅ Title cell edit + Shift+Enter → `op:"upd"` history event (`pid: _1tdjp0a`).
- ✅ Two consecutive ➕ clicks → two `op:"new"` history events with **distinct pids** (`_l87kyrh`, `_t5ecc8x`) — no #144 regression.
- ✅ `viewof paste`, `compile_and_update`, `pasteObservableCellsIntoModule` all `hasValue: true, hasError: false`.
- ✅ Console: clean (only the pre-existing `notebookwebhook.mov` 404 and `blob:null` aborts noted in `qa/per-notebook/editor-5.md`).

## Out of scope

`@tomlarkworthy/import-notebook._importNotebook` also uses the `importShim ? "importShim" : "import"` pattern, but it's a separate userspace function — not the compiler — and the issue scopes the fix to the toolchain. Leaving it alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)