### PR TITLE
Fix: ⬆/⬇ keep moved cell at same screen position (#163)

### DIFF
--- a/notebooks/@tomlarkworthy_atlas.html
+++ b/notebooks/@tomlarkworthy_atlas.html
@@ -5689,63 +5689,50 @@ md`## Sync editors`
 const _hdieof = function _editors(){return(
 new Map()
 )};
-const _ye6ey = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,TRACE_CELL,editors,cellEditor)
+const _ipx6cz = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,editors,cellEditor)
 {
-  keepalive(editorModule, "editor_jobs");
-  syncers;
-
-  const placed = new Set();
-
-  if (attachContextManu) {
-    document.querySelectorAll(".observablehq").forEach((div) => {
-      const variable = divToVar(runtime, div);
-      if (!variable) return;
-      if (variable._name == TRACE_CELL) debugger;
-
-      if (!editors.has(variable)) {
-        editors.set(variable, cellEditor(variable));
-      }
-
-      const editor = editors.get(variable);
-      const next = div.nextSibling;
-      if (next !== editor) {
-        const ae = document.activeElement;
-        const hadFocus = ae && editor.contains(ae);
-
-        let restore = null;
-        if (hadFocus) {
-          const fe = ae;
-          if (
-            fe &&
-            (fe.tagName === "INPUT" || fe.tagName === "TEXTAREA") &&
-            "selectionStart" in fe
-          ) {
-            const start = fe.selectionStart,
-              end = fe.selectionEnd;
-            restore = () => {
-              fe.focus({ preventScroll: true });
-              fe.setSelectionRange(start, end);
-            };
-          } else {
-            restore = () => fe?.focus?.({ preventScroll: true });
-          }
-        }
-
-        div.after(editor);
-        restore?.();
-      }
-
-      placed.add(variable);
-    });
-  }
-
-  [...editors.entries()].forEach(([variable, editor]) => {
-    if (!placed.has(variable)) {
-      editor.dispose?.();
-      editor.remove();
-      editors.delete(variable);
+    keepalive(editorModule, 'editor_jobs');
+    syncers;
+    const placed = new Set();
+    if (attachContextManu) {
+        document.querySelectorAll('.observablehq').forEach(div => {
+            const variable = divToVar(runtime, div);
+            if (!variable)
+                return;
+            if (!editors.has(variable)) {
+                editors.set(variable, cellEditor(variable));
+            }
+            const editor = editors.get(variable);
+            const next = div.nextSibling;
+            if (next !== editor) {
+                const ae = document.activeElement;
+                const hadFocus = ae && editor.contains(ae);
+                let restore = null;
+                if (hadFocus) {
+                    const fe = ae;
+                    if (fe && (fe.tagName === 'INPUT' || fe.tagName === 'TEXTAREA') && 'selectionStart' in fe) {
+                        const start = fe.selectionStart, end = fe.selectionEnd;
+                        restore = () => {
+                            fe.focus({ preventScroll: true });
+                            fe.setSelectionRange(start, end);
+                        };
+                    } else {
+                        restore = () => fe?.focus?.({ preventScroll: true });
+                    }
+                }
+                div.after(editor);
+                restore?.();
+            }
+            placed.add(variable);
+        });
     }
-  });
+    [...editors.entries()].forEach(([variable, editor]) => {
+        if (!placed.has(variable)) {
+            editor.dispose?.();
+            editor.remove();
+            editors.delete(variable);
+        }
+    });
 };
 const _1iwobxt = function _divToVar(){return(
 function divToVar(runtime, div) {
@@ -6051,10 +6038,9 @@ async function selectVariable(variable, dom = undefined) {
   return cell;
 }
 )};
-const _kyzl8l = function _24(selectVariable,hotbarTemplate)
+const _mri5h3 = function _24(selectVariable,hotbarTemplate)
 {
-  debugger;
-  return selectVariable(hotbarTemplate[5]);
+return selectVariable(hotbarTemplate[5]);
 };
 const _49mpmh = function _hotbar($0,Event,setOption,$1,htl,edit,toolbar,nav,reversibleAttach,combine,code_editor)
 {
@@ -6386,7 +6372,7 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _2pkmxz = async function _command_processor(command,$0,compile_and_update,remove_variables,$1,findCellIndex,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
     if (command.processed)
         return;
@@ -6402,19 +6388,44 @@ const _16ufqhw = async function _command_processor(command,$0,compile_and_update
         remove_variables(command.args.cell.variables);
         result = true;
     } else if (command.command == 'moveCell') {
-        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const cellList = $1.value.get(command.args.cell.module.module);
+        const cellIndex = findCellIndex(command.args.cell.variables, cellList);
         const targetCellIndex = cellIndex + command.args.amount;
-        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
-        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
-        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-        const change = targetFirstVariableIndex - currentFirstVariableIndex;
-        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
-        command.args.cell.variables.forEach(v => {
-            const currentIndex = findVariableIndex(v);
-            repositionSetElement(runtime._variables, v, currentIndex + change);
-        });
-        // recompute
-        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        const targetCell = lookupCellByIndex(targetCellIndex, cellList);
+        if (targetCell) {
+            const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+            const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+            const change = targetFirstVariableIndex - currentFirstVariableIndex;
+            const dom = command.args.cell.dom;
+            const preY = dom?.getBoundingClientRect?.().top;
+            command.args.cell.variables.forEach(v => {
+                const currentIndex = findVariableIndex(v);
+                repositionSetElement(runtime._variables, v, currentIndex + change);
+            });
+            await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+            // Keep moved cell at same screen position so neighbours shift around it.
+            // Cells here have wildly varying heights (some embed 500+ px iframes), so
+            // a one-position move can otherwise jump hundreds of pixels (#163). Poll
+            // for syncers' reactive DOM reorder before measuring postY — the chain
+            // runs on macrotasks, so requestAnimationFrame is not sufficient.
+            if (preY != null && dom?.isConnected) {
+                let postY = preY;
+                for (let i = 0; i < 30 && postY === preY; i++) {
+                    await new Promise(r => setTimeout(r, 50));
+                    if (!dom.isConnected)
+                        break;
+                    postY = dom.getBoundingClientRect().top;
+                }
+                const delta = postY - preY;
+                if (delta !== 0) {
+                    const scroller = dom.closest('.lm_content') || document.scrollingElement;
+                    scroller?.scrollBy?.({
+                        top: delta,
+                        behavior: 'instant'
+                    });
+                }
+            }
+        }
         result = true;
     }
     if (result) {
@@ -6811,11 +6822,10 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
+const _1ddju40 = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
     return async (source, variables = [], cell) => {
         try {
-            debugger;
             let reposition = false, insertionIndex = -1;
             const newVariables = compile(source);
             if (!variables || variables.length !== newVariables.length) {
@@ -6848,7 +6858,6 @@ const _1698wmw = function _compile_and_update(compile,runtime,realize,reposition
             return variables;
         } catch (e) {
             console.error(e);
-            debugger;
         }
     };
 };
@@ -6939,7 +6948,7 @@ export default function define(runtime, observer) {
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
-  $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
+  $def("_ipx6cz", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","editors","cellEditor"], _ipx6cz);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
   $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
@@ -6957,7 +6966,7 @@ export default function define(runtime, observer) {
   $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
-  $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
+  $def("_mri5h3", null, ["selectVariable","hotbarTemplate"], _mri5h3);  
   $def("_49mpmh", "hotbar", ["viewof edit","Event","setOption","viewof editedCell","htl","edit","toolbar","nav","reversibleAttach","combine","code_editor"], _49mpmh);  
   $def("_1uohwj8", null, ["viewof editedCell"], _1uohwj8);  
   $def("_jqia2f", null, ["nav","editedCell"], _jqia2f);  
@@ -7002,7 +7011,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
+  $def("_2pkmxz", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","viewof liveCellMap","findCellIndex","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _2pkmxz);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -7040,7 +7049,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
+  $def("_1ddju40", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1ddju40);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  

--- a/notebooks/@tomlarkworthy_atproto-comments.html
+++ b/notebooks/@tomlarkworthy_atproto-comments.html
@@ -4888,63 +4888,50 @@ md`## Sync editors`
 const _hdieof = function _editors(){return(
 new Map()
 )};
-const _ye6ey = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,TRACE_CELL,editors,cellEditor)
+const _ipx6cz = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,editors,cellEditor)
 {
-  keepalive(editorModule, "editor_jobs");
-  syncers;
-
-  const placed = new Set();
-
-  if (attachContextManu) {
-    document.querySelectorAll(".observablehq").forEach((div) => {
-      const variable = divToVar(runtime, div);
-      if (!variable) return;
-      if (variable._name == TRACE_CELL) debugger;
-
-      if (!editors.has(variable)) {
-        editors.set(variable, cellEditor(variable));
-      }
-
-      const editor = editors.get(variable);
-      const next = div.nextSibling;
-      if (next !== editor) {
-        const ae = document.activeElement;
-        const hadFocus = ae && editor.contains(ae);
-
-        let restore = null;
-        if (hadFocus) {
-          const fe = ae;
-          if (
-            fe &&
-            (fe.tagName === "INPUT" || fe.tagName === "TEXTAREA") &&
-            "selectionStart" in fe
-          ) {
-            const start = fe.selectionStart,
-              end = fe.selectionEnd;
-            restore = () => {
-              fe.focus({ preventScroll: true });
-              fe.setSelectionRange(start, end);
-            };
-          } else {
-            restore = () => fe?.focus?.({ preventScroll: true });
-          }
-        }
-
-        div.after(editor);
-        restore?.();
-      }
-
-      placed.add(variable);
-    });
-  }
-
-  [...editors.entries()].forEach(([variable, editor]) => {
-    if (!placed.has(variable)) {
-      editor.dispose?.();
-      editor.remove();
-      editors.delete(variable);
+    keepalive(editorModule, 'editor_jobs');
+    syncers;
+    const placed = new Set();
+    if (attachContextManu) {
+        document.querySelectorAll('.observablehq').forEach(div => {
+            const variable = divToVar(runtime, div);
+            if (!variable)
+                return;
+            if (!editors.has(variable)) {
+                editors.set(variable, cellEditor(variable));
+            }
+            const editor = editors.get(variable);
+            const next = div.nextSibling;
+            if (next !== editor) {
+                const ae = document.activeElement;
+                const hadFocus = ae && editor.contains(ae);
+                let restore = null;
+                if (hadFocus) {
+                    const fe = ae;
+                    if (fe && (fe.tagName === 'INPUT' || fe.tagName === 'TEXTAREA') && 'selectionStart' in fe) {
+                        const start = fe.selectionStart, end = fe.selectionEnd;
+                        restore = () => {
+                            fe.focus({ preventScroll: true });
+                            fe.setSelectionRange(start, end);
+                        };
+                    } else {
+                        restore = () => fe?.focus?.({ preventScroll: true });
+                    }
+                }
+                div.after(editor);
+                restore?.();
+            }
+            placed.add(variable);
+        });
     }
-  });
+    [...editors.entries()].forEach(([variable, editor]) => {
+        if (!placed.has(variable)) {
+            editor.dispose?.();
+            editor.remove();
+            editors.delete(variable);
+        }
+    });
 };
 const _1iwobxt = function _divToVar(){return(
 function divToVar(runtime, div) {
@@ -5250,10 +5237,9 @@ async function selectVariable(variable, dom = undefined) {
   return cell;
 }
 )};
-const _kyzl8l = function _24(selectVariable,hotbarTemplate)
+const _mri5h3 = function _24(selectVariable,hotbarTemplate)
 {
-  debugger;
-  return selectVariable(hotbarTemplate[5]);
+return selectVariable(hotbarTemplate[5]);
 };
 const _49mpmh = function _hotbar($0,Event,setOption,$1,htl,edit,toolbar,nav,reversibleAttach,combine,code_editor)
 {
@@ -5585,7 +5571,7 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _2pkmxz = async function _command_processor(command,$0,compile_and_update,remove_variables,$1,findCellIndex,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
     if (command.processed)
         return;
@@ -5601,19 +5587,44 @@ const _16ufqhw = async function _command_processor(command,$0,compile_and_update
         remove_variables(command.args.cell.variables);
         result = true;
     } else if (command.command == 'moveCell') {
-        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const cellList = $1.value.get(command.args.cell.module.module);
+        const cellIndex = findCellIndex(command.args.cell.variables, cellList);
         const targetCellIndex = cellIndex + command.args.amount;
-        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
-        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
-        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-        const change = targetFirstVariableIndex - currentFirstVariableIndex;
-        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
-        command.args.cell.variables.forEach(v => {
-            const currentIndex = findVariableIndex(v);
-            repositionSetElement(runtime._variables, v, currentIndex + change);
-        });
-        // recompute
-        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        const targetCell = lookupCellByIndex(targetCellIndex, cellList);
+        if (targetCell) {
+            const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+            const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+            const change = targetFirstVariableIndex - currentFirstVariableIndex;
+            const dom = command.args.cell.dom;
+            const preY = dom?.getBoundingClientRect?.().top;
+            command.args.cell.variables.forEach(v => {
+                const currentIndex = findVariableIndex(v);
+                repositionSetElement(runtime._variables, v, currentIndex + change);
+            });
+            await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+            // Keep moved cell at same screen position so neighbours shift around it.
+            // Cells here have wildly varying heights (some embed 500+ px iframes), so
+            // a one-position move can otherwise jump hundreds of pixels (#163). Poll
+            // for syncers' reactive DOM reorder before measuring postY — the chain
+            // runs on macrotasks, so requestAnimationFrame is not sufficient.
+            if (preY != null && dom?.isConnected) {
+                let postY = preY;
+                for (let i = 0; i < 30 && postY === preY; i++) {
+                    await new Promise(r => setTimeout(r, 50));
+                    if (!dom.isConnected)
+                        break;
+                    postY = dom.getBoundingClientRect().top;
+                }
+                const delta = postY - preY;
+                if (delta !== 0) {
+                    const scroller = dom.closest('.lm_content') || document.scrollingElement;
+                    scroller?.scrollBy?.({
+                        top: delta,
+                        behavior: 'instant'
+                    });
+                }
+            }
+        }
         result = true;
     }
     if (result) {
@@ -6010,11 +6021,10 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
+const _1ddju40 = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
     return async (source, variables = [], cell) => {
         try {
-            debugger;
             let reposition = false, insertionIndex = -1;
             const newVariables = compile(source);
             if (!variables || variables.length !== newVariables.length) {
@@ -6047,7 +6057,6 @@ const _1698wmw = function _compile_and_update(compile,runtime,realize,reposition
             return variables;
         } catch (e) {
             console.error(e);
-            debugger;
         }
     };
 };
@@ -6138,7 +6147,7 @@ export default function define(runtime, observer) {
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
-  $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
+  $def("_ipx6cz", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","editors","cellEditor"], _ipx6cz);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
   $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
@@ -6156,7 +6165,7 @@ export default function define(runtime, observer) {
   $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
-  $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
+  $def("_mri5h3", null, ["selectVariable","hotbarTemplate"], _mri5h3);  
   $def("_49mpmh", "hotbar", ["viewof edit","Event","setOption","viewof editedCell","htl","edit","toolbar","nav","reversibleAttach","combine","code_editor"], _49mpmh);  
   $def("_1uohwj8", null, ["viewof editedCell"], _1uohwj8);  
   $def("_jqia2f", null, ["nav","editedCell"], _jqia2f);  
@@ -6201,7 +6210,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
+  $def("_2pkmxz", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","viewof liveCellMap","findCellIndex","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _2pkmxz);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6239,7 +6248,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
+  $def("_1ddju40", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1ddju40);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  

--- a/notebooks/@tomlarkworthy_blank-notebook.html
+++ b/notebooks/@tomlarkworthy_blank-notebook.html
@@ -4778,63 +4778,50 @@ md`## Sync editors`
 const _hdieof = function _editors(){return(
 new Map()
 )};
-const _ye6ey = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,TRACE_CELL,editors,cellEditor)
+const _ipx6cz = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,editors,cellEditor)
 {
-  keepalive(editorModule, "editor_jobs");
-  syncers;
-
-  const placed = new Set();
-
-  if (attachContextManu) {
-    document.querySelectorAll(".observablehq").forEach((div) => {
-      const variable = divToVar(runtime, div);
-      if (!variable) return;
-      if (variable._name == TRACE_CELL) debugger;
-
-      if (!editors.has(variable)) {
-        editors.set(variable, cellEditor(variable));
-      }
-
-      const editor = editors.get(variable);
-      const next = div.nextSibling;
-      if (next !== editor) {
-        const ae = document.activeElement;
-        const hadFocus = ae && editor.contains(ae);
-
-        let restore = null;
-        if (hadFocus) {
-          const fe = ae;
-          if (
-            fe &&
-            (fe.tagName === "INPUT" || fe.tagName === "TEXTAREA") &&
-            "selectionStart" in fe
-          ) {
-            const start = fe.selectionStart,
-              end = fe.selectionEnd;
-            restore = () => {
-              fe.focus({ preventScroll: true });
-              fe.setSelectionRange(start, end);
-            };
-          } else {
-            restore = () => fe?.focus?.({ preventScroll: true });
-          }
-        }
-
-        div.after(editor);
-        restore?.();
-      }
-
-      placed.add(variable);
-    });
-  }
-
-  [...editors.entries()].forEach(([variable, editor]) => {
-    if (!placed.has(variable)) {
-      editor.dispose?.();
-      editor.remove();
-      editors.delete(variable);
+    keepalive(editorModule, 'editor_jobs');
+    syncers;
+    const placed = new Set();
+    if (attachContextManu) {
+        document.querySelectorAll('.observablehq').forEach(div => {
+            const variable = divToVar(runtime, div);
+            if (!variable)
+                return;
+            if (!editors.has(variable)) {
+                editors.set(variable, cellEditor(variable));
+            }
+            const editor = editors.get(variable);
+            const next = div.nextSibling;
+            if (next !== editor) {
+                const ae = document.activeElement;
+                const hadFocus = ae && editor.contains(ae);
+                let restore = null;
+                if (hadFocus) {
+                    const fe = ae;
+                    if (fe && (fe.tagName === 'INPUT' || fe.tagName === 'TEXTAREA') && 'selectionStart' in fe) {
+                        const start = fe.selectionStart, end = fe.selectionEnd;
+                        restore = () => {
+                            fe.focus({ preventScroll: true });
+                            fe.setSelectionRange(start, end);
+                        };
+                    } else {
+                        restore = () => fe?.focus?.({ preventScroll: true });
+                    }
+                }
+                div.after(editor);
+                restore?.();
+            }
+            placed.add(variable);
+        });
     }
-  });
+    [...editors.entries()].forEach(([variable, editor]) => {
+        if (!placed.has(variable)) {
+            editor.dispose?.();
+            editor.remove();
+            editors.delete(variable);
+        }
+    });
 };
 const _1iwobxt = function _divToVar(){return(
 function divToVar(runtime, div) {
@@ -5140,10 +5127,9 @@ async function selectVariable(variable, dom = undefined) {
   return cell;
 }
 )};
-const _kyzl8l = function _24(selectVariable,hotbarTemplate)
+const _mri5h3 = function _24(selectVariable,hotbarTemplate)
 {
-  debugger;
-  return selectVariable(hotbarTemplate[5]);
+return selectVariable(hotbarTemplate[5]);
 };
 const _49mpmh = function _hotbar($0,Event,setOption,$1,htl,edit,toolbar,nav,reversibleAttach,combine,code_editor)
 {
@@ -5475,7 +5461,7 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _2pkmxz = async function _command_processor(command,$0,compile_and_update,remove_variables,$1,findCellIndex,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
     if (command.processed)
         return;
@@ -5491,19 +5477,44 @@ const _16ufqhw = async function _command_processor(command,$0,compile_and_update
         remove_variables(command.args.cell.variables);
         result = true;
     } else if (command.command == 'moveCell') {
-        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const cellList = $1.value.get(command.args.cell.module.module);
+        const cellIndex = findCellIndex(command.args.cell.variables, cellList);
         const targetCellIndex = cellIndex + command.args.amount;
-        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
-        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
-        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-        const change = targetFirstVariableIndex - currentFirstVariableIndex;
-        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
-        command.args.cell.variables.forEach(v => {
-            const currentIndex = findVariableIndex(v);
-            repositionSetElement(runtime._variables, v, currentIndex + change);
-        });
-        // recompute
-        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        const targetCell = lookupCellByIndex(targetCellIndex, cellList);
+        if (targetCell) {
+            const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+            const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+            const change = targetFirstVariableIndex - currentFirstVariableIndex;
+            const dom = command.args.cell.dom;
+            const preY = dom?.getBoundingClientRect?.().top;
+            command.args.cell.variables.forEach(v => {
+                const currentIndex = findVariableIndex(v);
+                repositionSetElement(runtime._variables, v, currentIndex + change);
+            });
+            await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+            // Keep moved cell at same screen position so neighbours shift around it.
+            // Cells here have wildly varying heights (some embed 500+ px iframes), so
+            // a one-position move can otherwise jump hundreds of pixels (#163). Poll
+            // for syncers' reactive DOM reorder before measuring postY — the chain
+            // runs on macrotasks, so requestAnimationFrame is not sufficient.
+            if (preY != null && dom?.isConnected) {
+                let postY = preY;
+                for (let i = 0; i < 30 && postY === preY; i++) {
+                    await new Promise(r => setTimeout(r, 50));
+                    if (!dom.isConnected)
+                        break;
+                    postY = dom.getBoundingClientRect().top;
+                }
+                const delta = postY - preY;
+                if (delta !== 0) {
+                    const scroller = dom.closest('.lm_content') || document.scrollingElement;
+                    scroller?.scrollBy?.({
+                        top: delta,
+                        behavior: 'instant'
+                    });
+                }
+            }
+        }
         result = true;
     }
     if (result) {
@@ -5900,11 +5911,10 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
+const _1ddju40 = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
     return async (source, variables = [], cell) => {
         try {
-            debugger;
             let reposition = false, insertionIndex = -1;
             const newVariables = compile(source);
             if (!variables || variables.length !== newVariables.length) {
@@ -5937,7 +5947,6 @@ const _1698wmw = function _compile_and_update(compile,runtime,realize,reposition
             return variables;
         } catch (e) {
             console.error(e);
-            debugger;
         }
     };
 };
@@ -6028,7 +6037,7 @@ export default function define(runtime, observer) {
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
-  $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
+  $def("_ipx6cz", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","editors","cellEditor"], _ipx6cz);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
   $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
@@ -6046,7 +6055,7 @@ export default function define(runtime, observer) {
   $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
-  $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
+  $def("_mri5h3", null, ["selectVariable","hotbarTemplate"], _mri5h3);  
   $def("_49mpmh", "hotbar", ["viewof edit","Event","setOption","viewof editedCell","htl","edit","toolbar","nav","reversibleAttach","combine","code_editor"], _49mpmh);  
   $def("_1uohwj8", null, ["viewof editedCell"], _1uohwj8);  
   $def("_jqia2f", null, ["nav","editedCell"], _jqia2f);  
@@ -6091,7 +6100,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
+  $def("_2pkmxz", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","viewof liveCellMap","findCellIndex","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _2pkmxz);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6129,7 +6138,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
+  $def("_1ddju40", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1ddju40);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  

--- a/notebooks/@tomlarkworthy_bootloader.html
+++ b/notebooks/@tomlarkworthy_bootloader.html
@@ -4863,7 +4863,7 @@ export default function define(runtime, observer) {
 >
 e30K
 </script>
-<script id="@tomlarkworthy/editor-5" 
+<script id="@tomlarkworthy/editor-5"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -4913,63 +4913,50 @@ md`## Sync editors`
 const _hdieof = function _editors(){return(
 new Map()
 )};
-const _ye6ey = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,TRACE_CELL,editors,cellEditor)
+const _ipx6cz = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,editors,cellEditor)
 {
-  keepalive(editorModule, "editor_jobs");
-  syncers;
-
-  const placed = new Set();
-
-  if (attachContextManu) {
-    document.querySelectorAll(".observablehq").forEach((div) => {
-      const variable = divToVar(runtime, div);
-      if (!variable) return;
-      if (variable._name == TRACE_CELL) debugger;
-
-      if (!editors.has(variable)) {
-        editors.set(variable, cellEditor(variable));
-      }
-
-      const editor = editors.get(variable);
-      const next = div.nextSibling;
-      if (next !== editor) {
-        const ae = document.activeElement;
-        const hadFocus = ae && editor.contains(ae);
-
-        let restore = null;
-        if (hadFocus) {
-          const fe = ae;
-          if (
-            fe &&
-            (fe.tagName === "INPUT" || fe.tagName === "TEXTAREA") &&
-            "selectionStart" in fe
-          ) {
-            const start = fe.selectionStart,
-              end = fe.selectionEnd;
-            restore = () => {
-              fe.focus({ preventScroll: true });
-              fe.setSelectionRange(start, end);
-            };
-          } else {
-            restore = () => fe?.focus?.({ preventScroll: true });
-          }
-        }
-
-        div.after(editor);
-        restore?.();
-      }
-
-      placed.add(variable);
-    });
-  }
-
-  [...editors.entries()].forEach(([variable, editor]) => {
-    if (!placed.has(variable)) {
-      editor.dispose?.();
-      editor.remove();
-      editors.delete(variable);
+    keepalive(editorModule, 'editor_jobs');
+    syncers;
+    const placed = new Set();
+    if (attachContextManu) {
+        document.querySelectorAll('.observablehq').forEach(div => {
+            const variable = divToVar(runtime, div);
+            if (!variable)
+                return;
+            if (!editors.has(variable)) {
+                editors.set(variable, cellEditor(variable));
+            }
+            const editor = editors.get(variable);
+            const next = div.nextSibling;
+            if (next !== editor) {
+                const ae = document.activeElement;
+                const hadFocus = ae && editor.contains(ae);
+                let restore = null;
+                if (hadFocus) {
+                    const fe = ae;
+                    if (fe && (fe.tagName === 'INPUT' || fe.tagName === 'TEXTAREA') && 'selectionStart' in fe) {
+                        const start = fe.selectionStart, end = fe.selectionEnd;
+                        restore = () => {
+                            fe.focus({ preventScroll: true });
+                            fe.setSelectionRange(start, end);
+                        };
+                    } else {
+                        restore = () => fe?.focus?.({ preventScroll: true });
+                    }
+                }
+                div.after(editor);
+                restore?.();
+            }
+            placed.add(variable);
+        });
     }
-  });
+    [...editors.entries()].forEach(([variable, editor]) => {
+        if (!placed.has(variable)) {
+            editor.dispose?.();
+            editor.remove();
+            editors.delete(variable);
+        }
+    });
 };
 const _1iwobxt = function _divToVar(){return(
 function divToVar(runtime, div) {
@@ -5275,10 +5262,9 @@ async function selectVariable(variable, dom = undefined) {
   return cell;
 }
 )};
-const _kyzl8l = function _24(selectVariable,hotbarTemplate)
+const _mri5h3 = function _24(selectVariable,hotbarTemplate)
 {
-  debugger;
-  return selectVariable(hotbarTemplate[5]);
+return selectVariable(hotbarTemplate[5]);
 };
 const _49mpmh = function _hotbar($0,Event,setOption,$1,htl,edit,toolbar,nav,reversibleAttach,combine,code_editor)
 {
@@ -5610,7 +5596,7 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _2pkmxz = async function _command_processor(command,$0,compile_and_update,remove_variables,$1,findCellIndex,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
     if (command.processed)
         return;
@@ -5626,19 +5612,44 @@ const _16ufqhw = async function _command_processor(command,$0,compile_and_update
         remove_variables(command.args.cell.variables);
         result = true;
     } else if (command.command == 'moveCell') {
-        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const cellList = $1.value.get(command.args.cell.module.module);
+        const cellIndex = findCellIndex(command.args.cell.variables, cellList);
         const targetCellIndex = cellIndex + command.args.amount;
-        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
-        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
-        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-        const change = targetFirstVariableIndex - currentFirstVariableIndex;
-        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
-        command.args.cell.variables.forEach(v => {
-            const currentIndex = findVariableIndex(v);
-            repositionSetElement(runtime._variables, v, currentIndex + change);
-        });
-        // recompute
-        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        const targetCell = lookupCellByIndex(targetCellIndex, cellList);
+        if (targetCell) {
+            const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+            const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+            const change = targetFirstVariableIndex - currentFirstVariableIndex;
+            const dom = command.args.cell.dom;
+            const preY = dom?.getBoundingClientRect?.().top;
+            command.args.cell.variables.forEach(v => {
+                const currentIndex = findVariableIndex(v);
+                repositionSetElement(runtime._variables, v, currentIndex + change);
+            });
+            await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+            // Keep moved cell at same screen position so neighbours shift around it.
+            // Cells here have wildly varying heights (some embed 500+ px iframes), so
+            // a one-position move can otherwise jump hundreds of pixels (#163). Poll
+            // for syncers' reactive DOM reorder before measuring postY — the chain
+            // runs on macrotasks, so requestAnimationFrame is not sufficient.
+            if (preY != null && dom?.isConnected) {
+                let postY = preY;
+                for (let i = 0; i < 30 && postY === preY; i++) {
+                    await new Promise(r => setTimeout(r, 50));
+                    if (!dom.isConnected)
+                        break;
+                    postY = dom.getBoundingClientRect().top;
+                }
+                const delta = postY - preY;
+                if (delta !== 0) {
+                    const scroller = dom.closest('.lm_content') || document.scrollingElement;
+                    scroller?.scrollBy?.({
+                        top: delta,
+                        behavior: 'instant'
+                    });
+                }
+            }
+        }
         result = true;
     }
     if (result) {
@@ -6035,11 +6046,10 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
+const _1ddju40 = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
     return async (source, variables = [], cell) => {
         try {
-            debugger;
             let reposition = false, insertionIndex = -1;
             const newVariables = compile(source);
             if (!variables || variables.length !== newVariables.length) {
@@ -6072,7 +6082,6 @@ const _1698wmw = function _compile_and_update(compile,runtime,realize,reposition
             return variables;
         } catch (e) {
             console.error(e);
-            debugger;
         }
     };
 };
@@ -6163,7 +6172,7 @@ export default function define(runtime, observer) {
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
-  $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
+  $def("_ipx6cz", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","editors","cellEditor"], _ipx6cz);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
   $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
@@ -6181,7 +6190,7 @@ export default function define(runtime, observer) {
   $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
-  $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
+  $def("_mri5h3", null, ["selectVariable","hotbarTemplate"], _mri5h3);  
   $def("_49mpmh", "hotbar", ["viewof edit","Event","setOption","viewof editedCell","htl","edit","toolbar","nav","reversibleAttach","combine","code_editor"], _49mpmh);  
   $def("_1uohwj8", null, ["viewof editedCell"], _1uohwj8);  
   $def("_jqia2f", null, ["nav","editedCell"], _jqia2f);  
@@ -6226,7 +6235,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
+  $def("_2pkmxz", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","viewof liveCellMap","findCellIndex","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _2pkmxz);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6264,7 +6273,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
+  $def("_1ddju40", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1ddju40);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -6312,7 +6321,8 @@ export default function define(runtime, observer) {
   main.define("navHref", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("navHref", _));  
   main.define("cellsToClipboard", ["module @tomlarkworthy/cells-to-clipboard", "@variable"], (_, v) => v.import("cellsToClipboard", _));
   return main;
-}</script>
+}
+</script>
 <script id="@tomlarkworthy/escodegen/escodegen.browser.min.js.gz" 
   type="text/plain"
   data-encoding="base64"

--- a/notebooks/@tomlarkworthy_bulk-jumpgate.html
+++ b/notebooks/@tomlarkworthy_bulk-jumpgate.html
@@ -5631,62 +5631,50 @@ md`## Sync editors`
 const _hdieof = function _editors(){return(
 new Map()
 )};
-const _ye6ey = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,TRACE_CELL,editors,cellEditor)
+const _ipx6cz = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,editors,cellEditor)
 {
-  keepalive(editorModule, "editor_jobs");
-  syncers;
-
-  const placed = new Set();
-
-  if (attachContextManu) {
-    document.querySelectorAll(".observablehq").forEach((div) => {
-      const variable = divToVar(runtime, div);
-      if (!variable) return;
-
-      if (!editors.has(variable)) {
-        editors.set(variable, cellEditor(variable));
-      }
-
-      const editor = editors.get(variable);
-      const next = div.nextSibling;
-      if (next !== editor) {
-        const ae = document.activeElement;
-        const hadFocus = ae && editor.contains(ae);
-
-        let restore = null;
-        if (hadFocus) {
-          const fe = ae;
-          if (
-            fe &&
-            (fe.tagName === "INPUT" || fe.tagName === "TEXTAREA") &&
-            "selectionStart" in fe
-          ) {
-            const start = fe.selectionStart,
-              end = fe.selectionEnd;
-            restore = () => {
-              fe.focus({ preventScroll: true });
-              fe.setSelectionRange(start, end);
-            };
-          } else {
-            restore = () => fe?.focus?.({ preventScroll: true });
-          }
-        }
-
-        div.after(editor);
-        restore?.();
-      }
-
-      placed.add(variable);
-    });
-  }
-
-  [...editors.entries()].forEach(([variable, editor]) => {
-    if (!placed.has(variable)) {
-      editor.dispose?.();
-      editor.remove();
-      editors.delete(variable);
+    keepalive(editorModule, 'editor_jobs');
+    syncers;
+    const placed = new Set();
+    if (attachContextManu) {
+        document.querySelectorAll('.observablehq').forEach(div => {
+            const variable = divToVar(runtime, div);
+            if (!variable)
+                return;
+            if (!editors.has(variable)) {
+                editors.set(variable, cellEditor(variable));
+            }
+            const editor = editors.get(variable);
+            const next = div.nextSibling;
+            if (next !== editor) {
+                const ae = document.activeElement;
+                const hadFocus = ae && editor.contains(ae);
+                let restore = null;
+                if (hadFocus) {
+                    const fe = ae;
+                    if (fe && (fe.tagName === 'INPUT' || fe.tagName === 'TEXTAREA') && 'selectionStart' in fe) {
+                        const start = fe.selectionStart, end = fe.selectionEnd;
+                        restore = () => {
+                            fe.focus({ preventScroll: true });
+                            fe.setSelectionRange(start, end);
+                        };
+                    } else {
+                        restore = () => fe?.focus?.({ preventScroll: true });
+                    }
+                }
+                div.after(editor);
+                restore?.();
+            }
+            placed.add(variable);
+        });
     }
-  });
+    [...editors.entries()].forEach(([variable, editor]) => {
+        if (!placed.has(variable)) {
+            editor.dispose?.();
+            editor.remove();
+            editors.delete(variable);
+        }
+    });
 };
 const _1iwobxt = function _divToVar(){return(
 function divToVar(runtime, div) {
@@ -5992,9 +5980,9 @@ async function selectVariable(variable, dom = undefined) {
   return cell;
 }
 )};
-const _kyzl8l = function _24(selectVariable,hotbarTemplate)
+const _mri5h3 = function _24(selectVariable,hotbarTemplate)
 {
-  return selectVariable(hotbarTemplate[5]);
+return selectVariable(hotbarTemplate[5]);
 };
 const _49mpmh = function _hotbar($0,Event,setOption,$1,htl,edit,toolbar,nav,reversibleAttach,combine,code_editor)
 {
@@ -6342,19 +6330,40 @@ const _16ufqhw = async function _command_processor(command,$0,compile_and_update
         remove_variables(command.args.cell.variables);
         result = true;
     } else if (command.command == 'moveCell') {
-        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const cellList = $1.value.get(command.args.cell.module.module);
+        const cellIndex = findCellIndex(command.args.cell.variables, cellList);
         const targetCellIndex = cellIndex + command.args.amount;
-        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
-        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
-        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-        const change = targetFirstVariableIndex - currentFirstVariableIndex;
-        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
-        command.args.cell.variables.forEach(v => {
-            const currentIndex = findVariableIndex(v);
-            repositionSetElement(runtime._variables, v, currentIndex + change);
-        });
-        // recompute
-        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        const targetCell = lookupCellByIndex(targetCellIndex, cellList);
+        if (targetCell) {
+            const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+            const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+            const change = targetFirstVariableIndex - currentFirstVariableIndex;
+            const dom = command.args.cell.dom;
+            const preY = dom?.getBoundingClientRect?.().top;
+            command.args.cell.variables.forEach(v => {
+                const currentIndex = findVariableIndex(v);
+                repositionSetElement(runtime._variables, v, currentIndex + change);
+            });
+            await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+            // Keep moved cell at same screen position so neighbours shift around it.
+            // Cells here have wildly varying heights (some embed 500+ px iframes), so
+            // a one-position move can otherwise jump hundreds of pixels (#163). Poll
+            // for syncers' reactive DOM reorder before measuring postY — the chain
+            // runs on macrotasks, so requestAnimationFrame is not sufficient.
+            if (preY != null && dom?.isConnected) {
+                let postY = preY;
+                for (let i = 0; i < 30 && postY === preY; i++) {
+                    await new Promise(r => setTimeout(r, 50));
+                    if (!dom.isConnected) break;
+                    postY = dom.getBoundingClientRect().top;
+                }
+                const delta = postY - preY;
+                if (delta !== 0) {
+                    const scroller = dom.closest('.lm_content') || document.scrollingElement;
+                    scroller?.scrollBy?.({ top: delta, behavior: 'instant' });
+                }
+            }
+        }
         result = true;
     }
     if (result) {
@@ -6751,7 +6760,7 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
+const _1ddju40 = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
     return async (source, variables = [], cell) => {
         try {
@@ -6877,7 +6886,7 @@ export default function define(runtime, observer) {
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
-  $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
+  $def("_ipx6cz", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","editors","cellEditor"], _ipx6cz);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
   $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
@@ -6895,7 +6904,7 @@ export default function define(runtime, observer) {
   $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
-  $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
+  $def("_mri5h3", null, ["selectVariable","hotbarTemplate"], _mri5h3);  
   $def("_49mpmh", "hotbar", ["viewof edit","Event","setOption","viewof editedCell","htl","edit","toolbar","nav","reversibleAttach","combine","code_editor"], _49mpmh);  
   $def("_1uohwj8", null, ["viewof editedCell"], _1uohwj8);  
   $def("_jqia2f", null, ["nav","editedCell"], _jqia2f);  
@@ -6978,7 +6987,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
+  $def("_1ddju40", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1ddju40);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  

--- a/notebooks/@tomlarkworthy_cells-to-clipboard.html
+++ b/notebooks/@tomlarkworthy_cells-to-clipboard.html
@@ -4740,63 +4740,50 @@ md`## Sync editors`
 const _hdieof = function _editors(){return(
 new Map()
 )};
-const _ye6ey = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,TRACE_CELL,editors,cellEditor)
+const _ipx6cz = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,editors,cellEditor)
 {
-  keepalive(editorModule, "editor_jobs");
-  syncers;
-
-  const placed = new Set();
-
-  if (attachContextManu) {
-    document.querySelectorAll(".observablehq").forEach((div) => {
-      const variable = divToVar(runtime, div);
-      if (!variable) return;
-      if (variable._name == TRACE_CELL) debugger;
-
-      if (!editors.has(variable)) {
-        editors.set(variable, cellEditor(variable));
-      }
-
-      const editor = editors.get(variable);
-      const next = div.nextSibling;
-      if (next !== editor) {
-        const ae = document.activeElement;
-        const hadFocus = ae && editor.contains(ae);
-
-        let restore = null;
-        if (hadFocus) {
-          const fe = ae;
-          if (
-            fe &&
-            (fe.tagName === "INPUT" || fe.tagName === "TEXTAREA") &&
-            "selectionStart" in fe
-          ) {
-            const start = fe.selectionStart,
-              end = fe.selectionEnd;
-            restore = () => {
-              fe.focus({ preventScroll: true });
-              fe.setSelectionRange(start, end);
-            };
-          } else {
-            restore = () => fe?.focus?.({ preventScroll: true });
-          }
-        }
-
-        div.after(editor);
-        restore?.();
-      }
-
-      placed.add(variable);
-    });
-  }
-
-  [...editors.entries()].forEach(([variable, editor]) => {
-    if (!placed.has(variable)) {
-      editor.dispose?.();
-      editor.remove();
-      editors.delete(variable);
+    keepalive(editorModule, 'editor_jobs');
+    syncers;
+    const placed = new Set();
+    if (attachContextManu) {
+        document.querySelectorAll('.observablehq').forEach(div => {
+            const variable = divToVar(runtime, div);
+            if (!variable)
+                return;
+            if (!editors.has(variable)) {
+                editors.set(variable, cellEditor(variable));
+            }
+            const editor = editors.get(variable);
+            const next = div.nextSibling;
+            if (next !== editor) {
+                const ae = document.activeElement;
+                const hadFocus = ae && editor.contains(ae);
+                let restore = null;
+                if (hadFocus) {
+                    const fe = ae;
+                    if (fe && (fe.tagName === 'INPUT' || fe.tagName === 'TEXTAREA') && 'selectionStart' in fe) {
+                        const start = fe.selectionStart, end = fe.selectionEnd;
+                        restore = () => {
+                            fe.focus({ preventScroll: true });
+                            fe.setSelectionRange(start, end);
+                        };
+                    } else {
+                        restore = () => fe?.focus?.({ preventScroll: true });
+                    }
+                }
+                div.after(editor);
+                restore?.();
+            }
+            placed.add(variable);
+        });
     }
-  });
+    [...editors.entries()].forEach(([variable, editor]) => {
+        if (!placed.has(variable)) {
+            editor.dispose?.();
+            editor.remove();
+            editors.delete(variable);
+        }
+    });
 };
 const _1iwobxt = function _divToVar(){return(
 function divToVar(runtime, div) {
@@ -5102,10 +5089,9 @@ async function selectVariable(variable, dom = undefined) {
   return cell;
 }
 )};
-const _kyzl8l = function _24(selectVariable,hotbarTemplate)
+const _mri5h3 = function _24(selectVariable,hotbarTemplate)
 {
-  debugger;
-  return selectVariable(hotbarTemplate[5]);
+return selectVariable(hotbarTemplate[5]);
 };
 const _49mpmh = function _hotbar($0,Event,setOption,$1,htl,edit,toolbar,nav,reversibleAttach,combine,code_editor)
 {
@@ -5437,7 +5423,7 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _2pkmxz = async function _command_processor(command,$0,compile_and_update,remove_variables,$1,findCellIndex,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
     if (command.processed)
         return;
@@ -5453,19 +5439,44 @@ const _16ufqhw = async function _command_processor(command,$0,compile_and_update
         remove_variables(command.args.cell.variables);
         result = true;
     } else if (command.command == 'moveCell') {
-        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const cellList = $1.value.get(command.args.cell.module.module);
+        const cellIndex = findCellIndex(command.args.cell.variables, cellList);
         const targetCellIndex = cellIndex + command.args.amount;
-        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
-        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
-        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-        const change = targetFirstVariableIndex - currentFirstVariableIndex;
-        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
-        command.args.cell.variables.forEach(v => {
-            const currentIndex = findVariableIndex(v);
-            repositionSetElement(runtime._variables, v, currentIndex + change);
-        });
-        // recompute
-        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        const targetCell = lookupCellByIndex(targetCellIndex, cellList);
+        if (targetCell) {
+            const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+            const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+            const change = targetFirstVariableIndex - currentFirstVariableIndex;
+            const dom = command.args.cell.dom;
+            const preY = dom?.getBoundingClientRect?.().top;
+            command.args.cell.variables.forEach(v => {
+                const currentIndex = findVariableIndex(v);
+                repositionSetElement(runtime._variables, v, currentIndex + change);
+            });
+            await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+            // Keep moved cell at same screen position so neighbours shift around it.
+            // Cells here have wildly varying heights (some embed 500+ px iframes), so
+            // a one-position move can otherwise jump hundreds of pixels (#163). Poll
+            // for syncers' reactive DOM reorder before measuring postY — the chain
+            // runs on macrotasks, so requestAnimationFrame is not sufficient.
+            if (preY != null && dom?.isConnected) {
+                let postY = preY;
+                for (let i = 0; i < 30 && postY === preY; i++) {
+                    await new Promise(r => setTimeout(r, 50));
+                    if (!dom.isConnected)
+                        break;
+                    postY = dom.getBoundingClientRect().top;
+                }
+                const delta = postY - preY;
+                if (delta !== 0) {
+                    const scroller = dom.closest('.lm_content') || document.scrollingElement;
+                    scroller?.scrollBy?.({
+                        top: delta,
+                        behavior: 'instant'
+                    });
+                }
+            }
+        }
         result = true;
     }
     if (result) {
@@ -5862,11 +5873,10 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
+const _1ddju40 = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
     return async (source, variables = [], cell) => {
         try {
-            debugger;
             let reposition = false, insertionIndex = -1;
             const newVariables = compile(source);
             if (!variables || variables.length !== newVariables.length) {
@@ -5899,7 +5909,6 @@ const _1698wmw = function _compile_and_update(compile,runtime,realize,reposition
             return variables;
         } catch (e) {
             console.error(e);
-            debugger;
         }
     };
 };
@@ -5990,7 +5999,7 @@ export default function define(runtime, observer) {
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
-  $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
+  $def("_ipx6cz", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","editors","cellEditor"], _ipx6cz);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
   $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
@@ -6008,7 +6017,7 @@ export default function define(runtime, observer) {
   $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
-  $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
+  $def("_mri5h3", null, ["selectVariable","hotbarTemplate"], _mri5h3);  
   $def("_49mpmh", "hotbar", ["viewof edit","Event","setOption","viewof editedCell","htl","edit","toolbar","nav","reversibleAttach","combine","code_editor"], _49mpmh);  
   $def("_1uohwj8", null, ["viewof editedCell"], _1uohwj8);  
   $def("_jqia2f", null, ["nav","editedCell"], _jqia2f);  
@@ -6053,7 +6062,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
+  $def("_2pkmxz", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","viewof liveCellMap","findCellIndex","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _2pkmxz);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6091,7 +6100,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
+  $def("_1ddju40", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1ddju40);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  

--- a/notebooks/@tomlarkworthy_claude-code-pairing.html
+++ b/notebooks/@tomlarkworthy_claude-code-pairing.html
@@ -4716,63 +4716,50 @@ md`## Sync editors`
 const _hdieof = function _editors(){return(
 new Map()
 )};
-const _ye6ey = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,TRACE_CELL,editors,cellEditor)
+const _ipx6cz = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,editors,cellEditor)
 {
-  keepalive(editorModule, "editor_jobs");
-  syncers;
-
-  const placed = new Set();
-
-  if (attachContextManu) {
-    document.querySelectorAll(".observablehq").forEach((div) => {
-      const variable = divToVar(runtime, div);
-      if (!variable) return;
-      if (variable._name == TRACE_CELL) debugger;
-
-      if (!editors.has(variable)) {
-        editors.set(variable, cellEditor(variable));
-      }
-
-      const editor = editors.get(variable);
-      const next = div.nextSibling;
-      if (next !== editor) {
-        const ae = document.activeElement;
-        const hadFocus = ae && editor.contains(ae);
-
-        let restore = null;
-        if (hadFocus) {
-          const fe = ae;
-          if (
-            fe &&
-            (fe.tagName === "INPUT" || fe.tagName === "TEXTAREA") &&
-            "selectionStart" in fe
-          ) {
-            const start = fe.selectionStart,
-              end = fe.selectionEnd;
-            restore = () => {
-              fe.focus({ preventScroll: true });
-              fe.setSelectionRange(start, end);
-            };
-          } else {
-            restore = () => fe?.focus?.({ preventScroll: true });
-          }
-        }
-
-        div.after(editor);
-        restore?.();
-      }
-
-      placed.add(variable);
-    });
-  }
-
-  [...editors.entries()].forEach(([variable, editor]) => {
-    if (!placed.has(variable)) {
-      editor.dispose?.();
-      editor.remove();
-      editors.delete(variable);
+    keepalive(editorModule, 'editor_jobs');
+    syncers;
+    const placed = new Set();
+    if (attachContextManu) {
+        document.querySelectorAll('.observablehq').forEach(div => {
+            const variable = divToVar(runtime, div);
+            if (!variable)
+                return;
+            if (!editors.has(variable)) {
+                editors.set(variable, cellEditor(variable));
+            }
+            const editor = editors.get(variable);
+            const next = div.nextSibling;
+            if (next !== editor) {
+                const ae = document.activeElement;
+                const hadFocus = ae && editor.contains(ae);
+                let restore = null;
+                if (hadFocus) {
+                    const fe = ae;
+                    if (fe && (fe.tagName === 'INPUT' || fe.tagName === 'TEXTAREA') && 'selectionStart' in fe) {
+                        const start = fe.selectionStart, end = fe.selectionEnd;
+                        restore = () => {
+                            fe.focus({ preventScroll: true });
+                            fe.setSelectionRange(start, end);
+                        };
+                    } else {
+                        restore = () => fe?.focus?.({ preventScroll: true });
+                    }
+                }
+                div.after(editor);
+                restore?.();
+            }
+            placed.add(variable);
+        });
     }
-  });
+    [...editors.entries()].forEach(([variable, editor]) => {
+        if (!placed.has(variable)) {
+            editor.dispose?.();
+            editor.remove();
+            editors.delete(variable);
+        }
+    });
 };
 const _1iwobxt = function _divToVar(){return(
 function divToVar(runtime, div) {
@@ -5078,10 +5065,9 @@ async function selectVariable(variable, dom = undefined) {
   return cell;
 }
 )};
-const _kyzl8l = function _24(selectVariable,hotbarTemplate)
+const _mri5h3 = function _24(selectVariable,hotbarTemplate)
 {
-  debugger;
-  return selectVariable(hotbarTemplate[5]);
+return selectVariable(hotbarTemplate[5]);
 };
 const _49mpmh = function _hotbar($0,Event,setOption,$1,htl,edit,toolbar,nav,reversibleAttach,combine,code_editor)
 {
@@ -5413,7 +5399,7 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _2pkmxz = async function _command_processor(command,$0,compile_and_update,remove_variables,$1,findCellIndex,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
     if (command.processed)
         return;
@@ -5429,19 +5415,44 @@ const _16ufqhw = async function _command_processor(command,$0,compile_and_update
         remove_variables(command.args.cell.variables);
         result = true;
     } else if (command.command == 'moveCell') {
-        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const cellList = $1.value.get(command.args.cell.module.module);
+        const cellIndex = findCellIndex(command.args.cell.variables, cellList);
         const targetCellIndex = cellIndex + command.args.amount;
-        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
-        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
-        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-        const change = targetFirstVariableIndex - currentFirstVariableIndex;
-        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
-        command.args.cell.variables.forEach(v => {
-            const currentIndex = findVariableIndex(v);
-            repositionSetElement(runtime._variables, v, currentIndex + change);
-        });
-        // recompute
-        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        const targetCell = lookupCellByIndex(targetCellIndex, cellList);
+        if (targetCell) {
+            const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+            const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+            const change = targetFirstVariableIndex - currentFirstVariableIndex;
+            const dom = command.args.cell.dom;
+            const preY = dom?.getBoundingClientRect?.().top;
+            command.args.cell.variables.forEach(v => {
+                const currentIndex = findVariableIndex(v);
+                repositionSetElement(runtime._variables, v, currentIndex + change);
+            });
+            await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+            // Keep moved cell at same screen position so neighbours shift around it.
+            // Cells here have wildly varying heights (some embed 500+ px iframes), so
+            // a one-position move can otherwise jump hundreds of pixels (#163). Poll
+            // for syncers' reactive DOM reorder before measuring postY — the chain
+            // runs on macrotasks, so requestAnimationFrame is not sufficient.
+            if (preY != null && dom?.isConnected) {
+                let postY = preY;
+                for (let i = 0; i < 30 && postY === preY; i++) {
+                    await new Promise(r => setTimeout(r, 50));
+                    if (!dom.isConnected)
+                        break;
+                    postY = dom.getBoundingClientRect().top;
+                }
+                const delta = postY - preY;
+                if (delta !== 0) {
+                    const scroller = dom.closest('.lm_content') || document.scrollingElement;
+                    scroller?.scrollBy?.({
+                        top: delta,
+                        behavior: 'instant'
+                    });
+                }
+            }
+        }
         result = true;
     }
     if (result) {
@@ -5838,11 +5849,10 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
+const _1ddju40 = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
     return async (source, variables = [], cell) => {
         try {
-            debugger;
             let reposition = false, insertionIndex = -1;
             const newVariables = compile(source);
             if (!variables || variables.length !== newVariables.length) {
@@ -5875,7 +5885,6 @@ const _1698wmw = function _compile_and_update(compile,runtime,realize,reposition
             return variables;
         } catch (e) {
             console.error(e);
-            debugger;
         }
     };
 };
@@ -5966,7 +5975,7 @@ export default function define(runtime, observer) {
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
-  $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
+  $def("_ipx6cz", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","editors","cellEditor"], _ipx6cz);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
   $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
@@ -5984,7 +5993,7 @@ export default function define(runtime, observer) {
   $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
-  $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
+  $def("_mri5h3", null, ["selectVariable","hotbarTemplate"], _mri5h3);  
   $def("_49mpmh", "hotbar", ["viewof edit","Event","setOption","viewof editedCell","htl","edit","toolbar","nav","reversibleAttach","combine","code_editor"], _49mpmh);  
   $def("_1uohwj8", null, ["viewof editedCell"], _1uohwj8);  
   $def("_jqia2f", null, ["nav","editedCell"], _jqia2f);  
@@ -6029,7 +6038,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
+  $def("_2pkmxz", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","viewof liveCellMap","findCellIndex","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _2pkmxz);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6067,7 +6076,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
+  $def("_1ddju40", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1ddju40);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  

--- a/notebooks/@tomlarkworthy_codemirror-6-v2.html
+++ b/notebooks/@tomlarkworthy_codemirror-6-v2.html
@@ -4740,63 +4740,50 @@ md`## Sync editors`
 const _hdieof = function _editors(){return(
 new Map()
 )};
-const _ye6ey = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,TRACE_CELL,editors,cellEditor)
+const _ipx6cz = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,editors,cellEditor)
 {
-  keepalive(editorModule, "editor_jobs");
-  syncers;
-
-  const placed = new Set();
-
-  if (attachContextManu) {
-    document.querySelectorAll(".observablehq").forEach((div) => {
-      const variable = divToVar(runtime, div);
-      if (!variable) return;
-      if (variable._name == TRACE_CELL) debugger;
-
-      if (!editors.has(variable)) {
-        editors.set(variable, cellEditor(variable));
-      }
-
-      const editor = editors.get(variable);
-      const next = div.nextSibling;
-      if (next !== editor) {
-        const ae = document.activeElement;
-        const hadFocus = ae && editor.contains(ae);
-
-        let restore = null;
-        if (hadFocus) {
-          const fe = ae;
-          if (
-            fe &&
-            (fe.tagName === "INPUT" || fe.tagName === "TEXTAREA") &&
-            "selectionStart" in fe
-          ) {
-            const start = fe.selectionStart,
-              end = fe.selectionEnd;
-            restore = () => {
-              fe.focus({ preventScroll: true });
-              fe.setSelectionRange(start, end);
-            };
-          } else {
-            restore = () => fe?.focus?.({ preventScroll: true });
-          }
-        }
-
-        div.after(editor);
-        restore?.();
-      }
-
-      placed.add(variable);
-    });
-  }
-
-  [...editors.entries()].forEach(([variable, editor]) => {
-    if (!placed.has(variable)) {
-      editor.dispose?.();
-      editor.remove();
-      editors.delete(variable);
+    keepalive(editorModule, 'editor_jobs');
+    syncers;
+    const placed = new Set();
+    if (attachContextManu) {
+        document.querySelectorAll('.observablehq').forEach(div => {
+            const variable = divToVar(runtime, div);
+            if (!variable)
+                return;
+            if (!editors.has(variable)) {
+                editors.set(variable, cellEditor(variable));
+            }
+            const editor = editors.get(variable);
+            const next = div.nextSibling;
+            if (next !== editor) {
+                const ae = document.activeElement;
+                const hadFocus = ae && editor.contains(ae);
+                let restore = null;
+                if (hadFocus) {
+                    const fe = ae;
+                    if (fe && (fe.tagName === 'INPUT' || fe.tagName === 'TEXTAREA') && 'selectionStart' in fe) {
+                        const start = fe.selectionStart, end = fe.selectionEnd;
+                        restore = () => {
+                            fe.focus({ preventScroll: true });
+                            fe.setSelectionRange(start, end);
+                        };
+                    } else {
+                        restore = () => fe?.focus?.({ preventScroll: true });
+                    }
+                }
+                div.after(editor);
+                restore?.();
+            }
+            placed.add(variable);
+        });
     }
-  });
+    [...editors.entries()].forEach(([variable, editor]) => {
+        if (!placed.has(variable)) {
+            editor.dispose?.();
+            editor.remove();
+            editors.delete(variable);
+        }
+    });
 };
 const _1iwobxt = function _divToVar(){return(
 function divToVar(runtime, div) {
@@ -5102,10 +5089,9 @@ async function selectVariable(variable, dom = undefined) {
   return cell;
 }
 )};
-const _kyzl8l = function _24(selectVariable,hotbarTemplate)
+const _mri5h3 = function _24(selectVariable,hotbarTemplate)
 {
-  debugger;
-  return selectVariable(hotbarTemplate[5]);
+return selectVariable(hotbarTemplate[5]);
 };
 const _49mpmh = function _hotbar($0,Event,setOption,$1,htl,edit,toolbar,nav,reversibleAttach,combine,code_editor)
 {
@@ -5437,7 +5423,7 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _2pkmxz = async function _command_processor(command,$0,compile_and_update,remove_variables,$1,findCellIndex,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
     if (command.processed)
         return;
@@ -5453,19 +5439,44 @@ const _16ufqhw = async function _command_processor(command,$0,compile_and_update
         remove_variables(command.args.cell.variables);
         result = true;
     } else if (command.command == 'moveCell') {
-        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const cellList = $1.value.get(command.args.cell.module.module);
+        const cellIndex = findCellIndex(command.args.cell.variables, cellList);
         const targetCellIndex = cellIndex + command.args.amount;
-        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
-        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
-        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-        const change = targetFirstVariableIndex - currentFirstVariableIndex;
-        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
-        command.args.cell.variables.forEach(v => {
-            const currentIndex = findVariableIndex(v);
-            repositionSetElement(runtime._variables, v, currentIndex + change);
-        });
-        // recompute
-        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        const targetCell = lookupCellByIndex(targetCellIndex, cellList);
+        if (targetCell) {
+            const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+            const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+            const change = targetFirstVariableIndex - currentFirstVariableIndex;
+            const dom = command.args.cell.dom;
+            const preY = dom?.getBoundingClientRect?.().top;
+            command.args.cell.variables.forEach(v => {
+                const currentIndex = findVariableIndex(v);
+                repositionSetElement(runtime._variables, v, currentIndex + change);
+            });
+            await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+            // Keep moved cell at same screen position so neighbours shift around it.
+            // Cells here have wildly varying heights (some embed 500+ px iframes), so
+            // a one-position move can otherwise jump hundreds of pixels (#163). Poll
+            // for syncers' reactive DOM reorder before measuring postY — the chain
+            // runs on macrotasks, so requestAnimationFrame is not sufficient.
+            if (preY != null && dom?.isConnected) {
+                let postY = preY;
+                for (let i = 0; i < 30 && postY === preY; i++) {
+                    await new Promise(r => setTimeout(r, 50));
+                    if (!dom.isConnected)
+                        break;
+                    postY = dom.getBoundingClientRect().top;
+                }
+                const delta = postY - preY;
+                if (delta !== 0) {
+                    const scroller = dom.closest('.lm_content') || document.scrollingElement;
+                    scroller?.scrollBy?.({
+                        top: delta,
+                        behavior: 'instant'
+                    });
+                }
+            }
+        }
         result = true;
     }
     if (result) {
@@ -5862,11 +5873,10 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
+const _1ddju40 = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
     return async (source, variables = [], cell) => {
         try {
-            debugger;
             let reposition = false, insertionIndex = -1;
             const newVariables = compile(source);
             if (!variables || variables.length !== newVariables.length) {
@@ -5899,7 +5909,6 @@ const _1698wmw = function _compile_and_update(compile,runtime,realize,reposition
             return variables;
         } catch (e) {
             console.error(e);
-            debugger;
         }
     };
 };
@@ -5990,7 +5999,7 @@ export default function define(runtime, observer) {
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
-  $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
+  $def("_ipx6cz", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","editors","cellEditor"], _ipx6cz);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
   $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
@@ -6008,7 +6017,7 @@ export default function define(runtime, observer) {
   $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
-  $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
+  $def("_mri5h3", null, ["selectVariable","hotbarTemplate"], _mri5h3);  
   $def("_49mpmh", "hotbar", ["viewof edit","Event","setOption","viewof editedCell","htl","edit","toolbar","nav","reversibleAttach","combine","code_editor"], _49mpmh);  
   $def("_1uohwj8", null, ["viewof editedCell"], _1uohwj8);  
   $def("_jqia2f", null, ["nav","editedCell"], _jqia2f);  
@@ -6053,7 +6062,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
+  $def("_2pkmxz", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","viewof liveCellMap","findCellIndex","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _2pkmxz);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6091,7 +6100,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
+  $def("_1ddju40", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1ddju40);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  

--- a/notebooks/@tomlarkworthy_dataflow-templating.html
+++ b/notebooks/@tomlarkworthy_dataflow-templating.html
@@ -4740,63 +4740,50 @@ md`## Sync editors`
 const _hdieof = function _editors(){return(
 new Map()
 )};
-const _ye6ey = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,TRACE_CELL,editors,cellEditor)
+const _ipx6cz = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,editors,cellEditor)
 {
-  keepalive(editorModule, "editor_jobs");
-  syncers;
-
-  const placed = new Set();
-
-  if (attachContextManu) {
-    document.querySelectorAll(".observablehq").forEach((div) => {
-      const variable = divToVar(runtime, div);
-      if (!variable) return;
-      if (variable._name == TRACE_CELL) debugger;
-
-      if (!editors.has(variable)) {
-        editors.set(variable, cellEditor(variable));
-      }
-
-      const editor = editors.get(variable);
-      const next = div.nextSibling;
-      if (next !== editor) {
-        const ae = document.activeElement;
-        const hadFocus = ae && editor.contains(ae);
-
-        let restore = null;
-        if (hadFocus) {
-          const fe = ae;
-          if (
-            fe &&
-            (fe.tagName === "INPUT" || fe.tagName === "TEXTAREA") &&
-            "selectionStart" in fe
-          ) {
-            const start = fe.selectionStart,
-              end = fe.selectionEnd;
-            restore = () => {
-              fe.focus({ preventScroll: true });
-              fe.setSelectionRange(start, end);
-            };
-          } else {
-            restore = () => fe?.focus?.({ preventScroll: true });
-          }
-        }
-
-        div.after(editor);
-        restore?.();
-      }
-
-      placed.add(variable);
-    });
-  }
-
-  [...editors.entries()].forEach(([variable, editor]) => {
-    if (!placed.has(variable)) {
-      editor.dispose?.();
-      editor.remove();
-      editors.delete(variable);
+    keepalive(editorModule, 'editor_jobs');
+    syncers;
+    const placed = new Set();
+    if (attachContextManu) {
+        document.querySelectorAll('.observablehq').forEach(div => {
+            const variable = divToVar(runtime, div);
+            if (!variable)
+                return;
+            if (!editors.has(variable)) {
+                editors.set(variable, cellEditor(variable));
+            }
+            const editor = editors.get(variable);
+            const next = div.nextSibling;
+            if (next !== editor) {
+                const ae = document.activeElement;
+                const hadFocus = ae && editor.contains(ae);
+                let restore = null;
+                if (hadFocus) {
+                    const fe = ae;
+                    if (fe && (fe.tagName === 'INPUT' || fe.tagName === 'TEXTAREA') && 'selectionStart' in fe) {
+                        const start = fe.selectionStart, end = fe.selectionEnd;
+                        restore = () => {
+                            fe.focus({ preventScroll: true });
+                            fe.setSelectionRange(start, end);
+                        };
+                    } else {
+                        restore = () => fe?.focus?.({ preventScroll: true });
+                    }
+                }
+                div.after(editor);
+                restore?.();
+            }
+            placed.add(variable);
+        });
     }
-  });
+    [...editors.entries()].forEach(([variable, editor]) => {
+        if (!placed.has(variable)) {
+            editor.dispose?.();
+            editor.remove();
+            editors.delete(variable);
+        }
+    });
 };
 const _1iwobxt = function _divToVar(){return(
 function divToVar(runtime, div) {
@@ -5102,10 +5089,9 @@ async function selectVariable(variable, dom = undefined) {
   return cell;
 }
 )};
-const _kyzl8l = function _24(selectVariable,hotbarTemplate)
+const _mri5h3 = function _24(selectVariable,hotbarTemplate)
 {
-  debugger;
-  return selectVariable(hotbarTemplate[5]);
+return selectVariable(hotbarTemplate[5]);
 };
 const _49mpmh = function _hotbar($0,Event,setOption,$1,htl,edit,toolbar,nav,reversibleAttach,combine,code_editor)
 {
@@ -5437,7 +5423,7 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _2pkmxz = async function _command_processor(command,$0,compile_and_update,remove_variables,$1,findCellIndex,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
     if (command.processed)
         return;
@@ -5453,19 +5439,44 @@ const _16ufqhw = async function _command_processor(command,$0,compile_and_update
         remove_variables(command.args.cell.variables);
         result = true;
     } else if (command.command == 'moveCell') {
-        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const cellList = $1.value.get(command.args.cell.module.module);
+        const cellIndex = findCellIndex(command.args.cell.variables, cellList);
         const targetCellIndex = cellIndex + command.args.amount;
-        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
-        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
-        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-        const change = targetFirstVariableIndex - currentFirstVariableIndex;
-        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
-        command.args.cell.variables.forEach(v => {
-            const currentIndex = findVariableIndex(v);
-            repositionSetElement(runtime._variables, v, currentIndex + change);
-        });
-        // recompute
-        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        const targetCell = lookupCellByIndex(targetCellIndex, cellList);
+        if (targetCell) {
+            const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+            const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+            const change = targetFirstVariableIndex - currentFirstVariableIndex;
+            const dom = command.args.cell.dom;
+            const preY = dom?.getBoundingClientRect?.().top;
+            command.args.cell.variables.forEach(v => {
+                const currentIndex = findVariableIndex(v);
+                repositionSetElement(runtime._variables, v, currentIndex + change);
+            });
+            await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+            // Keep moved cell at same screen position so neighbours shift around it.
+            // Cells here have wildly varying heights (some embed 500+ px iframes), so
+            // a one-position move can otherwise jump hundreds of pixels (#163). Poll
+            // for syncers' reactive DOM reorder before measuring postY — the chain
+            // runs on macrotasks, so requestAnimationFrame is not sufficient.
+            if (preY != null && dom?.isConnected) {
+                let postY = preY;
+                for (let i = 0; i < 30 && postY === preY; i++) {
+                    await new Promise(r => setTimeout(r, 50));
+                    if (!dom.isConnected)
+                        break;
+                    postY = dom.getBoundingClientRect().top;
+                }
+                const delta = postY - preY;
+                if (delta !== 0) {
+                    const scroller = dom.closest('.lm_content') || document.scrollingElement;
+                    scroller?.scrollBy?.({
+                        top: delta,
+                        behavior: 'instant'
+                    });
+                }
+            }
+        }
         result = true;
     }
     if (result) {
@@ -5862,11 +5873,10 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
+const _1ddju40 = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
     return async (source, variables = [], cell) => {
         try {
-            debugger;
             let reposition = false, insertionIndex = -1;
             const newVariables = compile(source);
             if (!variables || variables.length !== newVariables.length) {
@@ -5899,7 +5909,6 @@ const _1698wmw = function _compile_and_update(compile,runtime,realize,reposition
             return variables;
         } catch (e) {
             console.error(e);
-            debugger;
         }
     };
 };
@@ -5990,7 +5999,7 @@ export default function define(runtime, observer) {
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
-  $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
+  $def("_ipx6cz", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","editors","cellEditor"], _ipx6cz);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
   $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
@@ -6008,7 +6017,7 @@ export default function define(runtime, observer) {
   $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
-  $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
+  $def("_mri5h3", null, ["selectVariable","hotbarTemplate"], _mri5h3);  
   $def("_49mpmh", "hotbar", ["viewof edit","Event","setOption","viewof editedCell","htl","edit","toolbar","nav","reversibleAttach","combine","code_editor"], _49mpmh);  
   $def("_1uohwj8", null, ["viewof editedCell"], _1uohwj8);  
   $def("_jqia2f", null, ["nav","editedCell"], _jqia2f);  
@@ -6053,7 +6062,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
+  $def("_2pkmxz", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","viewof liveCellMap","findCellIndex","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _2pkmxz);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6091,7 +6100,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
+  $def("_1ddju40", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1ddju40);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  

--- a/notebooks/@tomlarkworthy_debugger.html
+++ b/notebooks/@tomlarkworthy_debugger.html
@@ -5153,63 +5153,50 @@ md`## Sync editors`
 const _hdieof = function _editors(){return(
 new Map()
 )};
-const _ye6ey = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,TRACE_CELL,editors,cellEditor)
+const _ipx6cz = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,editors,cellEditor)
 {
-  keepalive(editorModule, "editor_jobs");
-  syncers;
-
-  const placed = new Set();
-
-  if (attachContextManu) {
-    document.querySelectorAll(".observablehq").forEach((div) => {
-      const variable = divToVar(runtime, div);
-      if (!variable) return;
-      if (variable._name == TRACE_CELL) debugger;
-
-      if (!editors.has(variable)) {
-        editors.set(variable, cellEditor(variable));
-      }
-
-      const editor = editors.get(variable);
-      const next = div.nextSibling;
-      if (next !== editor) {
-        const ae = document.activeElement;
-        const hadFocus = ae && editor.contains(ae);
-
-        let restore = null;
-        if (hadFocus) {
-          const fe = ae;
-          if (
-            fe &&
-            (fe.tagName === "INPUT" || fe.tagName === "TEXTAREA") &&
-            "selectionStart" in fe
-          ) {
-            const start = fe.selectionStart,
-              end = fe.selectionEnd;
-            restore = () => {
-              fe.focus({ preventScroll: true });
-              fe.setSelectionRange(start, end);
-            };
-          } else {
-            restore = () => fe?.focus?.({ preventScroll: true });
-          }
-        }
-
-        div.after(editor);
-        restore?.();
-      }
-
-      placed.add(variable);
-    });
-  }
-
-  [...editors.entries()].forEach(([variable, editor]) => {
-    if (!placed.has(variable)) {
-      editor.dispose?.();
-      editor.remove();
-      editors.delete(variable);
+    keepalive(editorModule, 'editor_jobs');
+    syncers;
+    const placed = new Set();
+    if (attachContextManu) {
+        document.querySelectorAll('.observablehq').forEach(div => {
+            const variable = divToVar(runtime, div);
+            if (!variable)
+                return;
+            if (!editors.has(variable)) {
+                editors.set(variable, cellEditor(variable));
+            }
+            const editor = editors.get(variable);
+            const next = div.nextSibling;
+            if (next !== editor) {
+                const ae = document.activeElement;
+                const hadFocus = ae && editor.contains(ae);
+                let restore = null;
+                if (hadFocus) {
+                    const fe = ae;
+                    if (fe && (fe.tagName === 'INPUT' || fe.tagName === 'TEXTAREA') && 'selectionStart' in fe) {
+                        const start = fe.selectionStart, end = fe.selectionEnd;
+                        restore = () => {
+                            fe.focus({ preventScroll: true });
+                            fe.setSelectionRange(start, end);
+                        };
+                    } else {
+                        restore = () => fe?.focus?.({ preventScroll: true });
+                    }
+                }
+                div.after(editor);
+                restore?.();
+            }
+            placed.add(variable);
+        });
     }
-  });
+    [...editors.entries()].forEach(([variable, editor]) => {
+        if (!placed.has(variable)) {
+            editor.dispose?.();
+            editor.remove();
+            editors.delete(variable);
+        }
+    });
 };
 const _1iwobxt = function _divToVar(){return(
 function divToVar(runtime, div) {
@@ -5515,10 +5502,9 @@ async function selectVariable(variable, dom = undefined) {
   return cell;
 }
 )};
-const _kyzl8l = function _24(selectVariable,hotbarTemplate)
+const _mri5h3 = function _24(selectVariable,hotbarTemplate)
 {
-  debugger;
-  return selectVariable(hotbarTemplate[5]);
+return selectVariable(hotbarTemplate[5]);
 };
 const _49mpmh = function _hotbar($0,Event,setOption,$1,htl,edit,toolbar,nav,reversibleAttach,combine,code_editor)
 {
@@ -5850,7 +5836,7 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _2pkmxz = async function _command_processor(command,$0,compile_and_update,remove_variables,$1,findCellIndex,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
     if (command.processed)
         return;
@@ -5866,19 +5852,44 @@ const _16ufqhw = async function _command_processor(command,$0,compile_and_update
         remove_variables(command.args.cell.variables);
         result = true;
     } else if (command.command == 'moveCell') {
-        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const cellList = $1.value.get(command.args.cell.module.module);
+        const cellIndex = findCellIndex(command.args.cell.variables, cellList);
         const targetCellIndex = cellIndex + command.args.amount;
-        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
-        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
-        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-        const change = targetFirstVariableIndex - currentFirstVariableIndex;
-        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
-        command.args.cell.variables.forEach(v => {
-            const currentIndex = findVariableIndex(v);
-            repositionSetElement(runtime._variables, v, currentIndex + change);
-        });
-        // recompute
-        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        const targetCell = lookupCellByIndex(targetCellIndex, cellList);
+        if (targetCell) {
+            const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+            const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+            const change = targetFirstVariableIndex - currentFirstVariableIndex;
+            const dom = command.args.cell.dom;
+            const preY = dom?.getBoundingClientRect?.().top;
+            command.args.cell.variables.forEach(v => {
+                const currentIndex = findVariableIndex(v);
+                repositionSetElement(runtime._variables, v, currentIndex + change);
+            });
+            await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+            // Keep moved cell at same screen position so neighbours shift around it.
+            // Cells here have wildly varying heights (some embed 500+ px iframes), so
+            // a one-position move can otherwise jump hundreds of pixels (#163). Poll
+            // for syncers' reactive DOM reorder before measuring postY — the chain
+            // runs on macrotasks, so requestAnimationFrame is not sufficient.
+            if (preY != null && dom?.isConnected) {
+                let postY = preY;
+                for (let i = 0; i < 30 && postY === preY; i++) {
+                    await new Promise(r => setTimeout(r, 50));
+                    if (!dom.isConnected)
+                        break;
+                    postY = dom.getBoundingClientRect().top;
+                }
+                const delta = postY - preY;
+                if (delta !== 0) {
+                    const scroller = dom.closest('.lm_content') || document.scrollingElement;
+                    scroller?.scrollBy?.({
+                        top: delta,
+                        behavior: 'instant'
+                    });
+                }
+            }
+        }
         result = true;
     }
     if (result) {
@@ -6275,11 +6286,10 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
+const _1ddju40 = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
     return async (source, variables = [], cell) => {
         try {
-            debugger;
             let reposition = false, insertionIndex = -1;
             const newVariables = compile(source);
             if (!variables || variables.length !== newVariables.length) {
@@ -6312,7 +6322,6 @@ const _1698wmw = function _compile_and_update(compile,runtime,realize,reposition
             return variables;
         } catch (e) {
             console.error(e);
-            debugger;
         }
     };
 };
@@ -6403,7 +6412,7 @@ export default function define(runtime, observer) {
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
-  $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
+  $def("_ipx6cz", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","editors","cellEditor"], _ipx6cz);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
   $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
@@ -6421,7 +6430,7 @@ export default function define(runtime, observer) {
   $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
-  $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
+  $def("_mri5h3", null, ["selectVariable","hotbarTemplate"], _mri5h3);  
   $def("_49mpmh", "hotbar", ["viewof edit","Event","setOption","viewof editedCell","htl","edit","toolbar","nav","reversibleAttach","combine","code_editor"], _49mpmh);  
   $def("_1uohwj8", null, ["viewof editedCell"], _1uohwj8);  
   $def("_jqia2f", null, ["nav","editedCell"], _jqia2f);  
@@ -6466,7 +6475,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
+  $def("_2pkmxz", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","viewof liveCellMap","findCellIndex","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _2pkmxz);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6504,7 +6513,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
+  $def("_1ddju40", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1ddju40);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  

--- a/notebooks/@tomlarkworthy_dom-view.html
+++ b/notebooks/@tomlarkworthy_dom-view.html
@@ -4740,63 +4740,50 @@ md`## Sync editors`
 const _hdieof = function _editors(){return(
 new Map()
 )};
-const _ye6ey = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,TRACE_CELL,editors,cellEditor)
+const _ipx6cz = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,editors,cellEditor)
 {
-  keepalive(editorModule, "editor_jobs");
-  syncers;
-
-  const placed = new Set();
-
-  if (attachContextManu) {
-    document.querySelectorAll(".observablehq").forEach((div) => {
-      const variable = divToVar(runtime, div);
-      if (!variable) return;
-      if (variable._name == TRACE_CELL) debugger;
-
-      if (!editors.has(variable)) {
-        editors.set(variable, cellEditor(variable));
-      }
-
-      const editor = editors.get(variable);
-      const next = div.nextSibling;
-      if (next !== editor) {
-        const ae = document.activeElement;
-        const hadFocus = ae && editor.contains(ae);
-
-        let restore = null;
-        if (hadFocus) {
-          const fe = ae;
-          if (
-            fe &&
-            (fe.tagName === "INPUT" || fe.tagName === "TEXTAREA") &&
-            "selectionStart" in fe
-          ) {
-            const start = fe.selectionStart,
-              end = fe.selectionEnd;
-            restore = () => {
-              fe.focus({ preventScroll: true });
-              fe.setSelectionRange(start, end);
-            };
-          } else {
-            restore = () => fe?.focus?.({ preventScroll: true });
-          }
-        }
-
-        div.after(editor);
-        restore?.();
-      }
-
-      placed.add(variable);
-    });
-  }
-
-  [...editors.entries()].forEach(([variable, editor]) => {
-    if (!placed.has(variable)) {
-      editor.dispose?.();
-      editor.remove();
-      editors.delete(variable);
+    keepalive(editorModule, 'editor_jobs');
+    syncers;
+    const placed = new Set();
+    if (attachContextManu) {
+        document.querySelectorAll('.observablehq').forEach(div => {
+            const variable = divToVar(runtime, div);
+            if (!variable)
+                return;
+            if (!editors.has(variable)) {
+                editors.set(variable, cellEditor(variable));
+            }
+            const editor = editors.get(variable);
+            const next = div.nextSibling;
+            if (next !== editor) {
+                const ae = document.activeElement;
+                const hadFocus = ae && editor.contains(ae);
+                let restore = null;
+                if (hadFocus) {
+                    const fe = ae;
+                    if (fe && (fe.tagName === 'INPUT' || fe.tagName === 'TEXTAREA') && 'selectionStart' in fe) {
+                        const start = fe.selectionStart, end = fe.selectionEnd;
+                        restore = () => {
+                            fe.focus({ preventScroll: true });
+                            fe.setSelectionRange(start, end);
+                        };
+                    } else {
+                        restore = () => fe?.focus?.({ preventScroll: true });
+                    }
+                }
+                div.after(editor);
+                restore?.();
+            }
+            placed.add(variable);
+        });
     }
-  });
+    [...editors.entries()].forEach(([variable, editor]) => {
+        if (!placed.has(variable)) {
+            editor.dispose?.();
+            editor.remove();
+            editors.delete(variable);
+        }
+    });
 };
 const _1iwobxt = function _divToVar(){return(
 function divToVar(runtime, div) {
@@ -5102,10 +5089,9 @@ async function selectVariable(variable, dom = undefined) {
   return cell;
 }
 )};
-const _kyzl8l = function _24(selectVariable,hotbarTemplate)
+const _mri5h3 = function _24(selectVariable,hotbarTemplate)
 {
-  debugger;
-  return selectVariable(hotbarTemplate[5]);
+return selectVariable(hotbarTemplate[5]);
 };
 const _49mpmh = function _hotbar($0,Event,setOption,$1,htl,edit,toolbar,nav,reversibleAttach,combine,code_editor)
 {
@@ -5437,7 +5423,7 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _2pkmxz = async function _command_processor(command,$0,compile_and_update,remove_variables,$1,findCellIndex,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
     if (command.processed)
         return;
@@ -5453,19 +5439,44 @@ const _16ufqhw = async function _command_processor(command,$0,compile_and_update
         remove_variables(command.args.cell.variables);
         result = true;
     } else if (command.command == 'moveCell') {
-        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const cellList = $1.value.get(command.args.cell.module.module);
+        const cellIndex = findCellIndex(command.args.cell.variables, cellList);
         const targetCellIndex = cellIndex + command.args.amount;
-        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
-        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
-        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-        const change = targetFirstVariableIndex - currentFirstVariableIndex;
-        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
-        command.args.cell.variables.forEach(v => {
-            const currentIndex = findVariableIndex(v);
-            repositionSetElement(runtime._variables, v, currentIndex + change);
-        });
-        // recompute
-        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        const targetCell = lookupCellByIndex(targetCellIndex, cellList);
+        if (targetCell) {
+            const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+            const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+            const change = targetFirstVariableIndex - currentFirstVariableIndex;
+            const dom = command.args.cell.dom;
+            const preY = dom?.getBoundingClientRect?.().top;
+            command.args.cell.variables.forEach(v => {
+                const currentIndex = findVariableIndex(v);
+                repositionSetElement(runtime._variables, v, currentIndex + change);
+            });
+            await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+            // Keep moved cell at same screen position so neighbours shift around it.
+            // Cells here have wildly varying heights (some embed 500+ px iframes), so
+            // a one-position move can otherwise jump hundreds of pixels (#163). Poll
+            // for syncers' reactive DOM reorder before measuring postY — the chain
+            // runs on macrotasks, so requestAnimationFrame is not sufficient.
+            if (preY != null && dom?.isConnected) {
+                let postY = preY;
+                for (let i = 0; i < 30 && postY === preY; i++) {
+                    await new Promise(r => setTimeout(r, 50));
+                    if (!dom.isConnected)
+                        break;
+                    postY = dom.getBoundingClientRect().top;
+                }
+                const delta = postY - preY;
+                if (delta !== 0) {
+                    const scroller = dom.closest('.lm_content') || document.scrollingElement;
+                    scroller?.scrollBy?.({
+                        top: delta,
+                        behavior: 'instant'
+                    });
+                }
+            }
+        }
         result = true;
     }
     if (result) {
@@ -5862,11 +5873,10 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
+const _1ddju40 = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
     return async (source, variables = [], cell) => {
         try {
-            debugger;
             let reposition = false, insertionIndex = -1;
             const newVariables = compile(source);
             if (!variables || variables.length !== newVariables.length) {
@@ -5899,7 +5909,6 @@ const _1698wmw = function _compile_and_update(compile,runtime,realize,reposition
             return variables;
         } catch (e) {
             console.error(e);
-            debugger;
         }
     };
 };
@@ -5990,7 +5999,7 @@ export default function define(runtime, observer) {
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
-  $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
+  $def("_ipx6cz", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","editors","cellEditor"], _ipx6cz);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
   $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
@@ -6008,7 +6017,7 @@ export default function define(runtime, observer) {
   $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
-  $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
+  $def("_mri5h3", null, ["selectVariable","hotbarTemplate"], _mri5h3);  
   $def("_49mpmh", "hotbar", ["viewof edit","Event","setOption","viewof editedCell","htl","edit","toolbar","nav","reversibleAttach","combine","code_editor"], _49mpmh);  
   $def("_1uohwj8", null, ["viewof editedCell"], _1uohwj8);  
   $def("_jqia2f", null, ["nav","editedCell"], _jqia2f);  
@@ -6053,7 +6062,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
+  $def("_2pkmxz", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","viewof liveCellMap","findCellIndex","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _2pkmxz);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6091,7 +6100,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
+  $def("_1ddju40", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1ddju40);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  

--- a/notebooks/@tomlarkworthy_editor-5.html
+++ b/notebooks/@tomlarkworthy_editor-5.html
@@ -5400,19 +5400,40 @@ const _16ufqhw = async function _command_processor(command,$0,compile_and_update
         remove_variables(command.args.cell.variables);
         result = true;
     } else if (command.command == 'moveCell') {
-        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const cellList = $1.value.get(command.args.cell.module.module);
+        const cellIndex = findCellIndex(command.args.cell.variables, cellList);
         const targetCellIndex = cellIndex + command.args.amount;
-        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
-        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
-        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-        const change = targetFirstVariableIndex - currentFirstVariableIndex;
-        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
-        command.args.cell.variables.forEach(v => {
-            const currentIndex = findVariableIndex(v);
-            repositionSetElement(runtime._variables, v, currentIndex + change);
-        });
-        // recompute
-        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        const targetCell = lookupCellByIndex(targetCellIndex, cellList);
+        if (targetCell) {
+            const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+            const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+            const change = targetFirstVariableIndex - currentFirstVariableIndex;
+            const dom = command.args.cell.dom;
+            const preY = dom?.getBoundingClientRect?.().top;
+            command.args.cell.variables.forEach(v => {
+                const currentIndex = findVariableIndex(v);
+                repositionSetElement(runtime._variables, v, currentIndex + change);
+            });
+            await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+            // Keep moved cell at same screen position so neighbours shift around it.
+            // Cells here have wildly varying heights (some embed 500+ px iframes), so
+            // a one-position move can otherwise jump hundreds of pixels (#163). Poll
+            // for syncers' reactive DOM reorder before measuring postY — the chain
+            // runs on macrotasks, so requestAnimationFrame is not sufficient.
+            if (preY != null && dom?.isConnected) {
+                let postY = preY;
+                for (let i = 0; i < 30 && postY === preY; i++) {
+                    await new Promise(r => setTimeout(r, 50));
+                    if (!dom.isConnected) break;
+                    postY = dom.getBoundingClientRect().top;
+                }
+                const delta = postY - preY;
+                if (delta !== 0) {
+                    const scroller = dom.closest('.lm_content') || document.scrollingElement;
+                    scroller?.scrollBy?.({ top: delta, behavior: 'instant' });
+                }
+            }
+        }
         result = true;
     }
     if (result) {

--- a/notebooks/@tomlarkworthy_editor-5.html
+++ b/notebooks/@tomlarkworthy_editor-5.html
@@ -5384,7 +5384,7 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _2pkmxz = async function _command_processor(command,$0,compile_and_update,remove_variables,$1,findCellIndex,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
     if (command.processed)
         return;
@@ -5424,13 +5424,17 @@ const _16ufqhw = async function _command_processor(command,$0,compile_and_update
                 let postY = preY;
                 for (let i = 0; i < 30 && postY === preY; i++) {
                     await new Promise(r => setTimeout(r, 50));
-                    if (!dom.isConnected) break;
+                    if (!dom.isConnected)
+                        break;
                     postY = dom.getBoundingClientRect().top;
                 }
                 const delta = postY - preY;
                 if (delta !== 0) {
                     const scroller = dom.closest('.lm_content') || document.scrollingElement;
-                    scroller?.scrollBy?.({ top: delta, behavior: 'instant' });
+                    scroller?.scrollBy?.({
+                        top: delta,
+                        behavior: 'instant'
+                    });
                 }
             }
         }
@@ -6019,7 +6023,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
+  $def("_2pkmxz", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","viewof liveCellMap","findCellIndex","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _2pkmxz);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  

--- a/notebooks/@tomlarkworthy_editor-5.json
+++ b/notebooks/@tomlarkworthy_editor-5.json
@@ -112,7 +112,7 @@
       ]
     },
     "@tomlarkworthy/editor-5": {
-      "hash": "bc3863c31cbb1f5d43f9b8431d440095",
+      "hash": "69f44f321f10d69b1ea8a345d1c98a89",
       "files": [
         "cell_options.json"
       ],
@@ -519,6 +519,6 @@
     }
   },
   "observablehq.com": "https://observablehq.com/@tomlarkworthy/editor-5",
-  "observable_version": 3949,
-  "observable_update_time": "2026-05-06T18:59:52.696Z"
+  "observable_version": 3950,
+  "observable_update_time": "2026-05-07T04:09:55.266Z"
 }

--- a/notebooks/@tomlarkworthy_exporter-2.html
+++ b/notebooks/@tomlarkworthy_exporter-2.html
@@ -4740,63 +4740,50 @@ md`## Sync editors`
 const _hdieof = function _editors(){return(
 new Map()
 )};
-const _ye6ey = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,TRACE_CELL,editors,cellEditor)
+const _ipx6cz = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,editors,cellEditor)
 {
-  keepalive(editorModule, "editor_jobs");
-  syncers;
-
-  const placed = new Set();
-
-  if (attachContextManu) {
-    document.querySelectorAll(".observablehq").forEach((div) => {
-      const variable = divToVar(runtime, div);
-      if (!variable) return;
-      if (variable._name == TRACE_CELL) debugger;
-
-      if (!editors.has(variable)) {
-        editors.set(variable, cellEditor(variable));
-      }
-
-      const editor = editors.get(variable);
-      const next = div.nextSibling;
-      if (next !== editor) {
-        const ae = document.activeElement;
-        const hadFocus = ae && editor.contains(ae);
-
-        let restore = null;
-        if (hadFocus) {
-          const fe = ae;
-          if (
-            fe &&
-            (fe.tagName === "INPUT" || fe.tagName === "TEXTAREA") &&
-            "selectionStart" in fe
-          ) {
-            const start = fe.selectionStart,
-              end = fe.selectionEnd;
-            restore = () => {
-              fe.focus({ preventScroll: true });
-              fe.setSelectionRange(start, end);
-            };
-          } else {
-            restore = () => fe?.focus?.({ preventScroll: true });
-          }
-        }
-
-        div.after(editor);
-        restore?.();
-      }
-
-      placed.add(variable);
-    });
-  }
-
-  [...editors.entries()].forEach(([variable, editor]) => {
-    if (!placed.has(variable)) {
-      editor.dispose?.();
-      editor.remove();
-      editors.delete(variable);
+    keepalive(editorModule, 'editor_jobs');
+    syncers;
+    const placed = new Set();
+    if (attachContextManu) {
+        document.querySelectorAll('.observablehq').forEach(div => {
+            const variable = divToVar(runtime, div);
+            if (!variable)
+                return;
+            if (!editors.has(variable)) {
+                editors.set(variable, cellEditor(variable));
+            }
+            const editor = editors.get(variable);
+            const next = div.nextSibling;
+            if (next !== editor) {
+                const ae = document.activeElement;
+                const hadFocus = ae && editor.contains(ae);
+                let restore = null;
+                if (hadFocus) {
+                    const fe = ae;
+                    if (fe && (fe.tagName === 'INPUT' || fe.tagName === 'TEXTAREA') && 'selectionStart' in fe) {
+                        const start = fe.selectionStart, end = fe.selectionEnd;
+                        restore = () => {
+                            fe.focus({ preventScroll: true });
+                            fe.setSelectionRange(start, end);
+                        };
+                    } else {
+                        restore = () => fe?.focus?.({ preventScroll: true });
+                    }
+                }
+                div.after(editor);
+                restore?.();
+            }
+            placed.add(variable);
+        });
     }
-  });
+    [...editors.entries()].forEach(([variable, editor]) => {
+        if (!placed.has(variable)) {
+            editor.dispose?.();
+            editor.remove();
+            editors.delete(variable);
+        }
+    });
 };
 const _1iwobxt = function _divToVar(){return(
 function divToVar(runtime, div) {
@@ -5102,10 +5089,9 @@ async function selectVariable(variable, dom = undefined) {
   return cell;
 }
 )};
-const _kyzl8l = function _24(selectVariable,hotbarTemplate)
+const _mri5h3 = function _24(selectVariable,hotbarTemplate)
 {
-  debugger;
-  return selectVariable(hotbarTemplate[5]);
+return selectVariable(hotbarTemplate[5]);
 };
 const _49mpmh = function _hotbar($0,Event,setOption,$1,htl,edit,toolbar,nav,reversibleAttach,combine,code_editor)
 {
@@ -5437,7 +5423,7 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _2pkmxz = async function _command_processor(command,$0,compile_and_update,remove_variables,$1,findCellIndex,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
     if (command.processed)
         return;
@@ -5453,19 +5439,44 @@ const _16ufqhw = async function _command_processor(command,$0,compile_and_update
         remove_variables(command.args.cell.variables);
         result = true;
     } else if (command.command == 'moveCell') {
-        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const cellList = $1.value.get(command.args.cell.module.module);
+        const cellIndex = findCellIndex(command.args.cell.variables, cellList);
         const targetCellIndex = cellIndex + command.args.amount;
-        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
-        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
-        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-        const change = targetFirstVariableIndex - currentFirstVariableIndex;
-        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
-        command.args.cell.variables.forEach(v => {
-            const currentIndex = findVariableIndex(v);
-            repositionSetElement(runtime._variables, v, currentIndex + change);
-        });
-        // recompute
-        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        const targetCell = lookupCellByIndex(targetCellIndex, cellList);
+        if (targetCell) {
+            const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+            const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+            const change = targetFirstVariableIndex - currentFirstVariableIndex;
+            const dom = command.args.cell.dom;
+            const preY = dom?.getBoundingClientRect?.().top;
+            command.args.cell.variables.forEach(v => {
+                const currentIndex = findVariableIndex(v);
+                repositionSetElement(runtime._variables, v, currentIndex + change);
+            });
+            await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+            // Keep moved cell at same screen position so neighbours shift around it.
+            // Cells here have wildly varying heights (some embed 500+ px iframes), so
+            // a one-position move can otherwise jump hundreds of pixels (#163). Poll
+            // for syncers' reactive DOM reorder before measuring postY — the chain
+            // runs on macrotasks, so requestAnimationFrame is not sufficient.
+            if (preY != null && dom?.isConnected) {
+                let postY = preY;
+                for (let i = 0; i < 30 && postY === preY; i++) {
+                    await new Promise(r => setTimeout(r, 50));
+                    if (!dom.isConnected)
+                        break;
+                    postY = dom.getBoundingClientRect().top;
+                }
+                const delta = postY - preY;
+                if (delta !== 0) {
+                    const scroller = dom.closest('.lm_content') || document.scrollingElement;
+                    scroller?.scrollBy?.({
+                        top: delta,
+                        behavior: 'instant'
+                    });
+                }
+            }
+        }
         result = true;
     }
     if (result) {
@@ -5862,11 +5873,10 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
+const _1ddju40 = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
     return async (source, variables = [], cell) => {
         try {
-            debugger;
             let reposition = false, insertionIndex = -1;
             const newVariables = compile(source);
             if (!variables || variables.length !== newVariables.length) {
@@ -5899,7 +5909,6 @@ const _1698wmw = function _compile_and_update(compile,runtime,realize,reposition
             return variables;
         } catch (e) {
             console.error(e);
-            debugger;
         }
     };
 };
@@ -5990,7 +5999,7 @@ export default function define(runtime, observer) {
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
-  $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
+  $def("_ipx6cz", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","editors","cellEditor"], _ipx6cz);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
   $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
@@ -6008,7 +6017,7 @@ export default function define(runtime, observer) {
   $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
-  $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
+  $def("_mri5h3", null, ["selectVariable","hotbarTemplate"], _mri5h3);  
   $def("_49mpmh", "hotbar", ["viewof edit","Event","setOption","viewof editedCell","htl","edit","toolbar","nav","reversibleAttach","combine","code_editor"], _49mpmh);  
   $def("_1uohwj8", null, ["viewof editedCell"], _1uohwj8);  
   $def("_jqia2f", null, ["nav","editedCell"], _jqia2f);  
@@ -6053,7 +6062,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
+  $def("_2pkmxz", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","viewof liveCellMap","findCellIndex","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _2pkmxz);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6091,7 +6100,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
+  $def("_1ddju40", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1ddju40);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  

--- a/notebooks/@tomlarkworthy_exporter-3.html
+++ b/notebooks/@tomlarkworthy_exporter-3.html
@@ -4645,7 +4645,7 @@ export default function define(runtime, observer) {
 >
 e30K
 </script>
-<script id="@tomlarkworthy/editor-5" 
+<script id="@tomlarkworthy/editor-5"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -4695,63 +4695,50 @@ md`## Sync editors`
 const _hdieof = function _editors(){return(
 new Map()
 )};
-const _ye6ey = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,TRACE_CELL,editors,cellEditor)
+const _ipx6cz = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,editors,cellEditor)
 {
-  keepalive(editorModule, "editor_jobs");
-  syncers;
-
-  const placed = new Set();
-
-  if (attachContextManu) {
-    document.querySelectorAll(".observablehq").forEach((div) => {
-      const variable = divToVar(runtime, div);
-      if (!variable) return;
-      if (variable._name == TRACE_CELL) debugger;
-
-      if (!editors.has(variable)) {
-        editors.set(variable, cellEditor(variable));
-      }
-
-      const editor = editors.get(variable);
-      const next = div.nextSibling;
-      if (next !== editor) {
-        const ae = document.activeElement;
-        const hadFocus = ae && editor.contains(ae);
-
-        let restore = null;
-        if (hadFocus) {
-          const fe = ae;
-          if (
-            fe &&
-            (fe.tagName === "INPUT" || fe.tagName === "TEXTAREA") &&
-            "selectionStart" in fe
-          ) {
-            const start = fe.selectionStart,
-              end = fe.selectionEnd;
-            restore = () => {
-              fe.focus({ preventScroll: true });
-              fe.setSelectionRange(start, end);
-            };
-          } else {
-            restore = () => fe?.focus?.({ preventScroll: true });
-          }
-        }
-
-        div.after(editor);
-        restore?.();
-      }
-
-      placed.add(variable);
-    });
-  }
-
-  [...editors.entries()].forEach(([variable, editor]) => {
-    if (!placed.has(variable)) {
-      editor.dispose?.();
-      editor.remove();
-      editors.delete(variable);
+    keepalive(editorModule, 'editor_jobs');
+    syncers;
+    const placed = new Set();
+    if (attachContextManu) {
+        document.querySelectorAll('.observablehq').forEach(div => {
+            const variable = divToVar(runtime, div);
+            if (!variable)
+                return;
+            if (!editors.has(variable)) {
+                editors.set(variable, cellEditor(variable));
+            }
+            const editor = editors.get(variable);
+            const next = div.nextSibling;
+            if (next !== editor) {
+                const ae = document.activeElement;
+                const hadFocus = ae && editor.contains(ae);
+                let restore = null;
+                if (hadFocus) {
+                    const fe = ae;
+                    if (fe && (fe.tagName === 'INPUT' || fe.tagName === 'TEXTAREA') && 'selectionStart' in fe) {
+                        const start = fe.selectionStart, end = fe.selectionEnd;
+                        restore = () => {
+                            fe.focus({ preventScroll: true });
+                            fe.setSelectionRange(start, end);
+                        };
+                    } else {
+                        restore = () => fe?.focus?.({ preventScroll: true });
+                    }
+                }
+                div.after(editor);
+                restore?.();
+            }
+            placed.add(variable);
+        });
     }
-  });
+    [...editors.entries()].forEach(([variable, editor]) => {
+        if (!placed.has(variable)) {
+            editor.dispose?.();
+            editor.remove();
+            editors.delete(variable);
+        }
+    });
 };
 const _1iwobxt = function _divToVar(){return(
 function divToVar(runtime, div) {
@@ -5057,10 +5044,9 @@ async function selectVariable(variable, dom = undefined) {
   return cell;
 }
 )};
-const _kyzl8l = function _24(selectVariable,hotbarTemplate)
+const _mri5h3 = function _24(selectVariable,hotbarTemplate)
 {
-  debugger;
-  return selectVariable(hotbarTemplate[5]);
+return selectVariable(hotbarTemplate[5]);
 };
 const _49mpmh = function _hotbar($0,Event,setOption,$1,htl,edit,toolbar,nav,reversibleAttach,combine,code_editor)
 {
@@ -5392,7 +5378,7 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _2pkmxz = async function _command_processor(command,$0,compile_and_update,remove_variables,$1,findCellIndex,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
     if (command.processed)
         return;
@@ -5408,19 +5394,44 @@ const _16ufqhw = async function _command_processor(command,$0,compile_and_update
         remove_variables(command.args.cell.variables);
         result = true;
     } else if (command.command == 'moveCell') {
-        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const cellList = $1.value.get(command.args.cell.module.module);
+        const cellIndex = findCellIndex(command.args.cell.variables, cellList);
         const targetCellIndex = cellIndex + command.args.amount;
-        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
-        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
-        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-        const change = targetFirstVariableIndex - currentFirstVariableIndex;
-        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
-        command.args.cell.variables.forEach(v => {
-            const currentIndex = findVariableIndex(v);
-            repositionSetElement(runtime._variables, v, currentIndex + change);
-        });
-        // recompute
-        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        const targetCell = lookupCellByIndex(targetCellIndex, cellList);
+        if (targetCell) {
+            const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+            const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+            const change = targetFirstVariableIndex - currentFirstVariableIndex;
+            const dom = command.args.cell.dom;
+            const preY = dom?.getBoundingClientRect?.().top;
+            command.args.cell.variables.forEach(v => {
+                const currentIndex = findVariableIndex(v);
+                repositionSetElement(runtime._variables, v, currentIndex + change);
+            });
+            await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+            // Keep moved cell at same screen position so neighbours shift around it.
+            // Cells here have wildly varying heights (some embed 500+ px iframes), so
+            // a one-position move can otherwise jump hundreds of pixels (#163). Poll
+            // for syncers' reactive DOM reorder before measuring postY — the chain
+            // runs on macrotasks, so requestAnimationFrame is not sufficient.
+            if (preY != null && dom?.isConnected) {
+                let postY = preY;
+                for (let i = 0; i < 30 && postY === preY; i++) {
+                    await new Promise(r => setTimeout(r, 50));
+                    if (!dom.isConnected)
+                        break;
+                    postY = dom.getBoundingClientRect().top;
+                }
+                const delta = postY - preY;
+                if (delta !== 0) {
+                    const scroller = dom.closest('.lm_content') || document.scrollingElement;
+                    scroller?.scrollBy?.({
+                        top: delta,
+                        behavior: 'instant'
+                    });
+                }
+            }
+        }
         result = true;
     }
     if (result) {
@@ -5817,11 +5828,10 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
+const _1ddju40 = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
     return async (source, variables = [], cell) => {
         try {
-            debugger;
             let reposition = false, insertionIndex = -1;
             const newVariables = compile(source);
             if (!variables || variables.length !== newVariables.length) {
@@ -5854,7 +5864,6 @@ const _1698wmw = function _compile_and_update(compile,runtime,realize,reposition
             return variables;
         } catch (e) {
             console.error(e);
-            debugger;
         }
     };
 };
@@ -5945,7 +5954,7 @@ export default function define(runtime, observer) {
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
-  $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
+  $def("_ipx6cz", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","editors","cellEditor"], _ipx6cz);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
   $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
@@ -5963,7 +5972,7 @@ export default function define(runtime, observer) {
   $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
-  $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
+  $def("_mri5h3", null, ["selectVariable","hotbarTemplate"], _mri5h3);  
   $def("_49mpmh", "hotbar", ["viewof edit","Event","setOption","viewof editedCell","htl","edit","toolbar","nav","reversibleAttach","combine","code_editor"], _49mpmh);  
   $def("_1uohwj8", null, ["viewof editedCell"], _1uohwj8);  
   $def("_jqia2f", null, ["nav","editedCell"], _jqia2f);  
@@ -6008,7 +6017,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
+  $def("_2pkmxz", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","viewof liveCellMap","findCellIndex","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _2pkmxz);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6046,7 +6055,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
+  $def("_1ddju40", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1ddju40);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -6094,7 +6103,8 @@ export default function define(runtime, observer) {
   main.define("navHref", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("navHref", _));  
   main.define("cellsToClipboard", ["module @tomlarkworthy/cells-to-clipboard", "@variable"], (_, v) => v.import("cellsToClipboard", _));
   return main;
-}</script>
+}
+</script>
 <script id="@tomlarkworthy/escodegen/escodegen.browser.min.js.gz" 
   type="text/plain"
   data-encoding="base64"

--- a/notebooks/@tomlarkworthy_fileattachments.html
+++ b/notebooks/@tomlarkworthy_fileattachments.html
@@ -4717,63 +4717,50 @@ md`## Sync editors`
 const _hdieof = function _editors(){return(
 new Map()
 )};
-const _ye6ey = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,TRACE_CELL,editors,cellEditor)
+const _ipx6cz = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,editors,cellEditor)
 {
-  keepalive(editorModule, "editor_jobs");
-  syncers;
-
-  const placed = new Set();
-
-  if (attachContextManu) {
-    document.querySelectorAll(".observablehq").forEach((div) => {
-      const variable = divToVar(runtime, div);
-      if (!variable) return;
-      if (variable._name == TRACE_CELL) debugger;
-
-      if (!editors.has(variable)) {
-        editors.set(variable, cellEditor(variable));
-      }
-
-      const editor = editors.get(variable);
-      const next = div.nextSibling;
-      if (next !== editor) {
-        const ae = document.activeElement;
-        const hadFocus = ae && editor.contains(ae);
-
-        let restore = null;
-        if (hadFocus) {
-          const fe = ae;
-          if (
-            fe &&
-            (fe.tagName === "INPUT" || fe.tagName === "TEXTAREA") &&
-            "selectionStart" in fe
-          ) {
-            const start = fe.selectionStart,
-              end = fe.selectionEnd;
-            restore = () => {
-              fe.focus({ preventScroll: true });
-              fe.setSelectionRange(start, end);
-            };
-          } else {
-            restore = () => fe?.focus?.({ preventScroll: true });
-          }
-        }
-
-        div.after(editor);
-        restore?.();
-      }
-
-      placed.add(variable);
-    });
-  }
-
-  [...editors.entries()].forEach(([variable, editor]) => {
-    if (!placed.has(variable)) {
-      editor.dispose?.();
-      editor.remove();
-      editors.delete(variable);
+    keepalive(editorModule, 'editor_jobs');
+    syncers;
+    const placed = new Set();
+    if (attachContextManu) {
+        document.querySelectorAll('.observablehq').forEach(div => {
+            const variable = divToVar(runtime, div);
+            if (!variable)
+                return;
+            if (!editors.has(variable)) {
+                editors.set(variable, cellEditor(variable));
+            }
+            const editor = editors.get(variable);
+            const next = div.nextSibling;
+            if (next !== editor) {
+                const ae = document.activeElement;
+                const hadFocus = ae && editor.contains(ae);
+                let restore = null;
+                if (hadFocus) {
+                    const fe = ae;
+                    if (fe && (fe.tagName === 'INPUT' || fe.tagName === 'TEXTAREA') && 'selectionStart' in fe) {
+                        const start = fe.selectionStart, end = fe.selectionEnd;
+                        restore = () => {
+                            fe.focus({ preventScroll: true });
+                            fe.setSelectionRange(start, end);
+                        };
+                    } else {
+                        restore = () => fe?.focus?.({ preventScroll: true });
+                    }
+                }
+                div.after(editor);
+                restore?.();
+            }
+            placed.add(variable);
+        });
     }
-  });
+    [...editors.entries()].forEach(([variable, editor]) => {
+        if (!placed.has(variable)) {
+            editor.dispose?.();
+            editor.remove();
+            editors.delete(variable);
+        }
+    });
 };
 const _1iwobxt = function _divToVar(){return(
 function divToVar(runtime, div) {
@@ -5079,10 +5066,9 @@ async function selectVariable(variable, dom = undefined) {
   return cell;
 }
 )};
-const _kyzl8l = function _24(selectVariable,hotbarTemplate)
+const _mri5h3 = function _24(selectVariable,hotbarTemplate)
 {
-  debugger;
-  return selectVariable(hotbarTemplate[5]);
+return selectVariable(hotbarTemplate[5]);
 };
 const _49mpmh = function _hotbar($0,Event,setOption,$1,htl,edit,toolbar,nav,reversibleAttach,combine,code_editor)
 {
@@ -5414,7 +5400,7 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _2pkmxz = async function _command_processor(command,$0,compile_and_update,remove_variables,$1,findCellIndex,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
     if (command.processed)
         return;
@@ -5430,19 +5416,44 @@ const _16ufqhw = async function _command_processor(command,$0,compile_and_update
         remove_variables(command.args.cell.variables);
         result = true;
     } else if (command.command == 'moveCell') {
-        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const cellList = $1.value.get(command.args.cell.module.module);
+        const cellIndex = findCellIndex(command.args.cell.variables, cellList);
         const targetCellIndex = cellIndex + command.args.amount;
-        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
-        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
-        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-        const change = targetFirstVariableIndex - currentFirstVariableIndex;
-        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
-        command.args.cell.variables.forEach(v => {
-            const currentIndex = findVariableIndex(v);
-            repositionSetElement(runtime._variables, v, currentIndex + change);
-        });
-        // recompute
-        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        const targetCell = lookupCellByIndex(targetCellIndex, cellList);
+        if (targetCell) {
+            const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+            const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+            const change = targetFirstVariableIndex - currentFirstVariableIndex;
+            const dom = command.args.cell.dom;
+            const preY = dom?.getBoundingClientRect?.().top;
+            command.args.cell.variables.forEach(v => {
+                const currentIndex = findVariableIndex(v);
+                repositionSetElement(runtime._variables, v, currentIndex + change);
+            });
+            await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+            // Keep moved cell at same screen position so neighbours shift around it.
+            // Cells here have wildly varying heights (some embed 500+ px iframes), so
+            // a one-position move can otherwise jump hundreds of pixels (#163). Poll
+            // for syncers' reactive DOM reorder before measuring postY — the chain
+            // runs on macrotasks, so requestAnimationFrame is not sufficient.
+            if (preY != null && dom?.isConnected) {
+                let postY = preY;
+                for (let i = 0; i < 30 && postY === preY; i++) {
+                    await new Promise(r => setTimeout(r, 50));
+                    if (!dom.isConnected)
+                        break;
+                    postY = dom.getBoundingClientRect().top;
+                }
+                const delta = postY - preY;
+                if (delta !== 0) {
+                    const scroller = dom.closest('.lm_content') || document.scrollingElement;
+                    scroller?.scrollBy?.({
+                        top: delta,
+                        behavior: 'instant'
+                    });
+                }
+            }
+        }
         result = true;
     }
     if (result) {
@@ -5839,11 +5850,10 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
+const _1ddju40 = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
     return async (source, variables = [], cell) => {
         try {
-            debugger;
             let reposition = false, insertionIndex = -1;
             const newVariables = compile(source);
             if (!variables || variables.length !== newVariables.length) {
@@ -5876,7 +5886,6 @@ const _1698wmw = function _compile_and_update(compile,runtime,realize,reposition
             return variables;
         } catch (e) {
             console.error(e);
-            debugger;
         }
     };
 };
@@ -5967,7 +5976,7 @@ export default function define(runtime, observer) {
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
-  $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
+  $def("_ipx6cz", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","editors","cellEditor"], _ipx6cz);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
   $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
@@ -5985,7 +5994,7 @@ export default function define(runtime, observer) {
   $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
-  $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
+  $def("_mri5h3", null, ["selectVariable","hotbarTemplate"], _mri5h3);  
   $def("_49mpmh", "hotbar", ["viewof edit","Event","setOption","viewof editedCell","htl","edit","toolbar","nav","reversibleAttach","combine","code_editor"], _49mpmh);  
   $def("_1uohwj8", null, ["viewof editedCell"], _1uohwj8);  
   $def("_jqia2f", null, ["nav","editedCell"], _jqia2f);  
@@ -6030,7 +6039,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
+  $def("_2pkmxz", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","viewof liveCellMap","findCellIndex","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _2pkmxz);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6068,7 +6077,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
+  $def("_1ddju40", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1ddju40);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  

--- a/notebooks/@tomlarkworthy_flow-queue.html
+++ b/notebooks/@tomlarkworthy_flow-queue.html
@@ -4740,63 +4740,50 @@ md`## Sync editors`
 const _hdieof = function _editors(){return(
 new Map()
 )};
-const _ye6ey = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,TRACE_CELL,editors,cellEditor)
+const _ipx6cz = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,editors,cellEditor)
 {
-  keepalive(editorModule, "editor_jobs");
-  syncers;
-
-  const placed = new Set();
-
-  if (attachContextManu) {
-    document.querySelectorAll(".observablehq").forEach((div) => {
-      const variable = divToVar(runtime, div);
-      if (!variable) return;
-      if (variable._name == TRACE_CELL) debugger;
-
-      if (!editors.has(variable)) {
-        editors.set(variable, cellEditor(variable));
-      }
-
-      const editor = editors.get(variable);
-      const next = div.nextSibling;
-      if (next !== editor) {
-        const ae = document.activeElement;
-        const hadFocus = ae && editor.contains(ae);
-
-        let restore = null;
-        if (hadFocus) {
-          const fe = ae;
-          if (
-            fe &&
-            (fe.tagName === "INPUT" || fe.tagName === "TEXTAREA") &&
-            "selectionStart" in fe
-          ) {
-            const start = fe.selectionStart,
-              end = fe.selectionEnd;
-            restore = () => {
-              fe.focus({ preventScroll: true });
-              fe.setSelectionRange(start, end);
-            };
-          } else {
-            restore = () => fe?.focus?.({ preventScroll: true });
-          }
-        }
-
-        div.after(editor);
-        restore?.();
-      }
-
-      placed.add(variable);
-    });
-  }
-
-  [...editors.entries()].forEach(([variable, editor]) => {
-    if (!placed.has(variable)) {
-      editor.dispose?.();
-      editor.remove();
-      editors.delete(variable);
+    keepalive(editorModule, 'editor_jobs');
+    syncers;
+    const placed = new Set();
+    if (attachContextManu) {
+        document.querySelectorAll('.observablehq').forEach(div => {
+            const variable = divToVar(runtime, div);
+            if (!variable)
+                return;
+            if (!editors.has(variable)) {
+                editors.set(variable, cellEditor(variable));
+            }
+            const editor = editors.get(variable);
+            const next = div.nextSibling;
+            if (next !== editor) {
+                const ae = document.activeElement;
+                const hadFocus = ae && editor.contains(ae);
+                let restore = null;
+                if (hadFocus) {
+                    const fe = ae;
+                    if (fe && (fe.tagName === 'INPUT' || fe.tagName === 'TEXTAREA') && 'selectionStart' in fe) {
+                        const start = fe.selectionStart, end = fe.selectionEnd;
+                        restore = () => {
+                            fe.focus({ preventScroll: true });
+                            fe.setSelectionRange(start, end);
+                        };
+                    } else {
+                        restore = () => fe?.focus?.({ preventScroll: true });
+                    }
+                }
+                div.after(editor);
+                restore?.();
+            }
+            placed.add(variable);
+        });
     }
-  });
+    [...editors.entries()].forEach(([variable, editor]) => {
+        if (!placed.has(variable)) {
+            editor.dispose?.();
+            editor.remove();
+            editors.delete(variable);
+        }
+    });
 };
 const _1iwobxt = function _divToVar(){return(
 function divToVar(runtime, div) {
@@ -5102,10 +5089,9 @@ async function selectVariable(variable, dom = undefined) {
   return cell;
 }
 )};
-const _kyzl8l = function _24(selectVariable,hotbarTemplate)
+const _mri5h3 = function _24(selectVariable,hotbarTemplate)
 {
-  debugger;
-  return selectVariable(hotbarTemplate[5]);
+return selectVariable(hotbarTemplate[5]);
 };
 const _49mpmh = function _hotbar($0,Event,setOption,$1,htl,edit,toolbar,nav,reversibleAttach,combine,code_editor)
 {
@@ -5437,7 +5423,7 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _2pkmxz = async function _command_processor(command,$0,compile_and_update,remove_variables,$1,findCellIndex,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
     if (command.processed)
         return;
@@ -5453,19 +5439,44 @@ const _16ufqhw = async function _command_processor(command,$0,compile_and_update
         remove_variables(command.args.cell.variables);
         result = true;
     } else if (command.command == 'moveCell') {
-        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const cellList = $1.value.get(command.args.cell.module.module);
+        const cellIndex = findCellIndex(command.args.cell.variables, cellList);
         const targetCellIndex = cellIndex + command.args.amount;
-        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
-        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
-        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-        const change = targetFirstVariableIndex - currentFirstVariableIndex;
-        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
-        command.args.cell.variables.forEach(v => {
-            const currentIndex = findVariableIndex(v);
-            repositionSetElement(runtime._variables, v, currentIndex + change);
-        });
-        // recompute
-        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        const targetCell = lookupCellByIndex(targetCellIndex, cellList);
+        if (targetCell) {
+            const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+            const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+            const change = targetFirstVariableIndex - currentFirstVariableIndex;
+            const dom = command.args.cell.dom;
+            const preY = dom?.getBoundingClientRect?.().top;
+            command.args.cell.variables.forEach(v => {
+                const currentIndex = findVariableIndex(v);
+                repositionSetElement(runtime._variables, v, currentIndex + change);
+            });
+            await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+            // Keep moved cell at same screen position so neighbours shift around it.
+            // Cells here have wildly varying heights (some embed 500+ px iframes), so
+            // a one-position move can otherwise jump hundreds of pixels (#163). Poll
+            // for syncers' reactive DOM reorder before measuring postY — the chain
+            // runs on macrotasks, so requestAnimationFrame is not sufficient.
+            if (preY != null && dom?.isConnected) {
+                let postY = preY;
+                for (let i = 0; i < 30 && postY === preY; i++) {
+                    await new Promise(r => setTimeout(r, 50));
+                    if (!dom.isConnected)
+                        break;
+                    postY = dom.getBoundingClientRect().top;
+                }
+                const delta = postY - preY;
+                if (delta !== 0) {
+                    const scroller = dom.closest('.lm_content') || document.scrollingElement;
+                    scroller?.scrollBy?.({
+                        top: delta,
+                        behavior: 'instant'
+                    });
+                }
+            }
+        }
         result = true;
     }
     if (result) {
@@ -5862,11 +5873,10 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
+const _1ddju40 = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
     return async (source, variables = [], cell) => {
         try {
-            debugger;
             let reposition = false, insertionIndex = -1;
             const newVariables = compile(source);
             if (!variables || variables.length !== newVariables.length) {
@@ -5899,7 +5909,6 @@ const _1698wmw = function _compile_and_update(compile,runtime,realize,reposition
             return variables;
         } catch (e) {
             console.error(e);
-            debugger;
         }
     };
 };
@@ -5990,7 +5999,7 @@ export default function define(runtime, observer) {
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
-  $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
+  $def("_ipx6cz", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","editors","cellEditor"], _ipx6cz);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
   $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
@@ -6008,7 +6017,7 @@ export default function define(runtime, observer) {
   $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
-  $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
+  $def("_mri5h3", null, ["selectVariable","hotbarTemplate"], _mri5h3);  
   $def("_49mpmh", "hotbar", ["viewof edit","Event","setOption","viewof editedCell","htl","edit","toolbar","nav","reversibleAttach","combine","code_editor"], _49mpmh);  
   $def("_1uohwj8", null, ["viewof editedCell"], _1uohwj8);  
   $def("_jqia2f", null, ["nav","editedCell"], _jqia2f);  
@@ -6053,7 +6062,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
+  $def("_2pkmxz", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","viewof liveCellMap","findCellIndex","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _2pkmxz);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6091,7 +6100,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
+  $def("_1ddju40", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1ddju40);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  

--- a/notebooks/@tomlarkworthy_global-search.html
+++ b/notebooks/@tomlarkworthy_global-search.html
@@ -4016,63 +4016,50 @@ md`## Sync editors`
 const _hdieof = function _editors(){return(
 new Map()
 )};
-const _ye6ey = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,TRACE_CELL,editors,cellEditor)
+const _ipx6cz = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,editors,cellEditor)
 {
-  keepalive(editorModule, "editor_jobs");
-  syncers;
-
-  const placed = new Set();
-
-  if (attachContextManu) {
-    document.querySelectorAll(".observablehq").forEach((div) => {
-      const variable = divToVar(runtime, div);
-      if (!variable) return;
-      if (variable._name == TRACE_CELL) debugger;
-
-      if (!editors.has(variable)) {
-        editors.set(variable, cellEditor(variable));
-      }
-
-      const editor = editors.get(variable);
-      const next = div.nextSibling;
-      if (next !== editor) {
-        const ae = document.activeElement;
-        const hadFocus = ae && editor.contains(ae);
-
-        let restore = null;
-        if (hadFocus) {
-          const fe = ae;
-          if (
-            fe &&
-            (fe.tagName === "INPUT" || fe.tagName === "TEXTAREA") &&
-            "selectionStart" in fe
-          ) {
-            const start = fe.selectionStart,
-              end = fe.selectionEnd;
-            restore = () => {
-              fe.focus({ preventScroll: true });
-              fe.setSelectionRange(start, end);
-            };
-          } else {
-            restore = () => fe?.focus?.({ preventScroll: true });
-          }
-        }
-
-        div.after(editor);
-        restore?.();
-      }
-
-      placed.add(variable);
-    });
-  }
-
-  [...editors.entries()].forEach(([variable, editor]) => {
-    if (!placed.has(variable)) {
-      editor.dispose?.();
-      editor.remove();
-      editors.delete(variable);
+    keepalive(editorModule, 'editor_jobs');
+    syncers;
+    const placed = new Set();
+    if (attachContextManu) {
+        document.querySelectorAll('.observablehq').forEach(div => {
+            const variable = divToVar(runtime, div);
+            if (!variable)
+                return;
+            if (!editors.has(variable)) {
+                editors.set(variable, cellEditor(variable));
+            }
+            const editor = editors.get(variable);
+            const next = div.nextSibling;
+            if (next !== editor) {
+                const ae = document.activeElement;
+                const hadFocus = ae && editor.contains(ae);
+                let restore = null;
+                if (hadFocus) {
+                    const fe = ae;
+                    if (fe && (fe.tagName === 'INPUT' || fe.tagName === 'TEXTAREA') && 'selectionStart' in fe) {
+                        const start = fe.selectionStart, end = fe.selectionEnd;
+                        restore = () => {
+                            fe.focus({ preventScroll: true });
+                            fe.setSelectionRange(start, end);
+                        };
+                    } else {
+                        restore = () => fe?.focus?.({ preventScroll: true });
+                    }
+                }
+                div.after(editor);
+                restore?.();
+            }
+            placed.add(variable);
+        });
     }
-  });
+    [...editors.entries()].forEach(([variable, editor]) => {
+        if (!placed.has(variable)) {
+            editor.dispose?.();
+            editor.remove();
+            editors.delete(variable);
+        }
+    });
 };
 const _1iwobxt = function _divToVar(){return(
 function divToVar(runtime, div) {
@@ -4378,10 +4365,9 @@ async function selectVariable(variable, dom = undefined) {
   return cell;
 }
 )};
-const _kyzl8l = function _24(selectVariable,hotbarTemplate)
+const _mri5h3 = function _24(selectVariable,hotbarTemplate)
 {
-  debugger;
-  return selectVariable(hotbarTemplate[5]);
+return selectVariable(hotbarTemplate[5]);
 };
 const _49mpmh = function _hotbar($0,Event,setOption,$1,htl,edit,toolbar,nav,reversibleAttach,combine,code_editor)
 {
@@ -4713,7 +4699,7 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _2pkmxz = async function _command_processor(command,$0,compile_and_update,remove_variables,$1,findCellIndex,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
     if (command.processed)
         return;
@@ -4729,19 +4715,44 @@ const _16ufqhw = async function _command_processor(command,$0,compile_and_update
         remove_variables(command.args.cell.variables);
         result = true;
     } else if (command.command == 'moveCell') {
-        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const cellList = $1.value.get(command.args.cell.module.module);
+        const cellIndex = findCellIndex(command.args.cell.variables, cellList);
         const targetCellIndex = cellIndex + command.args.amount;
-        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
-        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
-        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-        const change = targetFirstVariableIndex - currentFirstVariableIndex;
-        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
-        command.args.cell.variables.forEach(v => {
-            const currentIndex = findVariableIndex(v);
-            repositionSetElement(runtime._variables, v, currentIndex + change);
-        });
-        // recompute
-        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        const targetCell = lookupCellByIndex(targetCellIndex, cellList);
+        if (targetCell) {
+            const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+            const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+            const change = targetFirstVariableIndex - currentFirstVariableIndex;
+            const dom = command.args.cell.dom;
+            const preY = dom?.getBoundingClientRect?.().top;
+            command.args.cell.variables.forEach(v => {
+                const currentIndex = findVariableIndex(v);
+                repositionSetElement(runtime._variables, v, currentIndex + change);
+            });
+            await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+            // Keep moved cell at same screen position so neighbours shift around it.
+            // Cells here have wildly varying heights (some embed 500+ px iframes), so
+            // a one-position move can otherwise jump hundreds of pixels (#163). Poll
+            // for syncers' reactive DOM reorder before measuring postY — the chain
+            // runs on macrotasks, so requestAnimationFrame is not sufficient.
+            if (preY != null && dom?.isConnected) {
+                let postY = preY;
+                for (let i = 0; i < 30 && postY === preY; i++) {
+                    await new Promise(r => setTimeout(r, 50));
+                    if (!dom.isConnected)
+                        break;
+                    postY = dom.getBoundingClientRect().top;
+                }
+                const delta = postY - preY;
+                if (delta !== 0) {
+                    const scroller = dom.closest('.lm_content') || document.scrollingElement;
+                    scroller?.scrollBy?.({
+                        top: delta,
+                        behavior: 'instant'
+                    });
+                }
+            }
+        }
         result = true;
     }
     if (result) {
@@ -5138,11 +5149,10 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
+const _1ddju40 = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
     return async (source, variables = [], cell) => {
         try {
-            debugger;
             let reposition = false, insertionIndex = -1;
             const newVariables = compile(source);
             if (!variables || variables.length !== newVariables.length) {
@@ -5175,7 +5185,6 @@ const _1698wmw = function _compile_and_update(compile,runtime,realize,reposition
             return variables;
         } catch (e) {
             console.error(e);
-            debugger;
         }
     };
 };
@@ -5266,7 +5275,7 @@ export default function define(runtime, observer) {
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
-  $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
+  $def("_ipx6cz", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","editors","cellEditor"], _ipx6cz);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
   $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
@@ -5284,7 +5293,7 @@ export default function define(runtime, observer) {
   $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
-  $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
+  $def("_mri5h3", null, ["selectVariable","hotbarTemplate"], _mri5h3);  
   $def("_49mpmh", "hotbar", ["viewof edit","Event","setOption","viewof editedCell","htl","edit","toolbar","nav","reversibleAttach","combine","code_editor"], _49mpmh);  
   $def("_1uohwj8", null, ["viewof editedCell"], _1uohwj8);  
   $def("_jqia2f", null, ["nav","editedCell"], _jqia2f);  
@@ -5329,7 +5338,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
+  $def("_2pkmxz", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","viewof liveCellMap","findCellIndex","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _2pkmxz);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -5367,7 +5376,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
+  $def("_1ddju40", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1ddju40);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  

--- a/notebooks/@tomlarkworthy_golden-layout-2-6-0.html
+++ b/notebooks/@tomlarkworthy_golden-layout-2-6-0.html
@@ -4740,63 +4740,50 @@ md`## Sync editors`
 const _hdieof = function _editors(){return(
 new Map()
 )};
-const _ye6ey = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,TRACE_CELL,editors,cellEditor)
+const _ipx6cz = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,editors,cellEditor)
 {
-  keepalive(editorModule, "editor_jobs");
-  syncers;
-
-  const placed = new Set();
-
-  if (attachContextManu) {
-    document.querySelectorAll(".observablehq").forEach((div) => {
-      const variable = divToVar(runtime, div);
-      if (!variable) return;
-      if (variable._name == TRACE_CELL) debugger;
-
-      if (!editors.has(variable)) {
-        editors.set(variable, cellEditor(variable));
-      }
-
-      const editor = editors.get(variable);
-      const next = div.nextSibling;
-      if (next !== editor) {
-        const ae = document.activeElement;
-        const hadFocus = ae && editor.contains(ae);
-
-        let restore = null;
-        if (hadFocus) {
-          const fe = ae;
-          if (
-            fe &&
-            (fe.tagName === "INPUT" || fe.tagName === "TEXTAREA") &&
-            "selectionStart" in fe
-          ) {
-            const start = fe.selectionStart,
-              end = fe.selectionEnd;
-            restore = () => {
-              fe.focus({ preventScroll: true });
-              fe.setSelectionRange(start, end);
-            };
-          } else {
-            restore = () => fe?.focus?.({ preventScroll: true });
-          }
-        }
-
-        div.after(editor);
-        restore?.();
-      }
-
-      placed.add(variable);
-    });
-  }
-
-  [...editors.entries()].forEach(([variable, editor]) => {
-    if (!placed.has(variable)) {
-      editor.dispose?.();
-      editor.remove();
-      editors.delete(variable);
+    keepalive(editorModule, 'editor_jobs');
+    syncers;
+    const placed = new Set();
+    if (attachContextManu) {
+        document.querySelectorAll('.observablehq').forEach(div => {
+            const variable = divToVar(runtime, div);
+            if (!variable)
+                return;
+            if (!editors.has(variable)) {
+                editors.set(variable, cellEditor(variable));
+            }
+            const editor = editors.get(variable);
+            const next = div.nextSibling;
+            if (next !== editor) {
+                const ae = document.activeElement;
+                const hadFocus = ae && editor.contains(ae);
+                let restore = null;
+                if (hadFocus) {
+                    const fe = ae;
+                    if (fe && (fe.tagName === 'INPUT' || fe.tagName === 'TEXTAREA') && 'selectionStart' in fe) {
+                        const start = fe.selectionStart, end = fe.selectionEnd;
+                        restore = () => {
+                            fe.focus({ preventScroll: true });
+                            fe.setSelectionRange(start, end);
+                        };
+                    } else {
+                        restore = () => fe?.focus?.({ preventScroll: true });
+                    }
+                }
+                div.after(editor);
+                restore?.();
+            }
+            placed.add(variable);
+        });
     }
-  });
+    [...editors.entries()].forEach(([variable, editor]) => {
+        if (!placed.has(variable)) {
+            editor.dispose?.();
+            editor.remove();
+            editors.delete(variable);
+        }
+    });
 };
 const _1iwobxt = function _divToVar(){return(
 function divToVar(runtime, div) {
@@ -5102,10 +5089,9 @@ async function selectVariable(variable, dom = undefined) {
   return cell;
 }
 )};
-const _kyzl8l = function _24(selectVariable,hotbarTemplate)
+const _mri5h3 = function _24(selectVariable,hotbarTemplate)
 {
-  debugger;
-  return selectVariable(hotbarTemplate[5]);
+return selectVariable(hotbarTemplate[5]);
 };
 const _49mpmh = function _hotbar($0,Event,setOption,$1,htl,edit,toolbar,nav,reversibleAttach,combine,code_editor)
 {
@@ -5437,7 +5423,7 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _2pkmxz = async function _command_processor(command,$0,compile_and_update,remove_variables,$1,findCellIndex,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
     if (command.processed)
         return;
@@ -5453,19 +5439,44 @@ const _16ufqhw = async function _command_processor(command,$0,compile_and_update
         remove_variables(command.args.cell.variables);
         result = true;
     } else if (command.command == 'moveCell') {
-        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const cellList = $1.value.get(command.args.cell.module.module);
+        const cellIndex = findCellIndex(command.args.cell.variables, cellList);
         const targetCellIndex = cellIndex + command.args.amount;
-        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
-        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
-        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-        const change = targetFirstVariableIndex - currentFirstVariableIndex;
-        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
-        command.args.cell.variables.forEach(v => {
-            const currentIndex = findVariableIndex(v);
-            repositionSetElement(runtime._variables, v, currentIndex + change);
-        });
-        // recompute
-        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        const targetCell = lookupCellByIndex(targetCellIndex, cellList);
+        if (targetCell) {
+            const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+            const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+            const change = targetFirstVariableIndex - currentFirstVariableIndex;
+            const dom = command.args.cell.dom;
+            const preY = dom?.getBoundingClientRect?.().top;
+            command.args.cell.variables.forEach(v => {
+                const currentIndex = findVariableIndex(v);
+                repositionSetElement(runtime._variables, v, currentIndex + change);
+            });
+            await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+            // Keep moved cell at same screen position so neighbours shift around it.
+            // Cells here have wildly varying heights (some embed 500+ px iframes), so
+            // a one-position move can otherwise jump hundreds of pixels (#163). Poll
+            // for syncers' reactive DOM reorder before measuring postY — the chain
+            // runs on macrotasks, so requestAnimationFrame is not sufficient.
+            if (preY != null && dom?.isConnected) {
+                let postY = preY;
+                for (let i = 0; i < 30 && postY === preY; i++) {
+                    await new Promise(r => setTimeout(r, 50));
+                    if (!dom.isConnected)
+                        break;
+                    postY = dom.getBoundingClientRect().top;
+                }
+                const delta = postY - preY;
+                if (delta !== 0) {
+                    const scroller = dom.closest('.lm_content') || document.scrollingElement;
+                    scroller?.scrollBy?.({
+                        top: delta,
+                        behavior: 'instant'
+                    });
+                }
+            }
+        }
         result = true;
     }
     if (result) {
@@ -5862,11 +5873,10 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
+const _1ddju40 = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
     return async (source, variables = [], cell) => {
         try {
-            debugger;
             let reposition = false, insertionIndex = -1;
             const newVariables = compile(source);
             if (!variables || variables.length !== newVariables.length) {
@@ -5899,7 +5909,6 @@ const _1698wmw = function _compile_and_update(compile,runtime,realize,reposition
             return variables;
         } catch (e) {
             console.error(e);
-            debugger;
         }
     };
 };
@@ -5990,7 +5999,7 @@ export default function define(runtime, observer) {
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
-  $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
+  $def("_ipx6cz", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","editors","cellEditor"], _ipx6cz);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
   $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
@@ -6008,7 +6017,7 @@ export default function define(runtime, observer) {
   $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
-  $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
+  $def("_mri5h3", null, ["selectVariable","hotbarTemplate"], _mri5h3);  
   $def("_49mpmh", "hotbar", ["viewof edit","Event","setOption","viewof editedCell","htl","edit","toolbar","nav","reversibleAttach","combine","code_editor"], _49mpmh);  
   $def("_1uohwj8", null, ["viewof editedCell"], _1uohwj8);  
   $def("_jqia2f", null, ["nav","editedCell"], _jqia2f);  
@@ -6053,7 +6062,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
+  $def("_2pkmxz", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","viewof liveCellMap","findCellIndex","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _2pkmxz);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6091,7 +6100,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
+  $def("_1ddju40", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1ddju40);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  

--- a/notebooks/@tomlarkworthy_import-notebook.html
+++ b/notebooks/@tomlarkworthy_import-notebook.html
@@ -4740,63 +4740,50 @@ md`## Sync editors`
 const _hdieof = function _editors(){return(
 new Map()
 )};
-const _ye6ey = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,TRACE_CELL,editors,cellEditor)
+const _ipx6cz = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,editors,cellEditor)
 {
-  keepalive(editorModule, "editor_jobs");
-  syncers;
-
-  const placed = new Set();
-
-  if (attachContextManu) {
-    document.querySelectorAll(".observablehq").forEach((div) => {
-      const variable = divToVar(runtime, div);
-      if (!variable) return;
-      if (variable._name == TRACE_CELL) debugger;
-
-      if (!editors.has(variable)) {
-        editors.set(variable, cellEditor(variable));
-      }
-
-      const editor = editors.get(variable);
-      const next = div.nextSibling;
-      if (next !== editor) {
-        const ae = document.activeElement;
-        const hadFocus = ae && editor.contains(ae);
-
-        let restore = null;
-        if (hadFocus) {
-          const fe = ae;
-          if (
-            fe &&
-            (fe.tagName === "INPUT" || fe.tagName === "TEXTAREA") &&
-            "selectionStart" in fe
-          ) {
-            const start = fe.selectionStart,
-              end = fe.selectionEnd;
-            restore = () => {
-              fe.focus({ preventScroll: true });
-              fe.setSelectionRange(start, end);
-            };
-          } else {
-            restore = () => fe?.focus?.({ preventScroll: true });
-          }
-        }
-
-        div.after(editor);
-        restore?.();
-      }
-
-      placed.add(variable);
-    });
-  }
-
-  [...editors.entries()].forEach(([variable, editor]) => {
-    if (!placed.has(variable)) {
-      editor.dispose?.();
-      editor.remove();
-      editors.delete(variable);
+    keepalive(editorModule, 'editor_jobs');
+    syncers;
+    const placed = new Set();
+    if (attachContextManu) {
+        document.querySelectorAll('.observablehq').forEach(div => {
+            const variable = divToVar(runtime, div);
+            if (!variable)
+                return;
+            if (!editors.has(variable)) {
+                editors.set(variable, cellEditor(variable));
+            }
+            const editor = editors.get(variable);
+            const next = div.nextSibling;
+            if (next !== editor) {
+                const ae = document.activeElement;
+                const hadFocus = ae && editor.contains(ae);
+                let restore = null;
+                if (hadFocus) {
+                    const fe = ae;
+                    if (fe && (fe.tagName === 'INPUT' || fe.tagName === 'TEXTAREA') && 'selectionStart' in fe) {
+                        const start = fe.selectionStart, end = fe.selectionEnd;
+                        restore = () => {
+                            fe.focus({ preventScroll: true });
+                            fe.setSelectionRange(start, end);
+                        };
+                    } else {
+                        restore = () => fe?.focus?.({ preventScroll: true });
+                    }
+                }
+                div.after(editor);
+                restore?.();
+            }
+            placed.add(variable);
+        });
     }
-  });
+    [...editors.entries()].forEach(([variable, editor]) => {
+        if (!placed.has(variable)) {
+            editor.dispose?.();
+            editor.remove();
+            editors.delete(variable);
+        }
+    });
 };
 const _1iwobxt = function _divToVar(){return(
 function divToVar(runtime, div) {
@@ -5102,10 +5089,9 @@ async function selectVariable(variable, dom = undefined) {
   return cell;
 }
 )};
-const _kyzl8l = function _24(selectVariable,hotbarTemplate)
+const _mri5h3 = function _24(selectVariable,hotbarTemplate)
 {
-  debugger;
-  return selectVariable(hotbarTemplate[5]);
+return selectVariable(hotbarTemplate[5]);
 };
 const _49mpmh = function _hotbar($0,Event,setOption,$1,htl,edit,toolbar,nav,reversibleAttach,combine,code_editor)
 {
@@ -5437,7 +5423,7 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _2pkmxz = async function _command_processor(command,$0,compile_and_update,remove_variables,$1,findCellIndex,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
     if (command.processed)
         return;
@@ -5453,19 +5439,44 @@ const _16ufqhw = async function _command_processor(command,$0,compile_and_update
         remove_variables(command.args.cell.variables);
         result = true;
     } else if (command.command == 'moveCell') {
-        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const cellList = $1.value.get(command.args.cell.module.module);
+        const cellIndex = findCellIndex(command.args.cell.variables, cellList);
         const targetCellIndex = cellIndex + command.args.amount;
-        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
-        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
-        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-        const change = targetFirstVariableIndex - currentFirstVariableIndex;
-        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
-        command.args.cell.variables.forEach(v => {
-            const currentIndex = findVariableIndex(v);
-            repositionSetElement(runtime._variables, v, currentIndex + change);
-        });
-        // recompute
-        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        const targetCell = lookupCellByIndex(targetCellIndex, cellList);
+        if (targetCell) {
+            const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+            const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+            const change = targetFirstVariableIndex - currentFirstVariableIndex;
+            const dom = command.args.cell.dom;
+            const preY = dom?.getBoundingClientRect?.().top;
+            command.args.cell.variables.forEach(v => {
+                const currentIndex = findVariableIndex(v);
+                repositionSetElement(runtime._variables, v, currentIndex + change);
+            });
+            await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+            // Keep moved cell at same screen position so neighbours shift around it.
+            // Cells here have wildly varying heights (some embed 500+ px iframes), so
+            // a one-position move can otherwise jump hundreds of pixels (#163). Poll
+            // for syncers' reactive DOM reorder before measuring postY — the chain
+            // runs on macrotasks, so requestAnimationFrame is not sufficient.
+            if (preY != null && dom?.isConnected) {
+                let postY = preY;
+                for (let i = 0; i < 30 && postY === preY; i++) {
+                    await new Promise(r => setTimeout(r, 50));
+                    if (!dom.isConnected)
+                        break;
+                    postY = dom.getBoundingClientRect().top;
+                }
+                const delta = postY - preY;
+                if (delta !== 0) {
+                    const scroller = dom.closest('.lm_content') || document.scrollingElement;
+                    scroller?.scrollBy?.({
+                        top: delta,
+                        behavior: 'instant'
+                    });
+                }
+            }
+        }
         result = true;
     }
     if (result) {
@@ -5862,11 +5873,10 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
+const _1ddju40 = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
     return async (source, variables = [], cell) => {
         try {
-            debugger;
             let reposition = false, insertionIndex = -1;
             const newVariables = compile(source);
             if (!variables || variables.length !== newVariables.length) {
@@ -5899,7 +5909,6 @@ const _1698wmw = function _compile_and_update(compile,runtime,realize,reposition
             return variables;
         } catch (e) {
             console.error(e);
-            debugger;
         }
     };
 };
@@ -5990,7 +5999,7 @@ export default function define(runtime, observer) {
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
-  $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
+  $def("_ipx6cz", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","editors","cellEditor"], _ipx6cz);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
   $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
@@ -6008,7 +6017,7 @@ export default function define(runtime, observer) {
   $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
-  $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
+  $def("_mri5h3", null, ["selectVariable","hotbarTemplate"], _mri5h3);  
   $def("_49mpmh", "hotbar", ["viewof edit","Event","setOption","viewof editedCell","htl","edit","toolbar","nav","reversibleAttach","combine","code_editor"], _49mpmh);  
   $def("_1uohwj8", null, ["viewof editedCell"], _1uohwj8);  
   $def("_jqia2f", null, ["nav","editedCell"], _jqia2f);  
@@ -6053,7 +6062,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
+  $def("_2pkmxz", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","viewof liveCellMap","findCellIndex","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _2pkmxz);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6091,7 +6100,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
+  $def("_1ddju40", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1ddju40);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  

--- a/notebooks/@tomlarkworthy_jest-expect-standalone.html
+++ b/notebooks/@tomlarkworthy_jest-expect-standalone.html
@@ -4740,63 +4740,50 @@ md`## Sync editors`
 const _hdieof = function _editors(){return(
 new Map()
 )};
-const _ye6ey = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,TRACE_CELL,editors,cellEditor)
+const _ipx6cz = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,editors,cellEditor)
 {
-  keepalive(editorModule, "editor_jobs");
-  syncers;
-
-  const placed = new Set();
-
-  if (attachContextManu) {
-    document.querySelectorAll(".observablehq").forEach((div) => {
-      const variable = divToVar(runtime, div);
-      if (!variable) return;
-      if (variable._name == TRACE_CELL) debugger;
-
-      if (!editors.has(variable)) {
-        editors.set(variable, cellEditor(variable));
-      }
-
-      const editor = editors.get(variable);
-      const next = div.nextSibling;
-      if (next !== editor) {
-        const ae = document.activeElement;
-        const hadFocus = ae && editor.contains(ae);
-
-        let restore = null;
-        if (hadFocus) {
-          const fe = ae;
-          if (
-            fe &&
-            (fe.tagName === "INPUT" || fe.tagName === "TEXTAREA") &&
-            "selectionStart" in fe
-          ) {
-            const start = fe.selectionStart,
-              end = fe.selectionEnd;
-            restore = () => {
-              fe.focus({ preventScroll: true });
-              fe.setSelectionRange(start, end);
-            };
-          } else {
-            restore = () => fe?.focus?.({ preventScroll: true });
-          }
-        }
-
-        div.after(editor);
-        restore?.();
-      }
-
-      placed.add(variable);
-    });
-  }
-
-  [...editors.entries()].forEach(([variable, editor]) => {
-    if (!placed.has(variable)) {
-      editor.dispose?.();
-      editor.remove();
-      editors.delete(variable);
+    keepalive(editorModule, 'editor_jobs');
+    syncers;
+    const placed = new Set();
+    if (attachContextManu) {
+        document.querySelectorAll('.observablehq').forEach(div => {
+            const variable = divToVar(runtime, div);
+            if (!variable)
+                return;
+            if (!editors.has(variable)) {
+                editors.set(variable, cellEditor(variable));
+            }
+            const editor = editors.get(variable);
+            const next = div.nextSibling;
+            if (next !== editor) {
+                const ae = document.activeElement;
+                const hadFocus = ae && editor.contains(ae);
+                let restore = null;
+                if (hadFocus) {
+                    const fe = ae;
+                    if (fe && (fe.tagName === 'INPUT' || fe.tagName === 'TEXTAREA') && 'selectionStart' in fe) {
+                        const start = fe.selectionStart, end = fe.selectionEnd;
+                        restore = () => {
+                            fe.focus({ preventScroll: true });
+                            fe.setSelectionRange(start, end);
+                        };
+                    } else {
+                        restore = () => fe?.focus?.({ preventScroll: true });
+                    }
+                }
+                div.after(editor);
+                restore?.();
+            }
+            placed.add(variable);
+        });
     }
-  });
+    [...editors.entries()].forEach(([variable, editor]) => {
+        if (!placed.has(variable)) {
+            editor.dispose?.();
+            editor.remove();
+            editors.delete(variable);
+        }
+    });
 };
 const _1iwobxt = function _divToVar(){return(
 function divToVar(runtime, div) {
@@ -5102,10 +5089,9 @@ async function selectVariable(variable, dom = undefined) {
   return cell;
 }
 )};
-const _kyzl8l = function _24(selectVariable,hotbarTemplate)
+const _mri5h3 = function _24(selectVariable,hotbarTemplate)
 {
-  debugger;
-  return selectVariable(hotbarTemplate[5]);
+return selectVariable(hotbarTemplate[5]);
 };
 const _49mpmh = function _hotbar($0,Event,setOption,$1,htl,edit,toolbar,nav,reversibleAttach,combine,code_editor)
 {
@@ -5437,7 +5423,7 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _2pkmxz = async function _command_processor(command,$0,compile_and_update,remove_variables,$1,findCellIndex,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
     if (command.processed)
         return;
@@ -5453,19 +5439,44 @@ const _16ufqhw = async function _command_processor(command,$0,compile_and_update
         remove_variables(command.args.cell.variables);
         result = true;
     } else if (command.command == 'moveCell') {
-        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const cellList = $1.value.get(command.args.cell.module.module);
+        const cellIndex = findCellIndex(command.args.cell.variables, cellList);
         const targetCellIndex = cellIndex + command.args.amount;
-        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
-        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
-        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-        const change = targetFirstVariableIndex - currentFirstVariableIndex;
-        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
-        command.args.cell.variables.forEach(v => {
-            const currentIndex = findVariableIndex(v);
-            repositionSetElement(runtime._variables, v, currentIndex + change);
-        });
-        // recompute
-        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        const targetCell = lookupCellByIndex(targetCellIndex, cellList);
+        if (targetCell) {
+            const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+            const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+            const change = targetFirstVariableIndex - currentFirstVariableIndex;
+            const dom = command.args.cell.dom;
+            const preY = dom?.getBoundingClientRect?.().top;
+            command.args.cell.variables.forEach(v => {
+                const currentIndex = findVariableIndex(v);
+                repositionSetElement(runtime._variables, v, currentIndex + change);
+            });
+            await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+            // Keep moved cell at same screen position so neighbours shift around it.
+            // Cells here have wildly varying heights (some embed 500+ px iframes), so
+            // a one-position move can otherwise jump hundreds of pixels (#163). Poll
+            // for syncers' reactive DOM reorder before measuring postY — the chain
+            // runs on macrotasks, so requestAnimationFrame is not sufficient.
+            if (preY != null && dom?.isConnected) {
+                let postY = preY;
+                for (let i = 0; i < 30 && postY === preY; i++) {
+                    await new Promise(r => setTimeout(r, 50));
+                    if (!dom.isConnected)
+                        break;
+                    postY = dom.getBoundingClientRect().top;
+                }
+                const delta = postY - preY;
+                if (delta !== 0) {
+                    const scroller = dom.closest('.lm_content') || document.scrollingElement;
+                    scroller?.scrollBy?.({
+                        top: delta,
+                        behavior: 'instant'
+                    });
+                }
+            }
+        }
         result = true;
     }
     if (result) {
@@ -5862,11 +5873,10 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
+const _1ddju40 = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
     return async (source, variables = [], cell) => {
         try {
-            debugger;
             let reposition = false, insertionIndex = -1;
             const newVariables = compile(source);
             if (!variables || variables.length !== newVariables.length) {
@@ -5899,7 +5909,6 @@ const _1698wmw = function _compile_and_update(compile,runtime,realize,reposition
             return variables;
         } catch (e) {
             console.error(e);
-            debugger;
         }
     };
 };
@@ -5990,7 +5999,7 @@ export default function define(runtime, observer) {
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
-  $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
+  $def("_ipx6cz", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","editors","cellEditor"], _ipx6cz);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
   $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
@@ -6008,7 +6017,7 @@ export default function define(runtime, observer) {
   $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
-  $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
+  $def("_mri5h3", null, ["selectVariable","hotbarTemplate"], _mri5h3);  
   $def("_49mpmh", "hotbar", ["viewof edit","Event","setOption","viewof editedCell","htl","edit","toolbar","nav","reversibleAttach","combine","code_editor"], _49mpmh);  
   $def("_1uohwj8", null, ["viewof editedCell"], _1uohwj8);  
   $def("_jqia2f", null, ["nav","editedCell"], _jqia2f);  
@@ -6053,7 +6062,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
+  $def("_2pkmxz", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","viewof liveCellMap","findCellIndex","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _2pkmxz);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6091,7 +6100,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
+  $def("_1ddju40", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1ddju40);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  

--- a/notebooks/@tomlarkworthy_jumpgate.html
+++ b/notebooks/@tomlarkworthy_jumpgate.html
@@ -4717,62 +4717,50 @@ md`## Sync editors`
 const _hdieof = function _editors(){return(
 new Map()
 )};
-const _ye6ey = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,TRACE_CELL,editors,cellEditor)
+const _ipx6cz = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,editors,cellEditor)
 {
-  keepalive(editorModule, "editor_jobs");
-  syncers;
-
-  const placed = new Set();
-
-  if (attachContextManu) {
-    document.querySelectorAll(".observablehq").forEach((div) => {
-      const variable = divToVar(runtime, div);
-      if (!variable) return;
-
-      if (!editors.has(variable)) {
-        editors.set(variable, cellEditor(variable));
-      }
-
-      const editor = editors.get(variable);
-      const next = div.nextSibling;
-      if (next !== editor) {
-        const ae = document.activeElement;
-        const hadFocus = ae && editor.contains(ae);
-
-        let restore = null;
-        if (hadFocus) {
-          const fe = ae;
-          if (
-            fe &&
-            (fe.tagName === "INPUT" || fe.tagName === "TEXTAREA") &&
-            "selectionStart" in fe
-          ) {
-            const start = fe.selectionStart,
-              end = fe.selectionEnd;
-            restore = () => {
-              fe.focus({ preventScroll: true });
-              fe.setSelectionRange(start, end);
-            };
-          } else {
-            restore = () => fe?.focus?.({ preventScroll: true });
-          }
-        }
-
-        div.after(editor);
-        restore?.();
-      }
-
-      placed.add(variable);
-    });
-  }
-
-  [...editors.entries()].forEach(([variable, editor]) => {
-    if (!placed.has(variable)) {
-      editor.dispose?.();
-      editor.remove();
-      editors.delete(variable);
+    keepalive(editorModule, 'editor_jobs');
+    syncers;
+    const placed = new Set();
+    if (attachContextManu) {
+        document.querySelectorAll('.observablehq').forEach(div => {
+            const variable = divToVar(runtime, div);
+            if (!variable)
+                return;
+            if (!editors.has(variable)) {
+                editors.set(variable, cellEditor(variable));
+            }
+            const editor = editors.get(variable);
+            const next = div.nextSibling;
+            if (next !== editor) {
+                const ae = document.activeElement;
+                const hadFocus = ae && editor.contains(ae);
+                let restore = null;
+                if (hadFocus) {
+                    const fe = ae;
+                    if (fe && (fe.tagName === 'INPUT' || fe.tagName === 'TEXTAREA') && 'selectionStart' in fe) {
+                        const start = fe.selectionStart, end = fe.selectionEnd;
+                        restore = () => {
+                            fe.focus({ preventScroll: true });
+                            fe.setSelectionRange(start, end);
+                        };
+                    } else {
+                        restore = () => fe?.focus?.({ preventScroll: true });
+                    }
+                }
+                div.after(editor);
+                restore?.();
+            }
+            placed.add(variable);
+        });
     }
-  });
+    [...editors.entries()].forEach(([variable, editor]) => {
+        if (!placed.has(variable)) {
+            editor.dispose?.();
+            editor.remove();
+            editors.delete(variable);
+        }
+    });
 };
 const _1iwobxt = function _divToVar(){return(
 function divToVar(runtime, div) {
@@ -5078,9 +5066,9 @@ async function selectVariable(variable, dom = undefined) {
   return cell;
 }
 )};
-const _kyzl8l = function _24(selectVariable,hotbarTemplate)
+const _mri5h3 = function _24(selectVariable,hotbarTemplate)
 {
-  return selectVariable(hotbarTemplate[5]);
+return selectVariable(hotbarTemplate[5]);
 };
 const _49mpmh = function _hotbar($0,Event,setOption,$1,htl,edit,toolbar,nav,reversibleAttach,combine,code_editor)
 {
@@ -5428,19 +5416,40 @@ const _16ufqhw = async function _command_processor(command,$0,compile_and_update
         remove_variables(command.args.cell.variables);
         result = true;
     } else if (command.command == 'moveCell') {
-        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const cellList = $1.value.get(command.args.cell.module.module);
+        const cellIndex = findCellIndex(command.args.cell.variables, cellList);
         const targetCellIndex = cellIndex + command.args.amount;
-        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
-        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
-        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-        const change = targetFirstVariableIndex - currentFirstVariableIndex;
-        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
-        command.args.cell.variables.forEach(v => {
-            const currentIndex = findVariableIndex(v);
-            repositionSetElement(runtime._variables, v, currentIndex + change);
-        });
-        // recompute
-        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        const targetCell = lookupCellByIndex(targetCellIndex, cellList);
+        if (targetCell) {
+            const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+            const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+            const change = targetFirstVariableIndex - currentFirstVariableIndex;
+            const dom = command.args.cell.dom;
+            const preY = dom?.getBoundingClientRect?.().top;
+            command.args.cell.variables.forEach(v => {
+                const currentIndex = findVariableIndex(v);
+                repositionSetElement(runtime._variables, v, currentIndex + change);
+            });
+            await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+            // Keep moved cell at same screen position so neighbours shift around it.
+            // Cells here have wildly varying heights (some embed 500+ px iframes), so
+            // a one-position move can otherwise jump hundreds of pixels (#163). Poll
+            // for syncers' reactive DOM reorder before measuring postY — the chain
+            // runs on macrotasks, so requestAnimationFrame is not sufficient.
+            if (preY != null && dom?.isConnected) {
+                let postY = preY;
+                for (let i = 0; i < 30 && postY === preY; i++) {
+                    await new Promise(r => setTimeout(r, 50));
+                    if (!dom.isConnected) break;
+                    postY = dom.getBoundingClientRect().top;
+                }
+                const delta = postY - preY;
+                if (delta !== 0) {
+                    const scroller = dom.closest('.lm_content') || document.scrollingElement;
+                    scroller?.scrollBy?.({ top: delta, behavior: 'instant' });
+                }
+            }
+        }
         result = true;
     }
     if (result) {
@@ -5837,7 +5846,7 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
+const _1ddju40 = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
     return async (source, variables = [], cell) => {
         try {
@@ -5963,7 +5972,7 @@ export default function define(runtime, observer) {
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
-  $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
+  $def("_ipx6cz", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","editors","cellEditor"], _ipx6cz);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
   $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
@@ -5981,7 +5990,7 @@ export default function define(runtime, observer) {
   $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
-  $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
+  $def("_mri5h3", null, ["selectVariable","hotbarTemplate"], _mri5h3);  
   $def("_49mpmh", "hotbar", ["viewof edit","Event","setOption","viewof editedCell","htl","edit","toolbar","nav","reversibleAttach","combine","code_editor"], _49mpmh);  
   $def("_1uohwj8", null, ["viewof editedCell"], _1uohwj8);  
   $def("_jqia2f", null, ["nav","editedCell"], _jqia2f);  
@@ -6064,7 +6073,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
+  $def("_1ddju40", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1ddju40);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  

--- a/notebooks/@tomlarkworthy_local-change-history.html
+++ b/notebooks/@tomlarkworthy_local-change-history.html
@@ -4718,63 +4718,50 @@ md`## Sync editors`
 const _hdieof = function _editors(){return(
 new Map()
 )};
-const _ye6ey = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,TRACE_CELL,editors,cellEditor)
+const _ipx6cz = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,editors,cellEditor)
 {
-  keepalive(editorModule, "editor_jobs");
-  syncers;
-
-  const placed = new Set();
-
-  if (attachContextManu) {
-    document.querySelectorAll(".observablehq").forEach((div) => {
-      const variable = divToVar(runtime, div);
-      if (!variable) return;
-      if (variable._name == TRACE_CELL) debugger;
-
-      if (!editors.has(variable)) {
-        editors.set(variable, cellEditor(variable));
-      }
-
-      const editor = editors.get(variable);
-      const next = div.nextSibling;
-      if (next !== editor) {
-        const ae = document.activeElement;
-        const hadFocus = ae && editor.contains(ae);
-
-        let restore = null;
-        if (hadFocus) {
-          const fe = ae;
-          if (
-            fe &&
-            (fe.tagName === "INPUT" || fe.tagName === "TEXTAREA") &&
-            "selectionStart" in fe
-          ) {
-            const start = fe.selectionStart,
-              end = fe.selectionEnd;
-            restore = () => {
-              fe.focus({ preventScroll: true });
-              fe.setSelectionRange(start, end);
-            };
-          } else {
-            restore = () => fe?.focus?.({ preventScroll: true });
-          }
-        }
-
-        div.after(editor);
-        restore?.();
-      }
-
-      placed.add(variable);
-    });
-  }
-
-  [...editors.entries()].forEach(([variable, editor]) => {
-    if (!placed.has(variable)) {
-      editor.dispose?.();
-      editor.remove();
-      editors.delete(variable);
+    keepalive(editorModule, 'editor_jobs');
+    syncers;
+    const placed = new Set();
+    if (attachContextManu) {
+        document.querySelectorAll('.observablehq').forEach(div => {
+            const variable = divToVar(runtime, div);
+            if (!variable)
+                return;
+            if (!editors.has(variable)) {
+                editors.set(variable, cellEditor(variable));
+            }
+            const editor = editors.get(variable);
+            const next = div.nextSibling;
+            if (next !== editor) {
+                const ae = document.activeElement;
+                const hadFocus = ae && editor.contains(ae);
+                let restore = null;
+                if (hadFocus) {
+                    const fe = ae;
+                    if (fe && (fe.tagName === 'INPUT' || fe.tagName === 'TEXTAREA') && 'selectionStart' in fe) {
+                        const start = fe.selectionStart, end = fe.selectionEnd;
+                        restore = () => {
+                            fe.focus({ preventScroll: true });
+                            fe.setSelectionRange(start, end);
+                        };
+                    } else {
+                        restore = () => fe?.focus?.({ preventScroll: true });
+                    }
+                }
+                div.after(editor);
+                restore?.();
+            }
+            placed.add(variable);
+        });
     }
-  });
+    [...editors.entries()].forEach(([variable, editor]) => {
+        if (!placed.has(variable)) {
+            editor.dispose?.();
+            editor.remove();
+            editors.delete(variable);
+        }
+    });
 };
 const _1iwobxt = function _divToVar(){return(
 function divToVar(runtime, div) {
@@ -5080,10 +5067,9 @@ async function selectVariable(variable, dom = undefined) {
   return cell;
 }
 )};
-const _kyzl8l = function _24(selectVariable,hotbarTemplate)
+const _mri5h3 = function _24(selectVariable,hotbarTemplate)
 {
-  debugger;
-  return selectVariable(hotbarTemplate[5]);
+return selectVariable(hotbarTemplate[5]);
 };
 const _49mpmh = function _hotbar($0,Event,setOption,$1,htl,edit,toolbar,nav,reversibleAttach,combine,code_editor)
 {
@@ -5415,7 +5401,7 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _2pkmxz = async function _command_processor(command,$0,compile_and_update,remove_variables,$1,findCellIndex,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
     if (command.processed)
         return;
@@ -5431,19 +5417,44 @@ const _16ufqhw = async function _command_processor(command,$0,compile_and_update
         remove_variables(command.args.cell.variables);
         result = true;
     } else if (command.command == 'moveCell') {
-        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const cellList = $1.value.get(command.args.cell.module.module);
+        const cellIndex = findCellIndex(command.args.cell.variables, cellList);
         const targetCellIndex = cellIndex + command.args.amount;
-        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
-        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
-        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-        const change = targetFirstVariableIndex - currentFirstVariableIndex;
-        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
-        command.args.cell.variables.forEach(v => {
-            const currentIndex = findVariableIndex(v);
-            repositionSetElement(runtime._variables, v, currentIndex + change);
-        });
-        // recompute
-        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        const targetCell = lookupCellByIndex(targetCellIndex, cellList);
+        if (targetCell) {
+            const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+            const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+            const change = targetFirstVariableIndex - currentFirstVariableIndex;
+            const dom = command.args.cell.dom;
+            const preY = dom?.getBoundingClientRect?.().top;
+            command.args.cell.variables.forEach(v => {
+                const currentIndex = findVariableIndex(v);
+                repositionSetElement(runtime._variables, v, currentIndex + change);
+            });
+            await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+            // Keep moved cell at same screen position so neighbours shift around it.
+            // Cells here have wildly varying heights (some embed 500+ px iframes), so
+            // a one-position move can otherwise jump hundreds of pixels (#163). Poll
+            // for syncers' reactive DOM reorder before measuring postY — the chain
+            // runs on macrotasks, so requestAnimationFrame is not sufficient.
+            if (preY != null && dom?.isConnected) {
+                let postY = preY;
+                for (let i = 0; i < 30 && postY === preY; i++) {
+                    await new Promise(r => setTimeout(r, 50));
+                    if (!dom.isConnected)
+                        break;
+                    postY = dom.getBoundingClientRect().top;
+                }
+                const delta = postY - preY;
+                if (delta !== 0) {
+                    const scroller = dom.closest('.lm_content') || document.scrollingElement;
+                    scroller?.scrollBy?.({
+                        top: delta,
+                        behavior: 'instant'
+                    });
+                }
+            }
+        }
         result = true;
     }
     if (result) {
@@ -5840,11 +5851,10 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
+const _1ddju40 = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
     return async (source, variables = [], cell) => {
         try {
-            debugger;
             let reposition = false, insertionIndex = -1;
             const newVariables = compile(source);
             if (!variables || variables.length !== newVariables.length) {
@@ -5877,7 +5887,6 @@ const _1698wmw = function _compile_and_update(compile,runtime,realize,reposition
             return variables;
         } catch (e) {
             console.error(e);
-            debugger;
         }
     };
 };
@@ -5968,7 +5977,7 @@ export default function define(runtime, observer) {
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
-  $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
+  $def("_ipx6cz", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","editors","cellEditor"], _ipx6cz);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
   $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
@@ -5986,7 +5995,7 @@ export default function define(runtime, observer) {
   $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
-  $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
+  $def("_mri5h3", null, ["selectVariable","hotbarTemplate"], _mri5h3);  
   $def("_49mpmh", "hotbar", ["viewof edit","Event","setOption","viewof editedCell","htl","edit","toolbar","nav","reversibleAttach","combine","code_editor"], _49mpmh);  
   $def("_1uohwj8", null, ["viewof editedCell"], _1uohwj8);  
   $def("_jqia2f", null, ["nav","editedCell"], _jqia2f);  
@@ -6031,7 +6040,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
+  $def("_2pkmxz", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","viewof liveCellMap","findCellIndex","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _2pkmxz);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6069,7 +6078,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
+  $def("_1ddju40", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1ddju40);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  

--- a/notebooks/@tomlarkworthy_local-storage-view.html
+++ b/notebooks/@tomlarkworthy_local-storage-view.html
@@ -4740,63 +4740,50 @@ md`## Sync editors`
 const _hdieof = function _editors(){return(
 new Map()
 )};
-const _ye6ey = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,TRACE_CELL,editors,cellEditor)
+const _ipx6cz = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,editors,cellEditor)
 {
-  keepalive(editorModule, "editor_jobs");
-  syncers;
-
-  const placed = new Set();
-
-  if (attachContextManu) {
-    document.querySelectorAll(".observablehq").forEach((div) => {
-      const variable = divToVar(runtime, div);
-      if (!variable) return;
-      if (variable._name == TRACE_CELL) debugger;
-
-      if (!editors.has(variable)) {
-        editors.set(variable, cellEditor(variable));
-      }
-
-      const editor = editors.get(variable);
-      const next = div.nextSibling;
-      if (next !== editor) {
-        const ae = document.activeElement;
-        const hadFocus = ae && editor.contains(ae);
-
-        let restore = null;
-        if (hadFocus) {
-          const fe = ae;
-          if (
-            fe &&
-            (fe.tagName === "INPUT" || fe.tagName === "TEXTAREA") &&
-            "selectionStart" in fe
-          ) {
-            const start = fe.selectionStart,
-              end = fe.selectionEnd;
-            restore = () => {
-              fe.focus({ preventScroll: true });
-              fe.setSelectionRange(start, end);
-            };
-          } else {
-            restore = () => fe?.focus?.({ preventScroll: true });
-          }
-        }
-
-        div.after(editor);
-        restore?.();
-      }
-
-      placed.add(variable);
-    });
-  }
-
-  [...editors.entries()].forEach(([variable, editor]) => {
-    if (!placed.has(variable)) {
-      editor.dispose?.();
-      editor.remove();
-      editors.delete(variable);
+    keepalive(editorModule, 'editor_jobs');
+    syncers;
+    const placed = new Set();
+    if (attachContextManu) {
+        document.querySelectorAll('.observablehq').forEach(div => {
+            const variable = divToVar(runtime, div);
+            if (!variable)
+                return;
+            if (!editors.has(variable)) {
+                editors.set(variable, cellEditor(variable));
+            }
+            const editor = editors.get(variable);
+            const next = div.nextSibling;
+            if (next !== editor) {
+                const ae = document.activeElement;
+                const hadFocus = ae && editor.contains(ae);
+                let restore = null;
+                if (hadFocus) {
+                    const fe = ae;
+                    if (fe && (fe.tagName === 'INPUT' || fe.tagName === 'TEXTAREA') && 'selectionStart' in fe) {
+                        const start = fe.selectionStart, end = fe.selectionEnd;
+                        restore = () => {
+                            fe.focus({ preventScroll: true });
+                            fe.setSelectionRange(start, end);
+                        };
+                    } else {
+                        restore = () => fe?.focus?.({ preventScroll: true });
+                    }
+                }
+                div.after(editor);
+                restore?.();
+            }
+            placed.add(variable);
+        });
     }
-  });
+    [...editors.entries()].forEach(([variable, editor]) => {
+        if (!placed.has(variable)) {
+            editor.dispose?.();
+            editor.remove();
+            editors.delete(variable);
+        }
+    });
 };
 const _1iwobxt = function _divToVar(){return(
 function divToVar(runtime, div) {
@@ -5102,10 +5089,9 @@ async function selectVariable(variable, dom = undefined) {
   return cell;
 }
 )};
-const _kyzl8l = function _24(selectVariable,hotbarTemplate)
+const _mri5h3 = function _24(selectVariable,hotbarTemplate)
 {
-  debugger;
-  return selectVariable(hotbarTemplate[5]);
+return selectVariable(hotbarTemplate[5]);
 };
 const _49mpmh = function _hotbar($0,Event,setOption,$1,htl,edit,toolbar,nav,reversibleAttach,combine,code_editor)
 {
@@ -5437,7 +5423,7 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _2pkmxz = async function _command_processor(command,$0,compile_and_update,remove_variables,$1,findCellIndex,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
     if (command.processed)
         return;
@@ -5453,19 +5439,44 @@ const _16ufqhw = async function _command_processor(command,$0,compile_and_update
         remove_variables(command.args.cell.variables);
         result = true;
     } else if (command.command == 'moveCell') {
-        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const cellList = $1.value.get(command.args.cell.module.module);
+        const cellIndex = findCellIndex(command.args.cell.variables, cellList);
         const targetCellIndex = cellIndex + command.args.amount;
-        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
-        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
-        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-        const change = targetFirstVariableIndex - currentFirstVariableIndex;
-        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
-        command.args.cell.variables.forEach(v => {
-            const currentIndex = findVariableIndex(v);
-            repositionSetElement(runtime._variables, v, currentIndex + change);
-        });
-        // recompute
-        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        const targetCell = lookupCellByIndex(targetCellIndex, cellList);
+        if (targetCell) {
+            const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+            const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+            const change = targetFirstVariableIndex - currentFirstVariableIndex;
+            const dom = command.args.cell.dom;
+            const preY = dom?.getBoundingClientRect?.().top;
+            command.args.cell.variables.forEach(v => {
+                const currentIndex = findVariableIndex(v);
+                repositionSetElement(runtime._variables, v, currentIndex + change);
+            });
+            await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+            // Keep moved cell at same screen position so neighbours shift around it.
+            // Cells here have wildly varying heights (some embed 500+ px iframes), so
+            // a one-position move can otherwise jump hundreds of pixels (#163). Poll
+            // for syncers' reactive DOM reorder before measuring postY — the chain
+            // runs on macrotasks, so requestAnimationFrame is not sufficient.
+            if (preY != null && dom?.isConnected) {
+                let postY = preY;
+                for (let i = 0; i < 30 && postY === preY; i++) {
+                    await new Promise(r => setTimeout(r, 50));
+                    if (!dom.isConnected)
+                        break;
+                    postY = dom.getBoundingClientRect().top;
+                }
+                const delta = postY - preY;
+                if (delta !== 0) {
+                    const scroller = dom.closest('.lm_content') || document.scrollingElement;
+                    scroller?.scrollBy?.({
+                        top: delta,
+                        behavior: 'instant'
+                    });
+                }
+            }
+        }
         result = true;
     }
     if (result) {
@@ -5862,11 +5873,10 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
+const _1ddju40 = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
     return async (source, variables = [], cell) => {
         try {
-            debugger;
             let reposition = false, insertionIndex = -1;
             const newVariables = compile(source);
             if (!variables || variables.length !== newVariables.length) {
@@ -5899,7 +5909,6 @@ const _1698wmw = function _compile_and_update(compile,runtime,realize,reposition
             return variables;
         } catch (e) {
             console.error(e);
-            debugger;
         }
     };
 };
@@ -5990,7 +5999,7 @@ export default function define(runtime, observer) {
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
-  $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
+  $def("_ipx6cz", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","editors","cellEditor"], _ipx6cz);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
   $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
@@ -6008,7 +6017,7 @@ export default function define(runtime, observer) {
   $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
-  $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
+  $def("_mri5h3", null, ["selectVariable","hotbarTemplate"], _mri5h3);  
   $def("_49mpmh", "hotbar", ["viewof edit","Event","setOption","viewof editedCell","htl","edit","toolbar","nav","reversibleAttach","combine","code_editor"], _49mpmh);  
   $def("_1uohwj8", null, ["viewof editedCell"], _1uohwj8);  
   $def("_jqia2f", null, ["nav","editedCell"], _jqia2f);  
@@ -6053,7 +6062,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
+  $def("_2pkmxz", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","viewof liveCellMap","findCellIndex","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _2pkmxz);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6091,7 +6100,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
+  $def("_1ddju40", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1ddju40);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  

--- a/notebooks/@tomlarkworthy_lopecode-tour.html
+++ b/notebooks/@tomlarkworthy_lopecode-tour.html
@@ -5561,63 +5561,50 @@ md`## Sync editors`
 const _hdieof = function _editors(){return(
 new Map()
 )};
-const _ye6ey = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,TRACE_CELL,editors,cellEditor)
+const _ipx6cz = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,editors,cellEditor)
 {
-  keepalive(editorModule, "editor_jobs");
-  syncers;
-
-  const placed = new Set();
-
-  if (attachContextManu) {
-    document.querySelectorAll(".observablehq").forEach((div) => {
-      const variable = divToVar(runtime, div);
-      if (!variable) return;
-      if (variable._name == TRACE_CELL) debugger;
-
-      if (!editors.has(variable)) {
-        editors.set(variable, cellEditor(variable));
-      }
-
-      const editor = editors.get(variable);
-      const next = div.nextSibling;
-      if (next !== editor) {
-        const ae = document.activeElement;
-        const hadFocus = ae && editor.contains(ae);
-
-        let restore = null;
-        if (hadFocus) {
-          const fe = ae;
-          if (
-            fe &&
-            (fe.tagName === "INPUT" || fe.tagName === "TEXTAREA") &&
-            "selectionStart" in fe
-          ) {
-            const start = fe.selectionStart,
-              end = fe.selectionEnd;
-            restore = () => {
-              fe.focus({ preventScroll: true });
-              fe.setSelectionRange(start, end);
-            };
-          } else {
-            restore = () => fe?.focus?.({ preventScroll: true });
-          }
-        }
-
-        div.after(editor);
-        restore?.();
-      }
-
-      placed.add(variable);
-    });
-  }
-
-  [...editors.entries()].forEach(([variable, editor]) => {
-    if (!placed.has(variable)) {
-      editor.dispose?.();
-      editor.remove();
-      editors.delete(variable);
+    keepalive(editorModule, 'editor_jobs');
+    syncers;
+    const placed = new Set();
+    if (attachContextManu) {
+        document.querySelectorAll('.observablehq').forEach(div => {
+            const variable = divToVar(runtime, div);
+            if (!variable)
+                return;
+            if (!editors.has(variable)) {
+                editors.set(variable, cellEditor(variable));
+            }
+            const editor = editors.get(variable);
+            const next = div.nextSibling;
+            if (next !== editor) {
+                const ae = document.activeElement;
+                const hadFocus = ae && editor.contains(ae);
+                let restore = null;
+                if (hadFocus) {
+                    const fe = ae;
+                    if (fe && (fe.tagName === 'INPUT' || fe.tagName === 'TEXTAREA') && 'selectionStart' in fe) {
+                        const start = fe.selectionStart, end = fe.selectionEnd;
+                        restore = () => {
+                            fe.focus({ preventScroll: true });
+                            fe.setSelectionRange(start, end);
+                        };
+                    } else {
+                        restore = () => fe?.focus?.({ preventScroll: true });
+                    }
+                }
+                div.after(editor);
+                restore?.();
+            }
+            placed.add(variable);
+        });
     }
-  });
+    [...editors.entries()].forEach(([variable, editor]) => {
+        if (!placed.has(variable)) {
+            editor.dispose?.();
+            editor.remove();
+            editors.delete(variable);
+        }
+    });
 };
 const _1iwobxt = function _divToVar(){return(
 function divToVar(runtime, div) {
@@ -5923,10 +5910,9 @@ async function selectVariable(variable, dom = undefined) {
   return cell;
 }
 )};
-const _kyzl8l = function _24(selectVariable,hotbarTemplate)
+const _mri5h3 = function _24(selectVariable,hotbarTemplate)
 {
-  debugger;
-  return selectVariable(hotbarTemplate[5]);
+return selectVariable(hotbarTemplate[5]);
 };
 const _49mpmh = function _hotbar($0,Event,setOption,$1,htl,edit,toolbar,nav,reversibleAttach,combine,code_editor)
 {
@@ -6258,7 +6244,7 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _2pkmxz = async function _command_processor(command,$0,compile_and_update,remove_variables,$1,findCellIndex,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
     if (command.processed)
         return;
@@ -6274,19 +6260,44 @@ const _16ufqhw = async function _command_processor(command,$0,compile_and_update
         remove_variables(command.args.cell.variables);
         result = true;
     } else if (command.command == 'moveCell') {
-        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const cellList = $1.value.get(command.args.cell.module.module);
+        const cellIndex = findCellIndex(command.args.cell.variables, cellList);
         const targetCellIndex = cellIndex + command.args.amount;
-        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
-        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
-        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-        const change = targetFirstVariableIndex - currentFirstVariableIndex;
-        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
-        command.args.cell.variables.forEach(v => {
-            const currentIndex = findVariableIndex(v);
-            repositionSetElement(runtime._variables, v, currentIndex + change);
-        });
-        // recompute
-        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        const targetCell = lookupCellByIndex(targetCellIndex, cellList);
+        if (targetCell) {
+            const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+            const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+            const change = targetFirstVariableIndex - currentFirstVariableIndex;
+            const dom = command.args.cell.dom;
+            const preY = dom?.getBoundingClientRect?.().top;
+            command.args.cell.variables.forEach(v => {
+                const currentIndex = findVariableIndex(v);
+                repositionSetElement(runtime._variables, v, currentIndex + change);
+            });
+            await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+            // Keep moved cell at same screen position so neighbours shift around it.
+            // Cells here have wildly varying heights (some embed 500+ px iframes), so
+            // a one-position move can otherwise jump hundreds of pixels (#163). Poll
+            // for syncers' reactive DOM reorder before measuring postY — the chain
+            // runs on macrotasks, so requestAnimationFrame is not sufficient.
+            if (preY != null && dom?.isConnected) {
+                let postY = preY;
+                for (let i = 0; i < 30 && postY === preY; i++) {
+                    await new Promise(r => setTimeout(r, 50));
+                    if (!dom.isConnected)
+                        break;
+                    postY = dom.getBoundingClientRect().top;
+                }
+                const delta = postY - preY;
+                if (delta !== 0) {
+                    const scroller = dom.closest('.lm_content') || document.scrollingElement;
+                    scroller?.scrollBy?.({
+                        top: delta,
+                        behavior: 'instant'
+                    });
+                }
+            }
+        }
         result = true;
     }
     if (result) {
@@ -6683,11 +6694,10 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
+const _1ddju40 = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
     return async (source, variables = [], cell) => {
         try {
-            debugger;
             let reposition = false, insertionIndex = -1;
             const newVariables = compile(source);
             if (!variables || variables.length !== newVariables.length) {
@@ -6720,7 +6730,6 @@ const _1698wmw = function _compile_and_update(compile,runtime,realize,reposition
             return variables;
         } catch (e) {
             console.error(e);
-            debugger;
         }
     };
 };
@@ -6811,7 +6820,7 @@ export default function define(runtime, observer) {
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
-  $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
+  $def("_ipx6cz", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","editors","cellEditor"], _ipx6cz);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
   $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
@@ -6829,7 +6838,7 @@ export default function define(runtime, observer) {
   $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
-  $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
+  $def("_mri5h3", null, ["selectVariable","hotbarTemplate"], _mri5h3);  
   $def("_49mpmh", "hotbar", ["viewof edit","Event","setOption","viewof editedCell","htl","edit","toolbar","nav","reversibleAttach","combine","code_editor"], _49mpmh);  
   $def("_1uohwj8", null, ["viewof editedCell"], _1uohwj8);  
   $def("_jqia2f", null, ["nav","editedCell"], _jqia2f);  
@@ -6874,7 +6883,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
+  $def("_2pkmxz", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","viewof liveCellMap","findCellIndex","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _2pkmxz);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6912,7 +6921,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
+  $def("_1ddju40", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1ddju40);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  

--- a/notebooks/@tomlarkworthy_lopecode-vision.html
+++ b/notebooks/@tomlarkworthy_lopecode-vision.html
@@ -5561,63 +5561,50 @@ md`## Sync editors`
 const _hdieof = function _editors(){return(
 new Map()
 )};
-const _ye6ey = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,TRACE_CELL,editors,cellEditor)
+const _ipx6cz = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,editors,cellEditor)
 {
-  keepalive(editorModule, "editor_jobs");
-  syncers;
-
-  const placed = new Set();
-
-  if (attachContextManu) {
-    document.querySelectorAll(".observablehq").forEach((div) => {
-      const variable = divToVar(runtime, div);
-      if (!variable) return;
-      if (variable._name == TRACE_CELL) debugger;
-
-      if (!editors.has(variable)) {
-        editors.set(variable, cellEditor(variable));
-      }
-
-      const editor = editors.get(variable);
-      const next = div.nextSibling;
-      if (next !== editor) {
-        const ae = document.activeElement;
-        const hadFocus = ae && editor.contains(ae);
-
-        let restore = null;
-        if (hadFocus) {
-          const fe = ae;
-          if (
-            fe &&
-            (fe.tagName === "INPUT" || fe.tagName === "TEXTAREA") &&
-            "selectionStart" in fe
-          ) {
-            const start = fe.selectionStart,
-              end = fe.selectionEnd;
-            restore = () => {
-              fe.focus({ preventScroll: true });
-              fe.setSelectionRange(start, end);
-            };
-          } else {
-            restore = () => fe?.focus?.({ preventScroll: true });
-          }
-        }
-
-        div.after(editor);
-        restore?.();
-      }
-
-      placed.add(variable);
-    });
-  }
-
-  [...editors.entries()].forEach(([variable, editor]) => {
-    if (!placed.has(variable)) {
-      editor.dispose?.();
-      editor.remove();
-      editors.delete(variable);
+    keepalive(editorModule, 'editor_jobs');
+    syncers;
+    const placed = new Set();
+    if (attachContextManu) {
+        document.querySelectorAll('.observablehq').forEach(div => {
+            const variable = divToVar(runtime, div);
+            if (!variable)
+                return;
+            if (!editors.has(variable)) {
+                editors.set(variable, cellEditor(variable));
+            }
+            const editor = editors.get(variable);
+            const next = div.nextSibling;
+            if (next !== editor) {
+                const ae = document.activeElement;
+                const hadFocus = ae && editor.contains(ae);
+                let restore = null;
+                if (hadFocus) {
+                    const fe = ae;
+                    if (fe && (fe.tagName === 'INPUT' || fe.tagName === 'TEXTAREA') && 'selectionStart' in fe) {
+                        const start = fe.selectionStart, end = fe.selectionEnd;
+                        restore = () => {
+                            fe.focus({ preventScroll: true });
+                            fe.setSelectionRange(start, end);
+                        };
+                    } else {
+                        restore = () => fe?.focus?.({ preventScroll: true });
+                    }
+                }
+                div.after(editor);
+                restore?.();
+            }
+            placed.add(variable);
+        });
     }
-  });
+    [...editors.entries()].forEach(([variable, editor]) => {
+        if (!placed.has(variable)) {
+            editor.dispose?.();
+            editor.remove();
+            editors.delete(variable);
+        }
+    });
 };
 const _1iwobxt = function _divToVar(){return(
 function divToVar(runtime, div) {
@@ -5923,10 +5910,9 @@ async function selectVariable(variable, dom = undefined) {
   return cell;
 }
 )};
-const _kyzl8l = function _24(selectVariable,hotbarTemplate)
+const _mri5h3 = function _24(selectVariable,hotbarTemplate)
 {
-  debugger;
-  return selectVariable(hotbarTemplate[5]);
+return selectVariable(hotbarTemplate[5]);
 };
 const _49mpmh = function _hotbar($0,Event,setOption,$1,htl,edit,toolbar,nav,reversibleAttach,combine,code_editor)
 {
@@ -6258,7 +6244,7 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _2pkmxz = async function _command_processor(command,$0,compile_and_update,remove_variables,$1,findCellIndex,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
     if (command.processed)
         return;
@@ -6274,19 +6260,44 @@ const _16ufqhw = async function _command_processor(command,$0,compile_and_update
         remove_variables(command.args.cell.variables);
         result = true;
     } else if (command.command == 'moveCell') {
-        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const cellList = $1.value.get(command.args.cell.module.module);
+        const cellIndex = findCellIndex(command.args.cell.variables, cellList);
         const targetCellIndex = cellIndex + command.args.amount;
-        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
-        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
-        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-        const change = targetFirstVariableIndex - currentFirstVariableIndex;
-        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
-        command.args.cell.variables.forEach(v => {
-            const currentIndex = findVariableIndex(v);
-            repositionSetElement(runtime._variables, v, currentIndex + change);
-        });
-        // recompute
-        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        const targetCell = lookupCellByIndex(targetCellIndex, cellList);
+        if (targetCell) {
+            const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+            const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+            const change = targetFirstVariableIndex - currentFirstVariableIndex;
+            const dom = command.args.cell.dom;
+            const preY = dom?.getBoundingClientRect?.().top;
+            command.args.cell.variables.forEach(v => {
+                const currentIndex = findVariableIndex(v);
+                repositionSetElement(runtime._variables, v, currentIndex + change);
+            });
+            await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+            // Keep moved cell at same screen position so neighbours shift around it.
+            // Cells here have wildly varying heights (some embed 500+ px iframes), so
+            // a one-position move can otherwise jump hundreds of pixels (#163). Poll
+            // for syncers' reactive DOM reorder before measuring postY — the chain
+            // runs on macrotasks, so requestAnimationFrame is not sufficient.
+            if (preY != null && dom?.isConnected) {
+                let postY = preY;
+                for (let i = 0; i < 30 && postY === preY; i++) {
+                    await new Promise(r => setTimeout(r, 50));
+                    if (!dom.isConnected)
+                        break;
+                    postY = dom.getBoundingClientRect().top;
+                }
+                const delta = postY - preY;
+                if (delta !== 0) {
+                    const scroller = dom.closest('.lm_content') || document.scrollingElement;
+                    scroller?.scrollBy?.({
+                        top: delta,
+                        behavior: 'instant'
+                    });
+                }
+            }
+        }
         result = true;
     }
     if (result) {
@@ -6683,11 +6694,10 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
+const _1ddju40 = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
     return async (source, variables = [], cell) => {
         try {
-            debugger;
             let reposition = false, insertionIndex = -1;
             const newVariables = compile(source);
             if (!variables || variables.length !== newVariables.length) {
@@ -6720,7 +6730,6 @@ const _1698wmw = function _compile_and_update(compile,runtime,realize,reposition
             return variables;
         } catch (e) {
             console.error(e);
-            debugger;
         }
     };
 };
@@ -6811,7 +6820,7 @@ export default function define(runtime, observer) {
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
-  $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
+  $def("_ipx6cz", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","editors","cellEditor"], _ipx6cz);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
   $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
@@ -6829,7 +6838,7 @@ export default function define(runtime, observer) {
   $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
-  $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
+  $def("_mri5h3", null, ["selectVariable","hotbarTemplate"], _mri5h3);  
   $def("_49mpmh", "hotbar", ["viewof edit","Event","setOption","viewof editedCell","htl","edit","toolbar","nav","reversibleAttach","combine","code_editor"], _49mpmh);  
   $def("_1uohwj8", null, ["viewof editedCell"], _1uohwj8);  
   $def("_jqia2f", null, ["nav","editedCell"], _jqia2f);  
@@ -6874,7 +6883,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
+  $def("_2pkmxz", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","viewof liveCellMap","findCellIndex","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _2pkmxz);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6912,7 +6921,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
+  $def("_1ddju40", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1ddju40);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  

--- a/notebooks/@tomlarkworthy_lopepage-urls.html
+++ b/notebooks/@tomlarkworthy_lopepage-urls.html
@@ -4717,63 +4717,50 @@ md`## Sync editors`
 const _hdieof = function _editors(){return(
 new Map()
 )};
-const _ye6ey = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,TRACE_CELL,editors,cellEditor)
+const _ipx6cz = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,editors,cellEditor)
 {
-  keepalive(editorModule, "editor_jobs");
-  syncers;
-
-  const placed = new Set();
-
-  if (attachContextManu) {
-    document.querySelectorAll(".observablehq").forEach((div) => {
-      const variable = divToVar(runtime, div);
-      if (!variable) return;
-      if (variable._name == TRACE_CELL) debugger;
-
-      if (!editors.has(variable)) {
-        editors.set(variable, cellEditor(variable));
-      }
-
-      const editor = editors.get(variable);
-      const next = div.nextSibling;
-      if (next !== editor) {
-        const ae = document.activeElement;
-        const hadFocus = ae && editor.contains(ae);
-
-        let restore = null;
-        if (hadFocus) {
-          const fe = ae;
-          if (
-            fe &&
-            (fe.tagName === "INPUT" || fe.tagName === "TEXTAREA") &&
-            "selectionStart" in fe
-          ) {
-            const start = fe.selectionStart,
-              end = fe.selectionEnd;
-            restore = () => {
-              fe.focus({ preventScroll: true });
-              fe.setSelectionRange(start, end);
-            };
-          } else {
-            restore = () => fe?.focus?.({ preventScroll: true });
-          }
-        }
-
-        div.after(editor);
-        restore?.();
-      }
-
-      placed.add(variable);
-    });
-  }
-
-  [...editors.entries()].forEach(([variable, editor]) => {
-    if (!placed.has(variable)) {
-      editor.dispose?.();
-      editor.remove();
-      editors.delete(variable);
+    keepalive(editorModule, 'editor_jobs');
+    syncers;
+    const placed = new Set();
+    if (attachContextManu) {
+        document.querySelectorAll('.observablehq').forEach(div => {
+            const variable = divToVar(runtime, div);
+            if (!variable)
+                return;
+            if (!editors.has(variable)) {
+                editors.set(variable, cellEditor(variable));
+            }
+            const editor = editors.get(variable);
+            const next = div.nextSibling;
+            if (next !== editor) {
+                const ae = document.activeElement;
+                const hadFocus = ae && editor.contains(ae);
+                let restore = null;
+                if (hadFocus) {
+                    const fe = ae;
+                    if (fe && (fe.tagName === 'INPUT' || fe.tagName === 'TEXTAREA') && 'selectionStart' in fe) {
+                        const start = fe.selectionStart, end = fe.selectionEnd;
+                        restore = () => {
+                            fe.focus({ preventScroll: true });
+                            fe.setSelectionRange(start, end);
+                        };
+                    } else {
+                        restore = () => fe?.focus?.({ preventScroll: true });
+                    }
+                }
+                div.after(editor);
+                restore?.();
+            }
+            placed.add(variable);
+        });
     }
-  });
+    [...editors.entries()].forEach(([variable, editor]) => {
+        if (!placed.has(variable)) {
+            editor.dispose?.();
+            editor.remove();
+            editors.delete(variable);
+        }
+    });
 };
 const _1iwobxt = function _divToVar(){return(
 function divToVar(runtime, div) {
@@ -5079,10 +5066,9 @@ async function selectVariable(variable, dom = undefined) {
   return cell;
 }
 )};
-const _kyzl8l = function _24(selectVariable,hotbarTemplate)
+const _mri5h3 = function _24(selectVariable,hotbarTemplate)
 {
-  debugger;
-  return selectVariable(hotbarTemplate[5]);
+return selectVariable(hotbarTemplate[5]);
 };
 const _49mpmh = function _hotbar($0,Event,setOption,$1,htl,edit,toolbar,nav,reversibleAttach,combine,code_editor)
 {
@@ -5414,7 +5400,7 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _2pkmxz = async function _command_processor(command,$0,compile_and_update,remove_variables,$1,findCellIndex,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
     if (command.processed)
         return;
@@ -5430,19 +5416,44 @@ const _16ufqhw = async function _command_processor(command,$0,compile_and_update
         remove_variables(command.args.cell.variables);
         result = true;
     } else if (command.command == 'moveCell') {
-        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const cellList = $1.value.get(command.args.cell.module.module);
+        const cellIndex = findCellIndex(command.args.cell.variables, cellList);
         const targetCellIndex = cellIndex + command.args.amount;
-        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
-        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
-        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-        const change = targetFirstVariableIndex - currentFirstVariableIndex;
-        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
-        command.args.cell.variables.forEach(v => {
-            const currentIndex = findVariableIndex(v);
-            repositionSetElement(runtime._variables, v, currentIndex + change);
-        });
-        // recompute
-        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        const targetCell = lookupCellByIndex(targetCellIndex, cellList);
+        if (targetCell) {
+            const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+            const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+            const change = targetFirstVariableIndex - currentFirstVariableIndex;
+            const dom = command.args.cell.dom;
+            const preY = dom?.getBoundingClientRect?.().top;
+            command.args.cell.variables.forEach(v => {
+                const currentIndex = findVariableIndex(v);
+                repositionSetElement(runtime._variables, v, currentIndex + change);
+            });
+            await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+            // Keep moved cell at same screen position so neighbours shift around it.
+            // Cells here have wildly varying heights (some embed 500+ px iframes), so
+            // a one-position move can otherwise jump hundreds of pixels (#163). Poll
+            // for syncers' reactive DOM reorder before measuring postY — the chain
+            // runs on macrotasks, so requestAnimationFrame is not sufficient.
+            if (preY != null && dom?.isConnected) {
+                let postY = preY;
+                for (let i = 0; i < 30 && postY === preY; i++) {
+                    await new Promise(r => setTimeout(r, 50));
+                    if (!dom.isConnected)
+                        break;
+                    postY = dom.getBoundingClientRect().top;
+                }
+                const delta = postY - preY;
+                if (delta !== 0) {
+                    const scroller = dom.closest('.lm_content') || document.scrollingElement;
+                    scroller?.scrollBy?.({
+                        top: delta,
+                        behavior: 'instant'
+                    });
+                }
+            }
+        }
         result = true;
     }
     if (result) {
@@ -5839,11 +5850,10 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
+const _1ddju40 = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
     return async (source, variables = [], cell) => {
         try {
-            debugger;
             let reposition = false, insertionIndex = -1;
             const newVariables = compile(source);
             if (!variables || variables.length !== newVariables.length) {
@@ -5876,7 +5886,6 @@ const _1698wmw = function _compile_and_update(compile,runtime,realize,reposition
             return variables;
         } catch (e) {
             console.error(e);
-            debugger;
         }
     };
 };
@@ -5967,7 +5976,7 @@ export default function define(runtime, observer) {
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
-  $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
+  $def("_ipx6cz", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","editors","cellEditor"], _ipx6cz);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
   $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
@@ -5985,7 +5994,7 @@ export default function define(runtime, observer) {
   $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
-  $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
+  $def("_mri5h3", null, ["selectVariable","hotbarTemplate"], _mri5h3);  
   $def("_49mpmh", "hotbar", ["viewof edit","Event","setOption","viewof editedCell","htl","edit","toolbar","nav","reversibleAttach","combine","code_editor"], _49mpmh);  
   $def("_1uohwj8", null, ["viewof editedCell"], _1uohwj8);  
   $def("_jqia2f", null, ["nav","editedCell"], _jqia2f);  
@@ -6030,7 +6039,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
+  $def("_2pkmxz", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","viewof liveCellMap","findCellIndex","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _2pkmxz);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6068,7 +6077,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
+  $def("_1ddju40", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1ddju40);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  

--- a/notebooks/@tomlarkworthy_lopepage.html
+++ b/notebooks/@tomlarkworthy_lopepage.html
@@ -4718,63 +4718,50 @@ md`## Sync editors`
 const _hdieof = function _editors(){return(
 new Map()
 )};
-const _ye6ey = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,TRACE_CELL,editors,cellEditor)
+const _ipx6cz = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,editors,cellEditor)
 {
-  keepalive(editorModule, "editor_jobs");
-  syncers;
-
-  const placed = new Set();
-
-  if (attachContextManu) {
-    document.querySelectorAll(".observablehq").forEach((div) => {
-      const variable = divToVar(runtime, div);
-      if (!variable) return;
-      if (variable._name == TRACE_CELL) debugger;
-
-      if (!editors.has(variable)) {
-        editors.set(variable, cellEditor(variable));
-      }
-
-      const editor = editors.get(variable);
-      const next = div.nextSibling;
-      if (next !== editor) {
-        const ae = document.activeElement;
-        const hadFocus = ae && editor.contains(ae);
-
-        let restore = null;
-        if (hadFocus) {
-          const fe = ae;
-          if (
-            fe &&
-            (fe.tagName === "INPUT" || fe.tagName === "TEXTAREA") &&
-            "selectionStart" in fe
-          ) {
-            const start = fe.selectionStart,
-              end = fe.selectionEnd;
-            restore = () => {
-              fe.focus({ preventScroll: true });
-              fe.setSelectionRange(start, end);
-            };
-          } else {
-            restore = () => fe?.focus?.({ preventScroll: true });
-          }
-        }
-
-        div.after(editor);
-        restore?.();
-      }
-
-      placed.add(variable);
-    });
-  }
-
-  [...editors.entries()].forEach(([variable, editor]) => {
-    if (!placed.has(variable)) {
-      editor.dispose?.();
-      editor.remove();
-      editors.delete(variable);
+    keepalive(editorModule, 'editor_jobs');
+    syncers;
+    const placed = new Set();
+    if (attachContextManu) {
+        document.querySelectorAll('.observablehq').forEach(div => {
+            const variable = divToVar(runtime, div);
+            if (!variable)
+                return;
+            if (!editors.has(variable)) {
+                editors.set(variable, cellEditor(variable));
+            }
+            const editor = editors.get(variable);
+            const next = div.nextSibling;
+            if (next !== editor) {
+                const ae = document.activeElement;
+                const hadFocus = ae && editor.contains(ae);
+                let restore = null;
+                if (hadFocus) {
+                    const fe = ae;
+                    if (fe && (fe.tagName === 'INPUT' || fe.tagName === 'TEXTAREA') && 'selectionStart' in fe) {
+                        const start = fe.selectionStart, end = fe.selectionEnd;
+                        restore = () => {
+                            fe.focus({ preventScroll: true });
+                            fe.setSelectionRange(start, end);
+                        };
+                    } else {
+                        restore = () => fe?.focus?.({ preventScroll: true });
+                    }
+                }
+                div.after(editor);
+                restore?.();
+            }
+            placed.add(variable);
+        });
     }
-  });
+    [...editors.entries()].forEach(([variable, editor]) => {
+        if (!placed.has(variable)) {
+            editor.dispose?.();
+            editor.remove();
+            editors.delete(variable);
+        }
+    });
 };
 const _1iwobxt = function _divToVar(){return(
 function divToVar(runtime, div) {
@@ -5080,10 +5067,9 @@ async function selectVariable(variable, dom = undefined) {
   return cell;
 }
 )};
-const _kyzl8l = function _24(selectVariable,hotbarTemplate)
+const _mri5h3 = function _24(selectVariable,hotbarTemplate)
 {
-  debugger;
-  return selectVariable(hotbarTemplate[5]);
+return selectVariable(hotbarTemplate[5]);
 };
 const _49mpmh = function _hotbar($0,Event,setOption,$1,htl,edit,toolbar,nav,reversibleAttach,combine,code_editor)
 {
@@ -5415,7 +5401,7 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _2pkmxz = async function _command_processor(command,$0,compile_and_update,remove_variables,$1,findCellIndex,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
     if (command.processed)
         return;
@@ -5431,19 +5417,44 @@ const _16ufqhw = async function _command_processor(command,$0,compile_and_update
         remove_variables(command.args.cell.variables);
         result = true;
     } else if (command.command == 'moveCell') {
-        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const cellList = $1.value.get(command.args.cell.module.module);
+        const cellIndex = findCellIndex(command.args.cell.variables, cellList);
         const targetCellIndex = cellIndex + command.args.amount;
-        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
-        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
-        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-        const change = targetFirstVariableIndex - currentFirstVariableIndex;
-        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
-        command.args.cell.variables.forEach(v => {
-            const currentIndex = findVariableIndex(v);
-            repositionSetElement(runtime._variables, v, currentIndex + change);
-        });
-        // recompute
-        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        const targetCell = lookupCellByIndex(targetCellIndex, cellList);
+        if (targetCell) {
+            const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+            const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+            const change = targetFirstVariableIndex - currentFirstVariableIndex;
+            const dom = command.args.cell.dom;
+            const preY = dom?.getBoundingClientRect?.().top;
+            command.args.cell.variables.forEach(v => {
+                const currentIndex = findVariableIndex(v);
+                repositionSetElement(runtime._variables, v, currentIndex + change);
+            });
+            await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+            // Keep moved cell at same screen position so neighbours shift around it.
+            // Cells here have wildly varying heights (some embed 500+ px iframes), so
+            // a one-position move can otherwise jump hundreds of pixels (#163). Poll
+            // for syncers' reactive DOM reorder before measuring postY — the chain
+            // runs on macrotasks, so requestAnimationFrame is not sufficient.
+            if (preY != null && dom?.isConnected) {
+                let postY = preY;
+                for (let i = 0; i < 30 && postY === preY; i++) {
+                    await new Promise(r => setTimeout(r, 50));
+                    if (!dom.isConnected)
+                        break;
+                    postY = dom.getBoundingClientRect().top;
+                }
+                const delta = postY - preY;
+                if (delta !== 0) {
+                    const scroller = dom.closest('.lm_content') || document.scrollingElement;
+                    scroller?.scrollBy?.({
+                        top: delta,
+                        behavior: 'instant'
+                    });
+                }
+            }
+        }
         result = true;
     }
     if (result) {
@@ -5840,11 +5851,10 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
+const _1ddju40 = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
     return async (source, variables = [], cell) => {
         try {
-            debugger;
             let reposition = false, insertionIndex = -1;
             const newVariables = compile(source);
             if (!variables || variables.length !== newVariables.length) {
@@ -5877,7 +5887,6 @@ const _1698wmw = function _compile_and_update(compile,runtime,realize,reposition
             return variables;
         } catch (e) {
             console.error(e);
-            debugger;
         }
     };
 };
@@ -5968,7 +5977,7 @@ export default function define(runtime, observer) {
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
-  $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
+  $def("_ipx6cz", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","editors","cellEditor"], _ipx6cz);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
   $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
@@ -5986,7 +5995,7 @@ export default function define(runtime, observer) {
   $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
-  $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
+  $def("_mri5h3", null, ["selectVariable","hotbarTemplate"], _mri5h3);  
   $def("_49mpmh", "hotbar", ["viewof edit","Event","setOption","viewof editedCell","htl","edit","toolbar","nav","reversibleAttach","combine","code_editor"], _49mpmh);  
   $def("_1uohwj8", null, ["viewof editedCell"], _1uohwj8);  
   $def("_jqia2f", null, ["nav","editedCell"], _jqia2f);  
@@ -6031,7 +6040,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
+  $def("_2pkmxz", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","viewof liveCellMap","findCellIndex","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _2pkmxz);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6069,7 +6078,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
+  $def("_1ddju40", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1ddju40);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  

--- a/notebooks/@tomlarkworthy_modern-screenshot.html
+++ b/notebooks/@tomlarkworthy_modern-screenshot.html
@@ -4740,63 +4740,50 @@ md`## Sync editors`
 const _hdieof = function _editors(){return(
 new Map()
 )};
-const _ye6ey = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,TRACE_CELL,editors,cellEditor)
+const _ipx6cz = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,editors,cellEditor)
 {
-  keepalive(editorModule, "editor_jobs");
-  syncers;
-
-  const placed = new Set();
-
-  if (attachContextManu) {
-    document.querySelectorAll(".observablehq").forEach((div) => {
-      const variable = divToVar(runtime, div);
-      if (!variable) return;
-      if (variable._name == TRACE_CELL) debugger;
-
-      if (!editors.has(variable)) {
-        editors.set(variable, cellEditor(variable));
-      }
-
-      const editor = editors.get(variable);
-      const next = div.nextSibling;
-      if (next !== editor) {
-        const ae = document.activeElement;
-        const hadFocus = ae && editor.contains(ae);
-
-        let restore = null;
-        if (hadFocus) {
-          const fe = ae;
-          if (
-            fe &&
-            (fe.tagName === "INPUT" || fe.tagName === "TEXTAREA") &&
-            "selectionStart" in fe
-          ) {
-            const start = fe.selectionStart,
-              end = fe.selectionEnd;
-            restore = () => {
-              fe.focus({ preventScroll: true });
-              fe.setSelectionRange(start, end);
-            };
-          } else {
-            restore = () => fe?.focus?.({ preventScroll: true });
-          }
-        }
-
-        div.after(editor);
-        restore?.();
-      }
-
-      placed.add(variable);
-    });
-  }
-
-  [...editors.entries()].forEach(([variable, editor]) => {
-    if (!placed.has(variable)) {
-      editor.dispose?.();
-      editor.remove();
-      editors.delete(variable);
+    keepalive(editorModule, 'editor_jobs');
+    syncers;
+    const placed = new Set();
+    if (attachContextManu) {
+        document.querySelectorAll('.observablehq').forEach(div => {
+            const variable = divToVar(runtime, div);
+            if (!variable)
+                return;
+            if (!editors.has(variable)) {
+                editors.set(variable, cellEditor(variable));
+            }
+            const editor = editors.get(variable);
+            const next = div.nextSibling;
+            if (next !== editor) {
+                const ae = document.activeElement;
+                const hadFocus = ae && editor.contains(ae);
+                let restore = null;
+                if (hadFocus) {
+                    const fe = ae;
+                    if (fe && (fe.tagName === 'INPUT' || fe.tagName === 'TEXTAREA') && 'selectionStart' in fe) {
+                        const start = fe.selectionStart, end = fe.selectionEnd;
+                        restore = () => {
+                            fe.focus({ preventScroll: true });
+                            fe.setSelectionRange(start, end);
+                        };
+                    } else {
+                        restore = () => fe?.focus?.({ preventScroll: true });
+                    }
+                }
+                div.after(editor);
+                restore?.();
+            }
+            placed.add(variable);
+        });
     }
-  });
+    [...editors.entries()].forEach(([variable, editor]) => {
+        if (!placed.has(variable)) {
+            editor.dispose?.();
+            editor.remove();
+            editors.delete(variable);
+        }
+    });
 };
 const _1iwobxt = function _divToVar(){return(
 function divToVar(runtime, div) {
@@ -5102,10 +5089,9 @@ async function selectVariable(variable, dom = undefined) {
   return cell;
 }
 )};
-const _kyzl8l = function _24(selectVariable,hotbarTemplate)
+const _mri5h3 = function _24(selectVariable,hotbarTemplate)
 {
-  debugger;
-  return selectVariable(hotbarTemplate[5]);
+return selectVariable(hotbarTemplate[5]);
 };
 const _49mpmh = function _hotbar($0,Event,setOption,$1,htl,edit,toolbar,nav,reversibleAttach,combine,code_editor)
 {
@@ -5437,7 +5423,7 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _2pkmxz = async function _command_processor(command,$0,compile_and_update,remove_variables,$1,findCellIndex,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
     if (command.processed)
         return;
@@ -5453,19 +5439,44 @@ const _16ufqhw = async function _command_processor(command,$0,compile_and_update
         remove_variables(command.args.cell.variables);
         result = true;
     } else if (command.command == 'moveCell') {
-        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const cellList = $1.value.get(command.args.cell.module.module);
+        const cellIndex = findCellIndex(command.args.cell.variables, cellList);
         const targetCellIndex = cellIndex + command.args.amount;
-        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
-        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
-        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-        const change = targetFirstVariableIndex - currentFirstVariableIndex;
-        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
-        command.args.cell.variables.forEach(v => {
-            const currentIndex = findVariableIndex(v);
-            repositionSetElement(runtime._variables, v, currentIndex + change);
-        });
-        // recompute
-        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        const targetCell = lookupCellByIndex(targetCellIndex, cellList);
+        if (targetCell) {
+            const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+            const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+            const change = targetFirstVariableIndex - currentFirstVariableIndex;
+            const dom = command.args.cell.dom;
+            const preY = dom?.getBoundingClientRect?.().top;
+            command.args.cell.variables.forEach(v => {
+                const currentIndex = findVariableIndex(v);
+                repositionSetElement(runtime._variables, v, currentIndex + change);
+            });
+            await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+            // Keep moved cell at same screen position so neighbours shift around it.
+            // Cells here have wildly varying heights (some embed 500+ px iframes), so
+            // a one-position move can otherwise jump hundreds of pixels (#163). Poll
+            // for syncers' reactive DOM reorder before measuring postY — the chain
+            // runs on macrotasks, so requestAnimationFrame is not sufficient.
+            if (preY != null && dom?.isConnected) {
+                let postY = preY;
+                for (let i = 0; i < 30 && postY === preY; i++) {
+                    await new Promise(r => setTimeout(r, 50));
+                    if (!dom.isConnected)
+                        break;
+                    postY = dom.getBoundingClientRect().top;
+                }
+                const delta = postY - preY;
+                if (delta !== 0) {
+                    const scroller = dom.closest('.lm_content') || document.scrollingElement;
+                    scroller?.scrollBy?.({
+                        top: delta,
+                        behavior: 'instant'
+                    });
+                }
+            }
+        }
         result = true;
     }
     if (result) {
@@ -5862,11 +5873,10 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
+const _1ddju40 = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
     return async (source, variables = [], cell) => {
         try {
-            debugger;
             let reposition = false, insertionIndex = -1;
             const newVariables = compile(source);
             if (!variables || variables.length !== newVariables.length) {
@@ -5899,7 +5909,6 @@ const _1698wmw = function _compile_and_update(compile,runtime,realize,reposition
             return variables;
         } catch (e) {
             console.error(e);
-            debugger;
         }
     };
 };
@@ -5990,7 +5999,7 @@ export default function define(runtime, observer) {
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
-  $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
+  $def("_ipx6cz", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","editors","cellEditor"], _ipx6cz);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
   $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
@@ -6008,7 +6017,7 @@ export default function define(runtime, observer) {
   $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
-  $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
+  $def("_mri5h3", null, ["selectVariable","hotbarTemplate"], _mri5h3);  
   $def("_49mpmh", "hotbar", ["viewof edit","Event","setOption","viewof editedCell","htl","edit","toolbar","nav","reversibleAttach","combine","code_editor"], _49mpmh);  
   $def("_1uohwj8", null, ["viewof editedCell"], _1uohwj8);  
   $def("_jqia2f", null, ["nav","editedCell"], _jqia2f);  
@@ -6053,7 +6062,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
+  $def("_2pkmxz", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","viewof liveCellMap","findCellIndex","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _2pkmxz);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6091,7 +6100,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
+  $def("_1ddju40", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1ddju40);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  

--- a/notebooks/@tomlarkworthy_module-selection.html
+++ b/notebooks/@tomlarkworthy_module-selection.html
@@ -4718,63 +4718,50 @@ md`## Sync editors`
 const _hdieof = function _editors(){return(
 new Map()
 )};
-const _ye6ey = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,TRACE_CELL,editors,cellEditor)
+const _ipx6cz = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,editors,cellEditor)
 {
-  keepalive(editorModule, "editor_jobs");
-  syncers;
-
-  const placed = new Set();
-
-  if (attachContextManu) {
-    document.querySelectorAll(".observablehq").forEach((div) => {
-      const variable = divToVar(runtime, div);
-      if (!variable) return;
-      if (variable._name == TRACE_CELL) debugger;
-
-      if (!editors.has(variable)) {
-        editors.set(variable, cellEditor(variable));
-      }
-
-      const editor = editors.get(variable);
-      const next = div.nextSibling;
-      if (next !== editor) {
-        const ae = document.activeElement;
-        const hadFocus = ae && editor.contains(ae);
-
-        let restore = null;
-        if (hadFocus) {
-          const fe = ae;
-          if (
-            fe &&
-            (fe.tagName === "INPUT" || fe.tagName === "TEXTAREA") &&
-            "selectionStart" in fe
-          ) {
-            const start = fe.selectionStart,
-              end = fe.selectionEnd;
-            restore = () => {
-              fe.focus({ preventScroll: true });
-              fe.setSelectionRange(start, end);
-            };
-          } else {
-            restore = () => fe?.focus?.({ preventScroll: true });
-          }
-        }
-
-        div.after(editor);
-        restore?.();
-      }
-
-      placed.add(variable);
-    });
-  }
-
-  [...editors.entries()].forEach(([variable, editor]) => {
-    if (!placed.has(variable)) {
-      editor.dispose?.();
-      editor.remove();
-      editors.delete(variable);
+    keepalive(editorModule, 'editor_jobs');
+    syncers;
+    const placed = new Set();
+    if (attachContextManu) {
+        document.querySelectorAll('.observablehq').forEach(div => {
+            const variable = divToVar(runtime, div);
+            if (!variable)
+                return;
+            if (!editors.has(variable)) {
+                editors.set(variable, cellEditor(variable));
+            }
+            const editor = editors.get(variable);
+            const next = div.nextSibling;
+            if (next !== editor) {
+                const ae = document.activeElement;
+                const hadFocus = ae && editor.contains(ae);
+                let restore = null;
+                if (hadFocus) {
+                    const fe = ae;
+                    if (fe && (fe.tagName === 'INPUT' || fe.tagName === 'TEXTAREA') && 'selectionStart' in fe) {
+                        const start = fe.selectionStart, end = fe.selectionEnd;
+                        restore = () => {
+                            fe.focus({ preventScroll: true });
+                            fe.setSelectionRange(start, end);
+                        };
+                    } else {
+                        restore = () => fe?.focus?.({ preventScroll: true });
+                    }
+                }
+                div.after(editor);
+                restore?.();
+            }
+            placed.add(variable);
+        });
     }
-  });
+    [...editors.entries()].forEach(([variable, editor]) => {
+        if (!placed.has(variable)) {
+            editor.dispose?.();
+            editor.remove();
+            editors.delete(variable);
+        }
+    });
 };
 const _1iwobxt = function _divToVar(){return(
 function divToVar(runtime, div) {
@@ -5080,10 +5067,9 @@ async function selectVariable(variable, dom = undefined) {
   return cell;
 }
 )};
-const _kyzl8l = function _24(selectVariable,hotbarTemplate)
+const _mri5h3 = function _24(selectVariable,hotbarTemplate)
 {
-  debugger;
-  return selectVariable(hotbarTemplate[5]);
+return selectVariable(hotbarTemplate[5]);
 };
 const _49mpmh = function _hotbar($0,Event,setOption,$1,htl,edit,toolbar,nav,reversibleAttach,combine,code_editor)
 {
@@ -5415,7 +5401,7 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _2pkmxz = async function _command_processor(command,$0,compile_and_update,remove_variables,$1,findCellIndex,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
     if (command.processed)
         return;
@@ -5431,19 +5417,44 @@ const _16ufqhw = async function _command_processor(command,$0,compile_and_update
         remove_variables(command.args.cell.variables);
         result = true;
     } else if (command.command == 'moveCell') {
-        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const cellList = $1.value.get(command.args.cell.module.module);
+        const cellIndex = findCellIndex(command.args.cell.variables, cellList);
         const targetCellIndex = cellIndex + command.args.amount;
-        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
-        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
-        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-        const change = targetFirstVariableIndex - currentFirstVariableIndex;
-        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
-        command.args.cell.variables.forEach(v => {
-            const currentIndex = findVariableIndex(v);
-            repositionSetElement(runtime._variables, v, currentIndex + change);
-        });
-        // recompute
-        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        const targetCell = lookupCellByIndex(targetCellIndex, cellList);
+        if (targetCell) {
+            const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+            const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+            const change = targetFirstVariableIndex - currentFirstVariableIndex;
+            const dom = command.args.cell.dom;
+            const preY = dom?.getBoundingClientRect?.().top;
+            command.args.cell.variables.forEach(v => {
+                const currentIndex = findVariableIndex(v);
+                repositionSetElement(runtime._variables, v, currentIndex + change);
+            });
+            await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+            // Keep moved cell at same screen position so neighbours shift around it.
+            // Cells here have wildly varying heights (some embed 500+ px iframes), so
+            // a one-position move can otherwise jump hundreds of pixels (#163). Poll
+            // for syncers' reactive DOM reorder before measuring postY — the chain
+            // runs on macrotasks, so requestAnimationFrame is not sufficient.
+            if (preY != null && dom?.isConnected) {
+                let postY = preY;
+                for (let i = 0; i < 30 && postY === preY; i++) {
+                    await new Promise(r => setTimeout(r, 50));
+                    if (!dom.isConnected)
+                        break;
+                    postY = dom.getBoundingClientRect().top;
+                }
+                const delta = postY - preY;
+                if (delta !== 0) {
+                    const scroller = dom.closest('.lm_content') || document.scrollingElement;
+                    scroller?.scrollBy?.({
+                        top: delta,
+                        behavior: 'instant'
+                    });
+                }
+            }
+        }
         result = true;
     }
     if (result) {
@@ -5840,11 +5851,10 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
+const _1ddju40 = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
     return async (source, variables = [], cell) => {
         try {
-            debugger;
             let reposition = false, insertionIndex = -1;
             const newVariables = compile(source);
             if (!variables || variables.length !== newVariables.length) {
@@ -5877,7 +5887,6 @@ const _1698wmw = function _compile_and_update(compile,runtime,realize,reposition
             return variables;
         } catch (e) {
             console.error(e);
-            debugger;
         }
     };
 };
@@ -5968,7 +5977,7 @@ export default function define(runtime, observer) {
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
-  $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
+  $def("_ipx6cz", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","editors","cellEditor"], _ipx6cz);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
   $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
@@ -5986,7 +5995,7 @@ export default function define(runtime, observer) {
   $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
-  $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
+  $def("_mri5h3", null, ["selectVariable","hotbarTemplate"], _mri5h3);  
   $def("_49mpmh", "hotbar", ["viewof edit","Event","setOption","viewof editedCell","htl","edit","toolbar","nav","reversibleAttach","combine","code_editor"], _49mpmh);  
   $def("_1uohwj8", null, ["viewof editedCell"], _1uohwj8);  
   $def("_jqia2f", null, ["nav","editedCell"], _jqia2f);  
@@ -6031,7 +6040,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
+  $def("_2pkmxz", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","viewof liveCellMap","findCellIndex","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _2pkmxz);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6069,7 +6078,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
+  $def("_1ddju40", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1ddju40);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  

--- a/notebooks/@tomlarkworthy_notes.html
+++ b/notebooks/@tomlarkworthy_notes.html
@@ -4767,63 +4767,50 @@ md`## Sync editors`
 const _hdieof = function _editors(){return(
 new Map()
 )};
-const _ye6ey = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,TRACE_CELL,editors,cellEditor)
+const _ipx6cz = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,editors,cellEditor)
 {
-  keepalive(editorModule, "editor_jobs");
-  syncers;
-
-  const placed = new Set();
-
-  if (attachContextManu) {
-    document.querySelectorAll(".observablehq").forEach((div) => {
-      const variable = divToVar(runtime, div);
-      if (!variable) return;
-      if (variable._name == TRACE_CELL) debugger;
-
-      if (!editors.has(variable)) {
-        editors.set(variable, cellEditor(variable));
-      }
-
-      const editor = editors.get(variable);
-      const next = div.nextSibling;
-      if (next !== editor) {
-        const ae = document.activeElement;
-        const hadFocus = ae && editor.contains(ae);
-
-        let restore = null;
-        if (hadFocus) {
-          const fe = ae;
-          if (
-            fe &&
-            (fe.tagName === "INPUT" || fe.tagName === "TEXTAREA") &&
-            "selectionStart" in fe
-          ) {
-            const start = fe.selectionStart,
-              end = fe.selectionEnd;
-            restore = () => {
-              fe.focus({ preventScroll: true });
-              fe.setSelectionRange(start, end);
-            };
-          } else {
-            restore = () => fe?.focus?.({ preventScroll: true });
-          }
-        }
-
-        div.after(editor);
-        restore?.();
-      }
-
-      placed.add(variable);
-    });
-  }
-
-  [...editors.entries()].forEach(([variable, editor]) => {
-    if (!placed.has(variable)) {
-      editor.dispose?.();
-      editor.remove();
-      editors.delete(variable);
+    keepalive(editorModule, 'editor_jobs');
+    syncers;
+    const placed = new Set();
+    if (attachContextManu) {
+        document.querySelectorAll('.observablehq').forEach(div => {
+            const variable = divToVar(runtime, div);
+            if (!variable)
+                return;
+            if (!editors.has(variable)) {
+                editors.set(variable, cellEditor(variable));
+            }
+            const editor = editors.get(variable);
+            const next = div.nextSibling;
+            if (next !== editor) {
+                const ae = document.activeElement;
+                const hadFocus = ae && editor.contains(ae);
+                let restore = null;
+                if (hadFocus) {
+                    const fe = ae;
+                    if (fe && (fe.tagName === 'INPUT' || fe.tagName === 'TEXTAREA') && 'selectionStart' in fe) {
+                        const start = fe.selectionStart, end = fe.selectionEnd;
+                        restore = () => {
+                            fe.focus({ preventScroll: true });
+                            fe.setSelectionRange(start, end);
+                        };
+                    } else {
+                        restore = () => fe?.focus?.({ preventScroll: true });
+                    }
+                }
+                div.after(editor);
+                restore?.();
+            }
+            placed.add(variable);
+        });
     }
-  });
+    [...editors.entries()].forEach(([variable, editor]) => {
+        if (!placed.has(variable)) {
+            editor.dispose?.();
+            editor.remove();
+            editors.delete(variable);
+        }
+    });
 };
 const _1iwobxt = function _divToVar(){return(
 function divToVar(runtime, div) {
@@ -5129,10 +5116,9 @@ async function selectVariable(variable, dom = undefined) {
   return cell;
 }
 )};
-const _kyzl8l = function _24(selectVariable,hotbarTemplate)
+const _mri5h3 = function _24(selectVariable,hotbarTemplate)
 {
-  debugger;
-  return selectVariable(hotbarTemplate[5]);
+return selectVariable(hotbarTemplate[5]);
 };
 const _49mpmh = function _hotbar($0,Event,setOption,$1,htl,edit,toolbar,nav,reversibleAttach,combine,code_editor)
 {
@@ -5464,7 +5450,7 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _2pkmxz = async function _command_processor(command,$0,compile_and_update,remove_variables,$1,findCellIndex,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
     if (command.processed)
         return;
@@ -5480,19 +5466,44 @@ const _16ufqhw = async function _command_processor(command,$0,compile_and_update
         remove_variables(command.args.cell.variables);
         result = true;
     } else if (command.command == 'moveCell') {
-        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const cellList = $1.value.get(command.args.cell.module.module);
+        const cellIndex = findCellIndex(command.args.cell.variables, cellList);
         const targetCellIndex = cellIndex + command.args.amount;
-        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
-        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
-        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-        const change = targetFirstVariableIndex - currentFirstVariableIndex;
-        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
-        command.args.cell.variables.forEach(v => {
-            const currentIndex = findVariableIndex(v);
-            repositionSetElement(runtime._variables, v, currentIndex + change);
-        });
-        // recompute
-        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        const targetCell = lookupCellByIndex(targetCellIndex, cellList);
+        if (targetCell) {
+            const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+            const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+            const change = targetFirstVariableIndex - currentFirstVariableIndex;
+            const dom = command.args.cell.dom;
+            const preY = dom?.getBoundingClientRect?.().top;
+            command.args.cell.variables.forEach(v => {
+                const currentIndex = findVariableIndex(v);
+                repositionSetElement(runtime._variables, v, currentIndex + change);
+            });
+            await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+            // Keep moved cell at same screen position so neighbours shift around it.
+            // Cells here have wildly varying heights (some embed 500+ px iframes), so
+            // a one-position move can otherwise jump hundreds of pixels (#163). Poll
+            // for syncers' reactive DOM reorder before measuring postY — the chain
+            // runs on macrotasks, so requestAnimationFrame is not sufficient.
+            if (preY != null && dom?.isConnected) {
+                let postY = preY;
+                for (let i = 0; i < 30 && postY === preY; i++) {
+                    await new Promise(r => setTimeout(r, 50));
+                    if (!dom.isConnected)
+                        break;
+                    postY = dom.getBoundingClientRect().top;
+                }
+                const delta = postY - preY;
+                if (delta !== 0) {
+                    const scroller = dom.closest('.lm_content') || document.scrollingElement;
+                    scroller?.scrollBy?.({
+                        top: delta,
+                        behavior: 'instant'
+                    });
+                }
+            }
+        }
         result = true;
     }
     if (result) {
@@ -5889,11 +5900,10 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
+const _1ddju40 = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
     return async (source, variables = [], cell) => {
         try {
-            debugger;
             let reposition = false, insertionIndex = -1;
             const newVariables = compile(source);
             if (!variables || variables.length !== newVariables.length) {
@@ -5926,7 +5936,6 @@ const _1698wmw = function _compile_and_update(compile,runtime,realize,reposition
             return variables;
         } catch (e) {
             console.error(e);
-            debugger;
         }
     };
 };
@@ -6017,7 +6026,7 @@ export default function define(runtime, observer) {
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
-  $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
+  $def("_ipx6cz", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","editors","cellEditor"], _ipx6cz);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
   $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
@@ -6035,7 +6044,7 @@ export default function define(runtime, observer) {
   $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
-  $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
+  $def("_mri5h3", null, ["selectVariable","hotbarTemplate"], _mri5h3);  
   $def("_49mpmh", "hotbar", ["viewof edit","Event","setOption","viewof editedCell","htl","edit","toolbar","nav","reversibleAttach","combine","code_editor"], _49mpmh);  
   $def("_1uohwj8", null, ["viewof editedCell"], _1uohwj8);  
   $def("_jqia2f", null, ["nav","editedCell"], _jqia2f);  
@@ -6080,7 +6089,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
+  $def("_2pkmxz", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","viewof liveCellMap","findCellIndex","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _2pkmxz);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6118,7 +6127,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
+  $def("_1ddju40", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1ddju40);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  

--- a/notebooks/@tomlarkworthy_observablejs-toolchain.html
+++ b/notebooks/@tomlarkworthy_observablejs-toolchain.html
@@ -4645,7 +4645,7 @@ export default function define(runtime, observer) {
 >
 e30K
 </script>
-<script id="@tomlarkworthy/editor-5" 
+<script id="@tomlarkworthy/editor-5"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -4695,63 +4695,50 @@ md`## Sync editors`
 const _hdieof = function _editors(){return(
 new Map()
 )};
-const _ye6ey = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,TRACE_CELL,editors,cellEditor)
+const _ipx6cz = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,editors,cellEditor)
 {
-  keepalive(editorModule, "editor_jobs");
-  syncers;
-
-  const placed = new Set();
-
-  if (attachContextManu) {
-    document.querySelectorAll(".observablehq").forEach((div) => {
-      const variable = divToVar(runtime, div);
-      if (!variable) return;
-      if (variable._name == TRACE_CELL) debugger;
-
-      if (!editors.has(variable)) {
-        editors.set(variable, cellEditor(variable));
-      }
-
-      const editor = editors.get(variable);
-      const next = div.nextSibling;
-      if (next !== editor) {
-        const ae = document.activeElement;
-        const hadFocus = ae && editor.contains(ae);
-
-        let restore = null;
-        if (hadFocus) {
-          const fe = ae;
-          if (
-            fe &&
-            (fe.tagName === "INPUT" || fe.tagName === "TEXTAREA") &&
-            "selectionStart" in fe
-          ) {
-            const start = fe.selectionStart,
-              end = fe.selectionEnd;
-            restore = () => {
-              fe.focus({ preventScroll: true });
-              fe.setSelectionRange(start, end);
-            };
-          } else {
-            restore = () => fe?.focus?.({ preventScroll: true });
-          }
-        }
-
-        div.after(editor);
-        restore?.();
-      }
-
-      placed.add(variable);
-    });
-  }
-
-  [...editors.entries()].forEach(([variable, editor]) => {
-    if (!placed.has(variable)) {
-      editor.dispose?.();
-      editor.remove();
-      editors.delete(variable);
+    keepalive(editorModule, 'editor_jobs');
+    syncers;
+    const placed = new Set();
+    if (attachContextManu) {
+        document.querySelectorAll('.observablehq').forEach(div => {
+            const variable = divToVar(runtime, div);
+            if (!variable)
+                return;
+            if (!editors.has(variable)) {
+                editors.set(variable, cellEditor(variable));
+            }
+            const editor = editors.get(variable);
+            const next = div.nextSibling;
+            if (next !== editor) {
+                const ae = document.activeElement;
+                const hadFocus = ae && editor.contains(ae);
+                let restore = null;
+                if (hadFocus) {
+                    const fe = ae;
+                    if (fe && (fe.tagName === 'INPUT' || fe.tagName === 'TEXTAREA') && 'selectionStart' in fe) {
+                        const start = fe.selectionStart, end = fe.selectionEnd;
+                        restore = () => {
+                            fe.focus({ preventScroll: true });
+                            fe.setSelectionRange(start, end);
+                        };
+                    } else {
+                        restore = () => fe?.focus?.({ preventScroll: true });
+                    }
+                }
+                div.after(editor);
+                restore?.();
+            }
+            placed.add(variable);
+        });
     }
-  });
+    [...editors.entries()].forEach(([variable, editor]) => {
+        if (!placed.has(variable)) {
+            editor.dispose?.();
+            editor.remove();
+            editors.delete(variable);
+        }
+    });
 };
 const _1iwobxt = function _divToVar(){return(
 function divToVar(runtime, div) {
@@ -5057,10 +5044,9 @@ async function selectVariable(variable, dom = undefined) {
   return cell;
 }
 )};
-const _kyzl8l = function _24(selectVariable,hotbarTemplate)
+const _mri5h3 = function _24(selectVariable,hotbarTemplate)
 {
-  debugger;
-  return selectVariable(hotbarTemplate[5]);
+return selectVariable(hotbarTemplate[5]);
 };
 const _49mpmh = function _hotbar($0,Event,setOption,$1,htl,edit,toolbar,nav,reversibleAttach,combine,code_editor)
 {
@@ -5392,7 +5378,7 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _2pkmxz = async function _command_processor(command,$0,compile_and_update,remove_variables,$1,findCellIndex,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
     if (command.processed)
         return;
@@ -5408,19 +5394,44 @@ const _16ufqhw = async function _command_processor(command,$0,compile_and_update
         remove_variables(command.args.cell.variables);
         result = true;
     } else if (command.command == 'moveCell') {
-        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const cellList = $1.value.get(command.args.cell.module.module);
+        const cellIndex = findCellIndex(command.args.cell.variables, cellList);
         const targetCellIndex = cellIndex + command.args.amount;
-        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
-        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
-        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-        const change = targetFirstVariableIndex - currentFirstVariableIndex;
-        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
-        command.args.cell.variables.forEach(v => {
-            const currentIndex = findVariableIndex(v);
-            repositionSetElement(runtime._variables, v, currentIndex + change);
-        });
-        // recompute
-        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        const targetCell = lookupCellByIndex(targetCellIndex, cellList);
+        if (targetCell) {
+            const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+            const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+            const change = targetFirstVariableIndex - currentFirstVariableIndex;
+            const dom = command.args.cell.dom;
+            const preY = dom?.getBoundingClientRect?.().top;
+            command.args.cell.variables.forEach(v => {
+                const currentIndex = findVariableIndex(v);
+                repositionSetElement(runtime._variables, v, currentIndex + change);
+            });
+            await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+            // Keep moved cell at same screen position so neighbours shift around it.
+            // Cells here have wildly varying heights (some embed 500+ px iframes), so
+            // a one-position move can otherwise jump hundreds of pixels (#163). Poll
+            // for syncers' reactive DOM reorder before measuring postY — the chain
+            // runs on macrotasks, so requestAnimationFrame is not sufficient.
+            if (preY != null && dom?.isConnected) {
+                let postY = preY;
+                for (let i = 0; i < 30 && postY === preY; i++) {
+                    await new Promise(r => setTimeout(r, 50));
+                    if (!dom.isConnected)
+                        break;
+                    postY = dom.getBoundingClientRect().top;
+                }
+                const delta = postY - preY;
+                if (delta !== 0) {
+                    const scroller = dom.closest('.lm_content') || document.scrollingElement;
+                    scroller?.scrollBy?.({
+                        top: delta,
+                        behavior: 'instant'
+                    });
+                }
+            }
+        }
         result = true;
     }
     if (result) {
@@ -5817,11 +5828,10 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
+const _1ddju40 = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
     return async (source, variables = [], cell) => {
         try {
-            debugger;
             let reposition = false, insertionIndex = -1;
             const newVariables = compile(source);
             if (!variables || variables.length !== newVariables.length) {
@@ -5854,7 +5864,6 @@ const _1698wmw = function _compile_and_update(compile,runtime,realize,reposition
             return variables;
         } catch (e) {
             console.error(e);
-            debugger;
         }
     };
 };
@@ -5945,7 +5954,7 @@ export default function define(runtime, observer) {
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
-  $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
+  $def("_ipx6cz", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","editors","cellEditor"], _ipx6cz);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
   $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
@@ -5963,7 +5972,7 @@ export default function define(runtime, observer) {
   $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
-  $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
+  $def("_mri5h3", null, ["selectVariable","hotbarTemplate"], _mri5h3);  
   $def("_49mpmh", "hotbar", ["viewof edit","Event","setOption","viewof editedCell","htl","edit","toolbar","nav","reversibleAttach","combine","code_editor"], _49mpmh);  
   $def("_1uohwj8", null, ["viewof editedCell"], _1uohwj8);  
   $def("_jqia2f", null, ["nav","editedCell"], _jqia2f);  
@@ -6008,7 +6017,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
+  $def("_2pkmxz", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","viewof liveCellMap","findCellIndex","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _2pkmxz);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6046,7 +6055,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
+  $def("_1ddju40", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1ddju40);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -6094,7 +6103,8 @@ export default function define(runtime, observer) {
   main.define("navHref", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("navHref", _));  
   main.define("cellsToClipboard", ["module @tomlarkworthy/cells-to-clipboard", "@variable"], (_, v) => v.import("cellsToClipboard", _));
   return main;
-}</script>
+}
+</script>
 <script id="@tomlarkworthy/escodegen/escodegen.browser.min.js.gz" 
   type="text/plain"
   data-encoding="base64"

--- a/notebooks/@tomlarkworthy_openai-responses-api.html
+++ b/notebooks/@tomlarkworthy_openai-responses-api.html
@@ -4740,63 +4740,50 @@ md`## Sync editors`
 const _hdieof = function _editors(){return(
 new Map()
 )};
-const _ye6ey = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,TRACE_CELL,editors,cellEditor)
+const _ipx6cz = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,editors,cellEditor)
 {
-  keepalive(editorModule, "editor_jobs");
-  syncers;
-
-  const placed = new Set();
-
-  if (attachContextManu) {
-    document.querySelectorAll(".observablehq").forEach((div) => {
-      const variable = divToVar(runtime, div);
-      if (!variable) return;
-      if (variable._name == TRACE_CELL) debugger;
-
-      if (!editors.has(variable)) {
-        editors.set(variable, cellEditor(variable));
-      }
-
-      const editor = editors.get(variable);
-      const next = div.nextSibling;
-      if (next !== editor) {
-        const ae = document.activeElement;
-        const hadFocus = ae && editor.contains(ae);
-
-        let restore = null;
-        if (hadFocus) {
-          const fe = ae;
-          if (
-            fe &&
-            (fe.tagName === "INPUT" || fe.tagName === "TEXTAREA") &&
-            "selectionStart" in fe
-          ) {
-            const start = fe.selectionStart,
-              end = fe.selectionEnd;
-            restore = () => {
-              fe.focus({ preventScroll: true });
-              fe.setSelectionRange(start, end);
-            };
-          } else {
-            restore = () => fe?.focus?.({ preventScroll: true });
-          }
-        }
-
-        div.after(editor);
-        restore?.();
-      }
-
-      placed.add(variable);
-    });
-  }
-
-  [...editors.entries()].forEach(([variable, editor]) => {
-    if (!placed.has(variable)) {
-      editor.dispose?.();
-      editor.remove();
-      editors.delete(variable);
+    keepalive(editorModule, 'editor_jobs');
+    syncers;
+    const placed = new Set();
+    if (attachContextManu) {
+        document.querySelectorAll('.observablehq').forEach(div => {
+            const variable = divToVar(runtime, div);
+            if (!variable)
+                return;
+            if (!editors.has(variable)) {
+                editors.set(variable, cellEditor(variable));
+            }
+            const editor = editors.get(variable);
+            const next = div.nextSibling;
+            if (next !== editor) {
+                const ae = document.activeElement;
+                const hadFocus = ae && editor.contains(ae);
+                let restore = null;
+                if (hadFocus) {
+                    const fe = ae;
+                    if (fe && (fe.tagName === 'INPUT' || fe.tagName === 'TEXTAREA') && 'selectionStart' in fe) {
+                        const start = fe.selectionStart, end = fe.selectionEnd;
+                        restore = () => {
+                            fe.focus({ preventScroll: true });
+                            fe.setSelectionRange(start, end);
+                        };
+                    } else {
+                        restore = () => fe?.focus?.({ preventScroll: true });
+                    }
+                }
+                div.after(editor);
+                restore?.();
+            }
+            placed.add(variable);
+        });
     }
-  });
+    [...editors.entries()].forEach(([variable, editor]) => {
+        if (!placed.has(variable)) {
+            editor.dispose?.();
+            editor.remove();
+            editors.delete(variable);
+        }
+    });
 };
 const _1iwobxt = function _divToVar(){return(
 function divToVar(runtime, div) {
@@ -5102,10 +5089,9 @@ async function selectVariable(variable, dom = undefined) {
   return cell;
 }
 )};
-const _kyzl8l = function _24(selectVariable,hotbarTemplate)
+const _mri5h3 = function _24(selectVariable,hotbarTemplate)
 {
-  debugger;
-  return selectVariable(hotbarTemplate[5]);
+return selectVariable(hotbarTemplate[5]);
 };
 const _49mpmh = function _hotbar($0,Event,setOption,$1,htl,edit,toolbar,nav,reversibleAttach,combine,code_editor)
 {
@@ -5437,7 +5423,7 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _2pkmxz = async function _command_processor(command,$0,compile_and_update,remove_variables,$1,findCellIndex,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
     if (command.processed)
         return;
@@ -5453,19 +5439,44 @@ const _16ufqhw = async function _command_processor(command,$0,compile_and_update
         remove_variables(command.args.cell.variables);
         result = true;
     } else if (command.command == 'moveCell') {
-        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const cellList = $1.value.get(command.args.cell.module.module);
+        const cellIndex = findCellIndex(command.args.cell.variables, cellList);
         const targetCellIndex = cellIndex + command.args.amount;
-        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
-        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
-        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-        const change = targetFirstVariableIndex - currentFirstVariableIndex;
-        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
-        command.args.cell.variables.forEach(v => {
-            const currentIndex = findVariableIndex(v);
-            repositionSetElement(runtime._variables, v, currentIndex + change);
-        });
-        // recompute
-        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        const targetCell = lookupCellByIndex(targetCellIndex, cellList);
+        if (targetCell) {
+            const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+            const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+            const change = targetFirstVariableIndex - currentFirstVariableIndex;
+            const dom = command.args.cell.dom;
+            const preY = dom?.getBoundingClientRect?.().top;
+            command.args.cell.variables.forEach(v => {
+                const currentIndex = findVariableIndex(v);
+                repositionSetElement(runtime._variables, v, currentIndex + change);
+            });
+            await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+            // Keep moved cell at same screen position so neighbours shift around it.
+            // Cells here have wildly varying heights (some embed 500+ px iframes), so
+            // a one-position move can otherwise jump hundreds of pixels (#163). Poll
+            // for syncers' reactive DOM reorder before measuring postY — the chain
+            // runs on macrotasks, so requestAnimationFrame is not sufficient.
+            if (preY != null && dom?.isConnected) {
+                let postY = preY;
+                for (let i = 0; i < 30 && postY === preY; i++) {
+                    await new Promise(r => setTimeout(r, 50));
+                    if (!dom.isConnected)
+                        break;
+                    postY = dom.getBoundingClientRect().top;
+                }
+                const delta = postY - preY;
+                if (delta !== 0) {
+                    const scroller = dom.closest('.lm_content') || document.scrollingElement;
+                    scroller?.scrollBy?.({
+                        top: delta,
+                        behavior: 'instant'
+                    });
+                }
+            }
+        }
         result = true;
     }
     if (result) {
@@ -5862,11 +5873,10 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
+const _1ddju40 = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
     return async (source, variables = [], cell) => {
         try {
-            debugger;
             let reposition = false, insertionIndex = -1;
             const newVariables = compile(source);
             if (!variables || variables.length !== newVariables.length) {
@@ -5899,7 +5909,6 @@ const _1698wmw = function _compile_and_update(compile,runtime,realize,reposition
             return variables;
         } catch (e) {
             console.error(e);
-            debugger;
         }
     };
 };
@@ -5990,7 +5999,7 @@ export default function define(runtime, observer) {
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
-  $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
+  $def("_ipx6cz", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","editors","cellEditor"], _ipx6cz);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
   $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
@@ -6008,7 +6017,7 @@ export default function define(runtime, observer) {
   $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
-  $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
+  $def("_mri5h3", null, ["selectVariable","hotbarTemplate"], _mri5h3);  
   $def("_49mpmh", "hotbar", ["viewof edit","Event","setOption","viewof editedCell","htl","edit","toolbar","nav","reversibleAttach","combine","code_editor"], _49mpmh);  
   $def("_1uohwj8", null, ["viewof editedCell"], _1uohwj8);  
   $def("_jqia2f", null, ["nav","editedCell"], _jqia2f);  
@@ -6053,7 +6062,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
+  $def("_2pkmxz", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","viewof liveCellMap","findCellIndex","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _2pkmxz);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6091,7 +6100,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
+  $def("_1ddju40", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1ddju40);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  

--- a/notebooks/@tomlarkworthy_reversible-attachment.html
+++ b/notebooks/@tomlarkworthy_reversible-attachment.html
@@ -4740,63 +4740,50 @@ md`## Sync editors`
 const _hdieof = function _editors(){return(
 new Map()
 )};
-const _ye6ey = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,TRACE_CELL,editors,cellEditor)
+const _ipx6cz = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,editors,cellEditor)
 {
-  keepalive(editorModule, "editor_jobs");
-  syncers;
-
-  const placed = new Set();
-
-  if (attachContextManu) {
-    document.querySelectorAll(".observablehq").forEach((div) => {
-      const variable = divToVar(runtime, div);
-      if (!variable) return;
-      if (variable._name == TRACE_CELL) debugger;
-
-      if (!editors.has(variable)) {
-        editors.set(variable, cellEditor(variable));
-      }
-
-      const editor = editors.get(variable);
-      const next = div.nextSibling;
-      if (next !== editor) {
-        const ae = document.activeElement;
-        const hadFocus = ae && editor.contains(ae);
-
-        let restore = null;
-        if (hadFocus) {
-          const fe = ae;
-          if (
-            fe &&
-            (fe.tagName === "INPUT" || fe.tagName === "TEXTAREA") &&
-            "selectionStart" in fe
-          ) {
-            const start = fe.selectionStart,
-              end = fe.selectionEnd;
-            restore = () => {
-              fe.focus({ preventScroll: true });
-              fe.setSelectionRange(start, end);
-            };
-          } else {
-            restore = () => fe?.focus?.({ preventScroll: true });
-          }
-        }
-
-        div.after(editor);
-        restore?.();
-      }
-
-      placed.add(variable);
-    });
-  }
-
-  [...editors.entries()].forEach(([variable, editor]) => {
-    if (!placed.has(variable)) {
-      editor.dispose?.();
-      editor.remove();
-      editors.delete(variable);
+    keepalive(editorModule, 'editor_jobs');
+    syncers;
+    const placed = new Set();
+    if (attachContextManu) {
+        document.querySelectorAll('.observablehq').forEach(div => {
+            const variable = divToVar(runtime, div);
+            if (!variable)
+                return;
+            if (!editors.has(variable)) {
+                editors.set(variable, cellEditor(variable));
+            }
+            const editor = editors.get(variable);
+            const next = div.nextSibling;
+            if (next !== editor) {
+                const ae = document.activeElement;
+                const hadFocus = ae && editor.contains(ae);
+                let restore = null;
+                if (hadFocus) {
+                    const fe = ae;
+                    if (fe && (fe.tagName === 'INPUT' || fe.tagName === 'TEXTAREA') && 'selectionStart' in fe) {
+                        const start = fe.selectionStart, end = fe.selectionEnd;
+                        restore = () => {
+                            fe.focus({ preventScroll: true });
+                            fe.setSelectionRange(start, end);
+                        };
+                    } else {
+                        restore = () => fe?.focus?.({ preventScroll: true });
+                    }
+                }
+                div.after(editor);
+                restore?.();
+            }
+            placed.add(variable);
+        });
     }
-  });
+    [...editors.entries()].forEach(([variable, editor]) => {
+        if (!placed.has(variable)) {
+            editor.dispose?.();
+            editor.remove();
+            editors.delete(variable);
+        }
+    });
 };
 const _1iwobxt = function _divToVar(){return(
 function divToVar(runtime, div) {
@@ -5102,10 +5089,9 @@ async function selectVariable(variable, dom = undefined) {
   return cell;
 }
 )};
-const _kyzl8l = function _24(selectVariable,hotbarTemplate)
+const _mri5h3 = function _24(selectVariable,hotbarTemplate)
 {
-  debugger;
-  return selectVariable(hotbarTemplate[5]);
+return selectVariable(hotbarTemplate[5]);
 };
 const _49mpmh = function _hotbar($0,Event,setOption,$1,htl,edit,toolbar,nav,reversibleAttach,combine,code_editor)
 {
@@ -5437,7 +5423,7 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _2pkmxz = async function _command_processor(command,$0,compile_and_update,remove_variables,$1,findCellIndex,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
     if (command.processed)
         return;
@@ -5453,19 +5439,44 @@ const _16ufqhw = async function _command_processor(command,$0,compile_and_update
         remove_variables(command.args.cell.variables);
         result = true;
     } else if (command.command == 'moveCell') {
-        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const cellList = $1.value.get(command.args.cell.module.module);
+        const cellIndex = findCellIndex(command.args.cell.variables, cellList);
         const targetCellIndex = cellIndex + command.args.amount;
-        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
-        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
-        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-        const change = targetFirstVariableIndex - currentFirstVariableIndex;
-        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
-        command.args.cell.variables.forEach(v => {
-            const currentIndex = findVariableIndex(v);
-            repositionSetElement(runtime._variables, v, currentIndex + change);
-        });
-        // recompute
-        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        const targetCell = lookupCellByIndex(targetCellIndex, cellList);
+        if (targetCell) {
+            const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+            const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+            const change = targetFirstVariableIndex - currentFirstVariableIndex;
+            const dom = command.args.cell.dom;
+            const preY = dom?.getBoundingClientRect?.().top;
+            command.args.cell.variables.forEach(v => {
+                const currentIndex = findVariableIndex(v);
+                repositionSetElement(runtime._variables, v, currentIndex + change);
+            });
+            await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+            // Keep moved cell at same screen position so neighbours shift around it.
+            // Cells here have wildly varying heights (some embed 500+ px iframes), so
+            // a one-position move can otherwise jump hundreds of pixels (#163). Poll
+            // for syncers' reactive DOM reorder before measuring postY — the chain
+            // runs on macrotasks, so requestAnimationFrame is not sufficient.
+            if (preY != null && dom?.isConnected) {
+                let postY = preY;
+                for (let i = 0; i < 30 && postY === preY; i++) {
+                    await new Promise(r => setTimeout(r, 50));
+                    if (!dom.isConnected)
+                        break;
+                    postY = dom.getBoundingClientRect().top;
+                }
+                const delta = postY - preY;
+                if (delta !== 0) {
+                    const scroller = dom.closest('.lm_content') || document.scrollingElement;
+                    scroller?.scrollBy?.({
+                        top: delta,
+                        behavior: 'instant'
+                    });
+                }
+            }
+        }
         result = true;
     }
     if (result) {
@@ -5862,11 +5873,10 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
+const _1ddju40 = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
     return async (source, variables = [], cell) => {
         try {
-            debugger;
             let reposition = false, insertionIndex = -1;
             const newVariables = compile(source);
             if (!variables || variables.length !== newVariables.length) {
@@ -5899,7 +5909,6 @@ const _1698wmw = function _compile_and_update(compile,runtime,realize,reposition
             return variables;
         } catch (e) {
             console.error(e);
-            debugger;
         }
     };
 };
@@ -5990,7 +5999,7 @@ export default function define(runtime, observer) {
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
-  $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
+  $def("_ipx6cz", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","editors","cellEditor"], _ipx6cz);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
   $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
@@ -6008,7 +6017,7 @@ export default function define(runtime, observer) {
   $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
-  $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
+  $def("_mri5h3", null, ["selectVariable","hotbarTemplate"], _mri5h3);  
   $def("_49mpmh", "hotbar", ["viewof edit","Event","setOption","viewof editedCell","htl","edit","toolbar","nav","reversibleAttach","combine","code_editor"], _49mpmh);  
   $def("_1uohwj8", null, ["viewof editedCell"], _1uohwj8);  
   $def("_jqia2f", null, ["nav","editedCell"], _jqia2f);  
@@ -6053,7 +6062,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
+  $def("_2pkmxz", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","viewof liveCellMap","findCellIndex","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _2pkmxz);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6091,7 +6100,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
+  $def("_1ddju40", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1ddju40);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  

--- a/notebooks/@tomlarkworthy_robocoop-2.html
+++ b/notebooks/@tomlarkworthy_robocoop-2.html
@@ -4740,63 +4740,50 @@ md`## Sync editors`
 const _hdieof = function _editors(){return(
 new Map()
 )};
-const _ye6ey = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,TRACE_CELL,editors,cellEditor)
+const _ipx6cz = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,editors,cellEditor)
 {
-  keepalive(editorModule, "editor_jobs");
-  syncers;
-
-  const placed = new Set();
-
-  if (attachContextManu) {
-    document.querySelectorAll(".observablehq").forEach((div) => {
-      const variable = divToVar(runtime, div);
-      if (!variable) return;
-      if (variable._name == TRACE_CELL) debugger;
-
-      if (!editors.has(variable)) {
-        editors.set(variable, cellEditor(variable));
-      }
-
-      const editor = editors.get(variable);
-      const next = div.nextSibling;
-      if (next !== editor) {
-        const ae = document.activeElement;
-        const hadFocus = ae && editor.contains(ae);
-
-        let restore = null;
-        if (hadFocus) {
-          const fe = ae;
-          if (
-            fe &&
-            (fe.tagName === "INPUT" || fe.tagName === "TEXTAREA") &&
-            "selectionStart" in fe
-          ) {
-            const start = fe.selectionStart,
-              end = fe.selectionEnd;
-            restore = () => {
-              fe.focus({ preventScroll: true });
-              fe.setSelectionRange(start, end);
-            };
-          } else {
-            restore = () => fe?.focus?.({ preventScroll: true });
-          }
-        }
-
-        div.after(editor);
-        restore?.();
-      }
-
-      placed.add(variable);
-    });
-  }
-
-  [...editors.entries()].forEach(([variable, editor]) => {
-    if (!placed.has(variable)) {
-      editor.dispose?.();
-      editor.remove();
-      editors.delete(variable);
+    keepalive(editorModule, 'editor_jobs');
+    syncers;
+    const placed = new Set();
+    if (attachContextManu) {
+        document.querySelectorAll('.observablehq').forEach(div => {
+            const variable = divToVar(runtime, div);
+            if (!variable)
+                return;
+            if (!editors.has(variable)) {
+                editors.set(variable, cellEditor(variable));
+            }
+            const editor = editors.get(variable);
+            const next = div.nextSibling;
+            if (next !== editor) {
+                const ae = document.activeElement;
+                const hadFocus = ae && editor.contains(ae);
+                let restore = null;
+                if (hadFocus) {
+                    const fe = ae;
+                    if (fe && (fe.tagName === 'INPUT' || fe.tagName === 'TEXTAREA') && 'selectionStart' in fe) {
+                        const start = fe.selectionStart, end = fe.selectionEnd;
+                        restore = () => {
+                            fe.focus({ preventScroll: true });
+                            fe.setSelectionRange(start, end);
+                        };
+                    } else {
+                        restore = () => fe?.focus?.({ preventScroll: true });
+                    }
+                }
+                div.after(editor);
+                restore?.();
+            }
+            placed.add(variable);
+        });
     }
-  });
+    [...editors.entries()].forEach(([variable, editor]) => {
+        if (!placed.has(variable)) {
+            editor.dispose?.();
+            editor.remove();
+            editors.delete(variable);
+        }
+    });
 };
 const _1iwobxt = function _divToVar(){return(
 function divToVar(runtime, div) {
@@ -5102,10 +5089,9 @@ async function selectVariable(variable, dom = undefined) {
   return cell;
 }
 )};
-const _kyzl8l = function _24(selectVariable,hotbarTemplate)
+const _mri5h3 = function _24(selectVariable,hotbarTemplate)
 {
-  debugger;
-  return selectVariable(hotbarTemplate[5]);
+return selectVariable(hotbarTemplate[5]);
 };
 const _49mpmh = function _hotbar($0,Event,setOption,$1,htl,edit,toolbar,nav,reversibleAttach,combine,code_editor)
 {
@@ -5437,7 +5423,7 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _2pkmxz = async function _command_processor(command,$0,compile_and_update,remove_variables,$1,findCellIndex,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
     if (command.processed)
         return;
@@ -5453,19 +5439,44 @@ const _16ufqhw = async function _command_processor(command,$0,compile_and_update
         remove_variables(command.args.cell.variables);
         result = true;
     } else if (command.command == 'moveCell') {
-        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const cellList = $1.value.get(command.args.cell.module.module);
+        const cellIndex = findCellIndex(command.args.cell.variables, cellList);
         const targetCellIndex = cellIndex + command.args.amount;
-        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
-        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
-        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-        const change = targetFirstVariableIndex - currentFirstVariableIndex;
-        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
-        command.args.cell.variables.forEach(v => {
-            const currentIndex = findVariableIndex(v);
-            repositionSetElement(runtime._variables, v, currentIndex + change);
-        });
-        // recompute
-        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        const targetCell = lookupCellByIndex(targetCellIndex, cellList);
+        if (targetCell) {
+            const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+            const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+            const change = targetFirstVariableIndex - currentFirstVariableIndex;
+            const dom = command.args.cell.dom;
+            const preY = dom?.getBoundingClientRect?.().top;
+            command.args.cell.variables.forEach(v => {
+                const currentIndex = findVariableIndex(v);
+                repositionSetElement(runtime._variables, v, currentIndex + change);
+            });
+            await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+            // Keep moved cell at same screen position so neighbours shift around it.
+            // Cells here have wildly varying heights (some embed 500+ px iframes), so
+            // a one-position move can otherwise jump hundreds of pixels (#163). Poll
+            // for syncers' reactive DOM reorder before measuring postY — the chain
+            // runs on macrotasks, so requestAnimationFrame is not sufficient.
+            if (preY != null && dom?.isConnected) {
+                let postY = preY;
+                for (let i = 0; i < 30 && postY === preY; i++) {
+                    await new Promise(r => setTimeout(r, 50));
+                    if (!dom.isConnected)
+                        break;
+                    postY = dom.getBoundingClientRect().top;
+                }
+                const delta = postY - preY;
+                if (delta !== 0) {
+                    const scroller = dom.closest('.lm_content') || document.scrollingElement;
+                    scroller?.scrollBy?.({
+                        top: delta,
+                        behavior: 'instant'
+                    });
+                }
+            }
+        }
         result = true;
     }
     if (result) {
@@ -5862,11 +5873,10 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
+const _1ddju40 = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
     return async (source, variables = [], cell) => {
         try {
-            debugger;
             let reposition = false, insertionIndex = -1;
             const newVariables = compile(source);
             if (!variables || variables.length !== newVariables.length) {
@@ -5899,7 +5909,6 @@ const _1698wmw = function _compile_and_update(compile,runtime,realize,reposition
             return variables;
         } catch (e) {
             console.error(e);
-            debugger;
         }
     };
 };
@@ -5990,7 +5999,7 @@ export default function define(runtime, observer) {
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
-  $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
+  $def("_ipx6cz", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","editors","cellEditor"], _ipx6cz);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
   $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
@@ -6008,7 +6017,7 @@ export default function define(runtime, observer) {
   $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
-  $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
+  $def("_mri5h3", null, ["selectVariable","hotbarTemplate"], _mri5h3);  
   $def("_49mpmh", "hotbar", ["viewof edit","Event","setOption","viewof editedCell","htl","edit","toolbar","nav","reversibleAttach","combine","code_editor"], _49mpmh);  
   $def("_1uohwj8", null, ["viewof editedCell"], _1uohwj8);  
   $def("_jqia2f", null, ["nav","editedCell"], _jqia2f);  
@@ -6053,7 +6062,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
+  $def("_2pkmxz", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","viewof liveCellMap","findCellIndex","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _2pkmxz);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6091,7 +6100,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
+  $def("_1ddju40", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1ddju40);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  

--- a/notebooks/@tomlarkworthy_robocoop-3.html
+++ b/notebooks/@tomlarkworthy_robocoop-3.html
@@ -4740,63 +4740,50 @@ md`## Sync editors`
 const _hdieof = function _editors(){return(
 new Map()
 )};
-const _ye6ey = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,TRACE_CELL,editors,cellEditor)
+const _ipx6cz = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,editors,cellEditor)
 {
-  keepalive(editorModule, "editor_jobs");
-  syncers;
-
-  const placed = new Set();
-
-  if (attachContextManu) {
-    document.querySelectorAll(".observablehq").forEach((div) => {
-      const variable = divToVar(runtime, div);
-      if (!variable) return;
-      if (variable._name == TRACE_CELL) debugger;
-
-      if (!editors.has(variable)) {
-        editors.set(variable, cellEditor(variable));
-      }
-
-      const editor = editors.get(variable);
-      const next = div.nextSibling;
-      if (next !== editor) {
-        const ae = document.activeElement;
-        const hadFocus = ae && editor.contains(ae);
-
-        let restore = null;
-        if (hadFocus) {
-          const fe = ae;
-          if (
-            fe &&
-            (fe.tagName === "INPUT" || fe.tagName === "TEXTAREA") &&
-            "selectionStart" in fe
-          ) {
-            const start = fe.selectionStart,
-              end = fe.selectionEnd;
-            restore = () => {
-              fe.focus({ preventScroll: true });
-              fe.setSelectionRange(start, end);
-            };
-          } else {
-            restore = () => fe?.focus?.({ preventScroll: true });
-          }
-        }
-
-        div.after(editor);
-        restore?.();
-      }
-
-      placed.add(variable);
-    });
-  }
-
-  [...editors.entries()].forEach(([variable, editor]) => {
-    if (!placed.has(variable)) {
-      editor.dispose?.();
-      editor.remove();
-      editors.delete(variable);
+    keepalive(editorModule, 'editor_jobs');
+    syncers;
+    const placed = new Set();
+    if (attachContextManu) {
+        document.querySelectorAll('.observablehq').forEach(div => {
+            const variable = divToVar(runtime, div);
+            if (!variable)
+                return;
+            if (!editors.has(variable)) {
+                editors.set(variable, cellEditor(variable));
+            }
+            const editor = editors.get(variable);
+            const next = div.nextSibling;
+            if (next !== editor) {
+                const ae = document.activeElement;
+                const hadFocus = ae && editor.contains(ae);
+                let restore = null;
+                if (hadFocus) {
+                    const fe = ae;
+                    if (fe && (fe.tagName === 'INPUT' || fe.tagName === 'TEXTAREA') && 'selectionStart' in fe) {
+                        const start = fe.selectionStart, end = fe.selectionEnd;
+                        restore = () => {
+                            fe.focus({ preventScroll: true });
+                            fe.setSelectionRange(start, end);
+                        };
+                    } else {
+                        restore = () => fe?.focus?.({ preventScroll: true });
+                    }
+                }
+                div.after(editor);
+                restore?.();
+            }
+            placed.add(variable);
+        });
     }
-  });
+    [...editors.entries()].forEach(([variable, editor]) => {
+        if (!placed.has(variable)) {
+            editor.dispose?.();
+            editor.remove();
+            editors.delete(variable);
+        }
+    });
 };
 const _1iwobxt = function _divToVar(){return(
 function divToVar(runtime, div) {
@@ -5102,10 +5089,9 @@ async function selectVariable(variable, dom = undefined) {
   return cell;
 }
 )};
-const _kyzl8l = function _24(selectVariable,hotbarTemplate)
+const _mri5h3 = function _24(selectVariable,hotbarTemplate)
 {
-  debugger;
-  return selectVariable(hotbarTemplate[5]);
+return selectVariable(hotbarTemplate[5]);
 };
 const _49mpmh = function _hotbar($0,Event,setOption,$1,htl,edit,toolbar,nav,reversibleAttach,combine,code_editor)
 {
@@ -5437,7 +5423,7 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _2pkmxz = async function _command_processor(command,$0,compile_and_update,remove_variables,$1,findCellIndex,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
     if (command.processed)
         return;
@@ -5453,19 +5439,44 @@ const _16ufqhw = async function _command_processor(command,$0,compile_and_update
         remove_variables(command.args.cell.variables);
         result = true;
     } else if (command.command == 'moveCell') {
-        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const cellList = $1.value.get(command.args.cell.module.module);
+        const cellIndex = findCellIndex(command.args.cell.variables, cellList);
         const targetCellIndex = cellIndex + command.args.amount;
-        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
-        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
-        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-        const change = targetFirstVariableIndex - currentFirstVariableIndex;
-        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
-        command.args.cell.variables.forEach(v => {
-            const currentIndex = findVariableIndex(v);
-            repositionSetElement(runtime._variables, v, currentIndex + change);
-        });
-        // recompute
-        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        const targetCell = lookupCellByIndex(targetCellIndex, cellList);
+        if (targetCell) {
+            const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+            const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+            const change = targetFirstVariableIndex - currentFirstVariableIndex;
+            const dom = command.args.cell.dom;
+            const preY = dom?.getBoundingClientRect?.().top;
+            command.args.cell.variables.forEach(v => {
+                const currentIndex = findVariableIndex(v);
+                repositionSetElement(runtime._variables, v, currentIndex + change);
+            });
+            await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+            // Keep moved cell at same screen position so neighbours shift around it.
+            // Cells here have wildly varying heights (some embed 500+ px iframes), so
+            // a one-position move can otherwise jump hundreds of pixels (#163). Poll
+            // for syncers' reactive DOM reorder before measuring postY — the chain
+            // runs on macrotasks, so requestAnimationFrame is not sufficient.
+            if (preY != null && dom?.isConnected) {
+                let postY = preY;
+                for (let i = 0; i < 30 && postY === preY; i++) {
+                    await new Promise(r => setTimeout(r, 50));
+                    if (!dom.isConnected)
+                        break;
+                    postY = dom.getBoundingClientRect().top;
+                }
+                const delta = postY - preY;
+                if (delta !== 0) {
+                    const scroller = dom.closest('.lm_content') || document.scrollingElement;
+                    scroller?.scrollBy?.({
+                        top: delta,
+                        behavior: 'instant'
+                    });
+                }
+            }
+        }
         result = true;
     }
     if (result) {
@@ -5862,11 +5873,10 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
+const _1ddju40 = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
     return async (source, variables = [], cell) => {
         try {
-            debugger;
             let reposition = false, insertionIndex = -1;
             const newVariables = compile(source);
             if (!variables || variables.length !== newVariables.length) {
@@ -5899,7 +5909,6 @@ const _1698wmw = function _compile_and_update(compile,runtime,realize,reposition
             return variables;
         } catch (e) {
             console.error(e);
-            debugger;
         }
     };
 };
@@ -5990,7 +5999,7 @@ export default function define(runtime, observer) {
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
-  $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
+  $def("_ipx6cz", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","editors","cellEditor"], _ipx6cz);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
   $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
@@ -6008,7 +6017,7 @@ export default function define(runtime, observer) {
   $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
-  $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
+  $def("_mri5h3", null, ["selectVariable","hotbarTemplate"], _mri5h3);  
   $def("_49mpmh", "hotbar", ["viewof edit","Event","setOption","viewof editedCell","htl","edit","toolbar","nav","reversibleAttach","combine","code_editor"], _49mpmh);  
   $def("_1uohwj8", null, ["viewof editedCell"], _1uohwj8);  
   $def("_jqia2f", null, ["nav","editedCell"], _jqia2f);  
@@ -6053,7 +6062,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
+  $def("_2pkmxz", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","viewof liveCellMap","findCellIndex","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _2pkmxz);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6091,7 +6100,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
+  $def("_1ddju40", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1ddju40);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  

--- a/notebooks/@tomlarkworthy_runtime-sdk.html
+++ b/notebooks/@tomlarkworthy_runtime-sdk.html
@@ -4740,63 +4740,50 @@ md`## Sync editors`
 const _hdieof = function _editors(){return(
 new Map()
 )};
-const _ye6ey = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,TRACE_CELL,editors,cellEditor)
+const _ipx6cz = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,editors,cellEditor)
 {
-  keepalive(editorModule, "editor_jobs");
-  syncers;
-
-  const placed = new Set();
-
-  if (attachContextManu) {
-    document.querySelectorAll(".observablehq").forEach((div) => {
-      const variable = divToVar(runtime, div);
-      if (!variable) return;
-      if (variable._name == TRACE_CELL) debugger;
-
-      if (!editors.has(variable)) {
-        editors.set(variable, cellEditor(variable));
-      }
-
-      const editor = editors.get(variable);
-      const next = div.nextSibling;
-      if (next !== editor) {
-        const ae = document.activeElement;
-        const hadFocus = ae && editor.contains(ae);
-
-        let restore = null;
-        if (hadFocus) {
-          const fe = ae;
-          if (
-            fe &&
-            (fe.tagName === "INPUT" || fe.tagName === "TEXTAREA") &&
-            "selectionStart" in fe
-          ) {
-            const start = fe.selectionStart,
-              end = fe.selectionEnd;
-            restore = () => {
-              fe.focus({ preventScroll: true });
-              fe.setSelectionRange(start, end);
-            };
-          } else {
-            restore = () => fe?.focus?.({ preventScroll: true });
-          }
-        }
-
-        div.after(editor);
-        restore?.();
-      }
-
-      placed.add(variable);
-    });
-  }
-
-  [...editors.entries()].forEach(([variable, editor]) => {
-    if (!placed.has(variable)) {
-      editor.dispose?.();
-      editor.remove();
-      editors.delete(variable);
+    keepalive(editorModule, 'editor_jobs');
+    syncers;
+    const placed = new Set();
+    if (attachContextManu) {
+        document.querySelectorAll('.observablehq').forEach(div => {
+            const variable = divToVar(runtime, div);
+            if (!variable)
+                return;
+            if (!editors.has(variable)) {
+                editors.set(variable, cellEditor(variable));
+            }
+            const editor = editors.get(variable);
+            const next = div.nextSibling;
+            if (next !== editor) {
+                const ae = document.activeElement;
+                const hadFocus = ae && editor.contains(ae);
+                let restore = null;
+                if (hadFocus) {
+                    const fe = ae;
+                    if (fe && (fe.tagName === 'INPUT' || fe.tagName === 'TEXTAREA') && 'selectionStart' in fe) {
+                        const start = fe.selectionStart, end = fe.selectionEnd;
+                        restore = () => {
+                            fe.focus({ preventScroll: true });
+                            fe.setSelectionRange(start, end);
+                        };
+                    } else {
+                        restore = () => fe?.focus?.({ preventScroll: true });
+                    }
+                }
+                div.after(editor);
+                restore?.();
+            }
+            placed.add(variable);
+        });
     }
-  });
+    [...editors.entries()].forEach(([variable, editor]) => {
+        if (!placed.has(variable)) {
+            editor.dispose?.();
+            editor.remove();
+            editors.delete(variable);
+        }
+    });
 };
 const _1iwobxt = function _divToVar(){return(
 function divToVar(runtime, div) {
@@ -5102,10 +5089,9 @@ async function selectVariable(variable, dom = undefined) {
   return cell;
 }
 )};
-const _kyzl8l = function _24(selectVariable,hotbarTemplate)
+const _mri5h3 = function _24(selectVariable,hotbarTemplate)
 {
-  debugger;
-  return selectVariable(hotbarTemplate[5]);
+return selectVariable(hotbarTemplate[5]);
 };
 const _49mpmh = function _hotbar($0,Event,setOption,$1,htl,edit,toolbar,nav,reversibleAttach,combine,code_editor)
 {
@@ -5437,7 +5423,7 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _2pkmxz = async function _command_processor(command,$0,compile_and_update,remove_variables,$1,findCellIndex,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
     if (command.processed)
         return;
@@ -5453,19 +5439,44 @@ const _16ufqhw = async function _command_processor(command,$0,compile_and_update
         remove_variables(command.args.cell.variables);
         result = true;
     } else if (command.command == 'moveCell') {
-        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const cellList = $1.value.get(command.args.cell.module.module);
+        const cellIndex = findCellIndex(command.args.cell.variables, cellList);
         const targetCellIndex = cellIndex + command.args.amount;
-        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
-        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
-        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-        const change = targetFirstVariableIndex - currentFirstVariableIndex;
-        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
-        command.args.cell.variables.forEach(v => {
-            const currentIndex = findVariableIndex(v);
-            repositionSetElement(runtime._variables, v, currentIndex + change);
-        });
-        // recompute
-        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        const targetCell = lookupCellByIndex(targetCellIndex, cellList);
+        if (targetCell) {
+            const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+            const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+            const change = targetFirstVariableIndex - currentFirstVariableIndex;
+            const dom = command.args.cell.dom;
+            const preY = dom?.getBoundingClientRect?.().top;
+            command.args.cell.variables.forEach(v => {
+                const currentIndex = findVariableIndex(v);
+                repositionSetElement(runtime._variables, v, currentIndex + change);
+            });
+            await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+            // Keep moved cell at same screen position so neighbours shift around it.
+            // Cells here have wildly varying heights (some embed 500+ px iframes), so
+            // a one-position move can otherwise jump hundreds of pixels (#163). Poll
+            // for syncers' reactive DOM reorder before measuring postY — the chain
+            // runs on macrotasks, so requestAnimationFrame is not sufficient.
+            if (preY != null && dom?.isConnected) {
+                let postY = preY;
+                for (let i = 0; i < 30 && postY === preY; i++) {
+                    await new Promise(r => setTimeout(r, 50));
+                    if (!dom.isConnected)
+                        break;
+                    postY = dom.getBoundingClientRect().top;
+                }
+                const delta = postY - preY;
+                if (delta !== 0) {
+                    const scroller = dom.closest('.lm_content') || document.scrollingElement;
+                    scroller?.scrollBy?.({
+                        top: delta,
+                        behavior: 'instant'
+                    });
+                }
+            }
+        }
         result = true;
     }
     if (result) {
@@ -5862,11 +5873,10 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
+const _1ddju40 = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
     return async (source, variables = [], cell) => {
         try {
-            debugger;
             let reposition = false, insertionIndex = -1;
             const newVariables = compile(source);
             if (!variables || variables.length !== newVariables.length) {
@@ -5899,7 +5909,6 @@ const _1698wmw = function _compile_and_update(compile,runtime,realize,reposition
             return variables;
         } catch (e) {
             console.error(e);
-            debugger;
         }
     };
 };
@@ -5990,7 +5999,7 @@ export default function define(runtime, observer) {
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
-  $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
+  $def("_ipx6cz", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","editors","cellEditor"], _ipx6cz);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
   $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
@@ -6008,7 +6017,7 @@ export default function define(runtime, observer) {
   $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
-  $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
+  $def("_mri5h3", null, ["selectVariable","hotbarTemplate"], _mri5h3);  
   $def("_49mpmh", "hotbar", ["viewof edit","Event","setOption","viewof editedCell","htl","edit","toolbar","nav","reversibleAttach","combine","code_editor"], _49mpmh);  
   $def("_1uohwj8", null, ["viewof editedCell"], _1uohwj8);  
   $def("_jqia2f", null, ["nav","editedCell"], _jqia2f);  
@@ -6053,7 +6062,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
+  $def("_2pkmxz", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","viewof liveCellMap","findCellIndex","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _2pkmxz);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6091,7 +6100,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
+  $def("_1ddju40", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1ddju40);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  

--- a/notebooks/@tomlarkworthy_secrets.html
+++ b/notebooks/@tomlarkworthy_secrets.html
@@ -4740,63 +4740,50 @@ md`## Sync editors`
 const _hdieof = function _editors(){return(
 new Map()
 )};
-const _ye6ey = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,TRACE_CELL,editors,cellEditor)
+const _ipx6cz = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,editors,cellEditor)
 {
-  keepalive(editorModule, "editor_jobs");
-  syncers;
-
-  const placed = new Set();
-
-  if (attachContextManu) {
-    document.querySelectorAll(".observablehq").forEach((div) => {
-      const variable = divToVar(runtime, div);
-      if (!variable) return;
-      if (variable._name == TRACE_CELL) debugger;
-
-      if (!editors.has(variable)) {
-        editors.set(variable, cellEditor(variable));
-      }
-
-      const editor = editors.get(variable);
-      const next = div.nextSibling;
-      if (next !== editor) {
-        const ae = document.activeElement;
-        const hadFocus = ae && editor.contains(ae);
-
-        let restore = null;
-        if (hadFocus) {
-          const fe = ae;
-          if (
-            fe &&
-            (fe.tagName === "INPUT" || fe.tagName === "TEXTAREA") &&
-            "selectionStart" in fe
-          ) {
-            const start = fe.selectionStart,
-              end = fe.selectionEnd;
-            restore = () => {
-              fe.focus({ preventScroll: true });
-              fe.setSelectionRange(start, end);
-            };
-          } else {
-            restore = () => fe?.focus?.({ preventScroll: true });
-          }
-        }
-
-        div.after(editor);
-        restore?.();
-      }
-
-      placed.add(variable);
-    });
-  }
-
-  [...editors.entries()].forEach(([variable, editor]) => {
-    if (!placed.has(variable)) {
-      editor.dispose?.();
-      editor.remove();
-      editors.delete(variable);
+    keepalive(editorModule, 'editor_jobs');
+    syncers;
+    const placed = new Set();
+    if (attachContextManu) {
+        document.querySelectorAll('.observablehq').forEach(div => {
+            const variable = divToVar(runtime, div);
+            if (!variable)
+                return;
+            if (!editors.has(variable)) {
+                editors.set(variable, cellEditor(variable));
+            }
+            const editor = editors.get(variable);
+            const next = div.nextSibling;
+            if (next !== editor) {
+                const ae = document.activeElement;
+                const hadFocus = ae && editor.contains(ae);
+                let restore = null;
+                if (hadFocus) {
+                    const fe = ae;
+                    if (fe && (fe.tagName === 'INPUT' || fe.tagName === 'TEXTAREA') && 'selectionStart' in fe) {
+                        const start = fe.selectionStart, end = fe.selectionEnd;
+                        restore = () => {
+                            fe.focus({ preventScroll: true });
+                            fe.setSelectionRange(start, end);
+                        };
+                    } else {
+                        restore = () => fe?.focus?.({ preventScroll: true });
+                    }
+                }
+                div.after(editor);
+                restore?.();
+            }
+            placed.add(variable);
+        });
     }
-  });
+    [...editors.entries()].forEach(([variable, editor]) => {
+        if (!placed.has(variable)) {
+            editor.dispose?.();
+            editor.remove();
+            editors.delete(variable);
+        }
+    });
 };
 const _1iwobxt = function _divToVar(){return(
 function divToVar(runtime, div) {
@@ -5102,10 +5089,9 @@ async function selectVariable(variable, dom = undefined) {
   return cell;
 }
 )};
-const _kyzl8l = function _24(selectVariable,hotbarTemplate)
+const _mri5h3 = function _24(selectVariable,hotbarTemplate)
 {
-  debugger;
-  return selectVariable(hotbarTemplate[5]);
+return selectVariable(hotbarTemplate[5]);
 };
 const _49mpmh = function _hotbar($0,Event,setOption,$1,htl,edit,toolbar,nav,reversibleAttach,combine,code_editor)
 {
@@ -5437,7 +5423,7 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _2pkmxz = async function _command_processor(command,$0,compile_and_update,remove_variables,$1,findCellIndex,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
     if (command.processed)
         return;
@@ -5453,19 +5439,44 @@ const _16ufqhw = async function _command_processor(command,$0,compile_and_update
         remove_variables(command.args.cell.variables);
         result = true;
     } else if (command.command == 'moveCell') {
-        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const cellList = $1.value.get(command.args.cell.module.module);
+        const cellIndex = findCellIndex(command.args.cell.variables, cellList);
         const targetCellIndex = cellIndex + command.args.amount;
-        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
-        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
-        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-        const change = targetFirstVariableIndex - currentFirstVariableIndex;
-        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
-        command.args.cell.variables.forEach(v => {
-            const currentIndex = findVariableIndex(v);
-            repositionSetElement(runtime._variables, v, currentIndex + change);
-        });
-        // recompute
-        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        const targetCell = lookupCellByIndex(targetCellIndex, cellList);
+        if (targetCell) {
+            const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+            const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+            const change = targetFirstVariableIndex - currentFirstVariableIndex;
+            const dom = command.args.cell.dom;
+            const preY = dom?.getBoundingClientRect?.().top;
+            command.args.cell.variables.forEach(v => {
+                const currentIndex = findVariableIndex(v);
+                repositionSetElement(runtime._variables, v, currentIndex + change);
+            });
+            await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+            // Keep moved cell at same screen position so neighbours shift around it.
+            // Cells here have wildly varying heights (some embed 500+ px iframes), so
+            // a one-position move can otherwise jump hundreds of pixels (#163). Poll
+            // for syncers' reactive DOM reorder before measuring postY — the chain
+            // runs on macrotasks, so requestAnimationFrame is not sufficient.
+            if (preY != null && dom?.isConnected) {
+                let postY = preY;
+                for (let i = 0; i < 30 && postY === preY; i++) {
+                    await new Promise(r => setTimeout(r, 50));
+                    if (!dom.isConnected)
+                        break;
+                    postY = dom.getBoundingClientRect().top;
+                }
+                const delta = postY - preY;
+                if (delta !== 0) {
+                    const scroller = dom.closest('.lm_content') || document.scrollingElement;
+                    scroller?.scrollBy?.({
+                        top: delta,
+                        behavior: 'instant'
+                    });
+                }
+            }
+        }
         result = true;
     }
     if (result) {
@@ -5862,11 +5873,10 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
+const _1ddju40 = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
     return async (source, variables = [], cell) => {
         try {
-            debugger;
             let reposition = false, insertionIndex = -1;
             const newVariables = compile(source);
             if (!variables || variables.length !== newVariables.length) {
@@ -5899,7 +5909,6 @@ const _1698wmw = function _compile_and_update(compile,runtime,realize,reposition
             return variables;
         } catch (e) {
             console.error(e);
-            debugger;
         }
     };
 };
@@ -5990,7 +5999,7 @@ export default function define(runtime, observer) {
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
-  $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
+  $def("_ipx6cz", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","editors","cellEditor"], _ipx6cz);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
   $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
@@ -6008,7 +6017,7 @@ export default function define(runtime, observer) {
   $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
-  $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
+  $def("_mri5h3", null, ["selectVariable","hotbarTemplate"], _mri5h3);  
   $def("_49mpmh", "hotbar", ["viewof edit","Event","setOption","viewof editedCell","htl","edit","toolbar","nav","reversibleAttach","combine","code_editor"], _49mpmh);  
   $def("_1uohwj8", null, ["viewof editedCell"], _1uohwj8);  
   $def("_jqia2f", null, ["nav","editedCell"], _jqia2f);  
@@ -6053,7 +6062,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
+  $def("_2pkmxz", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","viewof liveCellMap","findCellIndex","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _2pkmxz);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6091,7 +6100,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
+  $def("_1ddju40", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1ddju40);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  

--- a/notebooks/@tomlarkworthy_tests.html
+++ b/notebooks/@tomlarkworthy_tests.html
@@ -4740,63 +4740,50 @@ md`## Sync editors`
 const _hdieof = function _editors(){return(
 new Map()
 )};
-const _ye6ey = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,TRACE_CELL,editors,cellEditor)
+const _ipx6cz = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,editors,cellEditor)
 {
-  keepalive(editorModule, "editor_jobs");
-  syncers;
-
-  const placed = new Set();
-
-  if (attachContextManu) {
-    document.querySelectorAll(".observablehq").forEach((div) => {
-      const variable = divToVar(runtime, div);
-      if (!variable) return;
-      if (variable._name == TRACE_CELL) debugger;
-
-      if (!editors.has(variable)) {
-        editors.set(variable, cellEditor(variable));
-      }
-
-      const editor = editors.get(variable);
-      const next = div.nextSibling;
-      if (next !== editor) {
-        const ae = document.activeElement;
-        const hadFocus = ae && editor.contains(ae);
-
-        let restore = null;
-        if (hadFocus) {
-          const fe = ae;
-          if (
-            fe &&
-            (fe.tagName === "INPUT" || fe.tagName === "TEXTAREA") &&
-            "selectionStart" in fe
-          ) {
-            const start = fe.selectionStart,
-              end = fe.selectionEnd;
-            restore = () => {
-              fe.focus({ preventScroll: true });
-              fe.setSelectionRange(start, end);
-            };
-          } else {
-            restore = () => fe?.focus?.({ preventScroll: true });
-          }
-        }
-
-        div.after(editor);
-        restore?.();
-      }
-
-      placed.add(variable);
-    });
-  }
-
-  [...editors.entries()].forEach(([variable, editor]) => {
-    if (!placed.has(variable)) {
-      editor.dispose?.();
-      editor.remove();
-      editors.delete(variable);
+    keepalive(editorModule, 'editor_jobs');
+    syncers;
+    const placed = new Set();
+    if (attachContextManu) {
+        document.querySelectorAll('.observablehq').forEach(div => {
+            const variable = divToVar(runtime, div);
+            if (!variable)
+                return;
+            if (!editors.has(variable)) {
+                editors.set(variable, cellEditor(variable));
+            }
+            const editor = editors.get(variable);
+            const next = div.nextSibling;
+            if (next !== editor) {
+                const ae = document.activeElement;
+                const hadFocus = ae && editor.contains(ae);
+                let restore = null;
+                if (hadFocus) {
+                    const fe = ae;
+                    if (fe && (fe.tagName === 'INPUT' || fe.tagName === 'TEXTAREA') && 'selectionStart' in fe) {
+                        const start = fe.selectionStart, end = fe.selectionEnd;
+                        restore = () => {
+                            fe.focus({ preventScroll: true });
+                            fe.setSelectionRange(start, end);
+                        };
+                    } else {
+                        restore = () => fe?.focus?.({ preventScroll: true });
+                    }
+                }
+                div.after(editor);
+                restore?.();
+            }
+            placed.add(variable);
+        });
     }
-  });
+    [...editors.entries()].forEach(([variable, editor]) => {
+        if (!placed.has(variable)) {
+            editor.dispose?.();
+            editor.remove();
+            editors.delete(variable);
+        }
+    });
 };
 const _1iwobxt = function _divToVar(){return(
 function divToVar(runtime, div) {
@@ -5102,10 +5089,9 @@ async function selectVariable(variable, dom = undefined) {
   return cell;
 }
 )};
-const _kyzl8l = function _24(selectVariable,hotbarTemplate)
+const _mri5h3 = function _24(selectVariable,hotbarTemplate)
 {
-  debugger;
-  return selectVariable(hotbarTemplate[5]);
+return selectVariable(hotbarTemplate[5]);
 };
 const _49mpmh = function _hotbar($0,Event,setOption,$1,htl,edit,toolbar,nav,reversibleAttach,combine,code_editor)
 {
@@ -5437,7 +5423,7 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _2pkmxz = async function _command_processor(command,$0,compile_and_update,remove_variables,$1,findCellIndex,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
     if (command.processed)
         return;
@@ -5453,19 +5439,44 @@ const _16ufqhw = async function _command_processor(command,$0,compile_and_update
         remove_variables(command.args.cell.variables);
         result = true;
     } else if (command.command == 'moveCell') {
-        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const cellList = $1.value.get(command.args.cell.module.module);
+        const cellIndex = findCellIndex(command.args.cell.variables, cellList);
         const targetCellIndex = cellIndex + command.args.amount;
-        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
-        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
-        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-        const change = targetFirstVariableIndex - currentFirstVariableIndex;
-        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
-        command.args.cell.variables.forEach(v => {
-            const currentIndex = findVariableIndex(v);
-            repositionSetElement(runtime._variables, v, currentIndex + change);
-        });
-        // recompute
-        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        const targetCell = lookupCellByIndex(targetCellIndex, cellList);
+        if (targetCell) {
+            const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+            const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+            const change = targetFirstVariableIndex - currentFirstVariableIndex;
+            const dom = command.args.cell.dom;
+            const preY = dom?.getBoundingClientRect?.().top;
+            command.args.cell.variables.forEach(v => {
+                const currentIndex = findVariableIndex(v);
+                repositionSetElement(runtime._variables, v, currentIndex + change);
+            });
+            await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+            // Keep moved cell at same screen position so neighbours shift around it.
+            // Cells here have wildly varying heights (some embed 500+ px iframes), so
+            // a one-position move can otherwise jump hundreds of pixels (#163). Poll
+            // for syncers' reactive DOM reorder before measuring postY — the chain
+            // runs on macrotasks, so requestAnimationFrame is not sufficient.
+            if (preY != null && dom?.isConnected) {
+                let postY = preY;
+                for (let i = 0; i < 30 && postY === preY; i++) {
+                    await new Promise(r => setTimeout(r, 50));
+                    if (!dom.isConnected)
+                        break;
+                    postY = dom.getBoundingClientRect().top;
+                }
+                const delta = postY - preY;
+                if (delta !== 0) {
+                    const scroller = dom.closest('.lm_content') || document.scrollingElement;
+                    scroller?.scrollBy?.({
+                        top: delta,
+                        behavior: 'instant'
+                    });
+                }
+            }
+        }
         result = true;
     }
     if (result) {
@@ -5862,11 +5873,10 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
+const _1ddju40 = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
     return async (source, variables = [], cell) => {
         try {
-            debugger;
             let reposition = false, insertionIndex = -1;
             const newVariables = compile(source);
             if (!variables || variables.length !== newVariables.length) {
@@ -5899,7 +5909,6 @@ const _1698wmw = function _compile_and_update(compile,runtime,realize,reposition
             return variables;
         } catch (e) {
             console.error(e);
-            debugger;
         }
     };
 };
@@ -5990,7 +5999,7 @@ export default function define(runtime, observer) {
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
-  $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
+  $def("_ipx6cz", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","editors","cellEditor"], _ipx6cz);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
   $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
@@ -6008,7 +6017,7 @@ export default function define(runtime, observer) {
   $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
-  $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
+  $def("_mri5h3", null, ["selectVariable","hotbarTemplate"], _mri5h3);  
   $def("_49mpmh", "hotbar", ["viewof edit","Event","setOption","viewof editedCell","htl","edit","toolbar","nav","reversibleAttach","combine","code_editor"], _49mpmh);  
   $def("_1uohwj8", null, ["viewof editedCell"], _1uohwj8);  
   $def("_jqia2f", null, ["nav","editedCell"], _jqia2f);  
@@ -6053,7 +6062,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
+  $def("_2pkmxz", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","viewof liveCellMap","findCellIndex","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _2pkmxz);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6091,7 +6100,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
+  $def("_1ddju40", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1ddju40);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  

--- a/notebooks/@tomlarkworthy_themes.html
+++ b/notebooks/@tomlarkworthy_themes.html
@@ -4740,63 +4740,50 @@ md`## Sync editors`
 const _hdieof = function _editors(){return(
 new Map()
 )};
-const _ye6ey = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,TRACE_CELL,editors,cellEditor)
+const _ipx6cz = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,editors,cellEditor)
 {
-  keepalive(editorModule, "editor_jobs");
-  syncers;
-
-  const placed = new Set();
-
-  if (attachContextManu) {
-    document.querySelectorAll(".observablehq").forEach((div) => {
-      const variable = divToVar(runtime, div);
-      if (!variable) return;
-      if (variable._name == TRACE_CELL) debugger;
-
-      if (!editors.has(variable)) {
-        editors.set(variable, cellEditor(variable));
-      }
-
-      const editor = editors.get(variable);
-      const next = div.nextSibling;
-      if (next !== editor) {
-        const ae = document.activeElement;
-        const hadFocus = ae && editor.contains(ae);
-
-        let restore = null;
-        if (hadFocus) {
-          const fe = ae;
-          if (
-            fe &&
-            (fe.tagName === "INPUT" || fe.tagName === "TEXTAREA") &&
-            "selectionStart" in fe
-          ) {
-            const start = fe.selectionStart,
-              end = fe.selectionEnd;
-            restore = () => {
-              fe.focus({ preventScroll: true });
-              fe.setSelectionRange(start, end);
-            };
-          } else {
-            restore = () => fe?.focus?.({ preventScroll: true });
-          }
-        }
-
-        div.after(editor);
-        restore?.();
-      }
-
-      placed.add(variable);
-    });
-  }
-
-  [...editors.entries()].forEach(([variable, editor]) => {
-    if (!placed.has(variable)) {
-      editor.dispose?.();
-      editor.remove();
-      editors.delete(variable);
+    keepalive(editorModule, 'editor_jobs');
+    syncers;
+    const placed = new Set();
+    if (attachContextManu) {
+        document.querySelectorAll('.observablehq').forEach(div => {
+            const variable = divToVar(runtime, div);
+            if (!variable)
+                return;
+            if (!editors.has(variable)) {
+                editors.set(variable, cellEditor(variable));
+            }
+            const editor = editors.get(variable);
+            const next = div.nextSibling;
+            if (next !== editor) {
+                const ae = document.activeElement;
+                const hadFocus = ae && editor.contains(ae);
+                let restore = null;
+                if (hadFocus) {
+                    const fe = ae;
+                    if (fe && (fe.tagName === 'INPUT' || fe.tagName === 'TEXTAREA') && 'selectionStart' in fe) {
+                        const start = fe.selectionStart, end = fe.selectionEnd;
+                        restore = () => {
+                            fe.focus({ preventScroll: true });
+                            fe.setSelectionRange(start, end);
+                        };
+                    } else {
+                        restore = () => fe?.focus?.({ preventScroll: true });
+                    }
+                }
+                div.after(editor);
+                restore?.();
+            }
+            placed.add(variable);
+        });
     }
-  });
+    [...editors.entries()].forEach(([variable, editor]) => {
+        if (!placed.has(variable)) {
+            editor.dispose?.();
+            editor.remove();
+            editors.delete(variable);
+        }
+    });
 };
 const _1iwobxt = function _divToVar(){return(
 function divToVar(runtime, div) {
@@ -5102,10 +5089,9 @@ async function selectVariable(variable, dom = undefined) {
   return cell;
 }
 )};
-const _kyzl8l = function _24(selectVariable,hotbarTemplate)
+const _mri5h3 = function _24(selectVariable,hotbarTemplate)
 {
-  debugger;
-  return selectVariable(hotbarTemplate[5]);
+return selectVariable(hotbarTemplate[5]);
 };
 const _49mpmh = function _hotbar($0,Event,setOption,$1,htl,edit,toolbar,nav,reversibleAttach,combine,code_editor)
 {
@@ -5437,7 +5423,7 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _2pkmxz = async function _command_processor(command,$0,compile_and_update,remove_variables,$1,findCellIndex,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
     if (command.processed)
         return;
@@ -5453,19 +5439,44 @@ const _16ufqhw = async function _command_processor(command,$0,compile_and_update
         remove_variables(command.args.cell.variables);
         result = true;
     } else if (command.command == 'moveCell') {
-        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const cellList = $1.value.get(command.args.cell.module.module);
+        const cellIndex = findCellIndex(command.args.cell.variables, cellList);
         const targetCellIndex = cellIndex + command.args.amount;
-        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
-        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
-        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-        const change = targetFirstVariableIndex - currentFirstVariableIndex;
-        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
-        command.args.cell.variables.forEach(v => {
-            const currentIndex = findVariableIndex(v);
-            repositionSetElement(runtime._variables, v, currentIndex + change);
-        });
-        // recompute
-        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        const targetCell = lookupCellByIndex(targetCellIndex, cellList);
+        if (targetCell) {
+            const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+            const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+            const change = targetFirstVariableIndex - currentFirstVariableIndex;
+            const dom = command.args.cell.dom;
+            const preY = dom?.getBoundingClientRect?.().top;
+            command.args.cell.variables.forEach(v => {
+                const currentIndex = findVariableIndex(v);
+                repositionSetElement(runtime._variables, v, currentIndex + change);
+            });
+            await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+            // Keep moved cell at same screen position so neighbours shift around it.
+            // Cells here have wildly varying heights (some embed 500+ px iframes), so
+            // a one-position move can otherwise jump hundreds of pixels (#163). Poll
+            // for syncers' reactive DOM reorder before measuring postY — the chain
+            // runs on macrotasks, so requestAnimationFrame is not sufficient.
+            if (preY != null && dom?.isConnected) {
+                let postY = preY;
+                for (let i = 0; i < 30 && postY === preY; i++) {
+                    await new Promise(r => setTimeout(r, 50));
+                    if (!dom.isConnected)
+                        break;
+                    postY = dom.getBoundingClientRect().top;
+                }
+                const delta = postY - preY;
+                if (delta !== 0) {
+                    const scroller = dom.closest('.lm_content') || document.scrollingElement;
+                    scroller?.scrollBy?.({
+                        top: delta,
+                        behavior: 'instant'
+                    });
+                }
+            }
+        }
         result = true;
     }
     if (result) {
@@ -5862,11 +5873,10 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
+const _1ddju40 = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
     return async (source, variables = [], cell) => {
         try {
-            debugger;
             let reposition = false, insertionIndex = -1;
             const newVariables = compile(source);
             if (!variables || variables.length !== newVariables.length) {
@@ -5899,7 +5909,6 @@ const _1698wmw = function _compile_and_update(compile,runtime,realize,reposition
             return variables;
         } catch (e) {
             console.error(e);
-            debugger;
         }
     };
 };
@@ -5990,7 +5999,7 @@ export default function define(runtime, observer) {
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
-  $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
+  $def("_ipx6cz", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","editors","cellEditor"], _ipx6cz);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
   $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
@@ -6008,7 +6017,7 @@ export default function define(runtime, observer) {
   $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
-  $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
+  $def("_mri5h3", null, ["selectVariable","hotbarTemplate"], _mri5h3);  
   $def("_49mpmh", "hotbar", ["viewof edit","Event","setOption","viewof editedCell","htl","edit","toolbar","nav","reversibleAttach","combine","code_editor"], _49mpmh);  
   $def("_1uohwj8", null, ["viewof editedCell"], _1uohwj8);  
   $def("_jqia2f", null, ["nav","editedCell"], _jqia2f);  
@@ -6053,7 +6062,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
+  $def("_2pkmxz", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","viewof liveCellMap","findCellIndex","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _2pkmxz);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6091,7 +6100,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
+  $def("_1ddju40", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1ddju40);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  

--- a/notebooks/@tomlarkworthy_visualizer.html
+++ b/notebooks/@tomlarkworthy_visualizer.html
@@ -4651,7 +4651,7 @@ export default function define(runtime, observer) {
 >
 e30K
 </script>
-<script id="@tomlarkworthy/editor-5" 
+<script id="@tomlarkworthy/editor-5"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -4701,63 +4701,50 @@ md`## Sync editors`
 const _hdieof = function _editors(){return(
 new Map()
 )};
-const _ye6ey = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,TRACE_CELL,editors,cellEditor)
+const _ipx6cz = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,editors,cellEditor)
 {
-  keepalive(editorModule, "editor_jobs");
-  syncers;
-
-  const placed = new Set();
-
-  if (attachContextManu) {
-    document.querySelectorAll(".observablehq").forEach((div) => {
-      const variable = divToVar(runtime, div);
-      if (!variable) return;
-      if (variable._name == TRACE_CELL) debugger;
-
-      if (!editors.has(variable)) {
-        editors.set(variable, cellEditor(variable));
-      }
-
-      const editor = editors.get(variable);
-      const next = div.nextSibling;
-      if (next !== editor) {
-        const ae = document.activeElement;
-        const hadFocus = ae && editor.contains(ae);
-
-        let restore = null;
-        if (hadFocus) {
-          const fe = ae;
-          if (
-            fe &&
-            (fe.tagName === "INPUT" || fe.tagName === "TEXTAREA") &&
-            "selectionStart" in fe
-          ) {
-            const start = fe.selectionStart,
-              end = fe.selectionEnd;
-            restore = () => {
-              fe.focus({ preventScroll: true });
-              fe.setSelectionRange(start, end);
-            };
-          } else {
-            restore = () => fe?.focus?.({ preventScroll: true });
-          }
-        }
-
-        div.after(editor);
-        restore?.();
-      }
-
-      placed.add(variable);
-    });
-  }
-
-  [...editors.entries()].forEach(([variable, editor]) => {
-    if (!placed.has(variable)) {
-      editor.dispose?.();
-      editor.remove();
-      editors.delete(variable);
+    keepalive(editorModule, 'editor_jobs');
+    syncers;
+    const placed = new Set();
+    if (attachContextManu) {
+        document.querySelectorAll('.observablehq').forEach(div => {
+            const variable = divToVar(runtime, div);
+            if (!variable)
+                return;
+            if (!editors.has(variable)) {
+                editors.set(variable, cellEditor(variable));
+            }
+            const editor = editors.get(variable);
+            const next = div.nextSibling;
+            if (next !== editor) {
+                const ae = document.activeElement;
+                const hadFocus = ae && editor.contains(ae);
+                let restore = null;
+                if (hadFocus) {
+                    const fe = ae;
+                    if (fe && (fe.tagName === 'INPUT' || fe.tagName === 'TEXTAREA') && 'selectionStart' in fe) {
+                        const start = fe.selectionStart, end = fe.selectionEnd;
+                        restore = () => {
+                            fe.focus({ preventScroll: true });
+                            fe.setSelectionRange(start, end);
+                        };
+                    } else {
+                        restore = () => fe?.focus?.({ preventScroll: true });
+                    }
+                }
+                div.after(editor);
+                restore?.();
+            }
+            placed.add(variable);
+        });
     }
-  });
+    [...editors.entries()].forEach(([variable, editor]) => {
+        if (!placed.has(variable)) {
+            editor.dispose?.();
+            editor.remove();
+            editors.delete(variable);
+        }
+    });
 };
 const _1iwobxt = function _divToVar(){return(
 function divToVar(runtime, div) {
@@ -5063,10 +5050,9 @@ async function selectVariable(variable, dom = undefined) {
   return cell;
 }
 )};
-const _kyzl8l = function _24(selectVariable,hotbarTemplate)
+const _mri5h3 = function _24(selectVariable,hotbarTemplate)
 {
-  debugger;
-  return selectVariable(hotbarTemplate[5]);
+return selectVariable(hotbarTemplate[5]);
 };
 const _49mpmh = function _hotbar($0,Event,setOption,$1,htl,edit,toolbar,nav,reversibleAttach,combine,code_editor)
 {
@@ -5398,7 +5384,7 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _16ufqhw = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _2pkmxz = async function _command_processor(command,$0,compile_and_update,remove_variables,$1,findCellIndex,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
     if (command.processed)
         return;
@@ -5414,19 +5400,44 @@ const _16ufqhw = async function _command_processor(command,$0,compile_and_update
         remove_variables(command.args.cell.variables);
         result = true;
     } else if (command.command == 'moveCell') {
-        const cellIndex = findCellIndex(command.args.cell.variables, $1.value.get(command.args.cell.module.module));
+        const cellList = $1.value.get(command.args.cell.module.module);
+        const cellIndex = findCellIndex(command.args.cell.variables, cellList);
         const targetCellIndex = cellIndex + command.args.amount;
-        const targetCell = lookupCellByIndex(targetCellIndex, $1.value.get(command.args.cell.module.module));
-        const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
-        const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-        const change = targetFirstVariableIndex - currentFirstVariableIndex;
-        console.log('moveCell', cellIndex, targetCellIndex, targetCell, currentFirstVariableIndex, targetFirstVariableIndex, change);
-        command.args.cell.variables.forEach(v => {
-            const currentIndex = findVariableIndex(v);
-            repositionSetElement(runtime._variables, v, currentIndex + change);
-        });
-        // recompute
-        await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+        const targetCell = lookupCellByIndex(targetCellIndex, cellList);
+        if (targetCell) {
+            const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+            const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+            const change = targetFirstVariableIndex - currentFirstVariableIndex;
+            const dom = command.args.cell.dom;
+            const preY = dom?.getBoundingClientRect?.().top;
+            command.args.cell.variables.forEach(v => {
+                const currentIndex = findVariableIndex(v);
+                repositionSetElement(runtime._variables, v, currentIndex + change);
+            });
+            await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+            // Keep moved cell at same screen position so neighbours shift around it.
+            // Cells here have wildly varying heights (some embed 500+ px iframes), so
+            // a one-position move can otherwise jump hundreds of pixels (#163). Poll
+            // for syncers' reactive DOM reorder before measuring postY — the chain
+            // runs on macrotasks, so requestAnimationFrame is not sufficient.
+            if (preY != null && dom?.isConnected) {
+                let postY = preY;
+                for (let i = 0; i < 30 && postY === preY; i++) {
+                    await new Promise(r => setTimeout(r, 50));
+                    if (!dom.isConnected)
+                        break;
+                    postY = dom.getBoundingClientRect().top;
+                }
+                const delta = postY - preY;
+                if (delta !== 0) {
+                    const scroller = dom.closest('.lm_content') || document.scrollingElement;
+                    scroller?.scrollBy?.({
+                        top: delta,
+                        behavior: 'instant'
+                    });
+                }
+            }
+        }
         result = true;
     }
     if (result) {
@@ -5823,11 +5834,10 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _1698wmw = function _compile_and_update(compile,runtime,realize,repositionSetElement)
+const _1ddju40 = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
     return async (source, variables = [], cell) => {
         try {
-            debugger;
             let reposition = false, insertionIndex = -1;
             const newVariables = compile(source);
             if (!variables || variables.length !== newVariables.length) {
@@ -5860,7 +5870,6 @@ const _1698wmw = function _compile_and_update(compile,runtime,realize,reposition
             return variables;
         } catch (e) {
             console.error(e);
-            debugger;
         }
     };
 };
@@ -5951,7 +5960,7 @@ export default function define(runtime, observer) {
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
-  $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
+  $def("_ipx6cz", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","editors","cellEditor"], _ipx6cz);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
   $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
@@ -5969,7 +5978,7 @@ export default function define(runtime, observer) {
   $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
-  $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
+  $def("_mri5h3", null, ["selectVariable","hotbarTemplate"], _mri5h3);  
   $def("_49mpmh", "hotbar", ["viewof edit","Event","setOption","viewof editedCell","htl","edit","toolbar","nav","reversibleAttach","combine","code_editor"], _49mpmh);  
   $def("_1uohwj8", null, ["viewof editedCell"], _1uohwj8);  
   $def("_jqia2f", null, ["nav","editedCell"], _jqia2f);  
@@ -6014,7 +6023,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_16ufqhw", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _16ufqhw);  
+  $def("_2pkmxz", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","viewof liveCellMap","findCellIndex","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _2pkmxz);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -6052,7 +6061,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_1698wmw", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1698wmw);  
+  $def("_1ddju40", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1ddju40);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -6100,7 +6109,8 @@ export default function define(runtime, observer) {
   main.define("navHref", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("navHref", _));  
   main.define("cellsToClipboard", ["module @tomlarkworthy/cells-to-clipboard", "@variable"], (_, v) => v.import("cellsToClipboard", _));
   return main;
-}</script>
+}
+</script>
 <script id="@tomlarkworthy/escodegen/escodegen.browser.min.js.gz" 
   type="text/plain"
   data-encoding="base64"

--- a/notebooks/atproto.html
+++ b/notebooks/atproto.html
@@ -6221,7 +6221,7 @@ export default function define(runtime, observer) {
 >
 eyJAdG9tbGFya3dvcnRoeS9ibGFuay1ub3RlYm9vayI6eyJ2aWV3b2YgbG9naW5DbGljayI6eyJwaW5uZWQiOnRydWV9fSwiQHRvbWxhcmt3b3J0aHkvYXQtcmVhZCI6W251bGwseyJwaW5uZWQiOmZhbHNlfV0sIkB0b21sYXJrd29ydGh5L2F0cHJvdG8iOlt7InBpbm5lZCI6dHJ1ZX0seyJwaW5uZWQiOnRydWV9LG51bGwseyJwaW5uZWQiOmZhbHNlfV0sIkB0b21sYXJrd29ydGh5L2F0cHJvdG8tbG9naW4iOltudWxsLHsicGlubmVkIjpmYWxzZX1dLCJAdG9tbGFya3dvcnRoeS9hdC13cml0ZSI6eyJwdWJsaXNoV2lkZ2V0Ijp7InBpbm5lZCI6ZmFsc2V9fSwiQHRvbWxhcmt3b3J0aHkvbGVkZ2VyIjpbeyJwaW5uZWQiOnRydWV9XX0=
 </script>
-<script id="@tomlarkworthy/editor-5" 
+<script id="@tomlarkworthy/editor-5"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -6271,63 +6271,50 @@ md`## Sync editors`
 const _hdieof = function _editors(){return(
 new Map()
 )};
-const _ye6ey = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,TRACE_CELL,editors,cellEditor)
+const _ipx6cz = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,editors,cellEditor)
 {
-  keepalive(editorModule, "editor_jobs");
-  syncers;
-
-  const placed = new Set();
-
-  if (attachContextManu) {
-    document.querySelectorAll(".observablehq").forEach((div) => {
-      const variable = divToVar(runtime, div);
-      if (!variable) return;
-      if (variable._name == TRACE_CELL) debugger;
-
-      if (!editors.has(variable)) {
-        editors.set(variable, cellEditor(variable));
-      }
-
-      const editor = editors.get(variable);
-      const next = div.nextSibling;
-      if (next !== editor) {
-        const ae = document.activeElement;
-        const hadFocus = ae && editor.contains(ae);
-
-        let restore = null;
-        if (hadFocus) {
-          const fe = ae;
-          if (
-            fe &&
-            (fe.tagName === "INPUT" || fe.tagName === "TEXTAREA") &&
-            "selectionStart" in fe
-          ) {
-            const start = fe.selectionStart,
-              end = fe.selectionEnd;
-            restore = () => {
-              fe.focus({ preventScroll: true });
-              fe.setSelectionRange(start, end);
-            };
-          } else {
-            restore = () => fe?.focus?.({ preventScroll: true });
-          }
-        }
-
-        div.after(editor);
-        restore?.();
-      }
-
-      placed.add(variable);
-    });
-  }
-
-  [...editors.entries()].forEach(([variable, editor]) => {
-    if (!placed.has(variable)) {
-      editor.dispose?.();
-      editor.remove();
-      editors.delete(variable);
+    keepalive(editorModule, 'editor_jobs');
+    syncers;
+    const placed = new Set();
+    if (attachContextManu) {
+        document.querySelectorAll('.observablehq').forEach(div => {
+            const variable = divToVar(runtime, div);
+            if (!variable)
+                return;
+            if (!editors.has(variable)) {
+                editors.set(variable, cellEditor(variable));
+            }
+            const editor = editors.get(variable);
+            const next = div.nextSibling;
+            if (next !== editor) {
+                const ae = document.activeElement;
+                const hadFocus = ae && editor.contains(ae);
+                let restore = null;
+                if (hadFocus) {
+                    const fe = ae;
+                    if (fe && (fe.tagName === 'INPUT' || fe.tagName === 'TEXTAREA') && 'selectionStart' in fe) {
+                        const start = fe.selectionStart, end = fe.selectionEnd;
+                        restore = () => {
+                            fe.focus({ preventScroll: true });
+                            fe.setSelectionRange(start, end);
+                        };
+                    } else {
+                        restore = () => fe?.focus?.({ preventScroll: true });
+                    }
+                }
+                div.after(editor);
+                restore?.();
+            }
+            placed.add(variable);
+        });
     }
-  });
+    [...editors.entries()].forEach(([variable, editor]) => {
+        if (!placed.has(variable)) {
+            editor.dispose?.();
+            editor.remove();
+            editors.delete(variable);
+        }
+    });
 };
 const _1iwobxt = function _divToVar(){return(
 function divToVar(runtime, div) {
@@ -6633,10 +6620,9 @@ async function selectVariable(variable, dom = undefined) {
   return cell;
 }
 )};
-const _kyzl8l = function _24(selectVariable,hotbarTemplate)
+const _mri5h3 = function _24(selectVariable,hotbarTemplate)
 {
-  debugger;
-  return selectVariable(hotbarTemplate[5]);
+return selectVariable(hotbarTemplate[5]);
 };
 const _49mpmh = function _hotbar($0,Event,setOption,$1,htl,edit,toolbar,nav,reversibleAttach,combine,code_editor)
 {
@@ -6968,58 +6954,66 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _geoudp = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _2pkmxz = async function _command_processor(command,$0,compile_and_update,remove_variables,$1,findCellIndex,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
-  if (command.processed) return;
-
-  let result = undefined;
-  if (command.command == "createCell") {
-    $0.value = true;
-    result = compile_and_update("{}", [], command.args.cell);
-    // For the new one to get focus
-    // setTimeout(() => {
-    //   debugger;
-    //   setOption(result[0], "pinned", true);
-    // }, 100);
-  } else if (command.command == "deleteCell") {
-    remove_variables(command.args.cell.variables);
-    result = true;
-  } else if (command.command == "moveCell") {
-    const cellIndex = findCellIndex(
-      command.args.cell.variables,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const targetCellIndex = cellIndex + command.args.amount;
-    const targetCell = lookupCellByIndex(
-      targetCellIndex,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const currentFirstVariableIndex = findVariableIndex(
-      command.args.cell.variables[0]
-    );
-    const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-    const change = targetFirstVariableIndex - currentFirstVariableIndex;
-    console.log(
-      "moveCell",
-      cellIndex,
-      targetCellIndex,
-      targetCell,
-      currentFirstVariableIndex,
-      targetFirstVariableIndex,
-      change
-    );
-    command.args.cell.variables.forEach((v) => {
-      const currentIndex = findVariableIndex(v);
-      repositionSetElement(runtime._variables, v, currentIndex + change);
-    });
-    // recompute
-    await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
-    result = true;
-  }
-  if (result) {
-    command.processed = true;
-    $2.resolve(result);
-  }
+    if (command.processed)
+        return;
+    let result = undefined;
+    if (command.command == 'createCell') {
+        $0.value = true;
+        result = await compile_and_update('{}', [], command.args.cell);    // For the new one to get focus
+                                                                           // setTimeout(() => {
+                                                                           //   debugger;
+                                                                           //   setOption(result[0], "pinned", true);
+                                                                           // }, 100);
+    } else if (command.command == 'deleteCell') {
+        remove_variables(command.args.cell.variables);
+        result = true;
+    } else if (command.command == 'moveCell') {
+        const cellList = $1.value.get(command.args.cell.module.module);
+        const cellIndex = findCellIndex(command.args.cell.variables, cellList);
+        const targetCellIndex = cellIndex + command.args.amount;
+        const targetCell = lookupCellByIndex(targetCellIndex, cellList);
+        if (targetCell) {
+            const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+            const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+            const change = targetFirstVariableIndex - currentFirstVariableIndex;
+            const dom = command.args.cell.dom;
+            const preY = dom?.getBoundingClientRect?.().top;
+            command.args.cell.variables.forEach(v => {
+                const currentIndex = findVariableIndex(v);
+                repositionSetElement(runtime._variables, v, currentIndex + change);
+            });
+            await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+            // Keep moved cell at same screen position so neighbours shift around it.
+            // Cells here have wildly varying heights (some embed 500+ px iframes), so
+            // a one-position move can otherwise jump hundreds of pixels (#163). Poll
+            // for syncers' reactive DOM reorder before measuring postY — the chain
+            // runs on macrotasks, so requestAnimationFrame is not sufficient.
+            if (preY != null && dom?.isConnected) {
+                let postY = preY;
+                for (let i = 0; i < 30 && postY === preY; i++) {
+                    await new Promise(r => setTimeout(r, 50));
+                    if (!dom.isConnected)
+                        break;
+                    postY = dom.getBoundingClientRect().top;
+                }
+                const delta = postY - preY;
+                if (delta !== 0) {
+                    const scroller = dom.closest('.lm_content') || document.scrollingElement;
+                    scroller?.scrollBy?.({
+                        top: delta,
+                        behavior: 'instant'
+                    });
+                }
+            }
+        }
+        result = true;
+    }
+    if (result) {
+        command.processed = true;
+        $2.resolve(result);
+    }
 };
 const _1jadxoe = function _60(md){return(
 md`### UI Action`
@@ -7410,11 +7404,10 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+const _1ddju40 = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
-    return (source, variables = [], cell) => {
+    return async (source, variables = [], cell) => {
         try {
-            debugger;
             let reposition = false, insertionIndex = -1;
             const newVariables = compile(source);
             if (!variables || variables.length !== newVariables.length) {
@@ -7432,10 +7425,10 @@ const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElemen
             if (reposition) {
                 insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
+            const fns = await realize(newVariables.map(v => v._definition), runtime);
             newVariables.forEach((v, i) => {
                 const variable = variables[i];
-                let _fn;
-                eval('_fn = ' + v._definition);
+                const _fn = fns[i];
                 if (v._name) {
                     variable.define(v._name, v._inputs, _fn);
                 } else {
@@ -7447,7 +7440,6 @@ const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElemen
             return variables;
         } catch (e) {
             console.error(e);
-            debugger;
         }
     };
 };
@@ -7484,12 +7476,11 @@ Inputs.textarea({
 })
 )};
 const _b4rsn5 = (G, _) => G.input(_);
-const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
+const _ga6kci = function _98(Inputs,definition,variable,realize,runtime,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
-  reduce: () => {
-    let _fn;
-    eval("_fn = " + definition);
+  reduce: async () => {
+    const [_fn] = await realize([definition], runtime);
     variable.define(variable._name, inputs, _fn);
   }
 })
@@ -7539,7 +7530,7 @@ export default function define(runtime, observer) {
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
-  $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
+  $def("_ipx6cz", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","editors","cellEditor"], _ipx6cz);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
   $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
@@ -7557,7 +7548,7 @@ export default function define(runtime, observer) {
   $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
-  $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
+  $def("_mri5h3", null, ["selectVariable","hotbarTemplate"], _mri5h3);  
   $def("_49mpmh", "hotbar", ["viewof edit","Event","setOption","viewof editedCell","htl","edit","toolbar","nav","reversibleAttach","combine","code_editor"], _49mpmh);  
   $def("_1uohwj8", null, ["viewof editedCell"], _1uohwj8);  
   $def("_jqia2f", null, ["nav","editedCell"], _jqia2f);  
@@ -7602,7 +7593,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_geoudp", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _geoudp);  
+  $def("_2pkmxz", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","viewof liveCellMap","findCellIndex","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _2pkmxz);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -7640,7 +7631,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
+  $def("_1ddju40", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1ddju40);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -7650,8 +7641,9 @@ export default function define(runtime, observer) {
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
   $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
-  $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
+  $def("_ga6kci", null, ["Inputs","definition","variable","realize","runtime","inputs"], _ga6kci);  
   $def("_1q557s", null, ["md"], _1q557s);  
+  main.define("realize", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("realize", _));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -7687,7 +7679,8 @@ export default function define(runtime, observer) {
   main.define("navHref", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("navHref", _));  
   main.define("cellsToClipboard", ["module @tomlarkworthy/cells-to-clipboard", "@variable"], (_, v) => v.import("cellsToClipboard", _));
   return main;
-}</script>
+}
+</script>
 <script id="@tomlarkworthy/escodegen/escodegen.browser.min.js.gz" 
   type="text/plain"
   data-encoding="base64"

--- a/notebooks/ledger.html
+++ b/notebooks/ledger.html
@@ -6442,7 +6442,7 @@ export default function define(runtime, observer) {
 >
 eyJAdG9tbGFya3dvcnRoeS9ibGFuay1ub3RlYm9vayI6eyJ2aWV3b2YgbG9naW5DbGljayI6eyJwaW5uZWQiOnRydWV9fSwiQHRvbWxhcmt3b3J0aHkvYXQtcmVhZCI6W251bGwseyJwaW5uZWQiOmZhbHNlfV0sIkB0b21sYXJrd29ydGh5L2F0cHJvdG8iOlt7InBpbm5lZCI6dHJ1ZX0seyJwaW5uZWQiOnRydWV9LG51bGwseyJwaW5uZWQiOmZhbHNlfV0sIkB0b21sYXJrd29ydGh5L2F0cHJvdG8tbG9naW4iOltudWxsLHsicGlubmVkIjpmYWxzZX1dLCJAdG9tbGFya3dvcnRoeS9hdC13cml0ZSI6eyJwdWJsaXNoV2lkZ2V0Ijp7InBpbm5lZCI6dHJ1ZX19LCJAdG9tbGFya3dvcnRoeS9sZWRnZXIiOlt7InBpbm5lZCI6dHJ1ZX1dLCJAbG9wZWNvZGUvbGVkZ2VyIjp7Il90aXRsZSI6eyJwaW5uZWQiOnRydWV9LCJsZWRnZXJWaWV3Ijp7InBpbm5lZCI6ZmFsc2V9LCJjYWRlbmNlQ2hhcnQiOnsicGlubmVkIjpmYWxzZX0sImF1dGhTdHJpcCI6eyJwaW5uZWQiOmZhbHNlfSwidmlld29mIGxlZGdlclRhYmxlIjp7InBpbm5lZCI6dHJ1ZX0sImJ1bmRsZXMiOnsicGlubmVkIjpmYWxzZX0sInJvd3MiOnsicGlubmVkIjpmYWxzZX0sInNlbGVjdGVkUm93cyI6eyJwaW5uZWQiOmZhbHNlfSwiYnVsa0JhciI6eyJwaW5uZWQiOmZhbHNlfX19
 </script>
-<script id="@tomlarkworthy/editor-5" 
+<script id="@tomlarkworthy/editor-5"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -6492,63 +6492,50 @@ md`## Sync editors`
 const _hdieof = function _editors(){return(
 new Map()
 )};
-const _ye6ey = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,TRACE_CELL,editors,cellEditor)
+const _ipx6cz = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,editors,cellEditor)
 {
-  keepalive(editorModule, "editor_jobs");
-  syncers;
-
-  const placed = new Set();
-
-  if (attachContextManu) {
-    document.querySelectorAll(".observablehq").forEach((div) => {
-      const variable = divToVar(runtime, div);
-      if (!variable) return;
-      if (variable._name == TRACE_CELL) debugger;
-
-      if (!editors.has(variable)) {
-        editors.set(variable, cellEditor(variable));
-      }
-
-      const editor = editors.get(variable);
-      const next = div.nextSibling;
-      if (next !== editor) {
-        const ae = document.activeElement;
-        const hadFocus = ae && editor.contains(ae);
-
-        let restore = null;
-        if (hadFocus) {
-          const fe = ae;
-          if (
-            fe &&
-            (fe.tagName === "INPUT" || fe.tagName === "TEXTAREA") &&
-            "selectionStart" in fe
-          ) {
-            const start = fe.selectionStart,
-              end = fe.selectionEnd;
-            restore = () => {
-              fe.focus({ preventScroll: true });
-              fe.setSelectionRange(start, end);
-            };
-          } else {
-            restore = () => fe?.focus?.({ preventScroll: true });
-          }
-        }
-
-        div.after(editor);
-        restore?.();
-      }
-
-      placed.add(variable);
-    });
-  }
-
-  [...editors.entries()].forEach(([variable, editor]) => {
-    if (!placed.has(variable)) {
-      editor.dispose?.();
-      editor.remove();
-      editors.delete(variable);
+    keepalive(editorModule, 'editor_jobs');
+    syncers;
+    const placed = new Set();
+    if (attachContextManu) {
+        document.querySelectorAll('.observablehq').forEach(div => {
+            const variable = divToVar(runtime, div);
+            if (!variable)
+                return;
+            if (!editors.has(variable)) {
+                editors.set(variable, cellEditor(variable));
+            }
+            const editor = editors.get(variable);
+            const next = div.nextSibling;
+            if (next !== editor) {
+                const ae = document.activeElement;
+                const hadFocus = ae && editor.contains(ae);
+                let restore = null;
+                if (hadFocus) {
+                    const fe = ae;
+                    if (fe && (fe.tagName === 'INPUT' || fe.tagName === 'TEXTAREA') && 'selectionStart' in fe) {
+                        const start = fe.selectionStart, end = fe.selectionEnd;
+                        restore = () => {
+                            fe.focus({ preventScroll: true });
+                            fe.setSelectionRange(start, end);
+                        };
+                    } else {
+                        restore = () => fe?.focus?.({ preventScroll: true });
+                    }
+                }
+                div.after(editor);
+                restore?.();
+            }
+            placed.add(variable);
+        });
     }
-  });
+    [...editors.entries()].forEach(([variable, editor]) => {
+        if (!placed.has(variable)) {
+            editor.dispose?.();
+            editor.remove();
+            editors.delete(variable);
+        }
+    });
 };
 const _1iwobxt = function _divToVar(){return(
 function divToVar(runtime, div) {
@@ -6854,10 +6841,9 @@ async function selectVariable(variable, dom = undefined) {
   return cell;
 }
 )};
-const _kyzl8l = function _24(selectVariable,hotbarTemplate)
+const _mri5h3 = function _24(selectVariable,hotbarTemplate)
 {
-  debugger;
-  return selectVariable(hotbarTemplate[5]);
+return selectVariable(hotbarTemplate[5]);
 };
 const _49mpmh = function _hotbar($0,Event,setOption,$1,htl,edit,toolbar,nav,reversibleAttach,combine,code_editor)
 {
@@ -7189,58 +7175,66 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _geoudp = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _2pkmxz = async function _command_processor(command,$0,compile_and_update,remove_variables,$1,findCellIndex,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
-  if (command.processed) return;
-
-  let result = undefined;
-  if (command.command == "createCell") {
-    $0.value = true;
-    result = compile_and_update("{}", [], command.args.cell);
-    // For the new one to get focus
-    // setTimeout(() => {
-    //   debugger;
-    //   setOption(result[0], "pinned", true);
-    // }, 100);
-  } else if (command.command == "deleteCell") {
-    remove_variables(command.args.cell.variables);
-    result = true;
-  } else if (command.command == "moveCell") {
-    const cellIndex = findCellIndex(
-      command.args.cell.variables,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const targetCellIndex = cellIndex + command.args.amount;
-    const targetCell = lookupCellByIndex(
-      targetCellIndex,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const currentFirstVariableIndex = findVariableIndex(
-      command.args.cell.variables[0]
-    );
-    const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-    const change = targetFirstVariableIndex - currentFirstVariableIndex;
-    console.log(
-      "moveCell",
-      cellIndex,
-      targetCellIndex,
-      targetCell,
-      currentFirstVariableIndex,
-      targetFirstVariableIndex,
-      change
-    );
-    command.args.cell.variables.forEach((v) => {
-      const currentIndex = findVariableIndex(v);
-      repositionSetElement(runtime._variables, v, currentIndex + change);
-    });
-    // recompute
-    await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
-    result = true;
-  }
-  if (result) {
-    command.processed = true;
-    $2.resolve(result);
-  }
+    if (command.processed)
+        return;
+    let result = undefined;
+    if (command.command == 'createCell') {
+        $0.value = true;
+        result = await compile_and_update('{}', [], command.args.cell);    // For the new one to get focus
+                                                                           // setTimeout(() => {
+                                                                           //   debugger;
+                                                                           //   setOption(result[0], "pinned", true);
+                                                                           // }, 100);
+    } else if (command.command == 'deleteCell') {
+        remove_variables(command.args.cell.variables);
+        result = true;
+    } else if (command.command == 'moveCell') {
+        const cellList = $1.value.get(command.args.cell.module.module);
+        const cellIndex = findCellIndex(command.args.cell.variables, cellList);
+        const targetCellIndex = cellIndex + command.args.amount;
+        const targetCell = lookupCellByIndex(targetCellIndex, cellList);
+        if (targetCell) {
+            const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+            const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+            const change = targetFirstVariableIndex - currentFirstVariableIndex;
+            const dom = command.args.cell.dom;
+            const preY = dom?.getBoundingClientRect?.().top;
+            command.args.cell.variables.forEach(v => {
+                const currentIndex = findVariableIndex(v);
+                repositionSetElement(runtime._variables, v, currentIndex + change);
+            });
+            await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+            // Keep moved cell at same screen position so neighbours shift around it.
+            // Cells here have wildly varying heights (some embed 500+ px iframes), so
+            // a one-position move can otherwise jump hundreds of pixels (#163). Poll
+            // for syncers' reactive DOM reorder before measuring postY — the chain
+            // runs on macrotasks, so requestAnimationFrame is not sufficient.
+            if (preY != null && dom?.isConnected) {
+                let postY = preY;
+                for (let i = 0; i < 30 && postY === preY; i++) {
+                    await new Promise(r => setTimeout(r, 50));
+                    if (!dom.isConnected)
+                        break;
+                    postY = dom.getBoundingClientRect().top;
+                }
+                const delta = postY - preY;
+                if (delta !== 0) {
+                    const scroller = dom.closest('.lm_content') || document.scrollingElement;
+                    scroller?.scrollBy?.({
+                        top: delta,
+                        behavior: 'instant'
+                    });
+                }
+            }
+        }
+        result = true;
+    }
+    if (result) {
+        command.processed = true;
+        $2.resolve(result);
+    }
 };
 const _1jadxoe = function _60(md){return(
 md`### UI Action`
@@ -7631,11 +7625,10 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+const _1ddju40 = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
-    return (source, variables = [], cell) => {
+    return async (source, variables = [], cell) => {
         try {
-            debugger;
             let reposition = false, insertionIndex = -1;
             const newVariables = compile(source);
             if (!variables || variables.length !== newVariables.length) {
@@ -7653,10 +7646,10 @@ const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElemen
             if (reposition) {
                 insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
+            const fns = await realize(newVariables.map(v => v._definition), runtime);
             newVariables.forEach((v, i) => {
                 const variable = variables[i];
-                let _fn;
-                eval('_fn = ' + v._definition);
+                const _fn = fns[i];
                 if (v._name) {
                     variable.define(v._name, v._inputs, _fn);
                 } else {
@@ -7668,7 +7661,6 @@ const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElemen
             return variables;
         } catch (e) {
             console.error(e);
-            debugger;
         }
     };
 };
@@ -7705,12 +7697,11 @@ Inputs.textarea({
 })
 )};
 const _b4rsn5 = (G, _) => G.input(_);
-const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
+const _ga6kci = function _98(Inputs,definition,variable,realize,runtime,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
-  reduce: () => {
-    let _fn;
-    eval("_fn = " + definition);
+  reduce: async () => {
+    const [_fn] = await realize([definition], runtime);
     variable.define(variable._name, inputs, _fn);
   }
 })
@@ -7760,7 +7751,7 @@ export default function define(runtime, observer) {
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
-  $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
+  $def("_ipx6cz", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","editors","cellEditor"], _ipx6cz);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
   $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
@@ -7778,7 +7769,7 @@ export default function define(runtime, observer) {
   $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
-  $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
+  $def("_mri5h3", null, ["selectVariable","hotbarTemplate"], _mri5h3);  
   $def("_49mpmh", "hotbar", ["viewof edit","Event","setOption","viewof editedCell","htl","edit","toolbar","nav","reversibleAttach","combine","code_editor"], _49mpmh);  
   $def("_1uohwj8", null, ["viewof editedCell"], _1uohwj8);  
   $def("_jqia2f", null, ["nav","editedCell"], _jqia2f);  
@@ -7823,7 +7814,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_geoudp", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _geoudp);  
+  $def("_2pkmxz", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","viewof liveCellMap","findCellIndex","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _2pkmxz);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -7861,7 +7852,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
+  $def("_1ddju40", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1ddju40);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -7871,8 +7862,9 @@ export default function define(runtime, observer) {
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
   $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
-  $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
+  $def("_ga6kci", null, ["Inputs","definition","variable","realize","runtime","inputs"], _ga6kci);  
   $def("_1q557s", null, ["md"], _1q557s);  
+  main.define("realize", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("realize", _));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -7908,7 +7900,8 @@ export default function define(runtime, observer) {
   main.define("navHref", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("navHref", _));  
   main.define("cellsToClipboard", ["module @tomlarkworthy/cells-to-clipboard", "@variable"], (_, v) => v.import("cellsToClipboard", _));
   return main;
-}</script>
+}
+</script>
 <script id="@tomlarkworthy/escodegen/escodegen.browser.min.js.gz" 
   type="text/plain"
   data-encoding="base64"

--- a/notebooks/lopefeed.html
+++ b/notebooks/lopefeed.html
@@ -6295,7 +6295,7 @@ export default function define(runtime, observer) {
 >
 eyJAdG9tbGFya3dvcnRoeS9ibGFuay1ub3RlYm9vayI6eyJ2aWV3b2YgbG9naW5DbGljayI6eyJwaW5uZWQiOnRydWV9fSwiQHRvbWxhcmt3b3J0aHkvYXQtcmVhZCI6W251bGwseyJwaW5uZWQiOmZhbHNlfV0sIkB0b21sYXJrd29ydGh5L2F0cHJvdG8iOlt7InBpbm5lZCI6dHJ1ZX0seyJwaW5uZWQiOnRydWV9LG51bGwseyJwaW5uZWQiOmZhbHNlfV0sIkB0b21sYXJrd29ydGh5L2F0cHJvdG8tbG9naW4iOltudWxsLHsicGlubmVkIjpmYWxzZX1dLCJAdG9tbGFya3dvcnRoeS9hdC13cml0ZSI6eyJwdWJsaXNoV2lkZ2V0Ijp7InBpbm5lZCI6dHJ1ZX19LCJAdG9tbGFya3dvcnRoeS9sZWRnZXIiOlt7InBpbm5lZCI6dHJ1ZX1dLCJAbG9wZWNvZGUvbGVkZ2VyIjp7Il90aXRsZSI6eyJwaW5uZWQiOnRydWV9LCJsZWRnZXJWaWV3Ijp7InBpbm5lZCI6ZmFsc2V9fSwiQGxvcGVjb2RlL2xvcGVmZWVkIjpbeyJwaW5uZWQiOnRydWV9XX0=
 </script>
-<script id="@tomlarkworthy/editor-5" 
+<script id="@tomlarkworthy/editor-5"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -6345,63 +6345,50 @@ md`## Sync editors`
 const _hdieof = function _editors(){return(
 new Map()
 )};
-const _ye6ey = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,TRACE_CELL,editors,cellEditor)
+const _ipx6cz = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,editors,cellEditor)
 {
-  keepalive(editorModule, "editor_jobs");
-  syncers;
-
-  const placed = new Set();
-
-  if (attachContextManu) {
-    document.querySelectorAll(".observablehq").forEach((div) => {
-      const variable = divToVar(runtime, div);
-      if (!variable) return;
-      if (variable._name == TRACE_CELL) debugger;
-
-      if (!editors.has(variable)) {
-        editors.set(variable, cellEditor(variable));
-      }
-
-      const editor = editors.get(variable);
-      const next = div.nextSibling;
-      if (next !== editor) {
-        const ae = document.activeElement;
-        const hadFocus = ae && editor.contains(ae);
-
-        let restore = null;
-        if (hadFocus) {
-          const fe = ae;
-          if (
-            fe &&
-            (fe.tagName === "INPUT" || fe.tagName === "TEXTAREA") &&
-            "selectionStart" in fe
-          ) {
-            const start = fe.selectionStart,
-              end = fe.selectionEnd;
-            restore = () => {
-              fe.focus({ preventScroll: true });
-              fe.setSelectionRange(start, end);
-            };
-          } else {
-            restore = () => fe?.focus?.({ preventScroll: true });
-          }
-        }
-
-        div.after(editor);
-        restore?.();
-      }
-
-      placed.add(variable);
-    });
-  }
-
-  [...editors.entries()].forEach(([variable, editor]) => {
-    if (!placed.has(variable)) {
-      editor.dispose?.();
-      editor.remove();
-      editors.delete(variable);
+    keepalive(editorModule, 'editor_jobs');
+    syncers;
+    const placed = new Set();
+    if (attachContextManu) {
+        document.querySelectorAll('.observablehq').forEach(div => {
+            const variable = divToVar(runtime, div);
+            if (!variable)
+                return;
+            if (!editors.has(variable)) {
+                editors.set(variable, cellEditor(variable));
+            }
+            const editor = editors.get(variable);
+            const next = div.nextSibling;
+            if (next !== editor) {
+                const ae = document.activeElement;
+                const hadFocus = ae && editor.contains(ae);
+                let restore = null;
+                if (hadFocus) {
+                    const fe = ae;
+                    if (fe && (fe.tagName === 'INPUT' || fe.tagName === 'TEXTAREA') && 'selectionStart' in fe) {
+                        const start = fe.selectionStart, end = fe.selectionEnd;
+                        restore = () => {
+                            fe.focus({ preventScroll: true });
+                            fe.setSelectionRange(start, end);
+                        };
+                    } else {
+                        restore = () => fe?.focus?.({ preventScroll: true });
+                    }
+                }
+                div.after(editor);
+                restore?.();
+            }
+            placed.add(variable);
+        });
     }
-  });
+    [...editors.entries()].forEach(([variable, editor]) => {
+        if (!placed.has(variable)) {
+            editor.dispose?.();
+            editor.remove();
+            editors.delete(variable);
+        }
+    });
 };
 const _1iwobxt = function _divToVar(){return(
 function divToVar(runtime, div) {
@@ -6707,10 +6694,9 @@ async function selectVariable(variable, dom = undefined) {
   return cell;
 }
 )};
-const _kyzl8l = function _24(selectVariable,hotbarTemplate)
+const _mri5h3 = function _24(selectVariable,hotbarTemplate)
 {
-  debugger;
-  return selectVariable(hotbarTemplate[5]);
+return selectVariable(hotbarTemplate[5]);
 };
 const _49mpmh = function _hotbar($0,Event,setOption,$1,htl,edit,toolbar,nav,reversibleAttach,combine,code_editor)
 {
@@ -7042,58 +7028,66 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _geoudp = async function _command_processor(command,$0,compile_and_update,remove_variables,findCellIndex,$1,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
+const _2pkmxz = async function _command_processor(command,$0,compile_and_update,remove_variables,$1,findCellIndex,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2)
 {
-  if (command.processed) return;
-
-  let result = undefined;
-  if (command.command == "createCell") {
-    $0.value = true;
-    result = compile_and_update("{}", [], command.args.cell);
-    // For the new one to get focus
-    // setTimeout(() => {
-    //   debugger;
-    //   setOption(result[0], "pinned", true);
-    // }, 100);
-  } else if (command.command == "deleteCell") {
-    remove_variables(command.args.cell.variables);
-    result = true;
-  } else if (command.command == "moveCell") {
-    const cellIndex = findCellIndex(
-      command.args.cell.variables,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const targetCellIndex = cellIndex + command.args.amount;
-    const targetCell = lookupCellByIndex(
-      targetCellIndex,
-      $1.value.get(command.args.cell.module.module)
-    );
-    const currentFirstVariableIndex = findVariableIndex(
-      command.args.cell.variables[0]
-    );
-    const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-    const change = targetFirstVariableIndex - currentFirstVariableIndex;
-    console.log(
-      "moveCell",
-      cellIndex,
-      targetCellIndex,
-      targetCell,
-      currentFirstVariableIndex,
-      targetFirstVariableIndex,
-      change
-    );
-    command.args.cell.variables.forEach((v) => {
-      const currentIndex = findVariableIndex(v);
-      repositionSetElement(runtime._variables, v, currentIndex + change);
-    });
-    // recompute
-    await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
-    result = true;
-  }
-  if (result) {
-    command.processed = true;
-    $2.resolve(result);
-  }
+    if (command.processed)
+        return;
+    let result = undefined;
+    if (command.command == 'createCell') {
+        $0.value = true;
+        result = await compile_and_update('{}', [], command.args.cell);    // For the new one to get focus
+                                                                           // setTimeout(() => {
+                                                                           //   debugger;
+                                                                           //   setOption(result[0], "pinned", true);
+                                                                           // }, 100);
+    } else if (command.command == 'deleteCell') {
+        remove_variables(command.args.cell.variables);
+        result = true;
+    } else if (command.command == 'moveCell') {
+        const cellList = $1.value.get(command.args.cell.module.module);
+        const cellIndex = findCellIndex(command.args.cell.variables, cellList);
+        const targetCellIndex = cellIndex + command.args.amount;
+        const targetCell = lookupCellByIndex(targetCellIndex, cellList);
+        if (targetCell) {
+            const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+            const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+            const change = targetFirstVariableIndex - currentFirstVariableIndex;
+            const dom = command.args.cell.dom;
+            const preY = dom?.getBoundingClientRect?.().top;
+            command.args.cell.variables.forEach(v => {
+                const currentIndex = findVariableIndex(v);
+                repositionSetElement(runtime._variables, v, currentIndex + change);
+            });
+            await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+            // Keep moved cell at same screen position so neighbours shift around it.
+            // Cells here have wildly varying heights (some embed 500+ px iframes), so
+            // a one-position move can otherwise jump hundreds of pixels (#163). Poll
+            // for syncers' reactive DOM reorder before measuring postY — the chain
+            // runs on macrotasks, so requestAnimationFrame is not sufficient.
+            if (preY != null && dom?.isConnected) {
+                let postY = preY;
+                for (let i = 0; i < 30 && postY === preY; i++) {
+                    await new Promise(r => setTimeout(r, 50));
+                    if (!dom.isConnected)
+                        break;
+                    postY = dom.getBoundingClientRect().top;
+                }
+                const delta = postY - preY;
+                if (delta !== 0) {
+                    const scroller = dom.closest('.lm_content') || document.scrollingElement;
+                    scroller?.scrollBy?.({
+                        top: delta,
+                        behavior: 'instant'
+                    });
+                }
+            }
+        }
+        result = true;
+    }
+    if (result) {
+        command.processed = true;
+        $2.resolve(result);
+    }
 };
 const _1jadxoe = function _60(md){return(
 md`### UI Action`
@@ -7484,11 +7478,10 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _argpju = function _89(md){return(
 md`### Apply Update`
 )};
-const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElement)
+const _1ddju40 = function _compile_and_update(compile,runtime,realize,repositionSetElement)
 {
-    return (source, variables = [], cell) => {
+    return async (source, variables = [], cell) => {
         try {
-            debugger;
             let reposition = false, insertionIndex = -1;
             const newVariables = compile(source);
             if (!variables || variables.length !== newVariables.length) {
@@ -7506,10 +7499,10 @@ const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElemen
             if (reposition) {
                 insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
+            const fns = await realize(newVariables.map(v => v._definition), runtime);
             newVariables.forEach((v, i) => {
                 const variable = variables[i];
-                let _fn;
-                eval('_fn = ' + v._definition);
+                const _fn = fns[i];
                 if (v._name) {
                     variable.define(v._name, v._inputs, _fn);
                 } else {
@@ -7521,7 +7514,6 @@ const _nzhbow = function _compile_and_update(compile,runtime,repositionSetElemen
             return variables;
         } catch (e) {
             console.error(e);
-            debugger;
         }
     };
 };
@@ -7558,12 +7550,11 @@ Inputs.textarea({
 })
 )};
 const _b4rsn5 = (G, _) => G.input(_);
-const _t68yvv = function _98(Inputs,definition,variable,inputs){return(
+const _ga6kci = function _98(Inputs,definition,variable,realize,runtime,inputs){return(
 Inputs.button("update variable", {
   disabled: definition === variable._definition.toString(),
-  reduce: () => {
-    let _fn;
-    eval("_fn = " + definition);
+  reduce: async () => {
+    const [_fn] = await realize([definition], runtime);
     variable.define(variable._name, inputs, _fn);
   }
 })
@@ -7613,7 +7604,7 @@ export default function define(runtime, observer) {
   main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
   main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
   $def("_hdieof", "editors", [], _hdieof);  
-  $def("_ye6ey", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","TRACE_CELL","editors","cellEditor"], _ye6ey);  
+  $def("_ipx6cz", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","editors","cellEditor"], _ipx6cz);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
   $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
   $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
@@ -7631,7 +7622,7 @@ export default function define(runtime, observer) {
   $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
   $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
-  $def("_kyzl8l", null, ["selectVariable","hotbarTemplate"], _kyzl8l);  
+  $def("_mri5h3", null, ["selectVariable","hotbarTemplate"], _mri5h3);  
   $def("_49mpmh", "hotbar", ["viewof edit","Event","setOption","viewof editedCell","htl","edit","toolbar","nav","reversibleAttach","combine","code_editor"], _49mpmh);  
   $def("_1uohwj8", null, ["viewof editedCell"], _1uohwj8);  
   $def("_jqia2f", null, ["nav","editedCell"], _jqia2f);  
@@ -7676,7 +7667,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_geoudp", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","findCellIndex","viewof liveCellMap","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _geoudp);  
+  $def("_2pkmxz", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","viewof liveCellMap","findCellIndex","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command"], _2pkmxz);  
   $def("_1jadxoe", null, ["md"], _1jadxoe);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -7714,7 +7705,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_argpju", null, ["md"], _argpju);  
-  $def("_nzhbow", "compile_and_update", ["compile","runtime","repositionSetElement"], _nzhbow);  
+  $def("_1ddju40", "compile_and_update", ["compile","runtime","realize","repositionSetElement"], _1ddju40);  
   $def("_1jqs8in", null, ["md"], _1jqs8in);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1n8o4pt", null, ["md"], _1n8o4pt);  
@@ -7724,8 +7715,9 @@ export default function define(runtime, observer) {
   $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
   $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
   $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
-  $def("_t68yvv", null, ["Inputs","definition","variable","inputs"], _t68yvv);  
+  $def("_ga6kci", null, ["Inputs","definition","variable","realize","runtime","inputs"], _ga6kci);  
   $def("_1q557s", null, ["md"], _1q557s);  
+  main.define("realize", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("realize", _));  
   main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
@@ -7761,7 +7753,8 @@ export default function define(runtime, observer) {
   main.define("navHref", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("navHref", _));  
   main.define("cellsToClipboard", ["module @tomlarkworthy/cells-to-clipboard", "@variable"], (_, v) => v.import("cellsToClipboard", _));
   return main;
-}</script>
+}
+</script>
 <script id="@tomlarkworthy/escodegen/escodegen.browser.min.js.gz" 
   type="text/plain"
   data-encoding="base64"


### PR DESCRIPTION
Fixes tomlarkworthy/lopecode#163.

**This PR is a proposal** — the canonical HTML has been updated with the new `command_processor` cell, but ObservableHQ has not been pushed and consumer notebooks have not been re-synced yet. After approval, those steps will run and additional commits will be pushed to this branch.

## Root cause

`moveCell` correctly moves the focused cell by exactly one logical position in `liveCellMap`, but cells in editor-5 have wildly varying heights (some embed 500+ px iframes for documentation/examples). When the user clicks ⬆ on a cell adjacent to a tall doc cell, the focused cell jumps hundreds of pixels visually and the user thinks the move is broken — even though the runtime mutation is exactly one position.

Confirmed by reproduction in worktree: a fresh cell created after `title` (a 560 px-tall doc cell) and moved up by ⬆ landed at viewport y=21 from y=615, a 594 px jump consistent with the user's report (y=649 → y=55).

## Fix

After the runtime reorder, capture the cell DOM's pre-move screen position, poll for the visualizer's reactive DOM reorder (setTimeout, not raf — the syncers chain runs on macrotasks), then scroll the editor pane by the resulting delta so the moved cell stays put on screen while its neighbours shift around it. The user's cursor stays on the toolbar, ⬆/⬇ chaining works, and at content boundaries `scrollBy` clamps so the cell ends up at the boundary — still visible.

Also wrap the entire move branch in a `targetCell` guard so a click at the top/bottom boundary is a silent no-op rather than a `TypeError`.

## Targeted QA (live runtime against the canonical HTML)

| scenario | preY | postY | scroll Δ | screen Δ |
|----------|------|-------|----------|----------|
| Mid-pane move ⬆ on cell at idx ~50 (with title above) | 401 | 401 | -317 | **0** ✅ |
| Top-of-content move ⬆ on cell adjacent to title | 615 | 21 | 0 (clamped) | -594 (cell visible at top) |

Console: clean, no errors after move.

## What this PR does *not* address

- The "phantom close hotbar" the issue body mentions as case (3) — I could not reproduce it in this scenario; the cell-editor `auto_attach` re-placed the editor next to the moved cell correctly. If it remains an issue under the user's exact `▶️`-then-⬆ sequence, it'll need a separate investigation.
- The "new cell ends up at y=641 instead of adjacent to title" remark in the issue is a side effect of `title` being a 560 px doc cell — the new cell *is* adjacent to it in cellMap; the visual gap is content height, not a positioning bug.