### PR TITLE
Sync @tomlarkworthy/editable-md (drag-select keeps highlight) into consumers

### DIFF
--- a/notebooks/@tomlarkworthy_lopecode-tour.html
+++ b/notebooks/@tomlarkworthy_lopecode-tour.html
@@ -5849,7 +5849,7 @@ md`## Known Issues
 
 - escaped tagged template literal lose their escaping if they are not in a code block. This is due to \`prosemirror.defaultMarkdownParser.parse(markdown)\` removing redundant escapes. We should probably make template placeholders a 1st class concept but as there is an easy work around of putting them in a code fence it is enough for now. (see [\`test_defaultMarkdownParser_preserves_escapes\`](#test_defaultMarkdownParser_preserves_escapes))`
 )};
-const _1llvbnw = function _md(editor_theme_css,prosemirror,Element,randstr,originalMd,markdownToMdTagged,compile,runtime,decompile,mdCellSourceToMarkdown,invalidation)
+const _1z4iyw = function _md(editor_theme_css,prosemirror,Element,randstr,originalMd,markdownToMdTagged,compile,runtime,decompile,mdCellSourceToMarkdown,invalidation)
 {
   // Force the theme override stylesheet to be evaluated and inserted.
   editor_theme_css;
@@ -5959,6 +5959,10 @@ const _1llvbnw = function _md(editor_theme_css,prosemirror,Element,randstr,origi
         resolve(self);
         const listener = async event => {
           if (isInteractiveTarget(event, dom))
+            return;
+          // A click ending a drag-select would otherwise wipe the highlight.
+          const sel = dom.ownerDocument && dom.ownerDocument.getSelection && dom.ownerDocument.getSelection();
+          if (sel && !sel.isCollapsed && sel.anchorNode && sel.focusNode && dom.contains(sel.anchorNode) && dom.contains(sel.focusNode))
             return;
           dom.removeEventListener('click', listener);
           dom.addEventListener('focusout', lostFocus);
@@ -6276,7 +6280,7 @@ export default function define(runtime, observer) {
   $def("_t5sezz", null, ["md"], _t5sezz);  
   $def("_1lfncpk", null, ["title"], _1lfncpk);  
   $def("_u4o7gp", null, ["md"], _u4o7gp);  
-  $def("_1llvbnw", "md", ["editor_theme_css","prosemirror","Element","randstr","originalMd","markdownToMdTagged","compile","runtime","decompile","mdCellSourceToMarkdown","invalidation"], _1llvbnw);  
+  $def("_1z4iyw", "md", ["editor_theme_css","prosemirror","Element","randstr","originalMd","markdownToMdTagged","compile","runtime","decompile","mdCellSourceToMarkdown","invalidation"], _1z4iyw);  
   $def("_etlb83", "irToEditableText", [], _etlb83);  
   $def("_bpew19", "replaceArgPlaceholders", [], _bpew19);  
   main.define("exporter", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("exporter", _));  

--- a/notebooks/@tomlarkworthy_lopecode-vision.html
+++ b/notebooks/@tomlarkworthy_lopecode-vision.html
@@ -5849,7 +5849,7 @@ md`## Known Issues
 
 - escaped tagged template literal lose their escaping if they are not in a code block. This is due to \`prosemirror.defaultMarkdownParser.parse(markdown)\` removing redundant escapes. We should probably make template placeholders a 1st class concept but as there is an easy work around of putting them in a code fence it is enough for now. (see [\`test_defaultMarkdownParser_preserves_escapes\`](#test_defaultMarkdownParser_preserves_escapes))`
 )};
-const _1llvbnw = function _md(editor_theme_css,prosemirror,Element,randstr,originalMd,markdownToMdTagged,compile,runtime,decompile,mdCellSourceToMarkdown,invalidation)
+const _1z4iyw = function _md(editor_theme_css,prosemirror,Element,randstr,originalMd,markdownToMdTagged,compile,runtime,decompile,mdCellSourceToMarkdown,invalidation)
 {
   // Force the theme override stylesheet to be evaluated and inserted.
   editor_theme_css;
@@ -5959,6 +5959,10 @@ const _1llvbnw = function _md(editor_theme_css,prosemirror,Element,randstr,origi
         resolve(self);
         const listener = async event => {
           if (isInteractiveTarget(event, dom))
+            return;
+          // A click ending a drag-select would otherwise wipe the highlight.
+          const sel = dom.ownerDocument && dom.ownerDocument.getSelection && dom.ownerDocument.getSelection();
+          if (sel && !sel.isCollapsed && sel.anchorNode && sel.focusNode && dom.contains(sel.anchorNode) && dom.contains(sel.focusNode))
             return;
           dom.removeEventListener('click', listener);
           dom.addEventListener('focusout', lostFocus);
@@ -6276,7 +6280,7 @@ export default function define(runtime, observer) {
   $def("_t5sezz", null, ["md"], _t5sezz);  
   $def("_1lfncpk", null, ["title"], _1lfncpk);  
   $def("_u4o7gp", null, ["md"], _u4o7gp);  
-  $def("_1llvbnw", "md", ["editor_theme_css","prosemirror","Element","randstr","originalMd","markdownToMdTagged","compile","runtime","decompile","mdCellSourceToMarkdown","invalidation"], _1llvbnw);  
+  $def("_1z4iyw", "md", ["editor_theme_css","prosemirror","Element","randstr","originalMd","markdownToMdTagged","compile","runtime","decompile","mdCellSourceToMarkdown","invalidation"], _1z4iyw);  
   $def("_etlb83", "irToEditableText", [], _etlb83);  
   $def("_bpew19", "replaceArgPlaceholders", [], _bpew19);  
   main.define("exporter", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("exporter", _));  


### PR DESCRIPTION
Companion PR to tomlarkworthy/lopebooks#98.

Syncs the patched \`@tomlarkworthy/editable-md\` module into the two lopecode/ consumers (\`@tomlarkworthy_lopecode-tour.html\`, \`@tomlarkworthy_lopecode-vision.html\`). The module itself was pushed to ObservableHQ from the lopebooks PR (notebook v844) and the canonical bundle regenerated there via lope-jumpgate.

## Diff scope
Pure \`<script id="@tomlarkworthy/editable-md">\` block swap via \`tools/channel/sync-module.ts\` — no other module touched, no rebuild required. Verified the regenerated canonical contains the selection-empty guard before syncing.

## What the fix does
A click ending a drag-to-select gesture no longer mounts the inline editor, so the user's text highlight survives. Clean single-click still opens the editor as before. See lopebooks#98 for full root-cause analysis, repro evidence, and live-runtime QA results.