### PR TITLE
Fix: import cell collides with pre-existing module @X

### DIFF
--- a/notebooks/@tomlarkworthy_atlas.html
+++ b/notebooks/@tomlarkworthy_atlas.html
@@ -7872,47 +7872,63 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _1whoy5n = function _91(md){return(
 md`### Apply Update`
 )};
-const _2dqvsk = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
+const _1hyx2tv = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
 {
-    return async (source, variables = [], cell) => {
-        try {
-            let reposition = false, insertionIndex = -1;
-            const newVariables = compile(source);
-            if (!variables || variables.length !== newVariables.length) {
-                reposition = true;
-                variables.forEach(v => v.delete());
-                variables.length = 0;
-                for (let i = 0; i < newVariables.length; i++) {
-                    const newVariable = cell.module.module.variable({});
-                    // Assign a random pid up-front so blank/identical new cells don't
-                    // collide via persistentId's contentHash. See lopecode#144.
-                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
-                    variables.push(newVariable);
-                }
-            }
-            if (reposition) {
-                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-            }
-            const fns = await realize(newVariables.map(v => v._definition), runtime);
-            newVariables.forEach((v, i) => {
-                const variable = variables[i];
-                const _fn = fns[i];
-                if (v._name) {
-                    variable.define(v._name, v._inputs, _fn);
-                } else {
-                    variable.define(v._inputs, _fn);
-                }
-                if (reposition)
-                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
-            });
-            // Return the canonical decompiled source so the caller can push it
-            // back into its editor view if it has one. No caller currently uses
-            // the variables array directly.
-            return await decompile(variables);
-        } catch (e) {
-            console.error(e);
+  return async (source, variables = [], cell) => {
+    try {
+      const newVariables = compile(source);
+      // Skip emitting `module @X` if one already exists in the target
+      // module's scope and isn't one of OUR old variables. Without this,
+      // the second define() collides on the shared name and Observable
+      // rewrites BOTH the new and pre-existing module variables to a
+      // "defined more than once" thrower, breaking every pre-existing
+      // consumer of `@X` in the module. The new import-name bindings
+      // reference `module @X` by name and resolve to whatever module
+      // variable is currently in scope.
+      const targetScope = cell.module.module._scope;
+      const ourOldNames = new Set(variables.map(v => v._name));
+      const isModuleImport = nv => nv._name?.startsWith('module @') && nv._inputs.length === 0;
+      const shouldSkip = nv => isModuleImport(nv) && targetScope.has(nv._name) && !ourOldNames.has(nv._name);
+      const allocation = newVariables.map(nv => shouldSkip(nv) ? { reuse: targetScope.get(nv._name) } : { fresh: nv });
+      const freshNewVariables = allocation.filter(a => a.fresh).map(a => a.fresh);
+      let reposition = false, insertionIndex = -1;
+      if (!variables || variables.length !== freshNewVariables.length) {
+        reposition = true;
+        variables.forEach(v => v.delete());
+        variables.length = 0;
+        for (let i = 0; i < freshNewVariables.length; i++) {
+          const newVariable = cell.module.module.variable({});
+          // Assign a random pid up-front so blank/identical new cells don't
+          // collide via persistentId's contentHash. See lopecode#144.
+          newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+          variables.push(newVariable);
         }
-    };
+      }
+      if (reposition) {
+        insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
+      }
+      const fns = await realize(freshNewVariables.map(v => v._definition), runtime);
+      freshNewVariables.forEach((v, i) => {
+        const variable = variables[i];
+        const _fn = fns[i];
+        if (v._name) {
+          variable.define(v._name, v._inputs, _fn);
+        } else {
+          variable.define(v._inputs, _fn);
+        }
+        if (reposition)
+          repositionSetElement(runtime._variables, variable, insertionIndex + i);
+      });
+      // Build the full variable set for decompile, mixing reused module-import
+      // variables with the freshly-defined runtime variables, in the same order
+      // as `allocation`.
+      let freshIdx = 0;
+      const decompileVars = allocation.map(a => a.reuse ? a.reuse : variables[freshIdx++]);
+      return await decompile(decompileVars);
+    } catch (e) {
+      console.error(e);
+    }
+  };
 };
 const _1g3bdxp = function _93(md){return(
 md`### Remove Cells`
@@ -8097,7 +8113,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_1whoy5n", null, ["md"], _1whoy5n);  
-  $def("_2dqvsk", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _2dqvsk);  
+  $def("_1hyx2tv", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _1hyx2tv);  
   $def("_1g3bdxp", null, ["md"], _1g3bdxp);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1qb4uz", null, ["md"], _1qb4uz);  

--- a/notebooks/@tomlarkworthy_atproto-comments.html
+++ b/notebooks/@tomlarkworthy_atproto-comments.html
@@ -7043,47 +7043,63 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _1whoy5n = function _91(md){return(
 md`### Apply Update`
 )};
-const _2dqvsk = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
+const _1hyx2tv = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
 {
-    return async (source, variables = [], cell) => {
-        try {
-            let reposition = false, insertionIndex = -1;
-            const newVariables = compile(source);
-            if (!variables || variables.length !== newVariables.length) {
-                reposition = true;
-                variables.forEach(v => v.delete());
-                variables.length = 0;
-                for (let i = 0; i < newVariables.length; i++) {
-                    const newVariable = cell.module.module.variable({});
-                    // Assign a random pid up-front so blank/identical new cells don't
-                    // collide via persistentId's contentHash. See lopecode#144.
-                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
-                    variables.push(newVariable);
-                }
-            }
-            if (reposition) {
-                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-            }
-            const fns = await realize(newVariables.map(v => v._definition), runtime);
-            newVariables.forEach((v, i) => {
-                const variable = variables[i];
-                const _fn = fns[i];
-                if (v._name) {
-                    variable.define(v._name, v._inputs, _fn);
-                } else {
-                    variable.define(v._inputs, _fn);
-                }
-                if (reposition)
-                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
-            });
-            // Return the canonical decompiled source so the caller can push it
-            // back into its editor view if it has one. No caller currently uses
-            // the variables array directly.
-            return await decompile(variables);
-        } catch (e) {
-            console.error(e);
+  return async (source, variables = [], cell) => {
+    try {
+      const newVariables = compile(source);
+      // Skip emitting `module @X` if one already exists in the target
+      // module's scope and isn't one of OUR old variables. Without this,
+      // the second define() collides on the shared name and Observable
+      // rewrites BOTH the new and pre-existing module variables to a
+      // "defined more than once" thrower, breaking every pre-existing
+      // consumer of `@X` in the module. The new import-name bindings
+      // reference `module @X` by name and resolve to whatever module
+      // variable is currently in scope.
+      const targetScope = cell.module.module._scope;
+      const ourOldNames = new Set(variables.map(v => v._name));
+      const isModuleImport = nv => nv._name?.startsWith('module @') && nv._inputs.length === 0;
+      const shouldSkip = nv => isModuleImport(nv) && targetScope.has(nv._name) && !ourOldNames.has(nv._name);
+      const allocation = newVariables.map(nv => shouldSkip(nv) ? { reuse: targetScope.get(nv._name) } : { fresh: nv });
+      const freshNewVariables = allocation.filter(a => a.fresh).map(a => a.fresh);
+      let reposition = false, insertionIndex = -1;
+      if (!variables || variables.length !== freshNewVariables.length) {
+        reposition = true;
+        variables.forEach(v => v.delete());
+        variables.length = 0;
+        for (let i = 0; i < freshNewVariables.length; i++) {
+          const newVariable = cell.module.module.variable({});
+          // Assign a random pid up-front so blank/identical new cells don't
+          // collide via persistentId's contentHash. See lopecode#144.
+          newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+          variables.push(newVariable);
         }
-    };
+      }
+      if (reposition) {
+        insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
+      }
+      const fns = await realize(freshNewVariables.map(v => v._definition), runtime);
+      freshNewVariables.forEach((v, i) => {
+        const variable = variables[i];
+        const _fn = fns[i];
+        if (v._name) {
+          variable.define(v._name, v._inputs, _fn);
+        } else {
+          variable.define(v._inputs, _fn);
+        }
+        if (reposition)
+          repositionSetElement(runtime._variables, variable, insertionIndex + i);
+      });
+      // Build the full variable set for decompile, mixing reused module-import
+      // variables with the freshly-defined runtime variables, in the same order
+      // as `allocation`.
+      let freshIdx = 0;
+      const decompileVars = allocation.map(a => a.reuse ? a.reuse : variables[freshIdx++]);
+      return await decompile(decompileVars);
+    } catch (e) {
+      console.error(e);
+    }
+  };
 };
 const _1g3bdxp = function _93(md){return(
 md`### Remove Cells`
@@ -7268,7 +7284,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_1whoy5n", null, ["md"], _1whoy5n);  
-  $def("_2dqvsk", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _2dqvsk);  
+  $def("_1hyx2tv", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _1hyx2tv);  
   $def("_1g3bdxp", null, ["md"], _1g3bdxp);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1qb4uz", null, ["md"], _1qb4uz);  

--- a/notebooks/@tomlarkworthy_blank-notebook.html
+++ b/notebooks/@tomlarkworthy_blank-notebook.html
@@ -6934,47 +6934,63 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _1whoy5n = function _91(md){return(
 md`### Apply Update`
 )};
-const _2dqvsk = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
+const _1hyx2tv = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
 {
-    return async (source, variables = [], cell) => {
-        try {
-            let reposition = false, insertionIndex = -1;
-            const newVariables = compile(source);
-            if (!variables || variables.length !== newVariables.length) {
-                reposition = true;
-                variables.forEach(v => v.delete());
-                variables.length = 0;
-                for (let i = 0; i < newVariables.length; i++) {
-                    const newVariable = cell.module.module.variable({});
-                    // Assign a random pid up-front so blank/identical new cells don't
-                    // collide via persistentId's contentHash. See lopecode#144.
-                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
-                    variables.push(newVariable);
-                }
-            }
-            if (reposition) {
-                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-            }
-            const fns = await realize(newVariables.map(v => v._definition), runtime);
-            newVariables.forEach((v, i) => {
-                const variable = variables[i];
-                const _fn = fns[i];
-                if (v._name) {
-                    variable.define(v._name, v._inputs, _fn);
-                } else {
-                    variable.define(v._inputs, _fn);
-                }
-                if (reposition)
-                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
-            });
-            // Return the canonical decompiled source so the caller can push it
-            // back into its editor view if it has one. No caller currently uses
-            // the variables array directly.
-            return await decompile(variables);
-        } catch (e) {
-            console.error(e);
+  return async (source, variables = [], cell) => {
+    try {
+      const newVariables = compile(source);
+      // Skip emitting `module @X` if one already exists in the target
+      // module's scope and isn't one of OUR old variables. Without this,
+      // the second define() collides on the shared name and Observable
+      // rewrites BOTH the new and pre-existing module variables to a
+      // "defined more than once" thrower, breaking every pre-existing
+      // consumer of `@X` in the module. The new import-name bindings
+      // reference `module @X` by name and resolve to whatever module
+      // variable is currently in scope.
+      const targetScope = cell.module.module._scope;
+      const ourOldNames = new Set(variables.map(v => v._name));
+      const isModuleImport = nv => nv._name?.startsWith('module @') && nv._inputs.length === 0;
+      const shouldSkip = nv => isModuleImport(nv) && targetScope.has(nv._name) && !ourOldNames.has(nv._name);
+      const allocation = newVariables.map(nv => shouldSkip(nv) ? { reuse: targetScope.get(nv._name) } : { fresh: nv });
+      const freshNewVariables = allocation.filter(a => a.fresh).map(a => a.fresh);
+      let reposition = false, insertionIndex = -1;
+      if (!variables || variables.length !== freshNewVariables.length) {
+        reposition = true;
+        variables.forEach(v => v.delete());
+        variables.length = 0;
+        for (let i = 0; i < freshNewVariables.length; i++) {
+          const newVariable = cell.module.module.variable({});
+          // Assign a random pid up-front so blank/identical new cells don't
+          // collide via persistentId's contentHash. See lopecode#144.
+          newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+          variables.push(newVariable);
         }
-    };
+      }
+      if (reposition) {
+        insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
+      }
+      const fns = await realize(freshNewVariables.map(v => v._definition), runtime);
+      freshNewVariables.forEach((v, i) => {
+        const variable = variables[i];
+        const _fn = fns[i];
+        if (v._name) {
+          variable.define(v._name, v._inputs, _fn);
+        } else {
+          variable.define(v._inputs, _fn);
+        }
+        if (reposition)
+          repositionSetElement(runtime._variables, variable, insertionIndex + i);
+      });
+      // Build the full variable set for decompile, mixing reused module-import
+      // variables with the freshly-defined runtime variables, in the same order
+      // as `allocation`.
+      let freshIdx = 0;
+      const decompileVars = allocation.map(a => a.reuse ? a.reuse : variables[freshIdx++]);
+      return await decompile(decompileVars);
+    } catch (e) {
+      console.error(e);
+    }
+  };
 };
 const _1g3bdxp = function _93(md){return(
 md`### Remove Cells`
@@ -7159,7 +7175,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_1whoy5n", null, ["md"], _1whoy5n);  
-  $def("_2dqvsk", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _2dqvsk);  
+  $def("_1hyx2tv", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _1hyx2tv);  
   $def("_1g3bdxp", null, ["md"], _1g3bdxp);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1qb4uz", null, ["md"], _1qb4uz);  

--- a/notebooks/@tomlarkworthy_bootloader.html
+++ b/notebooks/@tomlarkworthy_bootloader.html
@@ -7151,47 +7151,63 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _1whoy5n = function _91(md){return(
 md`### Apply Update`
 )};
-const _2dqvsk = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
+const _1hyx2tv = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
 {
-    return async (source, variables = [], cell) => {
-        try {
-            let reposition = false, insertionIndex = -1;
-            const newVariables = compile(source);
-            if (!variables || variables.length !== newVariables.length) {
-                reposition = true;
-                variables.forEach(v => v.delete());
-                variables.length = 0;
-                for (let i = 0; i < newVariables.length; i++) {
-                    const newVariable = cell.module.module.variable({});
-                    // Assign a random pid up-front so blank/identical new cells don't
-                    // collide via persistentId's contentHash. See lopecode#144.
-                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
-                    variables.push(newVariable);
-                }
-            }
-            if (reposition) {
-                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-            }
-            const fns = await realize(newVariables.map(v => v._definition), runtime);
-            newVariables.forEach((v, i) => {
-                const variable = variables[i];
-                const _fn = fns[i];
-                if (v._name) {
-                    variable.define(v._name, v._inputs, _fn);
-                } else {
-                    variable.define(v._inputs, _fn);
-                }
-                if (reposition)
-                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
-            });
-            // Return the canonical decompiled source so the caller can push it
-            // back into its editor view if it has one. No caller currently uses
-            // the variables array directly.
-            return await decompile(variables);
-        } catch (e) {
-            console.error(e);
+  return async (source, variables = [], cell) => {
+    try {
+      const newVariables = compile(source);
+      // Skip emitting `module @X` if one already exists in the target
+      // module's scope and isn't one of OUR old variables. Without this,
+      // the second define() collides on the shared name and Observable
+      // rewrites BOTH the new and pre-existing module variables to a
+      // "defined more than once" thrower, breaking every pre-existing
+      // consumer of `@X` in the module. The new import-name bindings
+      // reference `module @X` by name and resolve to whatever module
+      // variable is currently in scope.
+      const targetScope = cell.module.module._scope;
+      const ourOldNames = new Set(variables.map(v => v._name));
+      const isModuleImport = nv => nv._name?.startsWith('module @') && nv._inputs.length === 0;
+      const shouldSkip = nv => isModuleImport(nv) && targetScope.has(nv._name) && !ourOldNames.has(nv._name);
+      const allocation = newVariables.map(nv => shouldSkip(nv) ? { reuse: targetScope.get(nv._name) } : { fresh: nv });
+      const freshNewVariables = allocation.filter(a => a.fresh).map(a => a.fresh);
+      let reposition = false, insertionIndex = -1;
+      if (!variables || variables.length !== freshNewVariables.length) {
+        reposition = true;
+        variables.forEach(v => v.delete());
+        variables.length = 0;
+        for (let i = 0; i < freshNewVariables.length; i++) {
+          const newVariable = cell.module.module.variable({});
+          // Assign a random pid up-front so blank/identical new cells don't
+          // collide via persistentId's contentHash. See lopecode#144.
+          newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+          variables.push(newVariable);
         }
-    };
+      }
+      if (reposition) {
+        insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
+      }
+      const fns = await realize(freshNewVariables.map(v => v._definition), runtime);
+      freshNewVariables.forEach((v, i) => {
+        const variable = variables[i];
+        const _fn = fns[i];
+        if (v._name) {
+          variable.define(v._name, v._inputs, _fn);
+        } else {
+          variable.define(v._inputs, _fn);
+        }
+        if (reposition)
+          repositionSetElement(runtime._variables, variable, insertionIndex + i);
+      });
+      // Build the full variable set for decompile, mixing reused module-import
+      // variables with the freshly-defined runtime variables, in the same order
+      // as `allocation`.
+      let freshIdx = 0;
+      const decompileVars = allocation.map(a => a.reuse ? a.reuse : variables[freshIdx++]);
+      return await decompile(decompileVars);
+    } catch (e) {
+      console.error(e);
+    }
+  };
 };
 const _1g3bdxp = function _93(md){return(
 md`### Remove Cells`
@@ -7376,7 +7392,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_1whoy5n", null, ["md"], _1whoy5n);  
-  $def("_2dqvsk", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _2dqvsk);  
+  $def("_1hyx2tv", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _1hyx2tv);  
   $def("_1g3bdxp", null, ["md"], _1g3bdxp);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1qb4uz", null, ["md"], _1qb4uz);  

--- a/notebooks/@tomlarkworthy_cells-to-clipboard.html
+++ b/notebooks/@tomlarkworthy_cells-to-clipboard.html
@@ -6901,47 +6901,63 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _1whoy5n = function _91(md){return(
 md`### Apply Update`
 )};
-const _2dqvsk = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
+const _1hyx2tv = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
 {
-    return async (source, variables = [], cell) => {
-        try {
-            let reposition = false, insertionIndex = -1;
-            const newVariables = compile(source);
-            if (!variables || variables.length !== newVariables.length) {
-                reposition = true;
-                variables.forEach(v => v.delete());
-                variables.length = 0;
-                for (let i = 0; i < newVariables.length; i++) {
-                    const newVariable = cell.module.module.variable({});
-                    // Assign a random pid up-front so blank/identical new cells don't
-                    // collide via persistentId's contentHash. See lopecode#144.
-                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
-                    variables.push(newVariable);
-                }
-            }
-            if (reposition) {
-                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-            }
-            const fns = await realize(newVariables.map(v => v._definition), runtime);
-            newVariables.forEach((v, i) => {
-                const variable = variables[i];
-                const _fn = fns[i];
-                if (v._name) {
-                    variable.define(v._name, v._inputs, _fn);
-                } else {
-                    variable.define(v._inputs, _fn);
-                }
-                if (reposition)
-                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
-            });
-            // Return the canonical decompiled source so the caller can push it
-            // back into its editor view if it has one. No caller currently uses
-            // the variables array directly.
-            return await decompile(variables);
-        } catch (e) {
-            console.error(e);
+  return async (source, variables = [], cell) => {
+    try {
+      const newVariables = compile(source);
+      // Skip emitting `module @X` if one already exists in the target
+      // module's scope and isn't one of OUR old variables. Without this,
+      // the second define() collides on the shared name and Observable
+      // rewrites BOTH the new and pre-existing module variables to a
+      // "defined more than once" thrower, breaking every pre-existing
+      // consumer of `@X` in the module. The new import-name bindings
+      // reference `module @X` by name and resolve to whatever module
+      // variable is currently in scope.
+      const targetScope = cell.module.module._scope;
+      const ourOldNames = new Set(variables.map(v => v._name));
+      const isModuleImport = nv => nv._name?.startsWith('module @') && nv._inputs.length === 0;
+      const shouldSkip = nv => isModuleImport(nv) && targetScope.has(nv._name) && !ourOldNames.has(nv._name);
+      const allocation = newVariables.map(nv => shouldSkip(nv) ? { reuse: targetScope.get(nv._name) } : { fresh: nv });
+      const freshNewVariables = allocation.filter(a => a.fresh).map(a => a.fresh);
+      let reposition = false, insertionIndex = -1;
+      if (!variables || variables.length !== freshNewVariables.length) {
+        reposition = true;
+        variables.forEach(v => v.delete());
+        variables.length = 0;
+        for (let i = 0; i < freshNewVariables.length; i++) {
+          const newVariable = cell.module.module.variable({});
+          // Assign a random pid up-front so blank/identical new cells don't
+          // collide via persistentId's contentHash. See lopecode#144.
+          newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+          variables.push(newVariable);
         }
-    };
+      }
+      if (reposition) {
+        insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
+      }
+      const fns = await realize(freshNewVariables.map(v => v._definition), runtime);
+      freshNewVariables.forEach((v, i) => {
+        const variable = variables[i];
+        const _fn = fns[i];
+        if (v._name) {
+          variable.define(v._name, v._inputs, _fn);
+        } else {
+          variable.define(v._inputs, _fn);
+        }
+        if (reposition)
+          repositionSetElement(runtime._variables, variable, insertionIndex + i);
+      });
+      // Build the full variable set for decompile, mixing reused module-import
+      // variables with the freshly-defined runtime variables, in the same order
+      // as `allocation`.
+      let freshIdx = 0;
+      const decompileVars = allocation.map(a => a.reuse ? a.reuse : variables[freshIdx++]);
+      return await decompile(decompileVars);
+    } catch (e) {
+      console.error(e);
+    }
+  };
 };
 const _1g3bdxp = function _93(md){return(
 md`### Remove Cells`
@@ -7126,7 +7142,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_1whoy5n", null, ["md"], _1whoy5n);  
-  $def("_2dqvsk", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _2dqvsk);  
+  $def("_1hyx2tv", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _1hyx2tv);  
   $def("_1g3bdxp", null, ["md"], _1g3bdxp);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1qb4uz", null, ["md"], _1qb4uz);  

--- a/notebooks/@tomlarkworthy_claude-code-pairing.html
+++ b/notebooks/@tomlarkworthy_claude-code-pairing.html
@@ -6901,47 +6901,63 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _1whoy5n = function _91(md){return(
 md`### Apply Update`
 )};
-const _2dqvsk = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
+const _1hyx2tv = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
 {
-    return async (source, variables = [], cell) => {
-        try {
-            let reposition = false, insertionIndex = -1;
-            const newVariables = compile(source);
-            if (!variables || variables.length !== newVariables.length) {
-                reposition = true;
-                variables.forEach(v => v.delete());
-                variables.length = 0;
-                for (let i = 0; i < newVariables.length; i++) {
-                    const newVariable = cell.module.module.variable({});
-                    // Assign a random pid up-front so blank/identical new cells don't
-                    // collide via persistentId's contentHash. See lopecode#144.
-                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
-                    variables.push(newVariable);
-                }
-            }
-            if (reposition) {
-                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-            }
-            const fns = await realize(newVariables.map(v => v._definition), runtime);
-            newVariables.forEach((v, i) => {
-                const variable = variables[i];
-                const _fn = fns[i];
-                if (v._name) {
-                    variable.define(v._name, v._inputs, _fn);
-                } else {
-                    variable.define(v._inputs, _fn);
-                }
-                if (reposition)
-                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
-            });
-            // Return the canonical decompiled source so the caller can push it
-            // back into its editor view if it has one. No caller currently uses
-            // the variables array directly.
-            return await decompile(variables);
-        } catch (e) {
-            console.error(e);
+  return async (source, variables = [], cell) => {
+    try {
+      const newVariables = compile(source);
+      // Skip emitting `module @X` if one already exists in the target
+      // module's scope and isn't one of OUR old variables. Without this,
+      // the second define() collides on the shared name and Observable
+      // rewrites BOTH the new and pre-existing module variables to a
+      // "defined more than once" thrower, breaking every pre-existing
+      // consumer of `@X` in the module. The new import-name bindings
+      // reference `module @X` by name and resolve to whatever module
+      // variable is currently in scope.
+      const targetScope = cell.module.module._scope;
+      const ourOldNames = new Set(variables.map(v => v._name));
+      const isModuleImport = nv => nv._name?.startsWith('module @') && nv._inputs.length === 0;
+      const shouldSkip = nv => isModuleImport(nv) && targetScope.has(nv._name) && !ourOldNames.has(nv._name);
+      const allocation = newVariables.map(nv => shouldSkip(nv) ? { reuse: targetScope.get(nv._name) } : { fresh: nv });
+      const freshNewVariables = allocation.filter(a => a.fresh).map(a => a.fresh);
+      let reposition = false, insertionIndex = -1;
+      if (!variables || variables.length !== freshNewVariables.length) {
+        reposition = true;
+        variables.forEach(v => v.delete());
+        variables.length = 0;
+        for (let i = 0; i < freshNewVariables.length; i++) {
+          const newVariable = cell.module.module.variable({});
+          // Assign a random pid up-front so blank/identical new cells don't
+          // collide via persistentId's contentHash. See lopecode#144.
+          newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+          variables.push(newVariable);
         }
-    };
+      }
+      if (reposition) {
+        insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
+      }
+      const fns = await realize(freshNewVariables.map(v => v._definition), runtime);
+      freshNewVariables.forEach((v, i) => {
+        const variable = variables[i];
+        const _fn = fns[i];
+        if (v._name) {
+          variable.define(v._name, v._inputs, _fn);
+        } else {
+          variable.define(v._inputs, _fn);
+        }
+        if (reposition)
+          repositionSetElement(runtime._variables, variable, insertionIndex + i);
+      });
+      // Build the full variable set for decompile, mixing reused module-import
+      // variables with the freshly-defined runtime variables, in the same order
+      // as `allocation`.
+      let freshIdx = 0;
+      const decompileVars = allocation.map(a => a.reuse ? a.reuse : variables[freshIdx++]);
+      return await decompile(decompileVars);
+    } catch (e) {
+      console.error(e);
+    }
+  };
 };
 const _1g3bdxp = function _93(md){return(
 md`### Remove Cells`
@@ -7126,7 +7142,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_1whoy5n", null, ["md"], _1whoy5n);  
-  $def("_2dqvsk", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _2dqvsk);  
+  $def("_1hyx2tv", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _1hyx2tv);  
   $def("_1g3bdxp", null, ["md"], _1g3bdxp);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1qb4uz", null, ["md"], _1qb4uz);  

--- a/notebooks/@tomlarkworthy_codemirror-6-v2.html
+++ b/notebooks/@tomlarkworthy_codemirror-6-v2.html
@@ -6901,47 +6901,63 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _1whoy5n = function _91(md){return(
 md`### Apply Update`
 )};
-const _2dqvsk = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
+const _1hyx2tv = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
 {
-    return async (source, variables = [], cell) => {
-        try {
-            let reposition = false, insertionIndex = -1;
-            const newVariables = compile(source);
-            if (!variables || variables.length !== newVariables.length) {
-                reposition = true;
-                variables.forEach(v => v.delete());
-                variables.length = 0;
-                for (let i = 0; i < newVariables.length; i++) {
-                    const newVariable = cell.module.module.variable({});
-                    // Assign a random pid up-front so blank/identical new cells don't
-                    // collide via persistentId's contentHash. See lopecode#144.
-                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
-                    variables.push(newVariable);
-                }
-            }
-            if (reposition) {
-                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-            }
-            const fns = await realize(newVariables.map(v => v._definition), runtime);
-            newVariables.forEach((v, i) => {
-                const variable = variables[i];
-                const _fn = fns[i];
-                if (v._name) {
-                    variable.define(v._name, v._inputs, _fn);
-                } else {
-                    variable.define(v._inputs, _fn);
-                }
-                if (reposition)
-                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
-            });
-            // Return the canonical decompiled source so the caller can push it
-            // back into its editor view if it has one. No caller currently uses
-            // the variables array directly.
-            return await decompile(variables);
-        } catch (e) {
-            console.error(e);
+  return async (source, variables = [], cell) => {
+    try {
+      const newVariables = compile(source);
+      // Skip emitting `module @X` if one already exists in the target
+      // module's scope and isn't one of OUR old variables. Without this,
+      // the second define() collides on the shared name and Observable
+      // rewrites BOTH the new and pre-existing module variables to a
+      // "defined more than once" thrower, breaking every pre-existing
+      // consumer of `@X` in the module. The new import-name bindings
+      // reference `module @X` by name and resolve to whatever module
+      // variable is currently in scope.
+      const targetScope = cell.module.module._scope;
+      const ourOldNames = new Set(variables.map(v => v._name));
+      const isModuleImport = nv => nv._name?.startsWith('module @') && nv._inputs.length === 0;
+      const shouldSkip = nv => isModuleImport(nv) && targetScope.has(nv._name) && !ourOldNames.has(nv._name);
+      const allocation = newVariables.map(nv => shouldSkip(nv) ? { reuse: targetScope.get(nv._name) } : { fresh: nv });
+      const freshNewVariables = allocation.filter(a => a.fresh).map(a => a.fresh);
+      let reposition = false, insertionIndex = -1;
+      if (!variables || variables.length !== freshNewVariables.length) {
+        reposition = true;
+        variables.forEach(v => v.delete());
+        variables.length = 0;
+        for (let i = 0; i < freshNewVariables.length; i++) {
+          const newVariable = cell.module.module.variable({});
+          // Assign a random pid up-front so blank/identical new cells don't
+          // collide via persistentId's contentHash. See lopecode#144.
+          newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+          variables.push(newVariable);
         }
-    };
+      }
+      if (reposition) {
+        insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
+      }
+      const fns = await realize(freshNewVariables.map(v => v._definition), runtime);
+      freshNewVariables.forEach((v, i) => {
+        const variable = variables[i];
+        const _fn = fns[i];
+        if (v._name) {
+          variable.define(v._name, v._inputs, _fn);
+        } else {
+          variable.define(v._inputs, _fn);
+        }
+        if (reposition)
+          repositionSetElement(runtime._variables, variable, insertionIndex + i);
+      });
+      // Build the full variable set for decompile, mixing reused module-import
+      // variables with the freshly-defined runtime variables, in the same order
+      // as `allocation`.
+      let freshIdx = 0;
+      const decompileVars = allocation.map(a => a.reuse ? a.reuse : variables[freshIdx++]);
+      return await decompile(decompileVars);
+    } catch (e) {
+      console.error(e);
+    }
+  };
 };
 const _1g3bdxp = function _93(md){return(
 md`### Remove Cells`
@@ -7126,7 +7142,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_1whoy5n", null, ["md"], _1whoy5n);  
-  $def("_2dqvsk", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _2dqvsk);  
+  $def("_1hyx2tv", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _1hyx2tv);  
   $def("_1g3bdxp", null, ["md"], _1g3bdxp);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1qb4uz", null, ["md"], _1qb4uz);  

--- a/notebooks/@tomlarkworthy_command-palette.html
+++ b/notebooks/@tomlarkworthy_command-palette.html
@@ -6901,47 +6901,63 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _1whoy5n = function _91(md){return(
 md`### Apply Update`
 )};
-const _2dqvsk = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
+const _1hyx2tv = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
 {
-    return async (source, variables = [], cell) => {
-        try {
-            let reposition = false, insertionIndex = -1;
-            const newVariables = compile(source);
-            if (!variables || variables.length !== newVariables.length) {
-                reposition = true;
-                variables.forEach(v => v.delete());
-                variables.length = 0;
-                for (let i = 0; i < newVariables.length; i++) {
-                    const newVariable = cell.module.module.variable({});
-                    // Assign a random pid up-front so blank/identical new cells don't
-                    // collide via persistentId's contentHash. See lopecode#144.
-                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
-                    variables.push(newVariable);
-                }
-            }
-            if (reposition) {
-                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-            }
-            const fns = await realize(newVariables.map(v => v._definition), runtime);
-            newVariables.forEach((v, i) => {
-                const variable = variables[i];
-                const _fn = fns[i];
-                if (v._name) {
-                    variable.define(v._name, v._inputs, _fn);
-                } else {
-                    variable.define(v._inputs, _fn);
-                }
-                if (reposition)
-                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
-            });
-            // Return the canonical decompiled source so the caller can push it
-            // back into its editor view if it has one. No caller currently uses
-            // the variables array directly.
-            return await decompile(variables);
-        } catch (e) {
-            console.error(e);
+  return async (source, variables = [], cell) => {
+    try {
+      const newVariables = compile(source);
+      // Skip emitting `module @X` if one already exists in the target
+      // module's scope and isn't one of OUR old variables. Without this,
+      // the second define() collides on the shared name and Observable
+      // rewrites BOTH the new and pre-existing module variables to a
+      // "defined more than once" thrower, breaking every pre-existing
+      // consumer of `@X` in the module. The new import-name bindings
+      // reference `module @X` by name and resolve to whatever module
+      // variable is currently in scope.
+      const targetScope = cell.module.module._scope;
+      const ourOldNames = new Set(variables.map(v => v._name));
+      const isModuleImport = nv => nv._name?.startsWith('module @') && nv._inputs.length === 0;
+      const shouldSkip = nv => isModuleImport(nv) && targetScope.has(nv._name) && !ourOldNames.has(nv._name);
+      const allocation = newVariables.map(nv => shouldSkip(nv) ? { reuse: targetScope.get(nv._name) } : { fresh: nv });
+      const freshNewVariables = allocation.filter(a => a.fresh).map(a => a.fresh);
+      let reposition = false, insertionIndex = -1;
+      if (!variables || variables.length !== freshNewVariables.length) {
+        reposition = true;
+        variables.forEach(v => v.delete());
+        variables.length = 0;
+        for (let i = 0; i < freshNewVariables.length; i++) {
+          const newVariable = cell.module.module.variable({});
+          // Assign a random pid up-front so blank/identical new cells don't
+          // collide via persistentId's contentHash. See lopecode#144.
+          newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+          variables.push(newVariable);
         }
-    };
+      }
+      if (reposition) {
+        insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
+      }
+      const fns = await realize(freshNewVariables.map(v => v._definition), runtime);
+      freshNewVariables.forEach((v, i) => {
+        const variable = variables[i];
+        const _fn = fns[i];
+        if (v._name) {
+          variable.define(v._name, v._inputs, _fn);
+        } else {
+          variable.define(v._inputs, _fn);
+        }
+        if (reposition)
+          repositionSetElement(runtime._variables, variable, insertionIndex + i);
+      });
+      // Build the full variable set for decompile, mixing reused module-import
+      // variables with the freshly-defined runtime variables, in the same order
+      // as `allocation`.
+      let freshIdx = 0;
+      const decompileVars = allocation.map(a => a.reuse ? a.reuse : variables[freshIdx++]);
+      return await decompile(decompileVars);
+    } catch (e) {
+      console.error(e);
+    }
+  };
 };
 const _1g3bdxp = function _93(md){return(
 md`### Remove Cells`
@@ -7126,7 +7142,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_1whoy5n", null, ["md"], _1whoy5n);  
-  $def("_2dqvsk", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _2dqvsk);  
+  $def("_1hyx2tv", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _1hyx2tv);  
   $def("_1g3bdxp", null, ["md"], _1g3bdxp);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1qb4uz", null, ["md"], _1qb4uz);  

--- a/notebooks/@tomlarkworthy_dataflow-templating.html
+++ b/notebooks/@tomlarkworthy_dataflow-templating.html
@@ -6901,47 +6901,63 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _1whoy5n = function _91(md){return(
 md`### Apply Update`
 )};
-const _2dqvsk = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
+const _1hyx2tv = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
 {
-    return async (source, variables = [], cell) => {
-        try {
-            let reposition = false, insertionIndex = -1;
-            const newVariables = compile(source);
-            if (!variables || variables.length !== newVariables.length) {
-                reposition = true;
-                variables.forEach(v => v.delete());
-                variables.length = 0;
-                for (let i = 0; i < newVariables.length; i++) {
-                    const newVariable = cell.module.module.variable({});
-                    // Assign a random pid up-front so blank/identical new cells don't
-                    // collide via persistentId's contentHash. See lopecode#144.
-                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
-                    variables.push(newVariable);
-                }
-            }
-            if (reposition) {
-                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-            }
-            const fns = await realize(newVariables.map(v => v._definition), runtime);
-            newVariables.forEach((v, i) => {
-                const variable = variables[i];
-                const _fn = fns[i];
-                if (v._name) {
-                    variable.define(v._name, v._inputs, _fn);
-                } else {
-                    variable.define(v._inputs, _fn);
-                }
-                if (reposition)
-                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
-            });
-            // Return the canonical decompiled source so the caller can push it
-            // back into its editor view if it has one. No caller currently uses
-            // the variables array directly.
-            return await decompile(variables);
-        } catch (e) {
-            console.error(e);
+  return async (source, variables = [], cell) => {
+    try {
+      const newVariables = compile(source);
+      // Skip emitting `module @X` if one already exists in the target
+      // module's scope and isn't one of OUR old variables. Without this,
+      // the second define() collides on the shared name and Observable
+      // rewrites BOTH the new and pre-existing module variables to a
+      // "defined more than once" thrower, breaking every pre-existing
+      // consumer of `@X` in the module. The new import-name bindings
+      // reference `module @X` by name and resolve to whatever module
+      // variable is currently in scope.
+      const targetScope = cell.module.module._scope;
+      const ourOldNames = new Set(variables.map(v => v._name));
+      const isModuleImport = nv => nv._name?.startsWith('module @') && nv._inputs.length === 0;
+      const shouldSkip = nv => isModuleImport(nv) && targetScope.has(nv._name) && !ourOldNames.has(nv._name);
+      const allocation = newVariables.map(nv => shouldSkip(nv) ? { reuse: targetScope.get(nv._name) } : { fresh: nv });
+      const freshNewVariables = allocation.filter(a => a.fresh).map(a => a.fresh);
+      let reposition = false, insertionIndex = -1;
+      if (!variables || variables.length !== freshNewVariables.length) {
+        reposition = true;
+        variables.forEach(v => v.delete());
+        variables.length = 0;
+        for (let i = 0; i < freshNewVariables.length; i++) {
+          const newVariable = cell.module.module.variable({});
+          // Assign a random pid up-front so blank/identical new cells don't
+          // collide via persistentId's contentHash. See lopecode#144.
+          newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+          variables.push(newVariable);
         }
-    };
+      }
+      if (reposition) {
+        insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
+      }
+      const fns = await realize(freshNewVariables.map(v => v._definition), runtime);
+      freshNewVariables.forEach((v, i) => {
+        const variable = variables[i];
+        const _fn = fns[i];
+        if (v._name) {
+          variable.define(v._name, v._inputs, _fn);
+        } else {
+          variable.define(v._inputs, _fn);
+        }
+        if (reposition)
+          repositionSetElement(runtime._variables, variable, insertionIndex + i);
+      });
+      // Build the full variable set for decompile, mixing reused module-import
+      // variables with the freshly-defined runtime variables, in the same order
+      // as `allocation`.
+      let freshIdx = 0;
+      const decompileVars = allocation.map(a => a.reuse ? a.reuse : variables[freshIdx++]);
+      return await decompile(decompileVars);
+    } catch (e) {
+      console.error(e);
+    }
+  };
 };
 const _1g3bdxp = function _93(md){return(
 md`### Remove Cells`
@@ -7126,7 +7142,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_1whoy5n", null, ["md"], _1whoy5n);  
-  $def("_2dqvsk", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _2dqvsk);  
+  $def("_1hyx2tv", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _1hyx2tv);  
   $def("_1g3bdxp", null, ["md"], _1g3bdxp);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1qb4uz", null, ["md"], _1qb4uz);  

--- a/notebooks/@tomlarkworthy_debugger-2.html
+++ b/notebooks/@tomlarkworthy_debugger-2.html
@@ -8063,47 +8063,63 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _1whoy5n = function _91(md){return(
 md`### Apply Update`
 )};
-const _2dqvsk = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
+const _1hyx2tv = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
 {
-    return async (source, variables = [], cell) => {
-        try {
-            let reposition = false, insertionIndex = -1;
-            const newVariables = compile(source);
-            if (!variables || variables.length !== newVariables.length) {
-                reposition = true;
-                variables.forEach(v => v.delete());
-                variables.length = 0;
-                for (let i = 0; i < newVariables.length; i++) {
-                    const newVariable = cell.module.module.variable({});
-                    // Assign a random pid up-front so blank/identical new cells don't
-                    // collide via persistentId's contentHash. See lopecode#144.
-                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
-                    variables.push(newVariable);
-                }
-            }
-            if (reposition) {
-                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-            }
-            const fns = await realize(newVariables.map(v => v._definition), runtime);
-            newVariables.forEach((v, i) => {
-                const variable = variables[i];
-                const _fn = fns[i];
-                if (v._name) {
-                    variable.define(v._name, v._inputs, _fn);
-                } else {
-                    variable.define(v._inputs, _fn);
-                }
-                if (reposition)
-                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
-            });
-            // Return the canonical decompiled source so the caller can push it
-            // back into its editor view if it has one. No caller currently uses
-            // the variables array directly.
-            return await decompile(variables);
-        } catch (e) {
-            console.error(e);
+  return async (source, variables = [], cell) => {
+    try {
+      const newVariables = compile(source);
+      // Skip emitting `module @X` if one already exists in the target
+      // module's scope and isn't one of OUR old variables. Without this,
+      // the second define() collides on the shared name and Observable
+      // rewrites BOTH the new and pre-existing module variables to a
+      // "defined more than once" thrower, breaking every pre-existing
+      // consumer of `@X` in the module. The new import-name bindings
+      // reference `module @X` by name and resolve to whatever module
+      // variable is currently in scope.
+      const targetScope = cell.module.module._scope;
+      const ourOldNames = new Set(variables.map(v => v._name));
+      const isModuleImport = nv => nv._name?.startsWith('module @') && nv._inputs.length === 0;
+      const shouldSkip = nv => isModuleImport(nv) && targetScope.has(nv._name) && !ourOldNames.has(nv._name);
+      const allocation = newVariables.map(nv => shouldSkip(nv) ? { reuse: targetScope.get(nv._name) } : { fresh: nv });
+      const freshNewVariables = allocation.filter(a => a.fresh).map(a => a.fresh);
+      let reposition = false, insertionIndex = -1;
+      if (!variables || variables.length !== freshNewVariables.length) {
+        reposition = true;
+        variables.forEach(v => v.delete());
+        variables.length = 0;
+        for (let i = 0; i < freshNewVariables.length; i++) {
+          const newVariable = cell.module.module.variable({});
+          // Assign a random pid up-front so blank/identical new cells don't
+          // collide via persistentId's contentHash. See lopecode#144.
+          newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+          variables.push(newVariable);
         }
-    };
+      }
+      if (reposition) {
+        insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
+      }
+      const fns = await realize(freshNewVariables.map(v => v._definition), runtime);
+      freshNewVariables.forEach((v, i) => {
+        const variable = variables[i];
+        const _fn = fns[i];
+        if (v._name) {
+          variable.define(v._name, v._inputs, _fn);
+        } else {
+          variable.define(v._inputs, _fn);
+        }
+        if (reposition)
+          repositionSetElement(runtime._variables, variable, insertionIndex + i);
+      });
+      // Build the full variable set for decompile, mixing reused module-import
+      // variables with the freshly-defined runtime variables, in the same order
+      // as `allocation`.
+      let freshIdx = 0;
+      const decompileVars = allocation.map(a => a.reuse ? a.reuse : variables[freshIdx++]);
+      return await decompile(decompileVars);
+    } catch (e) {
+      console.error(e);
+    }
+  };
 };
 const _1g3bdxp = function _93(md){return(
 md`### Remove Cells`
@@ -8288,7 +8304,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_1whoy5n", null, ["md"], _1whoy5n);  
-  $def("_2dqvsk", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _2dqvsk);  
+  $def("_1hyx2tv", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _1hyx2tv);  
   $def("_1g3bdxp", null, ["md"], _1g3bdxp);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1qb4uz", null, ["md"], _1qb4uz);  

--- a/notebooks/@tomlarkworthy_debugger.html
+++ b/notebooks/@tomlarkworthy_debugger.html
@@ -7322,47 +7322,63 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _1whoy5n = function _91(md){return(
 md`### Apply Update`
 )};
-const _2dqvsk = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
+const _1hyx2tv = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
 {
-    return async (source, variables = [], cell) => {
-        try {
-            let reposition = false, insertionIndex = -1;
-            const newVariables = compile(source);
-            if (!variables || variables.length !== newVariables.length) {
-                reposition = true;
-                variables.forEach(v => v.delete());
-                variables.length = 0;
-                for (let i = 0; i < newVariables.length; i++) {
-                    const newVariable = cell.module.module.variable({});
-                    // Assign a random pid up-front so blank/identical new cells don't
-                    // collide via persistentId's contentHash. See lopecode#144.
-                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
-                    variables.push(newVariable);
-                }
-            }
-            if (reposition) {
-                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-            }
-            const fns = await realize(newVariables.map(v => v._definition), runtime);
-            newVariables.forEach((v, i) => {
-                const variable = variables[i];
-                const _fn = fns[i];
-                if (v._name) {
-                    variable.define(v._name, v._inputs, _fn);
-                } else {
-                    variable.define(v._inputs, _fn);
-                }
-                if (reposition)
-                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
-            });
-            // Return the canonical decompiled source so the caller can push it
-            // back into its editor view if it has one. No caller currently uses
-            // the variables array directly.
-            return await decompile(variables);
-        } catch (e) {
-            console.error(e);
+  return async (source, variables = [], cell) => {
+    try {
+      const newVariables = compile(source);
+      // Skip emitting `module @X` if one already exists in the target
+      // module's scope and isn't one of OUR old variables. Without this,
+      // the second define() collides on the shared name and Observable
+      // rewrites BOTH the new and pre-existing module variables to a
+      // "defined more than once" thrower, breaking every pre-existing
+      // consumer of `@X` in the module. The new import-name bindings
+      // reference `module @X` by name and resolve to whatever module
+      // variable is currently in scope.
+      const targetScope = cell.module.module._scope;
+      const ourOldNames = new Set(variables.map(v => v._name));
+      const isModuleImport = nv => nv._name?.startsWith('module @') && nv._inputs.length === 0;
+      const shouldSkip = nv => isModuleImport(nv) && targetScope.has(nv._name) && !ourOldNames.has(nv._name);
+      const allocation = newVariables.map(nv => shouldSkip(nv) ? { reuse: targetScope.get(nv._name) } : { fresh: nv });
+      const freshNewVariables = allocation.filter(a => a.fresh).map(a => a.fresh);
+      let reposition = false, insertionIndex = -1;
+      if (!variables || variables.length !== freshNewVariables.length) {
+        reposition = true;
+        variables.forEach(v => v.delete());
+        variables.length = 0;
+        for (let i = 0; i < freshNewVariables.length; i++) {
+          const newVariable = cell.module.module.variable({});
+          // Assign a random pid up-front so blank/identical new cells don't
+          // collide via persistentId's contentHash. See lopecode#144.
+          newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+          variables.push(newVariable);
         }
-    };
+      }
+      if (reposition) {
+        insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
+      }
+      const fns = await realize(freshNewVariables.map(v => v._definition), runtime);
+      freshNewVariables.forEach((v, i) => {
+        const variable = variables[i];
+        const _fn = fns[i];
+        if (v._name) {
+          variable.define(v._name, v._inputs, _fn);
+        } else {
+          variable.define(v._inputs, _fn);
+        }
+        if (reposition)
+          repositionSetElement(runtime._variables, variable, insertionIndex + i);
+      });
+      // Build the full variable set for decompile, mixing reused module-import
+      // variables with the freshly-defined runtime variables, in the same order
+      // as `allocation`.
+      let freshIdx = 0;
+      const decompileVars = allocation.map(a => a.reuse ? a.reuse : variables[freshIdx++]);
+      return await decompile(decompileVars);
+    } catch (e) {
+      console.error(e);
+    }
+  };
 };
 const _1g3bdxp = function _93(md){return(
 md`### Remove Cells`
@@ -7547,7 +7563,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_1whoy5n", null, ["md"], _1whoy5n);  
-  $def("_2dqvsk", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _2dqvsk);  
+  $def("_1hyx2tv", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _1hyx2tv);  
   $def("_1g3bdxp", null, ["md"], _1g3bdxp);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1qb4uz", null, ["md"], _1qb4uz);  

--- a/notebooks/@tomlarkworthy_dom-view.html
+++ b/notebooks/@tomlarkworthy_dom-view.html
@@ -6901,47 +6901,63 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _1whoy5n = function _91(md){return(
 md`### Apply Update`
 )};
-const _2dqvsk = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
+const _1hyx2tv = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
 {
-    return async (source, variables = [], cell) => {
-        try {
-            let reposition = false, insertionIndex = -1;
-            const newVariables = compile(source);
-            if (!variables || variables.length !== newVariables.length) {
-                reposition = true;
-                variables.forEach(v => v.delete());
-                variables.length = 0;
-                for (let i = 0; i < newVariables.length; i++) {
-                    const newVariable = cell.module.module.variable({});
-                    // Assign a random pid up-front so blank/identical new cells don't
-                    // collide via persistentId's contentHash. See lopecode#144.
-                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
-                    variables.push(newVariable);
-                }
-            }
-            if (reposition) {
-                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-            }
-            const fns = await realize(newVariables.map(v => v._definition), runtime);
-            newVariables.forEach((v, i) => {
-                const variable = variables[i];
-                const _fn = fns[i];
-                if (v._name) {
-                    variable.define(v._name, v._inputs, _fn);
-                } else {
-                    variable.define(v._inputs, _fn);
-                }
-                if (reposition)
-                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
-            });
-            // Return the canonical decompiled source so the caller can push it
-            // back into its editor view if it has one. No caller currently uses
-            // the variables array directly.
-            return await decompile(variables);
-        } catch (e) {
-            console.error(e);
+  return async (source, variables = [], cell) => {
+    try {
+      const newVariables = compile(source);
+      // Skip emitting `module @X` if one already exists in the target
+      // module's scope and isn't one of OUR old variables. Without this,
+      // the second define() collides on the shared name and Observable
+      // rewrites BOTH the new and pre-existing module variables to a
+      // "defined more than once" thrower, breaking every pre-existing
+      // consumer of `@X` in the module. The new import-name bindings
+      // reference `module @X` by name and resolve to whatever module
+      // variable is currently in scope.
+      const targetScope = cell.module.module._scope;
+      const ourOldNames = new Set(variables.map(v => v._name));
+      const isModuleImport = nv => nv._name?.startsWith('module @') && nv._inputs.length === 0;
+      const shouldSkip = nv => isModuleImport(nv) && targetScope.has(nv._name) && !ourOldNames.has(nv._name);
+      const allocation = newVariables.map(nv => shouldSkip(nv) ? { reuse: targetScope.get(nv._name) } : { fresh: nv });
+      const freshNewVariables = allocation.filter(a => a.fresh).map(a => a.fresh);
+      let reposition = false, insertionIndex = -1;
+      if (!variables || variables.length !== freshNewVariables.length) {
+        reposition = true;
+        variables.forEach(v => v.delete());
+        variables.length = 0;
+        for (let i = 0; i < freshNewVariables.length; i++) {
+          const newVariable = cell.module.module.variable({});
+          // Assign a random pid up-front so blank/identical new cells don't
+          // collide via persistentId's contentHash. See lopecode#144.
+          newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+          variables.push(newVariable);
         }
-    };
+      }
+      if (reposition) {
+        insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
+      }
+      const fns = await realize(freshNewVariables.map(v => v._definition), runtime);
+      freshNewVariables.forEach((v, i) => {
+        const variable = variables[i];
+        const _fn = fns[i];
+        if (v._name) {
+          variable.define(v._name, v._inputs, _fn);
+        } else {
+          variable.define(v._inputs, _fn);
+        }
+        if (reposition)
+          repositionSetElement(runtime._variables, variable, insertionIndex + i);
+      });
+      // Build the full variable set for decompile, mixing reused module-import
+      // variables with the freshly-defined runtime variables, in the same order
+      // as `allocation`.
+      let freshIdx = 0;
+      const decompileVars = allocation.map(a => a.reuse ? a.reuse : variables[freshIdx++]);
+      return await decompile(decompileVars);
+    } catch (e) {
+      console.error(e);
+    }
+  };
 };
 const _1g3bdxp = function _93(md){return(
 md`### Remove Cells`
@@ -7126,7 +7142,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_1whoy5n", null, ["md"], _1whoy5n);  
-  $def("_2dqvsk", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _2dqvsk);  
+  $def("_1hyx2tv", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _1hyx2tv);  
   $def("_1g3bdxp", null, ["md"], _1g3bdxp);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1qb4uz", null, ["md"], _1qb4uz);  

--- a/notebooks/@tomlarkworthy_editor-5.html
+++ b/notebooks/@tomlarkworthy_editor-5.html
@@ -6905,13 +6905,30 @@ const _2dqvsk = function _compile_and_update(compile,runtime,realize,repositionS
 {
     return async (source, variables = [], cell) => {
         try {
-            let reposition = false, insertionIndex = -1;
             const newVariables = compile(source);
-            if (!variables || variables.length !== newVariables.length) {
+            // Skip emitting `module @X` if one already exists in the target
+            // module's scope and isn't one of OUR old variables. Without this,
+            // the second define() collides on the shared name and Observable
+            // rewrites BOTH the new and pre-existing module variables to a
+            // "defined more than once" thrower, breaking every pre-existing
+            // consumer of `@X` in the module. The new import-name bindings
+            // reference `module @X` by name and resolve to whatever module
+            // variable is currently in scope.
+            const targetScope = cell.module.module._scope;
+            const ourOldNames = new Set(variables.map(v => v._name));
+            const isModuleImport = nv => nv._name?.startsWith('module @') && nv._inputs.length === 0;
+            const shouldSkip = nv => isModuleImport(nv) && targetScope.has(nv._name) && !ourOldNames.has(nv._name);
+            const allocation = newVariables.map(nv =>
+                shouldSkip(nv) ? { reuse: targetScope.get(nv._name) } : { fresh: nv }
+            );
+            const freshNewVariables = allocation.filter(a => a.fresh).map(a => a.fresh);
+
+            let reposition = false, insertionIndex = -1;
+            if (!variables || variables.length !== freshNewVariables.length) {
                 reposition = true;
                 variables.forEach(v => v.delete());
                 variables.length = 0;
-                for (let i = 0; i < newVariables.length; i++) {
+                for (let i = 0; i < freshNewVariables.length; i++) {
                     const newVariable = cell.module.module.variable({});
                     // Assign a random pid up-front so blank/identical new cells don't
                     // collide via persistentId's contentHash. See lopecode#144.
@@ -6922,8 +6939,8 @@ const _2dqvsk = function _compile_and_update(compile,runtime,realize,repositionS
             if (reposition) {
                 insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
             }
-            const fns = await realize(newVariables.map(v => v._definition), runtime);
-            newVariables.forEach((v, i) => {
+            const fns = await realize(freshNewVariables.map(v => v._definition), runtime);
+            freshNewVariables.forEach((v, i) => {
                 const variable = variables[i];
                 const _fn = fns[i];
                 if (v._name) {
@@ -6934,10 +6951,12 @@ const _2dqvsk = function _compile_and_update(compile,runtime,realize,repositionS
                 if (reposition)
                     repositionSetElement(runtime._variables, variable, insertionIndex + i);
             });
-            // Return the canonical decompiled source so the caller can push it
-            // back into its editor view if it has one. No caller currently uses
-            // the variables array directly.
-            return await decompile(variables);
+            // Build the full variable set for decompile, mixing reused module-import
+            // variables with the freshly-defined runtime variables, in the same order
+            // as `allocation`.
+            let freshIdx = 0;
+            const decompileVars = allocation.map(a => a.reuse ? a.reuse : variables[freshIdx++]);
+            return await decompile(decompileVars);
         } catch (e) {
             console.error(e);
         }

--- a/notebooks/@tomlarkworthy_editor-5.html
+++ b/notebooks/@tomlarkworthy_editor-5.html
@@ -1943,10 +1943,9 @@ const _1hybsm8 = function _coverage_failures(runtime_variables,liveCellMap,modul
   }
   return failures;
 };
-const _4tg5tm = function _test_cell_map_covers_all_runtime_variables(coverage_failures)
+const _1p0qclg = function _test_cell_map_covers_all_runtime_variables(coverage_failures)
 {
   if (coverage_failures.length) {
-    debugger;
     throw JSON.stringify(coverage_failures);
   }
   return "pass";
@@ -2188,7 +2187,7 @@ export default function define(runtime, observer) {
   $def("_1rtpyzk", "cellMapVizView", ["viewof cellMapViz"], _1rtpyzk);  
   $def("_1srzrzc", null, ["md"], _1srzrzc);  
   $def("_1hybsm8", "coverage_failures", ["runtime_variables","liveCellMap","modules"], _1hybsm8);  
-  $def("_4tg5tm", "test_cell_map_covers_all_runtime_variables", ["coverage_failures"], _4tg5tm);  
+  $def("_1p0qclg", "test_cell_map_covers_all_runtime_variables", ["coverage_failures"], _1p0qclg);  
   $def("_1a18z7a", "test_cell_map_no_variable_in_more_than_one_cell", ["runtime_variables","liveCellMap","modules"], _1a18z7a);  
   $def("_8nkqnx", null, ["md"], _8nkqnx);  
   $def("_2h3a9s", "importedModule", [], _2h3a9s);  
@@ -2246,10 +2245,9 @@ const _1i8jhrq = function _copyCellButton(Inputs,cellsToClipboard){return(
 (cells) =>
   Inputs.button("Copy cells", { reduce: () => cellsToClipboard(cells) })
 )};
-const _1imaqds = function _makeCell($0,defaultJS,defaultOther){return(
+const _a7c096 = function _makeCell($0,defaultJS,defaultOther){return(
 (value) => {
   const id = $0.value++;
-  debugger;
   if (typeof value === "string") {
     return { ...defaultJS, id, value };
   } else if (typeof value === "object") {
@@ -2299,7 +2297,7 @@ export default function define(runtime, observer) {
   $def("_10uloef", null, ["md"], _10uloef);  
   $def("_1seifpc", "cellsToClipboard", ["makeCell"], _1seifpc);  
   $def("_1i8jhrq", "copyCellButton", ["Inputs","cellsToClipboard"], _1i8jhrq);  
-  $def("_1imaqds", "makeCell", ["mutable id","defaultJS","defaultOther"], _1imaqds);  
+  $def("_a7c096", "makeCell", ["mutable id","defaultJS","defaultOther"], _a7c096);  
   $def("_h1t91h", "defaultJS", [], _h1t91h);  
   $def("_but2s9", "defaultOther", [], _but2s9);  
   $def("_lj7470", "initial id", [], _lj7470);  
@@ -6901,66 +6899,63 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _1whoy5n = function _91(md){return(
 md`### Apply Update`
 )};
-const _2dqvsk = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
+const _1hyx2tv = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
 {
-    return async (source, variables = [], cell) => {
-        try {
-            const newVariables = compile(source);
-            // Skip emitting `module @X` if one already exists in the target
-            // module's scope and isn't one of OUR old variables. Without this,
-            // the second define() collides on the shared name and Observable
-            // rewrites BOTH the new and pre-existing module variables to a
-            // "defined more than once" thrower, breaking every pre-existing
-            // consumer of `@X` in the module. The new import-name bindings
-            // reference `module @X` by name and resolve to whatever module
-            // variable is currently in scope.
-            const targetScope = cell.module.module._scope;
-            const ourOldNames = new Set(variables.map(v => v._name));
-            const isModuleImport = nv => nv._name?.startsWith('module @') && nv._inputs.length === 0;
-            const shouldSkip = nv => isModuleImport(nv) && targetScope.has(nv._name) && !ourOldNames.has(nv._name);
-            const allocation = newVariables.map(nv =>
-                shouldSkip(nv) ? { reuse: targetScope.get(nv._name) } : { fresh: nv }
-            );
-            const freshNewVariables = allocation.filter(a => a.fresh).map(a => a.fresh);
-
-            let reposition = false, insertionIndex = -1;
-            if (!variables || variables.length !== freshNewVariables.length) {
-                reposition = true;
-                variables.forEach(v => v.delete());
-                variables.length = 0;
-                for (let i = 0; i < freshNewVariables.length; i++) {
-                    const newVariable = cell.module.module.variable({});
-                    // Assign a random pid up-front so blank/identical new cells don't
-                    // collide via persistentId's contentHash. See lopecode#144.
-                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
-                    variables.push(newVariable);
-                }
-            }
-            if (reposition) {
-                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-            }
-            const fns = await realize(freshNewVariables.map(v => v._definition), runtime);
-            freshNewVariables.forEach((v, i) => {
-                const variable = variables[i];
-                const _fn = fns[i];
-                if (v._name) {
-                    variable.define(v._name, v._inputs, _fn);
-                } else {
-                    variable.define(v._inputs, _fn);
-                }
-                if (reposition)
-                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
-            });
-            // Build the full variable set for decompile, mixing reused module-import
-            // variables with the freshly-defined runtime variables, in the same order
-            // as `allocation`.
-            let freshIdx = 0;
-            const decompileVars = allocation.map(a => a.reuse ? a.reuse : variables[freshIdx++]);
-            return await decompile(decompileVars);
-        } catch (e) {
-            console.error(e);
+  return async (source, variables = [], cell) => {
+    try {
+      const newVariables = compile(source);
+      // Skip emitting `module @X` if one already exists in the target
+      // module's scope and isn't one of OUR old variables. Without this,
+      // the second define() collides on the shared name and Observable
+      // rewrites BOTH the new and pre-existing module variables to a
+      // "defined more than once" thrower, breaking every pre-existing
+      // consumer of `@X` in the module. The new import-name bindings
+      // reference `module @X` by name and resolve to whatever module
+      // variable is currently in scope.
+      const targetScope = cell.module.module._scope;
+      const ourOldNames = new Set(variables.map(v => v._name));
+      const isModuleImport = nv => nv._name?.startsWith('module @') && nv._inputs.length === 0;
+      const shouldSkip = nv => isModuleImport(nv) && targetScope.has(nv._name) && !ourOldNames.has(nv._name);
+      const allocation = newVariables.map(nv => shouldSkip(nv) ? { reuse: targetScope.get(nv._name) } : { fresh: nv });
+      const freshNewVariables = allocation.filter(a => a.fresh).map(a => a.fresh);
+      let reposition = false, insertionIndex = -1;
+      if (!variables || variables.length !== freshNewVariables.length) {
+        reposition = true;
+        variables.forEach(v => v.delete());
+        variables.length = 0;
+        for (let i = 0; i < freshNewVariables.length; i++) {
+          const newVariable = cell.module.module.variable({});
+          // Assign a random pid up-front so blank/identical new cells don't
+          // collide via persistentId's contentHash. See lopecode#144.
+          newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+          variables.push(newVariable);
         }
-    };
+      }
+      if (reposition) {
+        insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
+      }
+      const fns = await realize(freshNewVariables.map(v => v._definition), runtime);
+      freshNewVariables.forEach((v, i) => {
+        const variable = variables[i];
+        const _fn = fns[i];
+        if (v._name) {
+          variable.define(v._name, v._inputs, _fn);
+        } else {
+          variable.define(v._inputs, _fn);
+        }
+        if (reposition)
+          repositionSetElement(runtime._variables, variable, insertionIndex + i);
+      });
+      // Build the full variable set for decompile, mixing reused module-import
+      // variables with the freshly-defined runtime variables, in the same order
+      // as `allocation`.
+      let freshIdx = 0;
+      const decompileVars = allocation.map(a => a.reuse ? a.reuse : variables[freshIdx++]);
+      return await decompile(decompileVars);
+    } catch (e) {
+      console.error(e);
+    }
+  };
 };
 const _1g3bdxp = function _93(md){return(
 md`### Remove Cells`
@@ -7145,7 +7140,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_1whoy5n", null, ["md"], _1whoy5n);  
-  $def("_2dqvsk", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _2dqvsk);  
+  $def("_1hyx2tv", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _1hyx2tv);  
   $def("_1g3bdxp", null, ["md"], _1g3bdxp);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1qb4uz", null, ["md"], _1qb4uz);  
@@ -24089,52 +24084,46 @@ const _1sdw5pf = (G, _) => G.input(_);
 const _1wzah21 = function _theme_name(themes,theme_assets){return(
 [...themes.entries()].find(([, assets]) => assets === theme_assets)?.[0] ?? 'unknown'
 )};
-const _nz55m5 = function _4(css,themes,theme_assets,html)
+const _1mut3rc = function _apply_theme(css,themes,theme_assets,html)
 {
-    const view = document.defaultView;
-    const sheets = [];
-    for (const [url, text] of css) {
-        if (typeof text !== 'string')
-            continue;
-        try {
-            const sheet = new view.CSSStyleSheet();
-            sheet.replaceSync(text);
-            sheets.push(sheet);
-        } catch (e) {
-            console.warn('Could not adopt stylesheet', url, e);
-        }
+  const view = document.defaultView;
+  const sheets = [];
+  for (const [url, text] of css) {
+    if (typeof text !== "string") continue;
+    try {
+      const sheet = new view.CSSStyleSheet();
+      sheet.replaceSync(text);
+      sheets.push(sheet);
+    } catch (e) {
+      console.warn("Could not adopt stylesheet", url, e);
     }
-    document.adoptedStyleSheets = sheets;
-    // Sync embedded <script id="<url>" data-mime="text/css"> cache blocks so
-    // current_theme (which sniffs by document.getElementById) and the next
-    // export reflect the live selection. Only touches blocks that belong to
-    // known theme URLs — leaves unrelated CSS asset blocks alone.
-    const knownThemeUrls = new Set();
-    for (const list of themes.values())
-        for (const u of list)
-            knownThemeUrls.add(u);
-    for (const u of knownThemeUrls) {
-        if (!theme_assets.includes(u))
-            document.getElementById(u)?.remove();
+  }
+  document.adoptedStyleSheets = sheets;
+  // Sync embedded <script id="<url>" data-mime="text/css"> cache blocks so
+  // current_theme (which sniffs by document.getElementById) and the next
+  // export reflect the live selection. Only touches blocks that belong to
+  // known theme URLs — leaves unrelated CSS asset blocks alone.
+  const knownThemeUrls = new Set();
+  for (const list of themes.values())
+    for (const u of list) knownThemeUrls.add(u);
+  for (const u of knownThemeUrls) {
+    if (!theme_assets.includes(u)) document.getElementById(u)?.remove();
+  }
+  for (const [url, text] of css) {
+    if (!url || !url.startsWith("http")) continue;
+    if (!theme_assets.includes(url)) continue;
+    let s = document.getElementById(url);
+    if (!s) {
+      s = document.createElement("script");
+      s.id = url;
+      s.type = "text/plain";
+      s.setAttribute("data-mime", "text/css");
+      document.head.appendChild(s);
     }
-    for (const [url, text] of css) {
-        if (!url || !url.startsWith('http'))
-            continue;
-        if (!theme_assets.includes(url))
-            continue;
-        let s = document.getElementById(url);
-        if (!s) {
-            s = document.createElement('script');
-            s.id = url;
-            s.type = 'text/plain';
-            s.setAttribute('data-mime', 'text/css');
-            document.head.appendChild(s);
-        }
-        // Always replace text so a freshly-fetched theme overwrites stale cache.
-        if (!s.hasAttribute('data-encoding'))
-            s.textContent = text;
-    }
-    return html`<div style="font:11px/1.4 var(--monospace, ui-monospace, monospace);color:var(--theme-foreground-muted);padding:6px 10px;border:1px solid var(--theme-foreground-faintest);border-radius:4px;display:inline-block">Applied ${ sheets.length } stylesheets to the page.</div>`;
+    // Always replace text so a freshly-fetched theme overwrites stale cache.
+    if (!s.hasAttribute("data-encoding")) s.textContent = text;
+  }
+  return html`<div style="font:11px/1.4 var(--monospace, ui-monospace, monospace);color:var(--theme-foreground-muted);padding:6px 10px;border:1px solid var(--theme-foreground-faintest);border-radius:4px;display:inline-block">Applied ${sheets.length} stylesheets to the page.</div>`;
 };
 const _11pe38r = function _5(theme_properties,html,htl,theme_name){return(
 (() => {
@@ -24498,7 +24487,7 @@ export default function define(runtime, observer) {
   $def("_1clcodb", "viewof theme_assets", ["Inputs","themes","current_theme"], _1clcodb);  
   $def("_1sdw5pf", "theme_assets", ["Generators","viewof theme_assets"], _1sdw5pf);  
   $def("_1wzah21", "theme_name", ["themes","theme_assets"], _1wzah21);  
-  $def("_nz55m5", null, ["css","themes","theme_assets","html"], _nz55m5);  
+  $def("_1mut3rc", "apply_theme", ["css","themes","theme_assets","html"], _1mut3rc);  
   $def("_11pe38r", null, ["theme_properties","html","htl","theme_name"], _11pe38r);  
   $def("_1txjoje", null, ["md"], _1txjoje);  
   $def("_1hu8vay", null, ["htl","theme_properties","html"], _1hu8vay);  

--- a/notebooks/@tomlarkworthy_editor-5.json
+++ b/notebooks/@tomlarkworthy_editor-5.json
@@ -44,7 +44,7 @@
       ]
     },
     "@tomlarkworthy/cell-map": {
-      "hash": "c8281cd25de378ac872c7e289b0b715a",
+      "hash": "a58cde1f33bf1d60ba83caa866a03be1",
       "dependsOn": [
         "@tomlarkworthy/lopepage-urls",
         "@tomlarkworthy/module-map",
@@ -63,7 +63,7 @@
       ]
     },
     "@tomlarkworthy/cells-to-clipboard": {
-      "hash": "f245a2a1ad646c1f9430b0ecdf9b0cbc",
+      "hash": "eee8d9f598d697409bb1296662d8bc06",
       "dependedBy": [
         "@tomlarkworthy/editor-5"
       ]
@@ -124,7 +124,7 @@
       ]
     },
     "@tomlarkworthy/editor-5": {
-      "hash": "fb8e916ca128e007c27542f4ce86ed4b",
+      "hash": "4175071d83af3ca54082813e24fd9f11",
       "files": [
         "cell_options.json"
       ],
@@ -317,7 +317,7 @@
       ]
     },
     "@tomlarkworthy/lopepage": {
-      "hash": "40d704b72338d342b63aca508662933f",
+      "hash": "58fc5d7eb298cc0fe3d8ffd2debe9e36",
       "dependsOn": [
         "@tomlarkworthy/golden-layout-2-6-0",
         "@tomlarkworthy/visualizer",
@@ -332,7 +332,7 @@
       ]
     },
     "@tomlarkworthy/lopepage-urls": {
-      "hash": "eee5c7951f9edd92f8fd1dba8442609b",
+      "hash": "28f1a31190b2a69e3c9d3ac522c41bd4",
       "dependsOn": [
         "@tomlarkworthy/runtime-sdk",
         "@tomlarkworthy/tests"
@@ -504,7 +504,7 @@
       ]
     },
     "@tomlarkworthy/themes": {
-      "hash": "2d0e95ad9db0f2e04ca5afa81cbdd089",
+      "hash": "165aee9edb066ab5989674d9a2faefa5",
       "dependedBy": [
         "@tomlarkworthy/command-palette",
         "@tomlarkworthy/exporter-3"
@@ -542,6 +542,6 @@
       "@tomlarkworthy/editor-5": "https://observablehq.com/@tomlarkworthy/editor-5"
     }
   },
-  "observable_version": 3986,
-  "observable_update_time": "2026-05-17T12:40:57.221Z"
+  "observable_version": 3987,
+  "observable_update_time": "2026-05-19T16:23:45.528Z"
 }

--- a/notebooks/@tomlarkworthy_exporter-2.html
+++ b/notebooks/@tomlarkworthy_exporter-2.html
@@ -6901,47 +6901,63 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _1whoy5n = function _91(md){return(
 md`### Apply Update`
 )};
-const _2dqvsk = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
+const _1hyx2tv = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
 {
-    return async (source, variables = [], cell) => {
-        try {
-            let reposition = false, insertionIndex = -1;
-            const newVariables = compile(source);
-            if (!variables || variables.length !== newVariables.length) {
-                reposition = true;
-                variables.forEach(v => v.delete());
-                variables.length = 0;
-                for (let i = 0; i < newVariables.length; i++) {
-                    const newVariable = cell.module.module.variable({});
-                    // Assign a random pid up-front so blank/identical new cells don't
-                    // collide via persistentId's contentHash. See lopecode#144.
-                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
-                    variables.push(newVariable);
-                }
-            }
-            if (reposition) {
-                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-            }
-            const fns = await realize(newVariables.map(v => v._definition), runtime);
-            newVariables.forEach((v, i) => {
-                const variable = variables[i];
-                const _fn = fns[i];
-                if (v._name) {
-                    variable.define(v._name, v._inputs, _fn);
-                } else {
-                    variable.define(v._inputs, _fn);
-                }
-                if (reposition)
-                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
-            });
-            // Return the canonical decompiled source so the caller can push it
-            // back into its editor view if it has one. No caller currently uses
-            // the variables array directly.
-            return await decompile(variables);
-        } catch (e) {
-            console.error(e);
+  return async (source, variables = [], cell) => {
+    try {
+      const newVariables = compile(source);
+      // Skip emitting `module @X` if one already exists in the target
+      // module's scope and isn't one of OUR old variables. Without this,
+      // the second define() collides on the shared name and Observable
+      // rewrites BOTH the new and pre-existing module variables to a
+      // "defined more than once" thrower, breaking every pre-existing
+      // consumer of `@X` in the module. The new import-name bindings
+      // reference `module @X` by name and resolve to whatever module
+      // variable is currently in scope.
+      const targetScope = cell.module.module._scope;
+      const ourOldNames = new Set(variables.map(v => v._name));
+      const isModuleImport = nv => nv._name?.startsWith('module @') && nv._inputs.length === 0;
+      const shouldSkip = nv => isModuleImport(nv) && targetScope.has(nv._name) && !ourOldNames.has(nv._name);
+      const allocation = newVariables.map(nv => shouldSkip(nv) ? { reuse: targetScope.get(nv._name) } : { fresh: nv });
+      const freshNewVariables = allocation.filter(a => a.fresh).map(a => a.fresh);
+      let reposition = false, insertionIndex = -1;
+      if (!variables || variables.length !== freshNewVariables.length) {
+        reposition = true;
+        variables.forEach(v => v.delete());
+        variables.length = 0;
+        for (let i = 0; i < freshNewVariables.length; i++) {
+          const newVariable = cell.module.module.variable({});
+          // Assign a random pid up-front so blank/identical new cells don't
+          // collide via persistentId's contentHash. See lopecode#144.
+          newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+          variables.push(newVariable);
         }
-    };
+      }
+      if (reposition) {
+        insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
+      }
+      const fns = await realize(freshNewVariables.map(v => v._definition), runtime);
+      freshNewVariables.forEach((v, i) => {
+        const variable = variables[i];
+        const _fn = fns[i];
+        if (v._name) {
+          variable.define(v._name, v._inputs, _fn);
+        } else {
+          variable.define(v._inputs, _fn);
+        }
+        if (reposition)
+          repositionSetElement(runtime._variables, variable, insertionIndex + i);
+      });
+      // Build the full variable set for decompile, mixing reused module-import
+      // variables with the freshly-defined runtime variables, in the same order
+      // as `allocation`.
+      let freshIdx = 0;
+      const decompileVars = allocation.map(a => a.reuse ? a.reuse : variables[freshIdx++]);
+      return await decompile(decompileVars);
+    } catch (e) {
+      console.error(e);
+    }
+  };
 };
 const _1g3bdxp = function _93(md){return(
 md`### Remove Cells`
@@ -7126,7 +7142,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_1whoy5n", null, ["md"], _1whoy5n);  
-  $def("_2dqvsk", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _2dqvsk);  
+  $def("_1hyx2tv", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _1hyx2tv);  
   $def("_1g3bdxp", null, ["md"], _1g3bdxp);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1qb4uz", null, ["md"], _1qb4uz);  

--- a/notebooks/@tomlarkworthy_exporter-3.html
+++ b/notebooks/@tomlarkworthy_exporter-3.html
@@ -6901,47 +6901,63 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _1whoy5n = function _91(md){return(
 md`### Apply Update`
 )};
-const _2dqvsk = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
+const _1hyx2tv = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
 {
-    return async (source, variables = [], cell) => {
-        try {
-            let reposition = false, insertionIndex = -1;
-            const newVariables = compile(source);
-            if (!variables || variables.length !== newVariables.length) {
-                reposition = true;
-                variables.forEach(v => v.delete());
-                variables.length = 0;
-                for (let i = 0; i < newVariables.length; i++) {
-                    const newVariable = cell.module.module.variable({});
-                    // Assign a random pid up-front so blank/identical new cells don't
-                    // collide via persistentId's contentHash. See lopecode#144.
-                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
-                    variables.push(newVariable);
-                }
-            }
-            if (reposition) {
-                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-            }
-            const fns = await realize(newVariables.map(v => v._definition), runtime);
-            newVariables.forEach((v, i) => {
-                const variable = variables[i];
-                const _fn = fns[i];
-                if (v._name) {
-                    variable.define(v._name, v._inputs, _fn);
-                } else {
-                    variable.define(v._inputs, _fn);
-                }
-                if (reposition)
-                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
-            });
-            // Return the canonical decompiled source so the caller can push it
-            // back into its editor view if it has one. No caller currently uses
-            // the variables array directly.
-            return await decompile(variables);
-        } catch (e) {
-            console.error(e);
+  return async (source, variables = [], cell) => {
+    try {
+      const newVariables = compile(source);
+      // Skip emitting `module @X` if one already exists in the target
+      // module's scope and isn't one of OUR old variables. Without this,
+      // the second define() collides on the shared name and Observable
+      // rewrites BOTH the new and pre-existing module variables to a
+      // "defined more than once" thrower, breaking every pre-existing
+      // consumer of `@X` in the module. The new import-name bindings
+      // reference `module @X` by name and resolve to whatever module
+      // variable is currently in scope.
+      const targetScope = cell.module.module._scope;
+      const ourOldNames = new Set(variables.map(v => v._name));
+      const isModuleImport = nv => nv._name?.startsWith('module @') && nv._inputs.length === 0;
+      const shouldSkip = nv => isModuleImport(nv) && targetScope.has(nv._name) && !ourOldNames.has(nv._name);
+      const allocation = newVariables.map(nv => shouldSkip(nv) ? { reuse: targetScope.get(nv._name) } : { fresh: nv });
+      const freshNewVariables = allocation.filter(a => a.fresh).map(a => a.fresh);
+      let reposition = false, insertionIndex = -1;
+      if (!variables || variables.length !== freshNewVariables.length) {
+        reposition = true;
+        variables.forEach(v => v.delete());
+        variables.length = 0;
+        for (let i = 0; i < freshNewVariables.length; i++) {
+          const newVariable = cell.module.module.variable({});
+          // Assign a random pid up-front so blank/identical new cells don't
+          // collide via persistentId's contentHash. See lopecode#144.
+          newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+          variables.push(newVariable);
         }
-    };
+      }
+      if (reposition) {
+        insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
+      }
+      const fns = await realize(freshNewVariables.map(v => v._definition), runtime);
+      freshNewVariables.forEach((v, i) => {
+        const variable = variables[i];
+        const _fn = fns[i];
+        if (v._name) {
+          variable.define(v._name, v._inputs, _fn);
+        } else {
+          variable.define(v._inputs, _fn);
+        }
+        if (reposition)
+          repositionSetElement(runtime._variables, variable, insertionIndex + i);
+      });
+      // Build the full variable set for decompile, mixing reused module-import
+      // variables with the freshly-defined runtime variables, in the same order
+      // as `allocation`.
+      let freshIdx = 0;
+      const decompileVars = allocation.map(a => a.reuse ? a.reuse : variables[freshIdx++]);
+      return await decompile(decompileVars);
+    } catch (e) {
+      console.error(e);
+    }
+  };
 };
 const _1g3bdxp = function _93(md){return(
 md`### Remove Cells`
@@ -7126,7 +7142,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_1whoy5n", null, ["md"], _1whoy5n);  
-  $def("_2dqvsk", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _2dqvsk);  
+  $def("_1hyx2tv", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _1hyx2tv);  
   $def("_1g3bdxp", null, ["md"], _1g3bdxp);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1qb4uz", null, ["md"], _1qb4uz);  

--- a/notebooks/@tomlarkworthy_fileattachments.html
+++ b/notebooks/@tomlarkworthy_fileattachments.html
@@ -6901,47 +6901,63 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _1whoy5n = function _91(md){return(
 md`### Apply Update`
 )};
-const _2dqvsk = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
+const _1hyx2tv = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
 {
-    return async (source, variables = [], cell) => {
-        try {
-            let reposition = false, insertionIndex = -1;
-            const newVariables = compile(source);
-            if (!variables || variables.length !== newVariables.length) {
-                reposition = true;
-                variables.forEach(v => v.delete());
-                variables.length = 0;
-                for (let i = 0; i < newVariables.length; i++) {
-                    const newVariable = cell.module.module.variable({});
-                    // Assign a random pid up-front so blank/identical new cells don't
-                    // collide via persistentId's contentHash. See lopecode#144.
-                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
-                    variables.push(newVariable);
-                }
-            }
-            if (reposition) {
-                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-            }
-            const fns = await realize(newVariables.map(v => v._definition), runtime);
-            newVariables.forEach((v, i) => {
-                const variable = variables[i];
-                const _fn = fns[i];
-                if (v._name) {
-                    variable.define(v._name, v._inputs, _fn);
-                } else {
-                    variable.define(v._inputs, _fn);
-                }
-                if (reposition)
-                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
-            });
-            // Return the canonical decompiled source so the caller can push it
-            // back into its editor view if it has one. No caller currently uses
-            // the variables array directly.
-            return await decompile(variables);
-        } catch (e) {
-            console.error(e);
+  return async (source, variables = [], cell) => {
+    try {
+      const newVariables = compile(source);
+      // Skip emitting `module @X` if one already exists in the target
+      // module's scope and isn't one of OUR old variables. Without this,
+      // the second define() collides on the shared name and Observable
+      // rewrites BOTH the new and pre-existing module variables to a
+      // "defined more than once" thrower, breaking every pre-existing
+      // consumer of `@X` in the module. The new import-name bindings
+      // reference `module @X` by name and resolve to whatever module
+      // variable is currently in scope.
+      const targetScope = cell.module.module._scope;
+      const ourOldNames = new Set(variables.map(v => v._name));
+      const isModuleImport = nv => nv._name?.startsWith('module @') && nv._inputs.length === 0;
+      const shouldSkip = nv => isModuleImport(nv) && targetScope.has(nv._name) && !ourOldNames.has(nv._name);
+      const allocation = newVariables.map(nv => shouldSkip(nv) ? { reuse: targetScope.get(nv._name) } : { fresh: nv });
+      const freshNewVariables = allocation.filter(a => a.fresh).map(a => a.fresh);
+      let reposition = false, insertionIndex = -1;
+      if (!variables || variables.length !== freshNewVariables.length) {
+        reposition = true;
+        variables.forEach(v => v.delete());
+        variables.length = 0;
+        for (let i = 0; i < freshNewVariables.length; i++) {
+          const newVariable = cell.module.module.variable({});
+          // Assign a random pid up-front so blank/identical new cells don't
+          // collide via persistentId's contentHash. See lopecode#144.
+          newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+          variables.push(newVariable);
         }
-    };
+      }
+      if (reposition) {
+        insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
+      }
+      const fns = await realize(freshNewVariables.map(v => v._definition), runtime);
+      freshNewVariables.forEach((v, i) => {
+        const variable = variables[i];
+        const _fn = fns[i];
+        if (v._name) {
+          variable.define(v._name, v._inputs, _fn);
+        } else {
+          variable.define(v._inputs, _fn);
+        }
+        if (reposition)
+          repositionSetElement(runtime._variables, variable, insertionIndex + i);
+      });
+      // Build the full variable set for decompile, mixing reused module-import
+      // variables with the freshly-defined runtime variables, in the same order
+      // as `allocation`.
+      let freshIdx = 0;
+      const decompileVars = allocation.map(a => a.reuse ? a.reuse : variables[freshIdx++]);
+      return await decompile(decompileVars);
+    } catch (e) {
+      console.error(e);
+    }
+  };
 };
 const _1g3bdxp = function _93(md){return(
 md`### Remove Cells`
@@ -7126,7 +7142,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_1whoy5n", null, ["md"], _1whoy5n);  
-  $def("_2dqvsk", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _2dqvsk);  
+  $def("_1hyx2tv", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _1hyx2tv);  
   $def("_1g3bdxp", null, ["md"], _1g3bdxp);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1qb4uz", null, ["md"], _1qb4uz);  

--- a/notebooks/@tomlarkworthy_flow-queue.html
+++ b/notebooks/@tomlarkworthy_flow-queue.html
@@ -6901,47 +6901,63 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _1whoy5n = function _91(md){return(
 md`### Apply Update`
 )};
-const _2dqvsk = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
+const _1hyx2tv = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
 {
-    return async (source, variables = [], cell) => {
-        try {
-            let reposition = false, insertionIndex = -1;
-            const newVariables = compile(source);
-            if (!variables || variables.length !== newVariables.length) {
-                reposition = true;
-                variables.forEach(v => v.delete());
-                variables.length = 0;
-                for (let i = 0; i < newVariables.length; i++) {
-                    const newVariable = cell.module.module.variable({});
-                    // Assign a random pid up-front so blank/identical new cells don't
-                    // collide via persistentId's contentHash. See lopecode#144.
-                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
-                    variables.push(newVariable);
-                }
-            }
-            if (reposition) {
-                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-            }
-            const fns = await realize(newVariables.map(v => v._definition), runtime);
-            newVariables.forEach((v, i) => {
-                const variable = variables[i];
-                const _fn = fns[i];
-                if (v._name) {
-                    variable.define(v._name, v._inputs, _fn);
-                } else {
-                    variable.define(v._inputs, _fn);
-                }
-                if (reposition)
-                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
-            });
-            // Return the canonical decompiled source so the caller can push it
-            // back into its editor view if it has one. No caller currently uses
-            // the variables array directly.
-            return await decompile(variables);
-        } catch (e) {
-            console.error(e);
+  return async (source, variables = [], cell) => {
+    try {
+      const newVariables = compile(source);
+      // Skip emitting `module @X` if one already exists in the target
+      // module's scope and isn't one of OUR old variables. Without this,
+      // the second define() collides on the shared name and Observable
+      // rewrites BOTH the new and pre-existing module variables to a
+      // "defined more than once" thrower, breaking every pre-existing
+      // consumer of `@X` in the module. The new import-name bindings
+      // reference `module @X` by name and resolve to whatever module
+      // variable is currently in scope.
+      const targetScope = cell.module.module._scope;
+      const ourOldNames = new Set(variables.map(v => v._name));
+      const isModuleImport = nv => nv._name?.startsWith('module @') && nv._inputs.length === 0;
+      const shouldSkip = nv => isModuleImport(nv) && targetScope.has(nv._name) && !ourOldNames.has(nv._name);
+      const allocation = newVariables.map(nv => shouldSkip(nv) ? { reuse: targetScope.get(nv._name) } : { fresh: nv });
+      const freshNewVariables = allocation.filter(a => a.fresh).map(a => a.fresh);
+      let reposition = false, insertionIndex = -1;
+      if (!variables || variables.length !== freshNewVariables.length) {
+        reposition = true;
+        variables.forEach(v => v.delete());
+        variables.length = 0;
+        for (let i = 0; i < freshNewVariables.length; i++) {
+          const newVariable = cell.module.module.variable({});
+          // Assign a random pid up-front so blank/identical new cells don't
+          // collide via persistentId's contentHash. See lopecode#144.
+          newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+          variables.push(newVariable);
         }
-    };
+      }
+      if (reposition) {
+        insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
+      }
+      const fns = await realize(freshNewVariables.map(v => v._definition), runtime);
+      freshNewVariables.forEach((v, i) => {
+        const variable = variables[i];
+        const _fn = fns[i];
+        if (v._name) {
+          variable.define(v._name, v._inputs, _fn);
+        } else {
+          variable.define(v._inputs, _fn);
+        }
+        if (reposition)
+          repositionSetElement(runtime._variables, variable, insertionIndex + i);
+      });
+      // Build the full variable set for decompile, mixing reused module-import
+      // variables with the freshly-defined runtime variables, in the same order
+      // as `allocation`.
+      let freshIdx = 0;
+      const decompileVars = allocation.map(a => a.reuse ? a.reuse : variables[freshIdx++]);
+      return await decompile(decompileVars);
+    } catch (e) {
+      console.error(e);
+    }
+  };
 };
 const _1g3bdxp = function _93(md){return(
 md`### Remove Cells`
@@ -7126,7 +7142,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_1whoy5n", null, ["md"], _1whoy5n);  
-  $def("_2dqvsk", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _2dqvsk);  
+  $def("_1hyx2tv", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _1hyx2tv);  
   $def("_1g3bdxp", null, ["md"], _1g3bdxp);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1qb4uz", null, ["md"], _1qb4uz);  

--- a/notebooks/@tomlarkworthy_golden-layout-2-6-0.html
+++ b/notebooks/@tomlarkworthy_golden-layout-2-6-0.html
@@ -6901,47 +6901,63 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _1whoy5n = function _91(md){return(
 md`### Apply Update`
 )};
-const _2dqvsk = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
+const _1hyx2tv = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
 {
-    return async (source, variables = [], cell) => {
-        try {
-            let reposition = false, insertionIndex = -1;
-            const newVariables = compile(source);
-            if (!variables || variables.length !== newVariables.length) {
-                reposition = true;
-                variables.forEach(v => v.delete());
-                variables.length = 0;
-                for (let i = 0; i < newVariables.length; i++) {
-                    const newVariable = cell.module.module.variable({});
-                    // Assign a random pid up-front so blank/identical new cells don't
-                    // collide via persistentId's contentHash. See lopecode#144.
-                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
-                    variables.push(newVariable);
-                }
-            }
-            if (reposition) {
-                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-            }
-            const fns = await realize(newVariables.map(v => v._definition), runtime);
-            newVariables.forEach((v, i) => {
-                const variable = variables[i];
-                const _fn = fns[i];
-                if (v._name) {
-                    variable.define(v._name, v._inputs, _fn);
-                } else {
-                    variable.define(v._inputs, _fn);
-                }
-                if (reposition)
-                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
-            });
-            // Return the canonical decompiled source so the caller can push it
-            // back into its editor view if it has one. No caller currently uses
-            // the variables array directly.
-            return await decompile(variables);
-        } catch (e) {
-            console.error(e);
+  return async (source, variables = [], cell) => {
+    try {
+      const newVariables = compile(source);
+      // Skip emitting `module @X` if one already exists in the target
+      // module's scope and isn't one of OUR old variables. Without this,
+      // the second define() collides on the shared name and Observable
+      // rewrites BOTH the new and pre-existing module variables to a
+      // "defined more than once" thrower, breaking every pre-existing
+      // consumer of `@X` in the module. The new import-name bindings
+      // reference `module @X` by name and resolve to whatever module
+      // variable is currently in scope.
+      const targetScope = cell.module.module._scope;
+      const ourOldNames = new Set(variables.map(v => v._name));
+      const isModuleImport = nv => nv._name?.startsWith('module @') && nv._inputs.length === 0;
+      const shouldSkip = nv => isModuleImport(nv) && targetScope.has(nv._name) && !ourOldNames.has(nv._name);
+      const allocation = newVariables.map(nv => shouldSkip(nv) ? { reuse: targetScope.get(nv._name) } : { fresh: nv });
+      const freshNewVariables = allocation.filter(a => a.fresh).map(a => a.fresh);
+      let reposition = false, insertionIndex = -1;
+      if (!variables || variables.length !== freshNewVariables.length) {
+        reposition = true;
+        variables.forEach(v => v.delete());
+        variables.length = 0;
+        for (let i = 0; i < freshNewVariables.length; i++) {
+          const newVariable = cell.module.module.variable({});
+          // Assign a random pid up-front so blank/identical new cells don't
+          // collide via persistentId's contentHash. See lopecode#144.
+          newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+          variables.push(newVariable);
         }
-    };
+      }
+      if (reposition) {
+        insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
+      }
+      const fns = await realize(freshNewVariables.map(v => v._definition), runtime);
+      freshNewVariables.forEach((v, i) => {
+        const variable = variables[i];
+        const _fn = fns[i];
+        if (v._name) {
+          variable.define(v._name, v._inputs, _fn);
+        } else {
+          variable.define(v._inputs, _fn);
+        }
+        if (reposition)
+          repositionSetElement(runtime._variables, variable, insertionIndex + i);
+      });
+      // Build the full variable set for decompile, mixing reused module-import
+      // variables with the freshly-defined runtime variables, in the same order
+      // as `allocation`.
+      let freshIdx = 0;
+      const decompileVars = allocation.map(a => a.reuse ? a.reuse : variables[freshIdx++]);
+      return await decompile(decompileVars);
+    } catch (e) {
+      console.error(e);
+    }
+  };
 };
 const _1g3bdxp = function _93(md){return(
 md`### Remove Cells`
@@ -7126,7 +7142,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_1whoy5n", null, ["md"], _1whoy5n);  
-  $def("_2dqvsk", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _2dqvsk);  
+  $def("_1hyx2tv", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _1hyx2tv);  
   $def("_1g3bdxp", null, ["md"], _1g3bdxp);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1qb4uz", null, ["md"], _1qb4uz);  

--- a/notebooks/@tomlarkworthy_import-notebook.html
+++ b/notebooks/@tomlarkworthy_import-notebook.html
@@ -6901,47 +6901,63 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _1whoy5n = function _91(md){return(
 md`### Apply Update`
 )};
-const _2dqvsk = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
+const _1hyx2tv = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
 {
-    return async (source, variables = [], cell) => {
-        try {
-            let reposition = false, insertionIndex = -1;
-            const newVariables = compile(source);
-            if (!variables || variables.length !== newVariables.length) {
-                reposition = true;
-                variables.forEach(v => v.delete());
-                variables.length = 0;
-                for (let i = 0; i < newVariables.length; i++) {
-                    const newVariable = cell.module.module.variable({});
-                    // Assign a random pid up-front so blank/identical new cells don't
-                    // collide via persistentId's contentHash. See lopecode#144.
-                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
-                    variables.push(newVariable);
-                }
-            }
-            if (reposition) {
-                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-            }
-            const fns = await realize(newVariables.map(v => v._definition), runtime);
-            newVariables.forEach((v, i) => {
-                const variable = variables[i];
-                const _fn = fns[i];
-                if (v._name) {
-                    variable.define(v._name, v._inputs, _fn);
-                } else {
-                    variable.define(v._inputs, _fn);
-                }
-                if (reposition)
-                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
-            });
-            // Return the canonical decompiled source so the caller can push it
-            // back into its editor view if it has one. No caller currently uses
-            // the variables array directly.
-            return await decompile(variables);
-        } catch (e) {
-            console.error(e);
+  return async (source, variables = [], cell) => {
+    try {
+      const newVariables = compile(source);
+      // Skip emitting `module @X` if one already exists in the target
+      // module's scope and isn't one of OUR old variables. Without this,
+      // the second define() collides on the shared name and Observable
+      // rewrites BOTH the new and pre-existing module variables to a
+      // "defined more than once" thrower, breaking every pre-existing
+      // consumer of `@X` in the module. The new import-name bindings
+      // reference `module @X` by name and resolve to whatever module
+      // variable is currently in scope.
+      const targetScope = cell.module.module._scope;
+      const ourOldNames = new Set(variables.map(v => v._name));
+      const isModuleImport = nv => nv._name?.startsWith('module @') && nv._inputs.length === 0;
+      const shouldSkip = nv => isModuleImport(nv) && targetScope.has(nv._name) && !ourOldNames.has(nv._name);
+      const allocation = newVariables.map(nv => shouldSkip(nv) ? { reuse: targetScope.get(nv._name) } : { fresh: nv });
+      const freshNewVariables = allocation.filter(a => a.fresh).map(a => a.fresh);
+      let reposition = false, insertionIndex = -1;
+      if (!variables || variables.length !== freshNewVariables.length) {
+        reposition = true;
+        variables.forEach(v => v.delete());
+        variables.length = 0;
+        for (let i = 0; i < freshNewVariables.length; i++) {
+          const newVariable = cell.module.module.variable({});
+          // Assign a random pid up-front so blank/identical new cells don't
+          // collide via persistentId's contentHash. See lopecode#144.
+          newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+          variables.push(newVariable);
         }
-    };
+      }
+      if (reposition) {
+        insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
+      }
+      const fns = await realize(freshNewVariables.map(v => v._definition), runtime);
+      freshNewVariables.forEach((v, i) => {
+        const variable = variables[i];
+        const _fn = fns[i];
+        if (v._name) {
+          variable.define(v._name, v._inputs, _fn);
+        } else {
+          variable.define(v._inputs, _fn);
+        }
+        if (reposition)
+          repositionSetElement(runtime._variables, variable, insertionIndex + i);
+      });
+      // Build the full variable set for decompile, mixing reused module-import
+      // variables with the freshly-defined runtime variables, in the same order
+      // as `allocation`.
+      let freshIdx = 0;
+      const decompileVars = allocation.map(a => a.reuse ? a.reuse : variables[freshIdx++]);
+      return await decompile(decompileVars);
+    } catch (e) {
+      console.error(e);
+    }
+  };
 };
 const _1g3bdxp = function _93(md){return(
 md`### Remove Cells`
@@ -7126,7 +7142,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_1whoy5n", null, ["md"], _1whoy5n);  
-  $def("_2dqvsk", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _2dqvsk);  
+  $def("_1hyx2tv", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _1hyx2tv);  
   $def("_1g3bdxp", null, ["md"], _1g3bdxp);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1qb4uz", null, ["md"], _1qb4uz);  

--- a/notebooks/@tomlarkworthy_jest-expect-standalone.html
+++ b/notebooks/@tomlarkworthy_jest-expect-standalone.html
@@ -6901,47 +6901,63 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _1whoy5n = function _91(md){return(
 md`### Apply Update`
 )};
-const _2dqvsk = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
+const _1hyx2tv = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
 {
-    return async (source, variables = [], cell) => {
-        try {
-            let reposition = false, insertionIndex = -1;
-            const newVariables = compile(source);
-            if (!variables || variables.length !== newVariables.length) {
-                reposition = true;
-                variables.forEach(v => v.delete());
-                variables.length = 0;
-                for (let i = 0; i < newVariables.length; i++) {
-                    const newVariable = cell.module.module.variable({});
-                    // Assign a random pid up-front so blank/identical new cells don't
-                    // collide via persistentId's contentHash. See lopecode#144.
-                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
-                    variables.push(newVariable);
-                }
-            }
-            if (reposition) {
-                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-            }
-            const fns = await realize(newVariables.map(v => v._definition), runtime);
-            newVariables.forEach((v, i) => {
-                const variable = variables[i];
-                const _fn = fns[i];
-                if (v._name) {
-                    variable.define(v._name, v._inputs, _fn);
-                } else {
-                    variable.define(v._inputs, _fn);
-                }
-                if (reposition)
-                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
-            });
-            // Return the canonical decompiled source so the caller can push it
-            // back into its editor view if it has one. No caller currently uses
-            // the variables array directly.
-            return await decompile(variables);
-        } catch (e) {
-            console.error(e);
+  return async (source, variables = [], cell) => {
+    try {
+      const newVariables = compile(source);
+      // Skip emitting `module @X` if one already exists in the target
+      // module's scope and isn't one of OUR old variables. Without this,
+      // the second define() collides on the shared name and Observable
+      // rewrites BOTH the new and pre-existing module variables to a
+      // "defined more than once" thrower, breaking every pre-existing
+      // consumer of `@X` in the module. The new import-name bindings
+      // reference `module @X` by name and resolve to whatever module
+      // variable is currently in scope.
+      const targetScope = cell.module.module._scope;
+      const ourOldNames = new Set(variables.map(v => v._name));
+      const isModuleImport = nv => nv._name?.startsWith('module @') && nv._inputs.length === 0;
+      const shouldSkip = nv => isModuleImport(nv) && targetScope.has(nv._name) && !ourOldNames.has(nv._name);
+      const allocation = newVariables.map(nv => shouldSkip(nv) ? { reuse: targetScope.get(nv._name) } : { fresh: nv });
+      const freshNewVariables = allocation.filter(a => a.fresh).map(a => a.fresh);
+      let reposition = false, insertionIndex = -1;
+      if (!variables || variables.length !== freshNewVariables.length) {
+        reposition = true;
+        variables.forEach(v => v.delete());
+        variables.length = 0;
+        for (let i = 0; i < freshNewVariables.length; i++) {
+          const newVariable = cell.module.module.variable({});
+          // Assign a random pid up-front so blank/identical new cells don't
+          // collide via persistentId's contentHash. See lopecode#144.
+          newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+          variables.push(newVariable);
         }
-    };
+      }
+      if (reposition) {
+        insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
+      }
+      const fns = await realize(freshNewVariables.map(v => v._definition), runtime);
+      freshNewVariables.forEach((v, i) => {
+        const variable = variables[i];
+        const _fn = fns[i];
+        if (v._name) {
+          variable.define(v._name, v._inputs, _fn);
+        } else {
+          variable.define(v._inputs, _fn);
+        }
+        if (reposition)
+          repositionSetElement(runtime._variables, variable, insertionIndex + i);
+      });
+      // Build the full variable set for decompile, mixing reused module-import
+      // variables with the freshly-defined runtime variables, in the same order
+      // as `allocation`.
+      let freshIdx = 0;
+      const decompileVars = allocation.map(a => a.reuse ? a.reuse : variables[freshIdx++]);
+      return await decompile(decompileVars);
+    } catch (e) {
+      console.error(e);
+    }
+  };
 };
 const _1g3bdxp = function _93(md){return(
 md`### Remove Cells`
@@ -7126,7 +7142,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_1whoy5n", null, ["md"], _1whoy5n);  
-  $def("_2dqvsk", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _2dqvsk);  
+  $def("_1hyx2tv", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _1hyx2tv);  
   $def("_1g3bdxp", null, ["md"], _1g3bdxp);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1qb4uz", null, ["md"], _1qb4uz);  

--- a/notebooks/@tomlarkworthy_local-change-history.html
+++ b/notebooks/@tomlarkworthy_local-change-history.html
@@ -6901,47 +6901,63 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _1whoy5n = function _91(md){return(
 md`### Apply Update`
 )};
-const _2dqvsk = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
+const _1hyx2tv = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
 {
-    return async (source, variables = [], cell) => {
-        try {
-            let reposition = false, insertionIndex = -1;
-            const newVariables = compile(source);
-            if (!variables || variables.length !== newVariables.length) {
-                reposition = true;
-                variables.forEach(v => v.delete());
-                variables.length = 0;
-                for (let i = 0; i < newVariables.length; i++) {
-                    const newVariable = cell.module.module.variable({});
-                    // Assign a random pid up-front so blank/identical new cells don't
-                    // collide via persistentId's contentHash. See lopecode#144.
-                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
-                    variables.push(newVariable);
-                }
-            }
-            if (reposition) {
-                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-            }
-            const fns = await realize(newVariables.map(v => v._definition), runtime);
-            newVariables.forEach((v, i) => {
-                const variable = variables[i];
-                const _fn = fns[i];
-                if (v._name) {
-                    variable.define(v._name, v._inputs, _fn);
-                } else {
-                    variable.define(v._inputs, _fn);
-                }
-                if (reposition)
-                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
-            });
-            // Return the canonical decompiled source so the caller can push it
-            // back into its editor view if it has one. No caller currently uses
-            // the variables array directly.
-            return await decompile(variables);
-        } catch (e) {
-            console.error(e);
+  return async (source, variables = [], cell) => {
+    try {
+      const newVariables = compile(source);
+      // Skip emitting `module @X` if one already exists in the target
+      // module's scope and isn't one of OUR old variables. Without this,
+      // the second define() collides on the shared name and Observable
+      // rewrites BOTH the new and pre-existing module variables to a
+      // "defined more than once" thrower, breaking every pre-existing
+      // consumer of `@X` in the module. The new import-name bindings
+      // reference `module @X` by name and resolve to whatever module
+      // variable is currently in scope.
+      const targetScope = cell.module.module._scope;
+      const ourOldNames = new Set(variables.map(v => v._name));
+      const isModuleImport = nv => nv._name?.startsWith('module @') && nv._inputs.length === 0;
+      const shouldSkip = nv => isModuleImport(nv) && targetScope.has(nv._name) && !ourOldNames.has(nv._name);
+      const allocation = newVariables.map(nv => shouldSkip(nv) ? { reuse: targetScope.get(nv._name) } : { fresh: nv });
+      const freshNewVariables = allocation.filter(a => a.fresh).map(a => a.fresh);
+      let reposition = false, insertionIndex = -1;
+      if (!variables || variables.length !== freshNewVariables.length) {
+        reposition = true;
+        variables.forEach(v => v.delete());
+        variables.length = 0;
+        for (let i = 0; i < freshNewVariables.length; i++) {
+          const newVariable = cell.module.module.variable({});
+          // Assign a random pid up-front so blank/identical new cells don't
+          // collide via persistentId's contentHash. See lopecode#144.
+          newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+          variables.push(newVariable);
         }
-    };
+      }
+      if (reposition) {
+        insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
+      }
+      const fns = await realize(freshNewVariables.map(v => v._definition), runtime);
+      freshNewVariables.forEach((v, i) => {
+        const variable = variables[i];
+        const _fn = fns[i];
+        if (v._name) {
+          variable.define(v._name, v._inputs, _fn);
+        } else {
+          variable.define(v._inputs, _fn);
+        }
+        if (reposition)
+          repositionSetElement(runtime._variables, variable, insertionIndex + i);
+      });
+      // Build the full variable set for decompile, mixing reused module-import
+      // variables with the freshly-defined runtime variables, in the same order
+      // as `allocation`.
+      let freshIdx = 0;
+      const decompileVars = allocation.map(a => a.reuse ? a.reuse : variables[freshIdx++]);
+      return await decompile(decompileVars);
+    } catch (e) {
+      console.error(e);
+    }
+  };
 };
 const _1g3bdxp = function _93(md){return(
 md`### Remove Cells`
@@ -7126,7 +7142,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_1whoy5n", null, ["md"], _1whoy5n);  
-  $def("_2dqvsk", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _2dqvsk);  
+  $def("_1hyx2tv", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _1hyx2tv);  
   $def("_1g3bdxp", null, ["md"], _1g3bdxp);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1qb4uz", null, ["md"], _1qb4uz);  

--- a/notebooks/@tomlarkworthy_local-storage-view.html
+++ b/notebooks/@tomlarkworthy_local-storage-view.html
@@ -6901,47 +6901,63 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _1whoy5n = function _91(md){return(
 md`### Apply Update`
 )};
-const _2dqvsk = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
+const _1hyx2tv = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
 {
-    return async (source, variables = [], cell) => {
-        try {
-            let reposition = false, insertionIndex = -1;
-            const newVariables = compile(source);
-            if (!variables || variables.length !== newVariables.length) {
-                reposition = true;
-                variables.forEach(v => v.delete());
-                variables.length = 0;
-                for (let i = 0; i < newVariables.length; i++) {
-                    const newVariable = cell.module.module.variable({});
-                    // Assign a random pid up-front so blank/identical new cells don't
-                    // collide via persistentId's contentHash. See lopecode#144.
-                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
-                    variables.push(newVariable);
-                }
-            }
-            if (reposition) {
-                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-            }
-            const fns = await realize(newVariables.map(v => v._definition), runtime);
-            newVariables.forEach((v, i) => {
-                const variable = variables[i];
-                const _fn = fns[i];
-                if (v._name) {
-                    variable.define(v._name, v._inputs, _fn);
-                } else {
-                    variable.define(v._inputs, _fn);
-                }
-                if (reposition)
-                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
-            });
-            // Return the canonical decompiled source so the caller can push it
-            // back into its editor view if it has one. No caller currently uses
-            // the variables array directly.
-            return await decompile(variables);
-        } catch (e) {
-            console.error(e);
+  return async (source, variables = [], cell) => {
+    try {
+      const newVariables = compile(source);
+      // Skip emitting `module @X` if one already exists in the target
+      // module's scope and isn't one of OUR old variables. Without this,
+      // the second define() collides on the shared name and Observable
+      // rewrites BOTH the new and pre-existing module variables to a
+      // "defined more than once" thrower, breaking every pre-existing
+      // consumer of `@X` in the module. The new import-name bindings
+      // reference `module @X` by name and resolve to whatever module
+      // variable is currently in scope.
+      const targetScope = cell.module.module._scope;
+      const ourOldNames = new Set(variables.map(v => v._name));
+      const isModuleImport = nv => nv._name?.startsWith('module @') && nv._inputs.length === 0;
+      const shouldSkip = nv => isModuleImport(nv) && targetScope.has(nv._name) && !ourOldNames.has(nv._name);
+      const allocation = newVariables.map(nv => shouldSkip(nv) ? { reuse: targetScope.get(nv._name) } : { fresh: nv });
+      const freshNewVariables = allocation.filter(a => a.fresh).map(a => a.fresh);
+      let reposition = false, insertionIndex = -1;
+      if (!variables || variables.length !== freshNewVariables.length) {
+        reposition = true;
+        variables.forEach(v => v.delete());
+        variables.length = 0;
+        for (let i = 0; i < freshNewVariables.length; i++) {
+          const newVariable = cell.module.module.variable({});
+          // Assign a random pid up-front so blank/identical new cells don't
+          // collide via persistentId's contentHash. See lopecode#144.
+          newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+          variables.push(newVariable);
         }
-    };
+      }
+      if (reposition) {
+        insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
+      }
+      const fns = await realize(freshNewVariables.map(v => v._definition), runtime);
+      freshNewVariables.forEach((v, i) => {
+        const variable = variables[i];
+        const _fn = fns[i];
+        if (v._name) {
+          variable.define(v._name, v._inputs, _fn);
+        } else {
+          variable.define(v._inputs, _fn);
+        }
+        if (reposition)
+          repositionSetElement(runtime._variables, variable, insertionIndex + i);
+      });
+      // Build the full variable set for decompile, mixing reused module-import
+      // variables with the freshly-defined runtime variables, in the same order
+      // as `allocation`.
+      let freshIdx = 0;
+      const decompileVars = allocation.map(a => a.reuse ? a.reuse : variables[freshIdx++]);
+      return await decompile(decompileVars);
+    } catch (e) {
+      console.error(e);
+    }
+  };
 };
 const _1g3bdxp = function _93(md){return(
 md`### Remove Cells`
@@ -7126,7 +7142,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_1whoy5n", null, ["md"], _1whoy5n);  
-  $def("_2dqvsk", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _2dqvsk);  
+  $def("_1hyx2tv", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _1hyx2tv);  
   $def("_1g3bdxp", null, ["md"], _1g3bdxp);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1qb4uz", null, ["md"], _1qb4uz);  

--- a/notebooks/@tomlarkworthy_lopecode-tour.html
+++ b/notebooks/@tomlarkworthy_lopecode-tour.html
@@ -7819,47 +7819,63 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _1whoy5n = function _91(md){return(
 md`### Apply Update`
 )};
-const _2dqvsk = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
+const _1hyx2tv = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
 {
-    return async (source, variables = [], cell) => {
-        try {
-            let reposition = false, insertionIndex = -1;
-            const newVariables = compile(source);
-            if (!variables || variables.length !== newVariables.length) {
-                reposition = true;
-                variables.forEach(v => v.delete());
-                variables.length = 0;
-                for (let i = 0; i < newVariables.length; i++) {
-                    const newVariable = cell.module.module.variable({});
-                    // Assign a random pid up-front so blank/identical new cells don't
-                    // collide via persistentId's contentHash. See lopecode#144.
-                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
-                    variables.push(newVariable);
-                }
-            }
-            if (reposition) {
-                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-            }
-            const fns = await realize(newVariables.map(v => v._definition), runtime);
-            newVariables.forEach((v, i) => {
-                const variable = variables[i];
-                const _fn = fns[i];
-                if (v._name) {
-                    variable.define(v._name, v._inputs, _fn);
-                } else {
-                    variable.define(v._inputs, _fn);
-                }
-                if (reposition)
-                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
-            });
-            // Return the canonical decompiled source so the caller can push it
-            // back into its editor view if it has one. No caller currently uses
-            // the variables array directly.
-            return await decompile(variables);
-        } catch (e) {
-            console.error(e);
+  return async (source, variables = [], cell) => {
+    try {
+      const newVariables = compile(source);
+      // Skip emitting `module @X` if one already exists in the target
+      // module's scope and isn't one of OUR old variables. Without this,
+      // the second define() collides on the shared name and Observable
+      // rewrites BOTH the new and pre-existing module variables to a
+      // "defined more than once" thrower, breaking every pre-existing
+      // consumer of `@X` in the module. The new import-name bindings
+      // reference `module @X` by name and resolve to whatever module
+      // variable is currently in scope.
+      const targetScope = cell.module.module._scope;
+      const ourOldNames = new Set(variables.map(v => v._name));
+      const isModuleImport = nv => nv._name?.startsWith('module @') && nv._inputs.length === 0;
+      const shouldSkip = nv => isModuleImport(nv) && targetScope.has(nv._name) && !ourOldNames.has(nv._name);
+      const allocation = newVariables.map(nv => shouldSkip(nv) ? { reuse: targetScope.get(nv._name) } : { fresh: nv });
+      const freshNewVariables = allocation.filter(a => a.fresh).map(a => a.fresh);
+      let reposition = false, insertionIndex = -1;
+      if (!variables || variables.length !== freshNewVariables.length) {
+        reposition = true;
+        variables.forEach(v => v.delete());
+        variables.length = 0;
+        for (let i = 0; i < freshNewVariables.length; i++) {
+          const newVariable = cell.module.module.variable({});
+          // Assign a random pid up-front so blank/identical new cells don't
+          // collide via persistentId's contentHash. See lopecode#144.
+          newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+          variables.push(newVariable);
         }
-    };
+      }
+      if (reposition) {
+        insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
+      }
+      const fns = await realize(freshNewVariables.map(v => v._definition), runtime);
+      freshNewVariables.forEach((v, i) => {
+        const variable = variables[i];
+        const _fn = fns[i];
+        if (v._name) {
+          variable.define(v._name, v._inputs, _fn);
+        } else {
+          variable.define(v._inputs, _fn);
+        }
+        if (reposition)
+          repositionSetElement(runtime._variables, variable, insertionIndex + i);
+      });
+      // Build the full variable set for decompile, mixing reused module-import
+      // variables with the freshly-defined runtime variables, in the same order
+      // as `allocation`.
+      let freshIdx = 0;
+      const decompileVars = allocation.map(a => a.reuse ? a.reuse : variables[freshIdx++]);
+      return await decompile(decompileVars);
+    } catch (e) {
+      console.error(e);
+    }
+  };
 };
 const _1g3bdxp = function _93(md){return(
 md`### Remove Cells`
@@ -8044,7 +8060,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_1whoy5n", null, ["md"], _1whoy5n);  
-  $def("_2dqvsk", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _2dqvsk);  
+  $def("_1hyx2tv", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _1hyx2tv);  
   $def("_1g3bdxp", null, ["md"], _1g3bdxp);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1qb4uz", null, ["md"], _1qb4uz);  

--- a/notebooks/@tomlarkworthy_lopecode-vision.html
+++ b/notebooks/@tomlarkworthy_lopecode-vision.html
@@ -7819,47 +7819,63 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _1whoy5n = function _91(md){return(
 md`### Apply Update`
 )};
-const _2dqvsk = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
+const _1hyx2tv = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
 {
-    return async (source, variables = [], cell) => {
-        try {
-            let reposition = false, insertionIndex = -1;
-            const newVariables = compile(source);
-            if (!variables || variables.length !== newVariables.length) {
-                reposition = true;
-                variables.forEach(v => v.delete());
-                variables.length = 0;
-                for (let i = 0; i < newVariables.length; i++) {
-                    const newVariable = cell.module.module.variable({});
-                    // Assign a random pid up-front so blank/identical new cells don't
-                    // collide via persistentId's contentHash. See lopecode#144.
-                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
-                    variables.push(newVariable);
-                }
-            }
-            if (reposition) {
-                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-            }
-            const fns = await realize(newVariables.map(v => v._definition), runtime);
-            newVariables.forEach((v, i) => {
-                const variable = variables[i];
-                const _fn = fns[i];
-                if (v._name) {
-                    variable.define(v._name, v._inputs, _fn);
-                } else {
-                    variable.define(v._inputs, _fn);
-                }
-                if (reposition)
-                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
-            });
-            // Return the canonical decompiled source so the caller can push it
-            // back into its editor view if it has one. No caller currently uses
-            // the variables array directly.
-            return await decompile(variables);
-        } catch (e) {
-            console.error(e);
+  return async (source, variables = [], cell) => {
+    try {
+      const newVariables = compile(source);
+      // Skip emitting `module @X` if one already exists in the target
+      // module's scope and isn't one of OUR old variables. Without this,
+      // the second define() collides on the shared name and Observable
+      // rewrites BOTH the new and pre-existing module variables to a
+      // "defined more than once" thrower, breaking every pre-existing
+      // consumer of `@X` in the module. The new import-name bindings
+      // reference `module @X` by name and resolve to whatever module
+      // variable is currently in scope.
+      const targetScope = cell.module.module._scope;
+      const ourOldNames = new Set(variables.map(v => v._name));
+      const isModuleImport = nv => nv._name?.startsWith('module @') && nv._inputs.length === 0;
+      const shouldSkip = nv => isModuleImport(nv) && targetScope.has(nv._name) && !ourOldNames.has(nv._name);
+      const allocation = newVariables.map(nv => shouldSkip(nv) ? { reuse: targetScope.get(nv._name) } : { fresh: nv });
+      const freshNewVariables = allocation.filter(a => a.fresh).map(a => a.fresh);
+      let reposition = false, insertionIndex = -1;
+      if (!variables || variables.length !== freshNewVariables.length) {
+        reposition = true;
+        variables.forEach(v => v.delete());
+        variables.length = 0;
+        for (let i = 0; i < freshNewVariables.length; i++) {
+          const newVariable = cell.module.module.variable({});
+          // Assign a random pid up-front so blank/identical new cells don't
+          // collide via persistentId's contentHash. See lopecode#144.
+          newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+          variables.push(newVariable);
         }
-    };
+      }
+      if (reposition) {
+        insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
+      }
+      const fns = await realize(freshNewVariables.map(v => v._definition), runtime);
+      freshNewVariables.forEach((v, i) => {
+        const variable = variables[i];
+        const _fn = fns[i];
+        if (v._name) {
+          variable.define(v._name, v._inputs, _fn);
+        } else {
+          variable.define(v._inputs, _fn);
+        }
+        if (reposition)
+          repositionSetElement(runtime._variables, variable, insertionIndex + i);
+      });
+      // Build the full variable set for decompile, mixing reused module-import
+      // variables with the freshly-defined runtime variables, in the same order
+      // as `allocation`.
+      let freshIdx = 0;
+      const decompileVars = allocation.map(a => a.reuse ? a.reuse : variables[freshIdx++]);
+      return await decompile(decompileVars);
+    } catch (e) {
+      console.error(e);
+    }
+  };
 };
 const _1g3bdxp = function _93(md){return(
 md`### Remove Cells`
@@ -8044,7 +8060,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_1whoy5n", null, ["md"], _1whoy5n);  
-  $def("_2dqvsk", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _2dqvsk);  
+  $def("_1hyx2tv", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _1hyx2tv);  
   $def("_1g3bdxp", null, ["md"], _1g3bdxp);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1qb4uz", null, ["md"], _1qb4uz);  

--- a/notebooks/@tomlarkworthy_lopepage-urls.html
+++ b/notebooks/@tomlarkworthy_lopepage-urls.html
@@ -6901,47 +6901,63 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _1whoy5n = function _91(md){return(
 md`### Apply Update`
 )};
-const _2dqvsk = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
+const _1hyx2tv = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
 {
-    return async (source, variables = [], cell) => {
-        try {
-            let reposition = false, insertionIndex = -1;
-            const newVariables = compile(source);
-            if (!variables || variables.length !== newVariables.length) {
-                reposition = true;
-                variables.forEach(v => v.delete());
-                variables.length = 0;
-                for (let i = 0; i < newVariables.length; i++) {
-                    const newVariable = cell.module.module.variable({});
-                    // Assign a random pid up-front so blank/identical new cells don't
-                    // collide via persistentId's contentHash. See lopecode#144.
-                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
-                    variables.push(newVariable);
-                }
-            }
-            if (reposition) {
-                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-            }
-            const fns = await realize(newVariables.map(v => v._definition), runtime);
-            newVariables.forEach((v, i) => {
-                const variable = variables[i];
-                const _fn = fns[i];
-                if (v._name) {
-                    variable.define(v._name, v._inputs, _fn);
-                } else {
-                    variable.define(v._inputs, _fn);
-                }
-                if (reposition)
-                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
-            });
-            // Return the canonical decompiled source so the caller can push it
-            // back into its editor view if it has one. No caller currently uses
-            // the variables array directly.
-            return await decompile(variables);
-        } catch (e) {
-            console.error(e);
+  return async (source, variables = [], cell) => {
+    try {
+      const newVariables = compile(source);
+      // Skip emitting `module @X` if one already exists in the target
+      // module's scope and isn't one of OUR old variables. Without this,
+      // the second define() collides on the shared name and Observable
+      // rewrites BOTH the new and pre-existing module variables to a
+      // "defined more than once" thrower, breaking every pre-existing
+      // consumer of `@X` in the module. The new import-name bindings
+      // reference `module @X` by name and resolve to whatever module
+      // variable is currently in scope.
+      const targetScope = cell.module.module._scope;
+      const ourOldNames = new Set(variables.map(v => v._name));
+      const isModuleImport = nv => nv._name?.startsWith('module @') && nv._inputs.length === 0;
+      const shouldSkip = nv => isModuleImport(nv) && targetScope.has(nv._name) && !ourOldNames.has(nv._name);
+      const allocation = newVariables.map(nv => shouldSkip(nv) ? { reuse: targetScope.get(nv._name) } : { fresh: nv });
+      const freshNewVariables = allocation.filter(a => a.fresh).map(a => a.fresh);
+      let reposition = false, insertionIndex = -1;
+      if (!variables || variables.length !== freshNewVariables.length) {
+        reposition = true;
+        variables.forEach(v => v.delete());
+        variables.length = 0;
+        for (let i = 0; i < freshNewVariables.length; i++) {
+          const newVariable = cell.module.module.variable({});
+          // Assign a random pid up-front so blank/identical new cells don't
+          // collide via persistentId's contentHash. See lopecode#144.
+          newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+          variables.push(newVariable);
         }
-    };
+      }
+      if (reposition) {
+        insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
+      }
+      const fns = await realize(freshNewVariables.map(v => v._definition), runtime);
+      freshNewVariables.forEach((v, i) => {
+        const variable = variables[i];
+        const _fn = fns[i];
+        if (v._name) {
+          variable.define(v._name, v._inputs, _fn);
+        } else {
+          variable.define(v._inputs, _fn);
+        }
+        if (reposition)
+          repositionSetElement(runtime._variables, variable, insertionIndex + i);
+      });
+      // Build the full variable set for decompile, mixing reused module-import
+      // variables with the freshly-defined runtime variables, in the same order
+      // as `allocation`.
+      let freshIdx = 0;
+      const decompileVars = allocation.map(a => a.reuse ? a.reuse : variables[freshIdx++]);
+      return await decompile(decompileVars);
+    } catch (e) {
+      console.error(e);
+    }
+  };
 };
 const _1g3bdxp = function _93(md){return(
 md`### Remove Cells`
@@ -7126,7 +7142,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_1whoy5n", null, ["md"], _1whoy5n);  
-  $def("_2dqvsk", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _2dqvsk);  
+  $def("_1hyx2tv", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _1hyx2tv);  
   $def("_1g3bdxp", null, ["md"], _1g3bdxp);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1qb4uz", null, ["md"], _1qb4uz);  

--- a/notebooks/@tomlarkworthy_lopepage.html
+++ b/notebooks/@tomlarkworthy_lopepage.html
@@ -6901,47 +6901,63 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _1whoy5n = function _91(md){return(
 md`### Apply Update`
 )};
-const _2dqvsk = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
+const _1hyx2tv = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
 {
-    return async (source, variables = [], cell) => {
-        try {
-            let reposition = false, insertionIndex = -1;
-            const newVariables = compile(source);
-            if (!variables || variables.length !== newVariables.length) {
-                reposition = true;
-                variables.forEach(v => v.delete());
-                variables.length = 0;
-                for (let i = 0; i < newVariables.length; i++) {
-                    const newVariable = cell.module.module.variable({});
-                    // Assign a random pid up-front so blank/identical new cells don't
-                    // collide via persistentId's contentHash. See lopecode#144.
-                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
-                    variables.push(newVariable);
-                }
-            }
-            if (reposition) {
-                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-            }
-            const fns = await realize(newVariables.map(v => v._definition), runtime);
-            newVariables.forEach((v, i) => {
-                const variable = variables[i];
-                const _fn = fns[i];
-                if (v._name) {
-                    variable.define(v._name, v._inputs, _fn);
-                } else {
-                    variable.define(v._inputs, _fn);
-                }
-                if (reposition)
-                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
-            });
-            // Return the canonical decompiled source so the caller can push it
-            // back into its editor view if it has one. No caller currently uses
-            // the variables array directly.
-            return await decompile(variables);
-        } catch (e) {
-            console.error(e);
+  return async (source, variables = [], cell) => {
+    try {
+      const newVariables = compile(source);
+      // Skip emitting `module @X` if one already exists in the target
+      // module's scope and isn't one of OUR old variables. Without this,
+      // the second define() collides on the shared name and Observable
+      // rewrites BOTH the new and pre-existing module variables to a
+      // "defined more than once" thrower, breaking every pre-existing
+      // consumer of `@X` in the module. The new import-name bindings
+      // reference `module @X` by name and resolve to whatever module
+      // variable is currently in scope.
+      const targetScope = cell.module.module._scope;
+      const ourOldNames = new Set(variables.map(v => v._name));
+      const isModuleImport = nv => nv._name?.startsWith('module @') && nv._inputs.length === 0;
+      const shouldSkip = nv => isModuleImport(nv) && targetScope.has(nv._name) && !ourOldNames.has(nv._name);
+      const allocation = newVariables.map(nv => shouldSkip(nv) ? { reuse: targetScope.get(nv._name) } : { fresh: nv });
+      const freshNewVariables = allocation.filter(a => a.fresh).map(a => a.fresh);
+      let reposition = false, insertionIndex = -1;
+      if (!variables || variables.length !== freshNewVariables.length) {
+        reposition = true;
+        variables.forEach(v => v.delete());
+        variables.length = 0;
+        for (let i = 0; i < freshNewVariables.length; i++) {
+          const newVariable = cell.module.module.variable({});
+          // Assign a random pid up-front so blank/identical new cells don't
+          // collide via persistentId's contentHash. See lopecode#144.
+          newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+          variables.push(newVariable);
         }
-    };
+      }
+      if (reposition) {
+        insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
+      }
+      const fns = await realize(freshNewVariables.map(v => v._definition), runtime);
+      freshNewVariables.forEach((v, i) => {
+        const variable = variables[i];
+        const _fn = fns[i];
+        if (v._name) {
+          variable.define(v._name, v._inputs, _fn);
+        } else {
+          variable.define(v._inputs, _fn);
+        }
+        if (reposition)
+          repositionSetElement(runtime._variables, variable, insertionIndex + i);
+      });
+      // Build the full variable set for decompile, mixing reused module-import
+      // variables with the freshly-defined runtime variables, in the same order
+      // as `allocation`.
+      let freshIdx = 0;
+      const decompileVars = allocation.map(a => a.reuse ? a.reuse : variables[freshIdx++]);
+      return await decompile(decompileVars);
+    } catch (e) {
+      console.error(e);
+    }
+  };
 };
 const _1g3bdxp = function _93(md){return(
 md`### Remove Cells`
@@ -7126,7 +7142,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_1whoy5n", null, ["md"], _1whoy5n);  
-  $def("_2dqvsk", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _2dqvsk);  
+  $def("_1hyx2tv", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _1hyx2tv);  
   $def("_1g3bdxp", null, ["md"], _1g3bdxp);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1qb4uz", null, ["md"], _1qb4uz);  

--- a/notebooks/@tomlarkworthy_modern-screenshot.html
+++ b/notebooks/@tomlarkworthy_modern-screenshot.html
@@ -6901,47 +6901,63 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _1whoy5n = function _91(md){return(
 md`### Apply Update`
 )};
-const _2dqvsk = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
+const _1hyx2tv = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
 {
-    return async (source, variables = [], cell) => {
-        try {
-            let reposition = false, insertionIndex = -1;
-            const newVariables = compile(source);
-            if (!variables || variables.length !== newVariables.length) {
-                reposition = true;
-                variables.forEach(v => v.delete());
-                variables.length = 0;
-                for (let i = 0; i < newVariables.length; i++) {
-                    const newVariable = cell.module.module.variable({});
-                    // Assign a random pid up-front so blank/identical new cells don't
-                    // collide via persistentId's contentHash. See lopecode#144.
-                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
-                    variables.push(newVariable);
-                }
-            }
-            if (reposition) {
-                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-            }
-            const fns = await realize(newVariables.map(v => v._definition), runtime);
-            newVariables.forEach((v, i) => {
-                const variable = variables[i];
-                const _fn = fns[i];
-                if (v._name) {
-                    variable.define(v._name, v._inputs, _fn);
-                } else {
-                    variable.define(v._inputs, _fn);
-                }
-                if (reposition)
-                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
-            });
-            // Return the canonical decompiled source so the caller can push it
-            // back into its editor view if it has one. No caller currently uses
-            // the variables array directly.
-            return await decompile(variables);
-        } catch (e) {
-            console.error(e);
+  return async (source, variables = [], cell) => {
+    try {
+      const newVariables = compile(source);
+      // Skip emitting `module @X` if one already exists in the target
+      // module's scope and isn't one of OUR old variables. Without this,
+      // the second define() collides on the shared name and Observable
+      // rewrites BOTH the new and pre-existing module variables to a
+      // "defined more than once" thrower, breaking every pre-existing
+      // consumer of `@X` in the module. The new import-name bindings
+      // reference `module @X` by name and resolve to whatever module
+      // variable is currently in scope.
+      const targetScope = cell.module.module._scope;
+      const ourOldNames = new Set(variables.map(v => v._name));
+      const isModuleImport = nv => nv._name?.startsWith('module @') && nv._inputs.length === 0;
+      const shouldSkip = nv => isModuleImport(nv) && targetScope.has(nv._name) && !ourOldNames.has(nv._name);
+      const allocation = newVariables.map(nv => shouldSkip(nv) ? { reuse: targetScope.get(nv._name) } : { fresh: nv });
+      const freshNewVariables = allocation.filter(a => a.fresh).map(a => a.fresh);
+      let reposition = false, insertionIndex = -1;
+      if (!variables || variables.length !== freshNewVariables.length) {
+        reposition = true;
+        variables.forEach(v => v.delete());
+        variables.length = 0;
+        for (let i = 0; i < freshNewVariables.length; i++) {
+          const newVariable = cell.module.module.variable({});
+          // Assign a random pid up-front so blank/identical new cells don't
+          // collide via persistentId's contentHash. See lopecode#144.
+          newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+          variables.push(newVariable);
         }
-    };
+      }
+      if (reposition) {
+        insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
+      }
+      const fns = await realize(freshNewVariables.map(v => v._definition), runtime);
+      freshNewVariables.forEach((v, i) => {
+        const variable = variables[i];
+        const _fn = fns[i];
+        if (v._name) {
+          variable.define(v._name, v._inputs, _fn);
+        } else {
+          variable.define(v._inputs, _fn);
+        }
+        if (reposition)
+          repositionSetElement(runtime._variables, variable, insertionIndex + i);
+      });
+      // Build the full variable set for decompile, mixing reused module-import
+      // variables with the freshly-defined runtime variables, in the same order
+      // as `allocation`.
+      let freshIdx = 0;
+      const decompileVars = allocation.map(a => a.reuse ? a.reuse : variables[freshIdx++]);
+      return await decompile(decompileVars);
+    } catch (e) {
+      console.error(e);
+    }
+  };
 };
 const _1g3bdxp = function _93(md){return(
 md`### Remove Cells`
@@ -7126,7 +7142,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_1whoy5n", null, ["md"], _1whoy5n);  
-  $def("_2dqvsk", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _2dqvsk);  
+  $def("_1hyx2tv", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _1hyx2tv);  
   $def("_1g3bdxp", null, ["md"], _1g3bdxp);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1qb4uz", null, ["md"], _1qb4uz);  

--- a/notebooks/@tomlarkworthy_module-selection.html
+++ b/notebooks/@tomlarkworthy_module-selection.html
@@ -6901,47 +6901,63 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _1whoy5n = function _91(md){return(
 md`### Apply Update`
 )};
-const _2dqvsk = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
+const _1hyx2tv = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
 {
-    return async (source, variables = [], cell) => {
-        try {
-            let reposition = false, insertionIndex = -1;
-            const newVariables = compile(source);
-            if (!variables || variables.length !== newVariables.length) {
-                reposition = true;
-                variables.forEach(v => v.delete());
-                variables.length = 0;
-                for (let i = 0; i < newVariables.length; i++) {
-                    const newVariable = cell.module.module.variable({});
-                    // Assign a random pid up-front so blank/identical new cells don't
-                    // collide via persistentId's contentHash. See lopecode#144.
-                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
-                    variables.push(newVariable);
-                }
-            }
-            if (reposition) {
-                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-            }
-            const fns = await realize(newVariables.map(v => v._definition), runtime);
-            newVariables.forEach((v, i) => {
-                const variable = variables[i];
-                const _fn = fns[i];
-                if (v._name) {
-                    variable.define(v._name, v._inputs, _fn);
-                } else {
-                    variable.define(v._inputs, _fn);
-                }
-                if (reposition)
-                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
-            });
-            // Return the canonical decompiled source so the caller can push it
-            // back into its editor view if it has one. No caller currently uses
-            // the variables array directly.
-            return await decompile(variables);
-        } catch (e) {
-            console.error(e);
+  return async (source, variables = [], cell) => {
+    try {
+      const newVariables = compile(source);
+      // Skip emitting `module @X` if one already exists in the target
+      // module's scope and isn't one of OUR old variables. Without this,
+      // the second define() collides on the shared name and Observable
+      // rewrites BOTH the new and pre-existing module variables to a
+      // "defined more than once" thrower, breaking every pre-existing
+      // consumer of `@X` in the module. The new import-name bindings
+      // reference `module @X` by name and resolve to whatever module
+      // variable is currently in scope.
+      const targetScope = cell.module.module._scope;
+      const ourOldNames = new Set(variables.map(v => v._name));
+      const isModuleImport = nv => nv._name?.startsWith('module @') && nv._inputs.length === 0;
+      const shouldSkip = nv => isModuleImport(nv) && targetScope.has(nv._name) && !ourOldNames.has(nv._name);
+      const allocation = newVariables.map(nv => shouldSkip(nv) ? { reuse: targetScope.get(nv._name) } : { fresh: nv });
+      const freshNewVariables = allocation.filter(a => a.fresh).map(a => a.fresh);
+      let reposition = false, insertionIndex = -1;
+      if (!variables || variables.length !== freshNewVariables.length) {
+        reposition = true;
+        variables.forEach(v => v.delete());
+        variables.length = 0;
+        for (let i = 0; i < freshNewVariables.length; i++) {
+          const newVariable = cell.module.module.variable({});
+          // Assign a random pid up-front so blank/identical new cells don't
+          // collide via persistentId's contentHash. See lopecode#144.
+          newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+          variables.push(newVariable);
         }
-    };
+      }
+      if (reposition) {
+        insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
+      }
+      const fns = await realize(freshNewVariables.map(v => v._definition), runtime);
+      freshNewVariables.forEach((v, i) => {
+        const variable = variables[i];
+        const _fn = fns[i];
+        if (v._name) {
+          variable.define(v._name, v._inputs, _fn);
+        } else {
+          variable.define(v._inputs, _fn);
+        }
+        if (reposition)
+          repositionSetElement(runtime._variables, variable, insertionIndex + i);
+      });
+      // Build the full variable set for decompile, mixing reused module-import
+      // variables with the freshly-defined runtime variables, in the same order
+      // as `allocation`.
+      let freshIdx = 0;
+      const decompileVars = allocation.map(a => a.reuse ? a.reuse : variables[freshIdx++]);
+      return await decompile(decompileVars);
+    } catch (e) {
+      console.error(e);
+    }
+  };
 };
 const _1g3bdxp = function _93(md){return(
 md`### Remove Cells`
@@ -7126,7 +7142,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_1whoy5n", null, ["md"], _1whoy5n);  
-  $def("_2dqvsk", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _2dqvsk);  
+  $def("_1hyx2tv", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _1hyx2tv);  
   $def("_1g3bdxp", null, ["md"], _1g3bdxp);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1qb4uz", null, ["md"], _1qb4uz);  

--- a/notebooks/@tomlarkworthy_notes.html
+++ b/notebooks/@tomlarkworthy_notes.html
@@ -6947,47 +6947,63 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _1whoy5n = function _91(md){return(
 md`### Apply Update`
 )};
-const _2dqvsk = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
+const _1hyx2tv = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
 {
-    return async (source, variables = [], cell) => {
-        try {
-            let reposition = false, insertionIndex = -1;
-            const newVariables = compile(source);
-            if (!variables || variables.length !== newVariables.length) {
-                reposition = true;
-                variables.forEach(v => v.delete());
-                variables.length = 0;
-                for (let i = 0; i < newVariables.length; i++) {
-                    const newVariable = cell.module.module.variable({});
-                    // Assign a random pid up-front so blank/identical new cells don't
-                    // collide via persistentId's contentHash. See lopecode#144.
-                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
-                    variables.push(newVariable);
-                }
-            }
-            if (reposition) {
-                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-            }
-            const fns = await realize(newVariables.map(v => v._definition), runtime);
-            newVariables.forEach((v, i) => {
-                const variable = variables[i];
-                const _fn = fns[i];
-                if (v._name) {
-                    variable.define(v._name, v._inputs, _fn);
-                } else {
-                    variable.define(v._inputs, _fn);
-                }
-                if (reposition)
-                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
-            });
-            // Return the canonical decompiled source so the caller can push it
-            // back into its editor view if it has one. No caller currently uses
-            // the variables array directly.
-            return await decompile(variables);
-        } catch (e) {
-            console.error(e);
+  return async (source, variables = [], cell) => {
+    try {
+      const newVariables = compile(source);
+      // Skip emitting `module @X` if one already exists in the target
+      // module's scope and isn't one of OUR old variables. Without this,
+      // the second define() collides on the shared name and Observable
+      // rewrites BOTH the new and pre-existing module variables to a
+      // "defined more than once" thrower, breaking every pre-existing
+      // consumer of `@X` in the module. The new import-name bindings
+      // reference `module @X` by name and resolve to whatever module
+      // variable is currently in scope.
+      const targetScope = cell.module.module._scope;
+      const ourOldNames = new Set(variables.map(v => v._name));
+      const isModuleImport = nv => nv._name?.startsWith('module @') && nv._inputs.length === 0;
+      const shouldSkip = nv => isModuleImport(nv) && targetScope.has(nv._name) && !ourOldNames.has(nv._name);
+      const allocation = newVariables.map(nv => shouldSkip(nv) ? { reuse: targetScope.get(nv._name) } : { fresh: nv });
+      const freshNewVariables = allocation.filter(a => a.fresh).map(a => a.fresh);
+      let reposition = false, insertionIndex = -1;
+      if (!variables || variables.length !== freshNewVariables.length) {
+        reposition = true;
+        variables.forEach(v => v.delete());
+        variables.length = 0;
+        for (let i = 0; i < freshNewVariables.length; i++) {
+          const newVariable = cell.module.module.variable({});
+          // Assign a random pid up-front so blank/identical new cells don't
+          // collide via persistentId's contentHash. See lopecode#144.
+          newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+          variables.push(newVariable);
         }
-    };
+      }
+      if (reposition) {
+        insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
+      }
+      const fns = await realize(freshNewVariables.map(v => v._definition), runtime);
+      freshNewVariables.forEach((v, i) => {
+        const variable = variables[i];
+        const _fn = fns[i];
+        if (v._name) {
+          variable.define(v._name, v._inputs, _fn);
+        } else {
+          variable.define(v._inputs, _fn);
+        }
+        if (reposition)
+          repositionSetElement(runtime._variables, variable, insertionIndex + i);
+      });
+      // Build the full variable set for decompile, mixing reused module-import
+      // variables with the freshly-defined runtime variables, in the same order
+      // as `allocation`.
+      let freshIdx = 0;
+      const decompileVars = allocation.map(a => a.reuse ? a.reuse : variables[freshIdx++]);
+      return await decompile(decompileVars);
+    } catch (e) {
+      console.error(e);
+    }
+  };
 };
 const _1g3bdxp = function _93(md){return(
 md`### Remove Cells`
@@ -7172,7 +7188,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_1whoy5n", null, ["md"], _1whoy5n);  
-  $def("_2dqvsk", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _2dqvsk);  
+  $def("_1hyx2tv", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _1hyx2tv);  
   $def("_1g3bdxp", null, ["md"], _1g3bdxp);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1qb4uz", null, ["md"], _1qb4uz);  

--- a/notebooks/@tomlarkworthy_observablehq-lezer.html
+++ b/notebooks/@tomlarkworthy_observablehq-lezer.html
@@ -6901,47 +6901,63 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _1whoy5n = function _91(md){return(
 md`### Apply Update`
 )};
-const _2dqvsk = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
+const _1hyx2tv = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
 {
-    return async (source, variables = [], cell) => {
-        try {
-            let reposition = false, insertionIndex = -1;
-            const newVariables = compile(source);
-            if (!variables || variables.length !== newVariables.length) {
-                reposition = true;
-                variables.forEach(v => v.delete());
-                variables.length = 0;
-                for (let i = 0; i < newVariables.length; i++) {
-                    const newVariable = cell.module.module.variable({});
-                    // Assign a random pid up-front so blank/identical new cells don't
-                    // collide via persistentId's contentHash. See lopecode#144.
-                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
-                    variables.push(newVariable);
-                }
-            }
-            if (reposition) {
-                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-            }
-            const fns = await realize(newVariables.map(v => v._definition), runtime);
-            newVariables.forEach((v, i) => {
-                const variable = variables[i];
-                const _fn = fns[i];
-                if (v._name) {
-                    variable.define(v._name, v._inputs, _fn);
-                } else {
-                    variable.define(v._inputs, _fn);
-                }
-                if (reposition)
-                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
-            });
-            // Return the canonical decompiled source so the caller can push it
-            // back into its editor view if it has one. No caller currently uses
-            // the variables array directly.
-            return await decompile(variables);
-        } catch (e) {
-            console.error(e);
+  return async (source, variables = [], cell) => {
+    try {
+      const newVariables = compile(source);
+      // Skip emitting `module @X` if one already exists in the target
+      // module's scope and isn't one of OUR old variables. Without this,
+      // the second define() collides on the shared name and Observable
+      // rewrites BOTH the new and pre-existing module variables to a
+      // "defined more than once" thrower, breaking every pre-existing
+      // consumer of `@X` in the module. The new import-name bindings
+      // reference `module @X` by name and resolve to whatever module
+      // variable is currently in scope.
+      const targetScope = cell.module.module._scope;
+      const ourOldNames = new Set(variables.map(v => v._name));
+      const isModuleImport = nv => nv._name?.startsWith('module @') && nv._inputs.length === 0;
+      const shouldSkip = nv => isModuleImport(nv) && targetScope.has(nv._name) && !ourOldNames.has(nv._name);
+      const allocation = newVariables.map(nv => shouldSkip(nv) ? { reuse: targetScope.get(nv._name) } : { fresh: nv });
+      const freshNewVariables = allocation.filter(a => a.fresh).map(a => a.fresh);
+      let reposition = false, insertionIndex = -1;
+      if (!variables || variables.length !== freshNewVariables.length) {
+        reposition = true;
+        variables.forEach(v => v.delete());
+        variables.length = 0;
+        for (let i = 0; i < freshNewVariables.length; i++) {
+          const newVariable = cell.module.module.variable({});
+          // Assign a random pid up-front so blank/identical new cells don't
+          // collide via persistentId's contentHash. See lopecode#144.
+          newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+          variables.push(newVariable);
         }
-    };
+      }
+      if (reposition) {
+        insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
+      }
+      const fns = await realize(freshNewVariables.map(v => v._definition), runtime);
+      freshNewVariables.forEach((v, i) => {
+        const variable = variables[i];
+        const _fn = fns[i];
+        if (v._name) {
+          variable.define(v._name, v._inputs, _fn);
+        } else {
+          variable.define(v._inputs, _fn);
+        }
+        if (reposition)
+          repositionSetElement(runtime._variables, variable, insertionIndex + i);
+      });
+      // Build the full variable set for decompile, mixing reused module-import
+      // variables with the freshly-defined runtime variables, in the same order
+      // as `allocation`.
+      let freshIdx = 0;
+      const decompileVars = allocation.map(a => a.reuse ? a.reuse : variables[freshIdx++]);
+      return await decompile(decompileVars);
+    } catch (e) {
+      console.error(e);
+    }
+  };
 };
 const _1g3bdxp = function _93(md){return(
 md`### Remove Cells`
@@ -7126,7 +7142,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_1whoy5n", null, ["md"], _1whoy5n);  
-  $def("_2dqvsk", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _2dqvsk);  
+  $def("_1hyx2tv", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _1hyx2tv);  
   $def("_1g3bdxp", null, ["md"], _1g3bdxp);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1qb4uz", null, ["md"], _1qb4uz);  

--- a/notebooks/@tomlarkworthy_observablejs-toolchain.html
+++ b/notebooks/@tomlarkworthy_observablejs-toolchain.html
@@ -6901,47 +6901,63 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _1whoy5n = function _91(md){return(
 md`### Apply Update`
 )};
-const _2dqvsk = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
+const _1hyx2tv = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
 {
-    return async (source, variables = [], cell) => {
-        try {
-            let reposition = false, insertionIndex = -1;
-            const newVariables = compile(source);
-            if (!variables || variables.length !== newVariables.length) {
-                reposition = true;
-                variables.forEach(v => v.delete());
-                variables.length = 0;
-                for (let i = 0; i < newVariables.length; i++) {
-                    const newVariable = cell.module.module.variable({});
-                    // Assign a random pid up-front so blank/identical new cells don't
-                    // collide via persistentId's contentHash. See lopecode#144.
-                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
-                    variables.push(newVariable);
-                }
-            }
-            if (reposition) {
-                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-            }
-            const fns = await realize(newVariables.map(v => v._definition), runtime);
-            newVariables.forEach((v, i) => {
-                const variable = variables[i];
-                const _fn = fns[i];
-                if (v._name) {
-                    variable.define(v._name, v._inputs, _fn);
-                } else {
-                    variable.define(v._inputs, _fn);
-                }
-                if (reposition)
-                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
-            });
-            // Return the canonical decompiled source so the caller can push it
-            // back into its editor view if it has one. No caller currently uses
-            // the variables array directly.
-            return await decompile(variables);
-        } catch (e) {
-            console.error(e);
+  return async (source, variables = [], cell) => {
+    try {
+      const newVariables = compile(source);
+      // Skip emitting `module @X` if one already exists in the target
+      // module's scope and isn't one of OUR old variables. Without this,
+      // the second define() collides on the shared name and Observable
+      // rewrites BOTH the new and pre-existing module variables to a
+      // "defined more than once" thrower, breaking every pre-existing
+      // consumer of `@X` in the module. The new import-name bindings
+      // reference `module @X` by name and resolve to whatever module
+      // variable is currently in scope.
+      const targetScope = cell.module.module._scope;
+      const ourOldNames = new Set(variables.map(v => v._name));
+      const isModuleImport = nv => nv._name?.startsWith('module @') && nv._inputs.length === 0;
+      const shouldSkip = nv => isModuleImport(nv) && targetScope.has(nv._name) && !ourOldNames.has(nv._name);
+      const allocation = newVariables.map(nv => shouldSkip(nv) ? { reuse: targetScope.get(nv._name) } : { fresh: nv });
+      const freshNewVariables = allocation.filter(a => a.fresh).map(a => a.fresh);
+      let reposition = false, insertionIndex = -1;
+      if (!variables || variables.length !== freshNewVariables.length) {
+        reposition = true;
+        variables.forEach(v => v.delete());
+        variables.length = 0;
+        for (let i = 0; i < freshNewVariables.length; i++) {
+          const newVariable = cell.module.module.variable({});
+          // Assign a random pid up-front so blank/identical new cells don't
+          // collide via persistentId's contentHash. See lopecode#144.
+          newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+          variables.push(newVariable);
         }
-    };
+      }
+      if (reposition) {
+        insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
+      }
+      const fns = await realize(freshNewVariables.map(v => v._definition), runtime);
+      freshNewVariables.forEach((v, i) => {
+        const variable = variables[i];
+        const _fn = fns[i];
+        if (v._name) {
+          variable.define(v._name, v._inputs, _fn);
+        } else {
+          variable.define(v._inputs, _fn);
+        }
+        if (reposition)
+          repositionSetElement(runtime._variables, variable, insertionIndex + i);
+      });
+      // Build the full variable set for decompile, mixing reused module-import
+      // variables with the freshly-defined runtime variables, in the same order
+      // as `allocation`.
+      let freshIdx = 0;
+      const decompileVars = allocation.map(a => a.reuse ? a.reuse : variables[freshIdx++]);
+      return await decompile(decompileVars);
+    } catch (e) {
+      console.error(e);
+    }
+  };
 };
 const _1g3bdxp = function _93(md){return(
 md`### Remove Cells`
@@ -7126,7 +7142,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_1whoy5n", null, ["md"], _1whoy5n);  
-  $def("_2dqvsk", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _2dqvsk);  
+  $def("_1hyx2tv", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _1hyx2tv);  
   $def("_1g3bdxp", null, ["md"], _1g3bdxp);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1qb4uz", null, ["md"], _1qb4uz);  

--- a/notebooks/@tomlarkworthy_openai-responses-api.html
+++ b/notebooks/@tomlarkworthy_openai-responses-api.html
@@ -6901,47 +6901,63 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _1whoy5n = function _91(md){return(
 md`### Apply Update`
 )};
-const _2dqvsk = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
+const _1hyx2tv = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
 {
-    return async (source, variables = [], cell) => {
-        try {
-            let reposition = false, insertionIndex = -1;
-            const newVariables = compile(source);
-            if (!variables || variables.length !== newVariables.length) {
-                reposition = true;
-                variables.forEach(v => v.delete());
-                variables.length = 0;
-                for (let i = 0; i < newVariables.length; i++) {
-                    const newVariable = cell.module.module.variable({});
-                    // Assign a random pid up-front so blank/identical new cells don't
-                    // collide via persistentId's contentHash. See lopecode#144.
-                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
-                    variables.push(newVariable);
-                }
-            }
-            if (reposition) {
-                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-            }
-            const fns = await realize(newVariables.map(v => v._definition), runtime);
-            newVariables.forEach((v, i) => {
-                const variable = variables[i];
-                const _fn = fns[i];
-                if (v._name) {
-                    variable.define(v._name, v._inputs, _fn);
-                } else {
-                    variable.define(v._inputs, _fn);
-                }
-                if (reposition)
-                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
-            });
-            // Return the canonical decompiled source so the caller can push it
-            // back into its editor view if it has one. No caller currently uses
-            // the variables array directly.
-            return await decompile(variables);
-        } catch (e) {
-            console.error(e);
+  return async (source, variables = [], cell) => {
+    try {
+      const newVariables = compile(source);
+      // Skip emitting `module @X` if one already exists in the target
+      // module's scope and isn't one of OUR old variables. Without this,
+      // the second define() collides on the shared name and Observable
+      // rewrites BOTH the new and pre-existing module variables to a
+      // "defined more than once" thrower, breaking every pre-existing
+      // consumer of `@X` in the module. The new import-name bindings
+      // reference `module @X` by name and resolve to whatever module
+      // variable is currently in scope.
+      const targetScope = cell.module.module._scope;
+      const ourOldNames = new Set(variables.map(v => v._name));
+      const isModuleImport = nv => nv._name?.startsWith('module @') && nv._inputs.length === 0;
+      const shouldSkip = nv => isModuleImport(nv) && targetScope.has(nv._name) && !ourOldNames.has(nv._name);
+      const allocation = newVariables.map(nv => shouldSkip(nv) ? { reuse: targetScope.get(nv._name) } : { fresh: nv });
+      const freshNewVariables = allocation.filter(a => a.fresh).map(a => a.fresh);
+      let reposition = false, insertionIndex = -1;
+      if (!variables || variables.length !== freshNewVariables.length) {
+        reposition = true;
+        variables.forEach(v => v.delete());
+        variables.length = 0;
+        for (let i = 0; i < freshNewVariables.length; i++) {
+          const newVariable = cell.module.module.variable({});
+          // Assign a random pid up-front so blank/identical new cells don't
+          // collide via persistentId's contentHash. See lopecode#144.
+          newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+          variables.push(newVariable);
         }
-    };
+      }
+      if (reposition) {
+        insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
+      }
+      const fns = await realize(freshNewVariables.map(v => v._definition), runtime);
+      freshNewVariables.forEach((v, i) => {
+        const variable = variables[i];
+        const _fn = fns[i];
+        if (v._name) {
+          variable.define(v._name, v._inputs, _fn);
+        } else {
+          variable.define(v._inputs, _fn);
+        }
+        if (reposition)
+          repositionSetElement(runtime._variables, variable, insertionIndex + i);
+      });
+      // Build the full variable set for decompile, mixing reused module-import
+      // variables with the freshly-defined runtime variables, in the same order
+      // as `allocation`.
+      let freshIdx = 0;
+      const decompileVars = allocation.map(a => a.reuse ? a.reuse : variables[freshIdx++]);
+      return await decompile(decompileVars);
+    } catch (e) {
+      console.error(e);
+    }
+  };
 };
 const _1g3bdxp = function _93(md){return(
 md`### Remove Cells`
@@ -7126,7 +7142,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_1whoy5n", null, ["md"], _1whoy5n);  
-  $def("_2dqvsk", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _2dqvsk);  
+  $def("_1hyx2tv", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _1hyx2tv);  
   $def("_1g3bdxp", null, ["md"], _1g3bdxp);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1qb4uz", null, ["md"], _1qb4uz);  

--- a/notebooks/@tomlarkworthy_reversible-attachment.html
+++ b/notebooks/@tomlarkworthy_reversible-attachment.html
@@ -6901,47 +6901,63 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _1whoy5n = function _91(md){return(
 md`### Apply Update`
 )};
-const _2dqvsk = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
+const _1hyx2tv = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
 {
-    return async (source, variables = [], cell) => {
-        try {
-            let reposition = false, insertionIndex = -1;
-            const newVariables = compile(source);
-            if (!variables || variables.length !== newVariables.length) {
-                reposition = true;
-                variables.forEach(v => v.delete());
-                variables.length = 0;
-                for (let i = 0; i < newVariables.length; i++) {
-                    const newVariable = cell.module.module.variable({});
-                    // Assign a random pid up-front so blank/identical new cells don't
-                    // collide via persistentId's contentHash. See lopecode#144.
-                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
-                    variables.push(newVariable);
-                }
-            }
-            if (reposition) {
-                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-            }
-            const fns = await realize(newVariables.map(v => v._definition), runtime);
-            newVariables.forEach((v, i) => {
-                const variable = variables[i];
-                const _fn = fns[i];
-                if (v._name) {
-                    variable.define(v._name, v._inputs, _fn);
-                } else {
-                    variable.define(v._inputs, _fn);
-                }
-                if (reposition)
-                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
-            });
-            // Return the canonical decompiled source so the caller can push it
-            // back into its editor view if it has one. No caller currently uses
-            // the variables array directly.
-            return await decompile(variables);
-        } catch (e) {
-            console.error(e);
+  return async (source, variables = [], cell) => {
+    try {
+      const newVariables = compile(source);
+      // Skip emitting `module @X` if one already exists in the target
+      // module's scope and isn't one of OUR old variables. Without this,
+      // the second define() collides on the shared name and Observable
+      // rewrites BOTH the new and pre-existing module variables to a
+      // "defined more than once" thrower, breaking every pre-existing
+      // consumer of `@X` in the module. The new import-name bindings
+      // reference `module @X` by name and resolve to whatever module
+      // variable is currently in scope.
+      const targetScope = cell.module.module._scope;
+      const ourOldNames = new Set(variables.map(v => v._name));
+      const isModuleImport = nv => nv._name?.startsWith('module @') && nv._inputs.length === 0;
+      const shouldSkip = nv => isModuleImport(nv) && targetScope.has(nv._name) && !ourOldNames.has(nv._name);
+      const allocation = newVariables.map(nv => shouldSkip(nv) ? { reuse: targetScope.get(nv._name) } : { fresh: nv });
+      const freshNewVariables = allocation.filter(a => a.fresh).map(a => a.fresh);
+      let reposition = false, insertionIndex = -1;
+      if (!variables || variables.length !== freshNewVariables.length) {
+        reposition = true;
+        variables.forEach(v => v.delete());
+        variables.length = 0;
+        for (let i = 0; i < freshNewVariables.length; i++) {
+          const newVariable = cell.module.module.variable({});
+          // Assign a random pid up-front so blank/identical new cells don't
+          // collide via persistentId's contentHash. See lopecode#144.
+          newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+          variables.push(newVariable);
         }
-    };
+      }
+      if (reposition) {
+        insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
+      }
+      const fns = await realize(freshNewVariables.map(v => v._definition), runtime);
+      freshNewVariables.forEach((v, i) => {
+        const variable = variables[i];
+        const _fn = fns[i];
+        if (v._name) {
+          variable.define(v._name, v._inputs, _fn);
+        } else {
+          variable.define(v._inputs, _fn);
+        }
+        if (reposition)
+          repositionSetElement(runtime._variables, variable, insertionIndex + i);
+      });
+      // Build the full variable set for decompile, mixing reused module-import
+      // variables with the freshly-defined runtime variables, in the same order
+      // as `allocation`.
+      let freshIdx = 0;
+      const decompileVars = allocation.map(a => a.reuse ? a.reuse : variables[freshIdx++]);
+      return await decompile(decompileVars);
+    } catch (e) {
+      console.error(e);
+    }
+  };
 };
 const _1g3bdxp = function _93(md){return(
 md`### Remove Cells`
@@ -7126,7 +7142,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_1whoy5n", null, ["md"], _1whoy5n);  
-  $def("_2dqvsk", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _2dqvsk);  
+  $def("_1hyx2tv", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _1hyx2tv);  
   $def("_1g3bdxp", null, ["md"], _1g3bdxp);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1qb4uz", null, ["md"], _1qb4uz);  

--- a/notebooks/@tomlarkworthy_robocoop-2.html
+++ b/notebooks/@tomlarkworthy_robocoop-2.html
@@ -6901,47 +6901,63 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _1whoy5n = function _91(md){return(
 md`### Apply Update`
 )};
-const _2dqvsk = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
+const _1hyx2tv = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
 {
-    return async (source, variables = [], cell) => {
-        try {
-            let reposition = false, insertionIndex = -1;
-            const newVariables = compile(source);
-            if (!variables || variables.length !== newVariables.length) {
-                reposition = true;
-                variables.forEach(v => v.delete());
-                variables.length = 0;
-                for (let i = 0; i < newVariables.length; i++) {
-                    const newVariable = cell.module.module.variable({});
-                    // Assign a random pid up-front so blank/identical new cells don't
-                    // collide via persistentId's contentHash. See lopecode#144.
-                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
-                    variables.push(newVariable);
-                }
-            }
-            if (reposition) {
-                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-            }
-            const fns = await realize(newVariables.map(v => v._definition), runtime);
-            newVariables.forEach((v, i) => {
-                const variable = variables[i];
-                const _fn = fns[i];
-                if (v._name) {
-                    variable.define(v._name, v._inputs, _fn);
-                } else {
-                    variable.define(v._inputs, _fn);
-                }
-                if (reposition)
-                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
-            });
-            // Return the canonical decompiled source so the caller can push it
-            // back into its editor view if it has one. No caller currently uses
-            // the variables array directly.
-            return await decompile(variables);
-        } catch (e) {
-            console.error(e);
+  return async (source, variables = [], cell) => {
+    try {
+      const newVariables = compile(source);
+      // Skip emitting `module @X` if one already exists in the target
+      // module's scope and isn't one of OUR old variables. Without this,
+      // the second define() collides on the shared name and Observable
+      // rewrites BOTH the new and pre-existing module variables to a
+      // "defined more than once" thrower, breaking every pre-existing
+      // consumer of `@X` in the module. The new import-name bindings
+      // reference `module @X` by name and resolve to whatever module
+      // variable is currently in scope.
+      const targetScope = cell.module.module._scope;
+      const ourOldNames = new Set(variables.map(v => v._name));
+      const isModuleImport = nv => nv._name?.startsWith('module @') && nv._inputs.length === 0;
+      const shouldSkip = nv => isModuleImport(nv) && targetScope.has(nv._name) && !ourOldNames.has(nv._name);
+      const allocation = newVariables.map(nv => shouldSkip(nv) ? { reuse: targetScope.get(nv._name) } : { fresh: nv });
+      const freshNewVariables = allocation.filter(a => a.fresh).map(a => a.fresh);
+      let reposition = false, insertionIndex = -1;
+      if (!variables || variables.length !== freshNewVariables.length) {
+        reposition = true;
+        variables.forEach(v => v.delete());
+        variables.length = 0;
+        for (let i = 0; i < freshNewVariables.length; i++) {
+          const newVariable = cell.module.module.variable({});
+          // Assign a random pid up-front so blank/identical new cells don't
+          // collide via persistentId's contentHash. See lopecode#144.
+          newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+          variables.push(newVariable);
         }
-    };
+      }
+      if (reposition) {
+        insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
+      }
+      const fns = await realize(freshNewVariables.map(v => v._definition), runtime);
+      freshNewVariables.forEach((v, i) => {
+        const variable = variables[i];
+        const _fn = fns[i];
+        if (v._name) {
+          variable.define(v._name, v._inputs, _fn);
+        } else {
+          variable.define(v._inputs, _fn);
+        }
+        if (reposition)
+          repositionSetElement(runtime._variables, variable, insertionIndex + i);
+      });
+      // Build the full variable set for decompile, mixing reused module-import
+      // variables with the freshly-defined runtime variables, in the same order
+      // as `allocation`.
+      let freshIdx = 0;
+      const decompileVars = allocation.map(a => a.reuse ? a.reuse : variables[freshIdx++]);
+      return await decompile(decompileVars);
+    } catch (e) {
+      console.error(e);
+    }
+  };
 };
 const _1g3bdxp = function _93(md){return(
 md`### Remove Cells`
@@ -7126,7 +7142,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_1whoy5n", null, ["md"], _1whoy5n);  
-  $def("_2dqvsk", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _2dqvsk);  
+  $def("_1hyx2tv", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _1hyx2tv);  
   $def("_1g3bdxp", null, ["md"], _1g3bdxp);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1qb4uz", null, ["md"], _1qb4uz);  

--- a/notebooks/@tomlarkworthy_robocoop-3.html
+++ b/notebooks/@tomlarkworthy_robocoop-3.html
@@ -6901,47 +6901,63 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _1whoy5n = function _91(md){return(
 md`### Apply Update`
 )};
-const _2dqvsk = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
+const _1hyx2tv = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
 {
-    return async (source, variables = [], cell) => {
-        try {
-            let reposition = false, insertionIndex = -1;
-            const newVariables = compile(source);
-            if (!variables || variables.length !== newVariables.length) {
-                reposition = true;
-                variables.forEach(v => v.delete());
-                variables.length = 0;
-                for (let i = 0; i < newVariables.length; i++) {
-                    const newVariable = cell.module.module.variable({});
-                    // Assign a random pid up-front so blank/identical new cells don't
-                    // collide via persistentId's contentHash. See lopecode#144.
-                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
-                    variables.push(newVariable);
-                }
-            }
-            if (reposition) {
-                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-            }
-            const fns = await realize(newVariables.map(v => v._definition), runtime);
-            newVariables.forEach((v, i) => {
-                const variable = variables[i];
-                const _fn = fns[i];
-                if (v._name) {
-                    variable.define(v._name, v._inputs, _fn);
-                } else {
-                    variable.define(v._inputs, _fn);
-                }
-                if (reposition)
-                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
-            });
-            // Return the canonical decompiled source so the caller can push it
-            // back into its editor view if it has one. No caller currently uses
-            // the variables array directly.
-            return await decompile(variables);
-        } catch (e) {
-            console.error(e);
+  return async (source, variables = [], cell) => {
+    try {
+      const newVariables = compile(source);
+      // Skip emitting `module @X` if one already exists in the target
+      // module's scope and isn't one of OUR old variables. Without this,
+      // the second define() collides on the shared name and Observable
+      // rewrites BOTH the new and pre-existing module variables to a
+      // "defined more than once" thrower, breaking every pre-existing
+      // consumer of `@X` in the module. The new import-name bindings
+      // reference `module @X` by name and resolve to whatever module
+      // variable is currently in scope.
+      const targetScope = cell.module.module._scope;
+      const ourOldNames = new Set(variables.map(v => v._name));
+      const isModuleImport = nv => nv._name?.startsWith('module @') && nv._inputs.length === 0;
+      const shouldSkip = nv => isModuleImport(nv) && targetScope.has(nv._name) && !ourOldNames.has(nv._name);
+      const allocation = newVariables.map(nv => shouldSkip(nv) ? { reuse: targetScope.get(nv._name) } : { fresh: nv });
+      const freshNewVariables = allocation.filter(a => a.fresh).map(a => a.fresh);
+      let reposition = false, insertionIndex = -1;
+      if (!variables || variables.length !== freshNewVariables.length) {
+        reposition = true;
+        variables.forEach(v => v.delete());
+        variables.length = 0;
+        for (let i = 0; i < freshNewVariables.length; i++) {
+          const newVariable = cell.module.module.variable({});
+          // Assign a random pid up-front so blank/identical new cells don't
+          // collide via persistentId's contentHash. See lopecode#144.
+          newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+          variables.push(newVariable);
         }
-    };
+      }
+      if (reposition) {
+        insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
+      }
+      const fns = await realize(freshNewVariables.map(v => v._definition), runtime);
+      freshNewVariables.forEach((v, i) => {
+        const variable = variables[i];
+        const _fn = fns[i];
+        if (v._name) {
+          variable.define(v._name, v._inputs, _fn);
+        } else {
+          variable.define(v._inputs, _fn);
+        }
+        if (reposition)
+          repositionSetElement(runtime._variables, variable, insertionIndex + i);
+      });
+      // Build the full variable set for decompile, mixing reused module-import
+      // variables with the freshly-defined runtime variables, in the same order
+      // as `allocation`.
+      let freshIdx = 0;
+      const decompileVars = allocation.map(a => a.reuse ? a.reuse : variables[freshIdx++]);
+      return await decompile(decompileVars);
+    } catch (e) {
+      console.error(e);
+    }
+  };
 };
 const _1g3bdxp = function _93(md){return(
 md`### Remove Cells`
@@ -7126,7 +7142,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_1whoy5n", null, ["md"], _1whoy5n);  
-  $def("_2dqvsk", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _2dqvsk);  
+  $def("_1hyx2tv", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _1hyx2tv);  
   $def("_1g3bdxp", null, ["md"], _1g3bdxp);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1qb4uz", null, ["md"], _1qb4uz);  

--- a/notebooks/@tomlarkworthy_runtime-sdk.html
+++ b/notebooks/@tomlarkworthy_runtime-sdk.html
@@ -6901,47 +6901,63 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _1whoy5n = function _91(md){return(
 md`### Apply Update`
 )};
-const _2dqvsk = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
+const _1hyx2tv = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
 {
-    return async (source, variables = [], cell) => {
-        try {
-            let reposition = false, insertionIndex = -1;
-            const newVariables = compile(source);
-            if (!variables || variables.length !== newVariables.length) {
-                reposition = true;
-                variables.forEach(v => v.delete());
-                variables.length = 0;
-                for (let i = 0; i < newVariables.length; i++) {
-                    const newVariable = cell.module.module.variable({});
-                    // Assign a random pid up-front so blank/identical new cells don't
-                    // collide via persistentId's contentHash. See lopecode#144.
-                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
-                    variables.push(newVariable);
-                }
-            }
-            if (reposition) {
-                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-            }
-            const fns = await realize(newVariables.map(v => v._definition), runtime);
-            newVariables.forEach((v, i) => {
-                const variable = variables[i];
-                const _fn = fns[i];
-                if (v._name) {
-                    variable.define(v._name, v._inputs, _fn);
-                } else {
-                    variable.define(v._inputs, _fn);
-                }
-                if (reposition)
-                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
-            });
-            // Return the canonical decompiled source so the caller can push it
-            // back into its editor view if it has one. No caller currently uses
-            // the variables array directly.
-            return await decompile(variables);
-        } catch (e) {
-            console.error(e);
+  return async (source, variables = [], cell) => {
+    try {
+      const newVariables = compile(source);
+      // Skip emitting `module @X` if one already exists in the target
+      // module's scope and isn't one of OUR old variables. Without this,
+      // the second define() collides on the shared name and Observable
+      // rewrites BOTH the new and pre-existing module variables to a
+      // "defined more than once" thrower, breaking every pre-existing
+      // consumer of `@X` in the module. The new import-name bindings
+      // reference `module @X` by name and resolve to whatever module
+      // variable is currently in scope.
+      const targetScope = cell.module.module._scope;
+      const ourOldNames = new Set(variables.map(v => v._name));
+      const isModuleImport = nv => nv._name?.startsWith('module @') && nv._inputs.length === 0;
+      const shouldSkip = nv => isModuleImport(nv) && targetScope.has(nv._name) && !ourOldNames.has(nv._name);
+      const allocation = newVariables.map(nv => shouldSkip(nv) ? { reuse: targetScope.get(nv._name) } : { fresh: nv });
+      const freshNewVariables = allocation.filter(a => a.fresh).map(a => a.fresh);
+      let reposition = false, insertionIndex = -1;
+      if (!variables || variables.length !== freshNewVariables.length) {
+        reposition = true;
+        variables.forEach(v => v.delete());
+        variables.length = 0;
+        for (let i = 0; i < freshNewVariables.length; i++) {
+          const newVariable = cell.module.module.variable({});
+          // Assign a random pid up-front so blank/identical new cells don't
+          // collide via persistentId's contentHash. See lopecode#144.
+          newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+          variables.push(newVariable);
         }
-    };
+      }
+      if (reposition) {
+        insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
+      }
+      const fns = await realize(freshNewVariables.map(v => v._definition), runtime);
+      freshNewVariables.forEach((v, i) => {
+        const variable = variables[i];
+        const _fn = fns[i];
+        if (v._name) {
+          variable.define(v._name, v._inputs, _fn);
+        } else {
+          variable.define(v._inputs, _fn);
+        }
+        if (reposition)
+          repositionSetElement(runtime._variables, variable, insertionIndex + i);
+      });
+      // Build the full variable set for decompile, mixing reused module-import
+      // variables with the freshly-defined runtime variables, in the same order
+      // as `allocation`.
+      let freshIdx = 0;
+      const decompileVars = allocation.map(a => a.reuse ? a.reuse : variables[freshIdx++]);
+      return await decompile(decompileVars);
+    } catch (e) {
+      console.error(e);
+    }
+  };
 };
 const _1g3bdxp = function _93(md){return(
 md`### Remove Cells`
@@ -7126,7 +7142,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_1whoy5n", null, ["md"], _1whoy5n);  
-  $def("_2dqvsk", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _2dqvsk);  
+  $def("_1hyx2tv", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _1hyx2tv);  
   $def("_1g3bdxp", null, ["md"], _1g3bdxp);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1qb4uz", null, ["md"], _1qb4uz);  

--- a/notebooks/@tomlarkworthy_secrets.html
+++ b/notebooks/@tomlarkworthy_secrets.html
@@ -6901,47 +6901,63 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _1whoy5n = function _91(md){return(
 md`### Apply Update`
 )};
-const _2dqvsk = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
+const _1hyx2tv = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
 {
-    return async (source, variables = [], cell) => {
-        try {
-            let reposition = false, insertionIndex = -1;
-            const newVariables = compile(source);
-            if (!variables || variables.length !== newVariables.length) {
-                reposition = true;
-                variables.forEach(v => v.delete());
-                variables.length = 0;
-                for (let i = 0; i < newVariables.length; i++) {
-                    const newVariable = cell.module.module.variable({});
-                    // Assign a random pid up-front so blank/identical new cells don't
-                    // collide via persistentId's contentHash. See lopecode#144.
-                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
-                    variables.push(newVariable);
-                }
-            }
-            if (reposition) {
-                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-            }
-            const fns = await realize(newVariables.map(v => v._definition), runtime);
-            newVariables.forEach((v, i) => {
-                const variable = variables[i];
-                const _fn = fns[i];
-                if (v._name) {
-                    variable.define(v._name, v._inputs, _fn);
-                } else {
-                    variable.define(v._inputs, _fn);
-                }
-                if (reposition)
-                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
-            });
-            // Return the canonical decompiled source so the caller can push it
-            // back into its editor view if it has one. No caller currently uses
-            // the variables array directly.
-            return await decompile(variables);
-        } catch (e) {
-            console.error(e);
+  return async (source, variables = [], cell) => {
+    try {
+      const newVariables = compile(source);
+      // Skip emitting `module @X` if one already exists in the target
+      // module's scope and isn't one of OUR old variables. Without this,
+      // the second define() collides on the shared name and Observable
+      // rewrites BOTH the new and pre-existing module variables to a
+      // "defined more than once" thrower, breaking every pre-existing
+      // consumer of `@X` in the module. The new import-name bindings
+      // reference `module @X` by name and resolve to whatever module
+      // variable is currently in scope.
+      const targetScope = cell.module.module._scope;
+      const ourOldNames = new Set(variables.map(v => v._name));
+      const isModuleImport = nv => nv._name?.startsWith('module @') && nv._inputs.length === 0;
+      const shouldSkip = nv => isModuleImport(nv) && targetScope.has(nv._name) && !ourOldNames.has(nv._name);
+      const allocation = newVariables.map(nv => shouldSkip(nv) ? { reuse: targetScope.get(nv._name) } : { fresh: nv });
+      const freshNewVariables = allocation.filter(a => a.fresh).map(a => a.fresh);
+      let reposition = false, insertionIndex = -1;
+      if (!variables || variables.length !== freshNewVariables.length) {
+        reposition = true;
+        variables.forEach(v => v.delete());
+        variables.length = 0;
+        for (let i = 0; i < freshNewVariables.length; i++) {
+          const newVariable = cell.module.module.variable({});
+          // Assign a random pid up-front so blank/identical new cells don't
+          // collide via persistentId's contentHash. See lopecode#144.
+          newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+          variables.push(newVariable);
         }
-    };
+      }
+      if (reposition) {
+        insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
+      }
+      const fns = await realize(freshNewVariables.map(v => v._definition), runtime);
+      freshNewVariables.forEach((v, i) => {
+        const variable = variables[i];
+        const _fn = fns[i];
+        if (v._name) {
+          variable.define(v._name, v._inputs, _fn);
+        } else {
+          variable.define(v._inputs, _fn);
+        }
+        if (reposition)
+          repositionSetElement(runtime._variables, variable, insertionIndex + i);
+      });
+      // Build the full variable set for decompile, mixing reused module-import
+      // variables with the freshly-defined runtime variables, in the same order
+      // as `allocation`.
+      let freshIdx = 0;
+      const decompileVars = allocation.map(a => a.reuse ? a.reuse : variables[freshIdx++]);
+      return await decompile(decompileVars);
+    } catch (e) {
+      console.error(e);
+    }
+  };
 };
 const _1g3bdxp = function _93(md){return(
 md`### Remove Cells`
@@ -7126,7 +7142,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_1whoy5n", null, ["md"], _1whoy5n);  
-  $def("_2dqvsk", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _2dqvsk);  
+  $def("_1hyx2tv", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _1hyx2tv);  
   $def("_1g3bdxp", null, ["md"], _1g3bdxp);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1qb4uz", null, ["md"], _1qb4uz);  

--- a/notebooks/@tomlarkworthy_tests.html
+++ b/notebooks/@tomlarkworthy_tests.html
@@ -6901,47 +6901,63 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _1whoy5n = function _91(md){return(
 md`### Apply Update`
 )};
-const _2dqvsk = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
+const _1hyx2tv = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
 {
-    return async (source, variables = [], cell) => {
-        try {
-            let reposition = false, insertionIndex = -1;
-            const newVariables = compile(source);
-            if (!variables || variables.length !== newVariables.length) {
-                reposition = true;
-                variables.forEach(v => v.delete());
-                variables.length = 0;
-                for (let i = 0; i < newVariables.length; i++) {
-                    const newVariable = cell.module.module.variable({});
-                    // Assign a random pid up-front so blank/identical new cells don't
-                    // collide via persistentId's contentHash. See lopecode#144.
-                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
-                    variables.push(newVariable);
-                }
-            }
-            if (reposition) {
-                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-            }
-            const fns = await realize(newVariables.map(v => v._definition), runtime);
-            newVariables.forEach((v, i) => {
-                const variable = variables[i];
-                const _fn = fns[i];
-                if (v._name) {
-                    variable.define(v._name, v._inputs, _fn);
-                } else {
-                    variable.define(v._inputs, _fn);
-                }
-                if (reposition)
-                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
-            });
-            // Return the canonical decompiled source so the caller can push it
-            // back into its editor view if it has one. No caller currently uses
-            // the variables array directly.
-            return await decompile(variables);
-        } catch (e) {
-            console.error(e);
+  return async (source, variables = [], cell) => {
+    try {
+      const newVariables = compile(source);
+      // Skip emitting `module @X` if one already exists in the target
+      // module's scope and isn't one of OUR old variables. Without this,
+      // the second define() collides on the shared name and Observable
+      // rewrites BOTH the new and pre-existing module variables to a
+      // "defined more than once" thrower, breaking every pre-existing
+      // consumer of `@X` in the module. The new import-name bindings
+      // reference `module @X` by name and resolve to whatever module
+      // variable is currently in scope.
+      const targetScope = cell.module.module._scope;
+      const ourOldNames = new Set(variables.map(v => v._name));
+      const isModuleImport = nv => nv._name?.startsWith('module @') && nv._inputs.length === 0;
+      const shouldSkip = nv => isModuleImport(nv) && targetScope.has(nv._name) && !ourOldNames.has(nv._name);
+      const allocation = newVariables.map(nv => shouldSkip(nv) ? { reuse: targetScope.get(nv._name) } : { fresh: nv });
+      const freshNewVariables = allocation.filter(a => a.fresh).map(a => a.fresh);
+      let reposition = false, insertionIndex = -1;
+      if (!variables || variables.length !== freshNewVariables.length) {
+        reposition = true;
+        variables.forEach(v => v.delete());
+        variables.length = 0;
+        for (let i = 0; i < freshNewVariables.length; i++) {
+          const newVariable = cell.module.module.variable({});
+          // Assign a random pid up-front so blank/identical new cells don't
+          // collide via persistentId's contentHash. See lopecode#144.
+          newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+          variables.push(newVariable);
         }
-    };
+      }
+      if (reposition) {
+        insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
+      }
+      const fns = await realize(freshNewVariables.map(v => v._definition), runtime);
+      freshNewVariables.forEach((v, i) => {
+        const variable = variables[i];
+        const _fn = fns[i];
+        if (v._name) {
+          variable.define(v._name, v._inputs, _fn);
+        } else {
+          variable.define(v._inputs, _fn);
+        }
+        if (reposition)
+          repositionSetElement(runtime._variables, variable, insertionIndex + i);
+      });
+      // Build the full variable set for decompile, mixing reused module-import
+      // variables with the freshly-defined runtime variables, in the same order
+      // as `allocation`.
+      let freshIdx = 0;
+      const decompileVars = allocation.map(a => a.reuse ? a.reuse : variables[freshIdx++]);
+      return await decompile(decompileVars);
+    } catch (e) {
+      console.error(e);
+    }
+  };
 };
 const _1g3bdxp = function _93(md){return(
 md`### Remove Cells`
@@ -7126,7 +7142,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_1whoy5n", null, ["md"], _1whoy5n);  
-  $def("_2dqvsk", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _2dqvsk);  
+  $def("_1hyx2tv", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _1hyx2tv);  
   $def("_1g3bdxp", null, ["md"], _1g3bdxp);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1qb4uz", null, ["md"], _1qb4uz);  

--- a/notebooks/@tomlarkworthy_themes.html
+++ b/notebooks/@tomlarkworthy_themes.html
@@ -6901,47 +6901,63 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _1whoy5n = function _91(md){return(
 md`### Apply Update`
 )};
-const _2dqvsk = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
+const _1hyx2tv = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
 {
-    return async (source, variables = [], cell) => {
-        try {
-            let reposition = false, insertionIndex = -1;
-            const newVariables = compile(source);
-            if (!variables || variables.length !== newVariables.length) {
-                reposition = true;
-                variables.forEach(v => v.delete());
-                variables.length = 0;
-                for (let i = 0; i < newVariables.length; i++) {
-                    const newVariable = cell.module.module.variable({});
-                    // Assign a random pid up-front so blank/identical new cells don't
-                    // collide via persistentId's contentHash. See lopecode#144.
-                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
-                    variables.push(newVariable);
-                }
-            }
-            if (reposition) {
-                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-            }
-            const fns = await realize(newVariables.map(v => v._definition), runtime);
-            newVariables.forEach((v, i) => {
-                const variable = variables[i];
-                const _fn = fns[i];
-                if (v._name) {
-                    variable.define(v._name, v._inputs, _fn);
-                } else {
-                    variable.define(v._inputs, _fn);
-                }
-                if (reposition)
-                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
-            });
-            // Return the canonical decompiled source so the caller can push it
-            // back into its editor view if it has one. No caller currently uses
-            // the variables array directly.
-            return await decompile(variables);
-        } catch (e) {
-            console.error(e);
+  return async (source, variables = [], cell) => {
+    try {
+      const newVariables = compile(source);
+      // Skip emitting `module @X` if one already exists in the target
+      // module's scope and isn't one of OUR old variables. Without this,
+      // the second define() collides on the shared name and Observable
+      // rewrites BOTH the new and pre-existing module variables to a
+      // "defined more than once" thrower, breaking every pre-existing
+      // consumer of `@X` in the module. The new import-name bindings
+      // reference `module @X` by name and resolve to whatever module
+      // variable is currently in scope.
+      const targetScope = cell.module.module._scope;
+      const ourOldNames = new Set(variables.map(v => v._name));
+      const isModuleImport = nv => nv._name?.startsWith('module @') && nv._inputs.length === 0;
+      const shouldSkip = nv => isModuleImport(nv) && targetScope.has(nv._name) && !ourOldNames.has(nv._name);
+      const allocation = newVariables.map(nv => shouldSkip(nv) ? { reuse: targetScope.get(nv._name) } : { fresh: nv });
+      const freshNewVariables = allocation.filter(a => a.fresh).map(a => a.fresh);
+      let reposition = false, insertionIndex = -1;
+      if (!variables || variables.length !== freshNewVariables.length) {
+        reposition = true;
+        variables.forEach(v => v.delete());
+        variables.length = 0;
+        for (let i = 0; i < freshNewVariables.length; i++) {
+          const newVariable = cell.module.module.variable({});
+          // Assign a random pid up-front so blank/identical new cells don't
+          // collide via persistentId's contentHash. See lopecode#144.
+          newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+          variables.push(newVariable);
         }
-    };
+      }
+      if (reposition) {
+        insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
+      }
+      const fns = await realize(freshNewVariables.map(v => v._definition), runtime);
+      freshNewVariables.forEach((v, i) => {
+        const variable = variables[i];
+        const _fn = fns[i];
+        if (v._name) {
+          variable.define(v._name, v._inputs, _fn);
+        } else {
+          variable.define(v._inputs, _fn);
+        }
+        if (reposition)
+          repositionSetElement(runtime._variables, variable, insertionIndex + i);
+      });
+      // Build the full variable set for decompile, mixing reused module-import
+      // variables with the freshly-defined runtime variables, in the same order
+      // as `allocation`.
+      let freshIdx = 0;
+      const decompileVars = allocation.map(a => a.reuse ? a.reuse : variables[freshIdx++]);
+      return await decompile(decompileVars);
+    } catch (e) {
+      console.error(e);
+    }
+  };
 };
 const _1g3bdxp = function _93(md){return(
 md`### Remove Cells`
@@ -7126,7 +7142,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_1whoy5n", null, ["md"], _1whoy5n);  
-  $def("_2dqvsk", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _2dqvsk);  
+  $def("_1hyx2tv", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _1hyx2tv);  
   $def("_1g3bdxp", null, ["md"], _1g3bdxp);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1qb4uz", null, ["md"], _1qb4uz);  

--- a/notebooks/@tomlarkworthy_visualizer.html
+++ b/notebooks/@tomlarkworthy_visualizer.html
@@ -6901,47 +6901,63 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _1whoy5n = function _91(md){return(
 md`### Apply Update`
 )};
-const _2dqvsk = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
+const _1hyx2tv = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
 {
-    return async (source, variables = [], cell) => {
-        try {
-            let reposition = false, insertionIndex = -1;
-            const newVariables = compile(source);
-            if (!variables || variables.length !== newVariables.length) {
-                reposition = true;
-                variables.forEach(v => v.delete());
-                variables.length = 0;
-                for (let i = 0; i < newVariables.length; i++) {
-                    const newVariable = cell.module.module.variable({});
-                    // Assign a random pid up-front so blank/identical new cells don't
-                    // collide via persistentId's contentHash. See lopecode#144.
-                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
-                    variables.push(newVariable);
-                }
-            }
-            if (reposition) {
-                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-            }
-            const fns = await realize(newVariables.map(v => v._definition), runtime);
-            newVariables.forEach((v, i) => {
-                const variable = variables[i];
-                const _fn = fns[i];
-                if (v._name) {
-                    variable.define(v._name, v._inputs, _fn);
-                } else {
-                    variable.define(v._inputs, _fn);
-                }
-                if (reposition)
-                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
-            });
-            // Return the canonical decompiled source so the caller can push it
-            // back into its editor view if it has one. No caller currently uses
-            // the variables array directly.
-            return await decompile(variables);
-        } catch (e) {
-            console.error(e);
+  return async (source, variables = [], cell) => {
+    try {
+      const newVariables = compile(source);
+      // Skip emitting `module @X` if one already exists in the target
+      // module's scope and isn't one of OUR old variables. Without this,
+      // the second define() collides on the shared name and Observable
+      // rewrites BOTH the new and pre-existing module variables to a
+      // "defined more than once" thrower, breaking every pre-existing
+      // consumer of `@X` in the module. The new import-name bindings
+      // reference `module @X` by name and resolve to whatever module
+      // variable is currently in scope.
+      const targetScope = cell.module.module._scope;
+      const ourOldNames = new Set(variables.map(v => v._name));
+      const isModuleImport = nv => nv._name?.startsWith('module @') && nv._inputs.length === 0;
+      const shouldSkip = nv => isModuleImport(nv) && targetScope.has(nv._name) && !ourOldNames.has(nv._name);
+      const allocation = newVariables.map(nv => shouldSkip(nv) ? { reuse: targetScope.get(nv._name) } : { fresh: nv });
+      const freshNewVariables = allocation.filter(a => a.fresh).map(a => a.fresh);
+      let reposition = false, insertionIndex = -1;
+      if (!variables || variables.length !== freshNewVariables.length) {
+        reposition = true;
+        variables.forEach(v => v.delete());
+        variables.length = 0;
+        for (let i = 0; i < freshNewVariables.length; i++) {
+          const newVariable = cell.module.module.variable({});
+          // Assign a random pid up-front so blank/identical new cells don't
+          // collide via persistentId's contentHash. See lopecode#144.
+          newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+          variables.push(newVariable);
         }
-    };
+      }
+      if (reposition) {
+        insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
+      }
+      const fns = await realize(freshNewVariables.map(v => v._definition), runtime);
+      freshNewVariables.forEach((v, i) => {
+        const variable = variables[i];
+        const _fn = fns[i];
+        if (v._name) {
+          variable.define(v._name, v._inputs, _fn);
+        } else {
+          variable.define(v._inputs, _fn);
+        }
+        if (reposition)
+          repositionSetElement(runtime._variables, variable, insertionIndex + i);
+      });
+      // Build the full variable set for decompile, mixing reused module-import
+      // variables with the freshly-defined runtime variables, in the same order
+      // as `allocation`.
+      let freshIdx = 0;
+      const decompileVars = allocation.map(a => a.reuse ? a.reuse : variables[freshIdx++]);
+      return await decompile(decompileVars);
+    } catch (e) {
+      console.error(e);
+    }
+  };
 };
 const _1g3bdxp = function _93(md){return(
 md`### Remove Cells`
@@ -7126,7 +7142,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_1whoy5n", null, ["md"], _1whoy5n);  
-  $def("_2dqvsk", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _2dqvsk);  
+  $def("_1hyx2tv", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _1hyx2tv);  
   $def("_1g3bdxp", null, ["md"], _1g3bdxp);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1qb4uz", null, ["md"], _1qb4uz);  

--- a/notebooks/atproto.html
+++ b/notebooks/atproto.html
@@ -9581,47 +9581,63 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _1whoy5n = function _91(md){return(
 md`### Apply Update`
 )};
-const _2dqvsk = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
+const _1hyx2tv = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
 {
-    return async (source, variables = [], cell) => {
-        try {
-            let reposition = false, insertionIndex = -1;
-            const newVariables = compile(source);
-            if (!variables || variables.length !== newVariables.length) {
-                reposition = true;
-                variables.forEach(v => v.delete());
-                variables.length = 0;
-                for (let i = 0; i < newVariables.length; i++) {
-                    const newVariable = cell.module.module.variable({});
-                    // Assign a random pid up-front so blank/identical new cells don't
-                    // collide via persistentId's contentHash. See lopecode#144.
-                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
-                    variables.push(newVariable);
-                }
-            }
-            if (reposition) {
-                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-            }
-            const fns = await realize(newVariables.map(v => v._definition), runtime);
-            newVariables.forEach((v, i) => {
-                const variable = variables[i];
-                const _fn = fns[i];
-                if (v._name) {
-                    variable.define(v._name, v._inputs, _fn);
-                } else {
-                    variable.define(v._inputs, _fn);
-                }
-                if (reposition)
-                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
-            });
-            // Return the canonical decompiled source so the caller can push it
-            // back into its editor view if it has one. No caller currently uses
-            // the variables array directly.
-            return await decompile(variables);
-        } catch (e) {
-            console.error(e);
+  return async (source, variables = [], cell) => {
+    try {
+      const newVariables = compile(source);
+      // Skip emitting `module @X` if one already exists in the target
+      // module's scope and isn't one of OUR old variables. Without this,
+      // the second define() collides on the shared name and Observable
+      // rewrites BOTH the new and pre-existing module variables to a
+      // "defined more than once" thrower, breaking every pre-existing
+      // consumer of `@X` in the module. The new import-name bindings
+      // reference `module @X` by name and resolve to whatever module
+      // variable is currently in scope.
+      const targetScope = cell.module.module._scope;
+      const ourOldNames = new Set(variables.map(v => v._name));
+      const isModuleImport = nv => nv._name?.startsWith('module @') && nv._inputs.length === 0;
+      const shouldSkip = nv => isModuleImport(nv) && targetScope.has(nv._name) && !ourOldNames.has(nv._name);
+      const allocation = newVariables.map(nv => shouldSkip(nv) ? { reuse: targetScope.get(nv._name) } : { fresh: nv });
+      const freshNewVariables = allocation.filter(a => a.fresh).map(a => a.fresh);
+      let reposition = false, insertionIndex = -1;
+      if (!variables || variables.length !== freshNewVariables.length) {
+        reposition = true;
+        variables.forEach(v => v.delete());
+        variables.length = 0;
+        for (let i = 0; i < freshNewVariables.length; i++) {
+          const newVariable = cell.module.module.variable({});
+          // Assign a random pid up-front so blank/identical new cells don't
+          // collide via persistentId's contentHash. See lopecode#144.
+          newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+          variables.push(newVariable);
         }
-    };
+      }
+      if (reposition) {
+        insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
+      }
+      const fns = await realize(freshNewVariables.map(v => v._definition), runtime);
+      freshNewVariables.forEach((v, i) => {
+        const variable = variables[i];
+        const _fn = fns[i];
+        if (v._name) {
+          variable.define(v._name, v._inputs, _fn);
+        } else {
+          variable.define(v._inputs, _fn);
+        }
+        if (reposition)
+          repositionSetElement(runtime._variables, variable, insertionIndex + i);
+      });
+      // Build the full variable set for decompile, mixing reused module-import
+      // variables with the freshly-defined runtime variables, in the same order
+      // as `allocation`.
+      let freshIdx = 0;
+      const decompileVars = allocation.map(a => a.reuse ? a.reuse : variables[freshIdx++]);
+      return await decompile(decompileVars);
+    } catch (e) {
+      console.error(e);
+    }
+  };
 };
 const _1g3bdxp = function _93(md){return(
 md`### Remove Cells`
@@ -9806,7 +9822,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_1whoy5n", null, ["md"], _1whoy5n);  
-  $def("_2dqvsk", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _2dqvsk);  
+  $def("_1hyx2tv", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _1hyx2tv);  
   $def("_1g3bdxp", null, ["md"], _1g3bdxp);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1qb4uz", null, ["md"], _1qb4uz);  

--- a/notebooks/jumpgates.html
+++ b/notebooks/jumpgates.html
@@ -7793,47 +7793,63 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _1whoy5n = function _91(md){return(
 md`### Apply Update`
 )};
-const _2dqvsk = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
+const _1hyx2tv = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
 {
-    return async (source, variables = [], cell) => {
-        try {
-            let reposition = false, insertionIndex = -1;
-            const newVariables = compile(source);
-            if (!variables || variables.length !== newVariables.length) {
-                reposition = true;
-                variables.forEach(v => v.delete());
-                variables.length = 0;
-                for (let i = 0; i < newVariables.length; i++) {
-                    const newVariable = cell.module.module.variable({});
-                    // Assign a random pid up-front so blank/identical new cells don't
-                    // collide via persistentId's contentHash. See lopecode#144.
-                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
-                    variables.push(newVariable);
-                }
-            }
-            if (reposition) {
-                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-            }
-            const fns = await realize(newVariables.map(v => v._definition), runtime);
-            newVariables.forEach((v, i) => {
-                const variable = variables[i];
-                const _fn = fns[i];
-                if (v._name) {
-                    variable.define(v._name, v._inputs, _fn);
-                } else {
-                    variable.define(v._inputs, _fn);
-                }
-                if (reposition)
-                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
-            });
-            // Return the canonical decompiled source so the caller can push it
-            // back into its editor view if it has one. No caller currently uses
-            // the variables array directly.
-            return await decompile(variables);
-        } catch (e) {
-            console.error(e);
+  return async (source, variables = [], cell) => {
+    try {
+      const newVariables = compile(source);
+      // Skip emitting `module @X` if one already exists in the target
+      // module's scope and isn't one of OUR old variables. Without this,
+      // the second define() collides on the shared name and Observable
+      // rewrites BOTH the new and pre-existing module variables to a
+      // "defined more than once" thrower, breaking every pre-existing
+      // consumer of `@X` in the module. The new import-name bindings
+      // reference `module @X` by name and resolve to whatever module
+      // variable is currently in scope.
+      const targetScope = cell.module.module._scope;
+      const ourOldNames = new Set(variables.map(v => v._name));
+      const isModuleImport = nv => nv._name?.startsWith('module @') && nv._inputs.length === 0;
+      const shouldSkip = nv => isModuleImport(nv) && targetScope.has(nv._name) && !ourOldNames.has(nv._name);
+      const allocation = newVariables.map(nv => shouldSkip(nv) ? { reuse: targetScope.get(nv._name) } : { fresh: nv });
+      const freshNewVariables = allocation.filter(a => a.fresh).map(a => a.fresh);
+      let reposition = false, insertionIndex = -1;
+      if (!variables || variables.length !== freshNewVariables.length) {
+        reposition = true;
+        variables.forEach(v => v.delete());
+        variables.length = 0;
+        for (let i = 0; i < freshNewVariables.length; i++) {
+          const newVariable = cell.module.module.variable({});
+          // Assign a random pid up-front so blank/identical new cells don't
+          // collide via persistentId's contentHash. See lopecode#144.
+          newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+          variables.push(newVariable);
         }
-    };
+      }
+      if (reposition) {
+        insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
+      }
+      const fns = await realize(freshNewVariables.map(v => v._definition), runtime);
+      freshNewVariables.forEach((v, i) => {
+        const variable = variables[i];
+        const _fn = fns[i];
+        if (v._name) {
+          variable.define(v._name, v._inputs, _fn);
+        } else {
+          variable.define(v._inputs, _fn);
+        }
+        if (reposition)
+          repositionSetElement(runtime._variables, variable, insertionIndex + i);
+      });
+      // Build the full variable set for decompile, mixing reused module-import
+      // variables with the freshly-defined runtime variables, in the same order
+      // as `allocation`.
+      let freshIdx = 0;
+      const decompileVars = allocation.map(a => a.reuse ? a.reuse : variables[freshIdx++]);
+      return await decompile(decompileVars);
+    } catch (e) {
+      console.error(e);
+    }
+  };
 };
 const _1g3bdxp = function _93(md){return(
 md`### Remove Cells`
@@ -8018,7 +8034,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_1whoy5n", null, ["md"], _1whoy5n);  
-  $def("_2dqvsk", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _2dqvsk);  
+  $def("_1hyx2tv", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _1hyx2tv);  
   $def("_1g3bdxp", null, ["md"], _1g3bdxp);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1qb4uz", null, ["md"], _1qb4uz);  

--- a/notebooks/ledger.html
+++ b/notebooks/ledger.html
@@ -9380,47 +9380,63 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _1whoy5n = function _91(md){return(
 md`### Apply Update`
 )};
-const _2dqvsk = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
+const _1hyx2tv = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
 {
-    return async (source, variables = [], cell) => {
-        try {
-            let reposition = false, insertionIndex = -1;
-            const newVariables = compile(source);
-            if (!variables || variables.length !== newVariables.length) {
-                reposition = true;
-                variables.forEach(v => v.delete());
-                variables.length = 0;
-                for (let i = 0; i < newVariables.length; i++) {
-                    const newVariable = cell.module.module.variable({});
-                    // Assign a random pid up-front so blank/identical new cells don't
-                    // collide via persistentId's contentHash. See lopecode#144.
-                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
-                    variables.push(newVariable);
-                }
-            }
-            if (reposition) {
-                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-            }
-            const fns = await realize(newVariables.map(v => v._definition), runtime);
-            newVariables.forEach((v, i) => {
-                const variable = variables[i];
-                const _fn = fns[i];
-                if (v._name) {
-                    variable.define(v._name, v._inputs, _fn);
-                } else {
-                    variable.define(v._inputs, _fn);
-                }
-                if (reposition)
-                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
-            });
-            // Return the canonical decompiled source so the caller can push it
-            // back into its editor view if it has one. No caller currently uses
-            // the variables array directly.
-            return await decompile(variables);
-        } catch (e) {
-            console.error(e);
+  return async (source, variables = [], cell) => {
+    try {
+      const newVariables = compile(source);
+      // Skip emitting `module @X` if one already exists in the target
+      // module's scope and isn't one of OUR old variables. Without this,
+      // the second define() collides on the shared name and Observable
+      // rewrites BOTH the new and pre-existing module variables to a
+      // "defined more than once" thrower, breaking every pre-existing
+      // consumer of `@X` in the module. The new import-name bindings
+      // reference `module @X` by name and resolve to whatever module
+      // variable is currently in scope.
+      const targetScope = cell.module.module._scope;
+      const ourOldNames = new Set(variables.map(v => v._name));
+      const isModuleImport = nv => nv._name?.startsWith('module @') && nv._inputs.length === 0;
+      const shouldSkip = nv => isModuleImport(nv) && targetScope.has(nv._name) && !ourOldNames.has(nv._name);
+      const allocation = newVariables.map(nv => shouldSkip(nv) ? { reuse: targetScope.get(nv._name) } : { fresh: nv });
+      const freshNewVariables = allocation.filter(a => a.fresh).map(a => a.fresh);
+      let reposition = false, insertionIndex = -1;
+      if (!variables || variables.length !== freshNewVariables.length) {
+        reposition = true;
+        variables.forEach(v => v.delete());
+        variables.length = 0;
+        for (let i = 0; i < freshNewVariables.length; i++) {
+          const newVariable = cell.module.module.variable({});
+          // Assign a random pid up-front so blank/identical new cells don't
+          // collide via persistentId's contentHash. See lopecode#144.
+          newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+          variables.push(newVariable);
         }
-    };
+      }
+      if (reposition) {
+        insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
+      }
+      const fns = await realize(freshNewVariables.map(v => v._definition), runtime);
+      freshNewVariables.forEach((v, i) => {
+        const variable = variables[i];
+        const _fn = fns[i];
+        if (v._name) {
+          variable.define(v._name, v._inputs, _fn);
+        } else {
+          variable.define(v._inputs, _fn);
+        }
+        if (reposition)
+          repositionSetElement(runtime._variables, variable, insertionIndex + i);
+      });
+      // Build the full variable set for decompile, mixing reused module-import
+      // variables with the freshly-defined runtime variables, in the same order
+      // as `allocation`.
+      let freshIdx = 0;
+      const decompileVars = allocation.map(a => a.reuse ? a.reuse : variables[freshIdx++]);
+      return await decompile(decompileVars);
+    } catch (e) {
+      console.error(e);
+    }
+  };
 };
 const _1g3bdxp = function _93(md){return(
 md`### Remove Cells`
@@ -9605,7 +9621,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_1whoy5n", null, ["md"], _1whoy5n);  
-  $def("_2dqvsk", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _2dqvsk);  
+  $def("_1hyx2tv", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _1hyx2tv);  
   $def("_1g3bdxp", null, ["md"], _1g3bdxp);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1qb4uz", null, ["md"], _1qb4uz);  

--- a/notebooks/lopefeed.html
+++ b/notebooks/lopefeed.html
@@ -9380,47 +9380,63 @@ const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_opti
 const _1whoy5n = function _91(md){return(
 md`### Apply Update`
 )};
-const _2dqvsk = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
+const _1hyx2tv = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
 {
-    return async (source, variables = [], cell) => {
-        try {
-            let reposition = false, insertionIndex = -1;
-            const newVariables = compile(source);
-            if (!variables || variables.length !== newVariables.length) {
-                reposition = true;
-                variables.forEach(v => v.delete());
-                variables.length = 0;
-                for (let i = 0; i < newVariables.length; i++) {
-                    const newVariable = cell.module.module.variable({});
-                    // Assign a random pid up-front so blank/identical new cells don't
-                    // collide via persistentId's contentHash. See lopecode#144.
-                    newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
-                    variables.push(newVariable);
-                }
-            }
-            if (reposition) {
-                insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-            }
-            const fns = await realize(newVariables.map(v => v._definition), runtime);
-            newVariables.forEach((v, i) => {
-                const variable = variables[i];
-                const _fn = fns[i];
-                if (v._name) {
-                    variable.define(v._name, v._inputs, _fn);
-                } else {
-                    variable.define(v._inputs, _fn);
-                }
-                if (reposition)
-                    repositionSetElement(runtime._variables, variable, insertionIndex + i);
-            });
-            // Return the canonical decompiled source so the caller can push it
-            // back into its editor view if it has one. No caller currently uses
-            // the variables array directly.
-            return await decompile(variables);
-        } catch (e) {
-            console.error(e);
+  return async (source, variables = [], cell) => {
+    try {
+      const newVariables = compile(source);
+      // Skip emitting `module @X` if one already exists in the target
+      // module's scope and isn't one of OUR old variables. Without this,
+      // the second define() collides on the shared name and Observable
+      // rewrites BOTH the new and pre-existing module variables to a
+      // "defined more than once" thrower, breaking every pre-existing
+      // consumer of `@X` in the module. The new import-name bindings
+      // reference `module @X` by name and resolve to whatever module
+      // variable is currently in scope.
+      const targetScope = cell.module.module._scope;
+      const ourOldNames = new Set(variables.map(v => v._name));
+      const isModuleImport = nv => nv._name?.startsWith('module @') && nv._inputs.length === 0;
+      const shouldSkip = nv => isModuleImport(nv) && targetScope.has(nv._name) && !ourOldNames.has(nv._name);
+      const allocation = newVariables.map(nv => shouldSkip(nv) ? { reuse: targetScope.get(nv._name) } : { fresh: nv });
+      const freshNewVariables = allocation.filter(a => a.fresh).map(a => a.fresh);
+      let reposition = false, insertionIndex = -1;
+      if (!variables || variables.length !== freshNewVariables.length) {
+        reposition = true;
+        variables.forEach(v => v.delete());
+        variables.length = 0;
+        for (let i = 0; i < freshNewVariables.length; i++) {
+          const newVariable = cell.module.module.variable({});
+          // Assign a random pid up-front so blank/identical new cells don't
+          // collide via persistentId's contentHash. See lopecode#144.
+          newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+          variables.push(newVariable);
         }
-    };
+      }
+      if (reposition) {
+        insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
+      }
+      const fns = await realize(freshNewVariables.map(v => v._definition), runtime);
+      freshNewVariables.forEach((v, i) => {
+        const variable = variables[i];
+        const _fn = fns[i];
+        if (v._name) {
+          variable.define(v._name, v._inputs, _fn);
+        } else {
+          variable.define(v._inputs, _fn);
+        }
+        if (reposition)
+          repositionSetElement(runtime._variables, variable, insertionIndex + i);
+      });
+      // Build the full variable set for decompile, mixing reused module-import
+      // variables with the freshly-defined runtime variables, in the same order
+      // as `allocation`.
+      let freshIdx = 0;
+      const decompileVars = allocation.map(a => a.reuse ? a.reuse : variables[freshIdx++]);
+      return await decompile(decompileVars);
+    } catch (e) {
+      console.error(e);
+    }
+  };
 };
 const _1g3bdxp = function _93(md){return(
 md`### Remove Cells`
@@ -9605,7 +9621,7 @@ export default function define(runtime, observer) {
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
   $def("_1whoy5n", null, ["md"], _1whoy5n);  
-  $def("_2dqvsk", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _2dqvsk);  
+  $def("_1hyx2tv", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _1hyx2tv);  
   $def("_1g3bdxp", null, ["md"], _1g3bdxp);  
   $def("_mhcibs", "remove_variables", [], _mhcibs);  
   $def("_1qb4uz", null, ["md"], _1qb4uz);  


### PR DESCRIPTION
**This PR is a proposal** — the canonical HTML has been updated with the new cell, but ObservableHQ has not been pushed and consumer notebooks have not been re-synced yet. After approval, those steps will run and additional commits will be pushed to this branch.

## Reported symptom
In `@tomlarkworthy/editor-5`, typing `import {a, b} from "@X"` into the cell editor and applying it (▶) corrupted the pre-existing `module @X` binding for every consumer in the editing module. Console: `module @X is defined more than once`. Verified repro: from the editor-5 demo (which already has `module @tomlarkworthy/visualizer` in scope via its compiled bundle), entering `import {visualize, Group} from "@tomlarkworthy/visualizer"` and clicking ▶ rewrites the pre-existing `module @tomlarkworthy/visualizer` Variable (pid `_1kr7q0e`) to a thrower.

## Root cause
`compile_and_update` blindly defines fresh runtime Variables for every cell `compile()` emits — including the `module @X` import stitch. If the target module already has `module @X` in scope, defining a second Variable with the same name triggers Observable's duplicate-name rule, which rewrites BOTH the new and the pre-existing Variable's definitions to `() => { throw new RuntimeError("module @X is defined more than once") }`. Every pre-existing consumer of `@X` in that module then throws.

## Fix
In `@tomlarkworthy/editor-5` `compile_and_update` (`_2dqvsk`): partition compile output into `{reuse}` vs `{fresh}` per allocation. A compile item is reused if it's a `module @X` stitch AND `module @X` is already in the target module's scope AND it isn't one of OUR previous variables (so an in-place edit of an existing user import doesn't accidentally reuse itself). Reused entries skip the `define()` call; fresh entries follow the existing reposition/realize/define pipeline. The import-name aliases (e.g. `visualize`, `Group`) bind to `module @X` by name string, so the runtime resolves them against scope — they correctly bind to whichever Variable is currently registered, no rebinding needed.

## Verification (live runtime)
- Reproduced collision in pre-fix code: `module @tomlarkworthy/visualizer` Variable definition rewritten to the thrower.
- With fix applied, same scenario: `preViz === postViz` (Variable identity preserved), `isThrown: false` (definition unchanged), new `visualize` and `Group` aliases defined cleanly.
- Edge cases analyzed: new cell no collision (fresh path), new cell with collision (fixed path), in-place edit same shape (still reuses fresh slots because our old `module @X` is in `ourOldNames`), edit changing module name (old `module @X` deleted, new one freshly defined or reused depending on target).

## Known limitation (pre-existing, not introduced by this PR)
`compile_and_update`'s returned decompile string for any runtime-compiled import (collision or not) comes back as `module @X = runtime.module(...)` instead of the canonical `import {a, b} from "@X"` form. This is because `compile()` emits alias variables with `_inputs = ['module @X', '@variable']` (two strings), but `decompileImport` only matches single-input cross-module-alias variables. The pre-fix collision case returned the thrower's source; this fix at least returns the runtime stitch's `runtime.module(...)` shape, matching the non-collision baseline. Will be filed as a separate issue (likely fix in `@tomlarkworthy/observablejs-toolchain.compile` or editor-5's `_decompileImport`).