### PR TITLE
Sync re-jumpgated editable-md into consumers

### DIFF
--- a/notebooks/@tomlarkworthy_lopecode-tour.html
+++ b/notebooks/@tomlarkworthy_lopecode-tour.html
@@ -5849,7 +5849,7 @@ md`## Known Issues
 
 - escaped tagged template literal lose their escaping if they are not in a code block. This is due to \`prosemirror.defaultMarkdownParser.parse(markdown)\` removing redundant escapes. We should probably make template placeholders a 1st class concept but as there is an easy work around of putting them in a code fence it is enough for now. (see [\`test_defaultMarkdownParser_preserves_escapes\`](#test_defaultMarkdownParser_preserves_escapes))`
 )};
-const _1a2tzk1 = function _md(editor_theme_css,prosemirror,Element,randstr,originalMd,markdownToMdTagged,compile,runtime,decompile,mdCellSourceToMarkdown,invalidation)
+const _1llvbnw = function _md(editor_theme_css,prosemirror,Element,randstr,originalMd,markdownToMdTagged,compile,runtime,decompile,mdCellSourceToMarkdown,invalidation)
 {
   // Force the theme override stylesheet to be evaluated and inserted.
   editor_theme_css;
@@ -5870,27 +5870,26 @@ const _1a2tzk1 = function _md(editor_theme_css,prosemirror,Element,randstr,origi
     ]]).concat(menuItems.blockMenu);
   // Copied and adjusted from exampleSetup.
   const blockQuoteRule = type => prosemirror.wrappingInputRule(/^\s*>\s$/, type);
-  const orderedListRule = type => prosemirror.wrappingInputRule(
-    /^(\d+)\.\s$/,
-    type,
-    m => ({ order: +m[1] }),
-    (m, n) => n.childCount + n.attrs.order == +m[1]
-  );
+  const orderedListRule = type => prosemirror.wrappingInputRule(/^(\d+)\.\s$/, type, m => ({ order: +m[1] }), (m, n) => n.childCount + n.attrs.order == +m[1]);
   const bulletListRule = type => prosemirror.wrappingInputRule(/^\s*([-+*])\s$/, type);
   const codeBlockRule = type => prosemirror.textblockTypeInputRule(/^```$/, type);
-  const headingRule = (type, maxLevel) => prosemirror.textblockTypeInputRule(
-    new RegExp('^(#{1,' + maxLevel + '})\\s$'),
-    type,
-    m => ({ level: m[1].length })
-  );
+  const headingRule = (type, maxLevel) => prosemirror.textblockTypeInputRule(new RegExp('^(#{1,' + maxLevel + '})\\s$'), type, m => ({ level: m[1].length }));
   const buildEditorInputRules = schema => {
-    const rules = [prosemirror.ellipsis, prosemirror.emDash];
+    const rules = [
+      prosemirror.ellipsis,
+      prosemirror.emDash
+    ];
     let type;
-    if ((type = schema.nodes.blockquote)) rules.push(blockQuoteRule(type));
-    if ((type = schema.nodes.ordered_list)) rules.push(orderedListRule(type));
-    if ((type = schema.nodes.bullet_list)) rules.push(bulletListRule(type));
-    if ((type = schema.nodes.code_block)) rules.push(codeBlockRule(type));
-    if ((type = schema.nodes.heading)) rules.push(headingRule(type, 6));
+    if (type = schema.nodes.blockquote)
+      rules.push(blockQuoteRule(type));
+    if (type = schema.nodes.ordered_list)
+      rules.push(orderedListRule(type));
+    if (type = schema.nodes.bullet_list)
+      rules.push(bulletListRule(type));
+    if (type = schema.nodes.code_block)
+      rules.push(codeBlockRule(type));
+    if (type = schema.nodes.heading)
+      rules.push(headingRule(type, 6));
     return prosemirror.inputRules({ rules });
   };
   const editorPlugins = [
@@ -5899,11 +5898,12 @@ const _1a2tzk1 = function _md(editor_theme_css,prosemirror,Element,randstr,origi
     prosemirror.keymap(prosemirror.baseKeymap),
     prosemirror.dropCursor(),
     prosemirror.gapCursor(),
-    prosemirror.menuBar({ floating: true, content: menuContent }),
+    prosemirror.menuBar({
+      floating: true,
+      content: menuContent
+    }),
     prosemirror.history(),
-    new prosemirror.Plugin({
-      props: { attributes: { class: 'ProseMirror-example-setup-style' } }
-    })
+    new prosemirror.Plugin({ props: { attributes: { class: 'ProseMirror-example-setup-style' } } })
   ];
   const isInteractiveTarget = (event, root) => {
     if (!event || !root)
@@ -6276,7 +6276,7 @@ export default function define(runtime, observer) {
   $def("_t5sezz", null, ["md"], _t5sezz);  
   $def("_1lfncpk", null, ["title"], _1lfncpk);  
   $def("_u4o7gp", null, ["md"], _u4o7gp);  
-  $def("_1a2tzk1", "md", ["editor_theme_css","prosemirror","Element","randstr","originalMd","markdownToMdTagged","compile","runtime","decompile","mdCellSourceToMarkdown","invalidation"], _1a2tzk1);  
+  $def("_1llvbnw", "md", ["editor_theme_css","prosemirror","Element","randstr","originalMd","markdownToMdTagged","compile","runtime","decompile","mdCellSourceToMarkdown","invalidation"], _1llvbnw);  
   $def("_etlb83", "irToEditableText", [], _etlb83);  
   $def("_bpew19", "replaceArgPlaceholders", [], _bpew19);  
   main.define("exporter", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("exporter", _));  

--- a/notebooks/@tomlarkworthy_lopecode-vision.html
+++ b/notebooks/@tomlarkworthy_lopecode-vision.html
@@ -5849,7 +5849,7 @@ md`## Known Issues
 
 - escaped tagged template literal lose their escaping if they are not in a code block. This is due to \`prosemirror.defaultMarkdownParser.parse(markdown)\` removing redundant escapes. We should probably make template placeholders a 1st class concept but as there is an easy work around of putting them in a code fence it is enough for now. (see [\`test_defaultMarkdownParser_preserves_escapes\`](#test_defaultMarkdownParser_preserves_escapes))`
 )};
