### PR TITLE
Fix: decompileImport handles all three Variable lifecycle stages + exhaustive in-notebook tests

### DIFF
--- a/notebooks/@tomlarkworthy_atlas.html
+++ b/notebooks/@tomlarkworthy_atlas.html
@@ -20497,56 +20497,103 @@ async (v) => {
 const _1effqg = function _96(md){return(
 md`### \`decompileImport\``
 )};
-const _1etqs71 = function _decompileImport(findModuleName,findImportedName)
+const _b7vai6 = function _decompileImport(findModuleName,findImportedName)
 {
-    return async function decompileImport(variables, options = {}) {
-        if (!variables || variables.length === 0)
-            throw new Error('no variables');
-        // #166: An import group is `[module @foo, ...aliases]` — the runtime stitch
-        // sits at index 0 by convention. Scan for the first alias (single _input,
-        // crosses module boundary) so this works whichever order the caller hands us.
-        const isCrossModuleAlias = v => {
-            const inputs = v?._inputs;
-            if (!Array.isArray(inputs) || inputs.length !== 1)
-                return false;
-            const i0 = inputs[0];
-            return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
-        };
-        const v0 = variables.find(isCrossModuleAlias);
-        if (!v0)
-            return null;
-        const input0 = v0._inputs[0];
-        const inputsLength = 1;
-        const crossesModuleBoundary = true;
-        const module_name = findModuleName(v0._module._scope, input0._module);
-        if (module_name == null)
-            throw new Error('module name could not be resolved');
-        // #166: Skip runtime-internal `module @foo` stitch variables — they belong to
-        // the import group but are not user-facing specifiers. Without this filter, an
-        // import group renders as `import {Range, module @foo} from "@foo"`.
-        const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
-            const imported = await findImportedName(v);
-            const local = v._name;
-            return {
-                imported,
-                local,
-                alias: imported !== local,
-                meta: { index }
-            };
-        }));
-        return {
-            type: 'import',
-            from: module_name,
-            specifiers,
-            meta: {
-                detection: {
-                    inputsLength,
-                    crossesModuleBoundary
-                },
-                variables: variables.map(v => v?._name ?? null)
-            }
-        };
+  return async function decompileImport(variables, options = {}) {
+    if (!variables || variables.length === 0)
+      throw new Error('no variables');
+    // An import-cell group is `[module @X stitch, ...aliases]`. Each alias goes
+    // through three lifecycle stages (documented in observable-runtime-v6's
+    // `importedModule` helper, lines ~1992-2049 of @tomlarkworthy/observable-runtime-v6):
+    //
+    //   Stage A — post-observation:
+    //     `_inputs = [Variable in source module]` (length 1, cross-module).
+    //     The Observable runtime rewrites _inputs after the alias is observed
+    //     and resolved against the source module.
+    //
+    //   Stage B — pre-observation, API-loaded (canonical compiled-bundle shape):
+    //     `_inputs = [Variable("module @X"), Variable("@variable")]` (length 2,
+    //     both in the importer module). What `runtime.define("name",
+    //     ["module @X", "@variable"], (_, v) => v.import("name", _))` produces.
+    //     Also what `compile_and_update` outputs for freshly-defined user-typed
+    //     imports until they're observed.
+    //
+    //   Stage C — pre-observation, inline live-notebook:
+    //     `_inputs = [Variable("@variable")]` (length 1) AND the definition
+    //     calls `import(...)` inside. We extract the imported module reference
+    //     by invoking the definition with a stub `import` capture.
+    //
+    // Detection order is post→pre because Stage A is unambiguous when present.
+    const isStageA = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
     };
+    const isStageB = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 2)
+        return false;
+      const [i0, i1] = inputs;
+      return !!(i0 && typeof i0 === 'object' && typeof i0._name === 'string' && i0._name.startsWith('module @') && i1 && typeof i1 === 'object' && i1._name === '@variable');
+    };
+    const isStageC = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && i0._name === '@variable' && typeof v._definition !== 'undefined' && String(v._definition).includes('import('));
+    };
+    let v0, module_name, stage;
+    if (v0 = variables.find(isStageA)) {
+      stage = 'A';
+      module_name = findModuleName(v0._module._scope, v0._inputs[0]._module);
+    } else if (v0 = variables.find(isStageB)) {
+      stage = 'B';
+      module_name = v0._inputs[0]._name.replace(/^module /, '');
+    } else if (v0 = variables.find(isStageC)) {
+      stage = 'C';
+      let capturedModule;
+      try {
+        await v0._definition({
+          import: (...args) => {
+            capturedModule = args[args.length - 1];
+          }
+        });
+      } catch (e) {
+      }
+      if (capturedModule && v0._module?._scope) {
+        module_name = findModuleName(v0._module._scope, capturedModule);
+      }
+    } else {
+      return null;
+    }
+    if (module_name == null)
+      throw new Error('module name could not be resolved');
+    // Skip runtime-internal `module @foo` stitch variables — they belong to
+    // the import group but are not user-facing specifiers. Without this filter, an
+    // import group renders as `import {Range, module @foo} from "@foo"`.
+    const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
+      const imported = await findImportedName(v);
+      const local = v._name;
+      return {
+        imported,
+        local,
+        alias: imported !== local,
+        meta: { index }
+      };
+    }));
+    return {
+      type: 'import',
+      from: module_name,
+      specifiers,
+      meta: {
+        detection: { stage },
+        variables: variables.map(v => v?._name ?? null)
+      }
+    };
+  };
 };
 const _1sylz7j = function _formatImportDeclaration(){return(
 function formatImportDeclaration(importInfo) {
@@ -21656,6 +21703,198 @@ const _1hiclbb = function _acorn_walk(acorn_walk_url) {
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
+const _1rc67k0 = function _stageB_importFake()
+{
+  return // Builds a Stage B (pre-observation, API-loaded) import group as POJOs.
+  // Mirrors what `runtime.define("name", ["module @X", "@variable"], (_, v) => v.import("name", _))`
+  // produces structurally. Used by the test_decompileImport_stageB_* tests to
+  // avoid spinning up a real Observable runtime per case.
+  function stageB_importFake(module_name, specifiers) {
+    const importerModule = { _scope: new Map() };
+    const stitch = {
+      _name: `module ${ module_name }`,
+      _module: importerModule,
+      _inputs: [],
+      _definition: `async () => null`
+    };
+    const atVariable = {
+      _name: '@variable',
+      _module: importerModule
+    };
+    const aliases = specifiers.map(s => ({
+      _name: s.local,
+      _module: importerModule,
+      _inputs: [
+        stitch,
+        atVariable
+      ],
+      _definition: s.imported === s.local ? `(_, v) => v.import("${ s.imported }", _)` : `(_, v) => v.import("${ s.imported }", "${ s.local }", _)`
+    }));
+    return [
+      stitch,
+      ...aliases
+    ];
+  };
+};
+const _1d53asg = async function _test_decompileImport_stageB_single(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [{
+      imported: 'visualize',
+      local: 'visualize'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _hv5gag = async function _test_decompileImport_stageB_aliased(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'x',
+      local: 'z'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(info.specifiers[0].alias).toEqual(true);
+  expect(formatImportDeclaration(info)).toEqual(`import {x as z} from "@user/y"`);
+  return 'ok';
+};
+const _avc18y = async function _test_decompileImport_stageB_multiple(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    },
+    {
+      imported: 'c',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b, c} from "@user/y"`);
+  return 'ok';
+};
+const _16gia7i = async function _test_decompileImport_stageB_mixed_alias(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b as c} from "@user/y"`);
+  return 'ok';
+};
+const _1slhdwo = async function _test_decompileImport_stageB_viewof(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/module-map', [{
+      imported: 'viewof currentModules',
+      local: 'viewof currentModules'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {viewof currentModules} from "@tomlarkworthy/module-map"`);
+  return 'ok';
+};
+const _qwlsf2 = async function _test_decompileImport_stageB_mutable(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'mutable counter',
+      local: 'mutable counter'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {mutable counter} from "@user/y"`);
+  return 'ok';
+};
+const _sy7jfx = async function _test_decompileImport_returns_null_for_non_import(decompileImport,expect)
+{
+  // A regular cell — no stitch, no @variable input, no cross-module reference.
+  const info = await decompileImport([{
+      _name: 'x',
+      _module: {},
+      _inputs: [],
+      _definition: `() => 42`
+    }]);
+  expect(info).toEqual(null);
+  return 'ok';
+};
+const _rk7ku3 = async function _test_decompileImport_compile_roundtrip_single(compile,expect,stageB_importFake,decompileImport,formatImportDeclaration)
+{
+  // What `compile()` emits for `import {x} from "@user/y"` is structurally the
+  // same as our stageB_importFake fixture (after runtime.define resolves the
+  // input name strings to Variable refs). Verify the fixture matches the
+  // shape compile() would produce.
+  const pojos = compile(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  expect(pojos.length).toEqual(3);
+  expect(pojos[0]._name).toEqual('module @tomlarkworthy/visualizer');
+  expect(pojos[1]._name).toEqual('visualize');
+  expect(pojos[2]._name).toEqual('Group');
+  expect(pojos[1]._inputs).toEqual([
+    'module @tomlarkworthy/visualizer',
+    '@variable'
+  ]);
+  // Now run our fixture through decompileImport — confirms the round-trip
+  // shape compile()-output-shape-when-defined → decompileImport produces the
+  // canonical import source string.
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [
+    {
+      imported: 'visualize',
+      local: 'visualize'
+    },
+    {
+      imported: 'Group',
+      local: 'Group'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _xynplo = async function _test_decompileImport_stageB_order_independent(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // The detection uses .find — it shouldn't matter whether the stitch is at
+  // index 0 or the aliases come first. Verify by reversing the array.
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    }
+  ]);
+  const reversed = [...vars].reverse();
+  const info = await decompileImport(reversed);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b} from "@user/y"`);
+  return 'ok';
+};
+const _16fpgac = async function _test_decompileImport_stageB_notebook_id(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // Observable supports `import {x} from "d/<hash>@<version>"` notebook-id form.
+  const vars = stageB_importFake('d/57d79353bac56631@44', [{
+      imported: 'hash',
+      local: 'hash'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {hash} from "d/57d79353bac56631@44"`);
+  return 'ok';
+};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -21776,7 +22015,7 @@ export default function define(runtime, observer) {
   $def("_1n7gw17", "findModuleName", ["extractModuleInfo"], _1n7gw17);  
   $def("_i47chb", "findImportedName", [], _i47chb);  
   $def("_1effqg", null, ["md"], _1effqg);  
-  $def("_1etqs71", "decompileImport", ["findModuleName","findImportedName"], _1etqs71);  
+  $def("_b7vai6", "decompileImport", ["findModuleName","findImportedName"], _b7vai6);  
   $def("_1sylz7j", "formatImportDeclaration", [], _1sylz7j);  
   $def("_13dctdn", "test_decompileImport_basic", ["importFake","decompileImport","expect"], _13dctdn);  
   $def("_ujr0xn", "test_formatImportDeclaration_roundtrip", ["importFake","decompileImport","expect","formatImportDeclaration","decompile"], _ujr0xn);  
@@ -21854,7 +22093,18 @@ export default function define(runtime, observer) {
   main.define("Runtime", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Runtime", _));  
   main.define("Inspector", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Inspector", _));  
   main.define("Library", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Library", _));  
-  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));
+  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));  
+  $def("_1rc67k0", "stageB_importFake", [], _1rc67k0);  
+  $def("_1d53asg", "test_decompileImport_stageB_single", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1d53asg);  
+  $def("_hv5gag", "test_decompileImport_stageB_aliased", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _hv5gag);  
+  $def("_avc18y", "test_decompileImport_stageB_multiple", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _avc18y);  
+  $def("_16gia7i", "test_decompileImport_stageB_mixed_alias", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16gia7i);  
+  $def("_1slhdwo", "test_decompileImport_stageB_viewof", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1slhdwo);  
+  $def("_qwlsf2", "test_decompileImport_stageB_mutable", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _qwlsf2);  
+  $def("_sy7jfx", "test_decompileImport_returns_null_for_non_import", ["decompileImport","expect"], _sy7jfx);  
+  $def("_rk7ku3", "test_decompileImport_compile_roundtrip_single", ["compile","expect","stageB_importFake","decompileImport","formatImportDeclaration"], _rk7ku3);  
+  $def("_xynplo", "test_decompileImport_stageB_order_independent", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _xynplo);  
+  $def("_16fpgac", "test_decompileImport_stageB_notebook_id", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16fpgac);
   return main;
 }</script>
 <script id="@tomlarkworthy/openai-responses-api/image.png" 

--- a/notebooks/@tomlarkworthy_atproto-comments.html
+++ b/notebooks/@tomlarkworthy_atproto-comments.html
@@ -19616,56 +19616,103 @@ async (v) => {
 const _1effqg = function _96(md){return(
 md`### \`decompileImport\``
 )};
-const _1etqs71 = function _decompileImport(findModuleName,findImportedName)
+const _b7vai6 = function _decompileImport(findModuleName,findImportedName)
 {
-    return async function decompileImport(variables, options = {}) {
-        if (!variables || variables.length === 0)
-            throw new Error('no variables');
-        // #166: An import group is `[module @foo, ...aliases]` — the runtime stitch
-        // sits at index 0 by convention. Scan for the first alias (single _input,
-        // crosses module boundary) so this works whichever order the caller hands us.
-        const isCrossModuleAlias = v => {
-            const inputs = v?._inputs;
-            if (!Array.isArray(inputs) || inputs.length !== 1)
-                return false;
-            const i0 = inputs[0];
-            return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
-        };
-        const v0 = variables.find(isCrossModuleAlias);
-        if (!v0)
-            return null;
-        const input0 = v0._inputs[0];
-        const inputsLength = 1;
-        const crossesModuleBoundary = true;
-        const module_name = findModuleName(v0._module._scope, input0._module);
-        if (module_name == null)
-            throw new Error('module name could not be resolved');
-        // #166: Skip runtime-internal `module @foo` stitch variables — they belong to
-        // the import group but are not user-facing specifiers. Without this filter, an
-        // import group renders as `import {Range, module @foo} from "@foo"`.
-        const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
-            const imported = await findImportedName(v);
-            const local = v._name;
-            return {
-                imported,
-                local,
-                alias: imported !== local,
-                meta: { index }
-            };
-        }));
-        return {
-            type: 'import',
-            from: module_name,
-            specifiers,
-            meta: {
-                detection: {
-                    inputsLength,
-                    crossesModuleBoundary
-                },
-                variables: variables.map(v => v?._name ?? null)
-            }
-        };
+  return async function decompileImport(variables, options = {}) {
+    if (!variables || variables.length === 0)
+      throw new Error('no variables');
+    // An import-cell group is `[module @X stitch, ...aliases]`. Each alias goes
+    // through three lifecycle stages (documented in observable-runtime-v6's
+    // `importedModule` helper, lines ~1992-2049 of @tomlarkworthy/observable-runtime-v6):
+    //
+    //   Stage A — post-observation:
+    //     `_inputs = [Variable in source module]` (length 1, cross-module).
+    //     The Observable runtime rewrites _inputs after the alias is observed
+    //     and resolved against the source module.
+    //
+    //   Stage B — pre-observation, API-loaded (canonical compiled-bundle shape):
+    //     `_inputs = [Variable("module @X"), Variable("@variable")]` (length 2,
+    //     both in the importer module). What `runtime.define("name",
+    //     ["module @X", "@variable"], (_, v) => v.import("name", _))` produces.
+    //     Also what `compile_and_update` outputs for freshly-defined user-typed
+    //     imports until they're observed.
+    //
+    //   Stage C — pre-observation, inline live-notebook:
+    //     `_inputs = [Variable("@variable")]` (length 1) AND the definition
+    //     calls `import(...)` inside. We extract the imported module reference
+    //     by invoking the definition with a stub `import` capture.
+    //
+    // Detection order is post→pre because Stage A is unambiguous when present.
+    const isStageA = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
     };
+    const isStageB = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 2)
+        return false;
+      const [i0, i1] = inputs;
+      return !!(i0 && typeof i0 === 'object' && typeof i0._name === 'string' && i0._name.startsWith('module @') && i1 && typeof i1 === 'object' && i1._name === '@variable');
+    };
+    const isStageC = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && i0._name === '@variable' && typeof v._definition !== 'undefined' && String(v._definition).includes('import('));
+    };
+    let v0, module_name, stage;
+    if (v0 = variables.find(isStageA)) {
+      stage = 'A';
+      module_name = findModuleName(v0._module._scope, v0._inputs[0]._module);
+    } else if (v0 = variables.find(isStageB)) {
+      stage = 'B';
+      module_name = v0._inputs[0]._name.replace(/^module /, '');
+    } else if (v0 = variables.find(isStageC)) {
+      stage = 'C';
+      let capturedModule;
+      try {
+        await v0._definition({
+          import: (...args) => {
+            capturedModule = args[args.length - 1];
+          }
+        });
+      } catch (e) {
+      }
+      if (capturedModule && v0._module?._scope) {
+        module_name = findModuleName(v0._module._scope, capturedModule);
+      }
+    } else {
+      return null;
+    }
+    if (module_name == null)
+      throw new Error('module name could not be resolved');
+    // Skip runtime-internal `module @foo` stitch variables — they belong to
+    // the import group but are not user-facing specifiers. Without this filter, an
+    // import group renders as `import {Range, module @foo} from "@foo"`.
+    const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
+      const imported = await findImportedName(v);
+      const local = v._name;
+      return {
+        imported,
+        local,
+        alias: imported !== local,
+        meta: { index }
+      };
+    }));
+    return {
+      type: 'import',
+      from: module_name,
+      specifiers,
+      meta: {
+        detection: { stage },
+        variables: variables.map(v => v?._name ?? null)
+      }
+    };
+  };
 };
 const _1sylz7j = function _formatImportDeclaration(){return(
 function formatImportDeclaration(importInfo) {
@@ -20775,6 +20822,198 @@ const _1hiclbb = function _acorn_walk(acorn_walk_url) {
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
+const _1rc67k0 = function _stageB_importFake()
+{
+  return // Builds a Stage B (pre-observation, API-loaded) import group as POJOs.
+  // Mirrors what `runtime.define("name", ["module @X", "@variable"], (_, v) => v.import("name", _))`
+  // produces structurally. Used by the test_decompileImport_stageB_* tests to
+  // avoid spinning up a real Observable runtime per case.
+  function stageB_importFake(module_name, specifiers) {
+    const importerModule = { _scope: new Map() };
+    const stitch = {
+      _name: `module ${ module_name }`,
+      _module: importerModule,
+      _inputs: [],
+      _definition: `async () => null`
+    };
+    const atVariable = {
+      _name: '@variable',
+      _module: importerModule
+    };
+    const aliases = specifiers.map(s => ({
+      _name: s.local,
+      _module: importerModule,
+      _inputs: [
+        stitch,
+        atVariable
+      ],
+      _definition: s.imported === s.local ? `(_, v) => v.import("${ s.imported }", _)` : `(_, v) => v.import("${ s.imported }", "${ s.local }", _)`
+    }));
+    return [
+      stitch,
+      ...aliases
+    ];
+  };
+};
+const _1d53asg = async function _test_decompileImport_stageB_single(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [{
+      imported: 'visualize',
+      local: 'visualize'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _hv5gag = async function _test_decompileImport_stageB_aliased(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'x',
+      local: 'z'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(info.specifiers[0].alias).toEqual(true);
+  expect(formatImportDeclaration(info)).toEqual(`import {x as z} from "@user/y"`);
+  return 'ok';
+};
+const _avc18y = async function _test_decompileImport_stageB_multiple(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    },
+    {
+      imported: 'c',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b, c} from "@user/y"`);
+  return 'ok';
+};
+const _16gia7i = async function _test_decompileImport_stageB_mixed_alias(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b as c} from "@user/y"`);
+  return 'ok';
+};
+const _1slhdwo = async function _test_decompileImport_stageB_viewof(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/module-map', [{
+      imported: 'viewof currentModules',
+      local: 'viewof currentModules'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {viewof currentModules} from "@tomlarkworthy/module-map"`);
+  return 'ok';
+};
+const _qwlsf2 = async function _test_decompileImport_stageB_mutable(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'mutable counter',
+      local: 'mutable counter'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {mutable counter} from "@user/y"`);
+  return 'ok';
+};
+const _sy7jfx = async function _test_decompileImport_returns_null_for_non_import(decompileImport,expect)
+{
+  // A regular cell — no stitch, no @variable input, no cross-module reference.
+  const info = await decompileImport([{
+      _name: 'x',
+      _module: {},
+      _inputs: [],
+      _definition: `() => 42`
+    }]);
+  expect(info).toEqual(null);
+  return 'ok';
+};
+const _rk7ku3 = async function _test_decompileImport_compile_roundtrip_single(compile,expect,stageB_importFake,decompileImport,formatImportDeclaration)
+{
+  // What `compile()` emits for `import {x} from "@user/y"` is structurally the
+  // same as our stageB_importFake fixture (after runtime.define resolves the
+  // input name strings to Variable refs). Verify the fixture matches the
+  // shape compile() would produce.
+  const pojos = compile(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  expect(pojos.length).toEqual(3);
+  expect(pojos[0]._name).toEqual('module @tomlarkworthy/visualizer');
+  expect(pojos[1]._name).toEqual('visualize');
+  expect(pojos[2]._name).toEqual('Group');
+  expect(pojos[1]._inputs).toEqual([
+    'module @tomlarkworthy/visualizer',
+    '@variable'
+  ]);
+  // Now run our fixture through decompileImport — confirms the round-trip
+  // shape compile()-output-shape-when-defined → decompileImport produces the
+  // canonical import source string.
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [
+    {
+      imported: 'visualize',
+      local: 'visualize'
+    },
+    {
+      imported: 'Group',
+      local: 'Group'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _xynplo = async function _test_decompileImport_stageB_order_independent(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // The detection uses .find — it shouldn't matter whether the stitch is at
+  // index 0 or the aliases come first. Verify by reversing the array.
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    }
+  ]);
+  const reversed = [...vars].reverse();
+  const info = await decompileImport(reversed);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b} from "@user/y"`);
+  return 'ok';
+};
+const _16fpgac = async function _test_decompileImport_stageB_notebook_id(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // Observable supports `import {x} from "d/<hash>@<version>"` notebook-id form.
+  const vars = stageB_importFake('d/57d79353bac56631@44', [{
+      imported: 'hash',
+      local: 'hash'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {hash} from "d/57d79353bac56631@44"`);
+  return 'ok';
+};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -20895,7 +21134,7 @@ export default function define(runtime, observer) {
   $def("_1n7gw17", "findModuleName", ["extractModuleInfo"], _1n7gw17);  
   $def("_i47chb", "findImportedName", [], _i47chb);  
   $def("_1effqg", null, ["md"], _1effqg);  
-  $def("_1etqs71", "decompileImport", ["findModuleName","findImportedName"], _1etqs71);  
+  $def("_b7vai6", "decompileImport", ["findModuleName","findImportedName"], _b7vai6);  
   $def("_1sylz7j", "formatImportDeclaration", [], _1sylz7j);  
   $def("_13dctdn", "test_decompileImport_basic", ["importFake","decompileImport","expect"], _13dctdn);  
   $def("_ujr0xn", "test_formatImportDeclaration_roundtrip", ["importFake","decompileImport","expect","formatImportDeclaration","decompile"], _ujr0xn);  
@@ -20973,7 +21212,18 @@ export default function define(runtime, observer) {
   main.define("Runtime", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Runtime", _));  
   main.define("Inspector", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Inspector", _));  
   main.define("Library", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Library", _));  
-  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));
+  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));  
+  $def("_1rc67k0", "stageB_importFake", [], _1rc67k0);  
+  $def("_1d53asg", "test_decompileImport_stageB_single", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1d53asg);  
+  $def("_hv5gag", "test_decompileImport_stageB_aliased", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _hv5gag);  
+  $def("_avc18y", "test_decompileImport_stageB_multiple", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _avc18y);  
+  $def("_16gia7i", "test_decompileImport_stageB_mixed_alias", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16gia7i);  
+  $def("_1slhdwo", "test_decompileImport_stageB_viewof", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1slhdwo);  
+  $def("_qwlsf2", "test_decompileImport_stageB_mutable", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _qwlsf2);  
+  $def("_sy7jfx", "test_decompileImport_returns_null_for_non_import", ["decompileImport","expect"], _sy7jfx);  
+  $def("_rk7ku3", "test_decompileImport_compile_roundtrip_single", ["compile","expect","stageB_importFake","decompileImport","formatImportDeclaration"], _rk7ku3);  
+  $def("_xynplo", "test_decompileImport_stageB_order_independent", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _xynplo);  
+  $def("_16fpgac", "test_decompileImport_stageB_notebook_id", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16fpgac);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_blank-notebook.html
+++ b/notebooks/@tomlarkworthy_blank-notebook.html
@@ -19507,56 +19507,103 @@ async (v) => {
 const _1effqg = function _96(md){return(
 md`### \`decompileImport\``
 )};
-const _1etqs71 = function _decompileImport(findModuleName,findImportedName)
+const _b7vai6 = function _decompileImport(findModuleName,findImportedName)
 {
-    return async function decompileImport(variables, options = {}) {
-        if (!variables || variables.length === 0)
-            throw new Error('no variables');
-        // #166: An import group is `[module @foo, ...aliases]` — the runtime stitch
-        // sits at index 0 by convention. Scan for the first alias (single _input,
-        // crosses module boundary) so this works whichever order the caller hands us.
-        const isCrossModuleAlias = v => {
-            const inputs = v?._inputs;
-            if (!Array.isArray(inputs) || inputs.length !== 1)
-                return false;
-            const i0 = inputs[0];
-            return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
-        };
-        const v0 = variables.find(isCrossModuleAlias);
-        if (!v0)
-            return null;
-        const input0 = v0._inputs[0];
-        const inputsLength = 1;
-        const crossesModuleBoundary = true;
-        const module_name = findModuleName(v0._module._scope, input0._module);
-        if (module_name == null)
-            throw new Error('module name could not be resolved');
-        // #166: Skip runtime-internal `module @foo` stitch variables — they belong to
-        // the import group but are not user-facing specifiers. Without this filter, an
-        // import group renders as `import {Range, module @foo} from "@foo"`.
-        const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
-            const imported = await findImportedName(v);
-            const local = v._name;
-            return {
-                imported,
-                local,
-                alias: imported !== local,
-                meta: { index }
-            };
-        }));
-        return {
-            type: 'import',
-            from: module_name,
-            specifiers,
-            meta: {
-                detection: {
-                    inputsLength,
-                    crossesModuleBoundary
-                },
-                variables: variables.map(v => v?._name ?? null)
-            }
-        };
+  return async function decompileImport(variables, options = {}) {
+    if (!variables || variables.length === 0)
+      throw new Error('no variables');
+    // An import-cell group is `[module @X stitch, ...aliases]`. Each alias goes
+    // through three lifecycle stages (documented in observable-runtime-v6's
+    // `importedModule` helper, lines ~1992-2049 of @tomlarkworthy/observable-runtime-v6):
+    //
+    //   Stage A — post-observation:
+    //     `_inputs = [Variable in source module]` (length 1, cross-module).
+    //     The Observable runtime rewrites _inputs after the alias is observed
+    //     and resolved against the source module.
+    //
+    //   Stage B — pre-observation, API-loaded (canonical compiled-bundle shape):
+    //     `_inputs = [Variable("module @X"), Variable("@variable")]` (length 2,
+    //     both in the importer module). What `runtime.define("name",
+    //     ["module @X", "@variable"], (_, v) => v.import("name", _))` produces.
+    //     Also what `compile_and_update` outputs for freshly-defined user-typed
+    //     imports until they're observed.
+    //
+    //   Stage C — pre-observation, inline live-notebook:
+    //     `_inputs = [Variable("@variable")]` (length 1) AND the definition
+    //     calls `import(...)` inside. We extract the imported module reference
+    //     by invoking the definition with a stub `import` capture.
+    //
+    // Detection order is post→pre because Stage A is unambiguous when present.
+    const isStageA = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
     };
+    const isStageB = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 2)
+        return false;
+      const [i0, i1] = inputs;
+      return !!(i0 && typeof i0 === 'object' && typeof i0._name === 'string' && i0._name.startsWith('module @') && i1 && typeof i1 === 'object' && i1._name === '@variable');
+    };
+    const isStageC = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && i0._name === '@variable' && typeof v._definition !== 'undefined' && String(v._definition).includes('import('));
+    };
+    let v0, module_name, stage;
+    if (v0 = variables.find(isStageA)) {
+      stage = 'A';
+      module_name = findModuleName(v0._module._scope, v0._inputs[0]._module);
+    } else if (v0 = variables.find(isStageB)) {
+      stage = 'B';
+      module_name = v0._inputs[0]._name.replace(/^module /, '');
+    } else if (v0 = variables.find(isStageC)) {
+      stage = 'C';
+      let capturedModule;
+      try {
+        await v0._definition({
+          import: (...args) => {
+            capturedModule = args[args.length - 1];
+          }
+        });
+      } catch (e) {
+      }
+      if (capturedModule && v0._module?._scope) {
+        module_name = findModuleName(v0._module._scope, capturedModule);
+      }
+    } else {
+      return null;
+    }
+    if (module_name == null)
+      throw new Error('module name could not be resolved');
+    // Skip runtime-internal `module @foo` stitch variables — they belong to
+    // the import group but are not user-facing specifiers. Without this filter, an
+    // import group renders as `import {Range, module @foo} from "@foo"`.
+    const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
+      const imported = await findImportedName(v);
+      const local = v._name;
+      return {
+        imported,
+        local,
+        alias: imported !== local,
+        meta: { index }
+      };
+    }));
+    return {
+      type: 'import',
+      from: module_name,
+      specifiers,
+      meta: {
+        detection: { stage },
+        variables: variables.map(v => v?._name ?? null)
+      }
+    };
+  };
 };
 const _1sylz7j = function _formatImportDeclaration(){return(
 function formatImportDeclaration(importInfo) {
@@ -20666,6 +20713,198 @@ const _1hiclbb = function _acorn_walk(acorn_walk_url) {
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
+const _1rc67k0 = function _stageB_importFake()
+{
+  return // Builds a Stage B (pre-observation, API-loaded) import group as POJOs.
+  // Mirrors what `runtime.define("name", ["module @X", "@variable"], (_, v) => v.import("name", _))`
+  // produces structurally. Used by the test_decompileImport_stageB_* tests to
+  // avoid spinning up a real Observable runtime per case.
+  function stageB_importFake(module_name, specifiers) {
+    const importerModule = { _scope: new Map() };
+    const stitch = {
+      _name: `module ${ module_name }`,
+      _module: importerModule,
+      _inputs: [],
+      _definition: `async () => null`
+    };
+    const atVariable = {
+      _name: '@variable',
+      _module: importerModule
+    };
+    const aliases = specifiers.map(s => ({
+      _name: s.local,
+      _module: importerModule,
+      _inputs: [
+        stitch,
+        atVariable
+      ],
+      _definition: s.imported === s.local ? `(_, v) => v.import("${ s.imported }", _)` : `(_, v) => v.import("${ s.imported }", "${ s.local }", _)`
+    }));
+    return [
+      stitch,
+      ...aliases
+    ];
+  };
+};
+const _1d53asg = async function _test_decompileImport_stageB_single(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [{
+      imported: 'visualize',
+      local: 'visualize'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _hv5gag = async function _test_decompileImport_stageB_aliased(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'x',
+      local: 'z'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(info.specifiers[0].alias).toEqual(true);
+  expect(formatImportDeclaration(info)).toEqual(`import {x as z} from "@user/y"`);
+  return 'ok';
+};
+const _avc18y = async function _test_decompileImport_stageB_multiple(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    },
+    {
+      imported: 'c',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b, c} from "@user/y"`);
+  return 'ok';
+};
+const _16gia7i = async function _test_decompileImport_stageB_mixed_alias(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b as c} from "@user/y"`);
+  return 'ok';
+};
+const _1slhdwo = async function _test_decompileImport_stageB_viewof(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/module-map', [{
+      imported: 'viewof currentModules',
+      local: 'viewof currentModules'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {viewof currentModules} from "@tomlarkworthy/module-map"`);
+  return 'ok';
+};
+const _qwlsf2 = async function _test_decompileImport_stageB_mutable(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'mutable counter',
+      local: 'mutable counter'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {mutable counter} from "@user/y"`);
+  return 'ok';
+};
+const _sy7jfx = async function _test_decompileImport_returns_null_for_non_import(decompileImport,expect)
+{
+  // A regular cell — no stitch, no @variable input, no cross-module reference.
+  const info = await decompileImport([{
+      _name: 'x',
+      _module: {},
+      _inputs: [],
+      _definition: `() => 42`
+    }]);
+  expect(info).toEqual(null);
+  return 'ok';
+};
+const _rk7ku3 = async function _test_decompileImport_compile_roundtrip_single(compile,expect,stageB_importFake,decompileImport,formatImportDeclaration)
+{
+  // What `compile()` emits for `import {x} from "@user/y"` is structurally the
+  // same as our stageB_importFake fixture (after runtime.define resolves the
+  // input name strings to Variable refs). Verify the fixture matches the
+  // shape compile() would produce.
+  const pojos = compile(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  expect(pojos.length).toEqual(3);
+  expect(pojos[0]._name).toEqual('module @tomlarkworthy/visualizer');
+  expect(pojos[1]._name).toEqual('visualize');
+  expect(pojos[2]._name).toEqual('Group');
+  expect(pojos[1]._inputs).toEqual([
+    'module @tomlarkworthy/visualizer',
+    '@variable'
+  ]);
+  // Now run our fixture through decompileImport — confirms the round-trip
+  // shape compile()-output-shape-when-defined → decompileImport produces the
+  // canonical import source string.
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [
+    {
+      imported: 'visualize',
+      local: 'visualize'
+    },
+    {
+      imported: 'Group',
+      local: 'Group'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _xynplo = async function _test_decompileImport_stageB_order_independent(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // The detection uses .find — it shouldn't matter whether the stitch is at
+  // index 0 or the aliases come first. Verify by reversing the array.
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    }
+  ]);
+  const reversed = [...vars].reverse();
+  const info = await decompileImport(reversed);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b} from "@user/y"`);
+  return 'ok';
+};
+const _16fpgac = async function _test_decompileImport_stageB_notebook_id(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // Observable supports `import {x} from "d/<hash>@<version>"` notebook-id form.
+  const vars = stageB_importFake('d/57d79353bac56631@44', [{
+      imported: 'hash',
+      local: 'hash'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {hash} from "d/57d79353bac56631@44"`);
+  return 'ok';
+};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -20786,7 +21025,7 @@ export default function define(runtime, observer) {
   $def("_1n7gw17", "findModuleName", ["extractModuleInfo"], _1n7gw17);  
   $def("_i47chb", "findImportedName", [], _i47chb);  
   $def("_1effqg", null, ["md"], _1effqg);  
-  $def("_1etqs71", "decompileImport", ["findModuleName","findImportedName"], _1etqs71);  
+  $def("_b7vai6", "decompileImport", ["findModuleName","findImportedName"], _b7vai6);  
   $def("_1sylz7j", "formatImportDeclaration", [], _1sylz7j);  
   $def("_13dctdn", "test_decompileImport_basic", ["importFake","decompileImport","expect"], _13dctdn);  
   $def("_ujr0xn", "test_formatImportDeclaration_roundtrip", ["importFake","decompileImport","expect","formatImportDeclaration","decompile"], _ujr0xn);  
@@ -20864,7 +21103,18 @@ export default function define(runtime, observer) {
   main.define("Runtime", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Runtime", _));  
   main.define("Inspector", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Inspector", _));  
   main.define("Library", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Library", _));  
-  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));
+  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));  
+  $def("_1rc67k0", "stageB_importFake", [], _1rc67k0);  
+  $def("_1d53asg", "test_decompileImport_stageB_single", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1d53asg);  
+  $def("_hv5gag", "test_decompileImport_stageB_aliased", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _hv5gag);  
+  $def("_avc18y", "test_decompileImport_stageB_multiple", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _avc18y);  
+  $def("_16gia7i", "test_decompileImport_stageB_mixed_alias", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16gia7i);  
+  $def("_1slhdwo", "test_decompileImport_stageB_viewof", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1slhdwo);  
+  $def("_qwlsf2", "test_decompileImport_stageB_mutable", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _qwlsf2);  
+  $def("_sy7jfx", "test_decompileImport_returns_null_for_non_import", ["decompileImport","expect"], _sy7jfx);  
+  $def("_rk7ku3", "test_decompileImport_compile_roundtrip_single", ["compile","expect","stageB_importFake","decompileImport","formatImportDeclaration"], _rk7ku3);  
+  $def("_xynplo", "test_decompileImport_stageB_order_independent", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _xynplo);  
+  $def("_16fpgac", "test_decompileImport_stageB_notebook_id", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16fpgac);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_bootloader.html
+++ b/notebooks/@tomlarkworthy_bootloader.html
@@ -19724,56 +19724,103 @@ async (v) => {
 const _1effqg = function _96(md){return(
 md`### \`decompileImport\``
 )};
-const _1etqs71 = function _decompileImport(findModuleName,findImportedName)
+const _b7vai6 = function _decompileImport(findModuleName,findImportedName)
 {
-    return async function decompileImport(variables, options = {}) {
-        if (!variables || variables.length === 0)
-            throw new Error('no variables');
-        // #166: An import group is `[module @foo, ...aliases]` — the runtime stitch
-        // sits at index 0 by convention. Scan for the first alias (single _input,
-        // crosses module boundary) so this works whichever order the caller hands us.
-        const isCrossModuleAlias = v => {
-            const inputs = v?._inputs;
-            if (!Array.isArray(inputs) || inputs.length !== 1)
-                return false;
-            const i0 = inputs[0];
-            return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
-        };
-        const v0 = variables.find(isCrossModuleAlias);
-        if (!v0)
-            return null;
-        const input0 = v0._inputs[0];
-        const inputsLength = 1;
-        const crossesModuleBoundary = true;
-        const module_name = findModuleName(v0._module._scope, input0._module);
-        if (module_name == null)
-            throw new Error('module name could not be resolved');
-        // #166: Skip runtime-internal `module @foo` stitch variables — they belong to
-        // the import group but are not user-facing specifiers. Without this filter, an
-        // import group renders as `import {Range, module @foo} from "@foo"`.
-        const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
-            const imported = await findImportedName(v);
-            const local = v._name;
-            return {
-                imported,
-                local,
-                alias: imported !== local,
-                meta: { index }
-            };
-        }));
-        return {
-            type: 'import',
-            from: module_name,
-            specifiers,
-            meta: {
-                detection: {
-                    inputsLength,
-                    crossesModuleBoundary
-                },
-                variables: variables.map(v => v?._name ?? null)
-            }
-        };
+  return async function decompileImport(variables, options = {}) {
+    if (!variables || variables.length === 0)
+      throw new Error('no variables');
+    // An import-cell group is `[module @X stitch, ...aliases]`. Each alias goes
+    // through three lifecycle stages (documented in observable-runtime-v6's
+    // `importedModule` helper, lines ~1992-2049 of @tomlarkworthy/observable-runtime-v6):
+    //
+    //   Stage A — post-observation:
+    //     `_inputs = [Variable in source module]` (length 1, cross-module).
+    //     The Observable runtime rewrites _inputs after the alias is observed
+    //     and resolved against the source module.
+    //
+    //   Stage B — pre-observation, API-loaded (canonical compiled-bundle shape):
+    //     `_inputs = [Variable("module @X"), Variable("@variable")]` (length 2,
+    //     both in the importer module). What `runtime.define("name",
+    //     ["module @X", "@variable"], (_, v) => v.import("name", _))` produces.
+    //     Also what `compile_and_update` outputs for freshly-defined user-typed
+    //     imports until they're observed.
+    //
+    //   Stage C — pre-observation, inline live-notebook:
+    //     `_inputs = [Variable("@variable")]` (length 1) AND the definition
+    //     calls `import(...)` inside. We extract the imported module reference
+    //     by invoking the definition with a stub `import` capture.
+    //
+    // Detection order is post→pre because Stage A is unambiguous when present.
+    const isStageA = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
     };
+    const isStageB = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 2)
+        return false;
+      const [i0, i1] = inputs;
+      return !!(i0 && typeof i0 === 'object' && typeof i0._name === 'string' && i0._name.startsWith('module @') && i1 && typeof i1 === 'object' && i1._name === '@variable');
+    };
+    const isStageC = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && i0._name === '@variable' && typeof v._definition !== 'undefined' && String(v._definition).includes('import('));
+    };
+    let v0, module_name, stage;
+    if (v0 = variables.find(isStageA)) {
+      stage = 'A';
+      module_name = findModuleName(v0._module._scope, v0._inputs[0]._module);
+    } else if (v0 = variables.find(isStageB)) {
+      stage = 'B';
+      module_name = v0._inputs[0]._name.replace(/^module /, '');
+    } else if (v0 = variables.find(isStageC)) {
+      stage = 'C';
+      let capturedModule;
+      try {
+        await v0._definition({
+          import: (...args) => {
+            capturedModule = args[args.length - 1];
+          }
+        });
+      } catch (e) {
+      }
+      if (capturedModule && v0._module?._scope) {
+        module_name = findModuleName(v0._module._scope, capturedModule);
+      }
+    } else {
+      return null;
+    }
+    if (module_name == null)
+      throw new Error('module name could not be resolved');
+    // Skip runtime-internal `module @foo` stitch variables — they belong to
+    // the import group but are not user-facing specifiers. Without this filter, an
+    // import group renders as `import {Range, module @foo} from "@foo"`.
+    const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
+      const imported = await findImportedName(v);
+      const local = v._name;
+      return {
+        imported,
+        local,
+        alias: imported !== local,
+        meta: { index }
+      };
+    }));
+    return {
+      type: 'import',
+      from: module_name,
+      specifiers,
+      meta: {
+        detection: { stage },
+        variables: variables.map(v => v?._name ?? null)
+      }
+    };
+  };
 };
 const _1sylz7j = function _formatImportDeclaration(){return(
 function formatImportDeclaration(importInfo) {
@@ -20883,6 +20930,198 @@ const _1hiclbb = function _acorn_walk(acorn_walk_url) {
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
+const _1rc67k0 = function _stageB_importFake()
+{
+  return // Builds a Stage B (pre-observation, API-loaded) import group as POJOs.
+  // Mirrors what `runtime.define("name", ["module @X", "@variable"], (_, v) => v.import("name", _))`
+  // produces structurally. Used by the test_decompileImport_stageB_* tests to
+  // avoid spinning up a real Observable runtime per case.
+  function stageB_importFake(module_name, specifiers) {
+    const importerModule = { _scope: new Map() };
+    const stitch = {
+      _name: `module ${ module_name }`,
+      _module: importerModule,
+      _inputs: [],
+      _definition: `async () => null`
+    };
+    const atVariable = {
+      _name: '@variable',
+      _module: importerModule
+    };
+    const aliases = specifiers.map(s => ({
+      _name: s.local,
+      _module: importerModule,
+      _inputs: [
+        stitch,
+        atVariable
+      ],
+      _definition: s.imported === s.local ? `(_, v) => v.import("${ s.imported }", _)` : `(_, v) => v.import("${ s.imported }", "${ s.local }", _)`
+    }));
+    return [
+      stitch,
+      ...aliases
+    ];
+  };
+};
+const _1d53asg = async function _test_decompileImport_stageB_single(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [{
+      imported: 'visualize',
+      local: 'visualize'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _hv5gag = async function _test_decompileImport_stageB_aliased(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'x',
+      local: 'z'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(info.specifiers[0].alias).toEqual(true);
+  expect(formatImportDeclaration(info)).toEqual(`import {x as z} from "@user/y"`);
+  return 'ok';
+};
+const _avc18y = async function _test_decompileImport_stageB_multiple(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    },
+    {
+      imported: 'c',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b, c} from "@user/y"`);
+  return 'ok';
+};
+const _16gia7i = async function _test_decompileImport_stageB_mixed_alias(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b as c} from "@user/y"`);
+  return 'ok';
+};
+const _1slhdwo = async function _test_decompileImport_stageB_viewof(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/module-map', [{
+      imported: 'viewof currentModules',
+      local: 'viewof currentModules'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {viewof currentModules} from "@tomlarkworthy/module-map"`);
+  return 'ok';
+};
+const _qwlsf2 = async function _test_decompileImport_stageB_mutable(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'mutable counter',
+      local: 'mutable counter'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {mutable counter} from "@user/y"`);
+  return 'ok';
+};
+const _sy7jfx = async function _test_decompileImport_returns_null_for_non_import(decompileImport,expect)
+{
+  // A regular cell — no stitch, no @variable input, no cross-module reference.
+  const info = await decompileImport([{
+      _name: 'x',
+      _module: {},
+      _inputs: [],
+      _definition: `() => 42`
+    }]);
+  expect(info).toEqual(null);
+  return 'ok';
+};
+const _rk7ku3 = async function _test_decompileImport_compile_roundtrip_single(compile,expect,stageB_importFake,decompileImport,formatImportDeclaration)
+{
+  // What `compile()` emits for `import {x} from "@user/y"` is structurally the
+  // same as our stageB_importFake fixture (after runtime.define resolves the
+  // input name strings to Variable refs). Verify the fixture matches the
+  // shape compile() would produce.
+  const pojos = compile(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  expect(pojos.length).toEqual(3);
+  expect(pojos[0]._name).toEqual('module @tomlarkworthy/visualizer');
+  expect(pojos[1]._name).toEqual('visualize');
+  expect(pojos[2]._name).toEqual('Group');
+  expect(pojos[1]._inputs).toEqual([
+    'module @tomlarkworthy/visualizer',
+    '@variable'
+  ]);
+  // Now run our fixture through decompileImport — confirms the round-trip
+  // shape compile()-output-shape-when-defined → decompileImport produces the
+  // canonical import source string.
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [
+    {
+      imported: 'visualize',
+      local: 'visualize'
+    },
+    {
+      imported: 'Group',
+      local: 'Group'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _xynplo = async function _test_decompileImport_stageB_order_independent(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // The detection uses .find — it shouldn't matter whether the stitch is at
+  // index 0 or the aliases come first. Verify by reversing the array.
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    }
+  ]);
+  const reversed = [...vars].reverse();
+  const info = await decompileImport(reversed);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b} from "@user/y"`);
+  return 'ok';
+};
+const _16fpgac = async function _test_decompileImport_stageB_notebook_id(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // Observable supports `import {x} from "d/<hash>@<version>"` notebook-id form.
+  const vars = stageB_importFake('d/57d79353bac56631@44', [{
+      imported: 'hash',
+      local: 'hash'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {hash} from "d/57d79353bac56631@44"`);
+  return 'ok';
+};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -21003,7 +21242,7 @@ export default function define(runtime, observer) {
   $def("_1n7gw17", "findModuleName", ["extractModuleInfo"], _1n7gw17);  
   $def("_i47chb", "findImportedName", [], _i47chb);  
   $def("_1effqg", null, ["md"], _1effqg);  
-  $def("_1etqs71", "decompileImport", ["findModuleName","findImportedName"], _1etqs71);  
+  $def("_b7vai6", "decompileImport", ["findModuleName","findImportedName"], _b7vai6);  
   $def("_1sylz7j", "formatImportDeclaration", [], _1sylz7j);  
   $def("_13dctdn", "test_decompileImport_basic", ["importFake","decompileImport","expect"], _13dctdn);  
   $def("_ujr0xn", "test_formatImportDeclaration_roundtrip", ["importFake","decompileImport","expect","formatImportDeclaration","decompile"], _ujr0xn);  
@@ -21081,7 +21320,18 @@ export default function define(runtime, observer) {
   main.define("Runtime", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Runtime", _));  
   main.define("Inspector", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Inspector", _));  
   main.define("Library", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Library", _));  
-  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));
+  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));  
+  $def("_1rc67k0", "stageB_importFake", [], _1rc67k0);  
+  $def("_1d53asg", "test_decompileImport_stageB_single", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1d53asg);  
+  $def("_hv5gag", "test_decompileImport_stageB_aliased", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _hv5gag);  
+  $def("_avc18y", "test_decompileImport_stageB_multiple", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _avc18y);  
+  $def("_16gia7i", "test_decompileImport_stageB_mixed_alias", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16gia7i);  
+  $def("_1slhdwo", "test_decompileImport_stageB_viewof", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1slhdwo);  
+  $def("_qwlsf2", "test_decompileImport_stageB_mutable", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _qwlsf2);  
+  $def("_sy7jfx", "test_decompileImport_returns_null_for_non_import", ["decompileImport","expect"], _sy7jfx);  
+  $def("_rk7ku3", "test_decompileImport_compile_roundtrip_single", ["compile","expect","stageB_importFake","decompileImport","formatImportDeclaration"], _rk7ku3);  
+  $def("_xynplo", "test_decompileImport_stageB_order_independent", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _xynplo);  
+  $def("_16fpgac", "test_decompileImport_stageB_notebook_id", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16fpgac);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_cells-to-clipboard.html
+++ b/notebooks/@tomlarkworthy_cells-to-clipboard.html
@@ -19474,56 +19474,103 @@ async (v) => {
 const _1effqg = function _96(md){return(
 md`### \`decompileImport\``
 )};
-const _1etqs71 = function _decompileImport(findModuleName,findImportedName)
+const _b7vai6 = function _decompileImport(findModuleName,findImportedName)
 {
-    return async function decompileImport(variables, options = {}) {
-        if (!variables || variables.length === 0)
-            throw new Error('no variables');
-        // #166: An import group is `[module @foo, ...aliases]` — the runtime stitch
-        // sits at index 0 by convention. Scan for the first alias (single _input,
-        // crosses module boundary) so this works whichever order the caller hands us.
-        const isCrossModuleAlias = v => {
-            const inputs = v?._inputs;
-            if (!Array.isArray(inputs) || inputs.length !== 1)
-                return false;
-            const i0 = inputs[0];
-            return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
-        };
-        const v0 = variables.find(isCrossModuleAlias);
-        if (!v0)
-            return null;
-        const input0 = v0._inputs[0];
-        const inputsLength = 1;
-        const crossesModuleBoundary = true;
-        const module_name = findModuleName(v0._module._scope, input0._module);
-        if (module_name == null)
-            throw new Error('module name could not be resolved');
-        // #166: Skip runtime-internal `module @foo` stitch variables — they belong to
-        // the import group but are not user-facing specifiers. Without this filter, an
-        // import group renders as `import {Range, module @foo} from "@foo"`.
-        const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
-            const imported = await findImportedName(v);
-            const local = v._name;
-            return {
-                imported,
-                local,
-                alias: imported !== local,
-                meta: { index }
-            };
-        }));
-        return {
-            type: 'import',
-            from: module_name,
-            specifiers,
-            meta: {
-                detection: {
-                    inputsLength,
-                    crossesModuleBoundary
-                },
-                variables: variables.map(v => v?._name ?? null)
-            }
-        };
+  return async function decompileImport(variables, options = {}) {
+    if (!variables || variables.length === 0)
+      throw new Error('no variables');
+    // An import-cell group is `[module @X stitch, ...aliases]`. Each alias goes
+    // through three lifecycle stages (documented in observable-runtime-v6's
+    // `importedModule` helper, lines ~1992-2049 of @tomlarkworthy/observable-runtime-v6):
+    //
+    //   Stage A — post-observation:
+    //     `_inputs = [Variable in source module]` (length 1, cross-module).
+    //     The Observable runtime rewrites _inputs after the alias is observed
+    //     and resolved against the source module.
+    //
+    //   Stage B — pre-observation, API-loaded (canonical compiled-bundle shape):
+    //     `_inputs = [Variable("module @X"), Variable("@variable")]` (length 2,
+    //     both in the importer module). What `runtime.define("name",
+    //     ["module @X", "@variable"], (_, v) => v.import("name", _))` produces.
+    //     Also what `compile_and_update` outputs for freshly-defined user-typed
+    //     imports until they're observed.
+    //
+    //   Stage C — pre-observation, inline live-notebook:
+    //     `_inputs = [Variable("@variable")]` (length 1) AND the definition
+    //     calls `import(...)` inside. We extract the imported module reference
+    //     by invoking the definition with a stub `import` capture.
+    //
+    // Detection order is post→pre because Stage A is unambiguous when present.
+    const isStageA = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
     };
+    const isStageB = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 2)
+        return false;
+      const [i0, i1] = inputs;
+      return !!(i0 && typeof i0 === 'object' && typeof i0._name === 'string' && i0._name.startsWith('module @') && i1 && typeof i1 === 'object' && i1._name === '@variable');
+    };
+    const isStageC = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && i0._name === '@variable' && typeof v._definition !== 'undefined' && String(v._definition).includes('import('));
+    };
+    let v0, module_name, stage;
+    if (v0 = variables.find(isStageA)) {
+      stage = 'A';
+      module_name = findModuleName(v0._module._scope, v0._inputs[0]._module);
+    } else if (v0 = variables.find(isStageB)) {
+      stage = 'B';
+      module_name = v0._inputs[0]._name.replace(/^module /, '');
+    } else if (v0 = variables.find(isStageC)) {
+      stage = 'C';
+      let capturedModule;
+      try {
+        await v0._definition({
+          import: (...args) => {
+            capturedModule = args[args.length - 1];
+          }
+        });
+      } catch (e) {
+      }
+      if (capturedModule && v0._module?._scope) {
+        module_name = findModuleName(v0._module._scope, capturedModule);
+      }
+    } else {
+      return null;
+    }
+    if (module_name == null)
+      throw new Error('module name could not be resolved');
+    // Skip runtime-internal `module @foo` stitch variables — they belong to
+    // the import group but are not user-facing specifiers. Without this filter, an
+    // import group renders as `import {Range, module @foo} from "@foo"`.
+    const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
+      const imported = await findImportedName(v);
+      const local = v._name;
+      return {
+        imported,
+        local,
+        alias: imported !== local,
+        meta: { index }
+      };
+    }));
+    return {
+      type: 'import',
+      from: module_name,
+      specifiers,
+      meta: {
+        detection: { stage },
+        variables: variables.map(v => v?._name ?? null)
+      }
+    };
+  };
 };
 const _1sylz7j = function _formatImportDeclaration(){return(
 function formatImportDeclaration(importInfo) {
@@ -20633,6 +20680,198 @@ const _1hiclbb = function _acorn_walk(acorn_walk_url) {
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
+const _1rc67k0 = function _stageB_importFake()
+{
+  return // Builds a Stage B (pre-observation, API-loaded) import group as POJOs.
+  // Mirrors what `runtime.define("name", ["module @X", "@variable"], (_, v) => v.import("name", _))`
+  // produces structurally. Used by the test_decompileImport_stageB_* tests to
+  // avoid spinning up a real Observable runtime per case.
+  function stageB_importFake(module_name, specifiers) {
+    const importerModule = { _scope: new Map() };
+    const stitch = {
+      _name: `module ${ module_name }`,
+      _module: importerModule,
+      _inputs: [],
+      _definition: `async () => null`
+    };
+    const atVariable = {
+      _name: '@variable',
+      _module: importerModule
+    };
+    const aliases = specifiers.map(s => ({
+      _name: s.local,
+      _module: importerModule,
+      _inputs: [
+        stitch,
+        atVariable
+      ],
+      _definition: s.imported === s.local ? `(_, v) => v.import("${ s.imported }", _)` : `(_, v) => v.import("${ s.imported }", "${ s.local }", _)`
+    }));
+    return [
+      stitch,
+      ...aliases
+    ];
+  };
+};
+const _1d53asg = async function _test_decompileImport_stageB_single(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [{
+      imported: 'visualize',
+      local: 'visualize'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _hv5gag = async function _test_decompileImport_stageB_aliased(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'x',
+      local: 'z'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(info.specifiers[0].alias).toEqual(true);
+  expect(formatImportDeclaration(info)).toEqual(`import {x as z} from "@user/y"`);
+  return 'ok';
+};
+const _avc18y = async function _test_decompileImport_stageB_multiple(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    },
+    {
+      imported: 'c',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b, c} from "@user/y"`);
+  return 'ok';
+};
+const _16gia7i = async function _test_decompileImport_stageB_mixed_alias(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b as c} from "@user/y"`);
+  return 'ok';
+};
+const _1slhdwo = async function _test_decompileImport_stageB_viewof(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/module-map', [{
+      imported: 'viewof currentModules',
+      local: 'viewof currentModules'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {viewof currentModules} from "@tomlarkworthy/module-map"`);
+  return 'ok';
+};
+const _qwlsf2 = async function _test_decompileImport_stageB_mutable(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'mutable counter',
+      local: 'mutable counter'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {mutable counter} from "@user/y"`);
+  return 'ok';
+};
+const _sy7jfx = async function _test_decompileImport_returns_null_for_non_import(decompileImport,expect)
+{
+  // A regular cell — no stitch, no @variable input, no cross-module reference.
+  const info = await decompileImport([{
+      _name: 'x',
+      _module: {},
+      _inputs: [],
+      _definition: `() => 42`
+    }]);
+  expect(info).toEqual(null);
+  return 'ok';
+};
+const _rk7ku3 = async function _test_decompileImport_compile_roundtrip_single(compile,expect,stageB_importFake,decompileImport,formatImportDeclaration)
+{
+  // What `compile()` emits for `import {x} from "@user/y"` is structurally the
+  // same as our stageB_importFake fixture (after runtime.define resolves the
+  // input name strings to Variable refs). Verify the fixture matches the
+  // shape compile() would produce.
+  const pojos = compile(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  expect(pojos.length).toEqual(3);
+  expect(pojos[0]._name).toEqual('module @tomlarkworthy/visualizer');
+  expect(pojos[1]._name).toEqual('visualize');
+  expect(pojos[2]._name).toEqual('Group');
+  expect(pojos[1]._inputs).toEqual([
+    'module @tomlarkworthy/visualizer',
+    '@variable'
+  ]);
+  // Now run our fixture through decompileImport — confirms the round-trip
+  // shape compile()-output-shape-when-defined → decompileImport produces the
+  // canonical import source string.
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [
+    {
+      imported: 'visualize',
+      local: 'visualize'
+    },
+    {
+      imported: 'Group',
+      local: 'Group'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _xynplo = async function _test_decompileImport_stageB_order_independent(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // The detection uses .find — it shouldn't matter whether the stitch is at
+  // index 0 or the aliases come first. Verify by reversing the array.
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    }
+  ]);
+  const reversed = [...vars].reverse();
+  const info = await decompileImport(reversed);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b} from "@user/y"`);
+  return 'ok';
+};
+const _16fpgac = async function _test_decompileImport_stageB_notebook_id(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // Observable supports `import {x} from "d/<hash>@<version>"` notebook-id form.
+  const vars = stageB_importFake('d/57d79353bac56631@44', [{
+      imported: 'hash',
+      local: 'hash'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {hash} from "d/57d79353bac56631@44"`);
+  return 'ok';
+};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -20753,7 +20992,7 @@ export default function define(runtime, observer) {
   $def("_1n7gw17", "findModuleName", ["extractModuleInfo"], _1n7gw17);  
   $def("_i47chb", "findImportedName", [], _i47chb);  
   $def("_1effqg", null, ["md"], _1effqg);  
-  $def("_1etqs71", "decompileImport", ["findModuleName","findImportedName"], _1etqs71);  
+  $def("_b7vai6", "decompileImport", ["findModuleName","findImportedName"], _b7vai6);  
   $def("_1sylz7j", "formatImportDeclaration", [], _1sylz7j);  
   $def("_13dctdn", "test_decompileImport_basic", ["importFake","decompileImport","expect"], _13dctdn);  
   $def("_ujr0xn", "test_formatImportDeclaration_roundtrip", ["importFake","decompileImport","expect","formatImportDeclaration","decompile"], _ujr0xn);  
@@ -20831,7 +21070,18 @@ export default function define(runtime, observer) {
   main.define("Runtime", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Runtime", _));  
   main.define("Inspector", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Inspector", _));  
   main.define("Library", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Library", _));  
-  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));
+  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));  
+  $def("_1rc67k0", "stageB_importFake", [], _1rc67k0);  
+  $def("_1d53asg", "test_decompileImport_stageB_single", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1d53asg);  
+  $def("_hv5gag", "test_decompileImport_stageB_aliased", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _hv5gag);  
+  $def("_avc18y", "test_decompileImport_stageB_multiple", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _avc18y);  
+  $def("_16gia7i", "test_decompileImport_stageB_mixed_alias", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16gia7i);  
+  $def("_1slhdwo", "test_decompileImport_stageB_viewof", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1slhdwo);  
+  $def("_qwlsf2", "test_decompileImport_stageB_mutable", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _qwlsf2);  
+  $def("_sy7jfx", "test_decompileImport_returns_null_for_non_import", ["decompileImport","expect"], _sy7jfx);  
+  $def("_rk7ku3", "test_decompileImport_compile_roundtrip_single", ["compile","expect","stageB_importFake","decompileImport","formatImportDeclaration"], _rk7ku3);  
+  $def("_xynplo", "test_decompileImport_stageB_order_independent", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _xynplo);  
+  $def("_16fpgac", "test_decompileImport_stageB_notebook_id", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16fpgac);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_claude-code-pairing.html
+++ b/notebooks/@tomlarkworthy_claude-code-pairing.html
@@ -19474,56 +19474,103 @@ async (v) => {
 const _1effqg = function _96(md){return(
 md`### \`decompileImport\``
 )};
-const _1etqs71 = function _decompileImport(findModuleName,findImportedName)
+const _b7vai6 = function _decompileImport(findModuleName,findImportedName)
 {
-    return async function decompileImport(variables, options = {}) {
-        if (!variables || variables.length === 0)
-            throw new Error('no variables');
-        // #166: An import group is `[module @foo, ...aliases]` — the runtime stitch
-        // sits at index 0 by convention. Scan for the first alias (single _input,
-        // crosses module boundary) so this works whichever order the caller hands us.
-        const isCrossModuleAlias = v => {
-            const inputs = v?._inputs;
-            if (!Array.isArray(inputs) || inputs.length !== 1)
-                return false;
-            const i0 = inputs[0];
-            return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
-        };
-        const v0 = variables.find(isCrossModuleAlias);
-        if (!v0)
-            return null;
-        const input0 = v0._inputs[0];
-        const inputsLength = 1;
-        const crossesModuleBoundary = true;
-        const module_name = findModuleName(v0._module._scope, input0._module);
-        if (module_name == null)
-            throw new Error('module name could not be resolved');
-        // #166: Skip runtime-internal `module @foo` stitch variables — they belong to
-        // the import group but are not user-facing specifiers. Without this filter, an
-        // import group renders as `import {Range, module @foo} from "@foo"`.
-        const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
-            const imported = await findImportedName(v);
-            const local = v._name;
-            return {
-                imported,
-                local,
-                alias: imported !== local,
-                meta: { index }
-            };
-        }));
-        return {
-            type: 'import',
-            from: module_name,
-            specifiers,
-            meta: {
-                detection: {
-                    inputsLength,
-                    crossesModuleBoundary
-                },
-                variables: variables.map(v => v?._name ?? null)
-            }
-        };
+  return async function decompileImport(variables, options = {}) {
+    if (!variables || variables.length === 0)
+      throw new Error('no variables');
+    // An import-cell group is `[module @X stitch, ...aliases]`. Each alias goes
+    // through three lifecycle stages (documented in observable-runtime-v6's
+    // `importedModule` helper, lines ~1992-2049 of @tomlarkworthy/observable-runtime-v6):
+    //
+    //   Stage A — post-observation:
+    //     `_inputs = [Variable in source module]` (length 1, cross-module).
+    //     The Observable runtime rewrites _inputs after the alias is observed
+    //     and resolved against the source module.
+    //
+    //   Stage B — pre-observation, API-loaded (canonical compiled-bundle shape):
+    //     `_inputs = [Variable("module @X"), Variable("@variable")]` (length 2,
+    //     both in the importer module). What `runtime.define("name",
+    //     ["module @X", "@variable"], (_, v) => v.import("name", _))` produces.
+    //     Also what `compile_and_update` outputs for freshly-defined user-typed
+    //     imports until they're observed.
+    //
+    //   Stage C — pre-observation, inline live-notebook:
+    //     `_inputs = [Variable("@variable")]` (length 1) AND the definition
+    //     calls `import(...)` inside. We extract the imported module reference
+    //     by invoking the definition with a stub `import` capture.
+    //
+    // Detection order is post→pre because Stage A is unambiguous when present.
+    const isStageA = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
     };
+    const isStageB = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 2)
+        return false;
+      const [i0, i1] = inputs;
+      return !!(i0 && typeof i0 === 'object' && typeof i0._name === 'string' && i0._name.startsWith('module @') && i1 && typeof i1 === 'object' && i1._name === '@variable');
+    };
+    const isStageC = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && i0._name === '@variable' && typeof v._definition !== 'undefined' && String(v._definition).includes('import('));
+    };
+    let v0, module_name, stage;
+    if (v0 = variables.find(isStageA)) {
+      stage = 'A';
+      module_name = findModuleName(v0._module._scope, v0._inputs[0]._module);
+    } else if (v0 = variables.find(isStageB)) {
+      stage = 'B';
+      module_name = v0._inputs[0]._name.replace(/^module /, '');
+    } else if (v0 = variables.find(isStageC)) {
+      stage = 'C';
+      let capturedModule;
+      try {
+        await v0._definition({
+          import: (...args) => {
+            capturedModule = args[args.length - 1];
+          }
+        });
+      } catch (e) {
+      }
+      if (capturedModule && v0._module?._scope) {
+        module_name = findModuleName(v0._module._scope, capturedModule);
+      }
+    } else {
+      return null;
+    }
+    if (module_name == null)
+      throw new Error('module name could not be resolved');
+    // Skip runtime-internal `module @foo` stitch variables — they belong to
+    // the import group but are not user-facing specifiers. Without this filter, an
+    // import group renders as `import {Range, module @foo} from "@foo"`.
+    const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
+      const imported = await findImportedName(v);
+      const local = v._name;
+      return {
+        imported,
+        local,
+        alias: imported !== local,
+        meta: { index }
+      };
+    }));
+    return {
+      type: 'import',
+      from: module_name,
+      specifiers,
+      meta: {
+        detection: { stage },
+        variables: variables.map(v => v?._name ?? null)
+      }
+    };
+  };
 };
 const _1sylz7j = function _formatImportDeclaration(){return(
 function formatImportDeclaration(importInfo) {
@@ -20633,6 +20680,198 @@ const _1hiclbb = function _acorn_walk(acorn_walk_url) {
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
+const _1rc67k0 = function _stageB_importFake()
+{
+  return // Builds a Stage B (pre-observation, API-loaded) import group as POJOs.
+  // Mirrors what `runtime.define("name", ["module @X", "@variable"], (_, v) => v.import("name", _))`
+  // produces structurally. Used by the test_decompileImport_stageB_* tests to
+  // avoid spinning up a real Observable runtime per case.
+  function stageB_importFake(module_name, specifiers) {
+    const importerModule = { _scope: new Map() };
+    const stitch = {
+      _name: `module ${ module_name }`,
+      _module: importerModule,
+      _inputs: [],
+      _definition: `async () => null`
+    };
+    const atVariable = {
+      _name: '@variable',
+      _module: importerModule
+    };
+    const aliases = specifiers.map(s => ({
+      _name: s.local,
+      _module: importerModule,
+      _inputs: [
+        stitch,
+        atVariable
+      ],
+      _definition: s.imported === s.local ? `(_, v) => v.import("${ s.imported }", _)` : `(_, v) => v.import("${ s.imported }", "${ s.local }", _)`
+    }));
+    return [
+      stitch,
+      ...aliases
+    ];
+  };
+};
+const _1d53asg = async function _test_decompileImport_stageB_single(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [{
+      imported: 'visualize',
+      local: 'visualize'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _hv5gag = async function _test_decompileImport_stageB_aliased(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'x',
+      local: 'z'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(info.specifiers[0].alias).toEqual(true);
+  expect(formatImportDeclaration(info)).toEqual(`import {x as z} from "@user/y"`);
+  return 'ok';
+};
+const _avc18y = async function _test_decompileImport_stageB_multiple(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    },
+    {
+      imported: 'c',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b, c} from "@user/y"`);
+  return 'ok';
+};
+const _16gia7i = async function _test_decompileImport_stageB_mixed_alias(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b as c} from "@user/y"`);
+  return 'ok';
+};
+const _1slhdwo = async function _test_decompileImport_stageB_viewof(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/module-map', [{
+      imported: 'viewof currentModules',
+      local: 'viewof currentModules'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {viewof currentModules} from "@tomlarkworthy/module-map"`);
+  return 'ok';
+};
+const _qwlsf2 = async function _test_decompileImport_stageB_mutable(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'mutable counter',
+      local: 'mutable counter'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {mutable counter} from "@user/y"`);
+  return 'ok';
+};
+const _sy7jfx = async function _test_decompileImport_returns_null_for_non_import(decompileImport,expect)
+{
+  // A regular cell — no stitch, no @variable input, no cross-module reference.
+  const info = await decompileImport([{
+      _name: 'x',
+      _module: {},
+      _inputs: [],
+      _definition: `() => 42`
+    }]);
+  expect(info).toEqual(null);
+  return 'ok';
+};
+const _rk7ku3 = async function _test_decompileImport_compile_roundtrip_single(compile,expect,stageB_importFake,decompileImport,formatImportDeclaration)
+{
+  // What `compile()` emits for `import {x} from "@user/y"` is structurally the
+  // same as our stageB_importFake fixture (after runtime.define resolves the
+  // input name strings to Variable refs). Verify the fixture matches the
+  // shape compile() would produce.
+  const pojos = compile(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  expect(pojos.length).toEqual(3);
+  expect(pojos[0]._name).toEqual('module @tomlarkworthy/visualizer');
+  expect(pojos[1]._name).toEqual('visualize');
+  expect(pojos[2]._name).toEqual('Group');
+  expect(pojos[1]._inputs).toEqual([
+    'module @tomlarkworthy/visualizer',
+    '@variable'
+  ]);
+  // Now run our fixture through decompileImport — confirms the round-trip
+  // shape compile()-output-shape-when-defined → decompileImport produces the
+  // canonical import source string.
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [
+    {
+      imported: 'visualize',
+      local: 'visualize'
+    },
+    {
+      imported: 'Group',
+      local: 'Group'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _xynplo = async function _test_decompileImport_stageB_order_independent(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // The detection uses .find — it shouldn't matter whether the stitch is at
+  // index 0 or the aliases come first. Verify by reversing the array.
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    }
+  ]);
+  const reversed = [...vars].reverse();
+  const info = await decompileImport(reversed);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b} from "@user/y"`);
+  return 'ok';
+};
+const _16fpgac = async function _test_decompileImport_stageB_notebook_id(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // Observable supports `import {x} from "d/<hash>@<version>"` notebook-id form.
+  const vars = stageB_importFake('d/57d79353bac56631@44', [{
+      imported: 'hash',
+      local: 'hash'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {hash} from "d/57d79353bac56631@44"`);
+  return 'ok';
+};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -20753,7 +20992,7 @@ export default function define(runtime, observer) {
   $def("_1n7gw17", "findModuleName", ["extractModuleInfo"], _1n7gw17);  
   $def("_i47chb", "findImportedName", [], _i47chb);  
   $def("_1effqg", null, ["md"], _1effqg);  
-  $def("_1etqs71", "decompileImport", ["findModuleName","findImportedName"], _1etqs71);  
+  $def("_b7vai6", "decompileImport", ["findModuleName","findImportedName"], _b7vai6);  
   $def("_1sylz7j", "formatImportDeclaration", [], _1sylz7j);  
   $def("_13dctdn", "test_decompileImport_basic", ["importFake","decompileImport","expect"], _13dctdn);  
   $def("_ujr0xn", "test_formatImportDeclaration_roundtrip", ["importFake","decompileImport","expect","formatImportDeclaration","decompile"], _ujr0xn);  
@@ -20831,7 +21070,18 @@ export default function define(runtime, observer) {
   main.define("Runtime", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Runtime", _));  
   main.define("Inspector", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Inspector", _));  
   main.define("Library", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Library", _));  
-  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));
+  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));  
+  $def("_1rc67k0", "stageB_importFake", [], _1rc67k0);  
+  $def("_1d53asg", "test_decompileImport_stageB_single", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1d53asg);  
+  $def("_hv5gag", "test_decompileImport_stageB_aliased", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _hv5gag);  
+  $def("_avc18y", "test_decompileImport_stageB_multiple", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _avc18y);  
+  $def("_16gia7i", "test_decompileImport_stageB_mixed_alias", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16gia7i);  
+  $def("_1slhdwo", "test_decompileImport_stageB_viewof", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1slhdwo);  
+  $def("_qwlsf2", "test_decompileImport_stageB_mutable", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _qwlsf2);  
+  $def("_sy7jfx", "test_decompileImport_returns_null_for_non_import", ["decompileImport","expect"], _sy7jfx);  
+  $def("_rk7ku3", "test_decompileImport_compile_roundtrip_single", ["compile","expect","stageB_importFake","decompileImport","formatImportDeclaration"], _rk7ku3);  
+  $def("_xynplo", "test_decompileImport_stageB_order_independent", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _xynplo);  
+  $def("_16fpgac", "test_decompileImport_stageB_notebook_id", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16fpgac);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_codemirror-6-v2.html
+++ b/notebooks/@tomlarkworthy_codemirror-6-v2.html
@@ -19474,56 +19474,103 @@ async (v) => {
 const _1effqg = function _96(md){return(
 md`### \`decompileImport\``
 )};
-const _1etqs71 = function _decompileImport(findModuleName,findImportedName)
+const _b7vai6 = function _decompileImport(findModuleName,findImportedName)
 {
-    return async function decompileImport(variables, options = {}) {
-        if (!variables || variables.length === 0)
-            throw new Error('no variables');
-        // #166: An import group is `[module @foo, ...aliases]` — the runtime stitch
-        // sits at index 0 by convention. Scan for the first alias (single _input,
-        // crosses module boundary) so this works whichever order the caller hands us.
-        const isCrossModuleAlias = v => {
-            const inputs = v?._inputs;
-            if (!Array.isArray(inputs) || inputs.length !== 1)
-                return false;
-            const i0 = inputs[0];
-            return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
-        };
-        const v0 = variables.find(isCrossModuleAlias);
-        if (!v0)
-            return null;
-        const input0 = v0._inputs[0];
-        const inputsLength = 1;
-        const crossesModuleBoundary = true;
-        const module_name = findModuleName(v0._module._scope, input0._module);
-        if (module_name == null)
-            throw new Error('module name could not be resolved');
-        // #166: Skip runtime-internal `module @foo` stitch variables — they belong to
-        // the import group but are not user-facing specifiers. Without this filter, an
-        // import group renders as `import {Range, module @foo} from "@foo"`.
-        const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
-            const imported = await findImportedName(v);
-            const local = v._name;
-            return {
-                imported,
-                local,
-                alias: imported !== local,
-                meta: { index }
-            };
-        }));
-        return {
-            type: 'import',
-            from: module_name,
-            specifiers,
-            meta: {
-                detection: {
-                    inputsLength,
-                    crossesModuleBoundary
-                },
-                variables: variables.map(v => v?._name ?? null)
-            }
-        };
+  return async function decompileImport(variables, options = {}) {
+    if (!variables || variables.length === 0)
+      throw new Error('no variables');
+    // An import-cell group is `[module @X stitch, ...aliases]`. Each alias goes
+    // through three lifecycle stages (documented in observable-runtime-v6's
+    // `importedModule` helper, lines ~1992-2049 of @tomlarkworthy/observable-runtime-v6):
+    //
+    //   Stage A — post-observation:
+    //     `_inputs = [Variable in source module]` (length 1, cross-module).
+    //     The Observable runtime rewrites _inputs after the alias is observed
+    //     and resolved against the source module.
+    //
+    //   Stage B — pre-observation, API-loaded (canonical compiled-bundle shape):
+    //     `_inputs = [Variable("module @X"), Variable("@variable")]` (length 2,
+    //     both in the importer module). What `runtime.define("name",
+    //     ["module @X", "@variable"], (_, v) => v.import("name", _))` produces.
+    //     Also what `compile_and_update` outputs for freshly-defined user-typed
+    //     imports until they're observed.
+    //
+    //   Stage C — pre-observation, inline live-notebook:
+    //     `_inputs = [Variable("@variable")]` (length 1) AND the definition
+    //     calls `import(...)` inside. We extract the imported module reference
+    //     by invoking the definition with a stub `import` capture.
+    //
+    // Detection order is post→pre because Stage A is unambiguous when present.
+    const isStageA = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
     };
+    const isStageB = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 2)
+        return false;
+      const [i0, i1] = inputs;
+      return !!(i0 && typeof i0 === 'object' && typeof i0._name === 'string' && i0._name.startsWith('module @') && i1 && typeof i1 === 'object' && i1._name === '@variable');
+    };
+    const isStageC = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && i0._name === '@variable' && typeof v._definition !== 'undefined' && String(v._definition).includes('import('));
+    };
+    let v0, module_name, stage;
+    if (v0 = variables.find(isStageA)) {
+      stage = 'A';
+      module_name = findModuleName(v0._module._scope, v0._inputs[0]._module);
+    } else if (v0 = variables.find(isStageB)) {
+      stage = 'B';
+      module_name = v0._inputs[0]._name.replace(/^module /, '');
+    } else if (v0 = variables.find(isStageC)) {
+      stage = 'C';
+      let capturedModule;
+      try {
+        await v0._definition({
+          import: (...args) => {
+            capturedModule = args[args.length - 1];
+          }
+        });
+      } catch (e) {
+      }
+      if (capturedModule && v0._module?._scope) {
+        module_name = findModuleName(v0._module._scope, capturedModule);
+      }
+    } else {
+      return null;
+    }
+    if (module_name == null)
+      throw new Error('module name could not be resolved');
+    // Skip runtime-internal `module @foo` stitch variables — they belong to
+    // the import group but are not user-facing specifiers. Without this filter, an
+    // import group renders as `import {Range, module @foo} from "@foo"`.
+    const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
+      const imported = await findImportedName(v);
+      const local = v._name;
+      return {
+        imported,
+        local,
+        alias: imported !== local,
+        meta: { index }
+      };
+    }));
+    return {
+      type: 'import',
+      from: module_name,
+      specifiers,
+      meta: {
+        detection: { stage },
+        variables: variables.map(v => v?._name ?? null)
+      }
+    };
+  };
 };
 const _1sylz7j = function _formatImportDeclaration(){return(
 function formatImportDeclaration(importInfo) {
@@ -20633,6 +20680,198 @@ const _1hiclbb = function _acorn_walk(acorn_walk_url) {
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
+const _1rc67k0 = function _stageB_importFake()
+{
+  return // Builds a Stage B (pre-observation, API-loaded) import group as POJOs.
+  // Mirrors what `runtime.define("name", ["module @X", "@variable"], (_, v) => v.import("name", _))`
+  // produces structurally. Used by the test_decompileImport_stageB_* tests to
+  // avoid spinning up a real Observable runtime per case.
+  function stageB_importFake(module_name, specifiers) {
+    const importerModule = { _scope: new Map() };
+    const stitch = {
+      _name: `module ${ module_name }`,
+      _module: importerModule,
+      _inputs: [],
+      _definition: `async () => null`
+    };
+    const atVariable = {
+      _name: '@variable',
+      _module: importerModule
+    };
+    const aliases = specifiers.map(s => ({
+      _name: s.local,
+      _module: importerModule,
+      _inputs: [
+        stitch,
+        atVariable
+      ],
+      _definition: s.imported === s.local ? `(_, v) => v.import("${ s.imported }", _)` : `(_, v) => v.import("${ s.imported }", "${ s.local }", _)`
+    }));
+    return [
+      stitch,
+      ...aliases
+    ];
+  };
+};
+const _1d53asg = async function _test_decompileImport_stageB_single(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [{
+      imported: 'visualize',
+      local: 'visualize'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _hv5gag = async function _test_decompileImport_stageB_aliased(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'x',
+      local: 'z'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(info.specifiers[0].alias).toEqual(true);
+  expect(formatImportDeclaration(info)).toEqual(`import {x as z} from "@user/y"`);
+  return 'ok';
+};
+const _avc18y = async function _test_decompileImport_stageB_multiple(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    },
+    {
+      imported: 'c',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b, c} from "@user/y"`);
+  return 'ok';
+};
+const _16gia7i = async function _test_decompileImport_stageB_mixed_alias(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b as c} from "@user/y"`);
+  return 'ok';
+};
+const _1slhdwo = async function _test_decompileImport_stageB_viewof(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/module-map', [{
+      imported: 'viewof currentModules',
+      local: 'viewof currentModules'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {viewof currentModules} from "@tomlarkworthy/module-map"`);
+  return 'ok';
+};
+const _qwlsf2 = async function _test_decompileImport_stageB_mutable(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'mutable counter',
+      local: 'mutable counter'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {mutable counter} from "@user/y"`);
+  return 'ok';
+};
+const _sy7jfx = async function _test_decompileImport_returns_null_for_non_import(decompileImport,expect)
+{
+  // A regular cell — no stitch, no @variable input, no cross-module reference.
+  const info = await decompileImport([{
+      _name: 'x',
+      _module: {},
+      _inputs: [],
+      _definition: `() => 42`
+    }]);
+  expect(info).toEqual(null);
+  return 'ok';
+};
+const _rk7ku3 = async function _test_decompileImport_compile_roundtrip_single(compile,expect,stageB_importFake,decompileImport,formatImportDeclaration)
+{
+  // What `compile()` emits for `import {x} from "@user/y"` is structurally the
+  // same as our stageB_importFake fixture (after runtime.define resolves the
+  // input name strings to Variable refs). Verify the fixture matches the
+  // shape compile() would produce.
+  const pojos = compile(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  expect(pojos.length).toEqual(3);
+  expect(pojos[0]._name).toEqual('module @tomlarkworthy/visualizer');
+  expect(pojos[1]._name).toEqual('visualize');
+  expect(pojos[2]._name).toEqual('Group');
+  expect(pojos[1]._inputs).toEqual([
+    'module @tomlarkworthy/visualizer',
+    '@variable'
+  ]);
+  // Now run our fixture through decompileImport — confirms the round-trip
+  // shape compile()-output-shape-when-defined → decompileImport produces the
+  // canonical import source string.
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [
+    {
+      imported: 'visualize',
+      local: 'visualize'
+    },
+    {
+      imported: 'Group',
+      local: 'Group'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _xynplo = async function _test_decompileImport_stageB_order_independent(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // The detection uses .find — it shouldn't matter whether the stitch is at
+  // index 0 or the aliases come first. Verify by reversing the array.
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    }
+  ]);
+  const reversed = [...vars].reverse();
+  const info = await decompileImport(reversed);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b} from "@user/y"`);
+  return 'ok';
+};
+const _16fpgac = async function _test_decompileImport_stageB_notebook_id(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // Observable supports `import {x} from "d/<hash>@<version>"` notebook-id form.
+  const vars = stageB_importFake('d/57d79353bac56631@44', [{
+      imported: 'hash',
+      local: 'hash'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {hash} from "d/57d79353bac56631@44"`);
+  return 'ok';
+};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -20753,7 +20992,7 @@ export default function define(runtime, observer) {
   $def("_1n7gw17", "findModuleName", ["extractModuleInfo"], _1n7gw17);  
   $def("_i47chb", "findImportedName", [], _i47chb);  
   $def("_1effqg", null, ["md"], _1effqg);  
-  $def("_1etqs71", "decompileImport", ["findModuleName","findImportedName"], _1etqs71);  
+  $def("_b7vai6", "decompileImport", ["findModuleName","findImportedName"], _b7vai6);  
   $def("_1sylz7j", "formatImportDeclaration", [], _1sylz7j);  
   $def("_13dctdn", "test_decompileImport_basic", ["importFake","decompileImport","expect"], _13dctdn);  
   $def("_ujr0xn", "test_formatImportDeclaration_roundtrip", ["importFake","decompileImport","expect","formatImportDeclaration","decompile"], _ujr0xn);  
@@ -20831,7 +21070,18 @@ export default function define(runtime, observer) {
   main.define("Runtime", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Runtime", _));  
   main.define("Inspector", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Inspector", _));  
   main.define("Library", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Library", _));  
-  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));
+  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));  
+  $def("_1rc67k0", "stageB_importFake", [], _1rc67k0);  
+  $def("_1d53asg", "test_decompileImport_stageB_single", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1d53asg);  
+  $def("_hv5gag", "test_decompileImport_stageB_aliased", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _hv5gag);  
+  $def("_avc18y", "test_decompileImport_stageB_multiple", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _avc18y);  
+  $def("_16gia7i", "test_decompileImport_stageB_mixed_alias", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16gia7i);  
+  $def("_1slhdwo", "test_decompileImport_stageB_viewof", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1slhdwo);  
+  $def("_qwlsf2", "test_decompileImport_stageB_mutable", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _qwlsf2);  
+  $def("_sy7jfx", "test_decompileImport_returns_null_for_non_import", ["decompileImport","expect"], _sy7jfx);  
+  $def("_rk7ku3", "test_decompileImport_compile_roundtrip_single", ["compile","expect","stageB_importFake","decompileImport","formatImportDeclaration"], _rk7ku3);  
+  $def("_xynplo", "test_decompileImport_stageB_order_independent", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _xynplo);  
+  $def("_16fpgac", "test_decompileImport_stageB_notebook_id", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16fpgac);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_command-palette.html
+++ b/notebooks/@tomlarkworthy_command-palette.html
@@ -19474,56 +19474,103 @@ async (v) => {
 const _1effqg = function _96(md){return(
 md`### \`decompileImport\``
 )};
-const _1etqs71 = function _decompileImport(findModuleName,findImportedName)
+const _b7vai6 = function _decompileImport(findModuleName,findImportedName)
 {
-    return async function decompileImport(variables, options = {}) {
-        if (!variables || variables.length === 0)
-            throw new Error('no variables');
-        // #166: An import group is `[module @foo, ...aliases]` — the runtime stitch
-        // sits at index 0 by convention. Scan for the first alias (single _input,
-        // crosses module boundary) so this works whichever order the caller hands us.
-        const isCrossModuleAlias = v => {
-            const inputs = v?._inputs;
-            if (!Array.isArray(inputs) || inputs.length !== 1)
-                return false;
-            const i0 = inputs[0];
-            return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
-        };
-        const v0 = variables.find(isCrossModuleAlias);
-        if (!v0)
-            return null;
-        const input0 = v0._inputs[0];
-        const inputsLength = 1;
-        const crossesModuleBoundary = true;
-        const module_name = findModuleName(v0._module._scope, input0._module);
-        if (module_name == null)
-            throw new Error('module name could not be resolved');
-        // #166: Skip runtime-internal `module @foo` stitch variables — they belong to
-        // the import group but are not user-facing specifiers. Without this filter, an
-        // import group renders as `import {Range, module @foo} from "@foo"`.
-        const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
-            const imported = await findImportedName(v);
-            const local = v._name;
-            return {
-                imported,
-                local,
-                alias: imported !== local,
-                meta: { index }
-            };
-        }));
-        return {
-            type: 'import',
-            from: module_name,
-            specifiers,
-            meta: {
-                detection: {
-                    inputsLength,
-                    crossesModuleBoundary
-                },
-                variables: variables.map(v => v?._name ?? null)
-            }
-        };
+  return async function decompileImport(variables, options = {}) {
+    if (!variables || variables.length === 0)
+      throw new Error('no variables');
+    // An import-cell group is `[module @X stitch, ...aliases]`. Each alias goes
+    // through three lifecycle stages (documented in observable-runtime-v6's
+    // `importedModule` helper, lines ~1992-2049 of @tomlarkworthy/observable-runtime-v6):
+    //
+    //   Stage A — post-observation:
+    //     `_inputs = [Variable in source module]` (length 1, cross-module).
+    //     The Observable runtime rewrites _inputs after the alias is observed
+    //     and resolved against the source module.
+    //
+    //   Stage B — pre-observation, API-loaded (canonical compiled-bundle shape):
+    //     `_inputs = [Variable("module @X"), Variable("@variable")]` (length 2,
+    //     both in the importer module). What `runtime.define("name",
+    //     ["module @X", "@variable"], (_, v) => v.import("name", _))` produces.
+    //     Also what `compile_and_update` outputs for freshly-defined user-typed
+    //     imports until they're observed.
+    //
+    //   Stage C — pre-observation, inline live-notebook:
+    //     `_inputs = [Variable("@variable")]` (length 1) AND the definition
+    //     calls `import(...)` inside. We extract the imported module reference
+    //     by invoking the definition with a stub `import` capture.
+    //
+    // Detection order is post→pre because Stage A is unambiguous when present.
+    const isStageA = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
     };
+    const isStageB = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 2)
+        return false;
+      const [i0, i1] = inputs;
+      return !!(i0 && typeof i0 === 'object' && typeof i0._name === 'string' && i0._name.startsWith('module @') && i1 && typeof i1 === 'object' && i1._name === '@variable');
+    };
+    const isStageC = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && i0._name === '@variable' && typeof v._definition !== 'undefined' && String(v._definition).includes('import('));
+    };
+    let v0, module_name, stage;
+    if (v0 = variables.find(isStageA)) {
+      stage = 'A';
+      module_name = findModuleName(v0._module._scope, v0._inputs[0]._module);
+    } else if (v0 = variables.find(isStageB)) {
+      stage = 'B';
+      module_name = v0._inputs[0]._name.replace(/^module /, '');
+    } else if (v0 = variables.find(isStageC)) {
+      stage = 'C';
+      let capturedModule;
+      try {
+        await v0._definition({
+          import: (...args) => {
+            capturedModule = args[args.length - 1];
+          }
+        });
+      } catch (e) {
+      }
+      if (capturedModule && v0._module?._scope) {
+        module_name = findModuleName(v0._module._scope, capturedModule);
+      }
+    } else {
+      return null;
+    }
+    if (module_name == null)
+      throw new Error('module name could not be resolved');
+    // Skip runtime-internal `module @foo` stitch variables — they belong to
+    // the import group but are not user-facing specifiers. Without this filter, an
+    // import group renders as `import {Range, module @foo} from "@foo"`.
+    const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
+      const imported = await findImportedName(v);
+      const local = v._name;
+      return {
+        imported,
+        local,
+        alias: imported !== local,
+        meta: { index }
+      };
+    }));
+    return {
+      type: 'import',
+      from: module_name,
+      specifiers,
+      meta: {
+        detection: { stage },
+        variables: variables.map(v => v?._name ?? null)
+      }
+    };
+  };
 };
 const _1sylz7j = function _formatImportDeclaration(){return(
 function formatImportDeclaration(importInfo) {
@@ -20633,6 +20680,198 @@ const _1hiclbb = function _acorn_walk(acorn_walk_url) {
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
+const _1rc67k0 = function _stageB_importFake()
+{
+  return // Builds a Stage B (pre-observation, API-loaded) import group as POJOs.
+  // Mirrors what `runtime.define("name", ["module @X", "@variable"], (_, v) => v.import("name", _))`
+  // produces structurally. Used by the test_decompileImport_stageB_* tests to
+  // avoid spinning up a real Observable runtime per case.
+  function stageB_importFake(module_name, specifiers) {
+    const importerModule = { _scope: new Map() };
+    const stitch = {
+      _name: `module ${ module_name }`,
+      _module: importerModule,
+      _inputs: [],
+      _definition: `async () => null`
+    };
+    const atVariable = {
+      _name: '@variable',
+      _module: importerModule
+    };
+    const aliases = specifiers.map(s => ({
+      _name: s.local,
+      _module: importerModule,
+      _inputs: [
+        stitch,
+        atVariable
+      ],
+      _definition: s.imported === s.local ? `(_, v) => v.import("${ s.imported }", _)` : `(_, v) => v.import("${ s.imported }", "${ s.local }", _)`
+    }));
+    return [
+      stitch,
+      ...aliases
+    ];
+  };
+};
+const _1d53asg = async function _test_decompileImport_stageB_single(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [{
+      imported: 'visualize',
+      local: 'visualize'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _hv5gag = async function _test_decompileImport_stageB_aliased(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'x',
+      local: 'z'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(info.specifiers[0].alias).toEqual(true);
+  expect(formatImportDeclaration(info)).toEqual(`import {x as z} from "@user/y"`);
+  return 'ok';
+};
+const _avc18y = async function _test_decompileImport_stageB_multiple(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    },
+    {
+      imported: 'c',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b, c} from "@user/y"`);
+  return 'ok';
+};
+const _16gia7i = async function _test_decompileImport_stageB_mixed_alias(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b as c} from "@user/y"`);
+  return 'ok';
+};
+const _1slhdwo = async function _test_decompileImport_stageB_viewof(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/module-map', [{
+      imported: 'viewof currentModules',
+      local: 'viewof currentModules'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {viewof currentModules} from "@tomlarkworthy/module-map"`);
+  return 'ok';
+};
+const _qwlsf2 = async function _test_decompileImport_stageB_mutable(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'mutable counter',
+      local: 'mutable counter'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {mutable counter} from "@user/y"`);
+  return 'ok';
+};
+const _sy7jfx = async function _test_decompileImport_returns_null_for_non_import(decompileImport,expect)
+{
+  // A regular cell — no stitch, no @variable input, no cross-module reference.
+  const info = await decompileImport([{
+      _name: 'x',
+      _module: {},
+      _inputs: [],
+      _definition: `() => 42`
+    }]);
+  expect(info).toEqual(null);
+  return 'ok';
+};
+const _rk7ku3 = async function _test_decompileImport_compile_roundtrip_single(compile,expect,stageB_importFake,decompileImport,formatImportDeclaration)
+{
+  // What `compile()` emits for `import {x} from "@user/y"` is structurally the
+  // same as our stageB_importFake fixture (after runtime.define resolves the
+  // input name strings to Variable refs). Verify the fixture matches the
+  // shape compile() would produce.
+  const pojos = compile(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  expect(pojos.length).toEqual(3);
+  expect(pojos[0]._name).toEqual('module @tomlarkworthy/visualizer');
+  expect(pojos[1]._name).toEqual('visualize');
+  expect(pojos[2]._name).toEqual('Group');
+  expect(pojos[1]._inputs).toEqual([
+    'module @tomlarkworthy/visualizer',
+    '@variable'
+  ]);
+  // Now run our fixture through decompileImport — confirms the round-trip
+  // shape compile()-output-shape-when-defined → decompileImport produces the
+  // canonical import source string.
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [
+    {
+      imported: 'visualize',
+      local: 'visualize'
+    },
+    {
+      imported: 'Group',
+      local: 'Group'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _xynplo = async function _test_decompileImport_stageB_order_independent(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // The detection uses .find — it shouldn't matter whether the stitch is at
+  // index 0 or the aliases come first. Verify by reversing the array.
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    }
+  ]);
+  const reversed = [...vars].reverse();
+  const info = await decompileImport(reversed);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b} from "@user/y"`);
+  return 'ok';
+};
+const _16fpgac = async function _test_decompileImport_stageB_notebook_id(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // Observable supports `import {x} from "d/<hash>@<version>"` notebook-id form.
+  const vars = stageB_importFake('d/57d79353bac56631@44', [{
+      imported: 'hash',
+      local: 'hash'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {hash} from "d/57d79353bac56631@44"`);
+  return 'ok';
+};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -20753,7 +20992,7 @@ export default function define(runtime, observer) {
   $def("_1n7gw17", "findModuleName", ["extractModuleInfo"], _1n7gw17);  
   $def("_i47chb", "findImportedName", [], _i47chb);  
   $def("_1effqg", null, ["md"], _1effqg);  
-  $def("_1etqs71", "decompileImport", ["findModuleName","findImportedName"], _1etqs71);  
+  $def("_b7vai6", "decompileImport", ["findModuleName","findImportedName"], _b7vai6);  
   $def("_1sylz7j", "formatImportDeclaration", [], _1sylz7j);  
   $def("_13dctdn", "test_decompileImport_basic", ["importFake","decompileImport","expect"], _13dctdn);  
   $def("_ujr0xn", "test_formatImportDeclaration_roundtrip", ["importFake","decompileImport","expect","formatImportDeclaration","decompile"], _ujr0xn);  
@@ -20831,7 +21070,18 @@ export default function define(runtime, observer) {
   main.define("Runtime", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Runtime", _));  
   main.define("Inspector", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Inspector", _));  
   main.define("Library", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Library", _));  
-  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));
+  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));  
+  $def("_1rc67k0", "stageB_importFake", [], _1rc67k0);  
+  $def("_1d53asg", "test_decompileImport_stageB_single", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1d53asg);  
+  $def("_hv5gag", "test_decompileImport_stageB_aliased", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _hv5gag);  
+  $def("_avc18y", "test_decompileImport_stageB_multiple", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _avc18y);  
+  $def("_16gia7i", "test_decompileImport_stageB_mixed_alias", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16gia7i);  
+  $def("_1slhdwo", "test_decompileImport_stageB_viewof", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1slhdwo);  
+  $def("_qwlsf2", "test_decompileImport_stageB_mutable", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _qwlsf2);  
+  $def("_sy7jfx", "test_decompileImport_returns_null_for_non_import", ["decompileImport","expect"], _sy7jfx);  
+  $def("_rk7ku3", "test_decompileImport_compile_roundtrip_single", ["compile","expect","stageB_importFake","decompileImport","formatImportDeclaration"], _rk7ku3);  
+  $def("_xynplo", "test_decompileImport_stageB_order_independent", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _xynplo);  
+  $def("_16fpgac", "test_decompileImport_stageB_notebook_id", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16fpgac);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_dataflow-templating.html
+++ b/notebooks/@tomlarkworthy_dataflow-templating.html
@@ -19474,56 +19474,103 @@ async (v) => {
 const _1effqg = function _96(md){return(
 md`### \`decompileImport\``
 )};
-const _1etqs71 = function _decompileImport(findModuleName,findImportedName)
+const _b7vai6 = function _decompileImport(findModuleName,findImportedName)
 {
-    return async function decompileImport(variables, options = {}) {
-        if (!variables || variables.length === 0)
-            throw new Error('no variables');
-        // #166: An import group is `[module @foo, ...aliases]` — the runtime stitch
-        // sits at index 0 by convention. Scan for the first alias (single _input,
-        // crosses module boundary) so this works whichever order the caller hands us.
-        const isCrossModuleAlias = v => {
-            const inputs = v?._inputs;
-            if (!Array.isArray(inputs) || inputs.length !== 1)
-                return false;
-            const i0 = inputs[0];
-            return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
-        };
-        const v0 = variables.find(isCrossModuleAlias);
-        if (!v0)
-            return null;
-        const input0 = v0._inputs[0];
-        const inputsLength = 1;
-        const crossesModuleBoundary = true;
-        const module_name = findModuleName(v0._module._scope, input0._module);
-        if (module_name == null)
-            throw new Error('module name could not be resolved');
-        // #166: Skip runtime-internal `module @foo` stitch variables — they belong to
-        // the import group but are not user-facing specifiers. Without this filter, an
-        // import group renders as `import {Range, module @foo} from "@foo"`.
-        const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
-            const imported = await findImportedName(v);
-            const local = v._name;
-            return {
-                imported,
-                local,
-                alias: imported !== local,
-                meta: { index }
-            };
-        }));
-        return {
-            type: 'import',
-            from: module_name,
-            specifiers,
-            meta: {
-                detection: {
-                    inputsLength,
-                    crossesModuleBoundary
-                },
-                variables: variables.map(v => v?._name ?? null)
-            }
-        };
+  return async function decompileImport(variables, options = {}) {
+    if (!variables || variables.length === 0)
+      throw new Error('no variables');
+    // An import-cell group is `[module @X stitch, ...aliases]`. Each alias goes
+    // through three lifecycle stages (documented in observable-runtime-v6's
+    // `importedModule` helper, lines ~1992-2049 of @tomlarkworthy/observable-runtime-v6):
+    //
+    //   Stage A — post-observation:
+    //     `_inputs = [Variable in source module]` (length 1, cross-module).
+    //     The Observable runtime rewrites _inputs after the alias is observed
+    //     and resolved against the source module.
+    //
+    //   Stage B — pre-observation, API-loaded (canonical compiled-bundle shape):
+    //     `_inputs = [Variable("module @X"), Variable("@variable")]` (length 2,
+    //     both in the importer module). What `runtime.define("name",
+    //     ["module @X", "@variable"], (_, v) => v.import("name", _))` produces.
+    //     Also what `compile_and_update` outputs for freshly-defined user-typed
+    //     imports until they're observed.
+    //
+    //   Stage C — pre-observation, inline live-notebook:
+    //     `_inputs = [Variable("@variable")]` (length 1) AND the definition
+    //     calls `import(...)` inside. We extract the imported module reference
+    //     by invoking the definition with a stub `import` capture.
+    //
+    // Detection order is post→pre because Stage A is unambiguous when present.
+    const isStageA = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
     };
+    const isStageB = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 2)
+        return false;
+      const [i0, i1] = inputs;
+      return !!(i0 && typeof i0 === 'object' && typeof i0._name === 'string' && i0._name.startsWith('module @') && i1 && typeof i1 === 'object' && i1._name === '@variable');
+    };
+    const isStageC = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && i0._name === '@variable' && typeof v._definition !== 'undefined' && String(v._definition).includes('import('));
+    };
+    let v0, module_name, stage;
+    if (v0 = variables.find(isStageA)) {
+      stage = 'A';
+      module_name = findModuleName(v0._module._scope, v0._inputs[0]._module);
+    } else if (v0 = variables.find(isStageB)) {
+      stage = 'B';
+      module_name = v0._inputs[0]._name.replace(/^module /, '');
+    } else if (v0 = variables.find(isStageC)) {
+      stage = 'C';
+      let capturedModule;
+      try {
+        await v0._definition({
+          import: (...args) => {
+            capturedModule = args[args.length - 1];
+          }
+        });
+      } catch (e) {
+      }
+      if (capturedModule && v0._module?._scope) {
+        module_name = findModuleName(v0._module._scope, capturedModule);
+      }
+    } else {
+      return null;
+    }
+    if (module_name == null)
+      throw new Error('module name could not be resolved');
+    // Skip runtime-internal `module @foo` stitch variables — they belong to
+    // the import group but are not user-facing specifiers. Without this filter, an
+    // import group renders as `import {Range, module @foo} from "@foo"`.
+    const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
+      const imported = await findImportedName(v);
+      const local = v._name;
+      return {
+        imported,
+        local,
+        alias: imported !== local,
+        meta: { index }
+      };
+    }));
+    return {
+      type: 'import',
+      from: module_name,
+      specifiers,
+      meta: {
+        detection: { stage },
+        variables: variables.map(v => v?._name ?? null)
+      }
+    };
+  };
 };
 const _1sylz7j = function _formatImportDeclaration(){return(
 function formatImportDeclaration(importInfo) {
@@ -20633,6 +20680,198 @@ const _1hiclbb = function _acorn_walk(acorn_walk_url) {
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
+const _1rc67k0 = function _stageB_importFake()
+{
+  return // Builds a Stage B (pre-observation, API-loaded) import group as POJOs.
+  // Mirrors what `runtime.define("name", ["module @X", "@variable"], (_, v) => v.import("name", _))`
+  // produces structurally. Used by the test_decompileImport_stageB_* tests to
+  // avoid spinning up a real Observable runtime per case.
+  function stageB_importFake(module_name, specifiers) {
+    const importerModule = { _scope: new Map() };
+    const stitch = {
+      _name: `module ${ module_name }`,
+      _module: importerModule,
+      _inputs: [],
+      _definition: `async () => null`
+    };
+    const atVariable = {
+      _name: '@variable',
+      _module: importerModule
+    };
+    const aliases = specifiers.map(s => ({
+      _name: s.local,
+      _module: importerModule,
+      _inputs: [
+        stitch,
+        atVariable
+      ],
+      _definition: s.imported === s.local ? `(_, v) => v.import("${ s.imported }", _)` : `(_, v) => v.import("${ s.imported }", "${ s.local }", _)`
+    }));
+    return [
+      stitch,
+      ...aliases
+    ];
+  };
+};
+const _1d53asg = async function _test_decompileImport_stageB_single(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [{
+      imported: 'visualize',
+      local: 'visualize'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _hv5gag = async function _test_decompileImport_stageB_aliased(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'x',
+      local: 'z'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(info.specifiers[0].alias).toEqual(true);
+  expect(formatImportDeclaration(info)).toEqual(`import {x as z} from "@user/y"`);
+  return 'ok';
+};
+const _avc18y = async function _test_decompileImport_stageB_multiple(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    },
+    {
+      imported: 'c',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b, c} from "@user/y"`);
+  return 'ok';
+};
+const _16gia7i = async function _test_decompileImport_stageB_mixed_alias(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b as c} from "@user/y"`);
+  return 'ok';
+};
+const _1slhdwo = async function _test_decompileImport_stageB_viewof(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/module-map', [{
+      imported: 'viewof currentModules',
+      local: 'viewof currentModules'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {viewof currentModules} from "@tomlarkworthy/module-map"`);
+  return 'ok';
+};
+const _qwlsf2 = async function _test_decompileImport_stageB_mutable(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'mutable counter',
+      local: 'mutable counter'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {mutable counter} from "@user/y"`);
+  return 'ok';
+};
+const _sy7jfx = async function _test_decompileImport_returns_null_for_non_import(decompileImport,expect)
+{
+  // A regular cell — no stitch, no @variable input, no cross-module reference.
+  const info = await decompileImport([{
+      _name: 'x',
+      _module: {},
+      _inputs: [],
+      _definition: `() => 42`
+    }]);
+  expect(info).toEqual(null);
+  return 'ok';
+};
+const _rk7ku3 = async function _test_decompileImport_compile_roundtrip_single(compile,expect,stageB_importFake,decompileImport,formatImportDeclaration)
+{
+  // What `compile()` emits for `import {x} from "@user/y"` is structurally the
+  // same as our stageB_importFake fixture (after runtime.define resolves the
+  // input name strings to Variable refs). Verify the fixture matches the
+  // shape compile() would produce.
+  const pojos = compile(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  expect(pojos.length).toEqual(3);
+  expect(pojos[0]._name).toEqual('module @tomlarkworthy/visualizer');
+  expect(pojos[1]._name).toEqual('visualize');
+  expect(pojos[2]._name).toEqual('Group');
+  expect(pojos[1]._inputs).toEqual([
+    'module @tomlarkworthy/visualizer',
+    '@variable'
+  ]);
+  // Now run our fixture through decompileImport — confirms the round-trip
+  // shape compile()-output-shape-when-defined → decompileImport produces the
+  // canonical import source string.
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [
+    {
+      imported: 'visualize',
+      local: 'visualize'
+    },
+    {
+      imported: 'Group',
+      local: 'Group'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _xynplo = async function _test_decompileImport_stageB_order_independent(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // The detection uses .find — it shouldn't matter whether the stitch is at
+  // index 0 or the aliases come first. Verify by reversing the array.
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    }
+  ]);
+  const reversed = [...vars].reverse();
+  const info = await decompileImport(reversed);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b} from "@user/y"`);
+  return 'ok';
+};
+const _16fpgac = async function _test_decompileImport_stageB_notebook_id(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // Observable supports `import {x} from "d/<hash>@<version>"` notebook-id form.
+  const vars = stageB_importFake('d/57d79353bac56631@44', [{
+      imported: 'hash',
+      local: 'hash'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {hash} from "d/57d79353bac56631@44"`);
+  return 'ok';
+};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -20753,7 +20992,7 @@ export default function define(runtime, observer) {
   $def("_1n7gw17", "findModuleName", ["extractModuleInfo"], _1n7gw17);  
   $def("_i47chb", "findImportedName", [], _i47chb);  
   $def("_1effqg", null, ["md"], _1effqg);  
-  $def("_1etqs71", "decompileImport", ["findModuleName","findImportedName"], _1etqs71);  
+  $def("_b7vai6", "decompileImport", ["findModuleName","findImportedName"], _b7vai6);  
   $def("_1sylz7j", "formatImportDeclaration", [], _1sylz7j);  
   $def("_13dctdn", "test_decompileImport_basic", ["importFake","decompileImport","expect"], _13dctdn);  
   $def("_ujr0xn", "test_formatImportDeclaration_roundtrip", ["importFake","decompileImport","expect","formatImportDeclaration","decompile"], _ujr0xn);  
@@ -20831,7 +21070,18 @@ export default function define(runtime, observer) {
   main.define("Runtime", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Runtime", _));  
   main.define("Inspector", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Inspector", _));  
   main.define("Library", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Library", _));  
-  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));
+  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));  
+  $def("_1rc67k0", "stageB_importFake", [], _1rc67k0);  
+  $def("_1d53asg", "test_decompileImport_stageB_single", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1d53asg);  
+  $def("_hv5gag", "test_decompileImport_stageB_aliased", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _hv5gag);  
+  $def("_avc18y", "test_decompileImport_stageB_multiple", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _avc18y);  
+  $def("_16gia7i", "test_decompileImport_stageB_mixed_alias", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16gia7i);  
+  $def("_1slhdwo", "test_decompileImport_stageB_viewof", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1slhdwo);  
+  $def("_qwlsf2", "test_decompileImport_stageB_mutable", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _qwlsf2);  
+  $def("_sy7jfx", "test_decompileImport_returns_null_for_non_import", ["decompileImport","expect"], _sy7jfx);  
+  $def("_rk7ku3", "test_decompileImport_compile_roundtrip_single", ["compile","expect","stageB_importFake","decompileImport","formatImportDeclaration"], _rk7ku3);  
+  $def("_xynplo", "test_decompileImport_stageB_order_independent", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _xynplo);  
+  $def("_16fpgac", "test_decompileImport_stageB_notebook_id", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16fpgac);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_debugger-2.html
+++ b/notebooks/@tomlarkworthy_debugger-2.html
@@ -20636,56 +20636,103 @@ async (v) => {
 const _1effqg = function _96(md){return(
 md`### \`decompileImport\``
 )};
-const _1etqs71 = function _decompileImport(findModuleName,findImportedName)
+const _b7vai6 = function _decompileImport(findModuleName,findImportedName)
 {
-    return async function decompileImport(variables, options = {}) {
-        if (!variables || variables.length === 0)
-            throw new Error('no variables');
-        // #166: An import group is `[module @foo, ...aliases]` — the runtime stitch
-        // sits at index 0 by convention. Scan for the first alias (single _input,
-        // crosses module boundary) so this works whichever order the caller hands us.
-        const isCrossModuleAlias = v => {
-            const inputs = v?._inputs;
-            if (!Array.isArray(inputs) || inputs.length !== 1)
-                return false;
-            const i0 = inputs[0];
-            return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
-        };
-        const v0 = variables.find(isCrossModuleAlias);
-        if (!v0)
-            return null;
-        const input0 = v0._inputs[0];
-        const inputsLength = 1;
-        const crossesModuleBoundary = true;
-        const module_name = findModuleName(v0._module._scope, input0._module);
-        if (module_name == null)
-            throw new Error('module name could not be resolved');
-        // #166: Skip runtime-internal `module @foo` stitch variables — they belong to
-        // the import group but are not user-facing specifiers. Without this filter, an
-        // import group renders as `import {Range, module @foo} from "@foo"`.
-        const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
-            const imported = await findImportedName(v);
-            const local = v._name;
-            return {
-                imported,
-                local,
-                alias: imported !== local,
-                meta: { index }
-            };
-        }));
-        return {
-            type: 'import',
-            from: module_name,
-            specifiers,
-            meta: {
-                detection: {
-                    inputsLength,
-                    crossesModuleBoundary
-                },
-                variables: variables.map(v => v?._name ?? null)
-            }
-        };
+  return async function decompileImport(variables, options = {}) {
+    if (!variables || variables.length === 0)
+      throw new Error('no variables');
+    // An import-cell group is `[module @X stitch, ...aliases]`. Each alias goes
+    // through three lifecycle stages (documented in observable-runtime-v6's
+    // `importedModule` helper, lines ~1992-2049 of @tomlarkworthy/observable-runtime-v6):
+    //
+    //   Stage A — post-observation:
+    //     `_inputs = [Variable in source module]` (length 1, cross-module).
+    //     The Observable runtime rewrites _inputs after the alias is observed
+    //     and resolved against the source module.
+    //
+    //   Stage B — pre-observation, API-loaded (canonical compiled-bundle shape):
+    //     `_inputs = [Variable("module @X"), Variable("@variable")]` (length 2,
+    //     both in the importer module). What `runtime.define("name",
+    //     ["module @X", "@variable"], (_, v) => v.import("name", _))` produces.
+    //     Also what `compile_and_update` outputs for freshly-defined user-typed
+    //     imports until they're observed.
+    //
+    //   Stage C — pre-observation, inline live-notebook:
+    //     `_inputs = [Variable("@variable")]` (length 1) AND the definition
+    //     calls `import(...)` inside. We extract the imported module reference
+    //     by invoking the definition with a stub `import` capture.
+    //
+    // Detection order is post→pre because Stage A is unambiguous when present.
+    const isStageA = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
     };
+    const isStageB = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 2)
+        return false;
+      const [i0, i1] = inputs;
+      return !!(i0 && typeof i0 === 'object' && typeof i0._name === 'string' && i0._name.startsWith('module @') && i1 && typeof i1 === 'object' && i1._name === '@variable');
+    };
+    const isStageC = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && i0._name === '@variable' && typeof v._definition !== 'undefined' && String(v._definition).includes('import('));
+    };
+    let v0, module_name, stage;
+    if (v0 = variables.find(isStageA)) {
+      stage = 'A';
+      module_name = findModuleName(v0._module._scope, v0._inputs[0]._module);
+    } else if (v0 = variables.find(isStageB)) {
+      stage = 'B';
+      module_name = v0._inputs[0]._name.replace(/^module /, '');
+    } else if (v0 = variables.find(isStageC)) {
+      stage = 'C';
+      let capturedModule;
+      try {
+        await v0._definition({
+          import: (...args) => {
+            capturedModule = args[args.length - 1];
+          }
+        });
+      } catch (e) {
+      }
+      if (capturedModule && v0._module?._scope) {
+        module_name = findModuleName(v0._module._scope, capturedModule);
+      }
+    } else {
+      return null;
+    }
+    if (module_name == null)
+      throw new Error('module name could not be resolved');
+    // Skip runtime-internal `module @foo` stitch variables — they belong to
+    // the import group but are not user-facing specifiers. Without this filter, an
+    // import group renders as `import {Range, module @foo} from "@foo"`.
+    const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
+      const imported = await findImportedName(v);
+      const local = v._name;
+      return {
+        imported,
+        local,
+        alias: imported !== local,
+        meta: { index }
+      };
+    }));
+    return {
+      type: 'import',
+      from: module_name,
+      specifiers,
+      meta: {
+        detection: { stage },
+        variables: variables.map(v => v?._name ?? null)
+      }
+    };
+  };
 };
 const _1sylz7j = function _formatImportDeclaration(){return(
 function formatImportDeclaration(importInfo) {
@@ -21795,6 +21842,198 @@ const _1hiclbb = function _acorn_walk(acorn_walk_url) {
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
+const _1rc67k0 = function _stageB_importFake()
+{
+  return // Builds a Stage B (pre-observation, API-loaded) import group as POJOs.
+  // Mirrors what `runtime.define("name", ["module @X", "@variable"], (_, v) => v.import("name", _))`
+  // produces structurally. Used by the test_decompileImport_stageB_* tests to
+  // avoid spinning up a real Observable runtime per case.
+  function stageB_importFake(module_name, specifiers) {
+    const importerModule = { _scope: new Map() };
+    const stitch = {
+      _name: `module ${ module_name }`,
+      _module: importerModule,
+      _inputs: [],
+      _definition: `async () => null`
+    };
+    const atVariable = {
+      _name: '@variable',
+      _module: importerModule
+    };
+    const aliases = specifiers.map(s => ({
+      _name: s.local,
+      _module: importerModule,
+      _inputs: [
+        stitch,
+        atVariable
+      ],
+      _definition: s.imported === s.local ? `(_, v) => v.import("${ s.imported }", _)` : `(_, v) => v.import("${ s.imported }", "${ s.local }", _)`
+    }));
+    return [
+      stitch,
+      ...aliases
+    ];
+  };
+};
+const _1d53asg = async function _test_decompileImport_stageB_single(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [{
+      imported: 'visualize',
+      local: 'visualize'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _hv5gag = async function _test_decompileImport_stageB_aliased(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'x',
+      local: 'z'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(info.specifiers[0].alias).toEqual(true);
+  expect(formatImportDeclaration(info)).toEqual(`import {x as z} from "@user/y"`);
+  return 'ok';
+};
+const _avc18y = async function _test_decompileImport_stageB_multiple(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    },
+    {
+      imported: 'c',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b, c} from "@user/y"`);
+  return 'ok';
+};
+const _16gia7i = async function _test_decompileImport_stageB_mixed_alias(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b as c} from "@user/y"`);
+  return 'ok';
+};
+const _1slhdwo = async function _test_decompileImport_stageB_viewof(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/module-map', [{
+      imported: 'viewof currentModules',
+      local: 'viewof currentModules'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {viewof currentModules} from "@tomlarkworthy/module-map"`);
+  return 'ok';
+};
+const _qwlsf2 = async function _test_decompileImport_stageB_mutable(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'mutable counter',
+      local: 'mutable counter'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {mutable counter} from "@user/y"`);
+  return 'ok';
+};
+const _sy7jfx = async function _test_decompileImport_returns_null_for_non_import(decompileImport,expect)
+{
+  // A regular cell — no stitch, no @variable input, no cross-module reference.
+  const info = await decompileImport([{
+      _name: 'x',
+      _module: {},
+      _inputs: [],
+      _definition: `() => 42`
+    }]);
+  expect(info).toEqual(null);
+  return 'ok';
+};
+const _rk7ku3 = async function _test_decompileImport_compile_roundtrip_single(compile,expect,stageB_importFake,decompileImport,formatImportDeclaration)
+{
+  // What `compile()` emits for `import {x} from "@user/y"` is structurally the
+  // same as our stageB_importFake fixture (after runtime.define resolves the
+  // input name strings to Variable refs). Verify the fixture matches the
+  // shape compile() would produce.
+  const pojos = compile(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  expect(pojos.length).toEqual(3);
+  expect(pojos[0]._name).toEqual('module @tomlarkworthy/visualizer');
+  expect(pojos[1]._name).toEqual('visualize');
+  expect(pojos[2]._name).toEqual('Group');
+  expect(pojos[1]._inputs).toEqual([
+    'module @tomlarkworthy/visualizer',
+    '@variable'
+  ]);
+  // Now run our fixture through decompileImport — confirms the round-trip
+  // shape compile()-output-shape-when-defined → decompileImport produces the
+  // canonical import source string.
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [
+    {
+      imported: 'visualize',
+      local: 'visualize'
+    },
+    {
+      imported: 'Group',
+      local: 'Group'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _xynplo = async function _test_decompileImport_stageB_order_independent(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // The detection uses .find — it shouldn't matter whether the stitch is at
+  // index 0 or the aliases come first. Verify by reversing the array.
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    }
+  ]);
+  const reversed = [...vars].reverse();
+  const info = await decompileImport(reversed);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b} from "@user/y"`);
+  return 'ok';
+};
+const _16fpgac = async function _test_decompileImport_stageB_notebook_id(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // Observable supports `import {x} from "d/<hash>@<version>"` notebook-id form.
+  const vars = stageB_importFake('d/57d79353bac56631@44', [{
+      imported: 'hash',
+      local: 'hash'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {hash} from "d/57d79353bac56631@44"`);
+  return 'ok';
+};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -21915,7 +22154,7 @@ export default function define(runtime, observer) {
   $def("_1n7gw17", "findModuleName", ["extractModuleInfo"], _1n7gw17);  
   $def("_i47chb", "findImportedName", [], _i47chb);  
   $def("_1effqg", null, ["md"], _1effqg);  
-  $def("_1etqs71", "decompileImport", ["findModuleName","findImportedName"], _1etqs71);  
+  $def("_b7vai6", "decompileImport", ["findModuleName","findImportedName"], _b7vai6);  
   $def("_1sylz7j", "formatImportDeclaration", [], _1sylz7j);  
   $def("_13dctdn", "test_decompileImport_basic", ["importFake","decompileImport","expect"], _13dctdn);  
   $def("_ujr0xn", "test_formatImportDeclaration_roundtrip", ["importFake","decompileImport","expect","formatImportDeclaration","decompile"], _ujr0xn);  
@@ -21993,7 +22232,18 @@ export default function define(runtime, observer) {
   main.define("Runtime", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Runtime", _));  
   main.define("Inspector", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Inspector", _));  
   main.define("Library", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Library", _));  
-  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));
+  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));  
+  $def("_1rc67k0", "stageB_importFake", [], _1rc67k0);  
+  $def("_1d53asg", "test_decompileImport_stageB_single", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1d53asg);  
+  $def("_hv5gag", "test_decompileImport_stageB_aliased", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _hv5gag);  
+  $def("_avc18y", "test_decompileImport_stageB_multiple", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _avc18y);  
+  $def("_16gia7i", "test_decompileImport_stageB_mixed_alias", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16gia7i);  
+  $def("_1slhdwo", "test_decompileImport_stageB_viewof", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1slhdwo);  
+  $def("_qwlsf2", "test_decompileImport_stageB_mutable", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _qwlsf2);  
+  $def("_sy7jfx", "test_decompileImport_returns_null_for_non_import", ["decompileImport","expect"], _sy7jfx);  
+  $def("_rk7ku3", "test_decompileImport_compile_roundtrip_single", ["compile","expect","stageB_importFake","decompileImport","formatImportDeclaration"], _rk7ku3);  
+  $def("_xynplo", "test_decompileImport_stageB_order_independent", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _xynplo);  
+  $def("_16fpgac", "test_decompileImport_stageB_notebook_id", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16fpgac);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_debugger.html
+++ b/notebooks/@tomlarkworthy_debugger.html
@@ -19895,56 +19895,103 @@ async (v) => {
 const _1effqg = function _96(md){return(
 md`### \`decompileImport\``
 )};
-const _1etqs71 = function _decompileImport(findModuleName,findImportedName)
+const _b7vai6 = function _decompileImport(findModuleName,findImportedName)
 {
-    return async function decompileImport(variables, options = {}) {
-        if (!variables || variables.length === 0)
-            throw new Error('no variables');
-        // #166: An import group is `[module @foo, ...aliases]` — the runtime stitch
-        // sits at index 0 by convention. Scan for the first alias (single _input,
-        // crosses module boundary) so this works whichever order the caller hands us.
-        const isCrossModuleAlias = v => {
-            const inputs = v?._inputs;
-            if (!Array.isArray(inputs) || inputs.length !== 1)
-                return false;
-            const i0 = inputs[0];
-            return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
-        };
-        const v0 = variables.find(isCrossModuleAlias);
-        if (!v0)
-            return null;
-        const input0 = v0._inputs[0];
-        const inputsLength = 1;
-        const crossesModuleBoundary = true;
-        const module_name = findModuleName(v0._module._scope, input0._module);
-        if (module_name == null)
-            throw new Error('module name could not be resolved');
-        // #166: Skip runtime-internal `module @foo` stitch variables — they belong to
-        // the import group but are not user-facing specifiers. Without this filter, an
-        // import group renders as `import {Range, module @foo} from "@foo"`.
-        const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
-            const imported = await findImportedName(v);
-            const local = v._name;
-            return {
-                imported,
-                local,
-                alias: imported !== local,
-                meta: { index }
-            };
-        }));
-        return {
-            type: 'import',
-            from: module_name,
-            specifiers,
-            meta: {
-                detection: {
-                    inputsLength,
-                    crossesModuleBoundary
-                },
-                variables: variables.map(v => v?._name ?? null)
-            }
-        };
+  return async function decompileImport(variables, options = {}) {
+    if (!variables || variables.length === 0)
+      throw new Error('no variables');
+    // An import-cell group is `[module @X stitch, ...aliases]`. Each alias goes
+    // through three lifecycle stages (documented in observable-runtime-v6's
+    // `importedModule` helper, lines ~1992-2049 of @tomlarkworthy/observable-runtime-v6):
+    //
+    //   Stage A — post-observation:
+    //     `_inputs = [Variable in source module]` (length 1, cross-module).
+    //     The Observable runtime rewrites _inputs after the alias is observed
+    //     and resolved against the source module.
+    //
+    //   Stage B — pre-observation, API-loaded (canonical compiled-bundle shape):
+    //     `_inputs = [Variable("module @X"), Variable("@variable")]` (length 2,
+    //     both in the importer module). What `runtime.define("name",
+    //     ["module @X", "@variable"], (_, v) => v.import("name", _))` produces.
+    //     Also what `compile_and_update` outputs for freshly-defined user-typed
+    //     imports until they're observed.
+    //
+    //   Stage C — pre-observation, inline live-notebook:
+    //     `_inputs = [Variable("@variable")]` (length 1) AND the definition
+    //     calls `import(...)` inside. We extract the imported module reference
+    //     by invoking the definition with a stub `import` capture.
+    //
+    // Detection order is post→pre because Stage A is unambiguous when present.
+    const isStageA = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
     };
+    const isStageB = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 2)
+        return false;
+      const [i0, i1] = inputs;
+      return !!(i0 && typeof i0 === 'object' && typeof i0._name === 'string' && i0._name.startsWith('module @') && i1 && typeof i1 === 'object' && i1._name === '@variable');
+    };
+    const isStageC = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && i0._name === '@variable' && typeof v._definition !== 'undefined' && String(v._definition).includes('import('));
+    };
+    let v0, module_name, stage;
+    if (v0 = variables.find(isStageA)) {
+      stage = 'A';
+      module_name = findModuleName(v0._module._scope, v0._inputs[0]._module);
+    } else if (v0 = variables.find(isStageB)) {
+      stage = 'B';
+      module_name = v0._inputs[0]._name.replace(/^module /, '');
+    } else if (v0 = variables.find(isStageC)) {
+      stage = 'C';
+      let capturedModule;
+      try {
+        await v0._definition({
+          import: (...args) => {
+            capturedModule = args[args.length - 1];
+          }
+        });
+      } catch (e) {
+      }
+      if (capturedModule && v0._module?._scope) {
+        module_name = findModuleName(v0._module._scope, capturedModule);
+      }
+    } else {
+      return null;
+    }
+    if (module_name == null)
+      throw new Error('module name could not be resolved');
+    // Skip runtime-internal `module @foo` stitch variables — they belong to
+    // the import group but are not user-facing specifiers. Without this filter, an
+    // import group renders as `import {Range, module @foo} from "@foo"`.
+    const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
+      const imported = await findImportedName(v);
+      const local = v._name;
+      return {
+        imported,
+        local,
+        alias: imported !== local,
+        meta: { index }
+      };
+    }));
+    return {
+      type: 'import',
+      from: module_name,
+      specifiers,
+      meta: {
+        detection: { stage },
+        variables: variables.map(v => v?._name ?? null)
+      }
+    };
+  };
 };
 const _1sylz7j = function _formatImportDeclaration(){return(
 function formatImportDeclaration(importInfo) {
@@ -21054,6 +21101,198 @@ const _1hiclbb = function _acorn_walk(acorn_walk_url) {
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
+const _1rc67k0 = function _stageB_importFake()
+{
+  return // Builds a Stage B (pre-observation, API-loaded) import group as POJOs.
+  // Mirrors what `runtime.define("name", ["module @X", "@variable"], (_, v) => v.import("name", _))`
+  // produces structurally. Used by the test_decompileImport_stageB_* tests to
+  // avoid spinning up a real Observable runtime per case.
+  function stageB_importFake(module_name, specifiers) {
+    const importerModule = { _scope: new Map() };
+    const stitch = {
+      _name: `module ${ module_name }`,
+      _module: importerModule,
+      _inputs: [],
+      _definition: `async () => null`
+    };
+    const atVariable = {
+      _name: '@variable',
+      _module: importerModule
+    };
+    const aliases = specifiers.map(s => ({
+      _name: s.local,
+      _module: importerModule,
+      _inputs: [
+        stitch,
+        atVariable
+      ],
+      _definition: s.imported === s.local ? `(_, v) => v.import("${ s.imported }", _)` : `(_, v) => v.import("${ s.imported }", "${ s.local }", _)`
+    }));
+    return [
+      stitch,
+      ...aliases
+    ];
+  };
+};
+const _1d53asg = async function _test_decompileImport_stageB_single(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [{
+      imported: 'visualize',
+      local: 'visualize'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _hv5gag = async function _test_decompileImport_stageB_aliased(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'x',
+      local: 'z'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(info.specifiers[0].alias).toEqual(true);
+  expect(formatImportDeclaration(info)).toEqual(`import {x as z} from "@user/y"`);
+  return 'ok';
+};
+const _avc18y = async function _test_decompileImport_stageB_multiple(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    },
+    {
+      imported: 'c',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b, c} from "@user/y"`);
+  return 'ok';
+};
+const _16gia7i = async function _test_decompileImport_stageB_mixed_alias(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b as c} from "@user/y"`);
+  return 'ok';
+};
+const _1slhdwo = async function _test_decompileImport_stageB_viewof(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/module-map', [{
+      imported: 'viewof currentModules',
+      local: 'viewof currentModules'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {viewof currentModules} from "@tomlarkworthy/module-map"`);
+  return 'ok';
+};
+const _qwlsf2 = async function _test_decompileImport_stageB_mutable(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'mutable counter',
+      local: 'mutable counter'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {mutable counter} from "@user/y"`);
+  return 'ok';
+};
+const _sy7jfx = async function _test_decompileImport_returns_null_for_non_import(decompileImport,expect)
+{
+  // A regular cell — no stitch, no @variable input, no cross-module reference.
+  const info = await decompileImport([{
+      _name: 'x',
+      _module: {},
+      _inputs: [],
+      _definition: `() => 42`
+    }]);
+  expect(info).toEqual(null);
+  return 'ok';
+};
+const _rk7ku3 = async function _test_decompileImport_compile_roundtrip_single(compile,expect,stageB_importFake,decompileImport,formatImportDeclaration)
+{
+  // What `compile()` emits for `import {x} from "@user/y"` is structurally the
+  // same as our stageB_importFake fixture (after runtime.define resolves the
+  // input name strings to Variable refs). Verify the fixture matches the
+  // shape compile() would produce.
+  const pojos = compile(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  expect(pojos.length).toEqual(3);
+  expect(pojos[0]._name).toEqual('module @tomlarkworthy/visualizer');
+  expect(pojos[1]._name).toEqual('visualize');
+  expect(pojos[2]._name).toEqual('Group');
+  expect(pojos[1]._inputs).toEqual([
+    'module @tomlarkworthy/visualizer',
+    '@variable'
+  ]);
+  // Now run our fixture through decompileImport — confirms the round-trip
+  // shape compile()-output-shape-when-defined → decompileImport produces the
+  // canonical import source string.
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [
+    {
+      imported: 'visualize',
+      local: 'visualize'
+    },
+    {
+      imported: 'Group',
+      local: 'Group'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _xynplo = async function _test_decompileImport_stageB_order_independent(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // The detection uses .find — it shouldn't matter whether the stitch is at
+  // index 0 or the aliases come first. Verify by reversing the array.
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    }
+  ]);
+  const reversed = [...vars].reverse();
+  const info = await decompileImport(reversed);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b} from "@user/y"`);
+  return 'ok';
+};
+const _16fpgac = async function _test_decompileImport_stageB_notebook_id(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // Observable supports `import {x} from "d/<hash>@<version>"` notebook-id form.
+  const vars = stageB_importFake('d/57d79353bac56631@44', [{
+      imported: 'hash',
+      local: 'hash'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {hash} from "d/57d79353bac56631@44"`);
+  return 'ok';
+};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -21174,7 +21413,7 @@ export default function define(runtime, observer) {
   $def("_1n7gw17", "findModuleName", ["extractModuleInfo"], _1n7gw17);  
   $def("_i47chb", "findImportedName", [], _i47chb);  
   $def("_1effqg", null, ["md"], _1effqg);  
-  $def("_1etqs71", "decompileImport", ["findModuleName","findImportedName"], _1etqs71);  
+  $def("_b7vai6", "decompileImport", ["findModuleName","findImportedName"], _b7vai6);  
   $def("_1sylz7j", "formatImportDeclaration", [], _1sylz7j);  
   $def("_13dctdn", "test_decompileImport_basic", ["importFake","decompileImport","expect"], _13dctdn);  
   $def("_ujr0xn", "test_formatImportDeclaration_roundtrip", ["importFake","decompileImport","expect","formatImportDeclaration","decompile"], _ujr0xn);  
@@ -21252,7 +21491,18 @@ export default function define(runtime, observer) {
   main.define("Runtime", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Runtime", _));  
   main.define("Inspector", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Inspector", _));  
   main.define("Library", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Library", _));  
-  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));
+  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));  
+  $def("_1rc67k0", "stageB_importFake", [], _1rc67k0);  
+  $def("_1d53asg", "test_decompileImport_stageB_single", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1d53asg);  
+  $def("_hv5gag", "test_decompileImport_stageB_aliased", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _hv5gag);  
+  $def("_avc18y", "test_decompileImport_stageB_multiple", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _avc18y);  
+  $def("_16gia7i", "test_decompileImport_stageB_mixed_alias", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16gia7i);  
+  $def("_1slhdwo", "test_decompileImport_stageB_viewof", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1slhdwo);  
+  $def("_qwlsf2", "test_decompileImport_stageB_mutable", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _qwlsf2);  
+  $def("_sy7jfx", "test_decompileImport_returns_null_for_non_import", ["decompileImport","expect"], _sy7jfx);  
+  $def("_rk7ku3", "test_decompileImport_compile_roundtrip_single", ["compile","expect","stageB_importFake","decompileImport","formatImportDeclaration"], _rk7ku3);  
+  $def("_xynplo", "test_decompileImport_stageB_order_independent", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _xynplo);  
+  $def("_16fpgac", "test_decompileImport_stageB_notebook_id", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16fpgac);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_dom-view.html
+++ b/notebooks/@tomlarkworthy_dom-view.html
@@ -19474,56 +19474,103 @@ async (v) => {
 const _1effqg = function _96(md){return(
 md`### \`decompileImport\``
 )};
-const _1etqs71 = function _decompileImport(findModuleName,findImportedName)
+const _b7vai6 = function _decompileImport(findModuleName,findImportedName)
 {
-    return async function decompileImport(variables, options = {}) {
-        if (!variables || variables.length === 0)
-            throw new Error('no variables');
-        // #166: An import group is `[module @foo, ...aliases]` — the runtime stitch
-        // sits at index 0 by convention. Scan for the first alias (single _input,
-        // crosses module boundary) so this works whichever order the caller hands us.
-        const isCrossModuleAlias = v => {
-            const inputs = v?._inputs;
-            if (!Array.isArray(inputs) || inputs.length !== 1)
-                return false;
-            const i0 = inputs[0];
-            return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
-        };
-        const v0 = variables.find(isCrossModuleAlias);
-        if (!v0)
-            return null;
-        const input0 = v0._inputs[0];
-        const inputsLength = 1;
-        const crossesModuleBoundary = true;
-        const module_name = findModuleName(v0._module._scope, input0._module);
-        if (module_name == null)
-            throw new Error('module name could not be resolved');
-        // #166: Skip runtime-internal `module @foo` stitch variables — they belong to
-        // the import group but are not user-facing specifiers. Without this filter, an
-        // import group renders as `import {Range, module @foo} from "@foo"`.
-        const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
-            const imported = await findImportedName(v);
-            const local = v._name;
-            return {
-                imported,
-                local,
-                alias: imported !== local,
-                meta: { index }
-            };
-        }));
-        return {
-            type: 'import',
-            from: module_name,
-            specifiers,
-            meta: {
-                detection: {
-                    inputsLength,
-                    crossesModuleBoundary
-                },
-                variables: variables.map(v => v?._name ?? null)
-            }
-        };
+  return async function decompileImport(variables, options = {}) {
+    if (!variables || variables.length === 0)
+      throw new Error('no variables');
+    // An import-cell group is `[module @X stitch, ...aliases]`. Each alias goes
+    // through three lifecycle stages (documented in observable-runtime-v6's
+    // `importedModule` helper, lines ~1992-2049 of @tomlarkworthy/observable-runtime-v6):
+    //
+    //   Stage A — post-observation:
+    //     `_inputs = [Variable in source module]` (length 1, cross-module).
+    //     The Observable runtime rewrites _inputs after the alias is observed
+    //     and resolved against the source module.
+    //
+    //   Stage B — pre-observation, API-loaded (canonical compiled-bundle shape):
+    //     `_inputs = [Variable("module @X"), Variable("@variable")]` (length 2,
+    //     both in the importer module). What `runtime.define("name",
+    //     ["module @X", "@variable"], (_, v) => v.import("name", _))` produces.
+    //     Also what `compile_and_update` outputs for freshly-defined user-typed
+    //     imports until they're observed.
+    //
+    //   Stage C — pre-observation, inline live-notebook:
+    //     `_inputs = [Variable("@variable")]` (length 1) AND the definition
+    //     calls `import(...)` inside. We extract the imported module reference
+    //     by invoking the definition with a stub `import` capture.
+    //
+    // Detection order is post→pre because Stage A is unambiguous when present.
+    const isStageA = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
     };
+    const isStageB = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 2)
+        return false;
+      const [i0, i1] = inputs;
+      return !!(i0 && typeof i0 === 'object' && typeof i0._name === 'string' && i0._name.startsWith('module @') && i1 && typeof i1 === 'object' && i1._name === '@variable');
+    };
+    const isStageC = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && i0._name === '@variable' && typeof v._definition !== 'undefined' && String(v._definition).includes('import('));
+    };
+    let v0, module_name, stage;
+    if (v0 = variables.find(isStageA)) {
+      stage = 'A';
+      module_name = findModuleName(v0._module._scope, v0._inputs[0]._module);
+    } else if (v0 = variables.find(isStageB)) {
+      stage = 'B';
+      module_name = v0._inputs[0]._name.replace(/^module /, '');
+    } else if (v0 = variables.find(isStageC)) {
+      stage = 'C';
+      let capturedModule;
+      try {
+        await v0._definition({
+          import: (...args) => {
+            capturedModule = args[args.length - 1];
+          }
+        });
+      } catch (e) {
+      }
+      if (capturedModule && v0._module?._scope) {
+        module_name = findModuleName(v0._module._scope, capturedModule);
+      }
+    } else {
+      return null;
+    }
+    if (module_name == null)
+      throw new Error('module name could not be resolved');
+    // Skip runtime-internal `module @foo` stitch variables — they belong to
+    // the import group but are not user-facing specifiers. Without this filter, an
+    // import group renders as `import {Range, module @foo} from "@foo"`.
+    const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
+      const imported = await findImportedName(v);
+      const local = v._name;
+      return {
+        imported,
+        local,
+        alias: imported !== local,
+        meta: { index }
+      };
+    }));
+    return {
+      type: 'import',
+      from: module_name,
+      specifiers,
+      meta: {
+        detection: { stage },
+        variables: variables.map(v => v?._name ?? null)
+      }
+    };
+  };
 };
 const _1sylz7j = function _formatImportDeclaration(){return(
 function formatImportDeclaration(importInfo) {
@@ -20633,6 +20680,198 @@ const _1hiclbb = function _acorn_walk(acorn_walk_url) {
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
+const _1rc67k0 = function _stageB_importFake()
+{
+  return // Builds a Stage B (pre-observation, API-loaded) import group as POJOs.
+  // Mirrors what `runtime.define("name", ["module @X", "@variable"], (_, v) => v.import("name", _))`
+  // produces structurally. Used by the test_decompileImport_stageB_* tests to
+  // avoid spinning up a real Observable runtime per case.
+  function stageB_importFake(module_name, specifiers) {
+    const importerModule = { _scope: new Map() };
+    const stitch = {
+      _name: `module ${ module_name }`,
+      _module: importerModule,
+      _inputs: [],
+      _definition: `async () => null`
+    };
+    const atVariable = {
+      _name: '@variable',
+      _module: importerModule
+    };
+    const aliases = specifiers.map(s => ({
+      _name: s.local,
+      _module: importerModule,
+      _inputs: [
+        stitch,
+        atVariable
+      ],
+      _definition: s.imported === s.local ? `(_, v) => v.import("${ s.imported }", _)` : `(_, v) => v.import("${ s.imported }", "${ s.local }", _)`
+    }));
+    return [
+      stitch,
+      ...aliases
+    ];
+  };
+};
+const _1d53asg = async function _test_decompileImport_stageB_single(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [{
+      imported: 'visualize',
+      local: 'visualize'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _hv5gag = async function _test_decompileImport_stageB_aliased(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'x',
+      local: 'z'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(info.specifiers[0].alias).toEqual(true);
+  expect(formatImportDeclaration(info)).toEqual(`import {x as z} from "@user/y"`);
+  return 'ok';
+};
+const _avc18y = async function _test_decompileImport_stageB_multiple(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    },
+    {
+      imported: 'c',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b, c} from "@user/y"`);
+  return 'ok';
+};
+const _16gia7i = async function _test_decompileImport_stageB_mixed_alias(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b as c} from "@user/y"`);
+  return 'ok';
+};
+const _1slhdwo = async function _test_decompileImport_stageB_viewof(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/module-map', [{
+      imported: 'viewof currentModules',
+      local: 'viewof currentModules'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {viewof currentModules} from "@tomlarkworthy/module-map"`);
+  return 'ok';
+};
+const _qwlsf2 = async function _test_decompileImport_stageB_mutable(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'mutable counter',
+      local: 'mutable counter'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {mutable counter} from "@user/y"`);
+  return 'ok';
+};
+const _sy7jfx = async function _test_decompileImport_returns_null_for_non_import(decompileImport,expect)
+{
+  // A regular cell — no stitch, no @variable input, no cross-module reference.
+  const info = await decompileImport([{
+      _name: 'x',
+      _module: {},
+      _inputs: [],
+      _definition: `() => 42`
+    }]);
+  expect(info).toEqual(null);
+  return 'ok';
+};
+const _rk7ku3 = async function _test_decompileImport_compile_roundtrip_single(compile,expect,stageB_importFake,decompileImport,formatImportDeclaration)
+{
+  // What `compile()` emits for `import {x} from "@user/y"` is structurally the
+  // same as our stageB_importFake fixture (after runtime.define resolves the
+  // input name strings to Variable refs). Verify the fixture matches the
+  // shape compile() would produce.
+  const pojos = compile(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  expect(pojos.length).toEqual(3);
+  expect(pojos[0]._name).toEqual('module @tomlarkworthy/visualizer');
+  expect(pojos[1]._name).toEqual('visualize');
+  expect(pojos[2]._name).toEqual('Group');
+  expect(pojos[1]._inputs).toEqual([
+    'module @tomlarkworthy/visualizer',
+    '@variable'
+  ]);
+  // Now run our fixture through decompileImport — confirms the round-trip
+  // shape compile()-output-shape-when-defined → decompileImport produces the
+  // canonical import source string.
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [
+    {
+      imported: 'visualize',
+      local: 'visualize'
+    },
+    {
+      imported: 'Group',
+      local: 'Group'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _xynplo = async function _test_decompileImport_stageB_order_independent(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // The detection uses .find — it shouldn't matter whether the stitch is at
+  // index 0 or the aliases come first. Verify by reversing the array.
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    }
+  ]);
+  const reversed = [...vars].reverse();
+  const info = await decompileImport(reversed);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b} from "@user/y"`);
+  return 'ok';
+};
+const _16fpgac = async function _test_decompileImport_stageB_notebook_id(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // Observable supports `import {x} from "d/<hash>@<version>"` notebook-id form.
+  const vars = stageB_importFake('d/57d79353bac56631@44', [{
+      imported: 'hash',
+      local: 'hash'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {hash} from "d/57d79353bac56631@44"`);
+  return 'ok';
+};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -20753,7 +20992,7 @@ export default function define(runtime, observer) {
   $def("_1n7gw17", "findModuleName", ["extractModuleInfo"], _1n7gw17);  
   $def("_i47chb", "findImportedName", [], _i47chb);  
   $def("_1effqg", null, ["md"], _1effqg);  
-  $def("_1etqs71", "decompileImport", ["findModuleName","findImportedName"], _1etqs71);  
+  $def("_b7vai6", "decompileImport", ["findModuleName","findImportedName"], _b7vai6);  
   $def("_1sylz7j", "formatImportDeclaration", [], _1sylz7j);  
   $def("_13dctdn", "test_decompileImport_basic", ["importFake","decompileImport","expect"], _13dctdn);  
   $def("_ujr0xn", "test_formatImportDeclaration_roundtrip", ["importFake","decompileImport","expect","formatImportDeclaration","decompile"], _ujr0xn);  
@@ -20831,7 +21070,18 @@ export default function define(runtime, observer) {
   main.define("Runtime", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Runtime", _));  
   main.define("Inspector", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Inspector", _));  
   main.define("Library", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Library", _));  
-  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));
+  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));  
+  $def("_1rc67k0", "stageB_importFake", [], _1rc67k0);  
+  $def("_1d53asg", "test_decompileImport_stageB_single", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1d53asg);  
+  $def("_hv5gag", "test_decompileImport_stageB_aliased", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _hv5gag);  
+  $def("_avc18y", "test_decompileImport_stageB_multiple", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _avc18y);  
+  $def("_16gia7i", "test_decompileImport_stageB_mixed_alias", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16gia7i);  
+  $def("_1slhdwo", "test_decompileImport_stageB_viewof", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1slhdwo);  
+  $def("_qwlsf2", "test_decompileImport_stageB_mutable", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _qwlsf2);  
+  $def("_sy7jfx", "test_decompileImport_returns_null_for_non_import", ["decompileImport","expect"], _sy7jfx);  
+  $def("_rk7ku3", "test_decompileImport_compile_roundtrip_single", ["compile","expect","stageB_importFake","decompileImport","formatImportDeclaration"], _rk7ku3);  
+  $def("_xynplo", "test_decompileImport_stageB_order_independent", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _xynplo);  
+  $def("_16fpgac", "test_decompileImport_stageB_notebook_id", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16fpgac);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_editor-5.html
+++ b/notebooks/@tomlarkworthy_editor-5.html
@@ -19472,104 +19472,103 @@ async (v) => {
 const _1effqg = function _96(md){return(
 md`### \`decompileImport\``
 )};
-const _1etqs71 = function _decompileImport(findModuleName,findImportedName)
+const _b7vai6 = function _decompileImport(findModuleName,findImportedName)
 {
-    return async function decompileImport(variables, options = {}) {
-        if (!variables || variables.length === 0)
-            throw new Error('no variables');
-        // An import-cell group is `[module @X stitch, ...aliases]`. Each alias goes
-        // through three lifecycle stages (documented in observable-runtime-v6's
-        // `importedModule` helper, lines ~1992-2049 of @tomlarkworthy/observable-runtime-v6):
-        //
-        //   Stage A — post-observation:
-        //     `_inputs = [Variable in source module]` (length 1, cross-module).
-        //     The Observable runtime rewrites _inputs after the alias is observed
-        //     and resolved against the source module.
-        //
-        //   Stage B — pre-observation, API-loaded (canonical compiled-bundle shape):
-        //     `_inputs = [Variable("module @X"), Variable("@variable")]` (length 2,
-        //     both in the importer module). What `runtime.define("name",
-        //     ["module @X", "@variable"], (_, v) => v.import("name", _))` produces.
-        //     Also what `compile_and_update` outputs for freshly-defined user-typed
-        //     imports until they're observed.
-        //
-        //   Stage C — pre-observation, inline live-notebook:
-        //     `_inputs = [Variable("@variable")]` (length 1) AND the definition
-        //     calls `import(...)` inside. We extract the imported module reference
-        //     by invoking the definition with a stub `import` capture.
-        //
-        // Detection order is post→pre because Stage A is unambiguous when present.
-        const isStageA = v => {
-            const inputs = v?._inputs;
-            if (!Array.isArray(inputs) || inputs.length !== 1)
-                return false;
-            const i0 = inputs[0];
-            return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
-        };
-        const isStageB = v => {
-            const inputs = v?._inputs;
-            if (!Array.isArray(inputs) || inputs.length !== 2)
-                return false;
-            const [i0, i1] = inputs;
-            return !!(i0 && typeof i0 === 'object' && typeof i0._name === 'string' && i0._name.startsWith('module @')
-                && i1 && typeof i1 === 'object' && i1._name === '@variable');
-        };
-        const isStageC = v => {
-            const inputs = v?._inputs;
-            if (!Array.isArray(inputs) || inputs.length !== 1)
-                return false;
-            const i0 = inputs[0];
-            return !!(i0 && typeof i0 === 'object' && i0._name === '@variable'
-                && typeof v._definition !== 'undefined' && String(v._definition).includes('import('));
-        };
-        let v0, module_name, stage;
-        if ((v0 = variables.find(isStageA))) {
-            stage = 'A';
-            module_name = findModuleName(v0._module._scope, v0._inputs[0]._module);
-        } else if ((v0 = variables.find(isStageB))) {
-            stage = 'B';
-            module_name = v0._inputs[0]._name.replace(/^module /, '');
-        } else if ((v0 = variables.find(isStageC))) {
-            stage = 'C';
-            let capturedModule;
-            try {
-                await v0._definition({
-                    import: (...args) => { capturedModule = args[args.length - 1]; }
-                });
-            } catch (e) {
-                // best-effort: definition may throw on stub; capture is opportunistic
-            }
-            if (capturedModule && v0._module?._scope) {
-                module_name = findModuleName(v0._module._scope, capturedModule);
-            }
-        } else {
-            return null;
-        }
-        if (module_name == null)
-            throw new Error('module name could not be resolved');
-        // Skip runtime-internal `module @foo` stitch variables — they belong to
-        // the import group but are not user-facing specifiers. Without this filter, an
-        // import group renders as `import {Range, module @foo} from "@foo"`.
-        const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
-            const imported = await findImportedName(v);
-            const local = v._name;
-            return {
-                imported,
-                local,
-                alias: imported !== local,
-                meta: { index }
-            };
-        }));
-        return {
-            type: 'import',
-            from: module_name,
-            specifiers,
-            meta: {
-                detection: { stage },
-                variables: variables.map(v => v?._name ?? null)
-            }
-        };
+  return async function decompileImport(variables, options = {}) {
+    if (!variables || variables.length === 0)
+      throw new Error('no variables');
+    // An import-cell group is `[module @X stitch, ...aliases]`. Each alias goes
+    // through three lifecycle stages (documented in observable-runtime-v6's
+    // `importedModule` helper, lines ~1992-2049 of @tomlarkworthy/observable-runtime-v6):
+    //
+    //   Stage A — post-observation:
+    //     `_inputs = [Variable in source module]` (length 1, cross-module).
+    //     The Observable runtime rewrites _inputs after the alias is observed
+    //     and resolved against the source module.
+    //
+    //   Stage B — pre-observation, API-loaded (canonical compiled-bundle shape):
+    //     `_inputs = [Variable("module @X"), Variable("@variable")]` (length 2,
+    //     both in the importer module). What `runtime.define("name",
+    //     ["module @X", "@variable"], (_, v) => v.import("name", _))` produces.
+    //     Also what `compile_and_update` outputs for freshly-defined user-typed
+    //     imports until they're observed.
+    //
+    //   Stage C — pre-observation, inline live-notebook:
+    //     `_inputs = [Variable("@variable")]` (length 1) AND the definition
+    //     calls `import(...)` inside. We extract the imported module reference
+    //     by invoking the definition with a stub `import` capture.
+    //
+    // Detection order is post→pre because Stage A is unambiguous when present.
+    const isStageA = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
     };
+    const isStageB = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 2)
+        return false;
+      const [i0, i1] = inputs;
+      return !!(i0 && typeof i0 === 'object' && typeof i0._name === 'string' && i0._name.startsWith('module @') && i1 && typeof i1 === 'object' && i1._name === '@variable');
+    };
+    const isStageC = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && i0._name === '@variable' && typeof v._definition !== 'undefined' && String(v._definition).includes('import('));
+    };
+    let v0, module_name, stage;
+    if (v0 = variables.find(isStageA)) {
+      stage = 'A';
+      module_name = findModuleName(v0._module._scope, v0._inputs[0]._module);
+    } else if (v0 = variables.find(isStageB)) {
+      stage = 'B';
+      module_name = v0._inputs[0]._name.replace(/^module /, '');
+    } else if (v0 = variables.find(isStageC)) {
+      stage = 'C';
+      let capturedModule;
+      try {
+        await v0._definition({
+          import: (...args) => {
+            capturedModule = args[args.length - 1];
+          }
+        });
+      } catch (e) {
+      }
+      if (capturedModule && v0._module?._scope) {
+        module_name = findModuleName(v0._module._scope, capturedModule);
+      }
+    } else {
+      return null;
+    }
+    if (module_name == null)
+      throw new Error('module name could not be resolved');
+    // Skip runtime-internal `module @foo` stitch variables — they belong to
+    // the import group but are not user-facing specifiers. Without this filter, an
+    // import group renders as `import {Range, module @foo} from "@foo"`.
+    const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
+      const imported = await findImportedName(v);
+      const local = v._name;
+      return {
+        imported,
+        local,
+        alias: imported !== local,
+        meta: { index }
+      };
+    }));
+    return {
+      type: 'import',
+      from: module_name,
+      specifiers,
+      meta: {
+        detection: { stage },
+        variables: variables.map(v => v?._name ?? null)
+      }
+    };
+  };
 };
 const _1sylz7j = function _formatImportDeclaration(){return(
 function formatImportDeclaration(importInfo) {
@@ -20679,6 +20678,198 @@ const _1hiclbb = function _acorn_walk(acorn_walk_url) {
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
+const _1rc67k0 = function _stageB_importFake()
+{
+  return // Builds a Stage B (pre-observation, API-loaded) import group as POJOs.
+  // Mirrors what `runtime.define("name", ["module @X", "@variable"], (_, v) => v.import("name", _))`
+  // produces structurally. Used by the test_decompileImport_stageB_* tests to
+  // avoid spinning up a real Observable runtime per case.
+  function stageB_importFake(module_name, specifiers) {
+    const importerModule = { _scope: new Map() };
+    const stitch = {
+      _name: `module ${ module_name }`,
+      _module: importerModule,
+      _inputs: [],
+      _definition: `async () => null`
+    };
+    const atVariable = {
+      _name: '@variable',
+      _module: importerModule
+    };
+    const aliases = specifiers.map(s => ({
+      _name: s.local,
+      _module: importerModule,
+      _inputs: [
+        stitch,
+        atVariable
+      ],
+      _definition: s.imported === s.local ? `(_, v) => v.import("${ s.imported }", _)` : `(_, v) => v.import("${ s.imported }", "${ s.local }", _)`
+    }));
+    return [
+      stitch,
+      ...aliases
+    ];
+  };
+};
+const _1d53asg = async function _test_decompileImport_stageB_single(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [{
+      imported: 'visualize',
+      local: 'visualize'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _hv5gag = async function _test_decompileImport_stageB_aliased(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'x',
+      local: 'z'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(info.specifiers[0].alias).toEqual(true);
+  expect(formatImportDeclaration(info)).toEqual(`import {x as z} from "@user/y"`);
+  return 'ok';
+};
+const _avc18y = async function _test_decompileImport_stageB_multiple(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    },
+    {
+      imported: 'c',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b, c} from "@user/y"`);
+  return 'ok';
+};
+const _16gia7i = async function _test_decompileImport_stageB_mixed_alias(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b as c} from "@user/y"`);
+  return 'ok';
+};
+const _1slhdwo = async function _test_decompileImport_stageB_viewof(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/module-map', [{
+      imported: 'viewof currentModules',
+      local: 'viewof currentModules'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {viewof currentModules} from "@tomlarkworthy/module-map"`);
+  return 'ok';
+};
+const _qwlsf2 = async function _test_decompileImport_stageB_mutable(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'mutable counter',
+      local: 'mutable counter'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {mutable counter} from "@user/y"`);
+  return 'ok';
+};
+const _sy7jfx = async function _test_decompileImport_returns_null_for_non_import(decompileImport,expect)
+{
+  // A regular cell — no stitch, no @variable input, no cross-module reference.
+  const info = await decompileImport([{
+      _name: 'x',
+      _module: {},
+      _inputs: [],
+      _definition: `() => 42`
+    }]);
+  expect(info).toEqual(null);
+  return 'ok';
+};
+const _rk7ku3 = async function _test_decompileImport_compile_roundtrip_single(compile,expect,stageB_importFake,decompileImport,formatImportDeclaration)
+{
+  // What `compile()` emits for `import {x} from "@user/y"` is structurally the
+  // same as our stageB_importFake fixture (after runtime.define resolves the
+  // input name strings to Variable refs). Verify the fixture matches the
+  // shape compile() would produce.
+  const pojos = compile(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  expect(pojos.length).toEqual(3);
+  expect(pojos[0]._name).toEqual('module @tomlarkworthy/visualizer');
+  expect(pojos[1]._name).toEqual('visualize');
+  expect(pojos[2]._name).toEqual('Group');
+  expect(pojos[1]._inputs).toEqual([
+    'module @tomlarkworthy/visualizer',
+    '@variable'
+  ]);
+  // Now run our fixture through decompileImport — confirms the round-trip
+  // shape compile()-output-shape-when-defined → decompileImport produces the
+  // canonical import source string.
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [
+    {
+      imported: 'visualize',
+      local: 'visualize'
+    },
+    {
+      imported: 'Group',
+      local: 'Group'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _xynplo = async function _test_decompileImport_stageB_order_independent(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // The detection uses .find — it shouldn't matter whether the stitch is at
+  // index 0 or the aliases come first. Verify by reversing the array.
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    }
+  ]);
+  const reversed = [...vars].reverse();
+  const info = await decompileImport(reversed);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b} from "@user/y"`);
+  return 'ok';
+};
+const _16fpgac = async function _test_decompileImport_stageB_notebook_id(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // Observable supports `import {x} from "d/<hash>@<version>"` notebook-id form.
+  const vars = stageB_importFake('d/57d79353bac56631@44', [{
+      imported: 'hash',
+      local: 'hash'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {hash} from "d/57d79353bac56631@44"`);
+  return 'ok';
+};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -20799,7 +20990,7 @@ export default function define(runtime, observer) {
   $def("_1n7gw17", "findModuleName", ["extractModuleInfo"], _1n7gw17);  
   $def("_i47chb", "findImportedName", [], _i47chb);  
   $def("_1effqg", null, ["md"], _1effqg);  
-  $def("_1etqs71", "decompileImport", ["findModuleName","findImportedName"], _1etqs71);  
+  $def("_b7vai6", "decompileImport", ["findModuleName","findImportedName"], _b7vai6);  
   $def("_1sylz7j", "formatImportDeclaration", [], _1sylz7j);  
   $def("_13dctdn", "test_decompileImport_basic", ["importFake","decompileImport","expect"], _13dctdn);  
   $def("_ujr0xn", "test_formatImportDeclaration_roundtrip", ["importFake","decompileImport","expect","formatImportDeclaration","decompile"], _ujr0xn);  
@@ -20877,7 +21068,18 @@ export default function define(runtime, observer) {
   main.define("Runtime", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Runtime", _));  
   main.define("Inspector", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Inspector", _));  
   main.define("Library", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Library", _));  
-  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));
+  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));  
+  $def("_1rc67k0", "stageB_importFake", [], _1rc67k0);  
+  $def("_1d53asg", "test_decompileImport_stageB_single", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1d53asg);  
+  $def("_hv5gag", "test_decompileImport_stageB_aliased", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _hv5gag);  
+  $def("_avc18y", "test_decompileImport_stageB_multiple", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _avc18y);  
+  $def("_16gia7i", "test_decompileImport_stageB_mixed_alias", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16gia7i);  
+  $def("_1slhdwo", "test_decompileImport_stageB_viewof", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1slhdwo);  
+  $def("_qwlsf2", "test_decompileImport_stageB_mutable", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _qwlsf2);  
+  $def("_sy7jfx", "test_decompileImport_returns_null_for_non_import", ["decompileImport","expect"], _sy7jfx);  
+  $def("_rk7ku3", "test_decompileImport_compile_roundtrip_single", ["compile","expect","stageB_importFake","decompileImport","formatImportDeclaration"], _rk7ku3);  
+  $def("_xynplo", "test_decompileImport_stageB_order_independent", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _xynplo);  
+  $def("_16fpgac", "test_decompileImport_stageB_notebook_id", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16fpgac);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_editor-5.html
+++ b/notebooks/@tomlarkworthy_editor-5.html
@@ -19477,26 +19477,77 @@ const _1etqs71 = function _decompileImport(findModuleName,findImportedName)
     return async function decompileImport(variables, options = {}) {
         if (!variables || variables.length === 0)
             throw new Error('no variables');
-        // #166: An import group is `[module @foo, ...aliases]` — the runtime stitch
-        // sits at index 0 by convention. Scan for the first alias (single _input,
-        // crosses module boundary) so this works whichever order the caller hands us.
-        const isCrossModuleAlias = v => {
+        // An import-cell group is `[module @X stitch, ...aliases]`. Each alias goes
+        // through three lifecycle stages (documented in observable-runtime-v6's
+        // `importedModule` helper, lines ~1992-2049 of @tomlarkworthy/observable-runtime-v6):
+        //
+        //   Stage A — post-observation:
+        //     `_inputs = [Variable in source module]` (length 1, cross-module).
+        //     The Observable runtime rewrites _inputs after the alias is observed
+        //     and resolved against the source module.
+        //
+        //   Stage B — pre-observation, API-loaded (canonical compiled-bundle shape):
+        //     `_inputs = [Variable("module @X"), Variable("@variable")]` (length 2,
+        //     both in the importer module). What `runtime.define("name",
+        //     ["module @X", "@variable"], (_, v) => v.import("name", _))` produces.
+        //     Also what `compile_and_update` outputs for freshly-defined user-typed
+        //     imports until they're observed.
+        //
+        //   Stage C — pre-observation, inline live-notebook:
+        //     `_inputs = [Variable("@variable")]` (length 1) AND the definition
+        //     calls `import(...)` inside. We extract the imported module reference
+        //     by invoking the definition with a stub `import` capture.
+        //
+        // Detection order is post→pre because Stage A is unambiguous when present.
+        const isStageA = v => {
             const inputs = v?._inputs;
             if (!Array.isArray(inputs) || inputs.length !== 1)
                 return false;
             const i0 = inputs[0];
             return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
         };
-        const v0 = variables.find(isCrossModuleAlias);
-        if (!v0)
+        const isStageB = v => {
+            const inputs = v?._inputs;
+            if (!Array.isArray(inputs) || inputs.length !== 2)
+                return false;
+            const [i0, i1] = inputs;
+            return !!(i0 && typeof i0 === 'object' && typeof i0._name === 'string' && i0._name.startsWith('module @')
+                && i1 && typeof i1 === 'object' && i1._name === '@variable');
+        };
+        const isStageC = v => {
+            const inputs = v?._inputs;
+            if (!Array.isArray(inputs) || inputs.length !== 1)
+                return false;
+            const i0 = inputs[0];
+            return !!(i0 && typeof i0 === 'object' && i0._name === '@variable'
+                && typeof v._definition !== 'undefined' && String(v._definition).includes('import('));
+        };
+        let v0, module_name, stage;
+        if ((v0 = variables.find(isStageA))) {
+            stage = 'A';
+            module_name = findModuleName(v0._module._scope, v0._inputs[0]._module);
+        } else if ((v0 = variables.find(isStageB))) {
+            stage = 'B';
+            module_name = v0._inputs[0]._name.replace(/^module /, '');
+        } else if ((v0 = variables.find(isStageC))) {
+            stage = 'C';
+            let capturedModule;
+            try {
+                await v0._definition({
+                    import: (...args) => { capturedModule = args[args.length - 1]; }
+                });
+            } catch (e) {
+                // best-effort: definition may throw on stub; capture is opportunistic
+            }
+            if (capturedModule && v0._module?._scope) {
+                module_name = findModuleName(v0._module._scope, capturedModule);
+            }
+        } else {
             return null;
-        const input0 = v0._inputs[0];
-        const inputsLength = 1;
-        const crossesModuleBoundary = true;
-        const module_name = findModuleName(v0._module._scope, input0._module);
+        }
         if (module_name == null)
             throw new Error('module name could not be resolved');
-        // #166: Skip runtime-internal `module @foo` stitch variables — they belong to
+        // Skip runtime-internal `module @foo` stitch variables — they belong to
         // the import group but are not user-facing specifiers. Without this filter, an
         // import group renders as `import {Range, module @foo} from "@foo"`.
         const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
@@ -19514,10 +19565,7 @@ const _1etqs71 = function _decompileImport(findModuleName,findImportedName)
             from: module_name,
             specifiers,
             meta: {
-                detection: {
-                    inputsLength,
-                    crossesModuleBoundary
-                },
+                detection: { stage },
                 variables: variables.map(v => v?._name ?? null)
             }
         };

--- a/notebooks/@tomlarkworthy_exporter-2.html
+++ b/notebooks/@tomlarkworthy_exporter-2.html
@@ -21520,56 +21520,103 @@ async (v) => {
 const _1effqg = function _96(md){return(
 md`### \`decompileImport\``
 )};
-const _1etqs71 = function _decompileImport(findModuleName,findImportedName)
+const _b7vai6 = function _decompileImport(findModuleName,findImportedName)
 {
-    return async function decompileImport(variables, options = {}) {
-        if (!variables || variables.length === 0)
-            throw new Error('no variables');
-        // #166: An import group is `[module @foo, ...aliases]` — the runtime stitch
-        // sits at index 0 by convention. Scan for the first alias (single _input,
-        // crosses module boundary) so this works whichever order the caller hands us.
-        const isCrossModuleAlias = v => {
-            const inputs = v?._inputs;
-            if (!Array.isArray(inputs) || inputs.length !== 1)
-                return false;
-            const i0 = inputs[0];
-            return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
-        };
-        const v0 = variables.find(isCrossModuleAlias);
-        if (!v0)
-            return null;
-        const input0 = v0._inputs[0];
-        const inputsLength = 1;
-        const crossesModuleBoundary = true;
-        const module_name = findModuleName(v0._module._scope, input0._module);
-        if (module_name == null)
-            throw new Error('module name could not be resolved');
-        // #166: Skip runtime-internal `module @foo` stitch variables — they belong to
-        // the import group but are not user-facing specifiers. Without this filter, an
-        // import group renders as `import {Range, module @foo} from "@foo"`.
-        const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
-            const imported = await findImportedName(v);
-            const local = v._name;
-            return {
-                imported,
-                local,
-                alias: imported !== local,
-                meta: { index }
-            };
-        }));
-        return {
-            type: 'import',
-            from: module_name,
-            specifiers,
-            meta: {
-                detection: {
-                    inputsLength,
-                    crossesModuleBoundary
-                },
-                variables: variables.map(v => v?._name ?? null)
-            }
-        };
+  return async function decompileImport(variables, options = {}) {
+    if (!variables || variables.length === 0)
+      throw new Error('no variables');
+    // An import-cell group is `[module @X stitch, ...aliases]`. Each alias goes
+    // through three lifecycle stages (documented in observable-runtime-v6's
+    // `importedModule` helper, lines ~1992-2049 of @tomlarkworthy/observable-runtime-v6):
+    //
+    //   Stage A — post-observation:
+    //     `_inputs = [Variable in source module]` (length 1, cross-module).
+    //     The Observable runtime rewrites _inputs after the alias is observed
+    //     and resolved against the source module.
+    //
+    //   Stage B — pre-observation, API-loaded (canonical compiled-bundle shape):
+    //     `_inputs = [Variable("module @X"), Variable("@variable")]` (length 2,
+    //     both in the importer module). What `runtime.define("name",
+    //     ["module @X", "@variable"], (_, v) => v.import("name", _))` produces.
+    //     Also what `compile_and_update` outputs for freshly-defined user-typed
+    //     imports until they're observed.
+    //
+    //   Stage C — pre-observation, inline live-notebook:
+    //     `_inputs = [Variable("@variable")]` (length 1) AND the definition
+    //     calls `import(...)` inside. We extract the imported module reference
+    //     by invoking the definition with a stub `import` capture.
+    //
+    // Detection order is post→pre because Stage A is unambiguous when present.
+    const isStageA = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
     };
+    const isStageB = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 2)
+        return false;
+      const [i0, i1] = inputs;
+      return !!(i0 && typeof i0 === 'object' && typeof i0._name === 'string' && i0._name.startsWith('module @') && i1 && typeof i1 === 'object' && i1._name === '@variable');
+    };
+    const isStageC = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && i0._name === '@variable' && typeof v._definition !== 'undefined' && String(v._definition).includes('import('));
+    };
+    let v0, module_name, stage;
+    if (v0 = variables.find(isStageA)) {
+      stage = 'A';
+      module_name = findModuleName(v0._module._scope, v0._inputs[0]._module);
+    } else if (v0 = variables.find(isStageB)) {
+      stage = 'B';
+      module_name = v0._inputs[0]._name.replace(/^module /, '');
+    } else if (v0 = variables.find(isStageC)) {
+      stage = 'C';
+      let capturedModule;
+      try {
+        await v0._definition({
+          import: (...args) => {
+            capturedModule = args[args.length - 1];
+          }
+        });
+      } catch (e) {
+      }
+      if (capturedModule && v0._module?._scope) {
+        module_name = findModuleName(v0._module._scope, capturedModule);
+      }
+    } else {
+      return null;
+    }
+    if (module_name == null)
+      throw new Error('module name could not be resolved');
+    // Skip runtime-internal `module @foo` stitch variables — they belong to
+    // the import group but are not user-facing specifiers. Without this filter, an
+    // import group renders as `import {Range, module @foo} from "@foo"`.
+    const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
+      const imported = await findImportedName(v);
+      const local = v._name;
+      return {
+        imported,
+        local,
+        alias: imported !== local,
+        meta: { index }
+      };
+    }));
+    return {
+      type: 'import',
+      from: module_name,
+      specifiers,
+      meta: {
+        detection: { stage },
+        variables: variables.map(v => v?._name ?? null)
+      }
+    };
+  };
 };
 const _1sylz7j = function _formatImportDeclaration(){return(
 function formatImportDeclaration(importInfo) {
@@ -22679,6 +22726,198 @@ const _1hiclbb = function _acorn_walk(acorn_walk_url) {
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
+const _1rc67k0 = function _stageB_importFake()
+{
+  return // Builds a Stage B (pre-observation, API-loaded) import group as POJOs.
+  // Mirrors what `runtime.define("name", ["module @X", "@variable"], (_, v) => v.import("name", _))`
+  // produces structurally. Used by the test_decompileImport_stageB_* tests to
+  // avoid spinning up a real Observable runtime per case.
+  function stageB_importFake(module_name, specifiers) {
+    const importerModule = { _scope: new Map() };
+    const stitch = {
+      _name: `module ${ module_name }`,
+      _module: importerModule,
+      _inputs: [],
+      _definition: `async () => null`
+    };
+    const atVariable = {
+      _name: '@variable',
+      _module: importerModule
+    };
+    const aliases = specifiers.map(s => ({
+      _name: s.local,
+      _module: importerModule,
+      _inputs: [
+        stitch,
+        atVariable
+      ],
+      _definition: s.imported === s.local ? `(_, v) => v.import("${ s.imported }", _)` : `(_, v) => v.import("${ s.imported }", "${ s.local }", _)`
+    }));
+    return [
+      stitch,
+      ...aliases
+    ];
+  };
+};
+const _1d53asg = async function _test_decompileImport_stageB_single(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [{
+      imported: 'visualize',
+      local: 'visualize'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _hv5gag = async function _test_decompileImport_stageB_aliased(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'x',
+      local: 'z'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(info.specifiers[0].alias).toEqual(true);
+  expect(formatImportDeclaration(info)).toEqual(`import {x as z} from "@user/y"`);
+  return 'ok';
+};
+const _avc18y = async function _test_decompileImport_stageB_multiple(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    },
+    {
+      imported: 'c',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b, c} from "@user/y"`);
+  return 'ok';
+};
+const _16gia7i = async function _test_decompileImport_stageB_mixed_alias(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b as c} from "@user/y"`);
+  return 'ok';
+};
+const _1slhdwo = async function _test_decompileImport_stageB_viewof(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/module-map', [{
+      imported: 'viewof currentModules',
+      local: 'viewof currentModules'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {viewof currentModules} from "@tomlarkworthy/module-map"`);
+  return 'ok';
+};
+const _qwlsf2 = async function _test_decompileImport_stageB_mutable(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'mutable counter',
+      local: 'mutable counter'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {mutable counter} from "@user/y"`);
+  return 'ok';
+};
+const _sy7jfx = async function _test_decompileImport_returns_null_for_non_import(decompileImport,expect)
+{
+  // A regular cell — no stitch, no @variable input, no cross-module reference.
+  const info = await decompileImport([{
+      _name: 'x',
+      _module: {},
+      _inputs: [],
+      _definition: `() => 42`
+    }]);
+  expect(info).toEqual(null);
+  return 'ok';
+};
+const _rk7ku3 = async function _test_decompileImport_compile_roundtrip_single(compile,expect,stageB_importFake,decompileImport,formatImportDeclaration)
+{
+  // What `compile()` emits for `import {x} from "@user/y"` is structurally the
+  // same as our stageB_importFake fixture (after runtime.define resolves the
+  // input name strings to Variable refs). Verify the fixture matches the
+  // shape compile() would produce.
+  const pojos = compile(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  expect(pojos.length).toEqual(3);
+  expect(pojos[0]._name).toEqual('module @tomlarkworthy/visualizer');
+  expect(pojos[1]._name).toEqual('visualize');
+  expect(pojos[2]._name).toEqual('Group');
+  expect(pojos[1]._inputs).toEqual([
+    'module @tomlarkworthy/visualizer',
+    '@variable'
+  ]);
+  // Now run our fixture through decompileImport — confirms the round-trip
+  // shape compile()-output-shape-when-defined → decompileImport produces the
+  // canonical import source string.
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [
+    {
+      imported: 'visualize',
+      local: 'visualize'
+    },
+    {
+      imported: 'Group',
+      local: 'Group'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _xynplo = async function _test_decompileImport_stageB_order_independent(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // The detection uses .find — it shouldn't matter whether the stitch is at
+  // index 0 or the aliases come first. Verify by reversing the array.
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    }
+  ]);
+  const reversed = [...vars].reverse();
+  const info = await decompileImport(reversed);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b} from "@user/y"`);
+  return 'ok';
+};
+const _16fpgac = async function _test_decompileImport_stageB_notebook_id(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // Observable supports `import {x} from "d/<hash>@<version>"` notebook-id form.
+  const vars = stageB_importFake('d/57d79353bac56631@44', [{
+      imported: 'hash',
+      local: 'hash'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {hash} from "d/57d79353bac56631@44"`);
+  return 'ok';
+};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -22799,7 +23038,7 @@ export default function define(runtime, observer) {
   $def("_1n7gw17", "findModuleName", ["extractModuleInfo"], _1n7gw17);  
   $def("_i47chb", "findImportedName", [], _i47chb);  
   $def("_1effqg", null, ["md"], _1effqg);  
-  $def("_1etqs71", "decompileImport", ["findModuleName","findImportedName"], _1etqs71);  
+  $def("_b7vai6", "decompileImport", ["findModuleName","findImportedName"], _b7vai6);  
   $def("_1sylz7j", "formatImportDeclaration", [], _1sylz7j);  
   $def("_13dctdn", "test_decompileImport_basic", ["importFake","decompileImport","expect"], _13dctdn);  
   $def("_ujr0xn", "test_formatImportDeclaration_roundtrip", ["importFake","decompileImport","expect","formatImportDeclaration","decompile"], _ujr0xn);  
@@ -22877,7 +23116,18 @@ export default function define(runtime, observer) {
   main.define("Runtime", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Runtime", _));  
   main.define("Inspector", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Inspector", _));  
   main.define("Library", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Library", _));  
-  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));
+  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));  
+  $def("_1rc67k0", "stageB_importFake", [], _1rc67k0);  
+  $def("_1d53asg", "test_decompileImport_stageB_single", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1d53asg);  
+  $def("_hv5gag", "test_decompileImport_stageB_aliased", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _hv5gag);  
+  $def("_avc18y", "test_decompileImport_stageB_multiple", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _avc18y);  
+  $def("_16gia7i", "test_decompileImport_stageB_mixed_alias", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16gia7i);  
+  $def("_1slhdwo", "test_decompileImport_stageB_viewof", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1slhdwo);  
+  $def("_qwlsf2", "test_decompileImport_stageB_mutable", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _qwlsf2);  
+  $def("_sy7jfx", "test_decompileImport_returns_null_for_non_import", ["decompileImport","expect"], _sy7jfx);  
+  $def("_rk7ku3", "test_decompileImport_compile_roundtrip_single", ["compile","expect","stageB_importFake","decompileImport","formatImportDeclaration"], _rk7ku3);  
+  $def("_xynplo", "test_decompileImport_stageB_order_independent", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _xynplo);  
+  $def("_16fpgac", "test_decompileImport_stageB_notebook_id", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16fpgac);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_exporter-3.html
+++ b/notebooks/@tomlarkworthy_exporter-3.html
@@ -19474,56 +19474,103 @@ async (v) => {
 const _1effqg = function _96(md){return(
 md`### \`decompileImport\``
 )};
-const _1etqs71 = function _decompileImport(findModuleName,findImportedName)
+const _b7vai6 = function _decompileImport(findModuleName,findImportedName)
 {
-    return async function decompileImport(variables, options = {}) {
-        if (!variables || variables.length === 0)
-            throw new Error('no variables');
-        // #166: An import group is `[module @foo, ...aliases]` — the runtime stitch
-        // sits at index 0 by convention. Scan for the first alias (single _input,
-        // crosses module boundary) so this works whichever order the caller hands us.
-        const isCrossModuleAlias = v => {
-            const inputs = v?._inputs;
-            if (!Array.isArray(inputs) || inputs.length !== 1)
-                return false;
-            const i0 = inputs[0];
-            return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
-        };
-        const v0 = variables.find(isCrossModuleAlias);
-        if (!v0)
-            return null;
-        const input0 = v0._inputs[0];
-        const inputsLength = 1;
-        const crossesModuleBoundary = true;
-        const module_name = findModuleName(v0._module._scope, input0._module);
-        if (module_name == null)
-            throw new Error('module name could not be resolved');
-        // #166: Skip runtime-internal `module @foo` stitch variables — they belong to
-        // the import group but are not user-facing specifiers. Without this filter, an
-        // import group renders as `import {Range, module @foo} from "@foo"`.
-        const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
-            const imported = await findImportedName(v);
-            const local = v._name;
-            return {
-                imported,
-                local,
-                alias: imported !== local,
-                meta: { index }
-            };
-        }));
-        return {
-            type: 'import',
-            from: module_name,
-            specifiers,
-            meta: {
-                detection: {
-                    inputsLength,
-                    crossesModuleBoundary
-                },
-                variables: variables.map(v => v?._name ?? null)
-            }
-        };
+  return async function decompileImport(variables, options = {}) {
+    if (!variables || variables.length === 0)
+      throw new Error('no variables');
+    // An import-cell group is `[module @X stitch, ...aliases]`. Each alias goes
+    // through three lifecycle stages (documented in observable-runtime-v6's
+    // `importedModule` helper, lines ~1992-2049 of @tomlarkworthy/observable-runtime-v6):
+    //
+    //   Stage A — post-observation:
+    //     `_inputs = [Variable in source module]` (length 1, cross-module).
+    //     The Observable runtime rewrites _inputs after the alias is observed
+    //     and resolved against the source module.
+    //
+    //   Stage B — pre-observation, API-loaded (canonical compiled-bundle shape):
+    //     `_inputs = [Variable("module @X"), Variable("@variable")]` (length 2,
+    //     both in the importer module). What `runtime.define("name",
+    //     ["module @X", "@variable"], (_, v) => v.import("name", _))` produces.
+    //     Also what `compile_and_update` outputs for freshly-defined user-typed
+    //     imports until they're observed.
+    //
+    //   Stage C — pre-observation, inline live-notebook:
+    //     `_inputs = [Variable("@variable")]` (length 1) AND the definition
+    //     calls `import(...)` inside. We extract the imported module reference
+    //     by invoking the definition with a stub `import` capture.
+    //
+    // Detection order is post→pre because Stage A is unambiguous when present.
+    const isStageA = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
     };
+    const isStageB = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 2)
+        return false;
+      const [i0, i1] = inputs;
+      return !!(i0 && typeof i0 === 'object' && typeof i0._name === 'string' && i0._name.startsWith('module @') && i1 && typeof i1 === 'object' && i1._name === '@variable');
+    };
+    const isStageC = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && i0._name === '@variable' && typeof v._definition !== 'undefined' && String(v._definition).includes('import('));
+    };
+    let v0, module_name, stage;
+    if (v0 = variables.find(isStageA)) {
+      stage = 'A';
+      module_name = findModuleName(v0._module._scope, v0._inputs[0]._module);
+    } else if (v0 = variables.find(isStageB)) {
+      stage = 'B';
+      module_name = v0._inputs[0]._name.replace(/^module /, '');
+    } else if (v0 = variables.find(isStageC)) {
+      stage = 'C';
+      let capturedModule;
+      try {
+        await v0._definition({
+          import: (...args) => {
+            capturedModule = args[args.length - 1];
+          }
+        });
+      } catch (e) {
+      }
+      if (capturedModule && v0._module?._scope) {
+        module_name = findModuleName(v0._module._scope, capturedModule);
+      }
+    } else {
+      return null;
+    }
+    if (module_name == null)
+      throw new Error('module name could not be resolved');
+    // Skip runtime-internal `module @foo` stitch variables — they belong to
+    // the import group but are not user-facing specifiers. Without this filter, an
+    // import group renders as `import {Range, module @foo} from "@foo"`.
+    const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
+      const imported = await findImportedName(v);
+      const local = v._name;
+      return {
+        imported,
+        local,
+        alias: imported !== local,
+        meta: { index }
+      };
+    }));
+    return {
+      type: 'import',
+      from: module_name,
+      specifiers,
+      meta: {
+        detection: { stage },
+        variables: variables.map(v => v?._name ?? null)
+      }
+    };
+  };
 };
 const _1sylz7j = function _formatImportDeclaration(){return(
 function formatImportDeclaration(importInfo) {
@@ -20633,6 +20680,198 @@ const _1hiclbb = function _acorn_walk(acorn_walk_url) {
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
+const _1rc67k0 = function _stageB_importFake()
+{
+  return // Builds a Stage B (pre-observation, API-loaded) import group as POJOs.
+  // Mirrors what `runtime.define("name", ["module @X", "@variable"], (_, v) => v.import("name", _))`
+  // produces structurally. Used by the test_decompileImport_stageB_* tests to
+  // avoid spinning up a real Observable runtime per case.
+  function stageB_importFake(module_name, specifiers) {
+    const importerModule = { _scope: new Map() };
+    const stitch = {
+      _name: `module ${ module_name }`,
+      _module: importerModule,
+      _inputs: [],
+      _definition: `async () => null`
+    };
+    const atVariable = {
+      _name: '@variable',
+      _module: importerModule
+    };
+    const aliases = specifiers.map(s => ({
+      _name: s.local,
+      _module: importerModule,
+      _inputs: [
+        stitch,
+        atVariable
+      ],
+      _definition: s.imported === s.local ? `(_, v) => v.import("${ s.imported }", _)` : `(_, v) => v.import("${ s.imported }", "${ s.local }", _)`
+    }));
+    return [
+      stitch,
+      ...aliases
+    ];
+  };
+};
+const _1d53asg = async function _test_decompileImport_stageB_single(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [{
+      imported: 'visualize',
+      local: 'visualize'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _hv5gag = async function _test_decompileImport_stageB_aliased(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'x',
+      local: 'z'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(info.specifiers[0].alias).toEqual(true);
+  expect(formatImportDeclaration(info)).toEqual(`import {x as z} from "@user/y"`);
+  return 'ok';
+};
+const _avc18y = async function _test_decompileImport_stageB_multiple(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    },
+    {
+      imported: 'c',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b, c} from "@user/y"`);
+  return 'ok';
+};
+const _16gia7i = async function _test_decompileImport_stageB_mixed_alias(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b as c} from "@user/y"`);
+  return 'ok';
+};
+const _1slhdwo = async function _test_decompileImport_stageB_viewof(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/module-map', [{
+      imported: 'viewof currentModules',
+      local: 'viewof currentModules'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {viewof currentModules} from "@tomlarkworthy/module-map"`);
+  return 'ok';
+};
+const _qwlsf2 = async function _test_decompileImport_stageB_mutable(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'mutable counter',
+      local: 'mutable counter'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {mutable counter} from "@user/y"`);
+  return 'ok';
+};
+const _sy7jfx = async function _test_decompileImport_returns_null_for_non_import(decompileImport,expect)
+{
+  // A regular cell — no stitch, no @variable input, no cross-module reference.
+  const info = await decompileImport([{
+      _name: 'x',
+      _module: {},
+      _inputs: [],
+      _definition: `() => 42`
+    }]);
+  expect(info).toEqual(null);
+  return 'ok';
+};
+const _rk7ku3 = async function _test_decompileImport_compile_roundtrip_single(compile,expect,stageB_importFake,decompileImport,formatImportDeclaration)
+{
+  // What `compile()` emits for `import {x} from "@user/y"` is structurally the
+  // same as our stageB_importFake fixture (after runtime.define resolves the
+  // input name strings to Variable refs). Verify the fixture matches the
+  // shape compile() would produce.
+  const pojos = compile(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  expect(pojos.length).toEqual(3);
+  expect(pojos[0]._name).toEqual('module @tomlarkworthy/visualizer');
+  expect(pojos[1]._name).toEqual('visualize');
+  expect(pojos[2]._name).toEqual('Group');
+  expect(pojos[1]._inputs).toEqual([
+    'module @tomlarkworthy/visualizer',
+    '@variable'
+  ]);
+  // Now run our fixture through decompileImport — confirms the round-trip
+  // shape compile()-output-shape-when-defined → decompileImport produces the
+  // canonical import source string.
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [
+    {
+      imported: 'visualize',
+      local: 'visualize'
+    },
+    {
+      imported: 'Group',
+      local: 'Group'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _xynplo = async function _test_decompileImport_stageB_order_independent(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // The detection uses .find — it shouldn't matter whether the stitch is at
+  // index 0 or the aliases come first. Verify by reversing the array.
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    }
+  ]);
+  const reversed = [...vars].reverse();
+  const info = await decompileImport(reversed);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b} from "@user/y"`);
+  return 'ok';
+};
+const _16fpgac = async function _test_decompileImport_stageB_notebook_id(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // Observable supports `import {x} from "d/<hash>@<version>"` notebook-id form.
+  const vars = stageB_importFake('d/57d79353bac56631@44', [{
+      imported: 'hash',
+      local: 'hash'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {hash} from "d/57d79353bac56631@44"`);
+  return 'ok';
+};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -20753,7 +20992,7 @@ export default function define(runtime, observer) {
   $def("_1n7gw17", "findModuleName", ["extractModuleInfo"], _1n7gw17);  
   $def("_i47chb", "findImportedName", [], _i47chb);  
   $def("_1effqg", null, ["md"], _1effqg);  
-  $def("_1etqs71", "decompileImport", ["findModuleName","findImportedName"], _1etqs71);  
+  $def("_b7vai6", "decompileImport", ["findModuleName","findImportedName"], _b7vai6);  
   $def("_1sylz7j", "formatImportDeclaration", [], _1sylz7j);  
   $def("_13dctdn", "test_decompileImport_basic", ["importFake","decompileImport","expect"], _13dctdn);  
   $def("_ujr0xn", "test_formatImportDeclaration_roundtrip", ["importFake","decompileImport","expect","formatImportDeclaration","decompile"], _ujr0xn);  
@@ -20831,7 +21070,18 @@ export default function define(runtime, observer) {
   main.define("Runtime", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Runtime", _));  
   main.define("Inspector", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Inspector", _));  
   main.define("Library", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Library", _));  
-  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));
+  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));  
+  $def("_1rc67k0", "stageB_importFake", [], _1rc67k0);  
+  $def("_1d53asg", "test_decompileImport_stageB_single", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1d53asg);  
+  $def("_hv5gag", "test_decompileImport_stageB_aliased", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _hv5gag);  
+  $def("_avc18y", "test_decompileImport_stageB_multiple", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _avc18y);  
+  $def("_16gia7i", "test_decompileImport_stageB_mixed_alias", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16gia7i);  
+  $def("_1slhdwo", "test_decompileImport_stageB_viewof", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1slhdwo);  
+  $def("_qwlsf2", "test_decompileImport_stageB_mutable", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _qwlsf2);  
+  $def("_sy7jfx", "test_decompileImport_returns_null_for_non_import", ["decompileImport","expect"], _sy7jfx);  
+  $def("_rk7ku3", "test_decompileImport_compile_roundtrip_single", ["compile","expect","stageB_importFake","decompileImport","formatImportDeclaration"], _rk7ku3);  
+  $def("_xynplo", "test_decompileImport_stageB_order_independent", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _xynplo);  
+  $def("_16fpgac", "test_decompileImport_stageB_notebook_id", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16fpgac);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_fileattachments.html
+++ b/notebooks/@tomlarkworthy_fileattachments.html
@@ -19474,56 +19474,103 @@ async (v) => {
 const _1effqg = function _96(md){return(
 md`### \`decompileImport\``
 )};
-const _1etqs71 = function _decompileImport(findModuleName,findImportedName)
+const _b7vai6 = function _decompileImport(findModuleName,findImportedName)
 {
-    return async function decompileImport(variables, options = {}) {
-        if (!variables || variables.length === 0)
-            throw new Error('no variables');
-        // #166: An import group is `[module @foo, ...aliases]` — the runtime stitch
-        // sits at index 0 by convention. Scan for the first alias (single _input,
-        // crosses module boundary) so this works whichever order the caller hands us.
-        const isCrossModuleAlias = v => {
-            const inputs = v?._inputs;
-            if (!Array.isArray(inputs) || inputs.length !== 1)
-                return false;
-            const i0 = inputs[0];
-            return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
-        };
-        const v0 = variables.find(isCrossModuleAlias);
-        if (!v0)
-            return null;
-        const input0 = v0._inputs[0];
-        const inputsLength = 1;
-        const crossesModuleBoundary = true;
-        const module_name = findModuleName(v0._module._scope, input0._module);
-        if (module_name == null)
-            throw new Error('module name could not be resolved');
-        // #166: Skip runtime-internal `module @foo` stitch variables — they belong to
-        // the import group but are not user-facing specifiers. Without this filter, an
-        // import group renders as `import {Range, module @foo} from "@foo"`.
-        const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
-            const imported = await findImportedName(v);
-            const local = v._name;
-            return {
-                imported,
-                local,
-                alias: imported !== local,
-                meta: { index }
-            };
-        }));
-        return {
-            type: 'import',
-            from: module_name,
-            specifiers,
-            meta: {
-                detection: {
-                    inputsLength,
-                    crossesModuleBoundary
-                },
-                variables: variables.map(v => v?._name ?? null)
-            }
-        };
+  return async function decompileImport(variables, options = {}) {
+    if (!variables || variables.length === 0)
+      throw new Error('no variables');
+    // An import-cell group is `[module @X stitch, ...aliases]`. Each alias goes
+    // through three lifecycle stages (documented in observable-runtime-v6's
+    // `importedModule` helper, lines ~1992-2049 of @tomlarkworthy/observable-runtime-v6):
+    //
+    //   Stage A — post-observation:
+    //     `_inputs = [Variable in source module]` (length 1, cross-module).
+    //     The Observable runtime rewrites _inputs after the alias is observed
+    //     and resolved against the source module.
+    //
+    //   Stage B — pre-observation, API-loaded (canonical compiled-bundle shape):
+    //     `_inputs = [Variable("module @X"), Variable("@variable")]` (length 2,
+    //     both in the importer module). What `runtime.define("name",
+    //     ["module @X", "@variable"], (_, v) => v.import("name", _))` produces.
+    //     Also what `compile_and_update` outputs for freshly-defined user-typed
+    //     imports until they're observed.
+    //
+    //   Stage C — pre-observation, inline live-notebook:
+    //     `_inputs = [Variable("@variable")]` (length 1) AND the definition
+    //     calls `import(...)` inside. We extract the imported module reference
+    //     by invoking the definition with a stub `import` capture.
+    //
+    // Detection order is post→pre because Stage A is unambiguous when present.
+    const isStageA = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
     };
+    const isStageB = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 2)
+        return false;
+      const [i0, i1] = inputs;
+      return !!(i0 && typeof i0 === 'object' && typeof i0._name === 'string' && i0._name.startsWith('module @') && i1 && typeof i1 === 'object' && i1._name === '@variable');
+    };
+    const isStageC = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && i0._name === '@variable' && typeof v._definition !== 'undefined' && String(v._definition).includes('import('));
+    };
+    let v0, module_name, stage;
+    if (v0 = variables.find(isStageA)) {
+      stage = 'A';
+      module_name = findModuleName(v0._module._scope, v0._inputs[0]._module);
+    } else if (v0 = variables.find(isStageB)) {
+      stage = 'B';
+      module_name = v0._inputs[0]._name.replace(/^module /, '');
+    } else if (v0 = variables.find(isStageC)) {
+      stage = 'C';
+      let capturedModule;
+      try {
+        await v0._definition({
+          import: (...args) => {
+            capturedModule = args[args.length - 1];
+          }
+        });
+      } catch (e) {
+      }
+      if (capturedModule && v0._module?._scope) {
+        module_name = findModuleName(v0._module._scope, capturedModule);
+      }
+    } else {
+      return null;
+    }
+    if (module_name == null)
+      throw new Error('module name could not be resolved');
+    // Skip runtime-internal `module @foo` stitch variables — they belong to
+    // the import group but are not user-facing specifiers. Without this filter, an
+    // import group renders as `import {Range, module @foo} from "@foo"`.
+    const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
+      const imported = await findImportedName(v);
+      const local = v._name;
+      return {
+        imported,
+        local,
+        alias: imported !== local,
+        meta: { index }
+      };
+    }));
+    return {
+      type: 'import',
+      from: module_name,
+      specifiers,
+      meta: {
+        detection: { stage },
+        variables: variables.map(v => v?._name ?? null)
+      }
+    };
+  };
 };
 const _1sylz7j = function _formatImportDeclaration(){return(
 function formatImportDeclaration(importInfo) {
@@ -20633,6 +20680,198 @@ const _1hiclbb = function _acorn_walk(acorn_walk_url) {
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
+const _1rc67k0 = function _stageB_importFake()
+{
+  return // Builds a Stage B (pre-observation, API-loaded) import group as POJOs.
+  // Mirrors what `runtime.define("name", ["module @X", "@variable"], (_, v) => v.import("name", _))`
+  // produces structurally. Used by the test_decompileImport_stageB_* tests to
+  // avoid spinning up a real Observable runtime per case.
+  function stageB_importFake(module_name, specifiers) {
+    const importerModule = { _scope: new Map() };
+    const stitch = {
+      _name: `module ${ module_name }`,
+      _module: importerModule,
+      _inputs: [],
+      _definition: `async () => null`
+    };
+    const atVariable = {
+      _name: '@variable',
+      _module: importerModule
+    };
+    const aliases = specifiers.map(s => ({
+      _name: s.local,
+      _module: importerModule,
+      _inputs: [
+        stitch,
+        atVariable
+      ],
+      _definition: s.imported === s.local ? `(_, v) => v.import("${ s.imported }", _)` : `(_, v) => v.import("${ s.imported }", "${ s.local }", _)`
+    }));
+    return [
+      stitch,
+      ...aliases
+    ];
+  };
+};
+const _1d53asg = async function _test_decompileImport_stageB_single(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [{
+      imported: 'visualize',
+      local: 'visualize'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _hv5gag = async function _test_decompileImport_stageB_aliased(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'x',
+      local: 'z'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(info.specifiers[0].alias).toEqual(true);
+  expect(formatImportDeclaration(info)).toEqual(`import {x as z} from "@user/y"`);
+  return 'ok';
+};
+const _avc18y = async function _test_decompileImport_stageB_multiple(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    },
+    {
+      imported: 'c',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b, c} from "@user/y"`);
+  return 'ok';
+};
+const _16gia7i = async function _test_decompileImport_stageB_mixed_alias(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b as c} from "@user/y"`);
+  return 'ok';
+};
+const _1slhdwo = async function _test_decompileImport_stageB_viewof(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/module-map', [{
+      imported: 'viewof currentModules',
+      local: 'viewof currentModules'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {viewof currentModules} from "@tomlarkworthy/module-map"`);
+  return 'ok';
+};
+const _qwlsf2 = async function _test_decompileImport_stageB_mutable(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'mutable counter',
+      local: 'mutable counter'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {mutable counter} from "@user/y"`);
+  return 'ok';
+};
+const _sy7jfx = async function _test_decompileImport_returns_null_for_non_import(decompileImport,expect)
+{
+  // A regular cell — no stitch, no @variable input, no cross-module reference.
+  const info = await decompileImport([{
+      _name: 'x',
+      _module: {},
+      _inputs: [],
+      _definition: `() => 42`
+    }]);
+  expect(info).toEqual(null);
+  return 'ok';
+};
+const _rk7ku3 = async function _test_decompileImport_compile_roundtrip_single(compile,expect,stageB_importFake,decompileImport,formatImportDeclaration)
+{
+  // What `compile()` emits for `import {x} from "@user/y"` is structurally the
+  // same as our stageB_importFake fixture (after runtime.define resolves the
+  // input name strings to Variable refs). Verify the fixture matches the
+  // shape compile() would produce.
+  const pojos = compile(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  expect(pojos.length).toEqual(3);
+  expect(pojos[0]._name).toEqual('module @tomlarkworthy/visualizer');
+  expect(pojos[1]._name).toEqual('visualize');
+  expect(pojos[2]._name).toEqual('Group');
+  expect(pojos[1]._inputs).toEqual([
+    'module @tomlarkworthy/visualizer',
+    '@variable'
+  ]);
+  // Now run our fixture through decompileImport — confirms the round-trip
+  // shape compile()-output-shape-when-defined → decompileImport produces the
+  // canonical import source string.
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [
+    {
+      imported: 'visualize',
+      local: 'visualize'
+    },
+    {
+      imported: 'Group',
+      local: 'Group'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _xynplo = async function _test_decompileImport_stageB_order_independent(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // The detection uses .find — it shouldn't matter whether the stitch is at
+  // index 0 or the aliases come first. Verify by reversing the array.
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    }
+  ]);
+  const reversed = [...vars].reverse();
+  const info = await decompileImport(reversed);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b} from "@user/y"`);
+  return 'ok';
+};
+const _16fpgac = async function _test_decompileImport_stageB_notebook_id(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // Observable supports `import {x} from "d/<hash>@<version>"` notebook-id form.
+  const vars = stageB_importFake('d/57d79353bac56631@44', [{
+      imported: 'hash',
+      local: 'hash'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {hash} from "d/57d79353bac56631@44"`);
+  return 'ok';
+};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -20753,7 +20992,7 @@ export default function define(runtime, observer) {
   $def("_1n7gw17", "findModuleName", ["extractModuleInfo"], _1n7gw17);  
   $def("_i47chb", "findImportedName", [], _i47chb);  
   $def("_1effqg", null, ["md"], _1effqg);  
-  $def("_1etqs71", "decompileImport", ["findModuleName","findImportedName"], _1etqs71);  
+  $def("_b7vai6", "decompileImport", ["findModuleName","findImportedName"], _b7vai6);  
   $def("_1sylz7j", "formatImportDeclaration", [], _1sylz7j);  
   $def("_13dctdn", "test_decompileImport_basic", ["importFake","decompileImport","expect"], _13dctdn);  
   $def("_ujr0xn", "test_formatImportDeclaration_roundtrip", ["importFake","decompileImport","expect","formatImportDeclaration","decompile"], _ujr0xn);  
@@ -20831,7 +21070,18 @@ export default function define(runtime, observer) {
   main.define("Runtime", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Runtime", _));  
   main.define("Inspector", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Inspector", _));  
   main.define("Library", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Library", _));  
-  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));
+  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));  
+  $def("_1rc67k0", "stageB_importFake", [], _1rc67k0);  
+  $def("_1d53asg", "test_decompileImport_stageB_single", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1d53asg);  
+  $def("_hv5gag", "test_decompileImport_stageB_aliased", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _hv5gag);  
+  $def("_avc18y", "test_decompileImport_stageB_multiple", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _avc18y);  
+  $def("_16gia7i", "test_decompileImport_stageB_mixed_alias", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16gia7i);  
+  $def("_1slhdwo", "test_decompileImport_stageB_viewof", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1slhdwo);  
+  $def("_qwlsf2", "test_decompileImport_stageB_mutable", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _qwlsf2);  
+  $def("_sy7jfx", "test_decompileImport_returns_null_for_non_import", ["decompileImport","expect"], _sy7jfx);  
+  $def("_rk7ku3", "test_decompileImport_compile_roundtrip_single", ["compile","expect","stageB_importFake","decompileImport","formatImportDeclaration"], _rk7ku3);  
+  $def("_xynplo", "test_decompileImport_stageB_order_independent", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _xynplo);  
+  $def("_16fpgac", "test_decompileImport_stageB_notebook_id", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16fpgac);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_flow-queue.html
+++ b/notebooks/@tomlarkworthy_flow-queue.html
@@ -19474,56 +19474,103 @@ async (v) => {
 const _1effqg = function _96(md){return(
 md`### \`decompileImport\``
 )};
-const _1etqs71 = function _decompileImport(findModuleName,findImportedName)
+const _b7vai6 = function _decompileImport(findModuleName,findImportedName)
 {
-    return async function decompileImport(variables, options = {}) {
-        if (!variables || variables.length === 0)
-            throw new Error('no variables');
-        // #166: An import group is `[module @foo, ...aliases]` — the runtime stitch
-        // sits at index 0 by convention. Scan for the first alias (single _input,
-        // crosses module boundary) so this works whichever order the caller hands us.
-        const isCrossModuleAlias = v => {
-            const inputs = v?._inputs;
-            if (!Array.isArray(inputs) || inputs.length !== 1)
-                return false;
-            const i0 = inputs[0];
-            return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
-        };
-        const v0 = variables.find(isCrossModuleAlias);
-        if (!v0)
-            return null;
-        const input0 = v0._inputs[0];
-        const inputsLength = 1;
-        const crossesModuleBoundary = true;
-        const module_name = findModuleName(v0._module._scope, input0._module);
-        if (module_name == null)
-            throw new Error('module name could not be resolved');
-        // #166: Skip runtime-internal `module @foo` stitch variables — they belong to
-        // the import group but are not user-facing specifiers. Without this filter, an
-        // import group renders as `import {Range, module @foo} from "@foo"`.
-        const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
-            const imported = await findImportedName(v);
-            const local = v._name;
-            return {
-                imported,
-                local,
-                alias: imported !== local,
-                meta: { index }
-            };
-        }));
-        return {
-            type: 'import',
-            from: module_name,
-            specifiers,
-            meta: {
-                detection: {
-                    inputsLength,
-                    crossesModuleBoundary
-                },
-                variables: variables.map(v => v?._name ?? null)
-            }
-        };
+  return async function decompileImport(variables, options = {}) {
+    if (!variables || variables.length === 0)
+      throw new Error('no variables');
+    // An import-cell group is `[module @X stitch, ...aliases]`. Each alias goes
+    // through three lifecycle stages (documented in observable-runtime-v6's
+    // `importedModule` helper, lines ~1992-2049 of @tomlarkworthy/observable-runtime-v6):
+    //
+    //   Stage A — post-observation:
+    //     `_inputs = [Variable in source module]` (length 1, cross-module).
+    //     The Observable runtime rewrites _inputs after the alias is observed
+    //     and resolved against the source module.
+    //
+    //   Stage B — pre-observation, API-loaded (canonical compiled-bundle shape):
+    //     `_inputs = [Variable("module @X"), Variable("@variable")]` (length 2,
+    //     both in the importer module). What `runtime.define("name",
+    //     ["module @X", "@variable"], (_, v) => v.import("name", _))` produces.
+    //     Also what `compile_and_update` outputs for freshly-defined user-typed
+    //     imports until they're observed.
+    //
+    //   Stage C — pre-observation, inline live-notebook:
+    //     `_inputs = [Variable("@variable")]` (length 1) AND the definition
+    //     calls `import(...)` inside. We extract the imported module reference
+    //     by invoking the definition with a stub `import` capture.
+    //
+    // Detection order is post→pre because Stage A is unambiguous when present.
+    const isStageA = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
     };
+    const isStageB = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 2)
+        return false;
+      const [i0, i1] = inputs;
+      return !!(i0 && typeof i0 === 'object' && typeof i0._name === 'string' && i0._name.startsWith('module @') && i1 && typeof i1 === 'object' && i1._name === '@variable');
+    };
+    const isStageC = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && i0._name === '@variable' && typeof v._definition !== 'undefined' && String(v._definition).includes('import('));
+    };
+    let v0, module_name, stage;
+    if (v0 = variables.find(isStageA)) {
+      stage = 'A';
+      module_name = findModuleName(v0._module._scope, v0._inputs[0]._module);
+    } else if (v0 = variables.find(isStageB)) {
+      stage = 'B';
+      module_name = v0._inputs[0]._name.replace(/^module /, '');
+    } else if (v0 = variables.find(isStageC)) {
+      stage = 'C';
+      let capturedModule;
+      try {
+        await v0._definition({
+          import: (...args) => {
+            capturedModule = args[args.length - 1];
+          }
+        });
+      } catch (e) {
+      }
+      if (capturedModule && v0._module?._scope) {
+        module_name = findModuleName(v0._module._scope, capturedModule);
+      }
+    } else {
+      return null;
+    }
+    if (module_name == null)
+      throw new Error('module name could not be resolved');
+    // Skip runtime-internal `module @foo` stitch variables — they belong to
+    // the import group but are not user-facing specifiers. Without this filter, an
+    // import group renders as `import {Range, module @foo} from "@foo"`.
+    const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
+      const imported = await findImportedName(v);
+      const local = v._name;
+      return {
+        imported,
+        local,
+        alias: imported !== local,
+        meta: { index }
+      };
+    }));
+    return {
+      type: 'import',
+      from: module_name,
+      specifiers,
+      meta: {
+        detection: { stage },
+        variables: variables.map(v => v?._name ?? null)
+      }
+    };
+  };
 };
 const _1sylz7j = function _formatImportDeclaration(){return(
 function formatImportDeclaration(importInfo) {
@@ -20633,6 +20680,198 @@ const _1hiclbb = function _acorn_walk(acorn_walk_url) {
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
+const _1rc67k0 = function _stageB_importFake()
+{
+  return // Builds a Stage B (pre-observation, API-loaded) import group as POJOs.
+  // Mirrors what `runtime.define("name", ["module @X", "@variable"], (_, v) => v.import("name", _))`
+  // produces structurally. Used by the test_decompileImport_stageB_* tests to
+  // avoid spinning up a real Observable runtime per case.
+  function stageB_importFake(module_name, specifiers) {
+    const importerModule = { _scope: new Map() };
+    const stitch = {
+      _name: `module ${ module_name }`,
+      _module: importerModule,
+      _inputs: [],
+      _definition: `async () => null`
+    };
+    const atVariable = {
+      _name: '@variable',
+      _module: importerModule
+    };
+    const aliases = specifiers.map(s => ({
+      _name: s.local,
+      _module: importerModule,
+      _inputs: [
+        stitch,
+        atVariable
+      ],
+      _definition: s.imported === s.local ? `(_, v) => v.import("${ s.imported }", _)` : `(_, v) => v.import("${ s.imported }", "${ s.local }", _)`
+    }));
+    return [
+      stitch,
+      ...aliases
+    ];
+  };
+};
+const _1d53asg = async function _test_decompileImport_stageB_single(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [{
+      imported: 'visualize',
+      local: 'visualize'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _hv5gag = async function _test_decompileImport_stageB_aliased(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'x',
+      local: 'z'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(info.specifiers[0].alias).toEqual(true);
+  expect(formatImportDeclaration(info)).toEqual(`import {x as z} from "@user/y"`);
+  return 'ok';
+};
+const _avc18y = async function _test_decompileImport_stageB_multiple(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    },
+    {
+      imported: 'c',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b, c} from "@user/y"`);
+  return 'ok';
+};
+const _16gia7i = async function _test_decompileImport_stageB_mixed_alias(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b as c} from "@user/y"`);
+  return 'ok';
+};
+const _1slhdwo = async function _test_decompileImport_stageB_viewof(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/module-map', [{
+      imported: 'viewof currentModules',
+      local: 'viewof currentModules'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {viewof currentModules} from "@tomlarkworthy/module-map"`);
+  return 'ok';
+};
+const _qwlsf2 = async function _test_decompileImport_stageB_mutable(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'mutable counter',
+      local: 'mutable counter'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {mutable counter} from "@user/y"`);
+  return 'ok';
+};
+const _sy7jfx = async function _test_decompileImport_returns_null_for_non_import(decompileImport,expect)
+{
+  // A regular cell — no stitch, no @variable input, no cross-module reference.
+  const info = await decompileImport([{
+      _name: 'x',
+      _module: {},
+      _inputs: [],
+      _definition: `() => 42`
+    }]);
+  expect(info).toEqual(null);
+  return 'ok';
+};
+const _rk7ku3 = async function _test_decompileImport_compile_roundtrip_single(compile,expect,stageB_importFake,decompileImport,formatImportDeclaration)
+{
+  // What `compile()` emits for `import {x} from "@user/y"` is structurally the
+  // same as our stageB_importFake fixture (after runtime.define resolves the
+  // input name strings to Variable refs). Verify the fixture matches the
+  // shape compile() would produce.
+  const pojos = compile(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  expect(pojos.length).toEqual(3);
+  expect(pojos[0]._name).toEqual('module @tomlarkworthy/visualizer');
+  expect(pojos[1]._name).toEqual('visualize');
+  expect(pojos[2]._name).toEqual('Group');
+  expect(pojos[1]._inputs).toEqual([
+    'module @tomlarkworthy/visualizer',
+    '@variable'
+  ]);
+  // Now run our fixture through decompileImport — confirms the round-trip
+  // shape compile()-output-shape-when-defined → decompileImport produces the
+  // canonical import source string.
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [
+    {
+      imported: 'visualize',
+      local: 'visualize'
+    },
+    {
+      imported: 'Group',
+      local: 'Group'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _xynplo = async function _test_decompileImport_stageB_order_independent(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // The detection uses .find — it shouldn't matter whether the stitch is at
+  // index 0 or the aliases come first. Verify by reversing the array.
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    }
+  ]);
+  const reversed = [...vars].reverse();
+  const info = await decompileImport(reversed);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b} from "@user/y"`);
+  return 'ok';
+};
+const _16fpgac = async function _test_decompileImport_stageB_notebook_id(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // Observable supports `import {x} from "d/<hash>@<version>"` notebook-id form.
+  const vars = stageB_importFake('d/57d79353bac56631@44', [{
+      imported: 'hash',
+      local: 'hash'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {hash} from "d/57d79353bac56631@44"`);
+  return 'ok';
+};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -20753,7 +20992,7 @@ export default function define(runtime, observer) {
   $def("_1n7gw17", "findModuleName", ["extractModuleInfo"], _1n7gw17);  
   $def("_i47chb", "findImportedName", [], _i47chb);  
   $def("_1effqg", null, ["md"], _1effqg);  
-  $def("_1etqs71", "decompileImport", ["findModuleName","findImportedName"], _1etqs71);  
+  $def("_b7vai6", "decompileImport", ["findModuleName","findImportedName"], _b7vai6);  
   $def("_1sylz7j", "formatImportDeclaration", [], _1sylz7j);  
   $def("_13dctdn", "test_decompileImport_basic", ["importFake","decompileImport","expect"], _13dctdn);  
   $def("_ujr0xn", "test_formatImportDeclaration_roundtrip", ["importFake","decompileImport","expect","formatImportDeclaration","decompile"], _ujr0xn);  
@@ -20831,7 +21070,18 @@ export default function define(runtime, observer) {
   main.define("Runtime", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Runtime", _));  
   main.define("Inspector", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Inspector", _));  
   main.define("Library", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Library", _));  
-  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));
+  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));  
+  $def("_1rc67k0", "stageB_importFake", [], _1rc67k0);  
+  $def("_1d53asg", "test_decompileImport_stageB_single", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1d53asg);  
+  $def("_hv5gag", "test_decompileImport_stageB_aliased", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _hv5gag);  
+  $def("_avc18y", "test_decompileImport_stageB_multiple", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _avc18y);  
+  $def("_16gia7i", "test_decompileImport_stageB_mixed_alias", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16gia7i);  
+  $def("_1slhdwo", "test_decompileImport_stageB_viewof", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1slhdwo);  
+  $def("_qwlsf2", "test_decompileImport_stageB_mutable", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _qwlsf2);  
+  $def("_sy7jfx", "test_decompileImport_returns_null_for_non_import", ["decompileImport","expect"], _sy7jfx);  
+  $def("_rk7ku3", "test_decompileImport_compile_roundtrip_single", ["compile","expect","stageB_importFake","decompileImport","formatImportDeclaration"], _rk7ku3);  
+  $def("_xynplo", "test_decompileImport_stageB_order_independent", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _xynplo);  
+  $def("_16fpgac", "test_decompileImport_stageB_notebook_id", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16fpgac);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_golden-layout-2-6-0.html
+++ b/notebooks/@tomlarkworthy_golden-layout-2-6-0.html
@@ -19474,56 +19474,103 @@ async (v) => {
 const _1effqg = function _96(md){return(
 md`### \`decompileImport\``
 )};
-const _1etqs71 = function _decompileImport(findModuleName,findImportedName)
+const _b7vai6 = function _decompileImport(findModuleName,findImportedName)
 {
-    return async function decompileImport(variables, options = {}) {
-        if (!variables || variables.length === 0)
-            throw new Error('no variables');
-        // #166: An import group is `[module @foo, ...aliases]` — the runtime stitch
-        // sits at index 0 by convention. Scan for the first alias (single _input,
-        // crosses module boundary) so this works whichever order the caller hands us.
-        const isCrossModuleAlias = v => {
-            const inputs = v?._inputs;
-            if (!Array.isArray(inputs) || inputs.length !== 1)
-                return false;
-            const i0 = inputs[0];
-            return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
-        };
-        const v0 = variables.find(isCrossModuleAlias);
-        if (!v0)
-            return null;
-        const input0 = v0._inputs[0];
-        const inputsLength = 1;
-        const crossesModuleBoundary = true;
-        const module_name = findModuleName(v0._module._scope, input0._module);
-        if (module_name == null)
-            throw new Error('module name could not be resolved');
-        // #166: Skip runtime-internal `module @foo` stitch variables — they belong to
-        // the import group but are not user-facing specifiers. Without this filter, an
-        // import group renders as `import {Range, module @foo} from "@foo"`.
-        const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
-            const imported = await findImportedName(v);
-            const local = v._name;
-            return {
-                imported,
-                local,
-                alias: imported !== local,
-                meta: { index }
-            };
-        }));
-        return {
-            type: 'import',
-            from: module_name,
-            specifiers,
-            meta: {
-                detection: {
-                    inputsLength,
-                    crossesModuleBoundary
-                },
-                variables: variables.map(v => v?._name ?? null)
-            }
-        };
+  return async function decompileImport(variables, options = {}) {
+    if (!variables || variables.length === 0)
+      throw new Error('no variables');
+    // An import-cell group is `[module @X stitch, ...aliases]`. Each alias goes
+    // through three lifecycle stages (documented in observable-runtime-v6's
+    // `importedModule` helper, lines ~1992-2049 of @tomlarkworthy/observable-runtime-v6):
+    //
+    //   Stage A — post-observation:
+    //     `_inputs = [Variable in source module]` (length 1, cross-module).
+    //     The Observable runtime rewrites _inputs after the alias is observed
+    //     and resolved against the source module.
+    //
+    //   Stage B — pre-observation, API-loaded (canonical compiled-bundle shape):
+    //     `_inputs = [Variable("module @X"), Variable("@variable")]` (length 2,
+    //     both in the importer module). What `runtime.define("name",
+    //     ["module @X", "@variable"], (_, v) => v.import("name", _))` produces.
+    //     Also what `compile_and_update` outputs for freshly-defined user-typed
+    //     imports until they're observed.
+    //
+    //   Stage C — pre-observation, inline live-notebook:
+    //     `_inputs = [Variable("@variable")]` (length 1) AND the definition
+    //     calls `import(...)` inside. We extract the imported module reference
+    //     by invoking the definition with a stub `import` capture.
+    //
+    // Detection order is post→pre because Stage A is unambiguous when present.
+    const isStageA = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
     };
+    const isStageB = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 2)
+        return false;
+      const [i0, i1] = inputs;
+      return !!(i0 && typeof i0 === 'object' && typeof i0._name === 'string' && i0._name.startsWith('module @') && i1 && typeof i1 === 'object' && i1._name === '@variable');
+    };
+    const isStageC = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && i0._name === '@variable' && typeof v._definition !== 'undefined' && String(v._definition).includes('import('));
+    };
+    let v0, module_name, stage;
+    if (v0 = variables.find(isStageA)) {
+      stage = 'A';
+      module_name = findModuleName(v0._module._scope, v0._inputs[0]._module);
+    } else if (v0 = variables.find(isStageB)) {
+      stage = 'B';
+      module_name = v0._inputs[0]._name.replace(/^module /, '');
+    } else if (v0 = variables.find(isStageC)) {
+      stage = 'C';
+      let capturedModule;
+      try {
+        await v0._definition({
+          import: (...args) => {
+            capturedModule = args[args.length - 1];
+          }
+        });
+      } catch (e) {
+      }
+      if (capturedModule && v0._module?._scope) {
+        module_name = findModuleName(v0._module._scope, capturedModule);
+      }
+    } else {
+      return null;
+    }
+    if (module_name == null)
+      throw new Error('module name could not be resolved');
+    // Skip runtime-internal `module @foo` stitch variables — they belong to
+    // the import group but are not user-facing specifiers. Without this filter, an
+    // import group renders as `import {Range, module @foo} from "@foo"`.
+    const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
+      const imported = await findImportedName(v);
+      const local = v._name;
+      return {
+        imported,
+        local,
+        alias: imported !== local,
+        meta: { index }
+      };
+    }));
+    return {
+      type: 'import',
+      from: module_name,
+      specifiers,
+      meta: {
+        detection: { stage },
+        variables: variables.map(v => v?._name ?? null)
+      }
+    };
+  };
 };
 const _1sylz7j = function _formatImportDeclaration(){return(
 function formatImportDeclaration(importInfo) {
@@ -20633,6 +20680,198 @@ const _1hiclbb = function _acorn_walk(acorn_walk_url) {
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
+const _1rc67k0 = function _stageB_importFake()
+{
+  return // Builds a Stage B (pre-observation, API-loaded) import group as POJOs.
+  // Mirrors what `runtime.define("name", ["module @X", "@variable"], (_, v) => v.import("name", _))`
+  // produces structurally. Used by the test_decompileImport_stageB_* tests to
+  // avoid spinning up a real Observable runtime per case.
+  function stageB_importFake(module_name, specifiers) {
+    const importerModule = { _scope: new Map() };
+    const stitch = {
+      _name: `module ${ module_name }`,
+      _module: importerModule,
+      _inputs: [],
+      _definition: `async () => null`
+    };
+    const atVariable = {
+      _name: '@variable',
+      _module: importerModule
+    };
+    const aliases = specifiers.map(s => ({
+      _name: s.local,
+      _module: importerModule,
+      _inputs: [
+        stitch,
+        atVariable
+      ],
+      _definition: s.imported === s.local ? `(_, v) => v.import("${ s.imported }", _)` : `(_, v) => v.import("${ s.imported }", "${ s.local }", _)`
+    }));
+    return [
+      stitch,
+      ...aliases
+    ];
+  };
+};
+const _1d53asg = async function _test_decompileImport_stageB_single(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [{
+      imported: 'visualize',
+      local: 'visualize'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _hv5gag = async function _test_decompileImport_stageB_aliased(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'x',
+      local: 'z'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(info.specifiers[0].alias).toEqual(true);
+  expect(formatImportDeclaration(info)).toEqual(`import {x as z} from "@user/y"`);
+  return 'ok';
+};
+const _avc18y = async function _test_decompileImport_stageB_multiple(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    },
+    {
+      imported: 'c',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b, c} from "@user/y"`);
+  return 'ok';
+};
+const _16gia7i = async function _test_decompileImport_stageB_mixed_alias(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b as c} from "@user/y"`);
+  return 'ok';
+};
+const _1slhdwo = async function _test_decompileImport_stageB_viewof(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/module-map', [{
+      imported: 'viewof currentModules',
+      local: 'viewof currentModules'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {viewof currentModules} from "@tomlarkworthy/module-map"`);
+  return 'ok';
+};
+const _qwlsf2 = async function _test_decompileImport_stageB_mutable(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'mutable counter',
+      local: 'mutable counter'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {mutable counter} from "@user/y"`);
+  return 'ok';
+};
+const _sy7jfx = async function _test_decompileImport_returns_null_for_non_import(decompileImport,expect)
+{
+  // A regular cell — no stitch, no @variable input, no cross-module reference.
+  const info = await decompileImport([{
+      _name: 'x',
+      _module: {},
+      _inputs: [],
+      _definition: `() => 42`
+    }]);
+  expect(info).toEqual(null);
+  return 'ok';
+};
+const _rk7ku3 = async function _test_decompileImport_compile_roundtrip_single(compile,expect,stageB_importFake,decompileImport,formatImportDeclaration)
+{
+  // What `compile()` emits for `import {x} from "@user/y"` is structurally the
+  // same as our stageB_importFake fixture (after runtime.define resolves the
+  // input name strings to Variable refs). Verify the fixture matches the
+  // shape compile() would produce.
+  const pojos = compile(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  expect(pojos.length).toEqual(3);
+  expect(pojos[0]._name).toEqual('module @tomlarkworthy/visualizer');
+  expect(pojos[1]._name).toEqual('visualize');
+  expect(pojos[2]._name).toEqual('Group');
+  expect(pojos[1]._inputs).toEqual([
+    'module @tomlarkworthy/visualizer',
+    '@variable'
+  ]);
+  // Now run our fixture through decompileImport — confirms the round-trip
+  // shape compile()-output-shape-when-defined → decompileImport produces the
+  // canonical import source string.
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [
+    {
+      imported: 'visualize',
+      local: 'visualize'
+    },
+    {
+      imported: 'Group',
+      local: 'Group'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _xynplo = async function _test_decompileImport_stageB_order_independent(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // The detection uses .find — it shouldn't matter whether the stitch is at
+  // index 0 or the aliases come first. Verify by reversing the array.
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    }
+  ]);
+  const reversed = [...vars].reverse();
+  const info = await decompileImport(reversed);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b} from "@user/y"`);
+  return 'ok';
+};
+const _16fpgac = async function _test_decompileImport_stageB_notebook_id(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // Observable supports `import {x} from "d/<hash>@<version>"` notebook-id form.
+  const vars = stageB_importFake('d/57d79353bac56631@44', [{
+      imported: 'hash',
+      local: 'hash'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {hash} from "d/57d79353bac56631@44"`);
+  return 'ok';
+};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -20753,7 +20992,7 @@ export default function define(runtime, observer) {
   $def("_1n7gw17", "findModuleName", ["extractModuleInfo"], _1n7gw17);  
   $def("_i47chb", "findImportedName", [], _i47chb);  
   $def("_1effqg", null, ["md"], _1effqg);  
-  $def("_1etqs71", "decompileImport", ["findModuleName","findImportedName"], _1etqs71);  
+  $def("_b7vai6", "decompileImport", ["findModuleName","findImportedName"], _b7vai6);  
   $def("_1sylz7j", "formatImportDeclaration", [], _1sylz7j);  
   $def("_13dctdn", "test_decompileImport_basic", ["importFake","decompileImport","expect"], _13dctdn);  
   $def("_ujr0xn", "test_formatImportDeclaration_roundtrip", ["importFake","decompileImport","expect","formatImportDeclaration","decompile"], _ujr0xn);  
@@ -20831,7 +21070,18 @@ export default function define(runtime, observer) {
   main.define("Runtime", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Runtime", _));  
   main.define("Inspector", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Inspector", _));  
   main.define("Library", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Library", _));  
-  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));
+  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));  
+  $def("_1rc67k0", "stageB_importFake", [], _1rc67k0);  
+  $def("_1d53asg", "test_decompileImport_stageB_single", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1d53asg);  
+  $def("_hv5gag", "test_decompileImport_stageB_aliased", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _hv5gag);  
+  $def("_avc18y", "test_decompileImport_stageB_multiple", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _avc18y);  
+  $def("_16gia7i", "test_decompileImport_stageB_mixed_alias", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16gia7i);  
+  $def("_1slhdwo", "test_decompileImport_stageB_viewof", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1slhdwo);  
+  $def("_qwlsf2", "test_decompileImport_stageB_mutable", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _qwlsf2);  
+  $def("_sy7jfx", "test_decompileImport_returns_null_for_non_import", ["decompileImport","expect"], _sy7jfx);  
+  $def("_rk7ku3", "test_decompileImport_compile_roundtrip_single", ["compile","expect","stageB_importFake","decompileImport","formatImportDeclaration"], _rk7ku3);  
+  $def("_xynplo", "test_decompileImport_stageB_order_independent", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _xynplo);  
+  $def("_16fpgac", "test_decompileImport_stageB_notebook_id", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16fpgac);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_import-notebook.html
+++ b/notebooks/@tomlarkworthy_import-notebook.html
@@ -19474,56 +19474,103 @@ async (v) => {
 const _1effqg = function _96(md){return(
 md`### \`decompileImport\``
 )};
-const _1etqs71 = function _decompileImport(findModuleName,findImportedName)
+const _b7vai6 = function _decompileImport(findModuleName,findImportedName)
 {
-    return async function decompileImport(variables, options = {}) {
-        if (!variables || variables.length === 0)
-            throw new Error('no variables');
-        // #166: An import group is `[module @foo, ...aliases]` — the runtime stitch
-        // sits at index 0 by convention. Scan for the first alias (single _input,
-        // crosses module boundary) so this works whichever order the caller hands us.
-        const isCrossModuleAlias = v => {
-            const inputs = v?._inputs;
-            if (!Array.isArray(inputs) || inputs.length !== 1)
-                return false;
-            const i0 = inputs[0];
-            return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
-        };
-        const v0 = variables.find(isCrossModuleAlias);
-        if (!v0)
-            return null;
-        const input0 = v0._inputs[0];
-        const inputsLength = 1;
-        const crossesModuleBoundary = true;
-        const module_name = findModuleName(v0._module._scope, input0._module);
-        if (module_name == null)
-            throw new Error('module name could not be resolved');
-        // #166: Skip runtime-internal `module @foo` stitch variables — they belong to
-        // the import group but are not user-facing specifiers. Without this filter, an
-        // import group renders as `import {Range, module @foo} from "@foo"`.
-        const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
-            const imported = await findImportedName(v);
-            const local = v._name;
-            return {
-                imported,
-                local,
-                alias: imported !== local,
-                meta: { index }
-            };
-        }));
-        return {
-            type: 'import',
-            from: module_name,
-            specifiers,
-            meta: {
-                detection: {
-                    inputsLength,
-                    crossesModuleBoundary
-                },
-                variables: variables.map(v => v?._name ?? null)
-            }
-        };
+  return async function decompileImport(variables, options = {}) {
+    if (!variables || variables.length === 0)
+      throw new Error('no variables');
+    // An import-cell group is `[module @X stitch, ...aliases]`. Each alias goes
+    // through three lifecycle stages (documented in observable-runtime-v6's
+    // `importedModule` helper, lines ~1992-2049 of @tomlarkworthy/observable-runtime-v6):
+    //
+    //   Stage A — post-observation:
+    //     `_inputs = [Variable in source module]` (length 1, cross-module).
+    //     The Observable runtime rewrites _inputs after the alias is observed
+    //     and resolved against the source module.
+    //
+    //   Stage B — pre-observation, API-loaded (canonical compiled-bundle shape):
+    //     `_inputs = [Variable("module @X"), Variable("@variable")]` (length 2,
+    //     both in the importer module). What `runtime.define("name",
+    //     ["module @X", "@variable"], (_, v) => v.import("name", _))` produces.
+    //     Also what `compile_and_update` outputs for freshly-defined user-typed
+    //     imports until they're observed.
+    //
+    //   Stage C — pre-observation, inline live-notebook:
+    //     `_inputs = [Variable("@variable")]` (length 1) AND the definition
+    //     calls `import(...)` inside. We extract the imported module reference
+    //     by invoking the definition with a stub `import` capture.
+    //
+    // Detection order is post→pre because Stage A is unambiguous when present.
+    const isStageA = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
     };
+    const isStageB = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 2)
+        return false;
+      const [i0, i1] = inputs;
+      return !!(i0 && typeof i0 === 'object' && typeof i0._name === 'string' && i0._name.startsWith('module @') && i1 && typeof i1 === 'object' && i1._name === '@variable');
+    };
+    const isStageC = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && i0._name === '@variable' && typeof v._definition !== 'undefined' && String(v._definition).includes('import('));
+    };
+    let v0, module_name, stage;
+    if (v0 = variables.find(isStageA)) {
+      stage = 'A';
+      module_name = findModuleName(v0._module._scope, v0._inputs[0]._module);
+    } else if (v0 = variables.find(isStageB)) {
+      stage = 'B';
+      module_name = v0._inputs[0]._name.replace(/^module /, '');
+    } else if (v0 = variables.find(isStageC)) {
+      stage = 'C';
+      let capturedModule;
+      try {
+        await v0._definition({
+          import: (...args) => {
+            capturedModule = args[args.length - 1];
+          }
+        });
+      } catch (e) {
+      }
+      if (capturedModule && v0._module?._scope) {
+        module_name = findModuleName(v0._module._scope, capturedModule);
+      }
+    } else {
+      return null;
+    }
+    if (module_name == null)
+      throw new Error('module name could not be resolved');
+    // Skip runtime-internal `module @foo` stitch variables — they belong to
+    // the import group but are not user-facing specifiers. Without this filter, an
+    // import group renders as `import {Range, module @foo} from "@foo"`.
+    const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
+      const imported = await findImportedName(v);
+      const local = v._name;
+      return {
+        imported,
+        local,
+        alias: imported !== local,
+        meta: { index }
+      };
+    }));
+    return {
+      type: 'import',
+      from: module_name,
+      specifiers,
+      meta: {
+        detection: { stage },
+        variables: variables.map(v => v?._name ?? null)
+      }
+    };
+  };
 };
 const _1sylz7j = function _formatImportDeclaration(){return(
 function formatImportDeclaration(importInfo) {
@@ -20633,6 +20680,198 @@ const _1hiclbb = function _acorn_walk(acorn_walk_url) {
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
+const _1rc67k0 = function _stageB_importFake()
+{
+  return // Builds a Stage B (pre-observation, API-loaded) import group as POJOs.
+  // Mirrors what `runtime.define("name", ["module @X", "@variable"], (_, v) => v.import("name", _))`
+  // produces structurally. Used by the test_decompileImport_stageB_* tests to
+  // avoid spinning up a real Observable runtime per case.
+  function stageB_importFake(module_name, specifiers) {
+    const importerModule = { _scope: new Map() };
+    const stitch = {
+      _name: `module ${ module_name }`,
+      _module: importerModule,
+      _inputs: [],
+      _definition: `async () => null`
+    };
+    const atVariable = {
+      _name: '@variable',
+      _module: importerModule
+    };
+    const aliases = specifiers.map(s => ({
+      _name: s.local,
+      _module: importerModule,
+      _inputs: [
+        stitch,
+        atVariable
+      ],
+      _definition: s.imported === s.local ? `(_, v) => v.import("${ s.imported }", _)` : `(_, v) => v.import("${ s.imported }", "${ s.local }", _)`
+    }));
+    return [
+      stitch,
+      ...aliases
+    ];
+  };
+};
+const _1d53asg = async function _test_decompileImport_stageB_single(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [{
+      imported: 'visualize',
+      local: 'visualize'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _hv5gag = async function _test_decompileImport_stageB_aliased(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'x',
+      local: 'z'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(info.specifiers[0].alias).toEqual(true);
+  expect(formatImportDeclaration(info)).toEqual(`import {x as z} from "@user/y"`);
+  return 'ok';
+};
+const _avc18y = async function _test_decompileImport_stageB_multiple(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    },
+    {
+      imported: 'c',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b, c} from "@user/y"`);
+  return 'ok';
+};
+const _16gia7i = async function _test_decompileImport_stageB_mixed_alias(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b as c} from "@user/y"`);
+  return 'ok';
+};
+const _1slhdwo = async function _test_decompileImport_stageB_viewof(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/module-map', [{
+      imported: 'viewof currentModules',
+      local: 'viewof currentModules'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {viewof currentModules} from "@tomlarkworthy/module-map"`);
+  return 'ok';
+};
+const _qwlsf2 = async function _test_decompileImport_stageB_mutable(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'mutable counter',
+      local: 'mutable counter'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {mutable counter} from "@user/y"`);
+  return 'ok';
+};
+const _sy7jfx = async function _test_decompileImport_returns_null_for_non_import(decompileImport,expect)
+{
+  // A regular cell — no stitch, no @variable input, no cross-module reference.
+  const info = await decompileImport([{
+      _name: 'x',
+      _module: {},
+      _inputs: [],
+      _definition: `() => 42`
+    }]);
+  expect(info).toEqual(null);
+  return 'ok';
+};
+const _rk7ku3 = async function _test_decompileImport_compile_roundtrip_single(compile,expect,stageB_importFake,decompileImport,formatImportDeclaration)
+{
+  // What `compile()` emits for `import {x} from "@user/y"` is structurally the
+  // same as our stageB_importFake fixture (after runtime.define resolves the
+  // input name strings to Variable refs). Verify the fixture matches the
+  // shape compile() would produce.
+  const pojos = compile(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  expect(pojos.length).toEqual(3);
+  expect(pojos[0]._name).toEqual('module @tomlarkworthy/visualizer');
+  expect(pojos[1]._name).toEqual('visualize');
+  expect(pojos[2]._name).toEqual('Group');
+  expect(pojos[1]._inputs).toEqual([
+    'module @tomlarkworthy/visualizer',
+    '@variable'
+  ]);
+  // Now run our fixture through decompileImport — confirms the round-trip
+  // shape compile()-output-shape-when-defined → decompileImport produces the
+  // canonical import source string.
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [
+    {
+      imported: 'visualize',
+      local: 'visualize'
+    },
+    {
+      imported: 'Group',
+      local: 'Group'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _xynplo = async function _test_decompileImport_stageB_order_independent(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // The detection uses .find — it shouldn't matter whether the stitch is at
+  // index 0 or the aliases come first. Verify by reversing the array.
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    }
+  ]);
+  const reversed = [...vars].reverse();
+  const info = await decompileImport(reversed);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b} from "@user/y"`);
+  return 'ok';
+};
+const _16fpgac = async function _test_decompileImport_stageB_notebook_id(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // Observable supports `import {x} from "d/<hash>@<version>"` notebook-id form.
+  const vars = stageB_importFake('d/57d79353bac56631@44', [{
+      imported: 'hash',
+      local: 'hash'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {hash} from "d/57d79353bac56631@44"`);
+  return 'ok';
+};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -20753,7 +20992,7 @@ export default function define(runtime, observer) {
   $def("_1n7gw17", "findModuleName", ["extractModuleInfo"], _1n7gw17);  
   $def("_i47chb", "findImportedName", [], _i47chb);  
   $def("_1effqg", null, ["md"], _1effqg);  
-  $def("_1etqs71", "decompileImport", ["findModuleName","findImportedName"], _1etqs71);  
+  $def("_b7vai6", "decompileImport", ["findModuleName","findImportedName"], _b7vai6);  
   $def("_1sylz7j", "formatImportDeclaration", [], _1sylz7j);  
   $def("_13dctdn", "test_decompileImport_basic", ["importFake","decompileImport","expect"], _13dctdn);  
   $def("_ujr0xn", "test_formatImportDeclaration_roundtrip", ["importFake","decompileImport","expect","formatImportDeclaration","decompile"], _ujr0xn);  
@@ -20831,7 +21070,18 @@ export default function define(runtime, observer) {
   main.define("Runtime", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Runtime", _));  
   main.define("Inspector", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Inspector", _));  
   main.define("Library", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Library", _));  
-  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));
+  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));  
+  $def("_1rc67k0", "stageB_importFake", [], _1rc67k0);  
+  $def("_1d53asg", "test_decompileImport_stageB_single", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1d53asg);  
+  $def("_hv5gag", "test_decompileImport_stageB_aliased", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _hv5gag);  
+  $def("_avc18y", "test_decompileImport_stageB_multiple", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _avc18y);  
+  $def("_16gia7i", "test_decompileImport_stageB_mixed_alias", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16gia7i);  
+  $def("_1slhdwo", "test_decompileImport_stageB_viewof", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1slhdwo);  
+  $def("_qwlsf2", "test_decompileImport_stageB_mutable", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _qwlsf2);  
+  $def("_sy7jfx", "test_decompileImport_returns_null_for_non_import", ["decompileImport","expect"], _sy7jfx);  
+  $def("_rk7ku3", "test_decompileImport_compile_roundtrip_single", ["compile","expect","stageB_importFake","decompileImport","formatImportDeclaration"], _rk7ku3);  
+  $def("_xynplo", "test_decompileImport_stageB_order_independent", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _xynplo);  
+  $def("_16fpgac", "test_decompileImport_stageB_notebook_id", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16fpgac);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_jest-expect-standalone.html
+++ b/notebooks/@tomlarkworthy_jest-expect-standalone.html
@@ -19474,56 +19474,103 @@ async (v) => {
 const _1effqg = function _96(md){return(
 md`### \`decompileImport\``
 )};
-const _1etqs71 = function _decompileImport(findModuleName,findImportedName)
+const _b7vai6 = function _decompileImport(findModuleName,findImportedName)
 {
-    return async function decompileImport(variables, options = {}) {
-        if (!variables || variables.length === 0)
-            throw new Error('no variables');
-        // #166: An import group is `[module @foo, ...aliases]` — the runtime stitch
-        // sits at index 0 by convention. Scan for the first alias (single _input,
-        // crosses module boundary) so this works whichever order the caller hands us.
-        const isCrossModuleAlias = v => {
-            const inputs = v?._inputs;
-            if (!Array.isArray(inputs) || inputs.length !== 1)
-                return false;
-            const i0 = inputs[0];
-            return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
-        };
-        const v0 = variables.find(isCrossModuleAlias);
-        if (!v0)
-            return null;
-        const input0 = v0._inputs[0];
-        const inputsLength = 1;
-        const crossesModuleBoundary = true;
-        const module_name = findModuleName(v0._module._scope, input0._module);
-        if (module_name == null)
-            throw new Error('module name could not be resolved');
-        // #166: Skip runtime-internal `module @foo` stitch variables — they belong to
-        // the import group but are not user-facing specifiers. Without this filter, an
-        // import group renders as `import {Range, module @foo} from "@foo"`.
-        const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
-            const imported = await findImportedName(v);
-            const local = v._name;
-            return {
-                imported,
-                local,
-                alias: imported !== local,
-                meta: { index }
-            };
-        }));
-        return {
-            type: 'import',
-            from: module_name,
-            specifiers,
-            meta: {
-                detection: {
-                    inputsLength,
-                    crossesModuleBoundary
-                },
-                variables: variables.map(v => v?._name ?? null)
-            }
-        };
+  return async function decompileImport(variables, options = {}) {
+    if (!variables || variables.length === 0)
+      throw new Error('no variables');
+    // An import-cell group is `[module @X stitch, ...aliases]`. Each alias goes
+    // through three lifecycle stages (documented in observable-runtime-v6's
+    // `importedModule` helper, lines ~1992-2049 of @tomlarkworthy/observable-runtime-v6):
+    //
+    //   Stage A — post-observation:
+    //     `_inputs = [Variable in source module]` (length 1, cross-module).
+    //     The Observable runtime rewrites _inputs after the alias is observed
+    //     and resolved against the source module.
+    //
+    //   Stage B — pre-observation, API-loaded (canonical compiled-bundle shape):
+    //     `_inputs = [Variable("module @X"), Variable("@variable")]` (length 2,
+    //     both in the importer module). What `runtime.define("name",
+    //     ["module @X", "@variable"], (_, v) => v.import("name", _))` produces.
+    //     Also what `compile_and_update` outputs for freshly-defined user-typed
+    //     imports until they're observed.
+    //
+    //   Stage C — pre-observation, inline live-notebook:
+    //     `_inputs = [Variable("@variable")]` (length 1) AND the definition
+    //     calls `import(...)` inside. We extract the imported module reference
+    //     by invoking the definition with a stub `import` capture.
+    //
+    // Detection order is post→pre because Stage A is unambiguous when present.
+    const isStageA = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
     };
+    const isStageB = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 2)
+        return false;
+      const [i0, i1] = inputs;
+      return !!(i0 && typeof i0 === 'object' && typeof i0._name === 'string' && i0._name.startsWith('module @') && i1 && typeof i1 === 'object' && i1._name === '@variable');
+    };
+    const isStageC = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && i0._name === '@variable' && typeof v._definition !== 'undefined' && String(v._definition).includes('import('));
+    };
+    let v0, module_name, stage;
+    if (v0 = variables.find(isStageA)) {
+      stage = 'A';
+      module_name = findModuleName(v0._module._scope, v0._inputs[0]._module);
+    } else if (v0 = variables.find(isStageB)) {
+      stage = 'B';
+      module_name = v0._inputs[0]._name.replace(/^module /, '');
+    } else if (v0 = variables.find(isStageC)) {
+      stage = 'C';
+      let capturedModule;
+      try {
+        await v0._definition({
+          import: (...args) => {
+            capturedModule = args[args.length - 1];
+          }
+        });
+      } catch (e) {
+      }
+      if (capturedModule && v0._module?._scope) {
+        module_name = findModuleName(v0._module._scope, capturedModule);
+      }
+    } else {
+      return null;
+    }
+    if (module_name == null)
+      throw new Error('module name could not be resolved');
+    // Skip runtime-internal `module @foo` stitch variables — they belong to
+    // the import group but are not user-facing specifiers. Without this filter, an
+    // import group renders as `import {Range, module @foo} from "@foo"`.
+    const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
+      const imported = await findImportedName(v);
+      const local = v._name;
+      return {
+        imported,
+        local,
+        alias: imported !== local,
+        meta: { index }
+      };
+    }));
+    return {
+      type: 'import',
+      from: module_name,
+      specifiers,
+      meta: {
+        detection: { stage },
+        variables: variables.map(v => v?._name ?? null)
+      }
+    };
+  };
 };
 const _1sylz7j = function _formatImportDeclaration(){return(
 function formatImportDeclaration(importInfo) {
@@ -20633,6 +20680,198 @@ const _1hiclbb = function _acorn_walk(acorn_walk_url) {
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
+const _1rc67k0 = function _stageB_importFake()
+{
+  return // Builds a Stage B (pre-observation, API-loaded) import group as POJOs.
+  // Mirrors what `runtime.define("name", ["module @X", "@variable"], (_, v) => v.import("name", _))`
+  // produces structurally. Used by the test_decompileImport_stageB_* tests to
+  // avoid spinning up a real Observable runtime per case.
+  function stageB_importFake(module_name, specifiers) {
+    const importerModule = { _scope: new Map() };
+    const stitch = {
+      _name: `module ${ module_name }`,
+      _module: importerModule,
+      _inputs: [],
+      _definition: `async () => null`
+    };
+    const atVariable = {
+      _name: '@variable',
+      _module: importerModule
+    };
+    const aliases = specifiers.map(s => ({
+      _name: s.local,
+      _module: importerModule,
+      _inputs: [
+        stitch,
+        atVariable
+      ],
+      _definition: s.imported === s.local ? `(_, v) => v.import("${ s.imported }", _)` : `(_, v) => v.import("${ s.imported }", "${ s.local }", _)`
+    }));
+    return [
+      stitch,
+      ...aliases
+    ];
+  };
+};
+const _1d53asg = async function _test_decompileImport_stageB_single(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [{
+      imported: 'visualize',
+      local: 'visualize'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _hv5gag = async function _test_decompileImport_stageB_aliased(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'x',
+      local: 'z'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(info.specifiers[0].alias).toEqual(true);
+  expect(formatImportDeclaration(info)).toEqual(`import {x as z} from "@user/y"`);
+  return 'ok';
+};
+const _avc18y = async function _test_decompileImport_stageB_multiple(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    },
+    {
+      imported: 'c',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b, c} from "@user/y"`);
+  return 'ok';
+};
+const _16gia7i = async function _test_decompileImport_stageB_mixed_alias(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b as c} from "@user/y"`);
+  return 'ok';
+};
+const _1slhdwo = async function _test_decompileImport_stageB_viewof(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/module-map', [{
+      imported: 'viewof currentModules',
+      local: 'viewof currentModules'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {viewof currentModules} from "@tomlarkworthy/module-map"`);
+  return 'ok';
+};
+const _qwlsf2 = async function _test_decompileImport_stageB_mutable(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'mutable counter',
+      local: 'mutable counter'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {mutable counter} from "@user/y"`);
+  return 'ok';
+};
+const _sy7jfx = async function _test_decompileImport_returns_null_for_non_import(decompileImport,expect)
+{
+  // A regular cell — no stitch, no @variable input, no cross-module reference.
+  const info = await decompileImport([{
+      _name: 'x',
+      _module: {},
+      _inputs: [],
+      _definition: `() => 42`
+    }]);
+  expect(info).toEqual(null);
+  return 'ok';
+};
+const _rk7ku3 = async function _test_decompileImport_compile_roundtrip_single(compile,expect,stageB_importFake,decompileImport,formatImportDeclaration)
+{
+  // What `compile()` emits for `import {x} from "@user/y"` is structurally the
+  // same as our stageB_importFake fixture (after runtime.define resolves the
+  // input name strings to Variable refs). Verify the fixture matches the
+  // shape compile() would produce.
+  const pojos = compile(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  expect(pojos.length).toEqual(3);
+  expect(pojos[0]._name).toEqual('module @tomlarkworthy/visualizer');
+  expect(pojos[1]._name).toEqual('visualize');
+  expect(pojos[2]._name).toEqual('Group');
+  expect(pojos[1]._inputs).toEqual([
+    'module @tomlarkworthy/visualizer',
+    '@variable'
+  ]);
+  // Now run our fixture through decompileImport — confirms the round-trip
+  // shape compile()-output-shape-when-defined → decompileImport produces the
+  // canonical import source string.
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [
+    {
+      imported: 'visualize',
+      local: 'visualize'
+    },
+    {
+      imported: 'Group',
+      local: 'Group'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _xynplo = async function _test_decompileImport_stageB_order_independent(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // The detection uses .find — it shouldn't matter whether the stitch is at
+  // index 0 or the aliases come first. Verify by reversing the array.
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    }
+  ]);
+  const reversed = [...vars].reverse();
+  const info = await decompileImport(reversed);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b} from "@user/y"`);
+  return 'ok';
+};
+const _16fpgac = async function _test_decompileImport_stageB_notebook_id(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // Observable supports `import {x} from "d/<hash>@<version>"` notebook-id form.
+  const vars = stageB_importFake('d/57d79353bac56631@44', [{
+      imported: 'hash',
+      local: 'hash'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {hash} from "d/57d79353bac56631@44"`);
+  return 'ok';
+};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -20753,7 +20992,7 @@ export default function define(runtime, observer) {
   $def("_1n7gw17", "findModuleName", ["extractModuleInfo"], _1n7gw17);  
   $def("_i47chb", "findImportedName", [], _i47chb);  
   $def("_1effqg", null, ["md"], _1effqg);  
-  $def("_1etqs71", "decompileImport", ["findModuleName","findImportedName"], _1etqs71);  
+  $def("_b7vai6", "decompileImport", ["findModuleName","findImportedName"], _b7vai6);  
   $def("_1sylz7j", "formatImportDeclaration", [], _1sylz7j);  
   $def("_13dctdn", "test_decompileImport_basic", ["importFake","decompileImport","expect"], _13dctdn);  
   $def("_ujr0xn", "test_formatImportDeclaration_roundtrip", ["importFake","decompileImport","expect","formatImportDeclaration","decompile"], _ujr0xn);  
@@ -20831,7 +21070,18 @@ export default function define(runtime, observer) {
   main.define("Runtime", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Runtime", _));  
   main.define("Inspector", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Inspector", _));  
   main.define("Library", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Library", _));  
-  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));
+  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));  
+  $def("_1rc67k0", "stageB_importFake", [], _1rc67k0);  
+  $def("_1d53asg", "test_decompileImport_stageB_single", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1d53asg);  
+  $def("_hv5gag", "test_decompileImport_stageB_aliased", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _hv5gag);  
+  $def("_avc18y", "test_decompileImport_stageB_multiple", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _avc18y);  
+  $def("_16gia7i", "test_decompileImport_stageB_mixed_alias", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16gia7i);  
+  $def("_1slhdwo", "test_decompileImport_stageB_viewof", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1slhdwo);  
+  $def("_qwlsf2", "test_decompileImport_stageB_mutable", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _qwlsf2);  
+  $def("_sy7jfx", "test_decompileImport_returns_null_for_non_import", ["decompileImport","expect"], _sy7jfx);  
+  $def("_rk7ku3", "test_decompileImport_compile_roundtrip_single", ["compile","expect","stageB_importFake","decompileImport","formatImportDeclaration"], _rk7ku3);  
+  $def("_xynplo", "test_decompileImport_stageB_order_independent", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _xynplo);  
+  $def("_16fpgac", "test_decompileImport_stageB_notebook_id", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16fpgac);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_local-change-history.html
+++ b/notebooks/@tomlarkworthy_local-change-history.html
@@ -19474,56 +19474,103 @@ async (v) => {
 const _1effqg = function _96(md){return(
 md`### \`decompileImport\``
 )};
-const _1etqs71 = function _decompileImport(findModuleName,findImportedName)
+const _b7vai6 = function _decompileImport(findModuleName,findImportedName)
 {
-    return async function decompileImport(variables, options = {}) {
-        if (!variables || variables.length === 0)
-            throw new Error('no variables');
-        // #166: An import group is `[module @foo, ...aliases]` — the runtime stitch
-        // sits at index 0 by convention. Scan for the first alias (single _input,
-        // crosses module boundary) so this works whichever order the caller hands us.
-        const isCrossModuleAlias = v => {
-            const inputs = v?._inputs;
-            if (!Array.isArray(inputs) || inputs.length !== 1)
-                return false;
-            const i0 = inputs[0];
-            return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
-        };
-        const v0 = variables.find(isCrossModuleAlias);
-        if (!v0)
-            return null;
-        const input0 = v0._inputs[0];
-        const inputsLength = 1;
-        const crossesModuleBoundary = true;
-        const module_name = findModuleName(v0._module._scope, input0._module);
-        if (module_name == null)
-            throw new Error('module name could not be resolved');
-        // #166: Skip runtime-internal `module @foo` stitch variables — they belong to
-        // the import group but are not user-facing specifiers. Without this filter, an
-        // import group renders as `import {Range, module @foo} from "@foo"`.
-        const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
-            const imported = await findImportedName(v);
-            const local = v._name;
-            return {
-                imported,
-                local,
-                alias: imported !== local,
-                meta: { index }
-            };
-        }));
-        return {
-            type: 'import',
-            from: module_name,
-            specifiers,
-            meta: {
-                detection: {
-                    inputsLength,
-                    crossesModuleBoundary
-                },
-                variables: variables.map(v => v?._name ?? null)
-            }
-        };
+  return async function decompileImport(variables, options = {}) {
+    if (!variables || variables.length === 0)
+      throw new Error('no variables');
+    // An import-cell group is `[module @X stitch, ...aliases]`. Each alias goes
+    // through three lifecycle stages (documented in observable-runtime-v6's
+    // `importedModule` helper, lines ~1992-2049 of @tomlarkworthy/observable-runtime-v6):
+    //
+    //   Stage A — post-observation:
+    //     `_inputs = [Variable in source module]` (length 1, cross-module).
+    //     The Observable runtime rewrites _inputs after the alias is observed
+    //     and resolved against the source module.
+    //
+    //   Stage B — pre-observation, API-loaded (canonical compiled-bundle shape):
+    //     `_inputs = [Variable("module @X"), Variable("@variable")]` (length 2,
+    //     both in the importer module). What `runtime.define("name",
+    //     ["module @X", "@variable"], (_, v) => v.import("name", _))` produces.
+    //     Also what `compile_and_update` outputs for freshly-defined user-typed
+    //     imports until they're observed.
+    //
+    //   Stage C — pre-observation, inline live-notebook:
+    //     `_inputs = [Variable("@variable")]` (length 1) AND the definition
+    //     calls `import(...)` inside. We extract the imported module reference
+    //     by invoking the definition with a stub `import` capture.
+    //
+    // Detection order is post→pre because Stage A is unambiguous when present.
+    const isStageA = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
     };
+    const isStageB = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 2)
+        return false;
+      const [i0, i1] = inputs;
+      return !!(i0 && typeof i0 === 'object' && typeof i0._name === 'string' && i0._name.startsWith('module @') && i1 && typeof i1 === 'object' && i1._name === '@variable');
+    };
+    const isStageC = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && i0._name === '@variable' && typeof v._definition !== 'undefined' && String(v._definition).includes('import('));
+    };
+    let v0, module_name, stage;
+    if (v0 = variables.find(isStageA)) {
+      stage = 'A';
+      module_name = findModuleName(v0._module._scope, v0._inputs[0]._module);
+    } else if (v0 = variables.find(isStageB)) {
+      stage = 'B';
+      module_name = v0._inputs[0]._name.replace(/^module /, '');
+    } else if (v0 = variables.find(isStageC)) {
+      stage = 'C';
+      let capturedModule;
+      try {
+        await v0._definition({
+          import: (...args) => {
+            capturedModule = args[args.length - 1];
+          }
+        });
+      } catch (e) {
+      }
+      if (capturedModule && v0._module?._scope) {
+        module_name = findModuleName(v0._module._scope, capturedModule);
+      }
+    } else {
+      return null;
+    }
+    if (module_name == null)
+      throw new Error('module name could not be resolved');
+    // Skip runtime-internal `module @foo` stitch variables — they belong to
+    // the import group but are not user-facing specifiers. Without this filter, an
+    // import group renders as `import {Range, module @foo} from "@foo"`.
+    const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
+      const imported = await findImportedName(v);
+      const local = v._name;
+      return {
+        imported,
+        local,
+        alias: imported !== local,
+        meta: { index }
+      };
+    }));
+    return {
+      type: 'import',
+      from: module_name,
+      specifiers,
+      meta: {
+        detection: { stage },
+        variables: variables.map(v => v?._name ?? null)
+      }
+    };
+  };
 };
 const _1sylz7j = function _formatImportDeclaration(){return(
 function formatImportDeclaration(importInfo) {
@@ -20633,6 +20680,198 @@ const _1hiclbb = function _acorn_walk(acorn_walk_url) {
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
+const _1rc67k0 = function _stageB_importFake()
+{
+  return // Builds a Stage B (pre-observation, API-loaded) import group as POJOs.
+  // Mirrors what `runtime.define("name", ["module @X", "@variable"], (_, v) => v.import("name", _))`
+  // produces structurally. Used by the test_decompileImport_stageB_* tests to
+  // avoid spinning up a real Observable runtime per case.
+  function stageB_importFake(module_name, specifiers) {
+    const importerModule = { _scope: new Map() };
+    const stitch = {
+      _name: `module ${ module_name }`,
+      _module: importerModule,
+      _inputs: [],
+      _definition: `async () => null`
+    };
+    const atVariable = {
+      _name: '@variable',
+      _module: importerModule
+    };
+    const aliases = specifiers.map(s => ({
+      _name: s.local,
+      _module: importerModule,
+      _inputs: [
+        stitch,
+        atVariable
+      ],
+      _definition: s.imported === s.local ? `(_, v) => v.import("${ s.imported }", _)` : `(_, v) => v.import("${ s.imported }", "${ s.local }", _)`
+    }));
+    return [
+      stitch,
+      ...aliases
+    ];
+  };
+};
+const _1d53asg = async function _test_decompileImport_stageB_single(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [{
+      imported: 'visualize',
+      local: 'visualize'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _hv5gag = async function _test_decompileImport_stageB_aliased(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'x',
+      local: 'z'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(info.specifiers[0].alias).toEqual(true);
+  expect(formatImportDeclaration(info)).toEqual(`import {x as z} from "@user/y"`);
+  return 'ok';
+};
+const _avc18y = async function _test_decompileImport_stageB_multiple(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    },
+    {
+      imported: 'c',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b, c} from "@user/y"`);
+  return 'ok';
+};
+const _16gia7i = async function _test_decompileImport_stageB_mixed_alias(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b as c} from "@user/y"`);
+  return 'ok';
+};
+const _1slhdwo = async function _test_decompileImport_stageB_viewof(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/module-map', [{
+      imported: 'viewof currentModules',
+      local: 'viewof currentModules'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {viewof currentModules} from "@tomlarkworthy/module-map"`);
+  return 'ok';
+};
+const _qwlsf2 = async function _test_decompileImport_stageB_mutable(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'mutable counter',
+      local: 'mutable counter'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {mutable counter} from "@user/y"`);
+  return 'ok';
+};
+const _sy7jfx = async function _test_decompileImport_returns_null_for_non_import(decompileImport,expect)
+{
+  // A regular cell — no stitch, no @variable input, no cross-module reference.
+  const info = await decompileImport([{
+      _name: 'x',
+      _module: {},
+      _inputs: [],
+      _definition: `() => 42`
+    }]);
+  expect(info).toEqual(null);
+  return 'ok';
+};
+const _rk7ku3 = async function _test_decompileImport_compile_roundtrip_single(compile,expect,stageB_importFake,decompileImport,formatImportDeclaration)
+{
+  // What `compile()` emits for `import {x} from "@user/y"` is structurally the
+  // same as our stageB_importFake fixture (after runtime.define resolves the
+  // input name strings to Variable refs). Verify the fixture matches the
+  // shape compile() would produce.
+  const pojos = compile(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  expect(pojos.length).toEqual(3);
+  expect(pojos[0]._name).toEqual('module @tomlarkworthy/visualizer');
+  expect(pojos[1]._name).toEqual('visualize');
+  expect(pojos[2]._name).toEqual('Group');
+  expect(pojos[1]._inputs).toEqual([
+    'module @tomlarkworthy/visualizer',
+    '@variable'
+  ]);
+  // Now run our fixture through decompileImport — confirms the round-trip
+  // shape compile()-output-shape-when-defined → decompileImport produces the
+  // canonical import source string.
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [
+    {
+      imported: 'visualize',
+      local: 'visualize'
+    },
+    {
+      imported: 'Group',
+      local: 'Group'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _xynplo = async function _test_decompileImport_stageB_order_independent(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // The detection uses .find — it shouldn't matter whether the stitch is at
+  // index 0 or the aliases come first. Verify by reversing the array.
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    }
+  ]);
+  const reversed = [...vars].reverse();
+  const info = await decompileImport(reversed);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b} from "@user/y"`);
+  return 'ok';
+};
+const _16fpgac = async function _test_decompileImport_stageB_notebook_id(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // Observable supports `import {x} from "d/<hash>@<version>"` notebook-id form.
+  const vars = stageB_importFake('d/57d79353bac56631@44', [{
+      imported: 'hash',
+      local: 'hash'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {hash} from "d/57d79353bac56631@44"`);
+  return 'ok';
+};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -20753,7 +20992,7 @@ export default function define(runtime, observer) {
   $def("_1n7gw17", "findModuleName", ["extractModuleInfo"], _1n7gw17);  
   $def("_i47chb", "findImportedName", [], _i47chb);  
   $def("_1effqg", null, ["md"], _1effqg);  
-  $def("_1etqs71", "decompileImport", ["findModuleName","findImportedName"], _1etqs71);  
+  $def("_b7vai6", "decompileImport", ["findModuleName","findImportedName"], _b7vai6);  
   $def("_1sylz7j", "formatImportDeclaration", [], _1sylz7j);  
   $def("_13dctdn", "test_decompileImport_basic", ["importFake","decompileImport","expect"], _13dctdn);  
   $def("_ujr0xn", "test_formatImportDeclaration_roundtrip", ["importFake","decompileImport","expect","formatImportDeclaration","decompile"], _ujr0xn);  
@@ -20831,7 +21070,18 @@ export default function define(runtime, observer) {
   main.define("Runtime", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Runtime", _));  
   main.define("Inspector", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Inspector", _));  
   main.define("Library", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Library", _));  
-  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));
+  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));  
+  $def("_1rc67k0", "stageB_importFake", [], _1rc67k0);  
+  $def("_1d53asg", "test_decompileImport_stageB_single", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1d53asg);  
+  $def("_hv5gag", "test_decompileImport_stageB_aliased", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _hv5gag);  
+  $def("_avc18y", "test_decompileImport_stageB_multiple", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _avc18y);  
+  $def("_16gia7i", "test_decompileImport_stageB_mixed_alias", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16gia7i);  
+  $def("_1slhdwo", "test_decompileImport_stageB_viewof", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1slhdwo);  
+  $def("_qwlsf2", "test_decompileImport_stageB_mutable", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _qwlsf2);  
+  $def("_sy7jfx", "test_decompileImport_returns_null_for_non_import", ["decompileImport","expect"], _sy7jfx);  
+  $def("_rk7ku3", "test_decompileImport_compile_roundtrip_single", ["compile","expect","stageB_importFake","decompileImport","formatImportDeclaration"], _rk7ku3);  
+  $def("_xynplo", "test_decompileImport_stageB_order_independent", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _xynplo);  
+  $def("_16fpgac", "test_decompileImport_stageB_notebook_id", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16fpgac);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_local-storage-view.html
+++ b/notebooks/@tomlarkworthy_local-storage-view.html
@@ -19474,56 +19474,103 @@ async (v) => {
 const _1effqg = function _96(md){return(
 md`### \`decompileImport\``
 )};
-const _1etqs71 = function _decompileImport(findModuleName,findImportedName)
+const _b7vai6 = function _decompileImport(findModuleName,findImportedName)
 {
-    return async function decompileImport(variables, options = {}) {
-        if (!variables || variables.length === 0)
-            throw new Error('no variables');
-        // #166: An import group is `[module @foo, ...aliases]` — the runtime stitch
-        // sits at index 0 by convention. Scan for the first alias (single _input,
-        // crosses module boundary) so this works whichever order the caller hands us.
-        const isCrossModuleAlias = v => {
-            const inputs = v?._inputs;
-            if (!Array.isArray(inputs) || inputs.length !== 1)
-                return false;
-            const i0 = inputs[0];
-            return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
-        };
-        const v0 = variables.find(isCrossModuleAlias);
-        if (!v0)
-            return null;
-        const input0 = v0._inputs[0];
-        const inputsLength = 1;
-        const crossesModuleBoundary = true;
-        const module_name = findModuleName(v0._module._scope, input0._module);
-        if (module_name == null)
-            throw new Error('module name could not be resolved');
-        // #166: Skip runtime-internal `module @foo` stitch variables — they belong to
-        // the import group but are not user-facing specifiers. Without this filter, an
-        // import group renders as `import {Range, module @foo} from "@foo"`.
-        const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
-            const imported = await findImportedName(v);
-            const local = v._name;
-            return {
-                imported,
-                local,
-                alias: imported !== local,
-                meta: { index }
-            };
-        }));
-        return {
-            type: 'import',
-            from: module_name,
-            specifiers,
-            meta: {
-                detection: {
-                    inputsLength,
-                    crossesModuleBoundary
-                },
-                variables: variables.map(v => v?._name ?? null)
-            }
-        };
+  return async function decompileImport(variables, options = {}) {
+    if (!variables || variables.length === 0)
+      throw new Error('no variables');
+    // An import-cell group is `[module @X stitch, ...aliases]`. Each alias goes
+    // through three lifecycle stages (documented in observable-runtime-v6's
+    // `importedModule` helper, lines ~1992-2049 of @tomlarkworthy/observable-runtime-v6):
+    //
+    //   Stage A — post-observation:
+    //     `_inputs = [Variable in source module]` (length 1, cross-module).
+    //     The Observable runtime rewrites _inputs after the alias is observed
+    //     and resolved against the source module.
+    //
+    //   Stage B — pre-observation, API-loaded (canonical compiled-bundle shape):
+    //     `_inputs = [Variable("module @X"), Variable("@variable")]` (length 2,
+    //     both in the importer module). What `runtime.define("name",
+    //     ["module @X", "@variable"], (_, v) => v.import("name", _))` produces.
+    //     Also what `compile_and_update` outputs for freshly-defined user-typed
+    //     imports until they're observed.
+    //
+    //   Stage C — pre-observation, inline live-notebook:
+    //     `_inputs = [Variable("@variable")]` (length 1) AND the definition
+    //     calls `import(...)` inside. We extract the imported module reference
+    //     by invoking the definition with a stub `import` capture.
+    //
+    // Detection order is post→pre because Stage A is unambiguous when present.
+    const isStageA = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
     };
+    const isStageB = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 2)
+        return false;
+      const [i0, i1] = inputs;
+      return !!(i0 && typeof i0 === 'object' && typeof i0._name === 'string' && i0._name.startsWith('module @') && i1 && typeof i1 === 'object' && i1._name === '@variable');
+    };
+    const isStageC = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && i0._name === '@variable' && typeof v._definition !== 'undefined' && String(v._definition).includes('import('));
+    };
+    let v0, module_name, stage;
+    if (v0 = variables.find(isStageA)) {
+      stage = 'A';
+      module_name = findModuleName(v0._module._scope, v0._inputs[0]._module);
+    } else if (v0 = variables.find(isStageB)) {
+      stage = 'B';
+      module_name = v0._inputs[0]._name.replace(/^module /, '');
+    } else if (v0 = variables.find(isStageC)) {
+      stage = 'C';
+      let capturedModule;
+      try {
+        await v0._definition({
+          import: (...args) => {
+            capturedModule = args[args.length - 1];
+          }
+        });
+      } catch (e) {
+      }
+      if (capturedModule && v0._module?._scope) {
+        module_name = findModuleName(v0._module._scope, capturedModule);
+      }
+    } else {
+      return null;
+    }
+    if (module_name == null)
+      throw new Error('module name could not be resolved');
+    // Skip runtime-internal `module @foo` stitch variables — they belong to
+    // the import group but are not user-facing specifiers. Without this filter, an
+    // import group renders as `import {Range, module @foo} from "@foo"`.
+    const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
+      const imported = await findImportedName(v);
+      const local = v._name;
+      return {
+        imported,
+        local,
+        alias: imported !== local,
+        meta: { index }
+      };
+    }));
+    return {
+      type: 'import',
+      from: module_name,
+      specifiers,
+      meta: {
+        detection: { stage },
+        variables: variables.map(v => v?._name ?? null)
+      }
+    };
+  };
 };
 const _1sylz7j = function _formatImportDeclaration(){return(
 function formatImportDeclaration(importInfo) {
@@ -20633,6 +20680,198 @@ const _1hiclbb = function _acorn_walk(acorn_walk_url) {
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
+const _1rc67k0 = function _stageB_importFake()
+{
+  return // Builds a Stage B (pre-observation, API-loaded) import group as POJOs.
+  // Mirrors what `runtime.define("name", ["module @X", "@variable"], (_, v) => v.import("name", _))`
+  // produces structurally. Used by the test_decompileImport_stageB_* tests to
+  // avoid spinning up a real Observable runtime per case.
+  function stageB_importFake(module_name, specifiers) {
+    const importerModule = { _scope: new Map() };
+    const stitch = {
+      _name: `module ${ module_name }`,
+      _module: importerModule,
+      _inputs: [],
+      _definition: `async () => null`
+    };
+    const atVariable = {
+      _name: '@variable',
+      _module: importerModule
+    };
+    const aliases = specifiers.map(s => ({
+      _name: s.local,
+      _module: importerModule,
+      _inputs: [
+        stitch,
+        atVariable
+      ],
+      _definition: s.imported === s.local ? `(_, v) => v.import("${ s.imported }", _)` : `(_, v) => v.import("${ s.imported }", "${ s.local }", _)`
+    }));
+    return [
+      stitch,
+      ...aliases
+    ];
+  };
+};
+const _1d53asg = async function _test_decompileImport_stageB_single(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [{
+      imported: 'visualize',
+      local: 'visualize'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _hv5gag = async function _test_decompileImport_stageB_aliased(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'x',
+      local: 'z'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(info.specifiers[0].alias).toEqual(true);
+  expect(formatImportDeclaration(info)).toEqual(`import {x as z} from "@user/y"`);
+  return 'ok';
+};
+const _avc18y = async function _test_decompileImport_stageB_multiple(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    },
+    {
+      imported: 'c',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b, c} from "@user/y"`);
+  return 'ok';
+};
+const _16gia7i = async function _test_decompileImport_stageB_mixed_alias(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b as c} from "@user/y"`);
+  return 'ok';
+};
+const _1slhdwo = async function _test_decompileImport_stageB_viewof(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/module-map', [{
+      imported: 'viewof currentModules',
+      local: 'viewof currentModules'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {viewof currentModules} from "@tomlarkworthy/module-map"`);
+  return 'ok';
+};
+const _qwlsf2 = async function _test_decompileImport_stageB_mutable(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'mutable counter',
+      local: 'mutable counter'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {mutable counter} from "@user/y"`);
+  return 'ok';
+};
+const _sy7jfx = async function _test_decompileImport_returns_null_for_non_import(decompileImport,expect)
+{
+  // A regular cell — no stitch, no @variable input, no cross-module reference.
+  const info = await decompileImport([{
+      _name: 'x',
+      _module: {},
+      _inputs: [],
+      _definition: `() => 42`
+    }]);
+  expect(info).toEqual(null);
+  return 'ok';
+};
+const _rk7ku3 = async function _test_decompileImport_compile_roundtrip_single(compile,expect,stageB_importFake,decompileImport,formatImportDeclaration)
+{
+  // What `compile()` emits for `import {x} from "@user/y"` is structurally the
+  // same as our stageB_importFake fixture (after runtime.define resolves the
+  // input name strings to Variable refs). Verify the fixture matches the
+  // shape compile() would produce.
+  const pojos = compile(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  expect(pojos.length).toEqual(3);
+  expect(pojos[0]._name).toEqual('module @tomlarkworthy/visualizer');
+  expect(pojos[1]._name).toEqual('visualize');
+  expect(pojos[2]._name).toEqual('Group');
+  expect(pojos[1]._inputs).toEqual([
+    'module @tomlarkworthy/visualizer',
+    '@variable'
+  ]);
+  // Now run our fixture through decompileImport — confirms the round-trip
+  // shape compile()-output-shape-when-defined → decompileImport produces the
+  // canonical import source string.
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [
+    {
+      imported: 'visualize',
+      local: 'visualize'
+    },
+    {
+      imported: 'Group',
+      local: 'Group'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _xynplo = async function _test_decompileImport_stageB_order_independent(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // The detection uses .find — it shouldn't matter whether the stitch is at
+  // index 0 or the aliases come first. Verify by reversing the array.
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    }
+  ]);
+  const reversed = [...vars].reverse();
+  const info = await decompileImport(reversed);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b} from "@user/y"`);
+  return 'ok';
+};
+const _16fpgac = async function _test_decompileImport_stageB_notebook_id(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // Observable supports `import {x} from "d/<hash>@<version>"` notebook-id form.
+  const vars = stageB_importFake('d/57d79353bac56631@44', [{
+      imported: 'hash',
+      local: 'hash'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {hash} from "d/57d79353bac56631@44"`);
+  return 'ok';
+};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -20753,7 +20992,7 @@ export default function define(runtime, observer) {
   $def("_1n7gw17", "findModuleName", ["extractModuleInfo"], _1n7gw17);  
   $def("_i47chb", "findImportedName", [], _i47chb);  
   $def("_1effqg", null, ["md"], _1effqg);  
-  $def("_1etqs71", "decompileImport", ["findModuleName","findImportedName"], _1etqs71);  
+  $def("_b7vai6", "decompileImport", ["findModuleName","findImportedName"], _b7vai6);  
   $def("_1sylz7j", "formatImportDeclaration", [], _1sylz7j);  
   $def("_13dctdn", "test_decompileImport_basic", ["importFake","decompileImport","expect"], _13dctdn);  
   $def("_ujr0xn", "test_formatImportDeclaration_roundtrip", ["importFake","decompileImport","expect","formatImportDeclaration","decompile"], _ujr0xn);  
@@ -20831,7 +21070,18 @@ export default function define(runtime, observer) {
   main.define("Runtime", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Runtime", _));  
   main.define("Inspector", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Inspector", _));  
   main.define("Library", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Library", _));  
-  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));
+  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));  
+  $def("_1rc67k0", "stageB_importFake", [], _1rc67k0);  
+  $def("_1d53asg", "test_decompileImport_stageB_single", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1d53asg);  
+  $def("_hv5gag", "test_decompileImport_stageB_aliased", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _hv5gag);  
+  $def("_avc18y", "test_decompileImport_stageB_multiple", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _avc18y);  
+  $def("_16gia7i", "test_decompileImport_stageB_mixed_alias", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16gia7i);  
+  $def("_1slhdwo", "test_decompileImport_stageB_viewof", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1slhdwo);  
+  $def("_qwlsf2", "test_decompileImport_stageB_mutable", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _qwlsf2);  
+  $def("_sy7jfx", "test_decompileImport_returns_null_for_non_import", ["decompileImport","expect"], _sy7jfx);  
+  $def("_rk7ku3", "test_decompileImport_compile_roundtrip_single", ["compile","expect","stageB_importFake","decompileImport","formatImportDeclaration"], _rk7ku3);  
+  $def("_xynplo", "test_decompileImport_stageB_order_independent", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _xynplo);  
+  $def("_16fpgac", "test_decompileImport_stageB_notebook_id", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16fpgac);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_lopecode-tour.html
+++ b/notebooks/@tomlarkworthy_lopecode-tour.html
@@ -23228,56 +23228,103 @@ async (v) => {
 const _1effqg = function _96(md){return(
 md`### \`decompileImport\``
 )};
-const _1etqs71 = function _decompileImport(findModuleName,findImportedName)
+const _b7vai6 = function _decompileImport(findModuleName,findImportedName)
 {
-    return async function decompileImport(variables, options = {}) {
-        if (!variables || variables.length === 0)
-            throw new Error('no variables');
-        // #166: An import group is `[module @foo, ...aliases]` — the runtime stitch
-        // sits at index 0 by convention. Scan for the first alias (single _input,
-        // crosses module boundary) so this works whichever order the caller hands us.
-        const isCrossModuleAlias = v => {
-            const inputs = v?._inputs;
-            if (!Array.isArray(inputs) || inputs.length !== 1)
-                return false;
-            const i0 = inputs[0];
-            return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
-        };
-        const v0 = variables.find(isCrossModuleAlias);
-        if (!v0)
-            return null;
-        const input0 = v0._inputs[0];
-        const inputsLength = 1;
-        const crossesModuleBoundary = true;
-        const module_name = findModuleName(v0._module._scope, input0._module);
-        if (module_name == null)
-            throw new Error('module name could not be resolved');
-        // #166: Skip runtime-internal `module @foo` stitch variables — they belong to
-        // the import group but are not user-facing specifiers. Without this filter, an
-        // import group renders as `import {Range, module @foo} from "@foo"`.
-        const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
-            const imported = await findImportedName(v);
-            const local = v._name;
-            return {
-                imported,
-                local,
-                alias: imported !== local,
-                meta: { index }
-            };
-        }));
-        return {
-            type: 'import',
-            from: module_name,
-            specifiers,
-            meta: {
-                detection: {
-                    inputsLength,
-                    crossesModuleBoundary
-                },
-                variables: variables.map(v => v?._name ?? null)
-            }
-        };
+  return async function decompileImport(variables, options = {}) {
+    if (!variables || variables.length === 0)
+      throw new Error('no variables');
+    // An import-cell group is `[module @X stitch, ...aliases]`. Each alias goes
+    // through three lifecycle stages (documented in observable-runtime-v6's
+    // `importedModule` helper, lines ~1992-2049 of @tomlarkworthy/observable-runtime-v6):
+    //
+    //   Stage A — post-observation:
+    //     `_inputs = [Variable in source module]` (length 1, cross-module).
+    //     The Observable runtime rewrites _inputs after the alias is observed
+    //     and resolved against the source module.
+    //
+    //   Stage B — pre-observation, API-loaded (canonical compiled-bundle shape):
+    //     `_inputs = [Variable("module @X"), Variable("@variable")]` (length 2,
+    //     both in the importer module). What `runtime.define("name",
+    //     ["module @X", "@variable"], (_, v) => v.import("name", _))` produces.
+    //     Also what `compile_and_update` outputs for freshly-defined user-typed
+    //     imports until they're observed.
+    //
+    //   Stage C — pre-observation, inline live-notebook:
+    //     `_inputs = [Variable("@variable")]` (length 1) AND the definition
+    //     calls `import(...)` inside. We extract the imported module reference
+    //     by invoking the definition with a stub `import` capture.
+    //
+    // Detection order is post→pre because Stage A is unambiguous when present.
+    const isStageA = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
     };
+    const isStageB = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 2)
+        return false;
+      const [i0, i1] = inputs;
+      return !!(i0 && typeof i0 === 'object' && typeof i0._name === 'string' && i0._name.startsWith('module @') && i1 && typeof i1 === 'object' && i1._name === '@variable');
+    };
+    const isStageC = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && i0._name === '@variable' && typeof v._definition !== 'undefined' && String(v._definition).includes('import('));
+    };
+    let v0, module_name, stage;
+    if (v0 = variables.find(isStageA)) {
+      stage = 'A';
+      module_name = findModuleName(v0._module._scope, v0._inputs[0]._module);
+    } else if (v0 = variables.find(isStageB)) {
+      stage = 'B';
+      module_name = v0._inputs[0]._name.replace(/^module /, '');
+    } else if (v0 = variables.find(isStageC)) {
+      stage = 'C';
+      let capturedModule;
+      try {
+        await v0._definition({
+          import: (...args) => {
+            capturedModule = args[args.length - 1];
+          }
+        });
+      } catch (e) {
+      }
+      if (capturedModule && v0._module?._scope) {
+        module_name = findModuleName(v0._module._scope, capturedModule);
+      }
+    } else {
+      return null;
+    }
+    if (module_name == null)
+      throw new Error('module name could not be resolved');
+    // Skip runtime-internal `module @foo` stitch variables — they belong to
+    // the import group but are not user-facing specifiers. Without this filter, an
+    // import group renders as `import {Range, module @foo} from "@foo"`.
+    const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
+      const imported = await findImportedName(v);
+      const local = v._name;
+      return {
+        imported,
+        local,
+        alias: imported !== local,
+        meta: { index }
+      };
+    }));
+    return {
+      type: 'import',
+      from: module_name,
+      specifiers,
+      meta: {
+        detection: { stage },
+        variables: variables.map(v => v?._name ?? null)
+      }
+    };
+  };
 };
 const _1sylz7j = function _formatImportDeclaration(){return(
 function formatImportDeclaration(importInfo) {
@@ -24387,6 +24434,198 @@ const _1hiclbb = function _acorn_walk(acorn_walk_url) {
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
+const _1rc67k0 = function _stageB_importFake()
+{
+  return // Builds a Stage B (pre-observation, API-loaded) import group as POJOs.
+  // Mirrors what `runtime.define("name", ["module @X", "@variable"], (_, v) => v.import("name", _))`
+  // produces structurally. Used by the test_decompileImport_stageB_* tests to
+  // avoid spinning up a real Observable runtime per case.
+  function stageB_importFake(module_name, specifiers) {
+    const importerModule = { _scope: new Map() };
+    const stitch = {
+      _name: `module ${ module_name }`,
+      _module: importerModule,
+      _inputs: [],
+      _definition: `async () => null`
+    };
+    const atVariable = {
+      _name: '@variable',
+      _module: importerModule
+    };
+    const aliases = specifiers.map(s => ({
+      _name: s.local,
+      _module: importerModule,
+      _inputs: [
+        stitch,
+        atVariable
+      ],
+      _definition: s.imported === s.local ? `(_, v) => v.import("${ s.imported }", _)` : `(_, v) => v.import("${ s.imported }", "${ s.local }", _)`
+    }));
+    return [
+      stitch,
+      ...aliases
+    ];
+  };
+};
+const _1d53asg = async function _test_decompileImport_stageB_single(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [{
+      imported: 'visualize',
+      local: 'visualize'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _hv5gag = async function _test_decompileImport_stageB_aliased(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'x',
+      local: 'z'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(info.specifiers[0].alias).toEqual(true);
+  expect(formatImportDeclaration(info)).toEqual(`import {x as z} from "@user/y"`);
+  return 'ok';
+};
+const _avc18y = async function _test_decompileImport_stageB_multiple(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    },
+    {
+      imported: 'c',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b, c} from "@user/y"`);
+  return 'ok';
+};
+const _16gia7i = async function _test_decompileImport_stageB_mixed_alias(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b as c} from "@user/y"`);
+  return 'ok';
+};
+const _1slhdwo = async function _test_decompileImport_stageB_viewof(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/module-map', [{
+      imported: 'viewof currentModules',
+      local: 'viewof currentModules'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {viewof currentModules} from "@tomlarkworthy/module-map"`);
+  return 'ok';
+};
+const _qwlsf2 = async function _test_decompileImport_stageB_mutable(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'mutable counter',
+      local: 'mutable counter'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {mutable counter} from "@user/y"`);
+  return 'ok';
+};
+const _sy7jfx = async function _test_decompileImport_returns_null_for_non_import(decompileImport,expect)
+{
+  // A regular cell — no stitch, no @variable input, no cross-module reference.
+  const info = await decompileImport([{
+      _name: 'x',
+      _module: {},
+      _inputs: [],
+      _definition: `() => 42`
+    }]);
+  expect(info).toEqual(null);
+  return 'ok';
+};
+const _rk7ku3 = async function _test_decompileImport_compile_roundtrip_single(compile,expect,stageB_importFake,decompileImport,formatImportDeclaration)
+{
+  // What `compile()` emits for `import {x} from "@user/y"` is structurally the
+  // same as our stageB_importFake fixture (after runtime.define resolves the
+  // input name strings to Variable refs). Verify the fixture matches the
+  // shape compile() would produce.
+  const pojos = compile(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  expect(pojos.length).toEqual(3);
+  expect(pojos[0]._name).toEqual('module @tomlarkworthy/visualizer');
+  expect(pojos[1]._name).toEqual('visualize');
+  expect(pojos[2]._name).toEqual('Group');
+  expect(pojos[1]._inputs).toEqual([
+    'module @tomlarkworthy/visualizer',
+    '@variable'
+  ]);
+  // Now run our fixture through decompileImport — confirms the round-trip
+  // shape compile()-output-shape-when-defined → decompileImport produces the
+  // canonical import source string.
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [
+    {
+      imported: 'visualize',
+      local: 'visualize'
+    },
+    {
+      imported: 'Group',
+      local: 'Group'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _xynplo = async function _test_decompileImport_stageB_order_independent(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // The detection uses .find — it shouldn't matter whether the stitch is at
+  // index 0 or the aliases come first. Verify by reversing the array.
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    }
+  ]);
+  const reversed = [...vars].reverse();
+  const info = await decompileImport(reversed);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b} from "@user/y"`);
+  return 'ok';
+};
+const _16fpgac = async function _test_decompileImport_stageB_notebook_id(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // Observable supports `import {x} from "d/<hash>@<version>"` notebook-id form.
+  const vars = stageB_importFake('d/57d79353bac56631@44', [{
+      imported: 'hash',
+      local: 'hash'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {hash} from "d/57d79353bac56631@44"`);
+  return 'ok';
+};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -24507,7 +24746,7 @@ export default function define(runtime, observer) {
   $def("_1n7gw17", "findModuleName", ["extractModuleInfo"], _1n7gw17);  
   $def("_i47chb", "findImportedName", [], _i47chb);  
   $def("_1effqg", null, ["md"], _1effqg);  
-  $def("_1etqs71", "decompileImport", ["findModuleName","findImportedName"], _1etqs71);  
+  $def("_b7vai6", "decompileImport", ["findModuleName","findImportedName"], _b7vai6);  
   $def("_1sylz7j", "formatImportDeclaration", [], _1sylz7j);  
   $def("_13dctdn", "test_decompileImport_basic", ["importFake","decompileImport","expect"], _13dctdn);  
   $def("_ujr0xn", "test_formatImportDeclaration_roundtrip", ["importFake","decompileImport","expect","formatImportDeclaration","decompile"], _ujr0xn);  
@@ -24585,7 +24824,18 @@ export default function define(runtime, observer) {
   main.define("Runtime", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Runtime", _));  
   main.define("Inspector", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Inspector", _));  
   main.define("Library", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Library", _));  
-  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));
+  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));  
+  $def("_1rc67k0", "stageB_importFake", [], _1rc67k0);  
+  $def("_1d53asg", "test_decompileImport_stageB_single", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1d53asg);  
+  $def("_hv5gag", "test_decompileImport_stageB_aliased", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _hv5gag);  
+  $def("_avc18y", "test_decompileImport_stageB_multiple", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _avc18y);  
+  $def("_16gia7i", "test_decompileImport_stageB_mixed_alias", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16gia7i);  
+  $def("_1slhdwo", "test_decompileImport_stageB_viewof", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1slhdwo);  
+  $def("_qwlsf2", "test_decompileImport_stageB_mutable", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _qwlsf2);  
+  $def("_sy7jfx", "test_decompileImport_returns_null_for_non_import", ["decompileImport","expect"], _sy7jfx);  
+  $def("_rk7ku3", "test_decompileImport_compile_roundtrip_single", ["compile","expect","stageB_importFake","decompileImport","formatImportDeclaration"], _rk7ku3);  
+  $def("_xynplo", "test_decompileImport_stageB_order_independent", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _xynplo);  
+  $def("_16fpgac", "test_decompileImport_stageB_notebook_id", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16fpgac);
   return main;
 }</script>
 <script id="@tomlarkworthy/openai-responses-api/image.png" 

--- a/notebooks/@tomlarkworthy_lopecode-vision.html
+++ b/notebooks/@tomlarkworthy_lopecode-vision.html
@@ -20752,56 +20752,103 @@ async (v) => {
 const _1effqg = function _96(md){return(
 md`### \`decompileImport\``
 )};
-const _1etqs71 = function _decompileImport(findModuleName,findImportedName)
+const _b7vai6 = function _decompileImport(findModuleName,findImportedName)
 {
-    return async function decompileImport(variables, options = {}) {
-        if (!variables || variables.length === 0)
-            throw new Error('no variables');
-        // #166: An import group is `[module @foo, ...aliases]` — the runtime stitch
-        // sits at index 0 by convention. Scan for the first alias (single _input,
-        // crosses module boundary) so this works whichever order the caller hands us.
-        const isCrossModuleAlias = v => {
-            const inputs = v?._inputs;
-            if (!Array.isArray(inputs) || inputs.length !== 1)
-                return false;
-            const i0 = inputs[0];
-            return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
-        };
-        const v0 = variables.find(isCrossModuleAlias);
-        if (!v0)
-            return null;
-        const input0 = v0._inputs[0];
-        const inputsLength = 1;
-        const crossesModuleBoundary = true;
-        const module_name = findModuleName(v0._module._scope, input0._module);
-        if (module_name == null)
-            throw new Error('module name could not be resolved');
-        // #166: Skip runtime-internal `module @foo` stitch variables — they belong to
-        // the import group but are not user-facing specifiers. Without this filter, an
-        // import group renders as `import {Range, module @foo} from "@foo"`.
-        const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
-            const imported = await findImportedName(v);
-            const local = v._name;
-            return {
-                imported,
-                local,
-                alias: imported !== local,
-                meta: { index }
-            };
-        }));
-        return {
-            type: 'import',
-            from: module_name,
-            specifiers,
-            meta: {
-                detection: {
-                    inputsLength,
-                    crossesModuleBoundary
-                },
-                variables: variables.map(v => v?._name ?? null)
-            }
-        };
+  return async function decompileImport(variables, options = {}) {
+    if (!variables || variables.length === 0)
+      throw new Error('no variables');
+    // An import-cell group is `[module @X stitch, ...aliases]`. Each alias goes
+    // through three lifecycle stages (documented in observable-runtime-v6's
+    // `importedModule` helper, lines ~1992-2049 of @tomlarkworthy/observable-runtime-v6):
+    //
+    //   Stage A — post-observation:
+    //     `_inputs = [Variable in source module]` (length 1, cross-module).
+    //     The Observable runtime rewrites _inputs after the alias is observed
+    //     and resolved against the source module.
+    //
+    //   Stage B — pre-observation, API-loaded (canonical compiled-bundle shape):
+    //     `_inputs = [Variable("module @X"), Variable("@variable")]` (length 2,
+    //     both in the importer module). What `runtime.define("name",
+    //     ["module @X", "@variable"], (_, v) => v.import("name", _))` produces.
+    //     Also what `compile_and_update` outputs for freshly-defined user-typed
+    //     imports until they're observed.
+    //
+    //   Stage C — pre-observation, inline live-notebook:
+    //     `_inputs = [Variable("@variable")]` (length 1) AND the definition
+    //     calls `import(...)` inside. We extract the imported module reference
+    //     by invoking the definition with a stub `import` capture.
+    //
+    // Detection order is post→pre because Stage A is unambiguous when present.
+    const isStageA = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
     };
+    const isStageB = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 2)
+        return false;
+      const [i0, i1] = inputs;
+      return !!(i0 && typeof i0 === 'object' && typeof i0._name === 'string' && i0._name.startsWith('module @') && i1 && typeof i1 === 'object' && i1._name === '@variable');
+    };
+    const isStageC = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && i0._name === '@variable' && typeof v._definition !== 'undefined' && String(v._definition).includes('import('));
+    };
+    let v0, module_name, stage;
+    if (v0 = variables.find(isStageA)) {
+      stage = 'A';
+      module_name = findModuleName(v0._module._scope, v0._inputs[0]._module);
+    } else if (v0 = variables.find(isStageB)) {
+      stage = 'B';
+      module_name = v0._inputs[0]._name.replace(/^module /, '');
+    } else if (v0 = variables.find(isStageC)) {
+      stage = 'C';
+      let capturedModule;
+      try {
+        await v0._definition({
+          import: (...args) => {
+            capturedModule = args[args.length - 1];
+          }
+        });
+      } catch (e) {
+      }
+      if (capturedModule && v0._module?._scope) {
+        module_name = findModuleName(v0._module._scope, capturedModule);
+      }
+    } else {
+      return null;
+    }
+    if (module_name == null)
+      throw new Error('module name could not be resolved');
+    // Skip runtime-internal `module @foo` stitch variables — they belong to
+    // the import group but are not user-facing specifiers. Without this filter, an
+    // import group renders as `import {Range, module @foo} from "@foo"`.
+    const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
+      const imported = await findImportedName(v);
+      const local = v._name;
+      return {
+        imported,
+        local,
+        alias: imported !== local,
+        meta: { index }
+      };
+    }));
+    return {
+      type: 'import',
+      from: module_name,
+      specifiers,
+      meta: {
+        detection: { stage },
+        variables: variables.map(v => v?._name ?? null)
+      }
+    };
+  };
 };
 const _1sylz7j = function _formatImportDeclaration(){return(
 function formatImportDeclaration(importInfo) {
@@ -21911,6 +21958,198 @@ const _1hiclbb = function _acorn_walk(acorn_walk_url) {
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
+const _1rc67k0 = function _stageB_importFake()
+{
+  return // Builds a Stage B (pre-observation, API-loaded) import group as POJOs.
+  // Mirrors what `runtime.define("name", ["module @X", "@variable"], (_, v) => v.import("name", _))`
+  // produces structurally. Used by the test_decompileImport_stageB_* tests to
+  // avoid spinning up a real Observable runtime per case.
+  function stageB_importFake(module_name, specifiers) {
+    const importerModule = { _scope: new Map() };
+    const stitch = {
+      _name: `module ${ module_name }`,
+      _module: importerModule,
+      _inputs: [],
+      _definition: `async () => null`
+    };
+    const atVariable = {
+      _name: '@variable',
+      _module: importerModule
+    };
+    const aliases = specifiers.map(s => ({
+      _name: s.local,
+      _module: importerModule,
+      _inputs: [
+        stitch,
+        atVariable
+      ],
+      _definition: s.imported === s.local ? `(_, v) => v.import("${ s.imported }", _)` : `(_, v) => v.import("${ s.imported }", "${ s.local }", _)`
+    }));
+    return [
+      stitch,
+      ...aliases
+    ];
+  };
+};
+const _1d53asg = async function _test_decompileImport_stageB_single(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [{
+      imported: 'visualize',
+      local: 'visualize'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _hv5gag = async function _test_decompileImport_stageB_aliased(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'x',
+      local: 'z'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(info.specifiers[0].alias).toEqual(true);
+  expect(formatImportDeclaration(info)).toEqual(`import {x as z} from "@user/y"`);
+  return 'ok';
+};
+const _avc18y = async function _test_decompileImport_stageB_multiple(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    },
+    {
+      imported: 'c',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b, c} from "@user/y"`);
+  return 'ok';
+};
+const _16gia7i = async function _test_decompileImport_stageB_mixed_alias(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b as c} from "@user/y"`);
+  return 'ok';
+};
+const _1slhdwo = async function _test_decompileImport_stageB_viewof(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/module-map', [{
+      imported: 'viewof currentModules',
+      local: 'viewof currentModules'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {viewof currentModules} from "@tomlarkworthy/module-map"`);
+  return 'ok';
+};
+const _qwlsf2 = async function _test_decompileImport_stageB_mutable(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'mutable counter',
+      local: 'mutable counter'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {mutable counter} from "@user/y"`);
+  return 'ok';
+};
+const _sy7jfx = async function _test_decompileImport_returns_null_for_non_import(decompileImport,expect)
+{
+  // A regular cell — no stitch, no @variable input, no cross-module reference.
+  const info = await decompileImport([{
+      _name: 'x',
+      _module: {},
+      _inputs: [],
+      _definition: `() => 42`
+    }]);
+  expect(info).toEqual(null);
+  return 'ok';
+};
+const _rk7ku3 = async function _test_decompileImport_compile_roundtrip_single(compile,expect,stageB_importFake,decompileImport,formatImportDeclaration)
+{
+  // What `compile()` emits for `import {x} from "@user/y"` is structurally the
+  // same as our stageB_importFake fixture (after runtime.define resolves the
+  // input name strings to Variable refs). Verify the fixture matches the
+  // shape compile() would produce.
+  const pojos = compile(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  expect(pojos.length).toEqual(3);
+  expect(pojos[0]._name).toEqual('module @tomlarkworthy/visualizer');
+  expect(pojos[1]._name).toEqual('visualize');
+  expect(pojos[2]._name).toEqual('Group');
+  expect(pojos[1]._inputs).toEqual([
+    'module @tomlarkworthy/visualizer',
+    '@variable'
+  ]);
+  // Now run our fixture through decompileImport — confirms the round-trip
+  // shape compile()-output-shape-when-defined → decompileImport produces the
+  // canonical import source string.
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [
+    {
+      imported: 'visualize',
+      local: 'visualize'
+    },
+    {
+      imported: 'Group',
+      local: 'Group'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _xynplo = async function _test_decompileImport_stageB_order_independent(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // The detection uses .find — it shouldn't matter whether the stitch is at
+  // index 0 or the aliases come first. Verify by reversing the array.
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    }
+  ]);
+  const reversed = [...vars].reverse();
+  const info = await decompileImport(reversed);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b} from "@user/y"`);
+  return 'ok';
+};
+const _16fpgac = async function _test_decompileImport_stageB_notebook_id(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // Observable supports `import {x} from "d/<hash>@<version>"` notebook-id form.
+  const vars = stageB_importFake('d/57d79353bac56631@44', [{
+      imported: 'hash',
+      local: 'hash'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {hash} from "d/57d79353bac56631@44"`);
+  return 'ok';
+};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -22031,7 +22270,7 @@ export default function define(runtime, observer) {
   $def("_1n7gw17", "findModuleName", ["extractModuleInfo"], _1n7gw17);  
   $def("_i47chb", "findImportedName", [], _i47chb);  
   $def("_1effqg", null, ["md"], _1effqg);  
-  $def("_1etqs71", "decompileImport", ["findModuleName","findImportedName"], _1etqs71);  
+  $def("_b7vai6", "decompileImport", ["findModuleName","findImportedName"], _b7vai6);  
   $def("_1sylz7j", "formatImportDeclaration", [], _1sylz7j);  
   $def("_13dctdn", "test_decompileImport_basic", ["importFake","decompileImport","expect"], _13dctdn);  
   $def("_ujr0xn", "test_formatImportDeclaration_roundtrip", ["importFake","decompileImport","expect","formatImportDeclaration","decompile"], _ujr0xn);  
@@ -22109,7 +22348,18 @@ export default function define(runtime, observer) {
   main.define("Runtime", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Runtime", _));  
   main.define("Inspector", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Inspector", _));  
   main.define("Library", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Library", _));  
-  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));
+  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));  
+  $def("_1rc67k0", "stageB_importFake", [], _1rc67k0);  
+  $def("_1d53asg", "test_decompileImport_stageB_single", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1d53asg);  
+  $def("_hv5gag", "test_decompileImport_stageB_aliased", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _hv5gag);  
+  $def("_avc18y", "test_decompileImport_stageB_multiple", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _avc18y);  
+  $def("_16gia7i", "test_decompileImport_stageB_mixed_alias", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16gia7i);  
+  $def("_1slhdwo", "test_decompileImport_stageB_viewof", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1slhdwo);  
+  $def("_qwlsf2", "test_decompileImport_stageB_mutable", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _qwlsf2);  
+  $def("_sy7jfx", "test_decompileImport_returns_null_for_non_import", ["decompileImport","expect"], _sy7jfx);  
+  $def("_rk7ku3", "test_decompileImport_compile_roundtrip_single", ["compile","expect","stageB_importFake","decompileImport","formatImportDeclaration"], _rk7ku3);  
+  $def("_xynplo", "test_decompileImport_stageB_order_independent", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _xynplo);  
+  $def("_16fpgac", "test_decompileImport_stageB_notebook_id", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16fpgac);
   return main;
 }</script>
 <script id="@tomlarkworthy/openai-responses-api/image.png" 

--- a/notebooks/@tomlarkworthy_lopepage-urls.html
+++ b/notebooks/@tomlarkworthy_lopepage-urls.html
@@ -19474,56 +19474,103 @@ async (v) => {
 const _1effqg = function _96(md){return(
 md`### \`decompileImport\``
 )};
-const _1etqs71 = function _decompileImport(findModuleName,findImportedName)
+const _b7vai6 = function _decompileImport(findModuleName,findImportedName)
 {
-    return async function decompileImport(variables, options = {}) {
-        if (!variables || variables.length === 0)
-            throw new Error('no variables');
-        // #166: An import group is `[module @foo, ...aliases]` — the runtime stitch
-        // sits at index 0 by convention. Scan for the first alias (single _input,
-        // crosses module boundary) so this works whichever order the caller hands us.
-        const isCrossModuleAlias = v => {
-            const inputs = v?._inputs;
-            if (!Array.isArray(inputs) || inputs.length !== 1)
-                return false;
-            const i0 = inputs[0];
-            return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
-        };
-        const v0 = variables.find(isCrossModuleAlias);
-        if (!v0)
-            return null;
-        const input0 = v0._inputs[0];
-        const inputsLength = 1;
-        const crossesModuleBoundary = true;
-        const module_name = findModuleName(v0._module._scope, input0._module);
-        if (module_name == null)
-            throw new Error('module name could not be resolved');
-        // #166: Skip runtime-internal `module @foo` stitch variables — they belong to
-        // the import group but are not user-facing specifiers. Without this filter, an
-        // import group renders as `import {Range, module @foo} from "@foo"`.
-        const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
-            const imported = await findImportedName(v);
-            const local = v._name;
-            return {
-                imported,
-                local,
-                alias: imported !== local,
-                meta: { index }
-            };
-        }));
-        return {
-            type: 'import',
-            from: module_name,
-            specifiers,
-            meta: {
-                detection: {
-                    inputsLength,
-                    crossesModuleBoundary
-                },
-                variables: variables.map(v => v?._name ?? null)
-            }
-        };
+  return async function decompileImport(variables, options = {}) {
+    if (!variables || variables.length === 0)
+      throw new Error('no variables');
+    // An import-cell group is `[module @X stitch, ...aliases]`. Each alias goes
+    // through three lifecycle stages (documented in observable-runtime-v6's
+    // `importedModule` helper, lines ~1992-2049 of @tomlarkworthy/observable-runtime-v6):
+    //
+    //   Stage A — post-observation:
+    //     `_inputs = [Variable in source module]` (length 1, cross-module).
+    //     The Observable runtime rewrites _inputs after the alias is observed
+    //     and resolved against the source module.
+    //
+    //   Stage B — pre-observation, API-loaded (canonical compiled-bundle shape):
+    //     `_inputs = [Variable("module @X"), Variable("@variable")]` (length 2,
+    //     both in the importer module). What `runtime.define("name",
+    //     ["module @X", "@variable"], (_, v) => v.import("name", _))` produces.
+    //     Also what `compile_and_update` outputs for freshly-defined user-typed
+    //     imports until they're observed.
+    //
+    //   Stage C — pre-observation, inline live-notebook:
+    //     `_inputs = [Variable("@variable")]` (length 1) AND the definition
+    //     calls `import(...)` inside. We extract the imported module reference
+    //     by invoking the definition with a stub `import` capture.
+    //
+    // Detection order is post→pre because Stage A is unambiguous when present.
+    const isStageA = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
     };
+    const isStageB = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 2)
+        return false;
+      const [i0, i1] = inputs;
+      return !!(i0 && typeof i0 === 'object' && typeof i0._name === 'string' && i0._name.startsWith('module @') && i1 && typeof i1 === 'object' && i1._name === '@variable');
+    };
+    const isStageC = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && i0._name === '@variable' && typeof v._definition !== 'undefined' && String(v._definition).includes('import('));
+    };
+    let v0, module_name, stage;
+    if (v0 = variables.find(isStageA)) {
+      stage = 'A';
+      module_name = findModuleName(v0._module._scope, v0._inputs[0]._module);
+    } else if (v0 = variables.find(isStageB)) {
+      stage = 'B';
+      module_name = v0._inputs[0]._name.replace(/^module /, '');
+    } else if (v0 = variables.find(isStageC)) {
+      stage = 'C';
+      let capturedModule;
+      try {
+        await v0._definition({
+          import: (...args) => {
+            capturedModule = args[args.length - 1];
+          }
+        });
+      } catch (e) {
+      }
+      if (capturedModule && v0._module?._scope) {
+        module_name = findModuleName(v0._module._scope, capturedModule);
+      }
+    } else {
+      return null;
+    }
+    if (module_name == null)
+      throw new Error('module name could not be resolved');
+    // Skip runtime-internal `module @foo` stitch variables — they belong to
+    // the import group but are not user-facing specifiers. Without this filter, an
+    // import group renders as `import {Range, module @foo} from "@foo"`.
+    const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
+      const imported = await findImportedName(v);
+      const local = v._name;
+      return {
+        imported,
+        local,
+        alias: imported !== local,
+        meta: { index }
+      };
+    }));
+    return {
+      type: 'import',
+      from: module_name,
+      specifiers,
+      meta: {
+        detection: { stage },
+        variables: variables.map(v => v?._name ?? null)
+      }
+    };
+  };
 };
 const _1sylz7j = function _formatImportDeclaration(){return(
 function formatImportDeclaration(importInfo) {
@@ -20633,6 +20680,198 @@ const _1hiclbb = function _acorn_walk(acorn_walk_url) {
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
+const _1rc67k0 = function _stageB_importFake()
+{
+  return // Builds a Stage B (pre-observation, API-loaded) import group as POJOs.
+  // Mirrors what `runtime.define("name", ["module @X", "@variable"], (_, v) => v.import("name", _))`
+  // produces structurally. Used by the test_decompileImport_stageB_* tests to
+  // avoid spinning up a real Observable runtime per case.
+  function stageB_importFake(module_name, specifiers) {
+    const importerModule = { _scope: new Map() };
+    const stitch = {
+      _name: `module ${ module_name }`,
+      _module: importerModule,
+      _inputs: [],
+      _definition: `async () => null`
+    };
+    const atVariable = {
+      _name: '@variable',
+      _module: importerModule
+    };
+    const aliases = specifiers.map(s => ({
+      _name: s.local,
+      _module: importerModule,
+      _inputs: [
+        stitch,
+        atVariable
+      ],
+      _definition: s.imported === s.local ? `(_, v) => v.import("${ s.imported }", _)` : `(_, v) => v.import("${ s.imported }", "${ s.local }", _)`
+    }));
+    return [
+      stitch,
+      ...aliases
+    ];
+  };
+};
+const _1d53asg = async function _test_decompileImport_stageB_single(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [{
+      imported: 'visualize',
+      local: 'visualize'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _hv5gag = async function _test_decompileImport_stageB_aliased(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'x',
+      local: 'z'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(info.specifiers[0].alias).toEqual(true);
+  expect(formatImportDeclaration(info)).toEqual(`import {x as z} from "@user/y"`);
+  return 'ok';
+};
+const _avc18y = async function _test_decompileImport_stageB_multiple(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    },
+    {
+      imported: 'c',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b, c} from "@user/y"`);
+  return 'ok';
+};
+const _16gia7i = async function _test_decompileImport_stageB_mixed_alias(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b as c} from "@user/y"`);
+  return 'ok';
+};
+const _1slhdwo = async function _test_decompileImport_stageB_viewof(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/module-map', [{
+      imported: 'viewof currentModules',
+      local: 'viewof currentModules'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {viewof currentModules} from "@tomlarkworthy/module-map"`);
+  return 'ok';
+};
+const _qwlsf2 = async function _test_decompileImport_stageB_mutable(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'mutable counter',
+      local: 'mutable counter'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {mutable counter} from "@user/y"`);
+  return 'ok';
+};
+const _sy7jfx = async function _test_decompileImport_returns_null_for_non_import(decompileImport,expect)
+{
+  // A regular cell — no stitch, no @variable input, no cross-module reference.
+  const info = await decompileImport([{
+      _name: 'x',
+      _module: {},
+      _inputs: [],
+      _definition: `() => 42`
+    }]);
+  expect(info).toEqual(null);
+  return 'ok';
+};
+const _rk7ku3 = async function _test_decompileImport_compile_roundtrip_single(compile,expect,stageB_importFake,decompileImport,formatImportDeclaration)
+{
+  // What `compile()` emits for `import {x} from "@user/y"` is structurally the
+  // same as our stageB_importFake fixture (after runtime.define resolves the
+  // input name strings to Variable refs). Verify the fixture matches the
+  // shape compile() would produce.
+  const pojos = compile(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  expect(pojos.length).toEqual(3);
+  expect(pojos[0]._name).toEqual('module @tomlarkworthy/visualizer');
+  expect(pojos[1]._name).toEqual('visualize');
+  expect(pojos[2]._name).toEqual('Group');
+  expect(pojos[1]._inputs).toEqual([
+    'module @tomlarkworthy/visualizer',
+    '@variable'
+  ]);
+  // Now run our fixture through decompileImport — confirms the round-trip
+  // shape compile()-output-shape-when-defined → decompileImport produces the
+  // canonical import source string.
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [
+    {
+      imported: 'visualize',
+      local: 'visualize'
+    },
+    {
+      imported: 'Group',
+      local: 'Group'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _xynplo = async function _test_decompileImport_stageB_order_independent(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // The detection uses .find — it shouldn't matter whether the stitch is at
+  // index 0 or the aliases come first. Verify by reversing the array.
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    }
+  ]);
+  const reversed = [...vars].reverse();
+  const info = await decompileImport(reversed);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b} from "@user/y"`);
+  return 'ok';
+};
+const _16fpgac = async function _test_decompileImport_stageB_notebook_id(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // Observable supports `import {x} from "d/<hash>@<version>"` notebook-id form.
+  const vars = stageB_importFake('d/57d79353bac56631@44', [{
+      imported: 'hash',
+      local: 'hash'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {hash} from "d/57d79353bac56631@44"`);
+  return 'ok';
+};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -20753,7 +20992,7 @@ export default function define(runtime, observer) {
   $def("_1n7gw17", "findModuleName", ["extractModuleInfo"], _1n7gw17);  
   $def("_i47chb", "findImportedName", [], _i47chb);  
   $def("_1effqg", null, ["md"], _1effqg);  
-  $def("_1etqs71", "decompileImport", ["findModuleName","findImportedName"], _1etqs71);  
+  $def("_b7vai6", "decompileImport", ["findModuleName","findImportedName"], _b7vai6);  
   $def("_1sylz7j", "formatImportDeclaration", [], _1sylz7j);  
   $def("_13dctdn", "test_decompileImport_basic", ["importFake","decompileImport","expect"], _13dctdn);  
   $def("_ujr0xn", "test_formatImportDeclaration_roundtrip", ["importFake","decompileImport","expect","formatImportDeclaration","decompile"], _ujr0xn);  
@@ -20831,7 +21070,18 @@ export default function define(runtime, observer) {
   main.define("Runtime", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Runtime", _));  
   main.define("Inspector", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Inspector", _));  
   main.define("Library", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Library", _));  
-  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));
+  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));  
+  $def("_1rc67k0", "stageB_importFake", [], _1rc67k0);  
+  $def("_1d53asg", "test_decompileImport_stageB_single", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1d53asg);  
+  $def("_hv5gag", "test_decompileImport_stageB_aliased", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _hv5gag);  
+  $def("_avc18y", "test_decompileImport_stageB_multiple", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _avc18y);  
+  $def("_16gia7i", "test_decompileImport_stageB_mixed_alias", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16gia7i);  
+  $def("_1slhdwo", "test_decompileImport_stageB_viewof", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1slhdwo);  
+  $def("_qwlsf2", "test_decompileImport_stageB_mutable", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _qwlsf2);  
+  $def("_sy7jfx", "test_decompileImport_returns_null_for_non_import", ["decompileImport","expect"], _sy7jfx);  
+  $def("_rk7ku3", "test_decompileImport_compile_roundtrip_single", ["compile","expect","stageB_importFake","decompileImport","formatImportDeclaration"], _rk7ku3);  
+  $def("_xynplo", "test_decompileImport_stageB_order_independent", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _xynplo);  
+  $def("_16fpgac", "test_decompileImport_stageB_notebook_id", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16fpgac);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_lopepage.html
+++ b/notebooks/@tomlarkworthy_lopepage.html
@@ -19474,56 +19474,103 @@ async (v) => {
 const _1effqg = function _96(md){return(
 md`### \`decompileImport\``
 )};
-const _1etqs71 = function _decompileImport(findModuleName,findImportedName)
+const _b7vai6 = function _decompileImport(findModuleName,findImportedName)
 {
-    return async function decompileImport(variables, options = {}) {
-        if (!variables || variables.length === 0)
-            throw new Error('no variables');
-        // #166: An import group is `[module @foo, ...aliases]` — the runtime stitch
-        // sits at index 0 by convention. Scan for the first alias (single _input,
-        // crosses module boundary) so this works whichever order the caller hands us.
-        const isCrossModuleAlias = v => {
-            const inputs = v?._inputs;
-            if (!Array.isArray(inputs) || inputs.length !== 1)
-                return false;
-            const i0 = inputs[0];
-            return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
-        };
-        const v0 = variables.find(isCrossModuleAlias);
-        if (!v0)
-            return null;
-        const input0 = v0._inputs[0];
-        const inputsLength = 1;
-        const crossesModuleBoundary = true;
-        const module_name = findModuleName(v0._module._scope, input0._module);
-        if (module_name == null)
-            throw new Error('module name could not be resolved');
-        // #166: Skip runtime-internal `module @foo` stitch variables — they belong to
-        // the import group but are not user-facing specifiers. Without this filter, an
-        // import group renders as `import {Range, module @foo} from "@foo"`.
-        const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
-            const imported = await findImportedName(v);
-            const local = v._name;
-            return {
-                imported,
-                local,
-                alias: imported !== local,
-                meta: { index }
-            };
-        }));
-        return {
-            type: 'import',
-            from: module_name,
-            specifiers,
-            meta: {
-                detection: {
-                    inputsLength,
-                    crossesModuleBoundary
-                },
-                variables: variables.map(v => v?._name ?? null)
-            }
-        };
+  return async function decompileImport(variables, options = {}) {
+    if (!variables || variables.length === 0)
+      throw new Error('no variables');
+    // An import-cell group is `[module @X stitch, ...aliases]`. Each alias goes
+    // through three lifecycle stages (documented in observable-runtime-v6's
+    // `importedModule` helper, lines ~1992-2049 of @tomlarkworthy/observable-runtime-v6):
+    //
+    //   Stage A — post-observation:
+    //     `_inputs = [Variable in source module]` (length 1, cross-module).
+    //     The Observable runtime rewrites _inputs after the alias is observed
+    //     and resolved against the source module.
+    //
+    //   Stage B — pre-observation, API-loaded (canonical compiled-bundle shape):
+    //     `_inputs = [Variable("module @X"), Variable("@variable")]` (length 2,
+    //     both in the importer module). What `runtime.define("name",
+    //     ["module @X", "@variable"], (_, v) => v.import("name", _))` produces.
+    //     Also what `compile_and_update` outputs for freshly-defined user-typed
+    //     imports until they're observed.
+    //
+    //   Stage C — pre-observation, inline live-notebook:
+    //     `_inputs = [Variable("@variable")]` (length 1) AND the definition
+    //     calls `import(...)` inside. We extract the imported module reference
+    //     by invoking the definition with a stub `import` capture.
+    //
+    // Detection order is post→pre because Stage A is unambiguous when present.
+    const isStageA = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
     };
+    const isStageB = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 2)
+        return false;
+      const [i0, i1] = inputs;
+      return !!(i0 && typeof i0 === 'object' && typeof i0._name === 'string' && i0._name.startsWith('module @') && i1 && typeof i1 === 'object' && i1._name === '@variable');
+    };
+    const isStageC = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && i0._name === '@variable' && typeof v._definition !== 'undefined' && String(v._definition).includes('import('));
+    };
+    let v0, module_name, stage;
+    if (v0 = variables.find(isStageA)) {
+      stage = 'A';
+      module_name = findModuleName(v0._module._scope, v0._inputs[0]._module);
+    } else if (v0 = variables.find(isStageB)) {
+      stage = 'B';
+      module_name = v0._inputs[0]._name.replace(/^module /, '');
+    } else if (v0 = variables.find(isStageC)) {
+      stage = 'C';
+      let capturedModule;
+      try {
+        await v0._definition({
+          import: (...args) => {
+            capturedModule = args[args.length - 1];
+          }
+        });
+      } catch (e) {
+      }
+      if (capturedModule && v0._module?._scope) {
+        module_name = findModuleName(v0._module._scope, capturedModule);
+      }
+    } else {
+      return null;
+    }
+    if (module_name == null)
+      throw new Error('module name could not be resolved');
+    // Skip runtime-internal `module @foo` stitch variables — they belong to
+    // the import group but are not user-facing specifiers. Without this filter, an
+    // import group renders as `import {Range, module @foo} from "@foo"`.
+    const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
+      const imported = await findImportedName(v);
+      const local = v._name;
+      return {
+        imported,
+        local,
+        alias: imported !== local,
+        meta: { index }
+      };
+    }));
+    return {
+      type: 'import',
+      from: module_name,
+      specifiers,
+      meta: {
+        detection: { stage },
+        variables: variables.map(v => v?._name ?? null)
+      }
+    };
+  };
 };
 const _1sylz7j = function _formatImportDeclaration(){return(
 function formatImportDeclaration(importInfo) {
@@ -20633,6 +20680,198 @@ const _1hiclbb = function _acorn_walk(acorn_walk_url) {
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
+const _1rc67k0 = function _stageB_importFake()
+{
+  return // Builds a Stage B (pre-observation, API-loaded) import group as POJOs.
+  // Mirrors what `runtime.define("name", ["module @X", "@variable"], (_, v) => v.import("name", _))`
+  // produces structurally. Used by the test_decompileImport_stageB_* tests to
+  // avoid spinning up a real Observable runtime per case.
+  function stageB_importFake(module_name, specifiers) {
+    const importerModule = { _scope: new Map() };
+    const stitch = {
+      _name: `module ${ module_name }`,
+      _module: importerModule,
+      _inputs: [],
+      _definition: `async () => null`
+    };
+    const atVariable = {
+      _name: '@variable',
+      _module: importerModule
+    };
+    const aliases = specifiers.map(s => ({
+      _name: s.local,
+      _module: importerModule,
+      _inputs: [
+        stitch,
+        atVariable
+      ],
+      _definition: s.imported === s.local ? `(_, v) => v.import("${ s.imported }", _)` : `(_, v) => v.import("${ s.imported }", "${ s.local }", _)`
+    }));
+    return [
+      stitch,
+      ...aliases
+    ];
+  };
+};
+const _1d53asg = async function _test_decompileImport_stageB_single(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [{
+      imported: 'visualize',
+      local: 'visualize'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _hv5gag = async function _test_decompileImport_stageB_aliased(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'x',
+      local: 'z'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(info.specifiers[0].alias).toEqual(true);
+  expect(formatImportDeclaration(info)).toEqual(`import {x as z} from "@user/y"`);
+  return 'ok';
+};
+const _avc18y = async function _test_decompileImport_stageB_multiple(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    },
+    {
+      imported: 'c',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b, c} from "@user/y"`);
+  return 'ok';
+};
+const _16gia7i = async function _test_decompileImport_stageB_mixed_alias(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b as c} from "@user/y"`);
+  return 'ok';
+};
+const _1slhdwo = async function _test_decompileImport_stageB_viewof(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/module-map', [{
+      imported: 'viewof currentModules',
+      local: 'viewof currentModules'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {viewof currentModules} from "@tomlarkworthy/module-map"`);
+  return 'ok';
+};
+const _qwlsf2 = async function _test_decompileImport_stageB_mutable(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'mutable counter',
+      local: 'mutable counter'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {mutable counter} from "@user/y"`);
+  return 'ok';
+};
+const _sy7jfx = async function _test_decompileImport_returns_null_for_non_import(decompileImport,expect)
+{
+  // A regular cell — no stitch, no @variable input, no cross-module reference.
+  const info = await decompileImport([{
+      _name: 'x',
+      _module: {},
+      _inputs: [],
+      _definition: `() => 42`
+    }]);
+  expect(info).toEqual(null);
+  return 'ok';
+};
+const _rk7ku3 = async function _test_decompileImport_compile_roundtrip_single(compile,expect,stageB_importFake,decompileImport,formatImportDeclaration)
+{
+  // What `compile()` emits for `import {x} from "@user/y"` is structurally the
+  // same as our stageB_importFake fixture (after runtime.define resolves the
+  // input name strings to Variable refs). Verify the fixture matches the
+  // shape compile() would produce.
+  const pojos = compile(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  expect(pojos.length).toEqual(3);
+  expect(pojos[0]._name).toEqual('module @tomlarkworthy/visualizer');
+  expect(pojos[1]._name).toEqual('visualize');
+  expect(pojos[2]._name).toEqual('Group');
+  expect(pojos[1]._inputs).toEqual([
+    'module @tomlarkworthy/visualizer',
+    '@variable'
+  ]);
+  // Now run our fixture through decompileImport — confirms the round-trip
+  // shape compile()-output-shape-when-defined → decompileImport produces the
+  // canonical import source string.
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [
+    {
+      imported: 'visualize',
+      local: 'visualize'
+    },
+    {
+      imported: 'Group',
+      local: 'Group'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _xynplo = async function _test_decompileImport_stageB_order_independent(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // The detection uses .find — it shouldn't matter whether the stitch is at
+  // index 0 or the aliases come first. Verify by reversing the array.
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    }
+  ]);
+  const reversed = [...vars].reverse();
+  const info = await decompileImport(reversed);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b} from "@user/y"`);
+  return 'ok';
+};
+const _16fpgac = async function _test_decompileImport_stageB_notebook_id(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // Observable supports `import {x} from "d/<hash>@<version>"` notebook-id form.
+  const vars = stageB_importFake('d/57d79353bac56631@44', [{
+      imported: 'hash',
+      local: 'hash'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {hash} from "d/57d79353bac56631@44"`);
+  return 'ok';
+};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -20753,7 +20992,7 @@ export default function define(runtime, observer) {
   $def("_1n7gw17", "findModuleName", ["extractModuleInfo"], _1n7gw17);  
   $def("_i47chb", "findImportedName", [], _i47chb);  
   $def("_1effqg", null, ["md"], _1effqg);  
-  $def("_1etqs71", "decompileImport", ["findModuleName","findImportedName"], _1etqs71);  
+  $def("_b7vai6", "decompileImport", ["findModuleName","findImportedName"], _b7vai6);  
   $def("_1sylz7j", "formatImportDeclaration", [], _1sylz7j);  
   $def("_13dctdn", "test_decompileImport_basic", ["importFake","decompileImport","expect"], _13dctdn);  
   $def("_ujr0xn", "test_formatImportDeclaration_roundtrip", ["importFake","decompileImport","expect","formatImportDeclaration","decompile"], _ujr0xn);  
@@ -20831,7 +21070,18 @@ export default function define(runtime, observer) {
   main.define("Runtime", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Runtime", _));  
   main.define("Inspector", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Inspector", _));  
   main.define("Library", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Library", _));  
-  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));
+  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));  
+  $def("_1rc67k0", "stageB_importFake", [], _1rc67k0);  
+  $def("_1d53asg", "test_decompileImport_stageB_single", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1d53asg);  
+  $def("_hv5gag", "test_decompileImport_stageB_aliased", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _hv5gag);  
+  $def("_avc18y", "test_decompileImport_stageB_multiple", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _avc18y);  
+  $def("_16gia7i", "test_decompileImport_stageB_mixed_alias", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16gia7i);  
+  $def("_1slhdwo", "test_decompileImport_stageB_viewof", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1slhdwo);  
+  $def("_qwlsf2", "test_decompileImport_stageB_mutable", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _qwlsf2);  
+  $def("_sy7jfx", "test_decompileImport_returns_null_for_non_import", ["decompileImport","expect"], _sy7jfx);  
+  $def("_rk7ku3", "test_decompileImport_compile_roundtrip_single", ["compile","expect","stageB_importFake","decompileImport","formatImportDeclaration"], _rk7ku3);  
+  $def("_xynplo", "test_decompileImport_stageB_order_independent", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _xynplo);  
+  $def("_16fpgac", "test_decompileImport_stageB_notebook_id", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16fpgac);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_modern-screenshot.html
+++ b/notebooks/@tomlarkworthy_modern-screenshot.html
@@ -19526,56 +19526,103 @@ async (v) => {
 const _1effqg = function _96(md){return(
 md`### \`decompileImport\``
 )};
-const _1etqs71 = function _decompileImport(findModuleName,findImportedName)
+const _b7vai6 = function _decompileImport(findModuleName,findImportedName)
 {
-    return async function decompileImport(variables, options = {}) {
-        if (!variables || variables.length === 0)
-            throw new Error('no variables');
-        // #166: An import group is `[module @foo, ...aliases]` — the runtime stitch
-        // sits at index 0 by convention. Scan for the first alias (single _input,
-        // crosses module boundary) so this works whichever order the caller hands us.
-        const isCrossModuleAlias = v => {
-            const inputs = v?._inputs;
-            if (!Array.isArray(inputs) || inputs.length !== 1)
-                return false;
-            const i0 = inputs[0];
-            return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
-        };
-        const v0 = variables.find(isCrossModuleAlias);
-        if (!v0)
-            return null;
-        const input0 = v0._inputs[0];
-        const inputsLength = 1;
-        const crossesModuleBoundary = true;
-        const module_name = findModuleName(v0._module._scope, input0._module);
-        if (module_name == null)
-            throw new Error('module name could not be resolved');
-        // #166: Skip runtime-internal `module @foo` stitch variables — they belong to
-        // the import group but are not user-facing specifiers. Without this filter, an
-        // import group renders as `import {Range, module @foo} from "@foo"`.
-        const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
-            const imported = await findImportedName(v);
-            const local = v._name;
-            return {
-                imported,
-                local,
-                alias: imported !== local,
-                meta: { index }
-            };
-        }));
-        return {
-            type: 'import',
-            from: module_name,
-            specifiers,
-            meta: {
-                detection: {
-                    inputsLength,
-                    crossesModuleBoundary
-                },
-                variables: variables.map(v => v?._name ?? null)
-            }
-        };
+  return async function decompileImport(variables, options = {}) {
+    if (!variables || variables.length === 0)
+      throw new Error('no variables');
+    // An import-cell group is `[module @X stitch, ...aliases]`. Each alias goes
+    // through three lifecycle stages (documented in observable-runtime-v6's
+    // `importedModule` helper, lines ~1992-2049 of @tomlarkworthy/observable-runtime-v6):
+    //
+    //   Stage A — post-observation:
+    //     `_inputs = [Variable in source module]` (length 1, cross-module).
+    //     The Observable runtime rewrites _inputs after the alias is observed
+    //     and resolved against the source module.
+    //
+    //   Stage B — pre-observation, API-loaded (canonical compiled-bundle shape):
+    //     `_inputs = [Variable("module @X"), Variable("@variable")]` (length 2,
+    //     both in the importer module). What `runtime.define("name",
+    //     ["module @X", "@variable"], (_, v) => v.import("name", _))` produces.
+    //     Also what `compile_and_update` outputs for freshly-defined user-typed
+    //     imports until they're observed.
+    //
+    //   Stage C — pre-observation, inline live-notebook:
+    //     `_inputs = [Variable("@variable")]` (length 1) AND the definition
+    //     calls `import(...)` inside. We extract the imported module reference
+    //     by invoking the definition with a stub `import` capture.
+    //
+    // Detection order is post→pre because Stage A is unambiguous when present.
+    const isStageA = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
     };
+    const isStageB = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 2)
+        return false;
+      const [i0, i1] = inputs;
+      return !!(i0 && typeof i0 === 'object' && typeof i0._name === 'string' && i0._name.startsWith('module @') && i1 && typeof i1 === 'object' && i1._name === '@variable');
+    };
+    const isStageC = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && i0._name === '@variable' && typeof v._definition !== 'undefined' && String(v._definition).includes('import('));
+    };
+    let v0, module_name, stage;
+    if (v0 = variables.find(isStageA)) {
+      stage = 'A';
+      module_name = findModuleName(v0._module._scope, v0._inputs[0]._module);
+    } else if (v0 = variables.find(isStageB)) {
+      stage = 'B';
+      module_name = v0._inputs[0]._name.replace(/^module /, '');
+    } else if (v0 = variables.find(isStageC)) {
+      stage = 'C';
+      let capturedModule;
+      try {
+        await v0._definition({
+          import: (...args) => {
+            capturedModule = args[args.length - 1];
+          }
+        });
+      } catch (e) {
+      }
+      if (capturedModule && v0._module?._scope) {
+        module_name = findModuleName(v0._module._scope, capturedModule);
+      }
+    } else {
+      return null;
+    }
+    if (module_name == null)
+      throw new Error('module name could not be resolved');
+    // Skip runtime-internal `module @foo` stitch variables — they belong to
+    // the import group but are not user-facing specifiers. Without this filter, an
+    // import group renders as `import {Range, module @foo} from "@foo"`.
+    const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
+      const imported = await findImportedName(v);
+      const local = v._name;
+      return {
+        imported,
+        local,
+        alias: imported !== local,
+        meta: { index }
+      };
+    }));
+    return {
+      type: 'import',
+      from: module_name,
+      specifiers,
+      meta: {
+        detection: { stage },
+        variables: variables.map(v => v?._name ?? null)
+      }
+    };
+  };
 };
 const _1sylz7j = function _formatImportDeclaration(){return(
 function formatImportDeclaration(importInfo) {
@@ -20685,6 +20732,198 @@ const _1hiclbb = function _acorn_walk(acorn_walk_url) {
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
+const _1rc67k0 = function _stageB_importFake()
+{
+  return // Builds a Stage B (pre-observation, API-loaded) import group as POJOs.
+  // Mirrors what `runtime.define("name", ["module @X", "@variable"], (_, v) => v.import("name", _))`
+  // produces structurally. Used by the test_decompileImport_stageB_* tests to
+  // avoid spinning up a real Observable runtime per case.
+  function stageB_importFake(module_name, specifiers) {
+    const importerModule = { _scope: new Map() };
+    const stitch = {
+      _name: `module ${ module_name }`,
+      _module: importerModule,
+      _inputs: [],
+      _definition: `async () => null`
+    };
+    const atVariable = {
+      _name: '@variable',
+      _module: importerModule
+    };
+    const aliases = specifiers.map(s => ({
+      _name: s.local,
+      _module: importerModule,
+      _inputs: [
+        stitch,
+        atVariable
+      ],
+      _definition: s.imported === s.local ? `(_, v) => v.import("${ s.imported }", _)` : `(_, v) => v.import("${ s.imported }", "${ s.local }", _)`
+    }));
+    return [
+      stitch,
+      ...aliases
+    ];
+  };
+};
+const _1d53asg = async function _test_decompileImport_stageB_single(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [{
+      imported: 'visualize',
+      local: 'visualize'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _hv5gag = async function _test_decompileImport_stageB_aliased(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'x',
+      local: 'z'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(info.specifiers[0].alias).toEqual(true);
+  expect(formatImportDeclaration(info)).toEqual(`import {x as z} from "@user/y"`);
+  return 'ok';
+};
+const _avc18y = async function _test_decompileImport_stageB_multiple(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    },
+    {
+      imported: 'c',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b, c} from "@user/y"`);
+  return 'ok';
+};
+const _16gia7i = async function _test_decompileImport_stageB_mixed_alias(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b as c} from "@user/y"`);
+  return 'ok';
+};
+const _1slhdwo = async function _test_decompileImport_stageB_viewof(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/module-map', [{
+      imported: 'viewof currentModules',
+      local: 'viewof currentModules'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {viewof currentModules} from "@tomlarkworthy/module-map"`);
+  return 'ok';
+};
+const _qwlsf2 = async function _test_decompileImport_stageB_mutable(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'mutable counter',
+      local: 'mutable counter'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {mutable counter} from "@user/y"`);
+  return 'ok';
+};
+const _sy7jfx = async function _test_decompileImport_returns_null_for_non_import(decompileImport,expect)
+{
+  // A regular cell — no stitch, no @variable input, no cross-module reference.
+  const info = await decompileImport([{
+      _name: 'x',
+      _module: {},
+      _inputs: [],
+      _definition: `() => 42`
+    }]);
+  expect(info).toEqual(null);
+  return 'ok';
+};
+const _rk7ku3 = async function _test_decompileImport_compile_roundtrip_single(compile,expect,stageB_importFake,decompileImport,formatImportDeclaration)
+{
+  // What `compile()` emits for `import {x} from "@user/y"` is structurally the
+  // same as our stageB_importFake fixture (after runtime.define resolves the
+  // input name strings to Variable refs). Verify the fixture matches the
+  // shape compile() would produce.
+  const pojos = compile(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  expect(pojos.length).toEqual(3);
+  expect(pojos[0]._name).toEqual('module @tomlarkworthy/visualizer');
+  expect(pojos[1]._name).toEqual('visualize');
+  expect(pojos[2]._name).toEqual('Group');
+  expect(pojos[1]._inputs).toEqual([
+    'module @tomlarkworthy/visualizer',
+    '@variable'
+  ]);
+  // Now run our fixture through decompileImport — confirms the round-trip
+  // shape compile()-output-shape-when-defined → decompileImport produces the
+  // canonical import source string.
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [
+    {
+      imported: 'visualize',
+      local: 'visualize'
+    },
+    {
+      imported: 'Group',
+      local: 'Group'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _xynplo = async function _test_decompileImport_stageB_order_independent(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // The detection uses .find — it shouldn't matter whether the stitch is at
+  // index 0 or the aliases come first. Verify by reversing the array.
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    }
+  ]);
+  const reversed = [...vars].reverse();
+  const info = await decompileImport(reversed);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b} from "@user/y"`);
+  return 'ok';
+};
+const _16fpgac = async function _test_decompileImport_stageB_notebook_id(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // Observable supports `import {x} from "d/<hash>@<version>"` notebook-id form.
+  const vars = stageB_importFake('d/57d79353bac56631@44', [{
+      imported: 'hash',
+      local: 'hash'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {hash} from "d/57d79353bac56631@44"`);
+  return 'ok';
+};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -20805,7 +21044,7 @@ export default function define(runtime, observer) {
   $def("_1n7gw17", "findModuleName", ["extractModuleInfo"], _1n7gw17);  
   $def("_i47chb", "findImportedName", [], _i47chb);  
   $def("_1effqg", null, ["md"], _1effqg);  
-  $def("_1etqs71", "decompileImport", ["findModuleName","findImportedName"], _1etqs71);  
+  $def("_b7vai6", "decompileImport", ["findModuleName","findImportedName"], _b7vai6);  
   $def("_1sylz7j", "formatImportDeclaration", [], _1sylz7j);  
   $def("_13dctdn", "test_decompileImport_basic", ["importFake","decompileImport","expect"], _13dctdn);  
   $def("_ujr0xn", "test_formatImportDeclaration_roundtrip", ["importFake","decompileImport","expect","formatImportDeclaration","decompile"], _ujr0xn);  
@@ -20883,7 +21122,18 @@ export default function define(runtime, observer) {
   main.define("Runtime", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Runtime", _));  
   main.define("Inspector", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Inspector", _));  
   main.define("Library", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Library", _));  
-  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));
+  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));  
+  $def("_1rc67k0", "stageB_importFake", [], _1rc67k0);  
+  $def("_1d53asg", "test_decompileImport_stageB_single", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1d53asg);  
+  $def("_hv5gag", "test_decompileImport_stageB_aliased", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _hv5gag);  
+  $def("_avc18y", "test_decompileImport_stageB_multiple", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _avc18y);  
+  $def("_16gia7i", "test_decompileImport_stageB_mixed_alias", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16gia7i);  
+  $def("_1slhdwo", "test_decompileImport_stageB_viewof", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1slhdwo);  
+  $def("_qwlsf2", "test_decompileImport_stageB_mutable", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _qwlsf2);  
+  $def("_sy7jfx", "test_decompileImport_returns_null_for_non_import", ["decompileImport","expect"], _sy7jfx);  
+  $def("_rk7ku3", "test_decompileImport_compile_roundtrip_single", ["compile","expect","stageB_importFake","decompileImport","formatImportDeclaration"], _rk7ku3);  
+  $def("_xynplo", "test_decompileImport_stageB_order_independent", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _xynplo);  
+  $def("_16fpgac", "test_decompileImport_stageB_notebook_id", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16fpgac);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_module-selection.html
+++ b/notebooks/@tomlarkworthy_module-selection.html
@@ -19474,56 +19474,103 @@ async (v) => {
 const _1effqg = function _96(md){return(
 md`### \`decompileImport\``
 )};
-const _1etqs71 = function _decompileImport(findModuleName,findImportedName)
+const _b7vai6 = function _decompileImport(findModuleName,findImportedName)
 {
-    return async function decompileImport(variables, options = {}) {
-        if (!variables || variables.length === 0)
-            throw new Error('no variables');
-        // #166: An import group is `[module @foo, ...aliases]` — the runtime stitch
-        // sits at index 0 by convention. Scan for the first alias (single _input,
-        // crosses module boundary) so this works whichever order the caller hands us.
-        const isCrossModuleAlias = v => {
-            const inputs = v?._inputs;
-            if (!Array.isArray(inputs) || inputs.length !== 1)
-                return false;
-            const i0 = inputs[0];
-            return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
-        };
-        const v0 = variables.find(isCrossModuleAlias);
-        if (!v0)
-            return null;
-        const input0 = v0._inputs[0];
-        const inputsLength = 1;
-        const crossesModuleBoundary = true;
-        const module_name = findModuleName(v0._module._scope, input0._module);
-        if (module_name == null)
-            throw new Error('module name could not be resolved');
-        // #166: Skip runtime-internal `module @foo` stitch variables — they belong to
-        // the import group but are not user-facing specifiers. Without this filter, an
-        // import group renders as `import {Range, module @foo} from "@foo"`.
-        const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
-            const imported = await findImportedName(v);
-            const local = v._name;
-            return {
-                imported,
-                local,
-                alias: imported !== local,
-                meta: { index }
-            };
-        }));
-        return {
-            type: 'import',
-            from: module_name,
-            specifiers,
-            meta: {
-                detection: {
-                    inputsLength,
-                    crossesModuleBoundary
-                },
-                variables: variables.map(v => v?._name ?? null)
-            }
-        };
+  return async function decompileImport(variables, options = {}) {
+    if (!variables || variables.length === 0)
+      throw new Error('no variables');
+    // An import-cell group is `[module @X stitch, ...aliases]`. Each alias goes
+    // through three lifecycle stages (documented in observable-runtime-v6's
+    // `importedModule` helper, lines ~1992-2049 of @tomlarkworthy/observable-runtime-v6):
+    //
+    //   Stage A — post-observation:
+    //     `_inputs = [Variable in source module]` (length 1, cross-module).
+    //     The Observable runtime rewrites _inputs after the alias is observed
+    //     and resolved against the source module.
+    //
+    //   Stage B — pre-observation, API-loaded (canonical compiled-bundle shape):
+    //     `_inputs = [Variable("module @X"), Variable("@variable")]` (length 2,
+    //     both in the importer module). What `runtime.define("name",
+    //     ["module @X", "@variable"], (_, v) => v.import("name", _))` produces.
+    //     Also what `compile_and_update` outputs for freshly-defined user-typed
+    //     imports until they're observed.
+    //
+    //   Stage C — pre-observation, inline live-notebook:
+    //     `_inputs = [Variable("@variable")]` (length 1) AND the definition
+    //     calls `import(...)` inside. We extract the imported module reference
+    //     by invoking the definition with a stub `import` capture.
+    //
+    // Detection order is post→pre because Stage A is unambiguous when present.
+    const isStageA = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
     };
+    const isStageB = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 2)
+        return false;
+      const [i0, i1] = inputs;
+      return !!(i0 && typeof i0 === 'object' && typeof i0._name === 'string' && i0._name.startsWith('module @') && i1 && typeof i1 === 'object' && i1._name === '@variable');
+    };
+    const isStageC = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && i0._name === '@variable' && typeof v._definition !== 'undefined' && String(v._definition).includes('import('));
+    };
+    let v0, module_name, stage;
+    if (v0 = variables.find(isStageA)) {
+      stage = 'A';
+      module_name = findModuleName(v0._module._scope, v0._inputs[0]._module);
+    } else if (v0 = variables.find(isStageB)) {
+      stage = 'B';
+      module_name = v0._inputs[0]._name.replace(/^module /, '');
+    } else if (v0 = variables.find(isStageC)) {
+      stage = 'C';
+      let capturedModule;
+      try {
+        await v0._definition({
+          import: (...args) => {
+            capturedModule = args[args.length - 1];
+          }
+        });
+      } catch (e) {
+      }
+      if (capturedModule && v0._module?._scope) {
+        module_name = findModuleName(v0._module._scope, capturedModule);
+      }
+    } else {
+      return null;
+    }
+    if (module_name == null)
+      throw new Error('module name could not be resolved');
+    // Skip runtime-internal `module @foo` stitch variables — they belong to
+    // the import group but are not user-facing specifiers. Without this filter, an
+    // import group renders as `import {Range, module @foo} from "@foo"`.
+    const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
+      const imported = await findImportedName(v);
+      const local = v._name;
+      return {
+        imported,
+        local,
+        alias: imported !== local,
+        meta: { index }
+      };
+    }));
+    return {
+      type: 'import',
+      from: module_name,
+      specifiers,
+      meta: {
+        detection: { stage },
+        variables: variables.map(v => v?._name ?? null)
+      }
+    };
+  };
 };
 const _1sylz7j = function _formatImportDeclaration(){return(
 function formatImportDeclaration(importInfo) {
@@ -20633,6 +20680,198 @@ const _1hiclbb = function _acorn_walk(acorn_walk_url) {
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
+const _1rc67k0 = function _stageB_importFake()
+{
+  return // Builds a Stage B (pre-observation, API-loaded) import group as POJOs.
+  // Mirrors what `runtime.define("name", ["module @X", "@variable"], (_, v) => v.import("name", _))`
+  // produces structurally. Used by the test_decompileImport_stageB_* tests to
+  // avoid spinning up a real Observable runtime per case.
+  function stageB_importFake(module_name, specifiers) {
+    const importerModule = { _scope: new Map() };
+    const stitch = {
+      _name: `module ${ module_name }`,
+      _module: importerModule,
+      _inputs: [],
+      _definition: `async () => null`
+    };
+    const atVariable = {
+      _name: '@variable',
+      _module: importerModule
+    };
+    const aliases = specifiers.map(s => ({
+      _name: s.local,
+      _module: importerModule,
+      _inputs: [
+        stitch,
+        atVariable
+      ],
+      _definition: s.imported === s.local ? `(_, v) => v.import("${ s.imported }", _)` : `(_, v) => v.import("${ s.imported }", "${ s.local }", _)`
+    }));
+    return [
+      stitch,
+      ...aliases
+    ];
+  };
+};
+const _1d53asg = async function _test_decompileImport_stageB_single(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [{
+      imported: 'visualize',
+      local: 'visualize'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _hv5gag = async function _test_decompileImport_stageB_aliased(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'x',
+      local: 'z'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(info.specifiers[0].alias).toEqual(true);
+  expect(formatImportDeclaration(info)).toEqual(`import {x as z} from "@user/y"`);
+  return 'ok';
+};
+const _avc18y = async function _test_decompileImport_stageB_multiple(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    },
+    {
+      imported: 'c',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b, c} from "@user/y"`);
+  return 'ok';
+};
+const _16gia7i = async function _test_decompileImport_stageB_mixed_alias(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b as c} from "@user/y"`);
+  return 'ok';
+};
+const _1slhdwo = async function _test_decompileImport_stageB_viewof(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/module-map', [{
+      imported: 'viewof currentModules',
+      local: 'viewof currentModules'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {viewof currentModules} from "@tomlarkworthy/module-map"`);
+  return 'ok';
+};
+const _qwlsf2 = async function _test_decompileImport_stageB_mutable(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'mutable counter',
+      local: 'mutable counter'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {mutable counter} from "@user/y"`);
+  return 'ok';
+};
+const _sy7jfx = async function _test_decompileImport_returns_null_for_non_import(decompileImport,expect)
+{
+  // A regular cell — no stitch, no @variable input, no cross-module reference.
+  const info = await decompileImport([{
+      _name: 'x',
+      _module: {},
+      _inputs: [],
+      _definition: `() => 42`
+    }]);
+  expect(info).toEqual(null);
+  return 'ok';
+};
+const _rk7ku3 = async function _test_decompileImport_compile_roundtrip_single(compile,expect,stageB_importFake,decompileImport,formatImportDeclaration)
+{
+  // What `compile()` emits for `import {x} from "@user/y"` is structurally the
+  // same as our stageB_importFake fixture (after runtime.define resolves the
+  // input name strings to Variable refs). Verify the fixture matches the
+  // shape compile() would produce.
+  const pojos = compile(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  expect(pojos.length).toEqual(3);
+  expect(pojos[0]._name).toEqual('module @tomlarkworthy/visualizer');
+  expect(pojos[1]._name).toEqual('visualize');
+  expect(pojos[2]._name).toEqual('Group');
+  expect(pojos[1]._inputs).toEqual([
+    'module @tomlarkworthy/visualizer',
+    '@variable'
+  ]);
+  // Now run our fixture through decompileImport — confirms the round-trip
+  // shape compile()-output-shape-when-defined → decompileImport produces the
+  // canonical import source string.
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [
+    {
+      imported: 'visualize',
+      local: 'visualize'
+    },
+    {
+      imported: 'Group',
+      local: 'Group'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _xynplo = async function _test_decompileImport_stageB_order_independent(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // The detection uses .find — it shouldn't matter whether the stitch is at
+  // index 0 or the aliases come first. Verify by reversing the array.
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    }
+  ]);
+  const reversed = [...vars].reverse();
+  const info = await decompileImport(reversed);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b} from "@user/y"`);
+  return 'ok';
+};
+const _16fpgac = async function _test_decompileImport_stageB_notebook_id(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // Observable supports `import {x} from "d/<hash>@<version>"` notebook-id form.
+  const vars = stageB_importFake('d/57d79353bac56631@44', [{
+      imported: 'hash',
+      local: 'hash'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {hash} from "d/57d79353bac56631@44"`);
+  return 'ok';
+};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -20753,7 +20992,7 @@ export default function define(runtime, observer) {
   $def("_1n7gw17", "findModuleName", ["extractModuleInfo"], _1n7gw17);  
   $def("_i47chb", "findImportedName", [], _i47chb);  
   $def("_1effqg", null, ["md"], _1effqg);  
-  $def("_1etqs71", "decompileImport", ["findModuleName","findImportedName"], _1etqs71);  
+  $def("_b7vai6", "decompileImport", ["findModuleName","findImportedName"], _b7vai6);  
   $def("_1sylz7j", "formatImportDeclaration", [], _1sylz7j);  
   $def("_13dctdn", "test_decompileImport_basic", ["importFake","decompileImport","expect"], _13dctdn);  
   $def("_ujr0xn", "test_formatImportDeclaration_roundtrip", ["importFake","decompileImport","expect","formatImportDeclaration","decompile"], _ujr0xn);  
@@ -20831,7 +21070,18 @@ export default function define(runtime, observer) {
   main.define("Runtime", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Runtime", _));  
   main.define("Inspector", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Inspector", _));  
   main.define("Library", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Library", _));  
-  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));
+  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));  
+  $def("_1rc67k0", "stageB_importFake", [], _1rc67k0);  
+  $def("_1d53asg", "test_decompileImport_stageB_single", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1d53asg);  
+  $def("_hv5gag", "test_decompileImport_stageB_aliased", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _hv5gag);  
+  $def("_avc18y", "test_decompileImport_stageB_multiple", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _avc18y);  
+  $def("_16gia7i", "test_decompileImport_stageB_mixed_alias", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16gia7i);  
+  $def("_1slhdwo", "test_decompileImport_stageB_viewof", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1slhdwo);  
+  $def("_qwlsf2", "test_decompileImport_stageB_mutable", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _qwlsf2);  
+  $def("_sy7jfx", "test_decompileImport_returns_null_for_non_import", ["decompileImport","expect"], _sy7jfx);  
+  $def("_rk7ku3", "test_decompileImport_compile_roundtrip_single", ["compile","expect","stageB_importFake","decompileImport","formatImportDeclaration"], _rk7ku3);  
+  $def("_xynplo", "test_decompileImport_stageB_order_independent", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _xynplo);  
+  $def("_16fpgac", "test_decompileImport_stageB_notebook_id", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16fpgac);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_notes.html
+++ b/notebooks/@tomlarkworthy_notes.html
@@ -20048,56 +20048,103 @@ async (v) => {
 const _1effqg = function _96(md){return(
 md`### \`decompileImport\``
 )};
-const _1etqs71 = function _decompileImport(findModuleName,findImportedName)
+const _b7vai6 = function _decompileImport(findModuleName,findImportedName)
 {
-    return async function decompileImport(variables, options = {}) {
-        if (!variables || variables.length === 0)
-            throw new Error('no variables');
-        // #166: An import group is `[module @foo, ...aliases]` — the runtime stitch
-        // sits at index 0 by convention. Scan for the first alias (single _input,
-        // crosses module boundary) so this works whichever order the caller hands us.
-        const isCrossModuleAlias = v => {
-            const inputs = v?._inputs;
-            if (!Array.isArray(inputs) || inputs.length !== 1)
-                return false;
-            const i0 = inputs[0];
-            return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
-        };
-        const v0 = variables.find(isCrossModuleAlias);
-        if (!v0)
-            return null;
-        const input0 = v0._inputs[0];
-        const inputsLength = 1;
-        const crossesModuleBoundary = true;
-        const module_name = findModuleName(v0._module._scope, input0._module);
-        if (module_name == null)
-            throw new Error('module name could not be resolved');
-        // #166: Skip runtime-internal `module @foo` stitch variables — they belong to
-        // the import group but are not user-facing specifiers. Without this filter, an
-        // import group renders as `import {Range, module @foo} from "@foo"`.
-        const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
-            const imported = await findImportedName(v);
-            const local = v._name;
-            return {
-                imported,
-                local,
-                alias: imported !== local,
-                meta: { index }
-            };
-        }));
-        return {
-            type: 'import',
-            from: module_name,
-            specifiers,
-            meta: {
-                detection: {
-                    inputsLength,
-                    crossesModuleBoundary
-                },
-                variables: variables.map(v => v?._name ?? null)
-            }
-        };
+  return async function decompileImport(variables, options = {}) {
+    if (!variables || variables.length === 0)
+      throw new Error('no variables');
+    // An import-cell group is `[module @X stitch, ...aliases]`. Each alias goes
+    // through three lifecycle stages (documented in observable-runtime-v6's
+    // `importedModule` helper, lines ~1992-2049 of @tomlarkworthy/observable-runtime-v6):
+    //
+    //   Stage A — post-observation:
+    //     `_inputs = [Variable in source module]` (length 1, cross-module).
+    //     The Observable runtime rewrites _inputs after the alias is observed
+    //     and resolved against the source module.
+    //
+    //   Stage B — pre-observation, API-loaded (canonical compiled-bundle shape):
+    //     `_inputs = [Variable("module @X"), Variable("@variable")]` (length 2,
+    //     both in the importer module). What `runtime.define("name",
+    //     ["module @X", "@variable"], (_, v) => v.import("name", _))` produces.
+    //     Also what `compile_and_update` outputs for freshly-defined user-typed
+    //     imports until they're observed.
+    //
+    //   Stage C — pre-observation, inline live-notebook:
+    //     `_inputs = [Variable("@variable")]` (length 1) AND the definition
+    //     calls `import(...)` inside. We extract the imported module reference
+    //     by invoking the definition with a stub `import` capture.
+    //
+    // Detection order is post→pre because Stage A is unambiguous when present.
+    const isStageA = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
     };
+    const isStageB = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 2)
+        return false;
+      const [i0, i1] = inputs;
+      return !!(i0 && typeof i0 === 'object' && typeof i0._name === 'string' && i0._name.startsWith('module @') && i1 && typeof i1 === 'object' && i1._name === '@variable');
+    };
+    const isStageC = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && i0._name === '@variable' && typeof v._definition !== 'undefined' && String(v._definition).includes('import('));
+    };
+    let v0, module_name, stage;
+    if (v0 = variables.find(isStageA)) {
+      stage = 'A';
+      module_name = findModuleName(v0._module._scope, v0._inputs[0]._module);
+    } else if (v0 = variables.find(isStageB)) {
+      stage = 'B';
+      module_name = v0._inputs[0]._name.replace(/^module /, '');
+    } else if (v0 = variables.find(isStageC)) {
+      stage = 'C';
+      let capturedModule;
+      try {
+        await v0._definition({
+          import: (...args) => {
+            capturedModule = args[args.length - 1];
+          }
+        });
+      } catch (e) {
+      }
+      if (capturedModule && v0._module?._scope) {
+        module_name = findModuleName(v0._module._scope, capturedModule);
+      }
+    } else {
+      return null;
+    }
+    if (module_name == null)
+      throw new Error('module name could not be resolved');
+    // Skip runtime-internal `module @foo` stitch variables — they belong to
+    // the import group but are not user-facing specifiers. Without this filter, an
+    // import group renders as `import {Range, module @foo} from "@foo"`.
+    const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
+      const imported = await findImportedName(v);
+      const local = v._name;
+      return {
+        imported,
+        local,
+        alias: imported !== local,
+        meta: { index }
+      };
+    }));
+    return {
+      type: 'import',
+      from: module_name,
+      specifiers,
+      meta: {
+        detection: { stage },
+        variables: variables.map(v => v?._name ?? null)
+      }
+    };
+  };
 };
 const _1sylz7j = function _formatImportDeclaration(){return(
 function formatImportDeclaration(importInfo) {
@@ -21207,6 +21254,198 @@ const _1hiclbb = function _acorn_walk(acorn_walk_url) {
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
+const _1rc67k0 = function _stageB_importFake()
+{
+  return // Builds a Stage B (pre-observation, API-loaded) import group as POJOs.
+  // Mirrors what `runtime.define("name", ["module @X", "@variable"], (_, v) => v.import("name", _))`
+  // produces structurally. Used by the test_decompileImport_stageB_* tests to
+  // avoid spinning up a real Observable runtime per case.
+  function stageB_importFake(module_name, specifiers) {
+    const importerModule = { _scope: new Map() };
+    const stitch = {
+      _name: `module ${ module_name }`,
+      _module: importerModule,
+      _inputs: [],
+      _definition: `async () => null`
+    };
+    const atVariable = {
+      _name: '@variable',
+      _module: importerModule
+    };
+    const aliases = specifiers.map(s => ({
+      _name: s.local,
+      _module: importerModule,
+      _inputs: [
+        stitch,
+        atVariable
+      ],
+      _definition: s.imported === s.local ? `(_, v) => v.import("${ s.imported }", _)` : `(_, v) => v.import("${ s.imported }", "${ s.local }", _)`
+    }));
+    return [
+      stitch,
+      ...aliases
+    ];
+  };
+};
+const _1d53asg = async function _test_decompileImport_stageB_single(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [{
+      imported: 'visualize',
+      local: 'visualize'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _hv5gag = async function _test_decompileImport_stageB_aliased(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'x',
+      local: 'z'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(info.specifiers[0].alias).toEqual(true);
+  expect(formatImportDeclaration(info)).toEqual(`import {x as z} from "@user/y"`);
+  return 'ok';
+};
+const _avc18y = async function _test_decompileImport_stageB_multiple(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    },
+    {
+      imported: 'c',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b, c} from "@user/y"`);
+  return 'ok';
+};
+const _16gia7i = async function _test_decompileImport_stageB_mixed_alias(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b as c} from "@user/y"`);
+  return 'ok';
+};
+const _1slhdwo = async function _test_decompileImport_stageB_viewof(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/module-map', [{
+      imported: 'viewof currentModules',
+      local: 'viewof currentModules'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {viewof currentModules} from "@tomlarkworthy/module-map"`);
+  return 'ok';
+};
+const _qwlsf2 = async function _test_decompileImport_stageB_mutable(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'mutable counter',
+      local: 'mutable counter'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {mutable counter} from "@user/y"`);
+  return 'ok';
+};
+const _sy7jfx = async function _test_decompileImport_returns_null_for_non_import(decompileImport,expect)
+{
+  // A regular cell — no stitch, no @variable input, no cross-module reference.
+  const info = await decompileImport([{
+      _name: 'x',
+      _module: {},
+      _inputs: [],
+      _definition: `() => 42`
+    }]);
+  expect(info).toEqual(null);
+  return 'ok';
+};
+const _rk7ku3 = async function _test_decompileImport_compile_roundtrip_single(compile,expect,stageB_importFake,decompileImport,formatImportDeclaration)
+{
+  // What `compile()` emits for `import {x} from "@user/y"` is structurally the
+  // same as our stageB_importFake fixture (after runtime.define resolves the
+  // input name strings to Variable refs). Verify the fixture matches the
+  // shape compile() would produce.
+  const pojos = compile(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  expect(pojos.length).toEqual(3);
+  expect(pojos[0]._name).toEqual('module @tomlarkworthy/visualizer');
+  expect(pojos[1]._name).toEqual('visualize');
+  expect(pojos[2]._name).toEqual('Group');
+  expect(pojos[1]._inputs).toEqual([
+    'module @tomlarkworthy/visualizer',
+    '@variable'
+  ]);
+  // Now run our fixture through decompileImport — confirms the round-trip
+  // shape compile()-output-shape-when-defined → decompileImport produces the
+  // canonical import source string.
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [
+    {
+      imported: 'visualize',
+      local: 'visualize'
+    },
+    {
+      imported: 'Group',
+      local: 'Group'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _xynplo = async function _test_decompileImport_stageB_order_independent(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // The detection uses .find — it shouldn't matter whether the stitch is at
+  // index 0 or the aliases come first. Verify by reversing the array.
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    }
+  ]);
+  const reversed = [...vars].reverse();
+  const info = await decompileImport(reversed);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b} from "@user/y"`);
+  return 'ok';
+};
+const _16fpgac = async function _test_decompileImport_stageB_notebook_id(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // Observable supports `import {x} from "d/<hash>@<version>"` notebook-id form.
+  const vars = stageB_importFake('d/57d79353bac56631@44', [{
+      imported: 'hash',
+      local: 'hash'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {hash} from "d/57d79353bac56631@44"`);
+  return 'ok';
+};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -21327,7 +21566,7 @@ export default function define(runtime, observer) {
   $def("_1n7gw17", "findModuleName", ["extractModuleInfo"], _1n7gw17);  
   $def("_i47chb", "findImportedName", [], _i47chb);  
   $def("_1effqg", null, ["md"], _1effqg);  
-  $def("_1etqs71", "decompileImport", ["findModuleName","findImportedName"], _1etqs71);  
+  $def("_b7vai6", "decompileImport", ["findModuleName","findImportedName"], _b7vai6);  
   $def("_1sylz7j", "formatImportDeclaration", [], _1sylz7j);  
   $def("_13dctdn", "test_decompileImport_basic", ["importFake","decompileImport","expect"], _13dctdn);  
   $def("_ujr0xn", "test_formatImportDeclaration_roundtrip", ["importFake","decompileImport","expect","formatImportDeclaration","decompile"], _ujr0xn);  
@@ -21405,7 +21644,18 @@ export default function define(runtime, observer) {
   main.define("Runtime", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Runtime", _));  
   main.define("Inspector", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Inspector", _));  
   main.define("Library", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Library", _));  
-  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));
+  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));  
+  $def("_1rc67k0", "stageB_importFake", [], _1rc67k0);  
+  $def("_1d53asg", "test_decompileImport_stageB_single", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1d53asg);  
+  $def("_hv5gag", "test_decompileImport_stageB_aliased", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _hv5gag);  
+  $def("_avc18y", "test_decompileImport_stageB_multiple", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _avc18y);  
+  $def("_16gia7i", "test_decompileImport_stageB_mixed_alias", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16gia7i);  
+  $def("_1slhdwo", "test_decompileImport_stageB_viewof", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1slhdwo);  
+  $def("_qwlsf2", "test_decompileImport_stageB_mutable", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _qwlsf2);  
+  $def("_sy7jfx", "test_decompileImport_returns_null_for_non_import", ["decompileImport","expect"], _sy7jfx);  
+  $def("_rk7ku3", "test_decompileImport_compile_roundtrip_single", ["compile","expect","stageB_importFake","decompileImport","formatImportDeclaration"], _rk7ku3);  
+  $def("_xynplo", "test_decompileImport_stageB_order_independent", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _xynplo);  
+  $def("_16fpgac", "test_decompileImport_stageB_notebook_id", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16fpgac);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_observablehq-lezer.html
+++ b/notebooks/@tomlarkworthy_observablehq-lezer.html
@@ -19474,56 +19474,103 @@ async (v) => {
 const _1effqg = function _96(md){return(
 md`### \`decompileImport\``
 )};
-const _1etqs71 = function _decompileImport(findModuleName,findImportedName)
+const _b7vai6 = function _decompileImport(findModuleName,findImportedName)
 {
-    return async function decompileImport(variables, options = {}) {
-        if (!variables || variables.length === 0)
-            throw new Error('no variables');
-        // #166: An import group is `[module @foo, ...aliases]` — the runtime stitch
-        // sits at index 0 by convention. Scan for the first alias (single _input,
-        // crosses module boundary) so this works whichever order the caller hands us.
-        const isCrossModuleAlias = v => {
-            const inputs = v?._inputs;
-            if (!Array.isArray(inputs) || inputs.length !== 1)
-                return false;
-            const i0 = inputs[0];
-            return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
-        };
-        const v0 = variables.find(isCrossModuleAlias);
-        if (!v0)
-            return null;
-        const input0 = v0._inputs[0];
-        const inputsLength = 1;
-        const crossesModuleBoundary = true;
-        const module_name = findModuleName(v0._module._scope, input0._module);
-        if (module_name == null)
-            throw new Error('module name could not be resolved');
-        // #166: Skip runtime-internal `module @foo` stitch variables — they belong to
-        // the import group but are not user-facing specifiers. Without this filter, an
-        // import group renders as `import {Range, module @foo} from "@foo"`.
-        const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
-            const imported = await findImportedName(v);
-            const local = v._name;
-            return {
-                imported,
-                local,
-                alias: imported !== local,
-                meta: { index }
-            };
-        }));
-        return {
-            type: 'import',
-            from: module_name,
-            specifiers,
-            meta: {
-                detection: {
-                    inputsLength,
-                    crossesModuleBoundary
-                },
-                variables: variables.map(v => v?._name ?? null)
-            }
-        };
+  return async function decompileImport(variables, options = {}) {
+    if (!variables || variables.length === 0)
+      throw new Error('no variables');
+    // An import-cell group is `[module @X stitch, ...aliases]`. Each alias goes
+    // through three lifecycle stages (documented in observable-runtime-v6's
+    // `importedModule` helper, lines ~1992-2049 of @tomlarkworthy/observable-runtime-v6):
+    //
+    //   Stage A — post-observation:
+    //     `_inputs = [Variable in source module]` (length 1, cross-module).
+    //     The Observable runtime rewrites _inputs after the alias is observed
+    //     and resolved against the source module.
+    //
+    //   Stage B — pre-observation, API-loaded (canonical compiled-bundle shape):
+    //     `_inputs = [Variable("module @X"), Variable("@variable")]` (length 2,
+    //     both in the importer module). What `runtime.define("name",
+    //     ["module @X", "@variable"], (_, v) => v.import("name", _))` produces.
+    //     Also what `compile_and_update` outputs for freshly-defined user-typed
+    //     imports until they're observed.
+    //
+    //   Stage C — pre-observation, inline live-notebook:
+    //     `_inputs = [Variable("@variable")]` (length 1) AND the definition
+    //     calls `import(...)` inside. We extract the imported module reference
+    //     by invoking the definition with a stub `import` capture.
+    //
+    // Detection order is post→pre because Stage A is unambiguous when present.
+    const isStageA = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
     };
+    const isStageB = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 2)
+        return false;
+      const [i0, i1] = inputs;
+      return !!(i0 && typeof i0 === 'object' && typeof i0._name === 'string' && i0._name.startsWith('module @') && i1 && typeof i1 === 'object' && i1._name === '@variable');
+    };
+    const isStageC = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && i0._name === '@variable' && typeof v._definition !== 'undefined' && String(v._definition).includes('import('));
+    };
+    let v0, module_name, stage;
+    if (v0 = variables.find(isStageA)) {
+      stage = 'A';
+      module_name = findModuleName(v0._module._scope, v0._inputs[0]._module);
+    } else if (v0 = variables.find(isStageB)) {
+      stage = 'B';
+      module_name = v0._inputs[0]._name.replace(/^module /, '');
+    } else if (v0 = variables.find(isStageC)) {
+      stage = 'C';
+      let capturedModule;
+      try {
+        await v0._definition({
+          import: (...args) => {
+            capturedModule = args[args.length - 1];
+          }
+        });
+      } catch (e) {
+      }
+      if (capturedModule && v0._module?._scope) {
+        module_name = findModuleName(v0._module._scope, capturedModule);
+      }
+    } else {
+      return null;
+    }
+    if (module_name == null)
+      throw new Error('module name could not be resolved');
+    // Skip runtime-internal `module @foo` stitch variables — they belong to
+    // the import group but are not user-facing specifiers. Without this filter, an
+    // import group renders as `import {Range, module @foo} from "@foo"`.
+    const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
+      const imported = await findImportedName(v);
+      const local = v._name;
+      return {
+        imported,
+        local,
+        alias: imported !== local,
+        meta: { index }
+      };
+    }));
+    return {
+      type: 'import',
+      from: module_name,
+      specifiers,
+      meta: {
+        detection: { stage },
+        variables: variables.map(v => v?._name ?? null)
+      }
+    };
+  };
 };
 const _1sylz7j = function _formatImportDeclaration(){return(
 function formatImportDeclaration(importInfo) {
@@ -20633,6 +20680,198 @@ const _1hiclbb = function _acorn_walk(acorn_walk_url) {
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
+const _1rc67k0 = function _stageB_importFake()
+{
+  return // Builds a Stage B (pre-observation, API-loaded) import group as POJOs.
+  // Mirrors what `runtime.define("name", ["module @X", "@variable"], (_, v) => v.import("name", _))`
+  // produces structurally. Used by the test_decompileImport_stageB_* tests to
+  // avoid spinning up a real Observable runtime per case.
+  function stageB_importFake(module_name, specifiers) {
+    const importerModule = { _scope: new Map() };
+    const stitch = {
+      _name: `module ${ module_name }`,
+      _module: importerModule,
+      _inputs: [],
+      _definition: `async () => null`
+    };
+    const atVariable = {
+      _name: '@variable',
+      _module: importerModule
+    };
+    const aliases = specifiers.map(s => ({
+      _name: s.local,
+      _module: importerModule,
+      _inputs: [
+        stitch,
+        atVariable
+      ],
+      _definition: s.imported === s.local ? `(_, v) => v.import("${ s.imported }", _)` : `(_, v) => v.import("${ s.imported }", "${ s.local }", _)`
+    }));
+    return [
+      stitch,
+      ...aliases
+    ];
+  };
+};
+const _1d53asg = async function _test_decompileImport_stageB_single(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [{
+      imported: 'visualize',
+      local: 'visualize'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _hv5gag = async function _test_decompileImport_stageB_aliased(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'x',
+      local: 'z'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(info.specifiers[0].alias).toEqual(true);
+  expect(formatImportDeclaration(info)).toEqual(`import {x as z} from "@user/y"`);
+  return 'ok';
+};
+const _avc18y = async function _test_decompileImport_stageB_multiple(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    },
+    {
+      imported: 'c',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b, c} from "@user/y"`);
+  return 'ok';
+};
+const _16gia7i = async function _test_decompileImport_stageB_mixed_alias(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b as c} from "@user/y"`);
+  return 'ok';
+};
+const _1slhdwo = async function _test_decompileImport_stageB_viewof(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/module-map', [{
+      imported: 'viewof currentModules',
+      local: 'viewof currentModules'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {viewof currentModules} from "@tomlarkworthy/module-map"`);
+  return 'ok';
+};
+const _qwlsf2 = async function _test_decompileImport_stageB_mutable(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'mutable counter',
+      local: 'mutable counter'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {mutable counter} from "@user/y"`);
+  return 'ok';
+};
+const _sy7jfx = async function _test_decompileImport_returns_null_for_non_import(decompileImport,expect)
+{
+  // A regular cell — no stitch, no @variable input, no cross-module reference.
+  const info = await decompileImport([{
+      _name: 'x',
+      _module: {},
+      _inputs: [],
+      _definition: `() => 42`
+    }]);
+  expect(info).toEqual(null);
+  return 'ok';
+};
+const _rk7ku3 = async function _test_decompileImport_compile_roundtrip_single(compile,expect,stageB_importFake,decompileImport,formatImportDeclaration)
+{
+  // What `compile()` emits for `import {x} from "@user/y"` is structurally the
+  // same as our stageB_importFake fixture (after runtime.define resolves the
+  // input name strings to Variable refs). Verify the fixture matches the
+  // shape compile() would produce.
+  const pojos = compile(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  expect(pojos.length).toEqual(3);
+  expect(pojos[0]._name).toEqual('module @tomlarkworthy/visualizer');
+  expect(pojos[1]._name).toEqual('visualize');
+  expect(pojos[2]._name).toEqual('Group');
+  expect(pojos[1]._inputs).toEqual([
+    'module @tomlarkworthy/visualizer',
+    '@variable'
+  ]);
+  // Now run our fixture through decompileImport — confirms the round-trip
+  // shape compile()-output-shape-when-defined → decompileImport produces the
+  // canonical import source string.
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [
+    {
+      imported: 'visualize',
+      local: 'visualize'
+    },
+    {
+      imported: 'Group',
+      local: 'Group'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _xynplo = async function _test_decompileImport_stageB_order_independent(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // The detection uses .find — it shouldn't matter whether the stitch is at
+  // index 0 or the aliases come first. Verify by reversing the array.
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    }
+  ]);
+  const reversed = [...vars].reverse();
+  const info = await decompileImport(reversed);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b} from "@user/y"`);
+  return 'ok';
+};
+const _16fpgac = async function _test_decompileImport_stageB_notebook_id(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // Observable supports `import {x} from "d/<hash>@<version>"` notebook-id form.
+  const vars = stageB_importFake('d/57d79353bac56631@44', [{
+      imported: 'hash',
+      local: 'hash'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {hash} from "d/57d79353bac56631@44"`);
+  return 'ok';
+};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -20753,7 +20992,7 @@ export default function define(runtime, observer) {
   $def("_1n7gw17", "findModuleName", ["extractModuleInfo"], _1n7gw17);  
   $def("_i47chb", "findImportedName", [], _i47chb);  
   $def("_1effqg", null, ["md"], _1effqg);  
-  $def("_1etqs71", "decompileImport", ["findModuleName","findImportedName"], _1etqs71);  
+  $def("_b7vai6", "decompileImport", ["findModuleName","findImportedName"], _b7vai6);  
   $def("_1sylz7j", "formatImportDeclaration", [], _1sylz7j);  
   $def("_13dctdn", "test_decompileImport_basic", ["importFake","decompileImport","expect"], _13dctdn);  
   $def("_ujr0xn", "test_formatImportDeclaration_roundtrip", ["importFake","decompileImport","expect","formatImportDeclaration","decompile"], _ujr0xn);  
@@ -20831,7 +21070,18 @@ export default function define(runtime, observer) {
   main.define("Runtime", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Runtime", _));  
   main.define("Inspector", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Inspector", _));  
   main.define("Library", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Library", _));  
-  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));
+  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));  
+  $def("_1rc67k0", "stageB_importFake", [], _1rc67k0);  
+  $def("_1d53asg", "test_decompileImport_stageB_single", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1d53asg);  
+  $def("_hv5gag", "test_decompileImport_stageB_aliased", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _hv5gag);  
+  $def("_avc18y", "test_decompileImport_stageB_multiple", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _avc18y);  
+  $def("_16gia7i", "test_decompileImport_stageB_mixed_alias", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16gia7i);  
+  $def("_1slhdwo", "test_decompileImport_stageB_viewof", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1slhdwo);  
+  $def("_qwlsf2", "test_decompileImport_stageB_mutable", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _qwlsf2);  
+  $def("_sy7jfx", "test_decompileImport_returns_null_for_non_import", ["decompileImport","expect"], _sy7jfx);  
+  $def("_rk7ku3", "test_decompileImport_compile_roundtrip_single", ["compile","expect","stageB_importFake","decompileImport","formatImportDeclaration"], _rk7ku3);  
+  $def("_xynplo", "test_decompileImport_stageB_order_independent", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _xynplo);  
+  $def("_16fpgac", "test_decompileImport_stageB_notebook_id", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16fpgac);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_observablejs-toolchain.html
+++ b/notebooks/@tomlarkworthy_observablejs-toolchain.html
@@ -19472,104 +19472,103 @@ async (v) => {
 const _1effqg = function _96(md){return(
 md`### \`decompileImport\``
 )};
-const _1etqs71 = function _decompileImport(findModuleName,findImportedName)
+const _b7vai6 = function _decompileImport(findModuleName,findImportedName)
 {
-    return async function decompileImport(variables, options = {}) {
-        if (!variables || variables.length === 0)
-            throw new Error('no variables');
-        // An import-cell group is `[module @X stitch, ...aliases]`. Each alias goes
-        // through three lifecycle stages (documented in observable-runtime-v6's
-        // `importedModule` helper, lines ~1992-2049 of @tomlarkworthy/observable-runtime-v6):
-        //
-        //   Stage A — post-observation:
-        //     `_inputs = [Variable in source module]` (length 1, cross-module).
-        //     The Observable runtime rewrites _inputs after the alias is observed
-        //     and resolved against the source module.
-        //
-        //   Stage B — pre-observation, API-loaded (canonical compiled-bundle shape):
-        //     `_inputs = [Variable("module @X"), Variable("@variable")]` (length 2,
-        //     both in the importer module). What `runtime.define("name",
-        //     ["module @X", "@variable"], (_, v) => v.import("name", _))` produces.
-        //     Also what `compile_and_update` outputs for freshly-defined user-typed
-        //     imports until they're observed.
-        //
-        //   Stage C — pre-observation, inline live-notebook:
-        //     `_inputs = [Variable("@variable")]` (length 1) AND the definition
-        //     calls `import(...)` inside. We extract the imported module reference
-        //     by invoking the definition with a stub `import` capture.
-        //
-        // Detection order is post→pre because Stage A is unambiguous when present.
-        const isStageA = v => {
-            const inputs = v?._inputs;
-            if (!Array.isArray(inputs) || inputs.length !== 1)
-                return false;
-            const i0 = inputs[0];
-            return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
-        };
-        const isStageB = v => {
-            const inputs = v?._inputs;
-            if (!Array.isArray(inputs) || inputs.length !== 2)
-                return false;
-            const [i0, i1] = inputs;
-            return !!(i0 && typeof i0 === 'object' && typeof i0._name === 'string' && i0._name.startsWith('module @')
-                && i1 && typeof i1 === 'object' && i1._name === '@variable');
-        };
-        const isStageC = v => {
-            const inputs = v?._inputs;
-            if (!Array.isArray(inputs) || inputs.length !== 1)
-                return false;
-            const i0 = inputs[0];
-            return !!(i0 && typeof i0 === 'object' && i0._name === '@variable'
-                && typeof v._definition !== 'undefined' && String(v._definition).includes('import('));
-        };
-        let v0, module_name, stage;
-        if ((v0 = variables.find(isStageA))) {
-            stage = 'A';
-            module_name = findModuleName(v0._module._scope, v0._inputs[0]._module);
-        } else if ((v0 = variables.find(isStageB))) {
-            stage = 'B';
-            module_name = v0._inputs[0]._name.replace(/^module /, '');
-        } else if ((v0 = variables.find(isStageC))) {
-            stage = 'C';
-            let capturedModule;
-            try {
-                await v0._definition({
-                    import: (...args) => { capturedModule = args[args.length - 1]; }
-                });
-            } catch (e) {
-                // best-effort: definition may throw on stub; capture is opportunistic
-            }
-            if (capturedModule && v0._module?._scope) {
-                module_name = findModuleName(v0._module._scope, capturedModule);
-            }
-        } else {
-            return null;
-        }
-        if (module_name == null)
-            throw new Error('module name could not be resolved');
-        // Skip runtime-internal `module @foo` stitch variables — they belong to
-        // the import group but are not user-facing specifiers. Without this filter, an
-        // import group renders as `import {Range, module @foo} from "@foo"`.
-        const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
-            const imported = await findImportedName(v);
-            const local = v._name;
-            return {
-                imported,
-                local,
-                alias: imported !== local,
-                meta: { index }
-            };
-        }));
-        return {
-            type: 'import',
-            from: module_name,
-            specifiers,
-            meta: {
-                detection: { stage },
-                variables: variables.map(v => v?._name ?? null)
-            }
-        };
+  return async function decompileImport(variables, options = {}) {
+    if (!variables || variables.length === 0)
+      throw new Error('no variables');
+    // An import-cell group is `[module @X stitch, ...aliases]`. Each alias goes
+    // through three lifecycle stages (documented in observable-runtime-v6's
+    // `importedModule` helper, lines ~1992-2049 of @tomlarkworthy/observable-runtime-v6):
+    //
+    //   Stage A — post-observation:
+    //     `_inputs = [Variable in source module]` (length 1, cross-module).
+    //     The Observable runtime rewrites _inputs after the alias is observed
+    //     and resolved against the source module.
+    //
+    //   Stage B — pre-observation, API-loaded (canonical compiled-bundle shape):
+    //     `_inputs = [Variable("module @X"), Variable("@variable")]` (length 2,
+    //     both in the importer module). What `runtime.define("name",
+    //     ["module @X", "@variable"], (_, v) => v.import("name", _))` produces.
+    //     Also what `compile_and_update` outputs for freshly-defined user-typed
+    //     imports until they're observed.
+    //
+    //   Stage C — pre-observation, inline live-notebook:
+    //     `_inputs = [Variable("@variable")]` (length 1) AND the definition
+    //     calls `import(...)` inside. We extract the imported module reference
+    //     by invoking the definition with a stub `import` capture.
+    //
+    // Detection order is post→pre because Stage A is unambiguous when present.
+    const isStageA = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
     };
+    const isStageB = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 2)
+        return false;
+      const [i0, i1] = inputs;
+      return !!(i0 && typeof i0 === 'object' && typeof i0._name === 'string' && i0._name.startsWith('module @') && i1 && typeof i1 === 'object' && i1._name === '@variable');
+    };
+    const isStageC = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && i0._name === '@variable' && typeof v._definition !== 'undefined' && String(v._definition).includes('import('));
+    };
+    let v0, module_name, stage;
+    if (v0 = variables.find(isStageA)) {
+      stage = 'A';
+      module_name = findModuleName(v0._module._scope, v0._inputs[0]._module);
+    } else if (v0 = variables.find(isStageB)) {
+      stage = 'B';
+      module_name = v0._inputs[0]._name.replace(/^module /, '');
+    } else if (v0 = variables.find(isStageC)) {
+      stage = 'C';
+      let capturedModule;
+      try {
+        await v0._definition({
+          import: (...args) => {
+            capturedModule = args[args.length - 1];
+          }
+        });
+      } catch (e) {
+      }
+      if (capturedModule && v0._module?._scope) {
+        module_name = findModuleName(v0._module._scope, capturedModule);
+      }
+    } else {
+      return null;
+    }
+    if (module_name == null)
+      throw new Error('module name could not be resolved');
+    // Skip runtime-internal `module @foo` stitch variables — they belong to
+    // the import group but are not user-facing specifiers. Without this filter, an
+    // import group renders as `import {Range, module @foo} from "@foo"`.
+    const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
+      const imported = await findImportedName(v);
+      const local = v._name;
+      return {
+        imported,
+        local,
+        alias: imported !== local,
+        meta: { index }
+      };
+    }));
+    return {
+      type: 'import',
+      from: module_name,
+      specifiers,
+      meta: {
+        detection: { stage },
+        variables: variables.map(v => v?._name ?? null)
+      }
+    };
+  };
 };
 const _1sylz7j = function _formatImportDeclaration(){return(
 function formatImportDeclaration(importInfo) {
@@ -19644,158 +19643,6 @@ const _1u6sfri = async function _test_decompileImport_alias(importFake,decompile
   );
 
   return "ok";
-};
-const _b5tba1 = function _stageB_importFake(){return(
-// Builds a Stage B (pre-observation, API-loaded) import group as POJOs.
-// Mirrors what `runtime.define("name", ["module @X", "@variable"], (_, v) => v.import("name", _))`
-// produces structurally. Used by the test_decompileImport_stageB_* tests to
-// avoid spinning up a real Observable runtime per case.
-function stageB_importFake(module_name, specifiers) {
-    const importerModule = { _scope: new Map() };
-    const stitch = {
-        _name: `module ${module_name}`,
-        _module: importerModule,
-        _inputs: [],
-        _definition: `async () => null`
-    };
-    const atVariable = { _name: '@variable', _module: importerModule };
-    const aliases = specifiers.map(s => ({
-        _name: s.local,
-        _module: importerModule,
-        _inputs: [stitch, atVariable],
-        _definition: s.imported === s.local
-            ? `(_, v) => v.import("${s.imported}", _)`
-            : `(_, v) => v.import("${s.imported}", "${s.local}", _)`
-    }));
-    return [stitch, ...aliases];
-}
-)};
-const _b5tba2 = async function _test_decompileImport_stageB_single(stageB_importFake,decompileImport,formatImportDeclaration,expect)
-{
-    const vars = stageB_importFake('@tomlarkworthy/visualizer', [
-        { imported: 'visualize', local: 'visualize' }
-    ]);
-    const info = await decompileImport(vars);
-    expect(info.meta.detection.stage).toEqual('B');
-    expect(formatImportDeclaration(info)).toEqual(
-        `import {visualize} from "@tomlarkworthy/visualizer"`
-    );
-    return 'ok';
-};
-const _b5tba3 = async function _test_decompileImport_stageB_aliased(stageB_importFake,decompileImport,formatImportDeclaration,expect)
-{
-    const vars = stageB_importFake('@user/y', [
-        { imported: 'x', local: 'z' }
-    ]);
-    const info = await decompileImport(vars);
-    expect(info.meta.detection.stage).toEqual('B');
-    expect(info.specifiers[0].alias).toEqual(true);
-    expect(formatImportDeclaration(info)).toEqual(`import {x as z} from "@user/y"`);
-    return 'ok';
-};
-const _b5tba4 = async function _test_decompileImport_stageB_multiple(stageB_importFake,decompileImport,formatImportDeclaration,expect)
-{
-    const vars = stageB_importFake('@user/y', [
-        { imported: 'a', local: 'a' },
-        { imported: 'b', local: 'b' },
-        { imported: 'c', local: 'c' }
-    ]);
-    const info = await decompileImport(vars);
-    expect(info.meta.detection.stage).toEqual('B');
-    expect(formatImportDeclaration(info)).toEqual(`import {a, b, c} from "@user/y"`);
-    return 'ok';
-};
-const _b5tba5 = async function _test_decompileImport_stageB_mixed_alias(stageB_importFake,decompileImport,formatImportDeclaration,expect)
-{
-    const vars = stageB_importFake('@user/y', [
-        { imported: 'a', local: 'a' },
-        { imported: 'b', local: 'c' }
-    ]);
-    const info = await decompileImport(vars);
-    expect(info.meta.detection.stage).toEqual('B');
-    expect(formatImportDeclaration(info)).toEqual(`import {a, b as c} from "@user/y"`);
-    return 'ok';
-};
-const _b5tba6 = async function _test_decompileImport_stageB_viewof(stageB_importFake,decompileImport,formatImportDeclaration,expect)
-{
-    const vars = stageB_importFake('@tomlarkworthy/module-map', [
-        { imported: 'viewof currentModules', local: 'viewof currentModules' }
-    ]);
-    const info = await decompileImport(vars);
-    expect(info.meta.detection.stage).toEqual('B');
-    expect(formatImportDeclaration(info)).toEqual(
-        `import {viewof currentModules} from "@tomlarkworthy/module-map"`
-    );
-    return 'ok';
-};
-const _b5tba7 = async function _test_decompileImport_stageB_mutable(stageB_importFake,decompileImport,formatImportDeclaration,expect)
-{
-    const vars = stageB_importFake('@user/y', [
-        { imported: 'mutable counter', local: 'mutable counter' }
-    ]);
-    const info = await decompileImport(vars);
-    expect(info.meta.detection.stage).toEqual('B');
-    expect(formatImportDeclaration(info)).toEqual(`import {mutable counter} from "@user/y"`);
-    return 'ok';
-};
-const _b5tba8 = async function _test_decompileImport_returns_null_for_non_import(decompileImport,expect)
-{
-    // A regular cell — no stitch, no @variable input, no cross-module reference.
-    const info = await decompileImport([
-        { _name: 'x', _module: {}, _inputs: [], _definition: `() => 42` }
-    ]);
-    expect(info).toEqual(null);
-    return 'ok';
-};
-const _b5tba9 = async function _test_decompileImport_compile_roundtrip_single(compile,stageB_importFake,decompileImport,formatImportDeclaration,expect)
-{
-    // What `compile()` emits for `import {x} from "@user/y"` is structurally the
-    // same as our stageB_importFake fixture (after runtime.define resolves the
-    // input name strings to Variable refs). Verify the fixture matches the
-    // shape compile() would produce.
-    const pojos = compile(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
-    expect(pojos.length).toEqual(3);
-    expect(pojos[0]._name).toEqual('module @tomlarkworthy/visualizer');
-    expect(pojos[1]._name).toEqual('visualize');
-    expect(pojos[2]._name).toEqual('Group');
-    expect(pojos[1]._inputs).toEqual(['module @tomlarkworthy/visualizer', '@variable']);
-    // Now run our fixture through decompileImport — confirms the round-trip
-    // shape compile()-output-shape-when-defined → decompileImport produces the
-    // canonical import source string.
-    const vars = stageB_importFake('@tomlarkworthy/visualizer', [
-        { imported: 'visualize', local: 'visualize' },
-        { imported: 'Group', local: 'Group' }
-    ]);
-    const info = await decompileImport(vars);
-    expect(formatImportDeclaration(info)).toEqual(
-        `import {visualize, Group} from "@tomlarkworthy/visualizer"`
-    );
-    return 'ok';
-};
-const _b5tbaa = async function _test_decompileImport_stageB_order_independent(stageB_importFake,decompileImport,formatImportDeclaration,expect)
-{
-    // The detection uses .find — it shouldn't matter whether the stitch is at
-    // index 0 or the aliases come first. Verify by reversing the array.
-    const vars = stageB_importFake('@user/y', [
-        { imported: 'a', local: 'a' },
-        { imported: 'b', local: 'b' }
-    ]);
-    const reversed = [...vars].reverse();
-    const info = await decompileImport(reversed);
-    expect(info.meta.detection.stage).toEqual('B');
-    expect(formatImportDeclaration(info)).toEqual(`import {a, b} from "@user/y"`);
-    return 'ok';
-};
-const _b5tbab = async function _test_decompileImport_stageB_notebook_id(stageB_importFake,decompileImport,formatImportDeclaration,expect)
-{
-    // Observable supports `import {x} from "d/<hash>@<version>"` notebook-id form.
-    const vars = stageB_importFake('d/57d79353bac56631@44', [
-        { imported: 'hash', local: 'hash' }
-    ]);
-    const info = await decompileImport(vars);
-    expect(info.meta.detection.stage).toEqual('B');
-    expect(formatImportDeclaration(info)).toEqual(`import {hash} from "d/57d79353bac56631@44"`);
-    return 'ok';
 };
 const _1lqhutp = function _102(md){return(
 md`## Javascript Source Normalization`
@@ -20831,6 +20678,198 @@ const _1hiclbb = function _acorn_walk(acorn_walk_url) {
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
+const _1rc67k0 = function _stageB_importFake()
+{
+  return // Builds a Stage B (pre-observation, API-loaded) import group as POJOs.
+  // Mirrors what `runtime.define("name", ["module @X", "@variable"], (_, v) => v.import("name", _))`
+  // produces structurally. Used by the test_decompileImport_stageB_* tests to
+  // avoid spinning up a real Observable runtime per case.
+  function stageB_importFake(module_name, specifiers) {
+    const importerModule = { _scope: new Map() };
+    const stitch = {
+      _name: `module ${ module_name }`,
+      _module: importerModule,
+      _inputs: [],
+      _definition: `async () => null`
+    };
+    const atVariable = {
+      _name: '@variable',
+      _module: importerModule
+    };
+    const aliases = specifiers.map(s => ({
+      _name: s.local,
+      _module: importerModule,
+      _inputs: [
+        stitch,
+        atVariable
+      ],
+      _definition: s.imported === s.local ? `(_, v) => v.import("${ s.imported }", _)` : `(_, v) => v.import("${ s.imported }", "${ s.local }", _)`
+    }));
+    return [
+      stitch,
+      ...aliases
+    ];
+  };
+};
+const _1d53asg = async function _test_decompileImport_stageB_single(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [{
+      imported: 'visualize',
+      local: 'visualize'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _hv5gag = async function _test_decompileImport_stageB_aliased(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'x',
+      local: 'z'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(info.specifiers[0].alias).toEqual(true);
+  expect(formatImportDeclaration(info)).toEqual(`import {x as z} from "@user/y"`);
+  return 'ok';
+};
+const _avc18y = async function _test_decompileImport_stageB_multiple(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    },
+    {
+      imported: 'c',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b, c} from "@user/y"`);
+  return 'ok';
+};
+const _16gia7i = async function _test_decompileImport_stageB_mixed_alias(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b as c} from "@user/y"`);
+  return 'ok';
+};
+const _1slhdwo = async function _test_decompileImport_stageB_viewof(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/module-map', [{
+      imported: 'viewof currentModules',
+      local: 'viewof currentModules'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {viewof currentModules} from "@tomlarkworthy/module-map"`);
+  return 'ok';
+};
+const _qwlsf2 = async function _test_decompileImport_stageB_mutable(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'mutable counter',
+      local: 'mutable counter'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {mutable counter} from "@user/y"`);
+  return 'ok';
+};
+const _sy7jfx = async function _test_decompileImport_returns_null_for_non_import(decompileImport,expect)
+{
+  // A regular cell — no stitch, no @variable input, no cross-module reference.
+  const info = await decompileImport([{
+      _name: 'x',
+      _module: {},
+      _inputs: [],
+      _definition: `() => 42`
+    }]);
+  expect(info).toEqual(null);
+  return 'ok';
+};
+const _rk7ku3 = async function _test_decompileImport_compile_roundtrip_single(compile,expect,stageB_importFake,decompileImport,formatImportDeclaration)
+{
+  // What `compile()` emits for `import {x} from "@user/y"` is structurally the
+  // same as our stageB_importFake fixture (after runtime.define resolves the
+  // input name strings to Variable refs). Verify the fixture matches the
+  // shape compile() would produce.
+  const pojos = compile(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  expect(pojos.length).toEqual(3);
+  expect(pojos[0]._name).toEqual('module @tomlarkworthy/visualizer');
+  expect(pojos[1]._name).toEqual('visualize');
+  expect(pojos[2]._name).toEqual('Group');
+  expect(pojos[1]._inputs).toEqual([
+    'module @tomlarkworthy/visualizer',
+    '@variable'
+  ]);
+  // Now run our fixture through decompileImport — confirms the round-trip
+  // shape compile()-output-shape-when-defined → decompileImport produces the
+  // canonical import source string.
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [
+    {
+      imported: 'visualize',
+      local: 'visualize'
+    },
+    {
+      imported: 'Group',
+      local: 'Group'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _xynplo = async function _test_decompileImport_stageB_order_independent(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // The detection uses .find — it shouldn't matter whether the stitch is at
+  // index 0 or the aliases come first. Verify by reversing the array.
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    }
+  ]);
+  const reversed = [...vars].reverse();
+  const info = await decompileImport(reversed);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b} from "@user/y"`);
+  return 'ok';
+};
+const _16fpgac = async function _test_decompileImport_stageB_notebook_id(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // Observable supports `import {x} from "d/<hash>@<version>"` notebook-id form.
+  const vars = stageB_importFake('d/57d79353bac56631@44', [{
+      imported: 'hash',
+      local: 'hash'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {hash} from "d/57d79353bac56631@44"`);
+  return 'ok';
+};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -20951,23 +20990,12 @@ export default function define(runtime, observer) {
   $def("_1n7gw17", "findModuleName", ["extractModuleInfo"], _1n7gw17);  
   $def("_i47chb", "findImportedName", [], _i47chb);  
   $def("_1effqg", null, ["md"], _1effqg);  
-  $def("_1etqs71", "decompileImport", ["findModuleName","findImportedName"], _1etqs71);  
+  $def("_b7vai6", "decompileImport", ["findModuleName","findImportedName"], _b7vai6);  
   $def("_1sylz7j", "formatImportDeclaration", [], _1sylz7j);  
   $def("_13dctdn", "test_decompileImport_basic", ["importFake","decompileImport","expect"], _13dctdn);  
   $def("_ujr0xn", "test_formatImportDeclaration_roundtrip", ["importFake","decompileImport","expect","formatImportDeclaration","decompile"], _ujr0xn);  
-  $def("_1u6sfri", "test_decompileImport_alias", ["importFake","decompileImport","expect","formatImportDeclaration"], _1u6sfri);
-  $def("_b5tba1", "stageB_importFake", [], _b5tba1);
-  $def("_b5tba2", "test_decompileImport_stageB_single", ["stageB_importFake","decompileImport","formatImportDeclaration","expect"], _b5tba2);
-  $def("_b5tba3", "test_decompileImport_stageB_aliased", ["stageB_importFake","decompileImport","formatImportDeclaration","expect"], _b5tba3);
-  $def("_b5tba4", "test_decompileImport_stageB_multiple", ["stageB_importFake","decompileImport","formatImportDeclaration","expect"], _b5tba4);
-  $def("_b5tba5", "test_decompileImport_stageB_mixed_alias", ["stageB_importFake","decompileImport","formatImportDeclaration","expect"], _b5tba5);
-  $def("_b5tba6", "test_decompileImport_stageB_viewof", ["stageB_importFake","decompileImport","formatImportDeclaration","expect"], _b5tba6);
-  $def("_b5tba7", "test_decompileImport_stageB_mutable", ["stageB_importFake","decompileImport","formatImportDeclaration","expect"], _b5tba7);
-  $def("_b5tba8", "test_decompileImport_returns_null_for_non_import", ["decompileImport","expect"], _b5tba8);
-  $def("_b5tba9", "test_decompileImport_compile_roundtrip_single", ["compile","stageB_importFake","decompileImport","formatImportDeclaration","expect"], _b5tba9);
-  $def("_b5tbaa", "test_decompileImport_stageB_order_independent", ["stageB_importFake","decompileImport","formatImportDeclaration","expect"], _b5tbaa);
-  $def("_b5tbab", "test_decompileImport_stageB_notebook_id", ["stageB_importFake","decompileImport","formatImportDeclaration","expect"], _b5tbab);
-  $def("_1lqhutp", null, ["md"], _1lqhutp);
+  $def("_1u6sfri", "test_decompileImport_alias", ["importFake","decompileImport","expect","formatImportDeclaration"], _1u6sfri);  
+  $def("_1lqhutp", null, ["md"], _1lqhutp);  
   $def("_ikzxev", "normalizeJavascriptSource", ["acorn","escodegen"], _ikzxev);  
   $def("_az8lo6", "normalizeVariables", ["variableToObject","normalizeJavascriptSource"], _az8lo6);  
   $def("_3knb9v", "variableToObject", [], _3knb9v);  
@@ -21040,7 +21068,18 @@ export default function define(runtime, observer) {
   main.define("Runtime", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Runtime", _));  
   main.define("Inspector", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Inspector", _));  
   main.define("Library", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Library", _));  
-  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));
+  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));  
+  $def("_1rc67k0", "stageB_importFake", [], _1rc67k0);  
+  $def("_1d53asg", "test_decompileImport_stageB_single", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1d53asg);  
+  $def("_hv5gag", "test_decompileImport_stageB_aliased", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _hv5gag);  
+  $def("_avc18y", "test_decompileImport_stageB_multiple", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _avc18y);  
+  $def("_16gia7i", "test_decompileImport_stageB_mixed_alias", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16gia7i);  
+  $def("_1slhdwo", "test_decompileImport_stageB_viewof", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1slhdwo);  
+  $def("_qwlsf2", "test_decompileImport_stageB_mutable", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _qwlsf2);  
+  $def("_sy7jfx", "test_decompileImport_returns_null_for_non_import", ["decompileImport","expect"], _sy7jfx);  
+  $def("_rk7ku3", "test_decompileImport_compile_roundtrip_single", ["compile","expect","stageB_importFake","decompileImport","formatImportDeclaration"], _rk7ku3);  
+  $def("_xynplo", "test_decompileImport_stageB_order_independent", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _xynplo);  
+  $def("_16fpgac", "test_decompileImport_stageB_notebook_id", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16fpgac);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_observablejs-toolchain.html
+++ b/notebooks/@tomlarkworthy_observablejs-toolchain.html
@@ -19477,26 +19477,77 @@ const _1etqs71 = function _decompileImport(findModuleName,findImportedName)
     return async function decompileImport(variables, options = {}) {
         if (!variables || variables.length === 0)
             throw new Error('no variables');
-        // #166: An import group is `[module @foo, ...aliases]` — the runtime stitch
-        // sits at index 0 by convention. Scan for the first alias (single _input,
-        // crosses module boundary) so this works whichever order the caller hands us.
-        const isCrossModuleAlias = v => {
+        // An import-cell group is `[module @X stitch, ...aliases]`. Each alias goes
+        // through three lifecycle stages (documented in observable-runtime-v6's
+        // `importedModule` helper, lines ~1992-2049 of @tomlarkworthy/observable-runtime-v6):
+        //
+        //   Stage A — post-observation:
+        //     `_inputs = [Variable in source module]` (length 1, cross-module).
+        //     The Observable runtime rewrites _inputs after the alias is observed
+        //     and resolved against the source module.
+        //
+        //   Stage B — pre-observation, API-loaded (canonical compiled-bundle shape):
+        //     `_inputs = [Variable("module @X"), Variable("@variable")]` (length 2,
+        //     both in the importer module). What `runtime.define("name",
+        //     ["module @X", "@variable"], (_, v) => v.import("name", _))` produces.
+        //     Also what `compile_and_update` outputs for freshly-defined user-typed
+        //     imports until they're observed.
+        //
+        //   Stage C — pre-observation, inline live-notebook:
+        //     `_inputs = [Variable("@variable")]` (length 1) AND the definition
+        //     calls `import(...)` inside. We extract the imported module reference
+        //     by invoking the definition with a stub `import` capture.
+        //
+        // Detection order is post→pre because Stage A is unambiguous when present.
+        const isStageA = v => {
             const inputs = v?._inputs;
             if (!Array.isArray(inputs) || inputs.length !== 1)
                 return false;
             const i0 = inputs[0];
             return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
         };
-        const v0 = variables.find(isCrossModuleAlias);
-        if (!v0)
+        const isStageB = v => {
+            const inputs = v?._inputs;
+            if (!Array.isArray(inputs) || inputs.length !== 2)
+                return false;
+            const [i0, i1] = inputs;
+            return !!(i0 && typeof i0 === 'object' && typeof i0._name === 'string' && i0._name.startsWith('module @')
+                && i1 && typeof i1 === 'object' && i1._name === '@variable');
+        };
+        const isStageC = v => {
+            const inputs = v?._inputs;
+            if (!Array.isArray(inputs) || inputs.length !== 1)
+                return false;
+            const i0 = inputs[0];
+            return !!(i0 && typeof i0 === 'object' && i0._name === '@variable'
+                && typeof v._definition !== 'undefined' && String(v._definition).includes('import('));
+        };
+        let v0, module_name, stage;
+        if ((v0 = variables.find(isStageA))) {
+            stage = 'A';
+            module_name = findModuleName(v0._module._scope, v0._inputs[0]._module);
+        } else if ((v0 = variables.find(isStageB))) {
+            stage = 'B';
+            module_name = v0._inputs[0]._name.replace(/^module /, '');
+        } else if ((v0 = variables.find(isStageC))) {
+            stage = 'C';
+            let capturedModule;
+            try {
+                await v0._definition({
+                    import: (...args) => { capturedModule = args[args.length - 1]; }
+                });
+            } catch (e) {
+                // best-effort: definition may throw on stub; capture is opportunistic
+            }
+            if (capturedModule && v0._module?._scope) {
+                module_name = findModuleName(v0._module._scope, capturedModule);
+            }
+        } else {
             return null;
-        const input0 = v0._inputs[0];
-        const inputsLength = 1;
-        const crossesModuleBoundary = true;
-        const module_name = findModuleName(v0._module._scope, input0._module);
+        }
         if (module_name == null)
             throw new Error('module name could not be resolved');
-        // #166: Skip runtime-internal `module @foo` stitch variables — they belong to
+        // Skip runtime-internal `module @foo` stitch variables — they belong to
         // the import group but are not user-facing specifiers. Without this filter, an
         // import group renders as `import {Range, module @foo} from "@foo"`.
         const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
@@ -19514,10 +19565,7 @@ const _1etqs71 = function _decompileImport(findModuleName,findImportedName)
             from: module_name,
             specifiers,
             meta: {
-                detection: {
-                    inputsLength,
-                    crossesModuleBoundary
-                },
+                detection: { stage },
                 variables: variables.map(v => v?._name ?? null)
             }
         };
@@ -19596,6 +19644,158 @@ const _1u6sfri = async function _test_decompileImport_alias(importFake,decompile
   );
 
   return "ok";
+};
+const _b5tba1 = function _stageB_importFake(){return(
+// Builds a Stage B (pre-observation, API-loaded) import group as POJOs.
+// Mirrors what `runtime.define("name", ["module @X", "@variable"], (_, v) => v.import("name", _))`
+// produces structurally. Used by the test_decompileImport_stageB_* tests to
+// avoid spinning up a real Observable runtime per case.
+function stageB_importFake(module_name, specifiers) {
+    const importerModule = { _scope: new Map() };
+    const stitch = {
+        _name: `module ${module_name}`,
+        _module: importerModule,
+        _inputs: [],
+        _definition: `async () => null`
+    };
+    const atVariable = { _name: '@variable', _module: importerModule };
+    const aliases = specifiers.map(s => ({
+        _name: s.local,
+        _module: importerModule,
+        _inputs: [stitch, atVariable],
+        _definition: s.imported === s.local
+            ? `(_, v) => v.import("${s.imported}", _)`
+            : `(_, v) => v.import("${s.imported}", "${s.local}", _)`
+    }));
+    return [stitch, ...aliases];
+}
+)};
+const _b5tba2 = async function _test_decompileImport_stageB_single(stageB_importFake,decompileImport,formatImportDeclaration,expect)
+{
+    const vars = stageB_importFake('@tomlarkworthy/visualizer', [
+        { imported: 'visualize', local: 'visualize' }
+    ]);
+    const info = await decompileImport(vars);
+    expect(info.meta.detection.stage).toEqual('B');
+    expect(formatImportDeclaration(info)).toEqual(
+        `import {visualize} from "@tomlarkworthy/visualizer"`
+    );
+    return 'ok';
+};
+const _b5tba3 = async function _test_decompileImport_stageB_aliased(stageB_importFake,decompileImport,formatImportDeclaration,expect)
+{
+    const vars = stageB_importFake('@user/y', [
+        { imported: 'x', local: 'z' }
+    ]);
+    const info = await decompileImport(vars);
+    expect(info.meta.detection.stage).toEqual('B');
+    expect(info.specifiers[0].alias).toEqual(true);
+    expect(formatImportDeclaration(info)).toEqual(`import {x as z} from "@user/y"`);
+    return 'ok';
+};
+const _b5tba4 = async function _test_decompileImport_stageB_multiple(stageB_importFake,decompileImport,formatImportDeclaration,expect)
+{
+    const vars = stageB_importFake('@user/y', [
+        { imported: 'a', local: 'a' },
+        { imported: 'b', local: 'b' },
+        { imported: 'c', local: 'c' }
+    ]);
+    const info = await decompileImport(vars);
+    expect(info.meta.detection.stage).toEqual('B');
+    expect(formatImportDeclaration(info)).toEqual(`import {a, b, c} from "@user/y"`);
+    return 'ok';
+};
+const _b5tba5 = async function _test_decompileImport_stageB_mixed_alias(stageB_importFake,decompileImport,formatImportDeclaration,expect)
+{
+    const vars = stageB_importFake('@user/y', [
+        { imported: 'a', local: 'a' },
+        { imported: 'b', local: 'c' }
+    ]);
+    const info = await decompileImport(vars);
+    expect(info.meta.detection.stage).toEqual('B');
+    expect(formatImportDeclaration(info)).toEqual(`import {a, b as c} from "@user/y"`);
+    return 'ok';
+};
+const _b5tba6 = async function _test_decompileImport_stageB_viewof(stageB_importFake,decompileImport,formatImportDeclaration,expect)
+{
+    const vars = stageB_importFake('@tomlarkworthy/module-map', [
+        { imported: 'viewof currentModules', local: 'viewof currentModules' }
+    ]);
+    const info = await decompileImport(vars);
+    expect(info.meta.detection.stage).toEqual('B');
+    expect(formatImportDeclaration(info)).toEqual(
+        `import {viewof currentModules} from "@tomlarkworthy/module-map"`
+    );
+    return 'ok';
+};
+const _b5tba7 = async function _test_decompileImport_stageB_mutable(stageB_importFake,decompileImport,formatImportDeclaration,expect)
+{
+    const vars = stageB_importFake('@user/y', [
+        { imported: 'mutable counter', local: 'mutable counter' }
+    ]);
+    const info = await decompileImport(vars);
+    expect(info.meta.detection.stage).toEqual('B');
+    expect(formatImportDeclaration(info)).toEqual(`import {mutable counter} from "@user/y"`);
+    return 'ok';
+};
+const _b5tba8 = async function _test_decompileImport_returns_null_for_non_import(decompileImport,expect)
+{
+    // A regular cell — no stitch, no @variable input, no cross-module reference.
+    const info = await decompileImport([
+        { _name: 'x', _module: {}, _inputs: [], _definition: `() => 42` }
+    ]);
+    expect(info).toEqual(null);
+    return 'ok';
+};
+const _b5tba9 = async function _test_decompileImport_compile_roundtrip_single(compile,stageB_importFake,decompileImport,formatImportDeclaration,expect)
+{
+    // What `compile()` emits for `import {x} from "@user/y"` is structurally the
+    // same as our stageB_importFake fixture (after runtime.define resolves the
+    // input name strings to Variable refs). Verify the fixture matches the
+    // shape compile() would produce.
+    const pojos = compile(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+    expect(pojos.length).toEqual(3);
+    expect(pojos[0]._name).toEqual('module @tomlarkworthy/visualizer');
+    expect(pojos[1]._name).toEqual('visualize');
+    expect(pojos[2]._name).toEqual('Group');
+    expect(pojos[1]._inputs).toEqual(['module @tomlarkworthy/visualizer', '@variable']);
+    // Now run our fixture through decompileImport — confirms the round-trip
+    // shape compile()-output-shape-when-defined → decompileImport produces the
+    // canonical import source string.
+    const vars = stageB_importFake('@tomlarkworthy/visualizer', [
+        { imported: 'visualize', local: 'visualize' },
+        { imported: 'Group', local: 'Group' }
+    ]);
+    const info = await decompileImport(vars);
+    expect(formatImportDeclaration(info)).toEqual(
+        `import {visualize, Group} from "@tomlarkworthy/visualizer"`
+    );
+    return 'ok';
+};
+const _b5tbaa = async function _test_decompileImport_stageB_order_independent(stageB_importFake,decompileImport,formatImportDeclaration,expect)
+{
+    // The detection uses .find — it shouldn't matter whether the stitch is at
+    // index 0 or the aliases come first. Verify by reversing the array.
+    const vars = stageB_importFake('@user/y', [
+        { imported: 'a', local: 'a' },
+        { imported: 'b', local: 'b' }
+    ]);
+    const reversed = [...vars].reverse();
+    const info = await decompileImport(reversed);
+    expect(info.meta.detection.stage).toEqual('B');
+    expect(formatImportDeclaration(info)).toEqual(`import {a, b} from "@user/y"`);
+    return 'ok';
+};
+const _b5tbab = async function _test_decompileImport_stageB_notebook_id(stageB_importFake,decompileImport,formatImportDeclaration,expect)
+{
+    // Observable supports `import {x} from "d/<hash>@<version>"` notebook-id form.
+    const vars = stageB_importFake('d/57d79353bac56631@44', [
+        { imported: 'hash', local: 'hash' }
+    ]);
+    const info = await decompileImport(vars);
+    expect(info.meta.detection.stage).toEqual('B');
+    expect(formatImportDeclaration(info)).toEqual(`import {hash} from "d/57d79353bac56631@44"`);
+    return 'ok';
 };
 const _1lqhutp = function _102(md){return(
 md`## Javascript Source Normalization`
@@ -20755,8 +20955,19 @@ export default function define(runtime, observer) {
   $def("_1sylz7j", "formatImportDeclaration", [], _1sylz7j);  
   $def("_13dctdn", "test_decompileImport_basic", ["importFake","decompileImport","expect"], _13dctdn);  
   $def("_ujr0xn", "test_formatImportDeclaration_roundtrip", ["importFake","decompileImport","expect","formatImportDeclaration","decompile"], _ujr0xn);  
-  $def("_1u6sfri", "test_decompileImport_alias", ["importFake","decompileImport","expect","formatImportDeclaration"], _1u6sfri);  
-  $def("_1lqhutp", null, ["md"], _1lqhutp);  
+  $def("_1u6sfri", "test_decompileImport_alias", ["importFake","decompileImport","expect","formatImportDeclaration"], _1u6sfri);
+  $def("_b5tba1", "stageB_importFake", [], _b5tba1);
+  $def("_b5tba2", "test_decompileImport_stageB_single", ["stageB_importFake","decompileImport","formatImportDeclaration","expect"], _b5tba2);
+  $def("_b5tba3", "test_decompileImport_stageB_aliased", ["stageB_importFake","decompileImport","formatImportDeclaration","expect"], _b5tba3);
+  $def("_b5tba4", "test_decompileImport_stageB_multiple", ["stageB_importFake","decompileImport","formatImportDeclaration","expect"], _b5tba4);
+  $def("_b5tba5", "test_decompileImport_stageB_mixed_alias", ["stageB_importFake","decompileImport","formatImportDeclaration","expect"], _b5tba5);
+  $def("_b5tba6", "test_decompileImport_stageB_viewof", ["stageB_importFake","decompileImport","formatImportDeclaration","expect"], _b5tba6);
+  $def("_b5tba7", "test_decompileImport_stageB_mutable", ["stageB_importFake","decompileImport","formatImportDeclaration","expect"], _b5tba7);
+  $def("_b5tba8", "test_decompileImport_returns_null_for_non_import", ["decompileImport","expect"], _b5tba8);
+  $def("_b5tba9", "test_decompileImport_compile_roundtrip_single", ["compile","stageB_importFake","decompileImport","formatImportDeclaration","expect"], _b5tba9);
+  $def("_b5tbaa", "test_decompileImport_stageB_order_independent", ["stageB_importFake","decompileImport","formatImportDeclaration","expect"], _b5tbaa);
+  $def("_b5tbab", "test_decompileImport_stageB_notebook_id", ["stageB_importFake","decompileImport","formatImportDeclaration","expect"], _b5tbab);
+  $def("_1lqhutp", null, ["md"], _1lqhutp);
   $def("_ikzxev", "normalizeJavascriptSource", ["acorn","escodegen"], _ikzxev);  
   $def("_az8lo6", "normalizeVariables", ["variableToObject","normalizeJavascriptSource"], _az8lo6);  
   $def("_3knb9v", "variableToObject", [], _3knb9v);  

--- a/notebooks/@tomlarkworthy_observablejs-toolchain.json
+++ b/notebooks/@tomlarkworthy_observablejs-toolchain.json
@@ -409,7 +409,7 @@
       ]
     },
     "@tomlarkworthy/observablejs-toolchain": {
-      "hash": "05cd278f6b9293068d951f5b689a9f96",
+      "hash": "d9a90e9fe4112061bbce4824bd88b307",
       "files": [
         "acorn-walk-8.3.2.js.gz",
         "parser-6.1.0.js.gz"
@@ -542,6 +542,6 @@
       "@tomlarkworthy/observablejs-toolchain": "https://observablehq.com/@tomlarkworthy/observablejs-toolchain"
     }
   },
-  "observable_version": 7762,
-  "observable_update_time": "2026-05-20T04:02:51.038Z"
+  "observable_version": 7774,
+  "observable_update_time": "2026-05-21T04:10:20.810Z"
 }

--- a/notebooks/@tomlarkworthy_openai-responses-api.html
+++ b/notebooks/@tomlarkworthy_openai-responses-api.html
@@ -19474,56 +19474,103 @@ async (v) => {
 const _1effqg = function _96(md){return(
 md`### \`decompileImport\``
 )};
-const _1etqs71 = function _decompileImport(findModuleName,findImportedName)
+const _b7vai6 = function _decompileImport(findModuleName,findImportedName)
 {
-    return async function decompileImport(variables, options = {}) {
-        if (!variables || variables.length === 0)
-            throw new Error('no variables');
-        // #166: An import group is `[module @foo, ...aliases]` — the runtime stitch
-        // sits at index 0 by convention. Scan for the first alias (single _input,
-        // crosses module boundary) so this works whichever order the caller hands us.
-        const isCrossModuleAlias = v => {
-            const inputs = v?._inputs;
-            if (!Array.isArray(inputs) || inputs.length !== 1)
-                return false;
-            const i0 = inputs[0];
-            return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
-        };
-        const v0 = variables.find(isCrossModuleAlias);
-        if (!v0)
-            return null;
-        const input0 = v0._inputs[0];
-        const inputsLength = 1;
-        const crossesModuleBoundary = true;
-        const module_name = findModuleName(v0._module._scope, input0._module);
-        if (module_name == null)
-            throw new Error('module name could not be resolved');
-        // #166: Skip runtime-internal `module @foo` stitch variables — they belong to
-        // the import group but are not user-facing specifiers. Without this filter, an
-        // import group renders as `import {Range, module @foo} from "@foo"`.
-        const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
-            const imported = await findImportedName(v);
-            const local = v._name;
-            return {
-                imported,
-                local,
-                alias: imported !== local,
-                meta: { index }
-            };
-        }));
-        return {
-            type: 'import',
-            from: module_name,
-            specifiers,
-            meta: {
-                detection: {
-                    inputsLength,
-                    crossesModuleBoundary
-                },
-                variables: variables.map(v => v?._name ?? null)
-            }
-        };
+  return async function decompileImport(variables, options = {}) {
+    if (!variables || variables.length === 0)
+      throw new Error('no variables');
+    // An import-cell group is `[module @X stitch, ...aliases]`. Each alias goes
+    // through three lifecycle stages (documented in observable-runtime-v6's
+    // `importedModule` helper, lines ~1992-2049 of @tomlarkworthy/observable-runtime-v6):
+    //
+    //   Stage A — post-observation:
+    //     `_inputs = [Variable in source module]` (length 1, cross-module).
+    //     The Observable runtime rewrites _inputs after the alias is observed
+    //     and resolved against the source module.
+    //
+    //   Stage B — pre-observation, API-loaded (canonical compiled-bundle shape):
+    //     `_inputs = [Variable("module @X"), Variable("@variable")]` (length 2,
+    //     both in the importer module). What `runtime.define("name",
+    //     ["module @X", "@variable"], (_, v) => v.import("name", _))` produces.
+    //     Also what `compile_and_update` outputs for freshly-defined user-typed
+    //     imports until they're observed.
+    //
+    //   Stage C — pre-observation, inline live-notebook:
+    //     `_inputs = [Variable("@variable")]` (length 1) AND the definition
+    //     calls `import(...)` inside. We extract the imported module reference
+    //     by invoking the definition with a stub `import` capture.
+    //
+    // Detection order is post→pre because Stage A is unambiguous when present.
+    const isStageA = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
     };
+    const isStageB = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 2)
+        return false;
+      const [i0, i1] = inputs;
+      return !!(i0 && typeof i0 === 'object' && typeof i0._name === 'string' && i0._name.startsWith('module @') && i1 && typeof i1 === 'object' && i1._name === '@variable');
+    };
+    const isStageC = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && i0._name === '@variable' && typeof v._definition !== 'undefined' && String(v._definition).includes('import('));
+    };
+    let v0, module_name, stage;
+    if (v0 = variables.find(isStageA)) {
+      stage = 'A';
+      module_name = findModuleName(v0._module._scope, v0._inputs[0]._module);
+    } else if (v0 = variables.find(isStageB)) {
+      stage = 'B';
+      module_name = v0._inputs[0]._name.replace(/^module /, '');
+    } else if (v0 = variables.find(isStageC)) {
+      stage = 'C';
+      let capturedModule;
+      try {
+        await v0._definition({
+          import: (...args) => {
+            capturedModule = args[args.length - 1];
+          }
+        });
+      } catch (e) {
+      }
+      if (capturedModule && v0._module?._scope) {
+        module_name = findModuleName(v0._module._scope, capturedModule);
+      }
+    } else {
+      return null;
+    }
+    if (module_name == null)
+      throw new Error('module name could not be resolved');
+    // Skip runtime-internal `module @foo` stitch variables — they belong to
+    // the import group but are not user-facing specifiers. Without this filter, an
+    // import group renders as `import {Range, module @foo} from "@foo"`.
+    const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
+      const imported = await findImportedName(v);
+      const local = v._name;
+      return {
+        imported,
+        local,
+        alias: imported !== local,
+        meta: { index }
+      };
+    }));
+    return {
+      type: 'import',
+      from: module_name,
+      specifiers,
+      meta: {
+        detection: { stage },
+        variables: variables.map(v => v?._name ?? null)
+      }
+    };
+  };
 };
 const _1sylz7j = function _formatImportDeclaration(){return(
 function formatImportDeclaration(importInfo) {
@@ -20633,6 +20680,198 @@ const _1hiclbb = function _acorn_walk(acorn_walk_url) {
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
+const _1rc67k0 = function _stageB_importFake()
+{
+  return // Builds a Stage B (pre-observation, API-loaded) import group as POJOs.
+  // Mirrors what `runtime.define("name", ["module @X", "@variable"], (_, v) => v.import("name", _))`
+  // produces structurally. Used by the test_decompileImport_stageB_* tests to
+  // avoid spinning up a real Observable runtime per case.
+  function stageB_importFake(module_name, specifiers) {
+    const importerModule = { _scope: new Map() };
+    const stitch = {
+      _name: `module ${ module_name }`,
+      _module: importerModule,
+      _inputs: [],
+      _definition: `async () => null`
+    };
+    const atVariable = {
+      _name: '@variable',
+      _module: importerModule
+    };
+    const aliases = specifiers.map(s => ({
+      _name: s.local,
+      _module: importerModule,
+      _inputs: [
+        stitch,
+        atVariable
+      ],
+      _definition: s.imported === s.local ? `(_, v) => v.import("${ s.imported }", _)` : `(_, v) => v.import("${ s.imported }", "${ s.local }", _)`
+    }));
+    return [
+      stitch,
+      ...aliases
+    ];
+  };
+};
+const _1d53asg = async function _test_decompileImport_stageB_single(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [{
+      imported: 'visualize',
+      local: 'visualize'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _hv5gag = async function _test_decompileImport_stageB_aliased(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'x',
+      local: 'z'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(info.specifiers[0].alias).toEqual(true);
+  expect(formatImportDeclaration(info)).toEqual(`import {x as z} from "@user/y"`);
+  return 'ok';
+};
+const _avc18y = async function _test_decompileImport_stageB_multiple(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    },
+    {
+      imported: 'c',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b, c} from "@user/y"`);
+  return 'ok';
+};
+const _16gia7i = async function _test_decompileImport_stageB_mixed_alias(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b as c} from "@user/y"`);
+  return 'ok';
+};
+const _1slhdwo = async function _test_decompileImport_stageB_viewof(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/module-map', [{
+      imported: 'viewof currentModules',
+      local: 'viewof currentModules'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {viewof currentModules} from "@tomlarkworthy/module-map"`);
+  return 'ok';
+};
+const _qwlsf2 = async function _test_decompileImport_stageB_mutable(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'mutable counter',
+      local: 'mutable counter'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {mutable counter} from "@user/y"`);
+  return 'ok';
+};
+const _sy7jfx = async function _test_decompileImport_returns_null_for_non_import(decompileImport,expect)
+{
+  // A regular cell — no stitch, no @variable input, no cross-module reference.
+  const info = await decompileImport([{
+      _name: 'x',
+      _module: {},
+      _inputs: [],
+      _definition: `() => 42`
+    }]);
+  expect(info).toEqual(null);
+  return 'ok';
+};
+const _rk7ku3 = async function _test_decompileImport_compile_roundtrip_single(compile,expect,stageB_importFake,decompileImport,formatImportDeclaration)
+{
+  // What `compile()` emits for `import {x} from "@user/y"` is structurally the
+  // same as our stageB_importFake fixture (after runtime.define resolves the
+  // input name strings to Variable refs). Verify the fixture matches the
+  // shape compile() would produce.
+  const pojos = compile(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  expect(pojos.length).toEqual(3);
+  expect(pojos[0]._name).toEqual('module @tomlarkworthy/visualizer');
+  expect(pojos[1]._name).toEqual('visualize');
+  expect(pojos[2]._name).toEqual('Group');
+  expect(pojos[1]._inputs).toEqual([
+    'module @tomlarkworthy/visualizer',
+    '@variable'
+  ]);
+  // Now run our fixture through decompileImport — confirms the round-trip
+  // shape compile()-output-shape-when-defined → decompileImport produces the
+  // canonical import source string.
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [
+    {
+      imported: 'visualize',
+      local: 'visualize'
+    },
+    {
+      imported: 'Group',
+      local: 'Group'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _xynplo = async function _test_decompileImport_stageB_order_independent(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // The detection uses .find — it shouldn't matter whether the stitch is at
+  // index 0 or the aliases come first. Verify by reversing the array.
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    }
+  ]);
+  const reversed = [...vars].reverse();
+  const info = await decompileImport(reversed);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b} from "@user/y"`);
+  return 'ok';
+};
+const _16fpgac = async function _test_decompileImport_stageB_notebook_id(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // Observable supports `import {x} from "d/<hash>@<version>"` notebook-id form.
+  const vars = stageB_importFake('d/57d79353bac56631@44', [{
+      imported: 'hash',
+      local: 'hash'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {hash} from "d/57d79353bac56631@44"`);
+  return 'ok';
+};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -20753,7 +20992,7 @@ export default function define(runtime, observer) {
   $def("_1n7gw17", "findModuleName", ["extractModuleInfo"], _1n7gw17);  
   $def("_i47chb", "findImportedName", [], _i47chb);  
   $def("_1effqg", null, ["md"], _1effqg);  
-  $def("_1etqs71", "decompileImport", ["findModuleName","findImportedName"], _1etqs71);  
+  $def("_b7vai6", "decompileImport", ["findModuleName","findImportedName"], _b7vai6);  
   $def("_1sylz7j", "formatImportDeclaration", [], _1sylz7j);  
   $def("_13dctdn", "test_decompileImport_basic", ["importFake","decompileImport","expect"], _13dctdn);  
   $def("_ujr0xn", "test_formatImportDeclaration_roundtrip", ["importFake","decompileImport","expect","formatImportDeclaration","decompile"], _ujr0xn);  
@@ -20831,7 +21070,18 @@ export default function define(runtime, observer) {
   main.define("Runtime", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Runtime", _));  
   main.define("Inspector", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Inspector", _));  
   main.define("Library", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Library", _));  
-  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));
+  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));  
+  $def("_1rc67k0", "stageB_importFake", [], _1rc67k0);  
+  $def("_1d53asg", "test_decompileImport_stageB_single", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1d53asg);  
+  $def("_hv5gag", "test_decompileImport_stageB_aliased", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _hv5gag);  
+  $def("_avc18y", "test_decompileImport_stageB_multiple", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _avc18y);  
+  $def("_16gia7i", "test_decompileImport_stageB_mixed_alias", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16gia7i);  
+  $def("_1slhdwo", "test_decompileImport_stageB_viewof", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1slhdwo);  
+  $def("_qwlsf2", "test_decompileImport_stageB_mutable", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _qwlsf2);  
+  $def("_sy7jfx", "test_decompileImport_returns_null_for_non_import", ["decompileImport","expect"], _sy7jfx);  
+  $def("_rk7ku3", "test_decompileImport_compile_roundtrip_single", ["compile","expect","stageB_importFake","decompileImport","formatImportDeclaration"], _rk7ku3);  
+  $def("_xynplo", "test_decompileImport_stageB_order_independent", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _xynplo);  
+  $def("_16fpgac", "test_decompileImport_stageB_notebook_id", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16fpgac);
   return main;
 }</script>
 <script id="@tomlarkworthy/openai-responses-api/image.png" 

--- a/notebooks/@tomlarkworthy_reversible-attachment.html
+++ b/notebooks/@tomlarkworthy_reversible-attachment.html
@@ -19474,56 +19474,103 @@ async (v) => {
 const _1effqg = function _96(md){return(
 md`### \`decompileImport\``
 )};
-const _1etqs71 = function _decompileImport(findModuleName,findImportedName)
+const _b7vai6 = function _decompileImport(findModuleName,findImportedName)
 {
-    return async function decompileImport(variables, options = {}) {
-        if (!variables || variables.length === 0)
-            throw new Error('no variables');
-        // #166: An import group is `[module @foo, ...aliases]` — the runtime stitch
-        // sits at index 0 by convention. Scan for the first alias (single _input,
-        // crosses module boundary) so this works whichever order the caller hands us.
-        const isCrossModuleAlias = v => {
-            const inputs = v?._inputs;
-            if (!Array.isArray(inputs) || inputs.length !== 1)
-                return false;
-            const i0 = inputs[0];
-            return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
-        };
-        const v0 = variables.find(isCrossModuleAlias);
-        if (!v0)
-            return null;
-        const input0 = v0._inputs[0];
-        const inputsLength = 1;
-        const crossesModuleBoundary = true;
-        const module_name = findModuleName(v0._module._scope, input0._module);
-        if (module_name == null)
-            throw new Error('module name could not be resolved');
-        // #166: Skip runtime-internal `module @foo` stitch variables — they belong to
-        // the import group but are not user-facing specifiers. Without this filter, an
-        // import group renders as `import {Range, module @foo} from "@foo"`.
-        const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
-            const imported = await findImportedName(v);
-            const local = v._name;
-            return {
-                imported,
-                local,
-                alias: imported !== local,
-                meta: { index }
-            };
-        }));
-        return {
-            type: 'import',
-            from: module_name,
-            specifiers,
-            meta: {
-                detection: {
-                    inputsLength,
-                    crossesModuleBoundary
-                },
-                variables: variables.map(v => v?._name ?? null)
-            }
-        };
+  return async function decompileImport(variables, options = {}) {
+    if (!variables || variables.length === 0)
+      throw new Error('no variables');
+    // An import-cell group is `[module @X stitch, ...aliases]`. Each alias goes
+    // through three lifecycle stages (documented in observable-runtime-v6's
+    // `importedModule` helper, lines ~1992-2049 of @tomlarkworthy/observable-runtime-v6):
+    //
+    //   Stage A — post-observation:
+    //     `_inputs = [Variable in source module]` (length 1, cross-module).
+    //     The Observable runtime rewrites _inputs after the alias is observed
+    //     and resolved against the source module.
+    //
+    //   Stage B — pre-observation, API-loaded (canonical compiled-bundle shape):
+    //     `_inputs = [Variable("module @X"), Variable("@variable")]` (length 2,
+    //     both in the importer module). What `runtime.define("name",
+    //     ["module @X", "@variable"], (_, v) => v.import("name", _))` produces.
+    //     Also what `compile_and_update` outputs for freshly-defined user-typed
+    //     imports until they're observed.
+    //
+    //   Stage C — pre-observation, inline live-notebook:
+    //     `_inputs = [Variable("@variable")]` (length 1) AND the definition
+    //     calls `import(...)` inside. We extract the imported module reference
+    //     by invoking the definition with a stub `import` capture.
+    //
+    // Detection order is post→pre because Stage A is unambiguous when present.
+    const isStageA = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
     };
+    const isStageB = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 2)
+        return false;
+      const [i0, i1] = inputs;
+      return !!(i0 && typeof i0 === 'object' && typeof i0._name === 'string' && i0._name.startsWith('module @') && i1 && typeof i1 === 'object' && i1._name === '@variable');
+    };
+    const isStageC = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && i0._name === '@variable' && typeof v._definition !== 'undefined' && String(v._definition).includes('import('));
+    };
+    let v0, module_name, stage;
+    if (v0 = variables.find(isStageA)) {
+      stage = 'A';
+      module_name = findModuleName(v0._module._scope, v0._inputs[0]._module);
+    } else if (v0 = variables.find(isStageB)) {
+      stage = 'B';
+      module_name = v0._inputs[0]._name.replace(/^module /, '');
+    } else if (v0 = variables.find(isStageC)) {
+      stage = 'C';
+      let capturedModule;
+      try {
+        await v0._definition({
+          import: (...args) => {
+            capturedModule = args[args.length - 1];
+          }
+        });
+      } catch (e) {
+      }
+      if (capturedModule && v0._module?._scope) {
+        module_name = findModuleName(v0._module._scope, capturedModule);
+      }
+    } else {
+      return null;
+    }
+    if (module_name == null)
+      throw new Error('module name could not be resolved');
+    // Skip runtime-internal `module @foo` stitch variables — they belong to
+    // the import group but are not user-facing specifiers. Without this filter, an
+    // import group renders as `import {Range, module @foo} from "@foo"`.
+    const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
+      const imported = await findImportedName(v);
+      const local = v._name;
+      return {
+        imported,
+        local,
+        alias: imported !== local,
+        meta: { index }
+      };
+    }));
+    return {
+      type: 'import',
+      from: module_name,
+      specifiers,
+      meta: {
+        detection: { stage },
+        variables: variables.map(v => v?._name ?? null)
+      }
+    };
+  };
 };
 const _1sylz7j = function _formatImportDeclaration(){return(
 function formatImportDeclaration(importInfo) {
@@ -20633,6 +20680,198 @@ const _1hiclbb = function _acorn_walk(acorn_walk_url) {
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
+const _1rc67k0 = function _stageB_importFake()
+{
+  return // Builds a Stage B (pre-observation, API-loaded) import group as POJOs.
+  // Mirrors what `runtime.define("name", ["module @X", "@variable"], (_, v) => v.import("name", _))`
+  // produces structurally. Used by the test_decompileImport_stageB_* tests to
+  // avoid spinning up a real Observable runtime per case.
+  function stageB_importFake(module_name, specifiers) {
+    const importerModule = { _scope: new Map() };
+    const stitch = {
+      _name: `module ${ module_name }`,
+      _module: importerModule,
+      _inputs: [],
+      _definition: `async () => null`
+    };
+    const atVariable = {
+      _name: '@variable',
+      _module: importerModule
+    };
+    const aliases = specifiers.map(s => ({
+      _name: s.local,
+      _module: importerModule,
+      _inputs: [
+        stitch,
+        atVariable
+      ],
+      _definition: s.imported === s.local ? `(_, v) => v.import("${ s.imported }", _)` : `(_, v) => v.import("${ s.imported }", "${ s.local }", _)`
+    }));
+    return [
+      stitch,
+      ...aliases
+    ];
+  };
+};
+const _1d53asg = async function _test_decompileImport_stageB_single(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [{
+      imported: 'visualize',
+      local: 'visualize'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _hv5gag = async function _test_decompileImport_stageB_aliased(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'x',
+      local: 'z'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(info.specifiers[0].alias).toEqual(true);
+  expect(formatImportDeclaration(info)).toEqual(`import {x as z} from "@user/y"`);
+  return 'ok';
+};
+const _avc18y = async function _test_decompileImport_stageB_multiple(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    },
+    {
+      imported: 'c',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b, c} from "@user/y"`);
+  return 'ok';
+};
+const _16gia7i = async function _test_decompileImport_stageB_mixed_alias(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b as c} from "@user/y"`);
+  return 'ok';
+};
+const _1slhdwo = async function _test_decompileImport_stageB_viewof(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/module-map', [{
+      imported: 'viewof currentModules',
+      local: 'viewof currentModules'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {viewof currentModules} from "@tomlarkworthy/module-map"`);
+  return 'ok';
+};
+const _qwlsf2 = async function _test_decompileImport_stageB_mutable(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'mutable counter',
+      local: 'mutable counter'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {mutable counter} from "@user/y"`);
+  return 'ok';
+};
+const _sy7jfx = async function _test_decompileImport_returns_null_for_non_import(decompileImport,expect)
+{
+  // A regular cell — no stitch, no @variable input, no cross-module reference.
+  const info = await decompileImport([{
+      _name: 'x',
+      _module: {},
+      _inputs: [],
+      _definition: `() => 42`
+    }]);
+  expect(info).toEqual(null);
+  return 'ok';
+};
+const _rk7ku3 = async function _test_decompileImport_compile_roundtrip_single(compile,expect,stageB_importFake,decompileImport,formatImportDeclaration)
+{
+  // What `compile()` emits for `import {x} from "@user/y"` is structurally the
+  // same as our stageB_importFake fixture (after runtime.define resolves the
+  // input name strings to Variable refs). Verify the fixture matches the
+  // shape compile() would produce.
+  const pojos = compile(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  expect(pojos.length).toEqual(3);
+  expect(pojos[0]._name).toEqual('module @tomlarkworthy/visualizer');
+  expect(pojos[1]._name).toEqual('visualize');
+  expect(pojos[2]._name).toEqual('Group');
+  expect(pojos[1]._inputs).toEqual([
+    'module @tomlarkworthy/visualizer',
+    '@variable'
+  ]);
+  // Now run our fixture through decompileImport — confirms the round-trip
+  // shape compile()-output-shape-when-defined → decompileImport produces the
+  // canonical import source string.
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [
+    {
+      imported: 'visualize',
+      local: 'visualize'
+    },
+    {
+      imported: 'Group',
+      local: 'Group'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _xynplo = async function _test_decompileImport_stageB_order_independent(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // The detection uses .find — it shouldn't matter whether the stitch is at
+  // index 0 or the aliases come first. Verify by reversing the array.
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    }
+  ]);
+  const reversed = [...vars].reverse();
+  const info = await decompileImport(reversed);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b} from "@user/y"`);
+  return 'ok';
+};
+const _16fpgac = async function _test_decompileImport_stageB_notebook_id(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // Observable supports `import {x} from "d/<hash>@<version>"` notebook-id form.
+  const vars = stageB_importFake('d/57d79353bac56631@44', [{
+      imported: 'hash',
+      local: 'hash'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {hash} from "d/57d79353bac56631@44"`);
+  return 'ok';
+};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -20753,7 +20992,7 @@ export default function define(runtime, observer) {
   $def("_1n7gw17", "findModuleName", ["extractModuleInfo"], _1n7gw17);  
   $def("_i47chb", "findImportedName", [], _i47chb);  
   $def("_1effqg", null, ["md"], _1effqg);  
-  $def("_1etqs71", "decompileImport", ["findModuleName","findImportedName"], _1etqs71);  
+  $def("_b7vai6", "decompileImport", ["findModuleName","findImportedName"], _b7vai6);  
   $def("_1sylz7j", "formatImportDeclaration", [], _1sylz7j);  
   $def("_13dctdn", "test_decompileImport_basic", ["importFake","decompileImport","expect"], _13dctdn);  
   $def("_ujr0xn", "test_formatImportDeclaration_roundtrip", ["importFake","decompileImport","expect","formatImportDeclaration","decompile"], _ujr0xn);  
@@ -20831,7 +21070,18 @@ export default function define(runtime, observer) {
   main.define("Runtime", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Runtime", _));  
   main.define("Inspector", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Inspector", _));  
   main.define("Library", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Library", _));  
-  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));
+  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));  
+  $def("_1rc67k0", "stageB_importFake", [], _1rc67k0);  
+  $def("_1d53asg", "test_decompileImport_stageB_single", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1d53asg);  
+  $def("_hv5gag", "test_decompileImport_stageB_aliased", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _hv5gag);  
+  $def("_avc18y", "test_decompileImport_stageB_multiple", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _avc18y);  
+  $def("_16gia7i", "test_decompileImport_stageB_mixed_alias", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16gia7i);  
+  $def("_1slhdwo", "test_decompileImport_stageB_viewof", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1slhdwo);  
+  $def("_qwlsf2", "test_decompileImport_stageB_mutable", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _qwlsf2);  
+  $def("_sy7jfx", "test_decompileImport_returns_null_for_non_import", ["decompileImport","expect"], _sy7jfx);  
+  $def("_rk7ku3", "test_decompileImport_compile_roundtrip_single", ["compile","expect","stageB_importFake","decompileImport","formatImportDeclaration"], _rk7ku3);  
+  $def("_xynplo", "test_decompileImport_stageB_order_independent", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _xynplo);  
+  $def("_16fpgac", "test_decompileImport_stageB_notebook_id", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16fpgac);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_robocoop-2.html
+++ b/notebooks/@tomlarkworthy_robocoop-2.html
@@ -19526,56 +19526,103 @@ async (v) => {
 const _1effqg = function _96(md){return(
 md`### \`decompileImport\``
 )};
-const _1etqs71 = function _decompileImport(findModuleName,findImportedName)
+const _b7vai6 = function _decompileImport(findModuleName,findImportedName)
 {
-    return async function decompileImport(variables, options = {}) {
-        if (!variables || variables.length === 0)
-            throw new Error('no variables');
-        // #166: An import group is `[module @foo, ...aliases]` — the runtime stitch
-        // sits at index 0 by convention. Scan for the first alias (single _input,
-        // crosses module boundary) so this works whichever order the caller hands us.
-        const isCrossModuleAlias = v => {
-            const inputs = v?._inputs;
-            if (!Array.isArray(inputs) || inputs.length !== 1)
-                return false;
-            const i0 = inputs[0];
-            return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
-        };
-        const v0 = variables.find(isCrossModuleAlias);
-        if (!v0)
-            return null;
-        const input0 = v0._inputs[0];
-        const inputsLength = 1;
-        const crossesModuleBoundary = true;
-        const module_name = findModuleName(v0._module._scope, input0._module);
-        if (module_name == null)
-            throw new Error('module name could not be resolved');
-        // #166: Skip runtime-internal `module @foo` stitch variables — they belong to
-        // the import group but are not user-facing specifiers. Without this filter, an
-        // import group renders as `import {Range, module @foo} from "@foo"`.
-        const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
-            const imported = await findImportedName(v);
-            const local = v._name;
-            return {
-                imported,
-                local,
-                alias: imported !== local,
-                meta: { index }
-            };
-        }));
-        return {
-            type: 'import',
-            from: module_name,
-            specifiers,
-            meta: {
-                detection: {
-                    inputsLength,
-                    crossesModuleBoundary
-                },
-                variables: variables.map(v => v?._name ?? null)
-            }
-        };
+  return async function decompileImport(variables, options = {}) {
+    if (!variables || variables.length === 0)
+      throw new Error('no variables');
+    // An import-cell group is `[module @X stitch, ...aliases]`. Each alias goes
+    // through three lifecycle stages (documented in observable-runtime-v6's
+    // `importedModule` helper, lines ~1992-2049 of @tomlarkworthy/observable-runtime-v6):
+    //
+    //   Stage A — post-observation:
+    //     `_inputs = [Variable in source module]` (length 1, cross-module).
+    //     The Observable runtime rewrites _inputs after the alias is observed
+    //     and resolved against the source module.
+    //
+    //   Stage B — pre-observation, API-loaded (canonical compiled-bundle shape):
+    //     `_inputs = [Variable("module @X"), Variable("@variable")]` (length 2,
+    //     both in the importer module). What `runtime.define("name",
+    //     ["module @X", "@variable"], (_, v) => v.import("name", _))` produces.
+    //     Also what `compile_and_update` outputs for freshly-defined user-typed
+    //     imports until they're observed.
+    //
+    //   Stage C — pre-observation, inline live-notebook:
+    //     `_inputs = [Variable("@variable")]` (length 1) AND the definition
+    //     calls `import(...)` inside. We extract the imported module reference
+    //     by invoking the definition with a stub `import` capture.
+    //
+    // Detection order is post→pre because Stage A is unambiguous when present.
+    const isStageA = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
     };
+    const isStageB = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 2)
+        return false;
+      const [i0, i1] = inputs;
+      return !!(i0 && typeof i0 === 'object' && typeof i0._name === 'string' && i0._name.startsWith('module @') && i1 && typeof i1 === 'object' && i1._name === '@variable');
+    };
+    const isStageC = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && i0._name === '@variable' && typeof v._definition !== 'undefined' && String(v._definition).includes('import('));
+    };
+    let v0, module_name, stage;
+    if (v0 = variables.find(isStageA)) {
+      stage = 'A';
+      module_name = findModuleName(v0._module._scope, v0._inputs[0]._module);
+    } else if (v0 = variables.find(isStageB)) {
+      stage = 'B';
+      module_name = v0._inputs[0]._name.replace(/^module /, '');
+    } else if (v0 = variables.find(isStageC)) {
+      stage = 'C';
+      let capturedModule;
+      try {
+        await v0._definition({
+          import: (...args) => {
+            capturedModule = args[args.length - 1];
+          }
+        });
+      } catch (e) {
+      }
+      if (capturedModule && v0._module?._scope) {
+        module_name = findModuleName(v0._module._scope, capturedModule);
+      }
+    } else {
+      return null;
+    }
+    if (module_name == null)
+      throw new Error('module name could not be resolved');
+    // Skip runtime-internal `module @foo` stitch variables — they belong to
+    // the import group but are not user-facing specifiers. Without this filter, an
+    // import group renders as `import {Range, module @foo} from "@foo"`.
+    const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
+      const imported = await findImportedName(v);
+      const local = v._name;
+      return {
+        imported,
+        local,
+        alias: imported !== local,
+        meta: { index }
+      };
+    }));
+    return {
+      type: 'import',
+      from: module_name,
+      specifiers,
+      meta: {
+        detection: { stage },
+        variables: variables.map(v => v?._name ?? null)
+      }
+    };
+  };
 };
 const _1sylz7j = function _formatImportDeclaration(){return(
 function formatImportDeclaration(importInfo) {
@@ -20685,6 +20732,198 @@ const _1hiclbb = function _acorn_walk(acorn_walk_url) {
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
+const _1rc67k0 = function _stageB_importFake()
+{
+  return // Builds a Stage B (pre-observation, API-loaded) import group as POJOs.
+  // Mirrors what `runtime.define("name", ["module @X", "@variable"], (_, v) => v.import("name", _))`
+  // produces structurally. Used by the test_decompileImport_stageB_* tests to
+  // avoid spinning up a real Observable runtime per case.
+  function stageB_importFake(module_name, specifiers) {
+    const importerModule = { _scope: new Map() };
+    const stitch = {
+      _name: `module ${ module_name }`,
+      _module: importerModule,
+      _inputs: [],
+      _definition: `async () => null`
+    };
+    const atVariable = {
+      _name: '@variable',
+      _module: importerModule
+    };
+    const aliases = specifiers.map(s => ({
+      _name: s.local,
+      _module: importerModule,
+      _inputs: [
+        stitch,
+        atVariable
+      ],
+      _definition: s.imported === s.local ? `(_, v) => v.import("${ s.imported }", _)` : `(_, v) => v.import("${ s.imported }", "${ s.local }", _)`
+    }));
+    return [
+      stitch,
+      ...aliases
+    ];
+  };
+};
+const _1d53asg = async function _test_decompileImport_stageB_single(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [{
+      imported: 'visualize',
+      local: 'visualize'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _hv5gag = async function _test_decompileImport_stageB_aliased(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'x',
+      local: 'z'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(info.specifiers[0].alias).toEqual(true);
+  expect(formatImportDeclaration(info)).toEqual(`import {x as z} from "@user/y"`);
+  return 'ok';
+};
+const _avc18y = async function _test_decompileImport_stageB_multiple(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    },
+    {
+      imported: 'c',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b, c} from "@user/y"`);
+  return 'ok';
+};
+const _16gia7i = async function _test_decompileImport_stageB_mixed_alias(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b as c} from "@user/y"`);
+  return 'ok';
+};
+const _1slhdwo = async function _test_decompileImport_stageB_viewof(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/module-map', [{
+      imported: 'viewof currentModules',
+      local: 'viewof currentModules'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {viewof currentModules} from "@tomlarkworthy/module-map"`);
+  return 'ok';
+};
+const _qwlsf2 = async function _test_decompileImport_stageB_mutable(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'mutable counter',
+      local: 'mutable counter'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {mutable counter} from "@user/y"`);
+  return 'ok';
+};
+const _sy7jfx = async function _test_decompileImport_returns_null_for_non_import(decompileImport,expect)
+{
+  // A regular cell — no stitch, no @variable input, no cross-module reference.
+  const info = await decompileImport([{
+      _name: 'x',
+      _module: {},
+      _inputs: [],
+      _definition: `() => 42`
+    }]);
+  expect(info).toEqual(null);
+  return 'ok';
+};
+const _rk7ku3 = async function _test_decompileImport_compile_roundtrip_single(compile,expect,stageB_importFake,decompileImport,formatImportDeclaration)
+{
+  // What `compile()` emits for `import {x} from "@user/y"` is structurally the
+  // same as our stageB_importFake fixture (after runtime.define resolves the
+  // input name strings to Variable refs). Verify the fixture matches the
+  // shape compile() would produce.
+  const pojos = compile(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  expect(pojos.length).toEqual(3);
+  expect(pojos[0]._name).toEqual('module @tomlarkworthy/visualizer');
+  expect(pojos[1]._name).toEqual('visualize');
+  expect(pojos[2]._name).toEqual('Group');
+  expect(pojos[1]._inputs).toEqual([
+    'module @tomlarkworthy/visualizer',
+    '@variable'
+  ]);
+  // Now run our fixture through decompileImport — confirms the round-trip
+  // shape compile()-output-shape-when-defined → decompileImport produces the
+  // canonical import source string.
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [
+    {
+      imported: 'visualize',
+      local: 'visualize'
+    },
+    {
+      imported: 'Group',
+      local: 'Group'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _xynplo = async function _test_decompileImport_stageB_order_independent(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // The detection uses .find — it shouldn't matter whether the stitch is at
+  // index 0 or the aliases come first. Verify by reversing the array.
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    }
+  ]);
+  const reversed = [...vars].reverse();
+  const info = await decompileImport(reversed);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b} from "@user/y"`);
+  return 'ok';
+};
+const _16fpgac = async function _test_decompileImport_stageB_notebook_id(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // Observable supports `import {x} from "d/<hash>@<version>"` notebook-id form.
+  const vars = stageB_importFake('d/57d79353bac56631@44', [{
+      imported: 'hash',
+      local: 'hash'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {hash} from "d/57d79353bac56631@44"`);
+  return 'ok';
+};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -20805,7 +21044,7 @@ export default function define(runtime, observer) {
   $def("_1n7gw17", "findModuleName", ["extractModuleInfo"], _1n7gw17);  
   $def("_i47chb", "findImportedName", [], _i47chb);  
   $def("_1effqg", null, ["md"], _1effqg);  
-  $def("_1etqs71", "decompileImport", ["findModuleName","findImportedName"], _1etqs71);  
+  $def("_b7vai6", "decompileImport", ["findModuleName","findImportedName"], _b7vai6);  
   $def("_1sylz7j", "formatImportDeclaration", [], _1sylz7j);  
   $def("_13dctdn", "test_decompileImport_basic", ["importFake","decompileImport","expect"], _13dctdn);  
   $def("_ujr0xn", "test_formatImportDeclaration_roundtrip", ["importFake","decompileImport","expect","formatImportDeclaration","decompile"], _ujr0xn);  
@@ -20883,7 +21122,18 @@ export default function define(runtime, observer) {
   main.define("Runtime", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Runtime", _));  
   main.define("Inspector", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Inspector", _));  
   main.define("Library", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Library", _));  
-  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));
+  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));  
+  $def("_1rc67k0", "stageB_importFake", [], _1rc67k0);  
+  $def("_1d53asg", "test_decompileImport_stageB_single", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1d53asg);  
+  $def("_hv5gag", "test_decompileImport_stageB_aliased", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _hv5gag);  
+  $def("_avc18y", "test_decompileImport_stageB_multiple", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _avc18y);  
+  $def("_16gia7i", "test_decompileImport_stageB_mixed_alias", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16gia7i);  
+  $def("_1slhdwo", "test_decompileImport_stageB_viewof", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1slhdwo);  
+  $def("_qwlsf2", "test_decompileImport_stageB_mutable", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _qwlsf2);  
+  $def("_sy7jfx", "test_decompileImport_returns_null_for_non_import", ["decompileImport","expect"], _sy7jfx);  
+  $def("_rk7ku3", "test_decompileImport_compile_roundtrip_single", ["compile","expect","stageB_importFake","decompileImport","formatImportDeclaration"], _rk7ku3);  
+  $def("_xynplo", "test_decompileImport_stageB_order_independent", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _xynplo);  
+  $def("_16fpgac", "test_decompileImport_stageB_notebook_id", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16fpgac);
   return main;
 }</script>
 <script id="@tomlarkworthy/openai-responses-api/image.png" 

--- a/notebooks/@tomlarkworthy_robocoop-3.html
+++ b/notebooks/@tomlarkworthy_robocoop-3.html
@@ -19526,56 +19526,103 @@ async (v) => {
 const _1effqg = function _96(md){return(
 md`### \`decompileImport\``
 )};
-const _1etqs71 = function _decompileImport(findModuleName,findImportedName)
+const _b7vai6 = function _decompileImport(findModuleName,findImportedName)
 {
-    return async function decompileImport(variables, options = {}) {
-        if (!variables || variables.length === 0)
-            throw new Error('no variables');
-        // #166: An import group is `[module @foo, ...aliases]` — the runtime stitch
-        // sits at index 0 by convention. Scan for the first alias (single _input,
-        // crosses module boundary) so this works whichever order the caller hands us.
-        const isCrossModuleAlias = v => {
-            const inputs = v?._inputs;
-            if (!Array.isArray(inputs) || inputs.length !== 1)
-                return false;
-            const i0 = inputs[0];
-            return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
-        };
-        const v0 = variables.find(isCrossModuleAlias);
-        if (!v0)
-            return null;
-        const input0 = v0._inputs[0];
-        const inputsLength = 1;
-        const crossesModuleBoundary = true;
-        const module_name = findModuleName(v0._module._scope, input0._module);
-        if (module_name == null)
-            throw new Error('module name could not be resolved');
-        // #166: Skip runtime-internal `module @foo` stitch variables — they belong to
-        // the import group but are not user-facing specifiers. Without this filter, an
-        // import group renders as `import {Range, module @foo} from "@foo"`.
-        const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
-            const imported = await findImportedName(v);
-            const local = v._name;
-            return {
-                imported,
-                local,
-                alias: imported !== local,
-                meta: { index }
-            };
-        }));
-        return {
-            type: 'import',
-            from: module_name,
-            specifiers,
-            meta: {
-                detection: {
-                    inputsLength,
-                    crossesModuleBoundary
-                },
-                variables: variables.map(v => v?._name ?? null)
-            }
-        };
+  return async function decompileImport(variables, options = {}) {
+    if (!variables || variables.length === 0)
+      throw new Error('no variables');
+    // An import-cell group is `[module @X stitch, ...aliases]`. Each alias goes
+    // through three lifecycle stages (documented in observable-runtime-v6's
+    // `importedModule` helper, lines ~1992-2049 of @tomlarkworthy/observable-runtime-v6):
+    //
+    //   Stage A — post-observation:
+    //     `_inputs = [Variable in source module]` (length 1, cross-module).
+    //     The Observable runtime rewrites _inputs after the alias is observed
+    //     and resolved against the source module.
+    //
+    //   Stage B — pre-observation, API-loaded (canonical compiled-bundle shape):
+    //     `_inputs = [Variable("module @X"), Variable("@variable")]` (length 2,
+    //     both in the importer module). What `runtime.define("name",
+    //     ["module @X", "@variable"], (_, v) => v.import("name", _))` produces.
+    //     Also what `compile_and_update` outputs for freshly-defined user-typed
+    //     imports until they're observed.
+    //
+    //   Stage C — pre-observation, inline live-notebook:
+    //     `_inputs = [Variable("@variable")]` (length 1) AND the definition
+    //     calls `import(...)` inside. We extract the imported module reference
+    //     by invoking the definition with a stub `import` capture.
+    //
+    // Detection order is post→pre because Stage A is unambiguous when present.
+    const isStageA = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
     };
+    const isStageB = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 2)
+        return false;
+      const [i0, i1] = inputs;
+      return !!(i0 && typeof i0 === 'object' && typeof i0._name === 'string' && i0._name.startsWith('module @') && i1 && typeof i1 === 'object' && i1._name === '@variable');
+    };
+    const isStageC = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && i0._name === '@variable' && typeof v._definition !== 'undefined' && String(v._definition).includes('import('));
+    };
+    let v0, module_name, stage;
+    if (v0 = variables.find(isStageA)) {
+      stage = 'A';
+      module_name = findModuleName(v0._module._scope, v0._inputs[0]._module);
+    } else if (v0 = variables.find(isStageB)) {
+      stage = 'B';
+      module_name = v0._inputs[0]._name.replace(/^module /, '');
+    } else if (v0 = variables.find(isStageC)) {
+      stage = 'C';
+      let capturedModule;
+      try {
+        await v0._definition({
+          import: (...args) => {
+            capturedModule = args[args.length - 1];
+          }
+        });
+      } catch (e) {
+      }
+      if (capturedModule && v0._module?._scope) {
+        module_name = findModuleName(v0._module._scope, capturedModule);
+      }
+    } else {
+      return null;
+    }
+    if (module_name == null)
+      throw new Error('module name could not be resolved');
+    // Skip runtime-internal `module @foo` stitch variables — they belong to
+    // the import group but are not user-facing specifiers. Without this filter, an
+    // import group renders as `import {Range, module @foo} from "@foo"`.
+    const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
+      const imported = await findImportedName(v);
+      const local = v._name;
+      return {
+        imported,
+        local,
+        alias: imported !== local,
+        meta: { index }
+      };
+    }));
+    return {
+      type: 'import',
+      from: module_name,
+      specifiers,
+      meta: {
+        detection: { stage },
+        variables: variables.map(v => v?._name ?? null)
+      }
+    };
+  };
 };
 const _1sylz7j = function _formatImportDeclaration(){return(
 function formatImportDeclaration(importInfo) {
@@ -20685,6 +20732,198 @@ const _1hiclbb = function _acorn_walk(acorn_walk_url) {
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
+const _1rc67k0 = function _stageB_importFake()
+{
+  return // Builds a Stage B (pre-observation, API-loaded) import group as POJOs.
+  // Mirrors what `runtime.define("name", ["module @X", "@variable"], (_, v) => v.import("name", _))`
+  // produces structurally. Used by the test_decompileImport_stageB_* tests to
+  // avoid spinning up a real Observable runtime per case.
+  function stageB_importFake(module_name, specifiers) {
+    const importerModule = { _scope: new Map() };
+    const stitch = {
+      _name: `module ${ module_name }`,
+      _module: importerModule,
+      _inputs: [],
+      _definition: `async () => null`
+    };
+    const atVariable = {
+      _name: '@variable',
+      _module: importerModule
+    };
+    const aliases = specifiers.map(s => ({
+      _name: s.local,
+      _module: importerModule,
+      _inputs: [
+        stitch,
+        atVariable
+      ],
+      _definition: s.imported === s.local ? `(_, v) => v.import("${ s.imported }", _)` : `(_, v) => v.import("${ s.imported }", "${ s.local }", _)`
+    }));
+    return [
+      stitch,
+      ...aliases
+    ];
+  };
+};
+const _1d53asg = async function _test_decompileImport_stageB_single(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [{
+      imported: 'visualize',
+      local: 'visualize'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _hv5gag = async function _test_decompileImport_stageB_aliased(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'x',
+      local: 'z'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(info.specifiers[0].alias).toEqual(true);
+  expect(formatImportDeclaration(info)).toEqual(`import {x as z} from "@user/y"`);
+  return 'ok';
+};
+const _avc18y = async function _test_decompileImport_stageB_multiple(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    },
+    {
+      imported: 'c',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b, c} from "@user/y"`);
+  return 'ok';
+};
+const _16gia7i = async function _test_decompileImport_stageB_mixed_alias(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b as c} from "@user/y"`);
+  return 'ok';
+};
+const _1slhdwo = async function _test_decompileImport_stageB_viewof(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/module-map', [{
+      imported: 'viewof currentModules',
+      local: 'viewof currentModules'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {viewof currentModules} from "@tomlarkworthy/module-map"`);
+  return 'ok';
+};
+const _qwlsf2 = async function _test_decompileImport_stageB_mutable(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'mutable counter',
+      local: 'mutable counter'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {mutable counter} from "@user/y"`);
+  return 'ok';
+};
+const _sy7jfx = async function _test_decompileImport_returns_null_for_non_import(decompileImport,expect)
+{
+  // A regular cell — no stitch, no @variable input, no cross-module reference.
+  const info = await decompileImport([{
+      _name: 'x',
+      _module: {},
+      _inputs: [],
+      _definition: `() => 42`
+    }]);
+  expect(info).toEqual(null);
+  return 'ok';
+};
+const _rk7ku3 = async function _test_decompileImport_compile_roundtrip_single(compile,expect,stageB_importFake,decompileImport,formatImportDeclaration)
+{
+  // What `compile()` emits for `import {x} from "@user/y"` is structurally the
+  // same as our stageB_importFake fixture (after runtime.define resolves the
+  // input name strings to Variable refs). Verify the fixture matches the
+  // shape compile() would produce.
+  const pojos = compile(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  expect(pojos.length).toEqual(3);
+  expect(pojos[0]._name).toEqual('module @tomlarkworthy/visualizer');
+  expect(pojos[1]._name).toEqual('visualize');
+  expect(pojos[2]._name).toEqual('Group');
+  expect(pojos[1]._inputs).toEqual([
+    'module @tomlarkworthy/visualizer',
+    '@variable'
+  ]);
+  // Now run our fixture through decompileImport — confirms the round-trip
+  // shape compile()-output-shape-when-defined → decompileImport produces the
+  // canonical import source string.
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [
+    {
+      imported: 'visualize',
+      local: 'visualize'
+    },
+    {
+      imported: 'Group',
+      local: 'Group'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _xynplo = async function _test_decompileImport_stageB_order_independent(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // The detection uses .find — it shouldn't matter whether the stitch is at
+  // index 0 or the aliases come first. Verify by reversing the array.
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    }
+  ]);
+  const reversed = [...vars].reverse();
+  const info = await decompileImport(reversed);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b} from "@user/y"`);
+  return 'ok';
+};
+const _16fpgac = async function _test_decompileImport_stageB_notebook_id(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // Observable supports `import {x} from "d/<hash>@<version>"` notebook-id form.
+  const vars = stageB_importFake('d/57d79353bac56631@44', [{
+      imported: 'hash',
+      local: 'hash'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {hash} from "d/57d79353bac56631@44"`);
+  return 'ok';
+};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -20805,7 +21044,7 @@ export default function define(runtime, observer) {
   $def("_1n7gw17", "findModuleName", ["extractModuleInfo"], _1n7gw17);  
   $def("_i47chb", "findImportedName", [], _i47chb);  
   $def("_1effqg", null, ["md"], _1effqg);  
-  $def("_1etqs71", "decompileImport", ["findModuleName","findImportedName"], _1etqs71);  
+  $def("_b7vai6", "decompileImport", ["findModuleName","findImportedName"], _b7vai6);  
   $def("_1sylz7j", "formatImportDeclaration", [], _1sylz7j);  
   $def("_13dctdn", "test_decompileImport_basic", ["importFake","decompileImport","expect"], _13dctdn);  
   $def("_ujr0xn", "test_formatImportDeclaration_roundtrip", ["importFake","decompileImport","expect","formatImportDeclaration","decompile"], _ujr0xn);  
@@ -20883,7 +21122,18 @@ export default function define(runtime, observer) {
   main.define("Runtime", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Runtime", _));  
   main.define("Inspector", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Inspector", _));  
   main.define("Library", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Library", _));  
-  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));
+  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));  
+  $def("_1rc67k0", "stageB_importFake", [], _1rc67k0);  
+  $def("_1d53asg", "test_decompileImport_stageB_single", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1d53asg);  
+  $def("_hv5gag", "test_decompileImport_stageB_aliased", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _hv5gag);  
+  $def("_avc18y", "test_decompileImport_stageB_multiple", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _avc18y);  
+  $def("_16gia7i", "test_decompileImport_stageB_mixed_alias", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16gia7i);  
+  $def("_1slhdwo", "test_decompileImport_stageB_viewof", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1slhdwo);  
+  $def("_qwlsf2", "test_decompileImport_stageB_mutable", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _qwlsf2);  
+  $def("_sy7jfx", "test_decompileImport_returns_null_for_non_import", ["decompileImport","expect"], _sy7jfx);  
+  $def("_rk7ku3", "test_decompileImport_compile_roundtrip_single", ["compile","expect","stageB_importFake","decompileImport","formatImportDeclaration"], _rk7ku3);  
+  $def("_xynplo", "test_decompileImport_stageB_order_independent", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _xynplo);  
+  $def("_16fpgac", "test_decompileImport_stageB_notebook_id", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16fpgac);
   return main;
 }</script>
 <script id="@tomlarkworthy/openai-responses-api/image.png" 

--- a/notebooks/@tomlarkworthy_runtime-sdk.html
+++ b/notebooks/@tomlarkworthy_runtime-sdk.html
@@ -19474,56 +19474,103 @@ async (v) => {
 const _1effqg = function _96(md){return(
 md`### \`decompileImport\``
 )};
-const _1etqs71 = function _decompileImport(findModuleName,findImportedName)
+const _b7vai6 = function _decompileImport(findModuleName,findImportedName)
 {
-    return async function decompileImport(variables, options = {}) {
-        if (!variables || variables.length === 0)
-            throw new Error('no variables');
-        // #166: An import group is `[module @foo, ...aliases]` — the runtime stitch
-        // sits at index 0 by convention. Scan for the first alias (single _input,
-        // crosses module boundary) so this works whichever order the caller hands us.
-        const isCrossModuleAlias = v => {
-            const inputs = v?._inputs;
-            if (!Array.isArray(inputs) || inputs.length !== 1)
-                return false;
-            const i0 = inputs[0];
-            return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
-        };
-        const v0 = variables.find(isCrossModuleAlias);
-        if (!v0)
-            return null;
-        const input0 = v0._inputs[0];
-        const inputsLength = 1;
-        const crossesModuleBoundary = true;
-        const module_name = findModuleName(v0._module._scope, input0._module);
-        if (module_name == null)
-            throw new Error('module name could not be resolved');
-        // #166: Skip runtime-internal `module @foo` stitch variables — they belong to
-        // the import group but are not user-facing specifiers. Without this filter, an
-        // import group renders as `import {Range, module @foo} from "@foo"`.
-        const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
-            const imported = await findImportedName(v);
-            const local = v._name;
-            return {
-                imported,
-                local,
-                alias: imported !== local,
-                meta: { index }
-            };
-        }));
-        return {
-            type: 'import',
-            from: module_name,
-            specifiers,
-            meta: {
-                detection: {
-                    inputsLength,
-                    crossesModuleBoundary
-                },
-                variables: variables.map(v => v?._name ?? null)
-            }
-        };
+  return async function decompileImport(variables, options = {}) {
+    if (!variables || variables.length === 0)
+      throw new Error('no variables');
+    // An import-cell group is `[module @X stitch, ...aliases]`. Each alias goes
+    // through three lifecycle stages (documented in observable-runtime-v6's
+    // `importedModule` helper, lines ~1992-2049 of @tomlarkworthy/observable-runtime-v6):
+    //
+    //   Stage A — post-observation:
+    //     `_inputs = [Variable in source module]` (length 1, cross-module).
+    //     The Observable runtime rewrites _inputs after the alias is observed
+    //     and resolved against the source module.
+    //
+    //   Stage B — pre-observation, API-loaded (canonical compiled-bundle shape):
+    //     `_inputs = [Variable("module @X"), Variable("@variable")]` (length 2,
+    //     both in the importer module). What `runtime.define("name",
+    //     ["module @X", "@variable"], (_, v) => v.import("name", _))` produces.
+    //     Also what `compile_and_update` outputs for freshly-defined user-typed
+    //     imports until they're observed.
+    //
+    //   Stage C — pre-observation, inline live-notebook:
+    //     `_inputs = [Variable("@variable")]` (length 1) AND the definition
+    //     calls `import(...)` inside. We extract the imported module reference
+    //     by invoking the definition with a stub `import` capture.
+    //
+    // Detection order is post→pre because Stage A is unambiguous when present.
+    const isStageA = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
     };
+    const isStageB = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 2)
+        return false;
+      const [i0, i1] = inputs;
+      return !!(i0 && typeof i0 === 'object' && typeof i0._name === 'string' && i0._name.startsWith('module @') && i1 && typeof i1 === 'object' && i1._name === '@variable');
+    };
+    const isStageC = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && i0._name === '@variable' && typeof v._definition !== 'undefined' && String(v._definition).includes('import('));
+    };
+    let v0, module_name, stage;
+    if (v0 = variables.find(isStageA)) {
+      stage = 'A';
+      module_name = findModuleName(v0._module._scope, v0._inputs[0]._module);
+    } else if (v0 = variables.find(isStageB)) {
+      stage = 'B';
+      module_name = v0._inputs[0]._name.replace(/^module /, '');
+    } else if (v0 = variables.find(isStageC)) {
+      stage = 'C';
+      let capturedModule;
+      try {
+        await v0._definition({
+          import: (...args) => {
+            capturedModule = args[args.length - 1];
+          }
+        });
+      } catch (e) {
+      }
+      if (capturedModule && v0._module?._scope) {
+        module_name = findModuleName(v0._module._scope, capturedModule);
+      }
+    } else {
+      return null;
+    }
+    if (module_name == null)
+      throw new Error('module name could not be resolved');
+    // Skip runtime-internal `module @foo` stitch variables — they belong to
+    // the import group but are not user-facing specifiers. Without this filter, an
+    // import group renders as `import {Range, module @foo} from "@foo"`.
+    const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
+      const imported = await findImportedName(v);
+      const local = v._name;
+      return {
+        imported,
+        local,
+        alias: imported !== local,
+        meta: { index }
+      };
+    }));
+    return {
+      type: 'import',
+      from: module_name,
+      specifiers,
+      meta: {
+        detection: { stage },
+        variables: variables.map(v => v?._name ?? null)
+      }
+    };
+  };
 };
 const _1sylz7j = function _formatImportDeclaration(){return(
 function formatImportDeclaration(importInfo) {
@@ -20633,6 +20680,198 @@ const _1hiclbb = function _acorn_walk(acorn_walk_url) {
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
+const _1rc67k0 = function _stageB_importFake()
+{
+  return // Builds a Stage B (pre-observation, API-loaded) import group as POJOs.
+  // Mirrors what `runtime.define("name", ["module @X", "@variable"], (_, v) => v.import("name", _))`
+  // produces structurally. Used by the test_decompileImport_stageB_* tests to
+  // avoid spinning up a real Observable runtime per case.
+  function stageB_importFake(module_name, specifiers) {
+    const importerModule = { _scope: new Map() };
+    const stitch = {
+      _name: `module ${ module_name }`,
+      _module: importerModule,
+      _inputs: [],
+      _definition: `async () => null`
+    };
+    const atVariable = {
+      _name: '@variable',
+      _module: importerModule
+    };
+    const aliases = specifiers.map(s => ({
+      _name: s.local,
+      _module: importerModule,
+      _inputs: [
+        stitch,
+        atVariable
+      ],
+      _definition: s.imported === s.local ? `(_, v) => v.import("${ s.imported }", _)` : `(_, v) => v.import("${ s.imported }", "${ s.local }", _)`
+    }));
+    return [
+      stitch,
+      ...aliases
+    ];
+  };
+};
+const _1d53asg = async function _test_decompileImport_stageB_single(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [{
+      imported: 'visualize',
+      local: 'visualize'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _hv5gag = async function _test_decompileImport_stageB_aliased(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'x',
+      local: 'z'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(info.specifiers[0].alias).toEqual(true);
+  expect(formatImportDeclaration(info)).toEqual(`import {x as z} from "@user/y"`);
+  return 'ok';
+};
+const _avc18y = async function _test_decompileImport_stageB_multiple(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    },
+    {
+      imported: 'c',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b, c} from "@user/y"`);
+  return 'ok';
+};
+const _16gia7i = async function _test_decompileImport_stageB_mixed_alias(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b as c} from "@user/y"`);
+  return 'ok';
+};
+const _1slhdwo = async function _test_decompileImport_stageB_viewof(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/module-map', [{
+      imported: 'viewof currentModules',
+      local: 'viewof currentModules'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {viewof currentModules} from "@tomlarkworthy/module-map"`);
+  return 'ok';
+};
+const _qwlsf2 = async function _test_decompileImport_stageB_mutable(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'mutable counter',
+      local: 'mutable counter'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {mutable counter} from "@user/y"`);
+  return 'ok';
+};
+const _sy7jfx = async function _test_decompileImport_returns_null_for_non_import(decompileImport,expect)
+{
+  // A regular cell — no stitch, no @variable input, no cross-module reference.
+  const info = await decompileImport([{
+      _name: 'x',
+      _module: {},
+      _inputs: [],
+      _definition: `() => 42`
+    }]);
+  expect(info).toEqual(null);
+  return 'ok';
+};
+const _rk7ku3 = async function _test_decompileImport_compile_roundtrip_single(compile,expect,stageB_importFake,decompileImport,formatImportDeclaration)
+{
+  // What `compile()` emits for `import {x} from "@user/y"` is structurally the
+  // same as our stageB_importFake fixture (after runtime.define resolves the
+  // input name strings to Variable refs). Verify the fixture matches the
+  // shape compile() would produce.
+  const pojos = compile(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  expect(pojos.length).toEqual(3);
+  expect(pojos[0]._name).toEqual('module @tomlarkworthy/visualizer');
+  expect(pojos[1]._name).toEqual('visualize');
+  expect(pojos[2]._name).toEqual('Group');
+  expect(pojos[1]._inputs).toEqual([
+    'module @tomlarkworthy/visualizer',
+    '@variable'
+  ]);
+  // Now run our fixture through decompileImport — confirms the round-trip
+  // shape compile()-output-shape-when-defined → decompileImport produces the
+  // canonical import source string.
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [
+    {
+      imported: 'visualize',
+      local: 'visualize'
+    },
+    {
+      imported: 'Group',
+      local: 'Group'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _xynplo = async function _test_decompileImport_stageB_order_independent(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // The detection uses .find — it shouldn't matter whether the stitch is at
+  // index 0 or the aliases come first. Verify by reversing the array.
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    }
+  ]);
+  const reversed = [...vars].reverse();
+  const info = await decompileImport(reversed);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b} from "@user/y"`);
+  return 'ok';
+};
+const _16fpgac = async function _test_decompileImport_stageB_notebook_id(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // Observable supports `import {x} from "d/<hash>@<version>"` notebook-id form.
+  const vars = stageB_importFake('d/57d79353bac56631@44', [{
+      imported: 'hash',
+      local: 'hash'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {hash} from "d/57d79353bac56631@44"`);
+  return 'ok';
+};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -20753,7 +20992,7 @@ export default function define(runtime, observer) {
   $def("_1n7gw17", "findModuleName", ["extractModuleInfo"], _1n7gw17);  
   $def("_i47chb", "findImportedName", [], _i47chb);  
   $def("_1effqg", null, ["md"], _1effqg);  
-  $def("_1etqs71", "decompileImport", ["findModuleName","findImportedName"], _1etqs71);  
+  $def("_b7vai6", "decompileImport", ["findModuleName","findImportedName"], _b7vai6);  
   $def("_1sylz7j", "formatImportDeclaration", [], _1sylz7j);  
   $def("_13dctdn", "test_decompileImport_basic", ["importFake","decompileImport","expect"], _13dctdn);  
   $def("_ujr0xn", "test_formatImportDeclaration_roundtrip", ["importFake","decompileImport","expect","formatImportDeclaration","decompile"], _ujr0xn);  
@@ -20831,7 +21070,18 @@ export default function define(runtime, observer) {
   main.define("Runtime", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Runtime", _));  
   main.define("Inspector", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Inspector", _));  
   main.define("Library", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Library", _));  
-  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));
+  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));  
+  $def("_1rc67k0", "stageB_importFake", [], _1rc67k0);  
+  $def("_1d53asg", "test_decompileImport_stageB_single", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1d53asg);  
+  $def("_hv5gag", "test_decompileImport_stageB_aliased", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _hv5gag);  
+  $def("_avc18y", "test_decompileImport_stageB_multiple", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _avc18y);  
+  $def("_16gia7i", "test_decompileImport_stageB_mixed_alias", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16gia7i);  
+  $def("_1slhdwo", "test_decompileImport_stageB_viewof", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1slhdwo);  
+  $def("_qwlsf2", "test_decompileImport_stageB_mutable", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _qwlsf2);  
+  $def("_sy7jfx", "test_decompileImport_returns_null_for_non_import", ["decompileImport","expect"], _sy7jfx);  
+  $def("_rk7ku3", "test_decompileImport_compile_roundtrip_single", ["compile","expect","stageB_importFake","decompileImport","formatImportDeclaration"], _rk7ku3);  
+  $def("_xynplo", "test_decompileImport_stageB_order_independent", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _xynplo);  
+  $def("_16fpgac", "test_decompileImport_stageB_notebook_id", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16fpgac);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_secrets.html
+++ b/notebooks/@tomlarkworthy_secrets.html
@@ -19474,56 +19474,103 @@ async (v) => {
 const _1effqg = function _96(md){return(
 md`### \`decompileImport\``
 )};
-const _1etqs71 = function _decompileImport(findModuleName,findImportedName)
+const _b7vai6 = function _decompileImport(findModuleName,findImportedName)
 {
-    return async function decompileImport(variables, options = {}) {
-        if (!variables || variables.length === 0)
-            throw new Error('no variables');
-        // #166: An import group is `[module @foo, ...aliases]` — the runtime stitch
-        // sits at index 0 by convention. Scan for the first alias (single _input,
-        // crosses module boundary) so this works whichever order the caller hands us.
-        const isCrossModuleAlias = v => {
-            const inputs = v?._inputs;
-            if (!Array.isArray(inputs) || inputs.length !== 1)
-                return false;
-            const i0 = inputs[0];
-            return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
-        };
-        const v0 = variables.find(isCrossModuleAlias);
-        if (!v0)
-            return null;
-        const input0 = v0._inputs[0];
-        const inputsLength = 1;
-        const crossesModuleBoundary = true;
-        const module_name = findModuleName(v0._module._scope, input0._module);
-        if (module_name == null)
-            throw new Error('module name could not be resolved');
-        // #166: Skip runtime-internal `module @foo` stitch variables — they belong to
-        // the import group but are not user-facing specifiers. Without this filter, an
-        // import group renders as `import {Range, module @foo} from "@foo"`.
-        const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
-            const imported = await findImportedName(v);
-            const local = v._name;
-            return {
-                imported,
-                local,
-                alias: imported !== local,
-                meta: { index }
-            };
-        }));
-        return {
-            type: 'import',
-            from: module_name,
-            specifiers,
-            meta: {
-                detection: {
-                    inputsLength,
-                    crossesModuleBoundary
-                },
-                variables: variables.map(v => v?._name ?? null)
-            }
-        };
+  return async function decompileImport(variables, options = {}) {
+    if (!variables || variables.length === 0)
+      throw new Error('no variables');
+    // An import-cell group is `[module @X stitch, ...aliases]`. Each alias goes
+    // through three lifecycle stages (documented in observable-runtime-v6's
+    // `importedModule` helper, lines ~1992-2049 of @tomlarkworthy/observable-runtime-v6):
+    //
+    //   Stage A — post-observation:
+    //     `_inputs = [Variable in source module]` (length 1, cross-module).
+    //     The Observable runtime rewrites _inputs after the alias is observed
+    //     and resolved against the source module.
+    //
+    //   Stage B — pre-observation, API-loaded (canonical compiled-bundle shape):
+    //     `_inputs = [Variable("module @X"), Variable("@variable")]` (length 2,
+    //     both in the importer module). What `runtime.define("name",
+    //     ["module @X", "@variable"], (_, v) => v.import("name", _))` produces.
+    //     Also what `compile_and_update` outputs for freshly-defined user-typed
+    //     imports until they're observed.
+    //
+    //   Stage C — pre-observation, inline live-notebook:
+    //     `_inputs = [Variable("@variable")]` (length 1) AND the definition
+    //     calls `import(...)` inside. We extract the imported module reference
+    //     by invoking the definition with a stub `import` capture.
+    //
+    // Detection order is post→pre because Stage A is unambiguous when present.
+    const isStageA = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
     };
+    const isStageB = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 2)
+        return false;
+      const [i0, i1] = inputs;
+      return !!(i0 && typeof i0 === 'object' && typeof i0._name === 'string' && i0._name.startsWith('module @') && i1 && typeof i1 === 'object' && i1._name === '@variable');
+    };
+    const isStageC = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && i0._name === '@variable' && typeof v._definition !== 'undefined' && String(v._definition).includes('import('));
+    };
+    let v0, module_name, stage;
+    if (v0 = variables.find(isStageA)) {
+      stage = 'A';
+      module_name = findModuleName(v0._module._scope, v0._inputs[0]._module);
+    } else if (v0 = variables.find(isStageB)) {
+      stage = 'B';
+      module_name = v0._inputs[0]._name.replace(/^module /, '');
+    } else if (v0 = variables.find(isStageC)) {
+      stage = 'C';
+      let capturedModule;
+      try {
+        await v0._definition({
+          import: (...args) => {
+            capturedModule = args[args.length - 1];
+          }
+        });
+      } catch (e) {
+      }
+      if (capturedModule && v0._module?._scope) {
+        module_name = findModuleName(v0._module._scope, capturedModule);
+      }
+    } else {
+      return null;
+    }
+    if (module_name == null)
+      throw new Error('module name could not be resolved');
+    // Skip runtime-internal `module @foo` stitch variables — they belong to
+    // the import group but are not user-facing specifiers. Without this filter, an
+    // import group renders as `import {Range, module @foo} from "@foo"`.
+    const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
+      const imported = await findImportedName(v);
+      const local = v._name;
+      return {
+        imported,
+        local,
+        alias: imported !== local,
+        meta: { index }
+      };
+    }));
+    return {
+      type: 'import',
+      from: module_name,
+      specifiers,
+      meta: {
+        detection: { stage },
+        variables: variables.map(v => v?._name ?? null)
+      }
+    };
+  };
 };
 const _1sylz7j = function _formatImportDeclaration(){return(
 function formatImportDeclaration(importInfo) {
@@ -20633,6 +20680,198 @@ const _1hiclbb = function _acorn_walk(acorn_walk_url) {
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
+const _1rc67k0 = function _stageB_importFake()
+{
+  return // Builds a Stage B (pre-observation, API-loaded) import group as POJOs.
+  // Mirrors what `runtime.define("name", ["module @X", "@variable"], (_, v) => v.import("name", _))`
+  // produces structurally. Used by the test_decompileImport_stageB_* tests to
+  // avoid spinning up a real Observable runtime per case.
+  function stageB_importFake(module_name, specifiers) {
+    const importerModule = { _scope: new Map() };
+    const stitch = {
+      _name: `module ${ module_name }`,
+      _module: importerModule,
+      _inputs: [],
+      _definition: `async () => null`
+    };
+    const atVariable = {
+      _name: '@variable',
+      _module: importerModule
+    };
+    const aliases = specifiers.map(s => ({
+      _name: s.local,
+      _module: importerModule,
+      _inputs: [
+        stitch,
+        atVariable
+      ],
+      _definition: s.imported === s.local ? `(_, v) => v.import("${ s.imported }", _)` : `(_, v) => v.import("${ s.imported }", "${ s.local }", _)`
+    }));
+    return [
+      stitch,
+      ...aliases
+    ];
+  };
+};
+const _1d53asg = async function _test_decompileImport_stageB_single(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [{
+      imported: 'visualize',
+      local: 'visualize'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _hv5gag = async function _test_decompileImport_stageB_aliased(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'x',
+      local: 'z'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(info.specifiers[0].alias).toEqual(true);
+  expect(formatImportDeclaration(info)).toEqual(`import {x as z} from "@user/y"`);
+  return 'ok';
+};
+const _avc18y = async function _test_decompileImport_stageB_multiple(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    },
+    {
+      imported: 'c',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b, c} from "@user/y"`);
+  return 'ok';
+};
+const _16gia7i = async function _test_decompileImport_stageB_mixed_alias(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b as c} from "@user/y"`);
+  return 'ok';
+};
+const _1slhdwo = async function _test_decompileImport_stageB_viewof(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/module-map', [{
+      imported: 'viewof currentModules',
+      local: 'viewof currentModules'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {viewof currentModules} from "@tomlarkworthy/module-map"`);
+  return 'ok';
+};
+const _qwlsf2 = async function _test_decompileImport_stageB_mutable(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'mutable counter',
+      local: 'mutable counter'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {mutable counter} from "@user/y"`);
+  return 'ok';
+};
+const _sy7jfx = async function _test_decompileImport_returns_null_for_non_import(decompileImport,expect)
+{
+  // A regular cell — no stitch, no @variable input, no cross-module reference.
+  const info = await decompileImport([{
+      _name: 'x',
+      _module: {},
+      _inputs: [],
+      _definition: `() => 42`
+    }]);
+  expect(info).toEqual(null);
+  return 'ok';
+};
+const _rk7ku3 = async function _test_decompileImport_compile_roundtrip_single(compile,expect,stageB_importFake,decompileImport,formatImportDeclaration)
+{
+  // What `compile()` emits for `import {x} from "@user/y"` is structurally the
+  // same as our stageB_importFake fixture (after runtime.define resolves the
+  // input name strings to Variable refs). Verify the fixture matches the
+  // shape compile() would produce.
+  const pojos = compile(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  expect(pojos.length).toEqual(3);
+  expect(pojos[0]._name).toEqual('module @tomlarkworthy/visualizer');
+  expect(pojos[1]._name).toEqual('visualize');
+  expect(pojos[2]._name).toEqual('Group');
+  expect(pojos[1]._inputs).toEqual([
+    'module @tomlarkworthy/visualizer',
+    '@variable'
+  ]);
+  // Now run our fixture through decompileImport — confirms the round-trip
+  // shape compile()-output-shape-when-defined → decompileImport produces the
+  // canonical import source string.
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [
+    {
+      imported: 'visualize',
+      local: 'visualize'
+    },
+    {
+      imported: 'Group',
+      local: 'Group'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _xynplo = async function _test_decompileImport_stageB_order_independent(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // The detection uses .find — it shouldn't matter whether the stitch is at
+  // index 0 or the aliases come first. Verify by reversing the array.
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    }
+  ]);
+  const reversed = [...vars].reverse();
+  const info = await decompileImport(reversed);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b} from "@user/y"`);
+  return 'ok';
+};
+const _16fpgac = async function _test_decompileImport_stageB_notebook_id(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // Observable supports `import {x} from "d/<hash>@<version>"` notebook-id form.
+  const vars = stageB_importFake('d/57d79353bac56631@44', [{
+      imported: 'hash',
+      local: 'hash'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {hash} from "d/57d79353bac56631@44"`);
+  return 'ok';
+};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -20753,7 +20992,7 @@ export default function define(runtime, observer) {
   $def("_1n7gw17", "findModuleName", ["extractModuleInfo"], _1n7gw17);  
   $def("_i47chb", "findImportedName", [], _i47chb);  
   $def("_1effqg", null, ["md"], _1effqg);  
-  $def("_1etqs71", "decompileImport", ["findModuleName","findImportedName"], _1etqs71);  
+  $def("_b7vai6", "decompileImport", ["findModuleName","findImportedName"], _b7vai6);  
   $def("_1sylz7j", "formatImportDeclaration", [], _1sylz7j);  
   $def("_13dctdn", "test_decompileImport_basic", ["importFake","decompileImport","expect"], _13dctdn);  
   $def("_ujr0xn", "test_formatImportDeclaration_roundtrip", ["importFake","decompileImport","expect","formatImportDeclaration","decompile"], _ujr0xn);  
@@ -20831,7 +21070,18 @@ export default function define(runtime, observer) {
   main.define("Runtime", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Runtime", _));  
   main.define("Inspector", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Inspector", _));  
   main.define("Library", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Library", _));  
-  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));
+  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));  
+  $def("_1rc67k0", "stageB_importFake", [], _1rc67k0);  
+  $def("_1d53asg", "test_decompileImport_stageB_single", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1d53asg);  
+  $def("_hv5gag", "test_decompileImport_stageB_aliased", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _hv5gag);  
+  $def("_avc18y", "test_decompileImport_stageB_multiple", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _avc18y);  
+  $def("_16gia7i", "test_decompileImport_stageB_mixed_alias", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16gia7i);  
+  $def("_1slhdwo", "test_decompileImport_stageB_viewof", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1slhdwo);  
+  $def("_qwlsf2", "test_decompileImport_stageB_mutable", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _qwlsf2);  
+  $def("_sy7jfx", "test_decompileImport_returns_null_for_non_import", ["decompileImport","expect"], _sy7jfx);  
+  $def("_rk7ku3", "test_decompileImport_compile_roundtrip_single", ["compile","expect","stageB_importFake","decompileImport","formatImportDeclaration"], _rk7ku3);  
+  $def("_xynplo", "test_decompileImport_stageB_order_independent", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _xynplo);  
+  $def("_16fpgac", "test_decompileImport_stageB_notebook_id", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16fpgac);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_tests.html
+++ b/notebooks/@tomlarkworthy_tests.html
@@ -19474,56 +19474,103 @@ async (v) => {
 const _1effqg = function _96(md){return(
 md`### \`decompileImport\``
 )};
-const _1etqs71 = function _decompileImport(findModuleName,findImportedName)
+const _b7vai6 = function _decompileImport(findModuleName,findImportedName)
 {
-    return async function decompileImport(variables, options = {}) {
-        if (!variables || variables.length === 0)
-            throw new Error('no variables');
-        // #166: An import group is `[module @foo, ...aliases]` — the runtime stitch
-        // sits at index 0 by convention. Scan for the first alias (single _input,
-        // crosses module boundary) so this works whichever order the caller hands us.
-        const isCrossModuleAlias = v => {
-            const inputs = v?._inputs;
-            if (!Array.isArray(inputs) || inputs.length !== 1)
-                return false;
-            const i0 = inputs[0];
-            return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
-        };
-        const v0 = variables.find(isCrossModuleAlias);
-        if (!v0)
-            return null;
-        const input0 = v0._inputs[0];
-        const inputsLength = 1;
-        const crossesModuleBoundary = true;
-        const module_name = findModuleName(v0._module._scope, input0._module);
-        if (module_name == null)
-            throw new Error('module name could not be resolved');
-        // #166: Skip runtime-internal `module @foo` stitch variables — they belong to
-        // the import group but are not user-facing specifiers. Without this filter, an
-        // import group renders as `import {Range, module @foo} from "@foo"`.
-        const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
-            const imported = await findImportedName(v);
-            const local = v._name;
-            return {
-                imported,
-                local,
-                alias: imported !== local,
-                meta: { index }
-            };
-        }));
-        return {
-            type: 'import',
-            from: module_name,
-            specifiers,
-            meta: {
-                detection: {
-                    inputsLength,
-                    crossesModuleBoundary
-                },
-                variables: variables.map(v => v?._name ?? null)
-            }
-        };
+  return async function decompileImport(variables, options = {}) {
+    if (!variables || variables.length === 0)
+      throw new Error('no variables');
+    // An import-cell group is `[module @X stitch, ...aliases]`. Each alias goes
+    // through three lifecycle stages (documented in observable-runtime-v6's
+    // `importedModule` helper, lines ~1992-2049 of @tomlarkworthy/observable-runtime-v6):
+    //
+    //   Stage A — post-observation:
+    //     `_inputs = [Variable in source module]` (length 1, cross-module).
+    //     The Observable runtime rewrites _inputs after the alias is observed
+    //     and resolved against the source module.
+    //
+    //   Stage B — pre-observation, API-loaded (canonical compiled-bundle shape):
+    //     `_inputs = [Variable("module @X"), Variable("@variable")]` (length 2,
+    //     both in the importer module). What `runtime.define("name",
+    //     ["module @X", "@variable"], (_, v) => v.import("name", _))` produces.
+    //     Also what `compile_and_update` outputs for freshly-defined user-typed
+    //     imports until they're observed.
+    //
+    //   Stage C — pre-observation, inline live-notebook:
+    //     `_inputs = [Variable("@variable")]` (length 1) AND the definition
+    //     calls `import(...)` inside. We extract the imported module reference
+    //     by invoking the definition with a stub `import` capture.
+    //
+    // Detection order is post→pre because Stage A is unambiguous when present.
+    const isStageA = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
     };
+    const isStageB = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 2)
+        return false;
+      const [i0, i1] = inputs;
+      return !!(i0 && typeof i0 === 'object' && typeof i0._name === 'string' && i0._name.startsWith('module @') && i1 && typeof i1 === 'object' && i1._name === '@variable');
+    };
+    const isStageC = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && i0._name === '@variable' && typeof v._definition !== 'undefined' && String(v._definition).includes('import('));
+    };
+    let v0, module_name, stage;
+    if (v0 = variables.find(isStageA)) {
+      stage = 'A';
+      module_name = findModuleName(v0._module._scope, v0._inputs[0]._module);
+    } else if (v0 = variables.find(isStageB)) {
+      stage = 'B';
+      module_name = v0._inputs[0]._name.replace(/^module /, '');
+    } else if (v0 = variables.find(isStageC)) {
+      stage = 'C';
+      let capturedModule;
+      try {
+        await v0._definition({
+          import: (...args) => {
+            capturedModule = args[args.length - 1];
+          }
+        });
+      } catch (e) {
+      }
+      if (capturedModule && v0._module?._scope) {
+        module_name = findModuleName(v0._module._scope, capturedModule);
+      }
+    } else {
+      return null;
+    }
+    if (module_name == null)
+      throw new Error('module name could not be resolved');
+    // Skip runtime-internal `module @foo` stitch variables — they belong to
+    // the import group but are not user-facing specifiers. Without this filter, an
+    // import group renders as `import {Range, module @foo} from "@foo"`.
+    const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
+      const imported = await findImportedName(v);
+      const local = v._name;
+      return {
+        imported,
+        local,
+        alias: imported !== local,
+        meta: { index }
+      };
+    }));
+    return {
+      type: 'import',
+      from: module_name,
+      specifiers,
+      meta: {
+        detection: { stage },
+        variables: variables.map(v => v?._name ?? null)
+      }
+    };
+  };
 };
 const _1sylz7j = function _formatImportDeclaration(){return(
 function formatImportDeclaration(importInfo) {
@@ -20633,6 +20680,198 @@ const _1hiclbb = function _acorn_walk(acorn_walk_url) {
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
+const _1rc67k0 = function _stageB_importFake()
+{
+  return // Builds a Stage B (pre-observation, API-loaded) import group as POJOs.
+  // Mirrors what `runtime.define("name", ["module @X", "@variable"], (_, v) => v.import("name", _))`
+  // produces structurally. Used by the test_decompileImport_stageB_* tests to
+  // avoid spinning up a real Observable runtime per case.
+  function stageB_importFake(module_name, specifiers) {
+    const importerModule = { _scope: new Map() };
+    const stitch = {
+      _name: `module ${ module_name }`,
+      _module: importerModule,
+      _inputs: [],
+      _definition: `async () => null`
+    };
+    const atVariable = {
+      _name: '@variable',
+      _module: importerModule
+    };
+    const aliases = specifiers.map(s => ({
+      _name: s.local,
+      _module: importerModule,
+      _inputs: [
+        stitch,
+        atVariable
+      ],
+      _definition: s.imported === s.local ? `(_, v) => v.import("${ s.imported }", _)` : `(_, v) => v.import("${ s.imported }", "${ s.local }", _)`
+    }));
+    return [
+      stitch,
+      ...aliases
+    ];
+  };
+};
+const _1d53asg = async function _test_decompileImport_stageB_single(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [{
+      imported: 'visualize',
+      local: 'visualize'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _hv5gag = async function _test_decompileImport_stageB_aliased(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'x',
+      local: 'z'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(info.specifiers[0].alias).toEqual(true);
+  expect(formatImportDeclaration(info)).toEqual(`import {x as z} from "@user/y"`);
+  return 'ok';
+};
+const _avc18y = async function _test_decompileImport_stageB_multiple(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    },
+    {
+      imported: 'c',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b, c} from "@user/y"`);
+  return 'ok';
+};
+const _16gia7i = async function _test_decompileImport_stageB_mixed_alias(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b as c} from "@user/y"`);
+  return 'ok';
+};
+const _1slhdwo = async function _test_decompileImport_stageB_viewof(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/module-map', [{
+      imported: 'viewof currentModules',
+      local: 'viewof currentModules'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {viewof currentModules} from "@tomlarkworthy/module-map"`);
+  return 'ok';
+};
+const _qwlsf2 = async function _test_decompileImport_stageB_mutable(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'mutable counter',
+      local: 'mutable counter'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {mutable counter} from "@user/y"`);
+  return 'ok';
+};
+const _sy7jfx = async function _test_decompileImport_returns_null_for_non_import(decompileImport,expect)
+{
+  // A regular cell — no stitch, no @variable input, no cross-module reference.
+  const info = await decompileImport([{
+      _name: 'x',
+      _module: {},
+      _inputs: [],
+      _definition: `() => 42`
+    }]);
+  expect(info).toEqual(null);
+  return 'ok';
+};
+const _rk7ku3 = async function _test_decompileImport_compile_roundtrip_single(compile,expect,stageB_importFake,decompileImport,formatImportDeclaration)
+{
+  // What `compile()` emits for `import {x} from "@user/y"` is structurally the
+  // same as our stageB_importFake fixture (after runtime.define resolves the
+  // input name strings to Variable refs). Verify the fixture matches the
+  // shape compile() would produce.
+  const pojos = compile(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  expect(pojos.length).toEqual(3);
+  expect(pojos[0]._name).toEqual('module @tomlarkworthy/visualizer');
+  expect(pojos[1]._name).toEqual('visualize');
+  expect(pojos[2]._name).toEqual('Group');
+  expect(pojos[1]._inputs).toEqual([
+    'module @tomlarkworthy/visualizer',
+    '@variable'
+  ]);
+  // Now run our fixture through decompileImport — confirms the round-trip
+  // shape compile()-output-shape-when-defined → decompileImport produces the
+  // canonical import source string.
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [
+    {
+      imported: 'visualize',
+      local: 'visualize'
+    },
+    {
+      imported: 'Group',
+      local: 'Group'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _xynplo = async function _test_decompileImport_stageB_order_independent(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // The detection uses .find — it shouldn't matter whether the stitch is at
+  // index 0 or the aliases come first. Verify by reversing the array.
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    }
+  ]);
+  const reversed = [...vars].reverse();
+  const info = await decompileImport(reversed);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b} from "@user/y"`);
+  return 'ok';
+};
+const _16fpgac = async function _test_decompileImport_stageB_notebook_id(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // Observable supports `import {x} from "d/<hash>@<version>"` notebook-id form.
+  const vars = stageB_importFake('d/57d79353bac56631@44', [{
+      imported: 'hash',
+      local: 'hash'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {hash} from "d/57d79353bac56631@44"`);
+  return 'ok';
+};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -20753,7 +20992,7 @@ export default function define(runtime, observer) {
   $def("_1n7gw17", "findModuleName", ["extractModuleInfo"], _1n7gw17);  
   $def("_i47chb", "findImportedName", [], _i47chb);  
   $def("_1effqg", null, ["md"], _1effqg);  
-  $def("_1etqs71", "decompileImport", ["findModuleName","findImportedName"], _1etqs71);  
+  $def("_b7vai6", "decompileImport", ["findModuleName","findImportedName"], _b7vai6);  
   $def("_1sylz7j", "formatImportDeclaration", [], _1sylz7j);  
   $def("_13dctdn", "test_decompileImport_basic", ["importFake","decompileImport","expect"], _13dctdn);  
   $def("_ujr0xn", "test_formatImportDeclaration_roundtrip", ["importFake","decompileImport","expect","formatImportDeclaration","decompile"], _ujr0xn);  
@@ -20831,7 +21070,18 @@ export default function define(runtime, observer) {
   main.define("Runtime", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Runtime", _));  
   main.define("Inspector", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Inspector", _));  
   main.define("Library", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Library", _));  
-  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));
+  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));  
+  $def("_1rc67k0", "stageB_importFake", [], _1rc67k0);  
+  $def("_1d53asg", "test_decompileImport_stageB_single", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1d53asg);  
+  $def("_hv5gag", "test_decompileImport_stageB_aliased", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _hv5gag);  
+  $def("_avc18y", "test_decompileImport_stageB_multiple", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _avc18y);  
+  $def("_16gia7i", "test_decompileImport_stageB_mixed_alias", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16gia7i);  
+  $def("_1slhdwo", "test_decompileImport_stageB_viewof", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1slhdwo);  
+  $def("_qwlsf2", "test_decompileImport_stageB_mutable", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _qwlsf2);  
+  $def("_sy7jfx", "test_decompileImport_returns_null_for_non_import", ["decompileImport","expect"], _sy7jfx);  
+  $def("_rk7ku3", "test_decompileImport_compile_roundtrip_single", ["compile","expect","stageB_importFake","decompileImport","formatImportDeclaration"], _rk7ku3);  
+  $def("_xynplo", "test_decompileImport_stageB_order_independent", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _xynplo);  
+  $def("_16fpgac", "test_decompileImport_stageB_notebook_id", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16fpgac);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_themes.html
+++ b/notebooks/@tomlarkworthy_themes.html
@@ -19474,56 +19474,103 @@ async (v) => {
 const _1effqg = function _96(md){return(
 md`### \`decompileImport\``
 )};
-const _1etqs71 = function _decompileImport(findModuleName,findImportedName)
+const _b7vai6 = function _decompileImport(findModuleName,findImportedName)
 {
-    return async function decompileImport(variables, options = {}) {
-        if (!variables || variables.length === 0)
-            throw new Error('no variables');
-        // #166: An import group is `[module @foo, ...aliases]` — the runtime stitch
-        // sits at index 0 by convention. Scan for the first alias (single _input,
-        // crosses module boundary) so this works whichever order the caller hands us.
-        const isCrossModuleAlias = v => {
-            const inputs = v?._inputs;
-            if (!Array.isArray(inputs) || inputs.length !== 1)
-                return false;
-            const i0 = inputs[0];
-            return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
-        };
-        const v0 = variables.find(isCrossModuleAlias);
-        if (!v0)
-            return null;
-        const input0 = v0._inputs[0];
-        const inputsLength = 1;
-        const crossesModuleBoundary = true;
-        const module_name = findModuleName(v0._module._scope, input0._module);
-        if (module_name == null)
-            throw new Error('module name could not be resolved');
-        // #166: Skip runtime-internal `module @foo` stitch variables — they belong to
-        // the import group but are not user-facing specifiers. Without this filter, an
-        // import group renders as `import {Range, module @foo} from "@foo"`.
-        const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
-            const imported = await findImportedName(v);
-            const local = v._name;
-            return {
-                imported,
-                local,
-                alias: imported !== local,
-                meta: { index }
-            };
-        }));
-        return {
-            type: 'import',
-            from: module_name,
-            specifiers,
-            meta: {
-                detection: {
-                    inputsLength,
-                    crossesModuleBoundary
-                },
-                variables: variables.map(v => v?._name ?? null)
-            }
-        };
+  return async function decompileImport(variables, options = {}) {
+    if (!variables || variables.length === 0)
+      throw new Error('no variables');
+    // An import-cell group is `[module @X stitch, ...aliases]`. Each alias goes
+    // through three lifecycle stages (documented in observable-runtime-v6's
+    // `importedModule` helper, lines ~1992-2049 of @tomlarkworthy/observable-runtime-v6):
+    //
+    //   Stage A — post-observation:
+    //     `_inputs = [Variable in source module]` (length 1, cross-module).
+    //     The Observable runtime rewrites _inputs after the alias is observed
+    //     and resolved against the source module.
+    //
+    //   Stage B — pre-observation, API-loaded (canonical compiled-bundle shape):
+    //     `_inputs = [Variable("module @X"), Variable("@variable")]` (length 2,
+    //     both in the importer module). What `runtime.define("name",
+    //     ["module @X", "@variable"], (_, v) => v.import("name", _))` produces.
+    //     Also what `compile_and_update` outputs for freshly-defined user-typed
+    //     imports until they're observed.
+    //
+    //   Stage C — pre-observation, inline live-notebook:
+    //     `_inputs = [Variable("@variable")]` (length 1) AND the definition
+    //     calls `import(...)` inside. We extract the imported module reference
+    //     by invoking the definition with a stub `import` capture.
+    //
+    // Detection order is post→pre because Stage A is unambiguous when present.
+    const isStageA = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
     };
+    const isStageB = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 2)
+        return false;
+      const [i0, i1] = inputs;
+      return !!(i0 && typeof i0 === 'object' && typeof i0._name === 'string' && i0._name.startsWith('module @') && i1 && typeof i1 === 'object' && i1._name === '@variable');
+    };
+    const isStageC = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && i0._name === '@variable' && typeof v._definition !== 'undefined' && String(v._definition).includes('import('));
+    };
+    let v0, module_name, stage;
+    if (v0 = variables.find(isStageA)) {
+      stage = 'A';
+      module_name = findModuleName(v0._module._scope, v0._inputs[0]._module);
+    } else if (v0 = variables.find(isStageB)) {
+      stage = 'B';
+      module_name = v0._inputs[0]._name.replace(/^module /, '');
+    } else if (v0 = variables.find(isStageC)) {
+      stage = 'C';
+      let capturedModule;
+      try {
+        await v0._definition({
+          import: (...args) => {
+            capturedModule = args[args.length - 1];
+          }
+        });
+      } catch (e) {
+      }
+      if (capturedModule && v0._module?._scope) {
+        module_name = findModuleName(v0._module._scope, capturedModule);
+      }
+    } else {
+      return null;
+    }
+    if (module_name == null)
+      throw new Error('module name could not be resolved');
+    // Skip runtime-internal `module @foo` stitch variables — they belong to
+    // the import group but are not user-facing specifiers. Without this filter, an
+    // import group renders as `import {Range, module @foo} from "@foo"`.
+    const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
+      const imported = await findImportedName(v);
+      const local = v._name;
+      return {
+        imported,
+        local,
+        alias: imported !== local,
+        meta: { index }
+      };
+    }));
+    return {
+      type: 'import',
+      from: module_name,
+      specifiers,
+      meta: {
+        detection: { stage },
+        variables: variables.map(v => v?._name ?? null)
+      }
+    };
+  };
 };
 const _1sylz7j = function _formatImportDeclaration(){return(
 function formatImportDeclaration(importInfo) {
@@ -20633,6 +20680,198 @@ const _1hiclbb = function _acorn_walk(acorn_walk_url) {
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
+const _1rc67k0 = function _stageB_importFake()
+{
+  return // Builds a Stage B (pre-observation, API-loaded) import group as POJOs.
+  // Mirrors what `runtime.define("name", ["module @X", "@variable"], (_, v) => v.import("name", _))`
+  // produces structurally. Used by the test_decompileImport_stageB_* tests to
+  // avoid spinning up a real Observable runtime per case.
+  function stageB_importFake(module_name, specifiers) {
+    const importerModule = { _scope: new Map() };
+    const stitch = {
+      _name: `module ${ module_name }`,
+      _module: importerModule,
+      _inputs: [],
+      _definition: `async () => null`
+    };
+    const atVariable = {
+      _name: '@variable',
+      _module: importerModule
+    };
+    const aliases = specifiers.map(s => ({
+      _name: s.local,
+      _module: importerModule,
+      _inputs: [
+        stitch,
+        atVariable
+      ],
+      _definition: s.imported === s.local ? `(_, v) => v.import("${ s.imported }", _)` : `(_, v) => v.import("${ s.imported }", "${ s.local }", _)`
+    }));
+    return [
+      stitch,
+      ...aliases
+    ];
+  };
+};
+const _1d53asg = async function _test_decompileImport_stageB_single(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [{
+      imported: 'visualize',
+      local: 'visualize'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _hv5gag = async function _test_decompileImport_stageB_aliased(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'x',
+      local: 'z'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(info.specifiers[0].alias).toEqual(true);
+  expect(formatImportDeclaration(info)).toEqual(`import {x as z} from "@user/y"`);
+  return 'ok';
+};
+const _avc18y = async function _test_decompileImport_stageB_multiple(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    },
+    {
+      imported: 'c',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b, c} from "@user/y"`);
+  return 'ok';
+};
+const _16gia7i = async function _test_decompileImport_stageB_mixed_alias(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b as c} from "@user/y"`);
+  return 'ok';
+};
+const _1slhdwo = async function _test_decompileImport_stageB_viewof(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/module-map', [{
+      imported: 'viewof currentModules',
+      local: 'viewof currentModules'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {viewof currentModules} from "@tomlarkworthy/module-map"`);
+  return 'ok';
+};
+const _qwlsf2 = async function _test_decompileImport_stageB_mutable(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'mutable counter',
+      local: 'mutable counter'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {mutable counter} from "@user/y"`);
+  return 'ok';
+};
+const _sy7jfx = async function _test_decompileImport_returns_null_for_non_import(decompileImport,expect)
+{
+  // A regular cell — no stitch, no @variable input, no cross-module reference.
+  const info = await decompileImport([{
+      _name: 'x',
+      _module: {},
+      _inputs: [],
+      _definition: `() => 42`
+    }]);
+  expect(info).toEqual(null);
+  return 'ok';
+};
+const _rk7ku3 = async function _test_decompileImport_compile_roundtrip_single(compile,expect,stageB_importFake,decompileImport,formatImportDeclaration)
+{
+  // What `compile()` emits for `import {x} from "@user/y"` is structurally the
+  // same as our stageB_importFake fixture (after runtime.define resolves the
+  // input name strings to Variable refs). Verify the fixture matches the
+  // shape compile() would produce.
+  const pojos = compile(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  expect(pojos.length).toEqual(3);
+  expect(pojos[0]._name).toEqual('module @tomlarkworthy/visualizer');
+  expect(pojos[1]._name).toEqual('visualize');
+  expect(pojos[2]._name).toEqual('Group');
+  expect(pojos[1]._inputs).toEqual([
+    'module @tomlarkworthy/visualizer',
+    '@variable'
+  ]);
+  // Now run our fixture through decompileImport — confirms the round-trip
+  // shape compile()-output-shape-when-defined → decompileImport produces the
+  // canonical import source string.
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [
+    {
+      imported: 'visualize',
+      local: 'visualize'
+    },
+    {
+      imported: 'Group',
+      local: 'Group'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _xynplo = async function _test_decompileImport_stageB_order_independent(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // The detection uses .find — it shouldn't matter whether the stitch is at
+  // index 0 or the aliases come first. Verify by reversing the array.
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    }
+  ]);
+  const reversed = [...vars].reverse();
+  const info = await decompileImport(reversed);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b} from "@user/y"`);
+  return 'ok';
+};
+const _16fpgac = async function _test_decompileImport_stageB_notebook_id(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // Observable supports `import {x} from "d/<hash>@<version>"` notebook-id form.
+  const vars = stageB_importFake('d/57d79353bac56631@44', [{
+      imported: 'hash',
+      local: 'hash'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {hash} from "d/57d79353bac56631@44"`);
+  return 'ok';
+};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -20753,7 +20992,7 @@ export default function define(runtime, observer) {
   $def("_1n7gw17", "findModuleName", ["extractModuleInfo"], _1n7gw17);  
   $def("_i47chb", "findImportedName", [], _i47chb);  
   $def("_1effqg", null, ["md"], _1effqg);  
-  $def("_1etqs71", "decompileImport", ["findModuleName","findImportedName"], _1etqs71);  
+  $def("_b7vai6", "decompileImport", ["findModuleName","findImportedName"], _b7vai6);  
   $def("_1sylz7j", "formatImportDeclaration", [], _1sylz7j);  
   $def("_13dctdn", "test_decompileImport_basic", ["importFake","decompileImport","expect"], _13dctdn);  
   $def("_ujr0xn", "test_formatImportDeclaration_roundtrip", ["importFake","decompileImport","expect","formatImportDeclaration","decompile"], _ujr0xn);  
@@ -20831,7 +21070,18 @@ export default function define(runtime, observer) {
   main.define("Runtime", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Runtime", _));  
   main.define("Inspector", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Inspector", _));  
   main.define("Library", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Library", _));  
-  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));
+  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));  
+  $def("_1rc67k0", "stageB_importFake", [], _1rc67k0);  
+  $def("_1d53asg", "test_decompileImport_stageB_single", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1d53asg);  
+  $def("_hv5gag", "test_decompileImport_stageB_aliased", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _hv5gag);  
+  $def("_avc18y", "test_decompileImport_stageB_multiple", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _avc18y);  
+  $def("_16gia7i", "test_decompileImport_stageB_mixed_alias", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16gia7i);  
+  $def("_1slhdwo", "test_decompileImport_stageB_viewof", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1slhdwo);  
+  $def("_qwlsf2", "test_decompileImport_stageB_mutable", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _qwlsf2);  
+  $def("_sy7jfx", "test_decompileImport_returns_null_for_non_import", ["decompileImport","expect"], _sy7jfx);  
+  $def("_rk7ku3", "test_decompileImport_compile_roundtrip_single", ["compile","expect","stageB_importFake","decompileImport","formatImportDeclaration"], _rk7ku3);  
+  $def("_xynplo", "test_decompileImport_stageB_order_independent", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _xynplo);  
+  $def("_16fpgac", "test_decompileImport_stageB_notebook_id", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16fpgac);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_visualizer.html
+++ b/notebooks/@tomlarkworthy_visualizer.html
@@ -19474,56 +19474,103 @@ async (v) => {
 const _1effqg = function _96(md){return(
 md`### \`decompileImport\``
 )};
-const _1etqs71 = function _decompileImport(findModuleName,findImportedName)
+const _b7vai6 = function _decompileImport(findModuleName,findImportedName)
 {
-    return async function decompileImport(variables, options = {}) {
-        if (!variables || variables.length === 0)
-            throw new Error('no variables');
-        // #166: An import group is `[module @foo, ...aliases]` — the runtime stitch
-        // sits at index 0 by convention. Scan for the first alias (single _input,
-        // crosses module boundary) so this works whichever order the caller hands us.
-        const isCrossModuleAlias = v => {
-            const inputs = v?._inputs;
-            if (!Array.isArray(inputs) || inputs.length !== 1)
-                return false;
-            const i0 = inputs[0];
-            return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
-        };
-        const v0 = variables.find(isCrossModuleAlias);
-        if (!v0)
-            return null;
-        const input0 = v0._inputs[0];
-        const inputsLength = 1;
-        const crossesModuleBoundary = true;
-        const module_name = findModuleName(v0._module._scope, input0._module);
-        if (module_name == null)
-            throw new Error('module name could not be resolved');
-        // #166: Skip runtime-internal `module @foo` stitch variables — they belong to
-        // the import group but are not user-facing specifiers. Without this filter, an
-        // import group renders as `import {Range, module @foo} from "@foo"`.
-        const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
-            const imported = await findImportedName(v);
-            const local = v._name;
-            return {
-                imported,
-                local,
-                alias: imported !== local,
-                meta: { index }
-            };
-        }));
-        return {
-            type: 'import',
-            from: module_name,
-            specifiers,
-            meta: {
-                detection: {
-                    inputsLength,
-                    crossesModuleBoundary
-                },
-                variables: variables.map(v => v?._name ?? null)
-            }
-        };
+  return async function decompileImport(variables, options = {}) {
+    if (!variables || variables.length === 0)
+      throw new Error('no variables');
+    // An import-cell group is `[module @X stitch, ...aliases]`. Each alias goes
+    // through three lifecycle stages (documented in observable-runtime-v6's
+    // `importedModule` helper, lines ~1992-2049 of @tomlarkworthy/observable-runtime-v6):
+    //
+    //   Stage A — post-observation:
+    //     `_inputs = [Variable in source module]` (length 1, cross-module).
+    //     The Observable runtime rewrites _inputs after the alias is observed
+    //     and resolved against the source module.
+    //
+    //   Stage B — pre-observation, API-loaded (canonical compiled-bundle shape):
+    //     `_inputs = [Variable("module @X"), Variable("@variable")]` (length 2,
+    //     both in the importer module). What `runtime.define("name",
+    //     ["module @X", "@variable"], (_, v) => v.import("name", _))` produces.
+    //     Also what `compile_and_update` outputs for freshly-defined user-typed
+    //     imports until they're observed.
+    //
+    //   Stage C — pre-observation, inline live-notebook:
+    //     `_inputs = [Variable("@variable")]` (length 1) AND the definition
+    //     calls `import(...)` inside. We extract the imported module reference
+    //     by invoking the definition with a stub `import` capture.
+    //
+    // Detection order is post→pre because Stage A is unambiguous when present.
+    const isStageA = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
     };
+    const isStageB = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 2)
+        return false;
+      const [i0, i1] = inputs;
+      return !!(i0 && typeof i0 === 'object' && typeof i0._name === 'string' && i0._name.startsWith('module @') && i1 && typeof i1 === 'object' && i1._name === '@variable');
+    };
+    const isStageC = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && i0._name === '@variable' && typeof v._definition !== 'undefined' && String(v._definition).includes('import('));
+    };
+    let v0, module_name, stage;
+    if (v0 = variables.find(isStageA)) {
+      stage = 'A';
+      module_name = findModuleName(v0._module._scope, v0._inputs[0]._module);
+    } else if (v0 = variables.find(isStageB)) {
+      stage = 'B';
+      module_name = v0._inputs[0]._name.replace(/^module /, '');
+    } else if (v0 = variables.find(isStageC)) {
+      stage = 'C';
+      let capturedModule;
+      try {
+        await v0._definition({
+          import: (...args) => {
+            capturedModule = args[args.length - 1];
+          }
+        });
+      } catch (e) {
+      }
+      if (capturedModule && v0._module?._scope) {
+        module_name = findModuleName(v0._module._scope, capturedModule);
+      }
+    } else {
+      return null;
+    }
+    if (module_name == null)
+      throw new Error('module name could not be resolved');
+    // Skip runtime-internal `module @foo` stitch variables — they belong to
+    // the import group but are not user-facing specifiers. Without this filter, an
+    // import group renders as `import {Range, module @foo} from "@foo"`.
+    const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
+      const imported = await findImportedName(v);
+      const local = v._name;
+      return {
+        imported,
+        local,
+        alias: imported !== local,
+        meta: { index }
+      };
+    }));
+    return {
+      type: 'import',
+      from: module_name,
+      specifiers,
+      meta: {
+        detection: { stage },
+        variables: variables.map(v => v?._name ?? null)
+      }
+    };
+  };
 };
 const _1sylz7j = function _formatImportDeclaration(){return(
 function formatImportDeclaration(importInfo) {
@@ -20633,6 +20680,198 @@ const _1hiclbb = function _acorn_walk(acorn_walk_url) {
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
+const _1rc67k0 = function _stageB_importFake()
+{
+  return // Builds a Stage B (pre-observation, API-loaded) import group as POJOs.
+  // Mirrors what `runtime.define("name", ["module @X", "@variable"], (_, v) => v.import("name", _))`
+  // produces structurally. Used by the test_decompileImport_stageB_* tests to
+  // avoid spinning up a real Observable runtime per case.
+  function stageB_importFake(module_name, specifiers) {
+    const importerModule = { _scope: new Map() };
+    const stitch = {
+      _name: `module ${ module_name }`,
+      _module: importerModule,
+      _inputs: [],
+      _definition: `async () => null`
+    };
+    const atVariable = {
+      _name: '@variable',
+      _module: importerModule
+    };
+    const aliases = specifiers.map(s => ({
+      _name: s.local,
+      _module: importerModule,
+      _inputs: [
+        stitch,
+        atVariable
+      ],
+      _definition: s.imported === s.local ? `(_, v) => v.import("${ s.imported }", _)` : `(_, v) => v.import("${ s.imported }", "${ s.local }", _)`
+    }));
+    return [
+      stitch,
+      ...aliases
+    ];
+  };
+};
+const _1d53asg = async function _test_decompileImport_stageB_single(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [{
+      imported: 'visualize',
+      local: 'visualize'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _hv5gag = async function _test_decompileImport_stageB_aliased(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'x',
+      local: 'z'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(info.specifiers[0].alias).toEqual(true);
+  expect(formatImportDeclaration(info)).toEqual(`import {x as z} from "@user/y"`);
+  return 'ok';
+};
+const _avc18y = async function _test_decompileImport_stageB_multiple(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    },
+    {
+      imported: 'c',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b, c} from "@user/y"`);
+  return 'ok';
+};
+const _16gia7i = async function _test_decompileImport_stageB_mixed_alias(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b as c} from "@user/y"`);
+  return 'ok';
+};
+const _1slhdwo = async function _test_decompileImport_stageB_viewof(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/module-map', [{
+      imported: 'viewof currentModules',
+      local: 'viewof currentModules'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {viewof currentModules} from "@tomlarkworthy/module-map"`);
+  return 'ok';
+};
+const _qwlsf2 = async function _test_decompileImport_stageB_mutable(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'mutable counter',
+      local: 'mutable counter'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {mutable counter} from "@user/y"`);
+  return 'ok';
+};
+const _sy7jfx = async function _test_decompileImport_returns_null_for_non_import(decompileImport,expect)
+{
+  // A regular cell — no stitch, no @variable input, no cross-module reference.
+  const info = await decompileImport([{
+      _name: 'x',
+      _module: {},
+      _inputs: [],
+      _definition: `() => 42`
+    }]);
+  expect(info).toEqual(null);
+  return 'ok';
+};
+const _rk7ku3 = async function _test_decompileImport_compile_roundtrip_single(compile,expect,stageB_importFake,decompileImport,formatImportDeclaration)
+{
+  // What `compile()` emits for `import {x} from "@user/y"` is structurally the
+  // same as our stageB_importFake fixture (after runtime.define resolves the
+  // input name strings to Variable refs). Verify the fixture matches the
+  // shape compile() would produce.
+  const pojos = compile(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  expect(pojos.length).toEqual(3);
+  expect(pojos[0]._name).toEqual('module @tomlarkworthy/visualizer');
+  expect(pojos[1]._name).toEqual('visualize');
+  expect(pojos[2]._name).toEqual('Group');
+  expect(pojos[1]._inputs).toEqual([
+    'module @tomlarkworthy/visualizer',
+    '@variable'
+  ]);
+  // Now run our fixture through decompileImport — confirms the round-trip
+  // shape compile()-output-shape-when-defined → decompileImport produces the
+  // canonical import source string.
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [
+    {
+      imported: 'visualize',
+      local: 'visualize'
+    },
+    {
+      imported: 'Group',
+      local: 'Group'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _xynplo = async function _test_decompileImport_stageB_order_independent(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // The detection uses .find — it shouldn't matter whether the stitch is at
+  // index 0 or the aliases come first. Verify by reversing the array.
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    }
+  ]);
+  const reversed = [...vars].reverse();
+  const info = await decompileImport(reversed);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b} from "@user/y"`);
+  return 'ok';
+};
+const _16fpgac = async function _test_decompileImport_stageB_notebook_id(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // Observable supports `import {x} from "d/<hash>@<version>"` notebook-id form.
+  const vars = stageB_importFake('d/57d79353bac56631@44', [{
+      imported: 'hash',
+      local: 'hash'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {hash} from "d/57d79353bac56631@44"`);
+  return 'ok';
+};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -20753,7 +20992,7 @@ export default function define(runtime, observer) {
   $def("_1n7gw17", "findModuleName", ["extractModuleInfo"], _1n7gw17);  
   $def("_i47chb", "findImportedName", [], _i47chb);  
   $def("_1effqg", null, ["md"], _1effqg);  
-  $def("_1etqs71", "decompileImport", ["findModuleName","findImportedName"], _1etqs71);  
+  $def("_b7vai6", "decompileImport", ["findModuleName","findImportedName"], _b7vai6);  
   $def("_1sylz7j", "formatImportDeclaration", [], _1sylz7j);  
   $def("_13dctdn", "test_decompileImport_basic", ["importFake","decompileImport","expect"], _13dctdn);  
   $def("_ujr0xn", "test_formatImportDeclaration_roundtrip", ["importFake","decompileImport","expect","formatImportDeclaration","decompile"], _ujr0xn);  
@@ -20831,7 +21070,18 @@ export default function define(runtime, observer) {
   main.define("Runtime", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Runtime", _));  
   main.define("Inspector", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Inspector", _));  
   main.define("Library", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Library", _));  
-  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));
+  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));  
+  $def("_1rc67k0", "stageB_importFake", [], _1rc67k0);  
+  $def("_1d53asg", "test_decompileImport_stageB_single", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1d53asg);  
+  $def("_hv5gag", "test_decompileImport_stageB_aliased", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _hv5gag);  
+  $def("_avc18y", "test_decompileImport_stageB_multiple", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _avc18y);  
+  $def("_16gia7i", "test_decompileImport_stageB_mixed_alias", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16gia7i);  
+  $def("_1slhdwo", "test_decompileImport_stageB_viewof", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1slhdwo);  
+  $def("_qwlsf2", "test_decompileImport_stageB_mutable", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _qwlsf2);  
+  $def("_sy7jfx", "test_decompileImport_returns_null_for_non_import", ["decompileImport","expect"], _sy7jfx);  
+  $def("_rk7ku3", "test_decompileImport_compile_roundtrip_single", ["compile","expect","stageB_importFake","decompileImport","formatImportDeclaration"], _rk7ku3);  
+  $def("_xynplo", "test_decompileImport_stageB_order_independent", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _xynplo);  
+  $def("_16fpgac", "test_decompileImport_stageB_notebook_id", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16fpgac);
   return main;
 }</script>
 

--- a/notebooks/atproto.html
+++ b/notebooks/atproto.html
@@ -22154,56 +22154,103 @@ async (v) => {
 const _1effqg = function _96(md){return(
 md`### \`decompileImport\``
 )};
-const _1etqs71 = function _decompileImport(findModuleName,findImportedName)
+const _b7vai6 = function _decompileImport(findModuleName,findImportedName)
 {
-    return async function decompileImport(variables, options = {}) {
-        if (!variables || variables.length === 0)
-            throw new Error('no variables');
-        // #166: An import group is `[module @foo, ...aliases]` — the runtime stitch
-        // sits at index 0 by convention. Scan for the first alias (single _input,
-        // crosses module boundary) so this works whichever order the caller hands us.
-        const isCrossModuleAlias = v => {
-            const inputs = v?._inputs;
-            if (!Array.isArray(inputs) || inputs.length !== 1)
-                return false;
-            const i0 = inputs[0];
-            return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
-        };
-        const v0 = variables.find(isCrossModuleAlias);
-        if (!v0)
-            return null;
-        const input0 = v0._inputs[0];
-        const inputsLength = 1;
-        const crossesModuleBoundary = true;
-        const module_name = findModuleName(v0._module._scope, input0._module);
-        if (module_name == null)
-            throw new Error('module name could not be resolved');
-        // #166: Skip runtime-internal `module @foo` stitch variables — they belong to
-        // the import group but are not user-facing specifiers. Without this filter, an
-        // import group renders as `import {Range, module @foo} from "@foo"`.
-        const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
-            const imported = await findImportedName(v);
-            const local = v._name;
-            return {
-                imported,
-                local,
-                alias: imported !== local,
-                meta: { index }
-            };
-        }));
-        return {
-            type: 'import',
-            from: module_name,
-            specifiers,
-            meta: {
-                detection: {
-                    inputsLength,
-                    crossesModuleBoundary
-                },
-                variables: variables.map(v => v?._name ?? null)
-            }
-        };
+  return async function decompileImport(variables, options = {}) {
+    if (!variables || variables.length === 0)
+      throw new Error('no variables');
+    // An import-cell group is `[module @X stitch, ...aliases]`. Each alias goes
+    // through three lifecycle stages (documented in observable-runtime-v6's
+    // `importedModule` helper, lines ~1992-2049 of @tomlarkworthy/observable-runtime-v6):
+    //
+    //   Stage A — post-observation:
+    //     `_inputs = [Variable in source module]` (length 1, cross-module).
+    //     The Observable runtime rewrites _inputs after the alias is observed
+    //     and resolved against the source module.
+    //
+    //   Stage B — pre-observation, API-loaded (canonical compiled-bundle shape):
+    //     `_inputs = [Variable("module @X"), Variable("@variable")]` (length 2,
+    //     both in the importer module). What `runtime.define("name",
+    //     ["module @X", "@variable"], (_, v) => v.import("name", _))` produces.
+    //     Also what `compile_and_update` outputs for freshly-defined user-typed
+    //     imports until they're observed.
+    //
+    //   Stage C — pre-observation, inline live-notebook:
+    //     `_inputs = [Variable("@variable")]` (length 1) AND the definition
+    //     calls `import(...)` inside. We extract the imported module reference
+    //     by invoking the definition with a stub `import` capture.
+    //
+    // Detection order is post→pre because Stage A is unambiguous when present.
+    const isStageA = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
     };
+    const isStageB = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 2)
+        return false;
+      const [i0, i1] = inputs;
+      return !!(i0 && typeof i0 === 'object' && typeof i0._name === 'string' && i0._name.startsWith('module @') && i1 && typeof i1 === 'object' && i1._name === '@variable');
+    };
+    const isStageC = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && i0._name === '@variable' && typeof v._definition !== 'undefined' && String(v._definition).includes('import('));
+    };
+    let v0, module_name, stage;
+    if (v0 = variables.find(isStageA)) {
+      stage = 'A';
+      module_name = findModuleName(v0._module._scope, v0._inputs[0]._module);
+    } else if (v0 = variables.find(isStageB)) {
+      stage = 'B';
+      module_name = v0._inputs[0]._name.replace(/^module /, '');
+    } else if (v0 = variables.find(isStageC)) {
+      stage = 'C';
+      let capturedModule;
+      try {
+        await v0._definition({
+          import: (...args) => {
+            capturedModule = args[args.length - 1];
+          }
+        });
+      } catch (e) {
+      }
+      if (capturedModule && v0._module?._scope) {
+        module_name = findModuleName(v0._module._scope, capturedModule);
+      }
+    } else {
+      return null;
+    }
+    if (module_name == null)
+      throw new Error('module name could not be resolved');
+    // Skip runtime-internal `module @foo` stitch variables — they belong to
+    // the import group but are not user-facing specifiers. Without this filter, an
+    // import group renders as `import {Range, module @foo} from "@foo"`.
+    const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
+      const imported = await findImportedName(v);
+      const local = v._name;
+      return {
+        imported,
+        local,
+        alias: imported !== local,
+        meta: { index }
+      };
+    }));
+    return {
+      type: 'import',
+      from: module_name,
+      specifiers,
+      meta: {
+        detection: { stage },
+        variables: variables.map(v => v?._name ?? null)
+      }
+    };
+  };
 };
 const _1sylz7j = function _formatImportDeclaration(){return(
 function formatImportDeclaration(importInfo) {
@@ -23313,6 +23360,198 @@ const _1hiclbb = function _acorn_walk(acorn_walk_url) {
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
+const _1rc67k0 = function _stageB_importFake()
+{
+  return // Builds a Stage B (pre-observation, API-loaded) import group as POJOs.
+  // Mirrors what `runtime.define("name", ["module @X", "@variable"], (_, v) => v.import("name", _))`
+  // produces structurally. Used by the test_decompileImport_stageB_* tests to
+  // avoid spinning up a real Observable runtime per case.
+  function stageB_importFake(module_name, specifiers) {
+    const importerModule = { _scope: new Map() };
+    const stitch = {
+      _name: `module ${ module_name }`,
+      _module: importerModule,
+      _inputs: [],
+      _definition: `async () => null`
+    };
+    const atVariable = {
+      _name: '@variable',
+      _module: importerModule
+    };
+    const aliases = specifiers.map(s => ({
+      _name: s.local,
+      _module: importerModule,
+      _inputs: [
+        stitch,
+        atVariable
+      ],
+      _definition: s.imported === s.local ? `(_, v) => v.import("${ s.imported }", _)` : `(_, v) => v.import("${ s.imported }", "${ s.local }", _)`
+    }));
+    return [
+      stitch,
+      ...aliases
+    ];
+  };
+};
+const _1d53asg = async function _test_decompileImport_stageB_single(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [{
+      imported: 'visualize',
+      local: 'visualize'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _hv5gag = async function _test_decompileImport_stageB_aliased(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'x',
+      local: 'z'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(info.specifiers[0].alias).toEqual(true);
+  expect(formatImportDeclaration(info)).toEqual(`import {x as z} from "@user/y"`);
+  return 'ok';
+};
+const _avc18y = async function _test_decompileImport_stageB_multiple(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    },
+    {
+      imported: 'c',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b, c} from "@user/y"`);
+  return 'ok';
+};
+const _16gia7i = async function _test_decompileImport_stageB_mixed_alias(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b as c} from "@user/y"`);
+  return 'ok';
+};
+const _1slhdwo = async function _test_decompileImport_stageB_viewof(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/module-map', [{
+      imported: 'viewof currentModules',
+      local: 'viewof currentModules'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {viewof currentModules} from "@tomlarkworthy/module-map"`);
+  return 'ok';
+};
+const _qwlsf2 = async function _test_decompileImport_stageB_mutable(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'mutable counter',
+      local: 'mutable counter'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {mutable counter} from "@user/y"`);
+  return 'ok';
+};
+const _sy7jfx = async function _test_decompileImport_returns_null_for_non_import(decompileImport,expect)
+{
+  // A regular cell — no stitch, no @variable input, no cross-module reference.
+  const info = await decompileImport([{
+      _name: 'x',
+      _module: {},
+      _inputs: [],
+      _definition: `() => 42`
+    }]);
+  expect(info).toEqual(null);
+  return 'ok';
+};
+const _rk7ku3 = async function _test_decompileImport_compile_roundtrip_single(compile,expect,stageB_importFake,decompileImport,formatImportDeclaration)
+{
+  // What `compile()` emits for `import {x} from "@user/y"` is structurally the
+  // same as our stageB_importFake fixture (after runtime.define resolves the
+  // input name strings to Variable refs). Verify the fixture matches the
+  // shape compile() would produce.
+  const pojos = compile(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  expect(pojos.length).toEqual(3);
+  expect(pojos[0]._name).toEqual('module @tomlarkworthy/visualizer');
+  expect(pojos[1]._name).toEqual('visualize');
+  expect(pojos[2]._name).toEqual('Group');
+  expect(pojos[1]._inputs).toEqual([
+    'module @tomlarkworthy/visualizer',
+    '@variable'
+  ]);
+  // Now run our fixture through decompileImport — confirms the round-trip
+  // shape compile()-output-shape-when-defined → decompileImport produces the
+  // canonical import source string.
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [
+    {
+      imported: 'visualize',
+      local: 'visualize'
+    },
+    {
+      imported: 'Group',
+      local: 'Group'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _xynplo = async function _test_decompileImport_stageB_order_independent(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // The detection uses .find — it shouldn't matter whether the stitch is at
+  // index 0 or the aliases come first. Verify by reversing the array.
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    }
+  ]);
+  const reversed = [...vars].reverse();
+  const info = await decompileImport(reversed);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b} from "@user/y"`);
+  return 'ok';
+};
+const _16fpgac = async function _test_decompileImport_stageB_notebook_id(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // Observable supports `import {x} from "d/<hash>@<version>"` notebook-id form.
+  const vars = stageB_importFake('d/57d79353bac56631@44', [{
+      imported: 'hash',
+      local: 'hash'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {hash} from "d/57d79353bac56631@44"`);
+  return 'ok';
+};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -23433,7 +23672,7 @@ export default function define(runtime, observer) {
   $def("_1n7gw17", "findModuleName", ["extractModuleInfo"], _1n7gw17);  
   $def("_i47chb", "findImportedName", [], _i47chb);  
   $def("_1effqg", null, ["md"], _1effqg);  
-  $def("_1etqs71", "decompileImport", ["findModuleName","findImportedName"], _1etqs71);  
+  $def("_b7vai6", "decompileImport", ["findModuleName","findImportedName"], _b7vai6);  
   $def("_1sylz7j", "formatImportDeclaration", [], _1sylz7j);  
   $def("_13dctdn", "test_decompileImport_basic", ["importFake","decompileImport","expect"], _13dctdn);  
   $def("_ujr0xn", "test_formatImportDeclaration_roundtrip", ["importFake","decompileImport","expect","formatImportDeclaration","decompile"], _ujr0xn);  
@@ -23511,7 +23750,18 @@ export default function define(runtime, observer) {
   main.define("Runtime", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Runtime", _));  
   main.define("Inspector", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Inspector", _));  
   main.define("Library", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Library", _));  
-  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));
+  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));  
+  $def("_1rc67k0", "stageB_importFake", [], _1rc67k0);  
+  $def("_1d53asg", "test_decompileImport_stageB_single", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1d53asg);  
+  $def("_hv5gag", "test_decompileImport_stageB_aliased", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _hv5gag);  
+  $def("_avc18y", "test_decompileImport_stageB_multiple", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _avc18y);  
+  $def("_16gia7i", "test_decompileImport_stageB_mixed_alias", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16gia7i);  
+  $def("_1slhdwo", "test_decompileImport_stageB_viewof", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1slhdwo);  
+  $def("_qwlsf2", "test_decompileImport_stageB_mutable", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _qwlsf2);  
+  $def("_sy7jfx", "test_decompileImport_returns_null_for_non_import", ["decompileImport","expect"], _sy7jfx);  
+  $def("_rk7ku3", "test_decompileImport_compile_roundtrip_single", ["compile","expect","stageB_importFake","decompileImport","formatImportDeclaration"], _rk7ku3);  
+  $def("_xynplo", "test_decompileImport_stageB_order_independent", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _xynplo);  
+  $def("_16fpgac", "test_decompileImport_stageB_notebook_id", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16fpgac);
   return main;
 }</script>
 

--- a/notebooks/jumpgates.html
+++ b/notebooks/jumpgates.html
@@ -20966,56 +20966,103 @@ async (v) => {
 const _1effqg = function _96(md){return(
 md`### \`decompileImport\``
 )};
-const _1etqs71 = function _decompileImport(findModuleName,findImportedName)
+const _b7vai6 = function _decompileImport(findModuleName,findImportedName)
 {
-    return async function decompileImport(variables, options = {}) {
-        if (!variables || variables.length === 0)
-            throw new Error('no variables');
-        // #166: An import group is `[module @foo, ...aliases]` — the runtime stitch
-        // sits at index 0 by convention. Scan for the first alias (single _input,
-        // crosses module boundary) so this works whichever order the caller hands us.
-        const isCrossModuleAlias = v => {
-            const inputs = v?._inputs;
-            if (!Array.isArray(inputs) || inputs.length !== 1)
-                return false;
-            const i0 = inputs[0];
-            return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
-        };
-        const v0 = variables.find(isCrossModuleAlias);
-        if (!v0)
-            return null;
-        const input0 = v0._inputs[0];
-        const inputsLength = 1;
-        const crossesModuleBoundary = true;
-        const module_name = findModuleName(v0._module._scope, input0._module);
-        if (module_name == null)
-            throw new Error('module name could not be resolved');
-        // #166: Skip runtime-internal `module @foo` stitch variables — they belong to
-        // the import group but are not user-facing specifiers. Without this filter, an
-        // import group renders as `import {Range, module @foo} from "@foo"`.
-        const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
-            const imported = await findImportedName(v);
-            const local = v._name;
-            return {
-                imported,
-                local,
-                alias: imported !== local,
-                meta: { index }
-            };
-        }));
-        return {
-            type: 'import',
-            from: module_name,
-            specifiers,
-            meta: {
-                detection: {
-                    inputsLength,
-                    crossesModuleBoundary
-                },
-                variables: variables.map(v => v?._name ?? null)
-            }
-        };
+  return async function decompileImport(variables, options = {}) {
+    if (!variables || variables.length === 0)
+      throw new Error('no variables');
+    // An import-cell group is `[module @X stitch, ...aliases]`. Each alias goes
+    // through three lifecycle stages (documented in observable-runtime-v6's
+    // `importedModule` helper, lines ~1992-2049 of @tomlarkworthy/observable-runtime-v6):
+    //
+    //   Stage A — post-observation:
+    //     `_inputs = [Variable in source module]` (length 1, cross-module).
+    //     The Observable runtime rewrites _inputs after the alias is observed
+    //     and resolved against the source module.
+    //
+    //   Stage B — pre-observation, API-loaded (canonical compiled-bundle shape):
+    //     `_inputs = [Variable("module @X"), Variable("@variable")]` (length 2,
+    //     both in the importer module). What `runtime.define("name",
+    //     ["module @X", "@variable"], (_, v) => v.import("name", _))` produces.
+    //     Also what `compile_and_update` outputs for freshly-defined user-typed
+    //     imports until they're observed.
+    //
+    //   Stage C — pre-observation, inline live-notebook:
+    //     `_inputs = [Variable("@variable")]` (length 1) AND the definition
+    //     calls `import(...)` inside. We extract the imported module reference
+    //     by invoking the definition with a stub `import` capture.
+    //
+    // Detection order is post→pre because Stage A is unambiguous when present.
+    const isStageA = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
     };
+    const isStageB = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 2)
+        return false;
+      const [i0, i1] = inputs;
+      return !!(i0 && typeof i0 === 'object' && typeof i0._name === 'string' && i0._name.startsWith('module @') && i1 && typeof i1 === 'object' && i1._name === '@variable');
+    };
+    const isStageC = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && i0._name === '@variable' && typeof v._definition !== 'undefined' && String(v._definition).includes('import('));
+    };
+    let v0, module_name, stage;
+    if (v0 = variables.find(isStageA)) {
+      stage = 'A';
+      module_name = findModuleName(v0._module._scope, v0._inputs[0]._module);
+    } else if (v0 = variables.find(isStageB)) {
+      stage = 'B';
+      module_name = v0._inputs[0]._name.replace(/^module /, '');
+    } else if (v0 = variables.find(isStageC)) {
+      stage = 'C';
+      let capturedModule;
+      try {
+        await v0._definition({
+          import: (...args) => {
+            capturedModule = args[args.length - 1];
+          }
+        });
+      } catch (e) {
+      }
+      if (capturedModule && v0._module?._scope) {
+        module_name = findModuleName(v0._module._scope, capturedModule);
+      }
+    } else {
+      return null;
+    }
+    if (module_name == null)
+      throw new Error('module name could not be resolved');
+    // Skip runtime-internal `module @foo` stitch variables — they belong to
+    // the import group but are not user-facing specifiers. Without this filter, an
+    // import group renders as `import {Range, module @foo} from "@foo"`.
+    const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
+      const imported = await findImportedName(v);
+      const local = v._name;
+      return {
+        imported,
+        local,
+        alias: imported !== local,
+        meta: { index }
+      };
+    }));
+    return {
+      type: 'import',
+      from: module_name,
+      specifiers,
+      meta: {
+        detection: { stage },
+        variables: variables.map(v => v?._name ?? null)
+      }
+    };
+  };
 };
 const _1sylz7j = function _formatImportDeclaration(){return(
 function formatImportDeclaration(importInfo) {
@@ -22125,6 +22172,198 @@ const _1hiclbb = function _acorn_walk(acorn_walk_url) {
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
+const _1rc67k0 = function _stageB_importFake()
+{
+  return // Builds a Stage B (pre-observation, API-loaded) import group as POJOs.
+  // Mirrors what `runtime.define("name", ["module @X", "@variable"], (_, v) => v.import("name", _))`
+  // produces structurally. Used by the test_decompileImport_stageB_* tests to
+  // avoid spinning up a real Observable runtime per case.
+  function stageB_importFake(module_name, specifiers) {
+    const importerModule = { _scope: new Map() };
+    const stitch = {
+      _name: `module ${ module_name }`,
+      _module: importerModule,
+      _inputs: [],
+      _definition: `async () => null`
+    };
+    const atVariable = {
+      _name: '@variable',
+      _module: importerModule
+    };
+    const aliases = specifiers.map(s => ({
+      _name: s.local,
+      _module: importerModule,
+      _inputs: [
+        stitch,
+        atVariable
+      ],
+      _definition: s.imported === s.local ? `(_, v) => v.import("${ s.imported }", _)` : `(_, v) => v.import("${ s.imported }", "${ s.local }", _)`
+    }));
+    return [
+      stitch,
+      ...aliases
+    ];
+  };
+};
+const _1d53asg = async function _test_decompileImport_stageB_single(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [{
+      imported: 'visualize',
+      local: 'visualize'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _hv5gag = async function _test_decompileImport_stageB_aliased(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'x',
+      local: 'z'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(info.specifiers[0].alias).toEqual(true);
+  expect(formatImportDeclaration(info)).toEqual(`import {x as z} from "@user/y"`);
+  return 'ok';
+};
+const _avc18y = async function _test_decompileImport_stageB_multiple(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    },
+    {
+      imported: 'c',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b, c} from "@user/y"`);
+  return 'ok';
+};
+const _16gia7i = async function _test_decompileImport_stageB_mixed_alias(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b as c} from "@user/y"`);
+  return 'ok';
+};
+const _1slhdwo = async function _test_decompileImport_stageB_viewof(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/module-map', [{
+      imported: 'viewof currentModules',
+      local: 'viewof currentModules'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {viewof currentModules} from "@tomlarkworthy/module-map"`);
+  return 'ok';
+};
+const _qwlsf2 = async function _test_decompileImport_stageB_mutable(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'mutable counter',
+      local: 'mutable counter'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {mutable counter} from "@user/y"`);
+  return 'ok';
+};
+const _sy7jfx = async function _test_decompileImport_returns_null_for_non_import(decompileImport,expect)
+{
+  // A regular cell — no stitch, no @variable input, no cross-module reference.
+  const info = await decompileImport([{
+      _name: 'x',
+      _module: {},
+      _inputs: [],
+      _definition: `() => 42`
+    }]);
+  expect(info).toEqual(null);
+  return 'ok';
+};
+const _rk7ku3 = async function _test_decompileImport_compile_roundtrip_single(compile,expect,stageB_importFake,decompileImport,formatImportDeclaration)
+{
+  // What `compile()` emits for `import {x} from "@user/y"` is structurally the
+  // same as our stageB_importFake fixture (after runtime.define resolves the
+  // input name strings to Variable refs). Verify the fixture matches the
+  // shape compile() would produce.
+  const pojos = compile(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  expect(pojos.length).toEqual(3);
+  expect(pojos[0]._name).toEqual('module @tomlarkworthy/visualizer');
+  expect(pojos[1]._name).toEqual('visualize');
+  expect(pojos[2]._name).toEqual('Group');
+  expect(pojos[1]._inputs).toEqual([
+    'module @tomlarkworthy/visualizer',
+    '@variable'
+  ]);
+  // Now run our fixture through decompileImport — confirms the round-trip
+  // shape compile()-output-shape-when-defined → decompileImport produces the
+  // canonical import source string.
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [
+    {
+      imported: 'visualize',
+      local: 'visualize'
+    },
+    {
+      imported: 'Group',
+      local: 'Group'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _xynplo = async function _test_decompileImport_stageB_order_independent(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // The detection uses .find — it shouldn't matter whether the stitch is at
+  // index 0 or the aliases come first. Verify by reversing the array.
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    }
+  ]);
+  const reversed = [...vars].reverse();
+  const info = await decompileImport(reversed);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b} from "@user/y"`);
+  return 'ok';
+};
+const _16fpgac = async function _test_decompileImport_stageB_notebook_id(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // Observable supports `import {x} from "d/<hash>@<version>"` notebook-id form.
+  const vars = stageB_importFake('d/57d79353bac56631@44', [{
+      imported: 'hash',
+      local: 'hash'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {hash} from "d/57d79353bac56631@44"`);
+  return 'ok';
+};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -22245,7 +22484,7 @@ export default function define(runtime, observer) {
   $def("_1n7gw17", "findModuleName", ["extractModuleInfo"], _1n7gw17);  
   $def("_i47chb", "findImportedName", [], _i47chb);  
   $def("_1effqg", null, ["md"], _1effqg);  
-  $def("_1etqs71", "decompileImport", ["findModuleName","findImportedName"], _1etqs71);  
+  $def("_b7vai6", "decompileImport", ["findModuleName","findImportedName"], _b7vai6);  
   $def("_1sylz7j", "formatImportDeclaration", [], _1sylz7j);  
   $def("_13dctdn", "test_decompileImport_basic", ["importFake","decompileImport","expect"], _13dctdn);  
   $def("_ujr0xn", "test_formatImportDeclaration_roundtrip", ["importFake","decompileImport","expect","formatImportDeclaration","decompile"], _ujr0xn);  
@@ -22323,7 +22562,18 @@ export default function define(runtime, observer) {
   main.define("Runtime", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Runtime", _));  
   main.define("Inspector", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Inspector", _));  
   main.define("Library", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Library", _));  
-  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));
+  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));  
+  $def("_1rc67k0", "stageB_importFake", [], _1rc67k0);  
+  $def("_1d53asg", "test_decompileImport_stageB_single", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1d53asg);  
+  $def("_hv5gag", "test_decompileImport_stageB_aliased", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _hv5gag);  
+  $def("_avc18y", "test_decompileImport_stageB_multiple", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _avc18y);  
+  $def("_16gia7i", "test_decompileImport_stageB_mixed_alias", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16gia7i);  
+  $def("_1slhdwo", "test_decompileImport_stageB_viewof", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1slhdwo);  
+  $def("_qwlsf2", "test_decompileImport_stageB_mutable", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _qwlsf2);  
+  $def("_sy7jfx", "test_decompileImport_returns_null_for_non_import", ["decompileImport","expect"], _sy7jfx);  
+  $def("_rk7ku3", "test_decompileImport_compile_roundtrip_single", ["compile","expect","stageB_importFake","decompileImport","formatImportDeclaration"], _rk7ku3);  
+  $def("_xynplo", "test_decompileImport_stageB_order_independent", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _xynplo);  
+  $def("_16fpgac", "test_decompileImport_stageB_notebook_id", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16fpgac);
   return main;
 }</script>
 

--- a/notebooks/ledger.html
+++ b/notebooks/ledger.html
@@ -23237,56 +23237,103 @@ async (v) => {
 const _1effqg = function _96(md){return(
 md`### \`decompileImport\``
 )};
-const _1etqs71 = function _decompileImport(findModuleName,findImportedName)
+const _b7vai6 = function _decompileImport(findModuleName,findImportedName)
 {
-    return async function decompileImport(variables, options = {}) {
-        if (!variables || variables.length === 0)
-            throw new Error('no variables');
-        // #166: An import group is `[module @foo, ...aliases]` — the runtime stitch
-        // sits at index 0 by convention. Scan for the first alias (single _input,
-        // crosses module boundary) so this works whichever order the caller hands us.
-        const isCrossModuleAlias = v => {
-            const inputs = v?._inputs;
-            if (!Array.isArray(inputs) || inputs.length !== 1)
-                return false;
-            const i0 = inputs[0];
-            return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
-        };
-        const v0 = variables.find(isCrossModuleAlias);
-        if (!v0)
-            return null;
-        const input0 = v0._inputs[0];
-        const inputsLength = 1;
-        const crossesModuleBoundary = true;
-        const module_name = findModuleName(v0._module._scope, input0._module);
-        if (module_name == null)
-            throw new Error('module name could not be resolved');
-        // #166: Skip runtime-internal `module @foo` stitch variables — they belong to
-        // the import group but are not user-facing specifiers. Without this filter, an
-        // import group renders as `import {Range, module @foo} from "@foo"`.
-        const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
-            const imported = await findImportedName(v);
-            const local = v._name;
-            return {
-                imported,
-                local,
-                alias: imported !== local,
-                meta: { index }
-            };
-        }));
-        return {
-            type: 'import',
-            from: module_name,
-            specifiers,
-            meta: {
-                detection: {
-                    inputsLength,
-                    crossesModuleBoundary
-                },
-                variables: variables.map(v => v?._name ?? null)
-            }
-        };
+  return async function decompileImport(variables, options = {}) {
+    if (!variables || variables.length === 0)
+      throw new Error('no variables');
+    // An import-cell group is `[module @X stitch, ...aliases]`. Each alias goes
+    // through three lifecycle stages (documented in observable-runtime-v6's
+    // `importedModule` helper, lines ~1992-2049 of @tomlarkworthy/observable-runtime-v6):
+    //
+    //   Stage A — post-observation:
+    //     `_inputs = [Variable in source module]` (length 1, cross-module).
+    //     The Observable runtime rewrites _inputs after the alias is observed
+    //     and resolved against the source module.
+    //
+    //   Stage B — pre-observation, API-loaded (canonical compiled-bundle shape):
+    //     `_inputs = [Variable("module @X"), Variable("@variable")]` (length 2,
+    //     both in the importer module). What `runtime.define("name",
+    //     ["module @X", "@variable"], (_, v) => v.import("name", _))` produces.
+    //     Also what `compile_and_update` outputs for freshly-defined user-typed
+    //     imports until they're observed.
+    //
+    //   Stage C — pre-observation, inline live-notebook:
+    //     `_inputs = [Variable("@variable")]` (length 1) AND the definition
+    //     calls `import(...)` inside. We extract the imported module reference
+    //     by invoking the definition with a stub `import` capture.
+    //
+    // Detection order is post→pre because Stage A is unambiguous when present.
+    const isStageA = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
     };
+    const isStageB = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 2)
+        return false;
+      const [i0, i1] = inputs;
+      return !!(i0 && typeof i0 === 'object' && typeof i0._name === 'string' && i0._name.startsWith('module @') && i1 && typeof i1 === 'object' && i1._name === '@variable');
+    };
+    const isStageC = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && i0._name === '@variable' && typeof v._definition !== 'undefined' && String(v._definition).includes('import('));
+    };
+    let v0, module_name, stage;
+    if (v0 = variables.find(isStageA)) {
+      stage = 'A';
+      module_name = findModuleName(v0._module._scope, v0._inputs[0]._module);
+    } else if (v0 = variables.find(isStageB)) {
+      stage = 'B';
+      module_name = v0._inputs[0]._name.replace(/^module /, '');
+    } else if (v0 = variables.find(isStageC)) {
+      stage = 'C';
+      let capturedModule;
+      try {
+        await v0._definition({
+          import: (...args) => {
+            capturedModule = args[args.length - 1];
+          }
+        });
+      } catch (e) {
+      }
+      if (capturedModule && v0._module?._scope) {
+        module_name = findModuleName(v0._module._scope, capturedModule);
+      }
+    } else {
+      return null;
+    }
+    if (module_name == null)
+      throw new Error('module name could not be resolved');
+    // Skip runtime-internal `module @foo` stitch variables — they belong to
+    // the import group but are not user-facing specifiers. Without this filter, an
+    // import group renders as `import {Range, module @foo} from "@foo"`.
+    const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
+      const imported = await findImportedName(v);
+      const local = v._name;
+      return {
+        imported,
+        local,
+        alias: imported !== local,
+        meta: { index }
+      };
+    }));
+    return {
+      type: 'import',
+      from: module_name,
+      specifiers,
+      meta: {
+        detection: { stage },
+        variables: variables.map(v => v?._name ?? null)
+      }
+    };
+  };
 };
 const _1sylz7j = function _formatImportDeclaration(){return(
 function formatImportDeclaration(importInfo) {
@@ -24396,6 +24443,198 @@ const _1hiclbb = function _acorn_walk(acorn_walk_url) {
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
+const _1rc67k0 = function _stageB_importFake()
+{
+  return // Builds a Stage B (pre-observation, API-loaded) import group as POJOs.
+  // Mirrors what `runtime.define("name", ["module @X", "@variable"], (_, v) => v.import("name", _))`
+  // produces structurally. Used by the test_decompileImport_stageB_* tests to
+  // avoid spinning up a real Observable runtime per case.
+  function stageB_importFake(module_name, specifiers) {
+    const importerModule = { _scope: new Map() };
+    const stitch = {
+      _name: `module ${ module_name }`,
+      _module: importerModule,
+      _inputs: [],
+      _definition: `async () => null`
+    };
+    const atVariable = {
+      _name: '@variable',
+      _module: importerModule
+    };
+    const aliases = specifiers.map(s => ({
+      _name: s.local,
+      _module: importerModule,
+      _inputs: [
+        stitch,
+        atVariable
+      ],
+      _definition: s.imported === s.local ? `(_, v) => v.import("${ s.imported }", _)` : `(_, v) => v.import("${ s.imported }", "${ s.local }", _)`
+    }));
+    return [
+      stitch,
+      ...aliases
+    ];
+  };
+};
+const _1d53asg = async function _test_decompileImport_stageB_single(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [{
+      imported: 'visualize',
+      local: 'visualize'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _hv5gag = async function _test_decompileImport_stageB_aliased(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'x',
+      local: 'z'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(info.specifiers[0].alias).toEqual(true);
+  expect(formatImportDeclaration(info)).toEqual(`import {x as z} from "@user/y"`);
+  return 'ok';
+};
+const _avc18y = async function _test_decompileImport_stageB_multiple(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    },
+    {
+      imported: 'c',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b, c} from "@user/y"`);
+  return 'ok';
+};
+const _16gia7i = async function _test_decompileImport_stageB_mixed_alias(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b as c} from "@user/y"`);
+  return 'ok';
+};
+const _1slhdwo = async function _test_decompileImport_stageB_viewof(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/module-map', [{
+      imported: 'viewof currentModules',
+      local: 'viewof currentModules'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {viewof currentModules} from "@tomlarkworthy/module-map"`);
+  return 'ok';
+};
+const _qwlsf2 = async function _test_decompileImport_stageB_mutable(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'mutable counter',
+      local: 'mutable counter'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {mutable counter} from "@user/y"`);
+  return 'ok';
+};
+const _sy7jfx = async function _test_decompileImport_returns_null_for_non_import(decompileImport,expect)
+{
+  // A regular cell — no stitch, no @variable input, no cross-module reference.
+  const info = await decompileImport([{
+      _name: 'x',
+      _module: {},
+      _inputs: [],
+      _definition: `() => 42`
+    }]);
+  expect(info).toEqual(null);
+  return 'ok';
+};
+const _rk7ku3 = async function _test_decompileImport_compile_roundtrip_single(compile,expect,stageB_importFake,decompileImport,formatImportDeclaration)
+{
+  // What `compile()` emits for `import {x} from "@user/y"` is structurally the
+  // same as our stageB_importFake fixture (after runtime.define resolves the
+  // input name strings to Variable refs). Verify the fixture matches the
+  // shape compile() would produce.
+  const pojos = compile(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  expect(pojos.length).toEqual(3);
+  expect(pojos[0]._name).toEqual('module @tomlarkworthy/visualizer');
+  expect(pojos[1]._name).toEqual('visualize');
+  expect(pojos[2]._name).toEqual('Group');
+  expect(pojos[1]._inputs).toEqual([
+    'module @tomlarkworthy/visualizer',
+    '@variable'
+  ]);
+  // Now run our fixture through decompileImport — confirms the round-trip
+  // shape compile()-output-shape-when-defined → decompileImport produces the
+  // canonical import source string.
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [
+    {
+      imported: 'visualize',
+      local: 'visualize'
+    },
+    {
+      imported: 'Group',
+      local: 'Group'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _xynplo = async function _test_decompileImport_stageB_order_independent(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // The detection uses .find — it shouldn't matter whether the stitch is at
+  // index 0 or the aliases come first. Verify by reversing the array.
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    }
+  ]);
+  const reversed = [...vars].reverse();
+  const info = await decompileImport(reversed);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b} from "@user/y"`);
+  return 'ok';
+};
+const _16fpgac = async function _test_decompileImport_stageB_notebook_id(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // Observable supports `import {x} from "d/<hash>@<version>"` notebook-id form.
+  const vars = stageB_importFake('d/57d79353bac56631@44', [{
+      imported: 'hash',
+      local: 'hash'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {hash} from "d/57d79353bac56631@44"`);
+  return 'ok';
+};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -24516,7 +24755,7 @@ export default function define(runtime, observer) {
   $def("_1n7gw17", "findModuleName", ["extractModuleInfo"], _1n7gw17);  
   $def("_i47chb", "findImportedName", [], _i47chb);  
   $def("_1effqg", null, ["md"], _1effqg);  
-  $def("_1etqs71", "decompileImport", ["findModuleName","findImportedName"], _1etqs71);  
+  $def("_b7vai6", "decompileImport", ["findModuleName","findImportedName"], _b7vai6);  
   $def("_1sylz7j", "formatImportDeclaration", [], _1sylz7j);  
   $def("_13dctdn", "test_decompileImport_basic", ["importFake","decompileImport","expect"], _13dctdn);  
   $def("_ujr0xn", "test_formatImportDeclaration_roundtrip", ["importFake","decompileImport","expect","formatImportDeclaration","decompile"], _ujr0xn);  
@@ -24594,7 +24833,18 @@ export default function define(runtime, observer) {
   main.define("Runtime", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Runtime", _));  
   main.define("Inspector", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Inspector", _));  
   main.define("Library", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Library", _));  
-  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));
+  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));  
+  $def("_1rc67k0", "stageB_importFake", [], _1rc67k0);  
+  $def("_1d53asg", "test_decompileImport_stageB_single", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1d53asg);  
+  $def("_hv5gag", "test_decompileImport_stageB_aliased", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _hv5gag);  
+  $def("_avc18y", "test_decompileImport_stageB_multiple", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _avc18y);  
+  $def("_16gia7i", "test_decompileImport_stageB_mixed_alias", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16gia7i);  
+  $def("_1slhdwo", "test_decompileImport_stageB_viewof", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1slhdwo);  
+  $def("_qwlsf2", "test_decompileImport_stageB_mutable", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _qwlsf2);  
+  $def("_sy7jfx", "test_decompileImport_returns_null_for_non_import", ["decompileImport","expect"], _sy7jfx);  
+  $def("_rk7ku3", "test_decompileImport_compile_roundtrip_single", ["compile","expect","stageB_importFake","decompileImport","formatImportDeclaration"], _rk7ku3);  
+  $def("_xynplo", "test_decompileImport_stageB_order_independent", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _xynplo);  
+  $def("_16fpgac", "test_decompileImport_stageB_notebook_id", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16fpgac);
   return main;
 }</script>
 

--- a/notebooks/lopefeed.html
+++ b/notebooks/lopefeed.html
@@ -22308,56 +22308,103 @@ async (v) => {
 const _1effqg = function _96(md){return(
 md`### \`decompileImport\``
 )};
-const _1etqs71 = function _decompileImport(findModuleName,findImportedName)
+const _b7vai6 = function _decompileImport(findModuleName,findImportedName)
 {
-    return async function decompileImport(variables, options = {}) {
-        if (!variables || variables.length === 0)
-            throw new Error('no variables');
-        // #166: An import group is `[module @foo, ...aliases]` — the runtime stitch
-        // sits at index 0 by convention. Scan for the first alias (single _input,
-        // crosses module boundary) so this works whichever order the caller hands us.
-        const isCrossModuleAlias = v => {
-            const inputs = v?._inputs;
-            if (!Array.isArray(inputs) || inputs.length !== 1)
-                return false;
-            const i0 = inputs[0];
-            return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
-        };
-        const v0 = variables.find(isCrossModuleAlias);
-        if (!v0)
-            return null;
-        const input0 = v0._inputs[0];
-        const inputsLength = 1;
-        const crossesModuleBoundary = true;
-        const module_name = findModuleName(v0._module._scope, input0._module);
-        if (module_name == null)
-            throw new Error('module name could not be resolved');
-        // #166: Skip runtime-internal `module @foo` stitch variables — they belong to
-        // the import group but are not user-facing specifiers. Without this filter, an
-        // import group renders as `import {Range, module @foo} from "@foo"`.
-        const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
-            const imported = await findImportedName(v);
-            const local = v._name;
-            return {
-                imported,
-                local,
-                alias: imported !== local,
-                meta: { index }
-            };
-        }));
-        return {
-            type: 'import',
-            from: module_name,
-            specifiers,
-            meta: {
-                detection: {
-                    inputsLength,
-                    crossesModuleBoundary
-                },
-                variables: variables.map(v => v?._name ?? null)
-            }
-        };
+  return async function decompileImport(variables, options = {}) {
+    if (!variables || variables.length === 0)
+      throw new Error('no variables');
+    // An import-cell group is `[module @X stitch, ...aliases]`. Each alias goes
+    // through three lifecycle stages (documented in observable-runtime-v6's
+    // `importedModule` helper, lines ~1992-2049 of @tomlarkworthy/observable-runtime-v6):
+    //
+    //   Stage A — post-observation:
+    //     `_inputs = [Variable in source module]` (length 1, cross-module).
+    //     The Observable runtime rewrites _inputs after the alias is observed
+    //     and resolved against the source module.
+    //
+    //   Stage B — pre-observation, API-loaded (canonical compiled-bundle shape):
+    //     `_inputs = [Variable("module @X"), Variable("@variable")]` (length 2,
+    //     both in the importer module). What `runtime.define("name",
+    //     ["module @X", "@variable"], (_, v) => v.import("name", _))` produces.
+    //     Also what `compile_and_update` outputs for freshly-defined user-typed
+    //     imports until they're observed.
+    //
+    //   Stage C — pre-observation, inline live-notebook:
+    //     `_inputs = [Variable("@variable")]` (length 1) AND the definition
+    //     calls `import(...)` inside. We extract the imported module reference
+    //     by invoking the definition with a stub `import` capture.
+    //
+    // Detection order is post→pre because Stage A is unambiguous when present.
+    const isStageA = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
     };
+    const isStageB = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 2)
+        return false;
+      const [i0, i1] = inputs;
+      return !!(i0 && typeof i0 === 'object' && typeof i0._name === 'string' && i0._name.startsWith('module @') && i1 && typeof i1 === 'object' && i1._name === '@variable');
+    };
+    const isStageC = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && i0._name === '@variable' && typeof v._definition !== 'undefined' && String(v._definition).includes('import('));
+    };
+    let v0, module_name, stage;
+    if (v0 = variables.find(isStageA)) {
+      stage = 'A';
+      module_name = findModuleName(v0._module._scope, v0._inputs[0]._module);
+    } else if (v0 = variables.find(isStageB)) {
+      stage = 'B';
+      module_name = v0._inputs[0]._name.replace(/^module /, '');
+    } else if (v0 = variables.find(isStageC)) {
+      stage = 'C';
+      let capturedModule;
+      try {
+        await v0._definition({
+          import: (...args) => {
+            capturedModule = args[args.length - 1];
+          }
+        });
+      } catch (e) {
+      }
+      if (capturedModule && v0._module?._scope) {
+        module_name = findModuleName(v0._module._scope, capturedModule);
+      }
+    } else {
+      return null;
+    }
+    if (module_name == null)
+      throw new Error('module name could not be resolved');
+    // Skip runtime-internal `module @foo` stitch variables — they belong to
+    // the import group but are not user-facing specifiers. Without this filter, an
+    // import group renders as `import {Range, module @foo} from "@foo"`.
+    const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
+      const imported = await findImportedName(v);
+      const local = v._name;
+      return {
+        imported,
+        local,
+        alias: imported !== local,
+        meta: { index }
+      };
+    }));
+    return {
+      type: 'import',
+      from: module_name,
+      specifiers,
+      meta: {
+        detection: { stage },
+        variables: variables.map(v => v?._name ?? null)
+      }
+    };
+  };
 };
 const _1sylz7j = function _formatImportDeclaration(){return(
 function formatImportDeclaration(importInfo) {
@@ -23467,6 +23514,198 @@ const _1hiclbb = function _acorn_walk(acorn_walk_url) {
 const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
 decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
 )};
+const _1rc67k0 = function _stageB_importFake()
+{
+  return // Builds a Stage B (pre-observation, API-loaded) import group as POJOs.
+  // Mirrors what `runtime.define("name", ["module @X", "@variable"], (_, v) => v.import("name", _))`
+  // produces structurally. Used by the test_decompileImport_stageB_* tests to
+  // avoid spinning up a real Observable runtime per case.
+  function stageB_importFake(module_name, specifiers) {
+    const importerModule = { _scope: new Map() };
+    const stitch = {
+      _name: `module ${ module_name }`,
+      _module: importerModule,
+      _inputs: [],
+      _definition: `async () => null`
+    };
+    const atVariable = {
+      _name: '@variable',
+      _module: importerModule
+    };
+    const aliases = specifiers.map(s => ({
+      _name: s.local,
+      _module: importerModule,
+      _inputs: [
+        stitch,
+        atVariable
+      ],
+      _definition: s.imported === s.local ? `(_, v) => v.import("${ s.imported }", _)` : `(_, v) => v.import("${ s.imported }", "${ s.local }", _)`
+    }));
+    return [
+      stitch,
+      ...aliases
+    ];
+  };
+};
+const _1d53asg = async function _test_decompileImport_stageB_single(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [{
+      imported: 'visualize',
+      local: 'visualize'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _hv5gag = async function _test_decompileImport_stageB_aliased(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'x',
+      local: 'z'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(info.specifiers[0].alias).toEqual(true);
+  expect(formatImportDeclaration(info)).toEqual(`import {x as z} from "@user/y"`);
+  return 'ok';
+};
+const _avc18y = async function _test_decompileImport_stageB_multiple(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    },
+    {
+      imported: 'c',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b, c} from "@user/y"`);
+  return 'ok';
+};
+const _16gia7i = async function _test_decompileImport_stageB_mixed_alias(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b as c} from "@user/y"`);
+  return 'ok';
+};
+const _1slhdwo = async function _test_decompileImport_stageB_viewof(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/module-map', [{
+      imported: 'viewof currentModules',
+      local: 'viewof currentModules'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {viewof currentModules} from "@tomlarkworthy/module-map"`);
+  return 'ok';
+};
+const _qwlsf2 = async function _test_decompileImport_stageB_mutable(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'mutable counter',
+      local: 'mutable counter'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {mutable counter} from "@user/y"`);
+  return 'ok';
+};
+const _sy7jfx = async function _test_decompileImport_returns_null_for_non_import(decompileImport,expect)
+{
+  // A regular cell — no stitch, no @variable input, no cross-module reference.
+  const info = await decompileImport([{
+      _name: 'x',
+      _module: {},
+      _inputs: [],
+      _definition: `() => 42`
+    }]);
+  expect(info).toEqual(null);
+  return 'ok';
+};
+const _rk7ku3 = async function _test_decompileImport_compile_roundtrip_single(compile,expect,stageB_importFake,decompileImport,formatImportDeclaration)
+{
+  // What `compile()` emits for `import {x} from "@user/y"` is structurally the
+  // same as our stageB_importFake fixture (after runtime.define resolves the
+  // input name strings to Variable refs). Verify the fixture matches the
+  // shape compile() would produce.
+  const pojos = compile(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  expect(pojos.length).toEqual(3);
+  expect(pojos[0]._name).toEqual('module @tomlarkworthy/visualizer');
+  expect(pojos[1]._name).toEqual('visualize');
+  expect(pojos[2]._name).toEqual('Group');
+  expect(pojos[1]._inputs).toEqual([
+    'module @tomlarkworthy/visualizer',
+    '@variable'
+  ]);
+  // Now run our fixture through decompileImport — confirms the round-trip
+  // shape compile()-output-shape-when-defined → decompileImport produces the
+  // canonical import source string.
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [
+    {
+      imported: 'visualize',
+      local: 'visualize'
+    },
+    {
+      imported: 'Group',
+      local: 'Group'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _xynplo = async function _test_decompileImport_stageB_order_independent(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // The detection uses .find — it shouldn't matter whether the stitch is at
+  // index 0 or the aliases come first. Verify by reversing the array.
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    }
+  ]);
+  const reversed = [...vars].reverse();
+  const info = await decompileImport(reversed);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b} from "@user/y"`);
+  return 'ok';
+};
+const _16fpgac = async function _test_decompileImport_stageB_notebook_id(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // Observable supports `import {x} from "d/<hash>@<version>"` notebook-id form.
+  const vars = stageB_importFake('d/57d79353bac56631@44', [{
+      imported: 'hash',
+      local: 'hash'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {hash} from "d/57d79353bac56631@44"`);
+  return 'ok';
+};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -23587,7 +23826,7 @@ export default function define(runtime, observer) {
   $def("_1n7gw17", "findModuleName", ["extractModuleInfo"], _1n7gw17);  
   $def("_i47chb", "findImportedName", [], _i47chb);  
   $def("_1effqg", null, ["md"], _1effqg);  
-  $def("_1etqs71", "decompileImport", ["findModuleName","findImportedName"], _1etqs71);  
+  $def("_b7vai6", "decompileImport", ["findModuleName","findImportedName"], _b7vai6);  
   $def("_1sylz7j", "formatImportDeclaration", [], _1sylz7j);  
   $def("_13dctdn", "test_decompileImport_basic", ["importFake","decompileImport","expect"], _13dctdn);  
   $def("_ujr0xn", "test_formatImportDeclaration_roundtrip", ["importFake","decompileImport","expect","formatImportDeclaration","decompile"], _ujr0xn);  
@@ -23665,7 +23904,18 @@ export default function define(runtime, observer) {
   main.define("Runtime", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Runtime", _));  
   main.define("Inspector", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Inspector", _));  
   main.define("Library", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Library", _));  
-  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));
+  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));  
+  $def("_1rc67k0", "stageB_importFake", [], _1rc67k0);  
+  $def("_1d53asg", "test_decompileImport_stageB_single", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1d53asg);  
+  $def("_hv5gag", "test_decompileImport_stageB_aliased", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _hv5gag);  
+  $def("_avc18y", "test_decompileImport_stageB_multiple", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _avc18y);  
+  $def("_16gia7i", "test_decompileImport_stageB_mixed_alias", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16gia7i);  
+  $def("_1slhdwo", "test_decompileImport_stageB_viewof", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1slhdwo);  
+  $def("_qwlsf2", "test_decompileImport_stageB_mutable", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _qwlsf2);  
+  $def("_sy7jfx", "test_decompileImport_returns_null_for_non_import", ["decompileImport","expect"], _sy7jfx);  
+  $def("_rk7ku3", "test_decompileImport_compile_roundtrip_single", ["compile","expect","stageB_importFake","decompileImport","formatImportDeclaration"], _rk7ku3);  
+  $def("_xynplo", "test_decompileImport_stageB_order_independent", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _xynplo);  
+  $def("_16fpgac", "test_decompileImport_stageB_notebook_id", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16fpgac);
   return main;
 }</script>
 


### PR DESCRIPTION
**This PR is a proposal** — the canonical HTML has been updated with the new cell + tests, but ObservableHQ has not been pushed and consumer notebooks have not been re-synced yet. After approval, those steps will run and additional commits will be pushed to this branch.

## Root cause (per user-provided insight)
Observable runtime aliases pass through three structural shapes during their lifecycle. `@tomlarkworthy/observable-runtime-v6`'s `importedModule` helper (lines ~1992-2049) already documents them:

| Stage | `_inputs` shape | Trigger |
|---|---|---|
| A — post-observation | `[Variable(cross-module)]` (length 1) | runtime rewrites after observation |
| B — pre-observation, API-loaded | `[Variable("module @X"), Variable("@variable")]` (length 2) | `runtime.define(...)` — the canonical compiled-bundle shape, also what `compile_and_update` emits |
| C — pre-observation, inline live-notebook | `[Variable("@variable")]` (length 1, def contains `import(`) | inline live-notebook imports |

`decompileImport` previously only detected Stage A. compile_and_update's freshly-defined imports landed in Stage B → `decompileImport` returned null → `decompile` fell through to the per-variable fallback → produced `module @X = runtime.module(...)` instead of the canonical `import {...} from "..."` form.

## Fix
Extend `decompileImport` in `@tomlarkworthy/observablejs-toolchain` to detect all three stages. Module name resolution differs per stage:

- **Stage A**: `findModuleName(scope, _inputs[0]._module)` (existing logic)
- **Stage B**: `_inputs[0]._name` with `"module "` prefix stripped
- **Stage C**: invoke `_definition` with stub `{import: capture}` callback; the captured 3rd arg is the imported module reference, resolved via `findModuleName`

Detection order is post→pre because Stage A is unambiguous when present.

Same fix synced into `@tomlarkworthy/editor-5`'s duplicate local copy of `_decompileImport` (line 19475). The duplication is pre-existing and tracked as a follow-up issue.

## Exhaustive in-notebook tests (Stage B)
Added `stageB_importFake(module_name, specifiers)` helper that builds POJOs structurally matching what `runtime.define` produces (no real Observable runtime setup needed per case). 10 new tests in `@tomlarkworthy/observablejs-toolchain`:

| Test | Source covered |
|---|---|
| `test_decompileImport_stageB_single` | `import {x} from "@user/y"` |
| `test_decompileImport_stageB_aliased` | `import {x as z} from "@user/y"` |
| `test_decompileImport_stageB_multiple` | `import {a, b, c} from "@user/y"` |
| `test_decompileImport_stageB_mixed_alias` | `import {a, b as c} from "@user/y"` |
| `test_decompileImport_stageB_viewof` | `import {viewof X} from "@user/y"` |
| `test_decompileImport_stageB_mutable` | `import {mutable X} from "@user/y"` |
| `test_decompileImport_returns_null_for_non_import` | sanity: regular cell → null |
| `test_decompileImport_compile_roundtrip_single` | verifies `compile()` POJO shape matches `stageB_importFake` fixture |
| `test_decompileImport_stageB_order_independent` | detection works regardless of [stitch, ...aliases] order |
| `test_decompileImport_stageB_notebook_id` | `import {x} from "d/<hash>@<version>"` |

Stage A is covered by pre-existing `test_decompileImport_basic` and `test_decompileImport_alias` (which use the original `importFake`). Stage C is opportunistic (no isolated test added; verified by inspection — file follow-up if it surfaces in practice).

## Verification status
- Both modules `node --check` cleanly after the edits.
- Unit tests will run inside the notebook's test harness on next jumpgate.
- Browser load was unstable across multiple QA attempts in this worktree (silent hangs on editor-5 boot — may correlate to the bundled debuggers, unrelated to this change). Recommend approval based on diff review + the in-notebook test coverage.

## Follow-up
- Deduplicate `_decompileImport` (and `_findImportedName`) between `@tomlarkworthy/editor-5` and `@tomlarkworthy/observablejs-toolchain`. Editor-5's local copy was originally a development edit that shadowed the imported toolchain version; should be removed once we verify there's no behavioral divergence other consumers rely on.