### PR TITLE
Sync visualizer fix into editor-5 notebook (#159)

### DIFF
--- a/notebooks/@tomlarkworthy_editor-5.html
+++ b/notebooks/@tomlarkworthy_editor-5.html
@@ -23888,7 +23888,7 @@ export default function define(runtime, observer) {
   return main;
 }</script>
 
-<script id="@tomlarkworthy/visualizer" 
+<script id="@tomlarkworthy/visualizer"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -24102,13 +24102,18 @@ const _zodkh8 = function _createImportCellHeader(){return(
   return header;
 }
 )};
-const _1hijbhn = function _variablesForCell(){return(
-(cell) => {
-  if (!cell) return [];
-  if (cell.type === "import") return [];
-  return [cell.variables?.[0]].filter(Boolean);
-}
-)};
+const _526jo = function _variablesForCell()
+{
+    return cell => {
+        if (!cell)
+            return [];
+        if (cell.type === 'import')
+            return [];
+        // mutable: variables = [initial X, mutable X, X]; render X (live), not initial (seed). #159
+        const i = cell.type === 'mutable' ? 2 : 0;
+        return [cell.variables?.[i]].filter(Boolean);
+    };
+};
 const _1xdl683 = function _renderImportCell(navHref){return(
 (cell, { isKnown = () => true } = {}) => {
   const ii = cell?.importInfo ?? null;
@@ -24395,7 +24400,7 @@ export default function define(runtime, observer) {
   $def("_1e4b50w", "TRACE_CELL", ["trace_variable"], _1e4b50w);  
   $def("_11ugoev", null, ["htl"], _11ugoev);  
   $def("_zodkh8", "createImportCellHeader", [], _zodkh8);  
-  $def("_1hijbhn", "variablesForCell", [], _1hijbhn);  
+  $def("_526jo", "variablesForCell", [], _526jo);  
   $def("_1xdl683", "renderImportCell", ["navHref"], _1xdl683);  
   $def("_17pe3vk", "syncers", ["observe","inspectors","viewof visualizersToDelete","liveCellMap","createImportCellHeader","renderImportCell","variablesForCell","visualizers","viewof visualizers"], _17pe3vk);  
   $def("_een5pq", null, ["md"], _een5pq);  
@@ -24421,7 +24426,8 @@ export default function define(runtime, observer) {
   main.define("liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("liveCellMap", _));  
   main.define("navHref", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("navHref", _));
   return main;
-}</script>
+}
+</script>
 
 <script id="d/57d79353bac56631@44" 
   type="text/plain"


### PR DESCRIPTION
Re-syncs the bundled \`@tomlarkworthy/visualizer\` module inside \`@tomlarkworthy_editor-5.html\` to pick up the fix from #160 (mutable cells now render the live value, not the initial seed).

QA: Opened the editor-5 worktree HTML, ran \`compile_and_update("mutable qa_counter = 0")\`, mutated to 77, and verified the rendered div is bound to \`qa_counter\` (live) and reads \`qa_counter = 77\` instead of being frozen at \`0\`. ✅

Other consumers of \`@tomlarkworthy/visualizer\` (atlas, atproto-comments, blank-notebook, bootloader, …) are intentionally still on the pre-fix bundle until you decide to fan out.