-const _1a2tzk1 = function _md(editor_theme_css,prosemirror,Element,randstr,originalMd,markdownToMdTagged,compile,runtime,decompile,mdCellSourceToMarkdown,invalidation)
+const _1llvbnw = function _md(editor_theme_css,prosemirror,Element,randstr,originalMd,markdownToMdTagged,compile,runtime,decompile,mdCellSourceToMarkdown,invalidation)
 {
   // Force the theme override stylesheet to be evaluated and inserted.
   editor_theme_css;
@@ -5870,27 +5870,26 @@ const _1a2tzk1 = function _md(editor_theme_css,prosemirror,Element,randstr,origi
     ]]).concat(menuItems.blockMenu);
   // Copied and adjusted from exampleSetup.
   const blockQuoteRule = type => prosemirror.wrappingInputRule(/^\s*>\s$/, type);
-  const orderedListRule = type => prosemirror.wrappingInputRule(
-    /^(\d+)\.\s$/,
-    type,
-    m => ({ order: +m[1] }),
-    (m, n) => n.childCount + n.attrs.order == +m[1]
-  );
+  const orderedListRule = type => prosemirror.wrappingInputRule(/^(\d+)\.\s$/, type, m => ({ order: +m[1] }), (m, n) => n.childCount + n.attrs.order == +m[1]);
   const bulletListRule = type => prosemirror.wrappingInputRule(/^\s*([-+*])\s$/, type);
   const codeBlockRule = type => prosemirror.textblockTypeInputRule(/^```$/, type);
-  const headingRule = (type, maxLevel) => prosemirror.textblockTypeInputRule(
-    new RegExp('^(#{1,' + maxLevel + '})\\s$'),
-    type,
-    m => ({ level: m[1].length })
-  );
+  const headingRule = (type, maxLevel) => prosemirror.textblockTypeInputRule(new RegExp('^(#{1,' + maxLevel + '})\\s$'), type, m => ({ level: m[1].length }));
   const buildEditorInputRules = schema => {
-    const rules = [prosemirror.ellipsis, prosemirror.emDash];
+    const rules = [
+      prosemirror.ellipsis,
+      prosemirror.emDash
+    ];
     let type;
-    if ((type = schema.nodes.blockquote)) rules.push(blockQuoteRule(type));
-    if ((type = schema.nodes.ordered_list)) rules.push(orderedListRule(type));
-    if ((type = schema.nodes.bullet_list)) rules.push(bulletListRule(type));
-    if ((type = schema.nodes.code_block)) rules.push(codeBlockRule(type));
-    if ((type = schema.nodes.heading)) rules.push(headingRule(type, 6));
+    if (type = schema.nodes.blockquote)
+      rules.push(blockQuoteRule(type));
+    if (type = schema.nodes.ordered_list)
+      rules.push(orderedListRule(type));
+    if (type = schema.nodes.bullet_list)
+      rules.push(bulletListRule(type));
+    if (type = schema.nodes.code_block)
+      rules.push(codeBlockRule(type));
+    if (type = schema.nodes.heading)
+      rules.push(headingRule(type, 6));
     return prosemirror.inputRules({ rules });
   };
   const editorPlugins = [
@@ -5899,11 +5898,12 @@ const _1a2tzk1 = function _md(editor_theme_css,prosemirror,Element,randstr,origi
     prosemirror.keymap(prosemirror.baseKeymap),
     prosemirror.dropCursor(),
     prosemirror.gapCursor(),
-    prosemirror.menuBar({ floating: true, content: menuContent }),
+    prosemirror.menuBar({
+      floating: true,
+      content: menuContent
+    }),
     prosemirror.history(),
-    new prosemirror.Plugin({
-      props: { attributes: { class: 'ProseMirror-example-setup-style' } }
-    })
+    new prosemirror.Plugin({ props: { attributes: { class: 'ProseMirror-example-setup-style' } } })
   ];
   const isInteractiveTarget = (event, root) => {
     if (!event || !root)
@@ -6276,7 +6276,7 @@ export default function define(runtime, observer) {
   $def("_t5sezz", null, ["md"], _t5sezz);  
   $def("_1lfncpk", null, ["title"], _1lfncpk);  
   $def("_u4o7gp", null, ["md"], _u4o7gp);  
-  $def("_1a2tzk1", "md", ["editor_theme_css","prosemirror","Element","randstr","originalMd","markdownToMdTagged","compile","runtime","decompile","mdCellSourceToMarkdown","invalidation"], _1a2tzk1);  
+  $def("_1llvbnw", "md", ["editor_theme_css","prosemirror","Element","randstr","originalMd","markdownToMdTagged","compile","runtime","decompile","mdCellSourceToMarkdown","invalidation"], _1llvbnw);  
   $def("_etlb83", "irToEditableText", [], _etlb83);  
   $def("_bpew19", "replaceArgPlaceholders", [], _bpew19);  
   main.define("exporter", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("exporter", _));  


### PR DESCRIPTION
Picks up the tighter `@tomlarkworthy/editable-md` bundle and stale-debugger cleanup from [lopebooks#96](https://github.com/tomlarkworthy/lopebooks/pull/96).

🤖 Generated with [Claude Code](https://claude.com/claude-code)