### PR TITLE
Fix: lopepage loses panel scroll when an adjacent panel is closed

### DIFF
--- a/notebooks/@tomlarkworthy_atlas.html
+++ b/notebooks/@tomlarkworthy_atlas.html
@@ -15008,138 +15008,196 @@ const _1nzpnqy = function _visualizer_cache(reload)
     reload;
     return new Map();
 };
-const _1l35721 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
+const _1ojown8 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
 {
-    return function (container, component) {
-        appendScrollLog('modulePanel:enter', {
-            title: container?.title ?? null,
-            componentCell: component?.cell ?? null
-        });
-        const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
-        if (!moduleInfo) {
-            // Fall through to file attachment: titles like @user/notebook/path.ext
-            // resolve via the lopecode bootloader's contentSync DOM lookup.
-            const title = container?.title ?? null;
-            if (title) {
-                let node = file_attachment_cache.get(title);
-                if (!node) {
-                    const r = window.lopecode?.contentSync?.(title);
-                    if (r && r.status === 200 && r.bytes) {
-                        node = renderFileAttachment(r.mime, r.bytes);
-                        file_attachment_cache.set(title, node);
-                        appendScrollLog('modulePanel:file_attachment_create', {
-                            title,
-                            mime: r.mime
-                        });
-                    }
-                }
-                if (node) {
-                    const c_element = container.getElement();
-                    if (node.parentNode !== c_element)
-                        c_element.appendChild(node);
-                    appendScrollLog('modulePanel:file_attachment_mount', { title });
-                    return;
-                }
-            }
-            appendScrollLog('modulePanel:missing_moduleInfo', { title });
-            return;
-        }
-        const module = moduleInfo.module;
-        let node;
-        if (!visualizer_cache.has(module)) {
-            appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
-            node = visualizer(runtime, {
-                invalidation: new Promise(r => {
-                }),
-                module,
-                detachNodes: isOnObservableCom(),
-                filter: (cell_name, variables) => {
-                    if (variables[0]._type !== 1)
-                        return false;
-                    if (typeof cell_name == 'string') {
-                        if (cell_name.startsWith('dynamic '))
-                            return false;
-                    }
-                    return true;
-                }
+  return function (container, component) {
+    appendScrollLog('modulePanel:enter', {
+      title: container?.title ?? null,
+      componentCell: component?.cell ?? null
+    });
+    const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
+    if (!moduleInfo) {
+      // Fall through to file attachment: titles like @user/notebook/path.ext
+      // resolve via the lopecode bootloader's contentSync DOM lookup.
+      const title = container?.title ?? null;
+      if (title) {
+        let node = file_attachment_cache.get(title);
+        if (!node) {
+          const r = window.lopecode?.contentSync?.(title);
+          if (r && r.status === 200 && r.bytes) {
+            node = renderFileAttachment(r.mime, r.bytes);
+            file_attachment_cache.set(title, node);
+            appendScrollLog('modulePanel:file_attachment_create', {
+              title,
+              mime: r.mime
             });
-            visualizer_cache.set(module, node);
-        } else {
-            node = visualizer_cache.get(module);
-            appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+          }
         }
-        const cell = module._scope.get(component.cell);
-        const scrollKey = scrollKeyFor(container);
-        fix_scroll(container, node, cell, scrollKey);
-        const el = container.getElement();
-        if (!el.__lope_scroll_bound) {
-            el.__lope_scroll_bound = true;
-            appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
-            el.addEventListener('scroll', () => {
-                const k = scrollKeyFor(container);
-                const scrollTop = el.scrollTop;
-                const scrollLeft = el.scrollLeft;
-                if (scrollTop == 0) {
-                    appendScrollLog('modulePanel:skip 0 scroll', {
-                        title: container?.title ?? null,
-                        scrollKey
-                    });
-                    return;
-                }
-                scroll_cache.set(k, {
-                    scrollTop,
-                    scrollLeft,
-                    t: Date.now()
-                });
-                appendScrollLog('scroll:event', {
-                    k,
-                    title: container?.title ?? null,
-                    scrollTop,
-                    scrollLeft
-                });
-            }, { passive: true });
+        if (node) {
+          const c_element = container.getElement();
+          if (node.parentNode !== c_element)
+            c_element.appendChild(node);
+          appendScrollLog('modulePanel:file_attachment_mount', { title });
+          return;
         }
-        // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
-        if (!container.__lope_destroy_bound) {
-            container.__lope_destroy_bound = true;
-            container.on('destroy', () => {
-                try {
-                    const k = scrollKeyFor(container);
-                    const scrollTop = el?.scrollTop;
-                    const scrollLeft = el?.scrollLeft;
-                    if (scrollTop == 0) {
-                        appendScrollLog('scroll:skip 0 scroll', {
-                            k,
-                            key: container?.title ?? null,
-                            scrollKey
-                        });
-                        return;
-                    }
-                    // do not skip 0 here: if the user is at top, preserve that state
-                    scroll_cache.set(k, {
-                        scrollTop,
-                        scrollLeft,
-                        t: Date.now()
-                    });
-                    appendScrollLog('scroll:destroy_capture', {
-                        k,
-                        title: container?.title ?? null,
-                        scrollTop,
-                        scrollLeft
-                    });
-                } catch (e) {
-                    appendScrollLog('scroll:destroy_capture:error', {
-                        title: container?.title ?? null,
-                        error: String(e)
-                    });
-                }
-            });
+      }
+      appendScrollLog('modulePanel:missing_moduleInfo', { title });
+      return;
+    }
+    const module = moduleInfo.module;
+    let node;
+    if (!visualizer_cache.has(module)) {
+      appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
+      node = visualizer(runtime, {
+        invalidation: new Promise(r => {
+        }),
+        module,
+        detachNodes: isOnObservableCom(),
+        filter: (cell_name, variables) => {
+          if (variables[0]._type !== 1)
+            return false;
+          if (typeof cell_name == 'string') {
+            if (cell_name.startsWith('dynamic '))
+              return false;
+          }
+          return true;
         }
-        appendScrollLog('modulePanel:exit', {
+      });
+      visualizer_cache.set(module, node);
+    } else {
+      node = visualizer_cache.get(module);
+      appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+    }
+    const cell = module._scope.get(component.cell);
+    const scrollKey = scrollKeyFor(container);
+    fix_scroll(container, node, cell, scrollKey);
+    const el = container.getElement();
+    if (!el.__lope_scroll_bound) {
+      el.__lope_scroll_bound = true;
+      appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
+      const markUserScroll = () => {
+        el.__lope_user_scroll_at = Date.now();
+      };
+      el.addEventListener('wheel', markUserScroll, { passive: true });
+      el.addEventListener('touchmove', markUserScroll, { passive: true });
+      el.addEventListener('keydown', markUserScroll, { passive: true });
+      el.addEventListener('scroll', () => {
+        if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+          appendScrollLog('scroll:skip_reflow', { title: container?.title ?? null });
+          return;
+        }
+        // Only cache scrolls following a genuine user gesture; reflow-induced
+        // scroll events (e.g. closing an adjacent panel) carry stale scrollTops.
+        if (Date.now() - (el.__lope_user_scroll_at || 0) > 400) {
+          appendScrollLog('scroll:skip_nonuser', { title: container?.title ?? null });
+          return;
+        }
+        const k = scrollKeyFor(container);
+        const scrollTop = el.scrollTop;
+        const scrollLeft = el.scrollLeft;
+        if (scrollTop == 0) {
+          appendScrollLog('modulePanel:skip 0 scroll', {
             title: container?.title ?? null,
             scrollKey
+          });
+          return;
+        }
+        scroll_cache.set(k, {
+          scrollTop,
+          scrollLeft,
+          t: Date.now()
         });
-    };
+        appendScrollLog('scroll:event', {
+          k,
+          title: container?.title ?? null,
+          scrollTop,
+          scrollLeft
+        });
+      }, { passive: true });
+    }
+    // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
+    if (!container.__lope_destroy_bound) {
+      container.__lope_destroy_bound = true;
+      container.on('destroy', () => {
+        try {
+          if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+            appendScrollLog('scroll:destroy_skip_reflow', { title: container?.title ?? null });
+            return;
+          }
+          const k = scrollKeyFor(container);
+          const scrollTop = el?.scrollTop;
+          const scrollLeft = el?.scrollLeft;
+          if (scrollTop == 0) {
+            appendScrollLog('scroll:skip 0 scroll', {
+              k,
+              key: container?.title ?? null,
+              scrollKey
+            });
+            return;
+          }
+          // do not skip 0 here: if the user is at top, preserve that state
+          scroll_cache.set(k, {
+            scrollTop,
+            scrollLeft,
+            t: Date.now()
+          });
+          appendScrollLog('scroll:destroy_capture', {
+            k,
+            title: container?.title ?? null,
+            scrollTop,
+            scrollLeft
+          });
+        } catch (e) {
+          appendScrollLog('scroll:destroy_capture:error', {
+            title: container?.title ?? null,
+            error: String(e)
+          });
+        }
+      });
+    }
+    // When GoldenLayout resizes this panel (e.g. an adjacent panel is closed) the
+    // browser can shift scrollTop; re-apply the user's cached position after the reflow.
+    if (!container.__lope_resize_bound) {
+      container.__lope_resize_bound = true;
+      container.on('resize', () => {
+        const rk = scrollKeyFor(container);
+        const cached = scroll_cache.get(rk);
+        if (!cached || cached.scrollTop == null)
+          return;
+        const c_el = container.getElement();
+        const at = Date.now();
+        scroll_cache.__reflowUntil = at + 800;
+        // The reflow can shift scrollTop in several passes (content relayout
+        // settles ~300ms later), so re-apply over a window. Bail if the user scrolls.
+        const apply = () => {
+          if ((c_el.__lope_user_scroll_at || 0) > at)
+            return;
+          if (c_el.scrollTop !== cached.scrollTop)
+            c_el.scrollTop = cached.scrollTop;
+          if (cached.scrollLeft != null && c_el.scrollLeft !== cached.scrollLeft)
+            c_el.scrollLeft = cached.scrollLeft;
+        };
+        requestAnimationFrame(apply);
+        for (const d of [
+            60,
+            150,
+            300,
+            450,
+            600
+          ])
+          setTimeout(apply, d);
+        appendScrollLog('scroll:resize_restore', {
+          k: rk,
+          title: container?.title ?? null,
+          scrollTop: cached.scrollTop
+        });
+      });
+    }
+    appendScrollLog('modulePanel:exit', {
+      title: container?.title ?? null,
+      scrollKey
+    });
+  };
 };
 const _1gm4gbf = function _blobPanel(){return(
 function (container, component) {
@@ -15257,112 +15315,115 @@ const _1d1nkw9 = function _scrollKeyFor(appendScrollLog)
 const _tb217h = function _scroll_cache(){return(
 new Map()
 )};
-const _5tyvpe = function _fix_scroll(scrollKeyFor,appendScrollLog,scroll_cache){return(
-function (container, node, cell_variable, key) {
+const _12p8mg7 = function _fix_scroll(scroll_cache,scrollKeyFor,appendScrollLog)
+{
+  return function (container, node, cell_variable, key) {
+    scroll_cache.__reflowUntil = Date.now() + 600;
+    // suppress reflow-induced scroll events that clobber the cache
     const c_element = container.getElement();
     let k = scrollKeyFor(container);
     appendScrollLog('fix_scroll:enter', {
-        title: container?.title ?? null,
-        k,
-        cell: cell_variable?._name ?? null
+      title: container?.title ?? null,
+      k,
+      cell: cell_variable?._name ?? null
     });
     if (node && node.parentNode !== c_element) {
-        c_element.appendChild(node);
-        appendScrollLog('fix_scroll:append_node', {
-            title: container?.title ?? null,
-            k
-        });
+      c_element.appendChild(node);
+      appendScrollLog('fix_scroll:append_node', {
+        title: container?.title ?? null,
+        k
+      });
     }
     const writeCache = (scrollTop, scrollLeft, why) => {
-        scroll_cache.set(k, {
-            scrollTop,
-            scrollLeft,
-            t: Date.now()
-        });
-        appendScrollLog('scroll_cache:write', {
-            k,
-            scrollTop,
-            scrollLeft,
-            why
-        });
+      scroll_cache.set(k, {
+        scrollTop,
+        scrollLeft,
+        t: Date.now()
+      });
+      appendScrollLog('scroll_cache:write', {
+        k,
+        scrollTop,
+        scrollLeft,
+        why
+      });
     };
     const scrollToCellIfPossible = why => {
-        if (!cell_variable)
-            return false;
-        const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
-        if (!dom) {
-            appendScrollLog('scroll:cell_dom_not_found', {
-                k,
-                why,
-                cell: cell_variable?._name ?? null
-            });
-            return false;
-        }
-        const top = dom.offsetTop - c_element.offsetTop;
-        const left = c_element.scrollLeft;
-        c_element.scrollTop = top;
-        appendScrollLog('scroll:set', {
-            k,
-            why: `${ why }:cell`,
-            scrollTop: top,
-            scrollLeft: left,
-            cell: cell_variable?._name ?? null
+      if (!cell_variable)
+        return false;
+      const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
+      if (!dom) {
+        appendScrollLog('scroll:cell_dom_not_found', {
+          k,
+          why,
+          cell: cell_variable?._name ?? null
         });
-        writeCache(top, left, `${ why }:cell`);
-        return true;
+        return false;
+      }
+      const top = dom.offsetTop - c_element.offsetTop;
+      const left = c_element.scrollLeft;
+      c_element.scrollTop = top;
+      appendScrollLog('scroll:set', {
+        k,
+        why: `${ why }:cell`,
+        scrollTop: top,
+        scrollLeft: left,
+        cell: cell_variable?._name ?? null
+      });
+      writeCache(top, left, `${ why }:cell`);
+      return true;
     };
     const restoreFromCache = why => {
-        k = scrollKeyFor(container);
-        const cached = scroll_cache.get(k);
-        appendScrollLog('scroll:restore_attempt', {
-            k,
-            why,
-            cachedScrollTop: cached?.scrollTop ?? null,
-            cachedScrollLeft: cached?.scrollLeft ?? null
+      k = scrollKeyFor(container);
+      const cached = scroll_cache.get(k);
+      appendScrollLog('scroll:restore_attempt', {
+        k,
+        why,
+        cachedScrollTop: cached?.scrollTop ?? null,
+        cachedScrollLeft: cached?.scrollLeft ?? null
+      });
+      if (!cached) {
+        appendScrollLog('scroll:restore_no_scroll', {
+          k,
+          why
         });
-        if (!cached) {
-            appendScrollLog('scroll:restore_no_scroll', {
-                k,
-                why
-            });
-            return;
-        }
-        if (cached.scrollTop != null)
-            c_element.scrollTop = cached.scrollTop;
-        if (cached.scrollLeft != null)
-            c_element.scrollLeft = cached.scrollLeft;
-        appendScrollLog('scroll:restore_applied', {
-            k,
-            why,
-            scrollTop: cached.scrollTop ?? null,
-            scrollLeft: cached.scrollLeft ?? null,
-            scrollTopFinal: c_element.scrollTop,
-            scrollLeftFinal: c_element.scrollLeft
-        });
+        return;
+      }
+      if (cached.scrollTop != null)
+        c_element.scrollTop = cached.scrollTop;
+      if (cached.scrollLeft != null)
+        c_element.scrollLeft = cached.scrollLeft;
+      appendScrollLog('scroll:restore_applied', {
+        k,
+        why,
+        scrollTop: cached.scrollTop ?? null,
+        scrollLeft: cached.scrollLeft ?? null,
+        scrollTopFinal: c_element.scrollTop,
+        scrollLeftFinal: c_element.scrollLeft
+      });
     };
     const setScroll = (why = 'setScroll') => {
-        if (scrollToCellIfPossible(why))
-            return;
-        restoreFromCache(why);
+      if (scrollToCellIfPossible(why))
+        return;
+      restoreFromCache(why);
     };
     const retryFrames = 6;
     for (let i = 0; i < retryFrames; i++) {
-        requestAnimationFrame(() => {
-            k = scrollKeyFor(container);
-            appendScrollLog('fix_scroll:raf_retry', {
-                i,
-                k,
-                title: container?.title ?? null
-            });
-            setScroll(`raf:${ i }`);
+      requestAnimationFrame(() => {
+        k = scrollKeyFor(container);
+        appendScrollLog('fix_scroll:raf_retry', {
+          i,
+          k,
+          title: container?.title ?? null
         });
+        setScroll(`raf:${ i }`);
+      });
     }
     appendScrollLog('fix_scroll:exit', {
-        k,
-        title: container?.title ?? null
+      k,
+      title: container?.title ?? null
     });
-}
-)};
+  };
+};
 const _arfw00 = function _scroll_fix_sync_layout(sync_layout_to_url,layout,appendScrollLog,modulePanel)
 {
     sync_layout_to_url;
@@ -16440,7 +16501,7 @@ export default function define(runtime, observer) {
   $def("_1we0ggl", "reload", ["Generators","viewof reload"], _1we0ggl);  
   $def("_plefwg", "onLoadConfig", ["parseGoldenDSL","URLSearchParams","location"], _plefwg);  
   $def("_1nzpnqy", "visualizer_cache", ["reload"], _1nzpnqy);  
-  $def("_1l35721", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1l35721);  
+  $def("_1ojown8", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1ojown8);  
   $def("_1gm4gbf", "blobPanel", [], _1gm4gbf);  
   $def("_lxv2e2", "settings", [], _lxv2e2);  
   $def("_lp1ggk", "is_mobile", ["width"], _lp1ggk);  
@@ -16461,7 +16522,7 @@ export default function define(runtime, observer) {
   $def("_1dyz4o0", "scrollLog", ["mutable scrollLog"], _1dyz4o0);  
   $def("_1d1nkw9", "scrollKeyFor", ["appendScrollLog"], _1d1nkw9);  
   $def("_tb217h", "scroll_cache", [], _tb217h);  
-  $def("_5tyvpe", "fix_scroll", ["scrollKeyFor","appendScrollLog","scroll_cache"], _5tyvpe);  
+  $def("_12p8mg7", "fix_scroll", ["scroll_cache","scrollKeyFor","appendScrollLog"], _12p8mg7);  
   $def("_arfw00", "scroll_fix_sync_layout", ["sync_layout_to_url","layout","appendScrollLog","modulePanel"], _arfw00);  
   $def("_3nwpp4", "URLrouting", ["md"], _3nwpp4);  
   $def("_14te9pl", "sync_layout_from_url", ["reload","resize","URLSearchParams","hash","appendScrollLog","parseGoldenDSL","gl","layout","serializeGoldenDSL","treeSyncGolden","invalidation"], _14te9pl);  

--- a/notebooks/@tomlarkworthy_atproto-comments.html
+++ b/notebooks/@tomlarkworthy_atproto-comments.html
@@ -14179,138 +14179,196 @@ const _1nzpnqy = function _visualizer_cache(reload)
     reload;
     return new Map();
 };
-const _1l35721 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
+const _1ojown8 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
 {
-    return function (container, component) {
-        appendScrollLog('modulePanel:enter', {
-            title: container?.title ?? null,
-            componentCell: component?.cell ?? null
-        });
-        const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
-        if (!moduleInfo) {
-            // Fall through to file attachment: titles like @user/notebook/path.ext
-            // resolve via the lopecode bootloader's contentSync DOM lookup.
-            const title = container?.title ?? null;
-            if (title) {
-                let node = file_attachment_cache.get(title);
-                if (!node) {
-                    const r = window.lopecode?.contentSync?.(title);
-                    if (r && r.status === 200 && r.bytes) {
-                        node = renderFileAttachment(r.mime, r.bytes);
-                        file_attachment_cache.set(title, node);
-                        appendScrollLog('modulePanel:file_attachment_create', {
-                            title,
-                            mime: r.mime
-                        });
-                    }
-                }
-                if (node) {
-                    const c_element = container.getElement();
-                    if (node.parentNode !== c_element)
-                        c_element.appendChild(node);
-                    appendScrollLog('modulePanel:file_attachment_mount', { title });
-                    return;
-                }
-            }
-            appendScrollLog('modulePanel:missing_moduleInfo', { title });
-            return;
-        }
-        const module = moduleInfo.module;
-        let node;
-        if (!visualizer_cache.has(module)) {
-            appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
-            node = visualizer(runtime, {
-                invalidation: new Promise(r => {
-                }),
-                module,
-                detachNodes: isOnObservableCom(),
-                filter: (cell_name, variables) => {
-                    if (variables[0]._type !== 1)
-                        return false;
-                    if (typeof cell_name == 'string') {
-                        if (cell_name.startsWith('dynamic '))
-                            return false;
-                    }
-                    return true;
-                }
+  return function (container, component) {
+    appendScrollLog('modulePanel:enter', {
+      title: container?.title ?? null,
+      componentCell: component?.cell ?? null
+    });
+    const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
+    if (!moduleInfo) {
+      // Fall through to file attachment: titles like @user/notebook/path.ext
+      // resolve via the lopecode bootloader's contentSync DOM lookup.
+      const title = container?.title ?? null;
+      if (title) {
+        let node = file_attachment_cache.get(title);
+        if (!node) {
+          const r = window.lopecode?.contentSync?.(title);
+          if (r && r.status === 200 && r.bytes) {
+            node = renderFileAttachment(r.mime, r.bytes);
+            file_attachment_cache.set(title, node);
+            appendScrollLog('modulePanel:file_attachment_create', {
+              title,
+              mime: r.mime
             });
-            visualizer_cache.set(module, node);
-        } else {
-            node = visualizer_cache.get(module);
-            appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+          }
         }
-        const cell = module._scope.get(component.cell);
-        const scrollKey = scrollKeyFor(container);
-        fix_scroll(container, node, cell, scrollKey);
-        const el = container.getElement();
-        if (!el.__lope_scroll_bound) {
-            el.__lope_scroll_bound = true;
-            appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
-            el.addEventListener('scroll', () => {
-                const k = scrollKeyFor(container);
-                const scrollTop = el.scrollTop;
-                const scrollLeft = el.scrollLeft;
-                if (scrollTop == 0) {
-                    appendScrollLog('modulePanel:skip 0 scroll', {
-                        title: container?.title ?? null,
-                        scrollKey
-                    });
-                    return;
-                }
-                scroll_cache.set(k, {
-                    scrollTop,
-                    scrollLeft,
-                    t: Date.now()
-                });
-                appendScrollLog('scroll:event', {
-                    k,
-                    title: container?.title ?? null,
-                    scrollTop,
-                    scrollLeft
-                });
-            }, { passive: true });
+        if (node) {
+          const c_element = container.getElement();
+          if (node.parentNode !== c_element)
+            c_element.appendChild(node);
+          appendScrollLog('modulePanel:file_attachment_mount', { title });
+          return;
         }
-        // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
-        if (!container.__lope_destroy_bound) {
-            container.__lope_destroy_bound = true;
-            container.on('destroy', () => {
-                try {
-                    const k = scrollKeyFor(container);
-                    const scrollTop = el?.scrollTop;
-                    const scrollLeft = el?.scrollLeft;
-                    if (scrollTop == 0) {
-                        appendScrollLog('scroll:skip 0 scroll', {
-                            k,
-                            key: container?.title ?? null,
-                            scrollKey
-                        });
-                        return;
-                    }
-                    // do not skip 0 here: if the user is at top, preserve that state
-                    scroll_cache.set(k, {
-                        scrollTop,
-                        scrollLeft,
-                        t: Date.now()
-                    });
-                    appendScrollLog('scroll:destroy_capture', {
-                        k,
-                        title: container?.title ?? null,
-                        scrollTop,
-                        scrollLeft
-                    });
-                } catch (e) {
-                    appendScrollLog('scroll:destroy_capture:error', {
-                        title: container?.title ?? null,
-                        error: String(e)
-                    });
-                }
-            });
+      }
+      appendScrollLog('modulePanel:missing_moduleInfo', { title });
+      return;
+    }
+    const module = moduleInfo.module;
+    let node;
+    if (!visualizer_cache.has(module)) {
+      appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
+      node = visualizer(runtime, {
+        invalidation: new Promise(r => {
+        }),
+        module,
+        detachNodes: isOnObservableCom(),
+        filter: (cell_name, variables) => {
+          if (variables[0]._type !== 1)
+            return false;
+          if (typeof cell_name == 'string') {
+            if (cell_name.startsWith('dynamic '))
+              return false;
+          }
+          return true;
         }
-        appendScrollLog('modulePanel:exit', {
+      });
+      visualizer_cache.set(module, node);
+    } else {
+      node = visualizer_cache.get(module);
+      appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+    }
+    const cell = module._scope.get(component.cell);
+    const scrollKey = scrollKeyFor(container);
+    fix_scroll(container, node, cell, scrollKey);
+    const el = container.getElement();
+    if (!el.__lope_scroll_bound) {
+      el.__lope_scroll_bound = true;
+      appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
+      const markUserScroll = () => {
+        el.__lope_user_scroll_at = Date.now();
+      };
+      el.addEventListener('wheel', markUserScroll, { passive: true });
+      el.addEventListener('touchmove', markUserScroll, { passive: true });
+      el.addEventListener('keydown', markUserScroll, { passive: true });
+      el.addEventListener('scroll', () => {
+        if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+          appendScrollLog('scroll:skip_reflow', { title: container?.title ?? null });
+          return;
+        }
+        // Only cache scrolls following a genuine user gesture; reflow-induced
+        // scroll events (e.g. closing an adjacent panel) carry stale scrollTops.
+        if (Date.now() - (el.__lope_user_scroll_at || 0) > 400) {
+          appendScrollLog('scroll:skip_nonuser', { title: container?.title ?? null });
+          return;
+        }
+        const k = scrollKeyFor(container);
+        const scrollTop = el.scrollTop;
+        const scrollLeft = el.scrollLeft;
+        if (scrollTop == 0) {
+          appendScrollLog('modulePanel:skip 0 scroll', {
             title: container?.title ?? null,
             scrollKey
+          });
+          return;
+        }
+        scroll_cache.set(k, {
+          scrollTop,
+          scrollLeft,
+          t: Date.now()
         });
-    };
+        appendScrollLog('scroll:event', {
+          k,
+          title: container?.title ?? null,
+          scrollTop,
+          scrollLeft
+        });
+      }, { passive: true });
+    }
+    // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
+    if (!container.__lope_destroy_bound) {
+      container.__lope_destroy_bound = true;
+      container.on('destroy', () => {
+        try {
+          if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+            appendScrollLog('scroll:destroy_skip_reflow', { title: container?.title ?? null });
+            return;
+          }
+          const k = scrollKeyFor(container);
+          const scrollTop = el?.scrollTop;
+          const scrollLeft = el?.scrollLeft;
+          if (scrollTop == 0) {
+            appendScrollLog('scroll:skip 0 scroll', {
+              k,
+              key: container?.title ?? null,
+              scrollKey
+            });
+            return;
+          }
+          // do not skip 0 here: if the user is at top, preserve that state
+          scroll_cache.set(k, {
+            scrollTop,
+            scrollLeft,
+            t: Date.now()
+          });
+          appendScrollLog('scroll:destroy_capture', {
+            k,
+            title: container?.title ?? null,
+            scrollTop,
+            scrollLeft
+          });
+        } catch (e) {
+          appendScrollLog('scroll:destroy_capture:error', {
+            title: container?.title ?? null,
+            error: String(e)
+          });
+        }
+      });
+    }
+    // When GoldenLayout resizes this panel (e.g. an adjacent panel is closed) the
+    // browser can shift scrollTop; re-apply the user's cached position after the reflow.
+    if (!container.__lope_resize_bound) {
+      container.__lope_resize_bound = true;
+      container.on('resize', () => {
+        const rk = scrollKeyFor(container);
+        const cached = scroll_cache.get(rk);
+        if (!cached || cached.scrollTop == null)
+          return;
+        const c_el = container.getElement();
+        const at = Date.now();
+        scroll_cache.__reflowUntil = at + 800;
+        // The reflow can shift scrollTop in several passes (content relayout
+        // settles ~300ms later), so re-apply over a window. Bail if the user scrolls.
+        const apply = () => {
+          if ((c_el.__lope_user_scroll_at || 0) > at)
+            return;
+          if (c_el.scrollTop !== cached.scrollTop)
+            c_el.scrollTop = cached.scrollTop;
+          if (cached.scrollLeft != null && c_el.scrollLeft !== cached.scrollLeft)
+            c_el.scrollLeft = cached.scrollLeft;
+        };
+        requestAnimationFrame(apply);
+        for (const d of [
+            60,
+            150,
+            300,
+            450,
+            600
+          ])
+          setTimeout(apply, d);
+        appendScrollLog('scroll:resize_restore', {
+          k: rk,
+          title: container?.title ?? null,
+          scrollTop: cached.scrollTop
+        });
+      });
+    }
+    appendScrollLog('modulePanel:exit', {
+      title: container?.title ?? null,
+      scrollKey
+    });
+  };
 };
 const _1gm4gbf = function _blobPanel(){return(
 function (container, component) {
@@ -14428,112 +14486,115 @@ const _1d1nkw9 = function _scrollKeyFor(appendScrollLog)
 const _tb217h = function _scroll_cache(){return(
 new Map()
 )};
-const _5tyvpe = function _fix_scroll(scrollKeyFor,appendScrollLog,scroll_cache){return(
-function (container, node, cell_variable, key) {
+const _12p8mg7 = function _fix_scroll(scroll_cache,scrollKeyFor,appendScrollLog)
+{
+  return function (container, node, cell_variable, key) {
+    scroll_cache.__reflowUntil = Date.now() + 600;
+    // suppress reflow-induced scroll events that clobber the cache
     const c_element = container.getElement();
     let k = scrollKeyFor(container);
     appendScrollLog('fix_scroll:enter', {
-        title: container?.title ?? null,
-        k,
-        cell: cell_variable?._name ?? null
+      title: container?.title ?? null,
+      k,
+      cell: cell_variable?._name ?? null
     });
     if (node && node.parentNode !== c_element) {
-        c_element.appendChild(node);
-        appendScrollLog('fix_scroll:append_node', {
-            title: container?.title ?? null,
-            k
-        });
+      c_element.appendChild(node);
+      appendScrollLog('fix_scroll:append_node', {
+        title: container?.title ?? null,
+        k
+      });
     }
     const writeCache = (scrollTop, scrollLeft, why) => {
-        scroll_cache.set(k, {
-            scrollTop,
-            scrollLeft,
-            t: Date.now()
-        });
-        appendScrollLog('scroll_cache:write', {
-            k,
-            scrollTop,
-            scrollLeft,
-            why
-        });
+      scroll_cache.set(k, {
+        scrollTop,
+        scrollLeft,
+        t: Date.now()
+      });
+      appendScrollLog('scroll_cache:write', {
+        k,
+        scrollTop,
+        scrollLeft,
+        why
+      });
     };
     const scrollToCellIfPossible = why => {
-        if (!cell_variable)
-            return false;
-        const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
-        if (!dom) {
-            appendScrollLog('scroll:cell_dom_not_found', {
-                k,
-                why,
-                cell: cell_variable?._name ?? null
-            });
-            return false;
-        }
-        const top = dom.offsetTop - c_element.offsetTop;
-        const left = c_element.scrollLeft;
-        c_element.scrollTop = top;
-        appendScrollLog('scroll:set', {
-            k,
-            why: `${ why }:cell`,
-            scrollTop: top,
-            scrollLeft: left,
-            cell: cell_variable?._name ?? null
+      if (!cell_variable)
+        return false;
+      const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
+      if (!dom) {
+        appendScrollLog('scroll:cell_dom_not_found', {
+          k,
+          why,
+          cell: cell_variable?._name ?? null
         });
-        writeCache(top, left, `${ why }:cell`);
-        return true;
+        return false;
+      }
+      const top = dom.offsetTop - c_element.offsetTop;
+      const left = c_element.scrollLeft;
+      c_element.scrollTop = top;
+      appendScrollLog('scroll:set', {
+        k,
+        why: `${ why }:cell`,
+        scrollTop: top,
+        scrollLeft: left,
+        cell: cell_variable?._name ?? null
+      });
+      writeCache(top, left, `${ why }:cell`);
+      return true;
     };
     const restoreFromCache = why => {
-        k = scrollKeyFor(container);
-        const cached = scroll_cache.get(k);
-        appendScrollLog('scroll:restore_attempt', {
-            k,
-            why,
-            cachedScrollTop: cached?.scrollTop ?? null,
-            cachedScrollLeft: cached?.scrollLeft ?? null
+      k = scrollKeyFor(container);
+      const cached = scroll_cache.get(k);
+      appendScrollLog('scroll:restore_attempt', {
+        k,
+        why,
+        cachedScrollTop: cached?.scrollTop ?? null,
+        cachedScrollLeft: cached?.scrollLeft ?? null
+      });
+      if (!cached) {
+        appendScrollLog('scroll:restore_no_scroll', {
+          k,
+          why
         });
-        if (!cached) {
-            appendScrollLog('scroll:restore_no_scroll', {
-                k,
-                why
-            });
-            return;
-        }
-        if (cached.scrollTop != null)
-            c_element.scrollTop = cached.scrollTop;
-        if (cached.scrollLeft != null)
-            c_element.scrollLeft = cached.scrollLeft;
-        appendScrollLog('scroll:restore_applied', {
-            k,
-            why,
-            scrollTop: cached.scrollTop ?? null,
-            scrollLeft: cached.scrollLeft ?? null,
-            scrollTopFinal: c_element.scrollTop,
-            scrollLeftFinal: c_element.scrollLeft
-        });
+        return;
+      }
+      if (cached.scrollTop != null)
+        c_element.scrollTop = cached.scrollTop;
+      if (cached.scrollLeft != null)
+        c_element.scrollLeft = cached.scrollLeft;
+      appendScrollLog('scroll:restore_applied', {
+        k,
+        why,
+        scrollTop: cached.scrollTop ?? null,
+        scrollLeft: cached.scrollLeft ?? null,
+        scrollTopFinal: c_element.scrollTop,
+        scrollLeftFinal: c_element.scrollLeft
+      });
     };
     const setScroll = (why = 'setScroll') => {
-        if (scrollToCellIfPossible(why))
-            return;
-        restoreFromCache(why);
+      if (scrollToCellIfPossible(why))
+        return;
+      restoreFromCache(why);
     };
     const retryFrames = 6;
     for (let i = 0; i < retryFrames; i++) {
-        requestAnimationFrame(() => {
-            k = scrollKeyFor(container);
-            appendScrollLog('fix_scroll:raf_retry', {
-                i,
-                k,
-                title: container?.title ?? null
-            });
-            setScroll(`raf:${ i }`);
+      requestAnimationFrame(() => {
+        k = scrollKeyFor(container);
+        appendScrollLog('fix_scroll:raf_retry', {
+          i,
+          k,
+          title: container?.title ?? null
         });
+        setScroll(`raf:${ i }`);
+      });
     }
     appendScrollLog('fix_scroll:exit', {
-        k,
-        title: container?.title ?? null
+      k,
+      title: container?.title ?? null
     });
-}
-)};
+  };
+};
 const _arfw00 = function _scroll_fix_sync_layout(sync_layout_to_url,layout,appendScrollLog,modulePanel)
 {
     sync_layout_to_url;
@@ -15611,7 +15672,7 @@ export default function define(runtime, observer) {
   $def("_1we0ggl", "reload", ["Generators","viewof reload"], _1we0ggl);  
   $def("_plefwg", "onLoadConfig", ["parseGoldenDSL","URLSearchParams","location"], _plefwg);  
   $def("_1nzpnqy", "visualizer_cache", ["reload"], _1nzpnqy);  
-  $def("_1l35721", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1l35721);  
+  $def("_1ojown8", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1ojown8);  
   $def("_1gm4gbf", "blobPanel", [], _1gm4gbf);  
   $def("_lxv2e2", "settings", [], _lxv2e2);  
   $def("_lp1ggk", "is_mobile", ["width"], _lp1ggk);  
@@ -15632,7 +15693,7 @@ export default function define(runtime, observer) {
   $def("_1dyz4o0", "scrollLog", ["mutable scrollLog"], _1dyz4o0);  
   $def("_1d1nkw9", "scrollKeyFor", ["appendScrollLog"], _1d1nkw9);  
   $def("_tb217h", "scroll_cache", [], _tb217h);  
-  $def("_5tyvpe", "fix_scroll", ["scrollKeyFor","appendScrollLog","scroll_cache"], _5tyvpe);  
+  $def("_12p8mg7", "fix_scroll", ["scroll_cache","scrollKeyFor","appendScrollLog"], _12p8mg7);  
   $def("_arfw00", "scroll_fix_sync_layout", ["sync_layout_to_url","layout","appendScrollLog","modulePanel"], _arfw00);  
   $def("_3nwpp4", "URLrouting", ["md"], _3nwpp4);  
   $def("_14te9pl", "sync_layout_from_url", ["reload","resize","URLSearchParams","hash","appendScrollLog","parseGoldenDSL","gl","layout","serializeGoldenDSL","treeSyncGolden","invalidation"], _14te9pl);  

--- a/notebooks/@tomlarkworthy_blank-notebook.html
+++ b/notebooks/@tomlarkworthy_blank-notebook.html
@@ -14070,138 +14070,196 @@ const _1nzpnqy = function _visualizer_cache(reload)
     reload;
     return new Map();
 };
-const _1l35721 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
+const _1ojown8 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
 {
-    return function (container, component) {
-        appendScrollLog('modulePanel:enter', {
-            title: container?.title ?? null,
-            componentCell: component?.cell ?? null
-        });
-        const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
-        if (!moduleInfo) {
-            // Fall through to file attachment: titles like @user/notebook/path.ext
-            // resolve via the lopecode bootloader's contentSync DOM lookup.
-            const title = container?.title ?? null;
-            if (title) {
-                let node = file_attachment_cache.get(title);
-                if (!node) {
-                    const r = window.lopecode?.contentSync?.(title);
-                    if (r && r.status === 200 && r.bytes) {
-                        node = renderFileAttachment(r.mime, r.bytes);
-                        file_attachment_cache.set(title, node);
-                        appendScrollLog('modulePanel:file_attachment_create', {
-                            title,
-                            mime: r.mime
-                        });
-                    }
-                }
-                if (node) {
-                    const c_element = container.getElement();
-                    if (node.parentNode !== c_element)
-                        c_element.appendChild(node);
-                    appendScrollLog('modulePanel:file_attachment_mount', { title });
-                    return;
-                }
-            }
-            appendScrollLog('modulePanel:missing_moduleInfo', { title });
-            return;
-        }
-        const module = moduleInfo.module;
-        let node;
-        if (!visualizer_cache.has(module)) {
-            appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
-            node = visualizer(runtime, {
-                invalidation: new Promise(r => {
-                }),
-                module,
-                detachNodes: isOnObservableCom(),
-                filter: (cell_name, variables) => {
-                    if (variables[0]._type !== 1)
-                        return false;
-                    if (typeof cell_name == 'string') {
-                        if (cell_name.startsWith('dynamic '))
-                            return false;
-                    }
-                    return true;
-                }
+  return function (container, component) {
+    appendScrollLog('modulePanel:enter', {
+      title: container?.title ?? null,
+      componentCell: component?.cell ?? null
+    });
+    const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
+    if (!moduleInfo) {
+      // Fall through to file attachment: titles like @user/notebook/path.ext
+      // resolve via the lopecode bootloader's contentSync DOM lookup.
+      const title = container?.title ?? null;
+      if (title) {
+        let node = file_attachment_cache.get(title);
+        if (!node) {
+          const r = window.lopecode?.contentSync?.(title);
+          if (r && r.status === 200 && r.bytes) {
+            node = renderFileAttachment(r.mime, r.bytes);
+            file_attachment_cache.set(title, node);
+            appendScrollLog('modulePanel:file_attachment_create', {
+              title,
+              mime: r.mime
             });
-            visualizer_cache.set(module, node);
-        } else {
-            node = visualizer_cache.get(module);
-            appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+          }
         }
-        const cell = module._scope.get(component.cell);
-        const scrollKey = scrollKeyFor(container);
-        fix_scroll(container, node, cell, scrollKey);
-        const el = container.getElement();
-        if (!el.__lope_scroll_bound) {
-            el.__lope_scroll_bound = true;
-            appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
-            el.addEventListener('scroll', () => {
-                const k = scrollKeyFor(container);
-                const scrollTop = el.scrollTop;
-                const scrollLeft = el.scrollLeft;
-                if (scrollTop == 0) {
-                    appendScrollLog('modulePanel:skip 0 scroll', {
-                        title: container?.title ?? null,
-                        scrollKey
-                    });
-                    return;
-                }
-                scroll_cache.set(k, {
-                    scrollTop,
-                    scrollLeft,
-                    t: Date.now()
-                });
-                appendScrollLog('scroll:event', {
-                    k,
-                    title: container?.title ?? null,
-                    scrollTop,
-                    scrollLeft
-                });
-            }, { passive: true });
+        if (node) {
+          const c_element = container.getElement();
+          if (node.parentNode !== c_element)
+            c_element.appendChild(node);
+          appendScrollLog('modulePanel:file_attachment_mount', { title });
+          return;
         }
-        // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
-        if (!container.__lope_destroy_bound) {
-            container.__lope_destroy_bound = true;
-            container.on('destroy', () => {
-                try {
-                    const k = scrollKeyFor(container);
-                    const scrollTop = el?.scrollTop;
-                    const scrollLeft = el?.scrollLeft;
-                    if (scrollTop == 0) {
-                        appendScrollLog('scroll:skip 0 scroll', {
-                            k,
-                            key: container?.title ?? null,
-                            scrollKey
-                        });
-                        return;
-                    }
-                    // do not skip 0 here: if the user is at top, preserve that state
-                    scroll_cache.set(k, {
-                        scrollTop,
-                        scrollLeft,
-                        t: Date.now()
-                    });
-                    appendScrollLog('scroll:destroy_capture', {
-                        k,
-                        title: container?.title ?? null,
-                        scrollTop,
-                        scrollLeft
-                    });
-                } catch (e) {
-                    appendScrollLog('scroll:destroy_capture:error', {
-                        title: container?.title ?? null,
-                        error: String(e)
-                    });
-                }
-            });
+      }
+      appendScrollLog('modulePanel:missing_moduleInfo', { title });
+      return;
+    }
+    const module = moduleInfo.module;
+    let node;
+    if (!visualizer_cache.has(module)) {
+      appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
+      node = visualizer(runtime, {
+        invalidation: new Promise(r => {
+        }),
+        module,
+        detachNodes: isOnObservableCom(),
+        filter: (cell_name, variables) => {
+          if (variables[0]._type !== 1)
+            return false;
+          if (typeof cell_name == 'string') {
+            if (cell_name.startsWith('dynamic '))
+              return false;
+          }
+          return true;
         }
-        appendScrollLog('modulePanel:exit', {
+      });
+      visualizer_cache.set(module, node);
+    } else {
+      node = visualizer_cache.get(module);
+      appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+    }
+    const cell = module._scope.get(component.cell);
+    const scrollKey = scrollKeyFor(container);
+    fix_scroll(container, node, cell, scrollKey);
+    const el = container.getElement();
+    if (!el.__lope_scroll_bound) {
+      el.__lope_scroll_bound = true;
+      appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
+      const markUserScroll = () => {
+        el.__lope_user_scroll_at = Date.now();
+      };
+      el.addEventListener('wheel', markUserScroll, { passive: true });
+      el.addEventListener('touchmove', markUserScroll, { passive: true });
+      el.addEventListener('keydown', markUserScroll, { passive: true });
+      el.addEventListener('scroll', () => {
+        if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+          appendScrollLog('scroll:skip_reflow', { title: container?.title ?? null });
+          return;
+        }
+        // Only cache scrolls following a genuine user gesture; reflow-induced
+        // scroll events (e.g. closing an adjacent panel) carry stale scrollTops.
+        if (Date.now() - (el.__lope_user_scroll_at || 0) > 400) {
+          appendScrollLog('scroll:skip_nonuser', { title: container?.title ?? null });
+          return;
+        }
+        const k = scrollKeyFor(container);
+        const scrollTop = el.scrollTop;
+        const scrollLeft = el.scrollLeft;
+        if (scrollTop == 0) {
+          appendScrollLog('modulePanel:skip 0 scroll', {
             title: container?.title ?? null,
             scrollKey
+          });
+          return;
+        }
+        scroll_cache.set(k, {
+          scrollTop,
+          scrollLeft,
+          t: Date.now()
         });
-    };
+        appendScrollLog('scroll:event', {
+          k,
+          title: container?.title ?? null,
+          scrollTop,
+          scrollLeft
+        });
+      }, { passive: true });
+    }
+    // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
+    if (!container.__lope_destroy_bound) {
+      container.__lope_destroy_bound = true;
+      container.on('destroy', () => {
+        try {
+          if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+            appendScrollLog('scroll:destroy_skip_reflow', { title: container?.title ?? null });
+            return;
+          }
+          const k = scrollKeyFor(container);
+          const scrollTop = el?.scrollTop;
+          const scrollLeft = el?.scrollLeft;
+          if (scrollTop == 0) {
+            appendScrollLog('scroll:skip 0 scroll', {
+              k,
+              key: container?.title ?? null,
+              scrollKey
+            });
+            return;
+          }
+          // do not skip 0 here: if the user is at top, preserve that state
+          scroll_cache.set(k, {
+            scrollTop,
+            scrollLeft,
+            t: Date.now()
+          });
+          appendScrollLog('scroll:destroy_capture', {
+            k,
+            title: container?.title ?? null,
+            scrollTop,
+            scrollLeft
+          });
+        } catch (e) {
+          appendScrollLog('scroll:destroy_capture:error', {
+            title: container?.title ?? null,
+            error: String(e)
+          });
+        }
+      });
+    }
+    // When GoldenLayout resizes this panel (e.g. an adjacent panel is closed) the
+    // browser can shift scrollTop; re-apply the user's cached position after the reflow.
+    if (!container.__lope_resize_bound) {
+      container.__lope_resize_bound = true;
+      container.on('resize', () => {
+        const rk = scrollKeyFor(container);
+        const cached = scroll_cache.get(rk);
+        if (!cached || cached.scrollTop == null)
+          return;
+        const c_el = container.getElement();
+        const at = Date.now();
+        scroll_cache.__reflowUntil = at + 800;
+        // The reflow can shift scrollTop in several passes (content relayout
+        // settles ~300ms later), so re-apply over a window. Bail if the user scrolls.
+        const apply = () => {
+          if ((c_el.__lope_user_scroll_at || 0) > at)
+            return;
+          if (c_el.scrollTop !== cached.scrollTop)
+            c_el.scrollTop = cached.scrollTop;
+          if (cached.scrollLeft != null && c_el.scrollLeft !== cached.scrollLeft)
+            c_el.scrollLeft = cached.scrollLeft;
+        };
+        requestAnimationFrame(apply);
+        for (const d of [
+            60,
+            150,
+            300,
+            450,
+            600
+          ])
+          setTimeout(apply, d);
+        appendScrollLog('scroll:resize_restore', {
+          k: rk,
+          title: container?.title ?? null,
+          scrollTop: cached.scrollTop
+        });
+      });
+    }
+    appendScrollLog('modulePanel:exit', {
+      title: container?.title ?? null,
+      scrollKey
+    });
+  };
 };
 const _1gm4gbf = function _blobPanel(){return(
 function (container, component) {
@@ -14319,112 +14377,115 @@ const _1d1nkw9 = function _scrollKeyFor(appendScrollLog)
 const _tb217h = function _scroll_cache(){return(
 new Map()
 )};
-const _5tyvpe = function _fix_scroll(scrollKeyFor,appendScrollLog,scroll_cache){return(
-function (container, node, cell_variable, key) {
+const _12p8mg7 = function _fix_scroll(scroll_cache,scrollKeyFor,appendScrollLog)
+{
+  return function (container, node, cell_variable, key) {
+    scroll_cache.__reflowUntil = Date.now() + 600;
+    // suppress reflow-induced scroll events that clobber the cache
     const c_element = container.getElement();
     let k = scrollKeyFor(container);
     appendScrollLog('fix_scroll:enter', {
-        title: container?.title ?? null,
-        k,
-        cell: cell_variable?._name ?? null
+      title: container?.title ?? null,
+      k,
+      cell: cell_variable?._name ?? null
     });
     if (node && node.parentNode !== c_element) {
-        c_element.appendChild(node);
-        appendScrollLog('fix_scroll:append_node', {
-            title: container?.title ?? null,
-            k
-        });
+      c_element.appendChild(node);
+      appendScrollLog('fix_scroll:append_node', {
+        title: container?.title ?? null,
+        k
+      });
     }
     const writeCache = (scrollTop, scrollLeft, why) => {
-        scroll_cache.set(k, {
-            scrollTop,
-            scrollLeft,
-            t: Date.now()
-        });
-        appendScrollLog('scroll_cache:write', {
-            k,
-            scrollTop,
-            scrollLeft,
-            why
-        });
+      scroll_cache.set(k, {
+        scrollTop,
+        scrollLeft,
+        t: Date.now()
+      });
+      appendScrollLog('scroll_cache:write', {
+        k,
+        scrollTop,
+        scrollLeft,
+        why
+      });
     };
     const scrollToCellIfPossible = why => {
-        if (!cell_variable)
-            return false;
-        const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
-        if (!dom) {
-            appendScrollLog('scroll:cell_dom_not_found', {
-                k,
-                why,
-                cell: cell_variable?._name ?? null
-            });
-            return false;
-        }
-        const top = dom.offsetTop - c_element.offsetTop;
-        const left = c_element.scrollLeft;
-        c_element.scrollTop = top;
-        appendScrollLog('scroll:set', {
-            k,
-            why: `${ why }:cell`,
-            scrollTop: top,
-            scrollLeft: left,
-            cell: cell_variable?._name ?? null
+      if (!cell_variable)
+        return false;
+      const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
+      if (!dom) {
+        appendScrollLog('scroll:cell_dom_not_found', {
+          k,
+          why,
+          cell: cell_variable?._name ?? null
         });
-        writeCache(top, left, `${ why }:cell`);
-        return true;
+        return false;
+      }
+      const top = dom.offsetTop - c_element.offsetTop;
+      const left = c_element.scrollLeft;
+      c_element.scrollTop = top;
+      appendScrollLog('scroll:set', {
+        k,
+        why: `${ why }:cell`,
+        scrollTop: top,
+        scrollLeft: left,
+        cell: cell_variable?._name ?? null
+      });
+      writeCache(top, left, `${ why }:cell`);
+      return true;
     };
     const restoreFromCache = why => {
-        k = scrollKeyFor(container);
-        const cached = scroll_cache.get(k);
-        appendScrollLog('scroll:restore_attempt', {
-            k,
-            why,
-            cachedScrollTop: cached?.scrollTop ?? null,
-            cachedScrollLeft: cached?.scrollLeft ?? null
+      k = scrollKeyFor(container);
+      const cached = scroll_cache.get(k);
+      appendScrollLog('scroll:restore_attempt', {
+        k,
+        why,
+        cachedScrollTop: cached?.scrollTop ?? null,
+        cachedScrollLeft: cached?.scrollLeft ?? null
+      });
+      if (!cached) {
+        appendScrollLog('scroll:restore_no_scroll', {
+          k,
+          why
         });
-        if (!cached) {
-            appendScrollLog('scroll:restore_no_scroll', {
-                k,
-                why
-            });
-            return;
-        }
-        if (cached.scrollTop != null)
-            c_element.scrollTop = cached.scrollTop;
-        if (cached.scrollLeft != null)
-            c_element.scrollLeft = cached.scrollLeft;
-        appendScrollLog('scroll:restore_applied', {
-            k,
-            why,
-            scrollTop: cached.scrollTop ?? null,
-            scrollLeft: cached.scrollLeft ?? null,
-            scrollTopFinal: c_element.scrollTop,
-            scrollLeftFinal: c_element.scrollLeft
-        });
+        return;
+      }
+      if (cached.scrollTop != null)
+        c_element.scrollTop = cached.scrollTop;
+      if (cached.scrollLeft != null)
+        c_element.scrollLeft = cached.scrollLeft;
+      appendScrollLog('scroll:restore_applied', {
+        k,
+        why,
+        scrollTop: cached.scrollTop ?? null,
+        scrollLeft: cached.scrollLeft ?? null,
+        scrollTopFinal: c_element.scrollTop,
+        scrollLeftFinal: c_element.scrollLeft
+      });
     };
     const setScroll = (why = 'setScroll') => {
-        if (scrollToCellIfPossible(why))
-            return;
-        restoreFromCache(why);
+      if (scrollToCellIfPossible(why))
+        return;
+      restoreFromCache(why);
     };
     const retryFrames = 6;
     for (let i = 0; i < retryFrames; i++) {
-        requestAnimationFrame(() => {
-            k = scrollKeyFor(container);
-            appendScrollLog('fix_scroll:raf_retry', {
-                i,
-                k,
-                title: container?.title ?? null
-            });
-            setScroll(`raf:${ i }`);
+      requestAnimationFrame(() => {
+        k = scrollKeyFor(container);
+        appendScrollLog('fix_scroll:raf_retry', {
+          i,
+          k,
+          title: container?.title ?? null
         });
+        setScroll(`raf:${ i }`);
+      });
     }
     appendScrollLog('fix_scroll:exit', {
-        k,
-        title: container?.title ?? null
+      k,
+      title: container?.title ?? null
     });
-}
-)};
+  };
+};
 const _arfw00 = function _scroll_fix_sync_layout(sync_layout_to_url,layout,appendScrollLog,modulePanel)
 {
     sync_layout_to_url;
@@ -15502,7 +15563,7 @@ export default function define(runtime, observer) {
   $def("_1we0ggl", "reload", ["Generators","viewof reload"], _1we0ggl);  
   $def("_plefwg", "onLoadConfig", ["parseGoldenDSL","URLSearchParams","location"], _plefwg);  
   $def("_1nzpnqy", "visualizer_cache", ["reload"], _1nzpnqy);  
-  $def("_1l35721", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1l35721);  
+  $def("_1ojown8", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1ojown8);  
   $def("_1gm4gbf", "blobPanel", [], _1gm4gbf);  
   $def("_lxv2e2", "settings", [], _lxv2e2);  
   $def("_lp1ggk", "is_mobile", ["width"], _lp1ggk);  
@@ -15523,7 +15584,7 @@ export default function define(runtime, observer) {
   $def("_1dyz4o0", "scrollLog", ["mutable scrollLog"], _1dyz4o0);  
   $def("_1d1nkw9", "scrollKeyFor", ["appendScrollLog"], _1d1nkw9);  
   $def("_tb217h", "scroll_cache", [], _tb217h);  
-  $def("_5tyvpe", "fix_scroll", ["scrollKeyFor","appendScrollLog","scroll_cache"], _5tyvpe);  
+  $def("_12p8mg7", "fix_scroll", ["scroll_cache","scrollKeyFor","appendScrollLog"], _12p8mg7);  
   $def("_arfw00", "scroll_fix_sync_layout", ["sync_layout_to_url","layout","appendScrollLog","modulePanel"], _arfw00);  
   $def("_3nwpp4", "URLrouting", ["md"], _3nwpp4);  
   $def("_14te9pl", "sync_layout_from_url", ["reload","resize","URLSearchParams","hash","appendScrollLog","parseGoldenDSL","gl","layout","serializeGoldenDSL","treeSyncGolden","invalidation"], _14te9pl);  

--- a/notebooks/@tomlarkworthy_bootloader.html
+++ b/notebooks/@tomlarkworthy_bootloader.html
@@ -14287,138 +14287,196 @@ const _1nzpnqy = function _visualizer_cache(reload)
     reload;
     return new Map();
 };
-const _1l35721 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
+const _1ojown8 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
 {
-    return function (container, component) {
-        appendScrollLog('modulePanel:enter', {
-            title: container?.title ?? null,
-            componentCell: component?.cell ?? null
-        });
-        const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
-        if (!moduleInfo) {
-            // Fall through to file attachment: titles like @user/notebook/path.ext
-            // resolve via the lopecode bootloader's contentSync DOM lookup.
-            const title = container?.title ?? null;
-            if (title) {
-                let node = file_attachment_cache.get(title);
-                if (!node) {
-                    const r = window.lopecode?.contentSync?.(title);
-                    if (r && r.status === 200 && r.bytes) {
-                        node = renderFileAttachment(r.mime, r.bytes);
-                        file_attachment_cache.set(title, node);
-                        appendScrollLog('modulePanel:file_attachment_create', {
-                            title,
-                            mime: r.mime
-                        });
-                    }
-                }
-                if (node) {
-                    const c_element = container.getElement();
-                    if (node.parentNode !== c_element)
-                        c_element.appendChild(node);
-                    appendScrollLog('modulePanel:file_attachment_mount', { title });
-                    return;
-                }
-            }
-            appendScrollLog('modulePanel:missing_moduleInfo', { title });
-            return;
-        }
-        const module = moduleInfo.module;
-        let node;
-        if (!visualizer_cache.has(module)) {
-            appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
-            node = visualizer(runtime, {
-                invalidation: new Promise(r => {
-                }),
-                module,
-                detachNodes: isOnObservableCom(),
-                filter: (cell_name, variables) => {
-                    if (variables[0]._type !== 1)
-                        return false;
-                    if (typeof cell_name == 'string') {
-                        if (cell_name.startsWith('dynamic '))
-                            return false;
-                    }
-                    return true;
-                }
+  return function (container, component) {
+    appendScrollLog('modulePanel:enter', {
+      title: container?.title ?? null,
+      componentCell: component?.cell ?? null
+    });
+    const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
+    if (!moduleInfo) {
+      // Fall through to file attachment: titles like @user/notebook/path.ext
+      // resolve via the lopecode bootloader's contentSync DOM lookup.
+      const title = container?.title ?? null;
+      if (title) {
+        let node = file_attachment_cache.get(title);
+        if (!node) {
+          const r = window.lopecode?.contentSync?.(title);
+          if (r && r.status === 200 && r.bytes) {
+            node = renderFileAttachment(r.mime, r.bytes);
+            file_attachment_cache.set(title, node);
+            appendScrollLog('modulePanel:file_attachment_create', {
+              title,
+              mime: r.mime
             });
-            visualizer_cache.set(module, node);
-        } else {
-            node = visualizer_cache.get(module);
-            appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+          }
         }
-        const cell = module._scope.get(component.cell);
-        const scrollKey = scrollKeyFor(container);
-        fix_scroll(container, node, cell, scrollKey);
-        const el = container.getElement();
-        if (!el.__lope_scroll_bound) {
-            el.__lope_scroll_bound = true;
-            appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
-            el.addEventListener('scroll', () => {
-                const k = scrollKeyFor(container);
-                const scrollTop = el.scrollTop;
-                const scrollLeft = el.scrollLeft;
-                if (scrollTop == 0) {
-                    appendScrollLog('modulePanel:skip 0 scroll', {
-                        title: container?.title ?? null,
-                        scrollKey
-                    });
-                    return;
-                }
-                scroll_cache.set(k, {
-                    scrollTop,
-                    scrollLeft,
-                    t: Date.now()
-                });
-                appendScrollLog('scroll:event', {
-                    k,
-                    title: container?.title ?? null,
-                    scrollTop,
-                    scrollLeft
-                });
-            }, { passive: true });
+        if (node) {
+          const c_element = container.getElement();
+          if (node.parentNode !== c_element)
+            c_element.appendChild(node);
+          appendScrollLog('modulePanel:file_attachment_mount', { title });
+          return;
         }
-        // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
-        if (!container.__lope_destroy_bound) {
-            container.__lope_destroy_bound = true;
-            container.on('destroy', () => {
-                try {
-                    const k = scrollKeyFor(container);
-                    const scrollTop = el?.scrollTop;
-                    const scrollLeft = el?.scrollLeft;
-                    if (scrollTop == 0) {
-                        appendScrollLog('scroll:skip 0 scroll', {
-                            k,
-                            key: container?.title ?? null,
-                            scrollKey
-                        });
-                        return;
-                    }
-                    // do not skip 0 here: if the user is at top, preserve that state
-                    scroll_cache.set(k, {
-                        scrollTop,
-                        scrollLeft,
-                        t: Date.now()
-                    });
-                    appendScrollLog('scroll:destroy_capture', {
-                        k,
-                        title: container?.title ?? null,
-                        scrollTop,
-                        scrollLeft
-                    });
-                } catch (e) {
-                    appendScrollLog('scroll:destroy_capture:error', {
-                        title: container?.title ?? null,
-                        error: String(e)
-                    });
-                }
-            });
+      }
+      appendScrollLog('modulePanel:missing_moduleInfo', { title });
+      return;
+    }
+    const module = moduleInfo.module;
+    let node;
+    if (!visualizer_cache.has(module)) {
+      appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
+      node = visualizer(runtime, {
+        invalidation: new Promise(r => {
+        }),
+        module,
+        detachNodes: isOnObservableCom(),
+        filter: (cell_name, variables) => {
+          if (variables[0]._type !== 1)
+            return false;
+          if (typeof cell_name == 'string') {
+            if (cell_name.startsWith('dynamic '))
+              return false;
+          }
+          return true;
         }
-        appendScrollLog('modulePanel:exit', {
+      });
+      visualizer_cache.set(module, node);
+    } else {
+      node = visualizer_cache.get(module);
+      appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+    }
+    const cell = module._scope.get(component.cell);
+    const scrollKey = scrollKeyFor(container);
+    fix_scroll(container, node, cell, scrollKey);
+    const el = container.getElement();
+    if (!el.__lope_scroll_bound) {
+      el.__lope_scroll_bound = true;
+      appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
+      const markUserScroll = () => {
+        el.__lope_user_scroll_at = Date.now();
+      };
+      el.addEventListener('wheel', markUserScroll, { passive: true });
+      el.addEventListener('touchmove', markUserScroll, { passive: true });
+      el.addEventListener('keydown', markUserScroll, { passive: true });
+      el.addEventListener('scroll', () => {
+        if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+          appendScrollLog('scroll:skip_reflow', { title: container?.title ?? null });
+          return;
+        }
+        // Only cache scrolls following a genuine user gesture; reflow-induced
+        // scroll events (e.g. closing an adjacent panel) carry stale scrollTops.
+        if (Date.now() - (el.__lope_user_scroll_at || 0) > 400) {
+          appendScrollLog('scroll:skip_nonuser', { title: container?.title ?? null });
+          return;
+        }
+        const k = scrollKeyFor(container);
+        const scrollTop = el.scrollTop;
+        const scrollLeft = el.scrollLeft;
+        if (scrollTop == 0) {
+          appendScrollLog('modulePanel:skip 0 scroll', {
             title: container?.title ?? null,
             scrollKey
+          });
+          return;
+        }
+        scroll_cache.set(k, {
+          scrollTop,
+          scrollLeft,
+          t: Date.now()
         });
-    };
+        appendScrollLog('scroll:event', {
+          k,
+          title: container?.title ?? null,
+          scrollTop,
+          scrollLeft
+        });
+      }, { passive: true });
+    }
+    // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
+    if (!container.__lope_destroy_bound) {
+      container.__lope_destroy_bound = true;
+      container.on('destroy', () => {
+        try {
+          if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+            appendScrollLog('scroll:destroy_skip_reflow', { title: container?.title ?? null });
+            return;
+          }
+          const k = scrollKeyFor(container);
+          const scrollTop = el?.scrollTop;
+          const scrollLeft = el?.scrollLeft;
+          if (scrollTop == 0) {
+            appendScrollLog('scroll:skip 0 scroll', {
+              k,
+              key: container?.title ?? null,
+              scrollKey
+            });
+            return;
+          }
+          // do not skip 0 here: if the user is at top, preserve that state
+          scroll_cache.set(k, {
+            scrollTop,
+            scrollLeft,
+            t: Date.now()
+          });
+          appendScrollLog('scroll:destroy_capture', {
+            k,
+            title: container?.title ?? null,
+            scrollTop,
+            scrollLeft
+          });
+        } catch (e) {
+          appendScrollLog('scroll:destroy_capture:error', {
+            title: container?.title ?? null,
+            error: String(e)
+          });
+        }
+      });
+    }
+    // When GoldenLayout resizes this panel (e.g. an adjacent panel is closed) the
+    // browser can shift scrollTop; re-apply the user's cached position after the reflow.
+    if (!container.__lope_resize_bound) {
+      container.__lope_resize_bound = true;
+      container.on('resize', () => {
+        const rk = scrollKeyFor(container);
+        const cached = scroll_cache.get(rk);
+        if (!cached || cached.scrollTop == null)
+          return;
+        const c_el = container.getElement();
+        const at = Date.now();
+        scroll_cache.__reflowUntil = at + 800;
+        // The reflow can shift scrollTop in several passes (content relayout
+        // settles ~300ms later), so re-apply over a window. Bail if the user scrolls.
+        const apply = () => {
+          if ((c_el.__lope_user_scroll_at || 0) > at)
+            return;
+          if (c_el.scrollTop !== cached.scrollTop)
+            c_el.scrollTop = cached.scrollTop;
+          if (cached.scrollLeft != null && c_el.scrollLeft !== cached.scrollLeft)
+            c_el.scrollLeft = cached.scrollLeft;
+        };
+        requestAnimationFrame(apply);
+        for (const d of [
+            60,
+            150,
+            300,
+            450,
+            600
+          ])
+          setTimeout(apply, d);
+        appendScrollLog('scroll:resize_restore', {
+          k: rk,
+          title: container?.title ?? null,
+          scrollTop: cached.scrollTop
+        });
+      });
+    }
+    appendScrollLog('modulePanel:exit', {
+      title: container?.title ?? null,
+      scrollKey
+    });
+  };
 };
 const _1gm4gbf = function _blobPanel(){return(
 function (container, component) {
@@ -14536,112 +14594,115 @@ const _1d1nkw9 = function _scrollKeyFor(appendScrollLog)
 const _tb217h = function _scroll_cache(){return(
 new Map()
 )};
-const _5tyvpe = function _fix_scroll(scrollKeyFor,appendScrollLog,scroll_cache){return(
-function (container, node, cell_variable, key) {
+const _12p8mg7 = function _fix_scroll(scroll_cache,scrollKeyFor,appendScrollLog)
+{
+  return function (container, node, cell_variable, key) {
+    scroll_cache.__reflowUntil = Date.now() + 600;
+    // suppress reflow-induced scroll events that clobber the cache
     const c_element = container.getElement();
     let k = scrollKeyFor(container);
     appendScrollLog('fix_scroll:enter', {
-        title: container?.title ?? null,
-        k,
-        cell: cell_variable?._name ?? null
+      title: container?.title ?? null,
+      k,
+      cell: cell_variable?._name ?? null
     });
     if (node && node.parentNode !== c_element) {
-        c_element.appendChild(node);
-        appendScrollLog('fix_scroll:append_node', {
-            title: container?.title ?? null,
-            k
-        });
+      c_element.appendChild(node);
+      appendScrollLog('fix_scroll:append_node', {
+        title: container?.title ?? null,
+        k
+      });
     }
     const writeCache = (scrollTop, scrollLeft, why) => {
-        scroll_cache.set(k, {
-            scrollTop,
-            scrollLeft,
-            t: Date.now()
-        });
-        appendScrollLog('scroll_cache:write', {
-            k,
-            scrollTop,
-            scrollLeft,
-            why
-        });
+      scroll_cache.set(k, {
+        scrollTop,
+        scrollLeft,
+        t: Date.now()
+      });
+      appendScrollLog('scroll_cache:write', {
+        k,
+        scrollTop,
+        scrollLeft,
+        why
+      });
     };
     const scrollToCellIfPossible = why => {
-        if (!cell_variable)
-            return false;
-        const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
-        if (!dom) {
-            appendScrollLog('scroll:cell_dom_not_found', {
-                k,
-                why,
-                cell: cell_variable?._name ?? null
-            });
-            return false;
-        }
-        const top = dom.offsetTop - c_element.offsetTop;
-        const left = c_element.scrollLeft;
-        c_element.scrollTop = top;
-        appendScrollLog('scroll:set', {
-            k,
-            why: `${ why }:cell`,
-            scrollTop: top,
-            scrollLeft: left,
-            cell: cell_variable?._name ?? null
+      if (!cell_variable)
+        return false;
+      const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
+      if (!dom) {
+        appendScrollLog('scroll:cell_dom_not_found', {
+          k,
+          why,
+          cell: cell_variable?._name ?? null
         });
-        writeCache(top, left, `${ why }:cell`);
-        return true;
+        return false;
+      }
+      const top = dom.offsetTop - c_element.offsetTop;
+      const left = c_element.scrollLeft;
+      c_element.scrollTop = top;
+      appendScrollLog('scroll:set', {
+        k,
+        why: `${ why }:cell`,
+        scrollTop: top,
+        scrollLeft: left,
+        cell: cell_variable?._name ?? null
+      });
+      writeCache(top, left, `${ why }:cell`);
+      return true;
     };
     const restoreFromCache = why => {
-        k = scrollKeyFor(container);
-        const cached = scroll_cache.get(k);
-        appendScrollLog('scroll:restore_attempt', {
-            k,
-            why,
-            cachedScrollTop: cached?.scrollTop ?? null,
-            cachedScrollLeft: cached?.scrollLeft ?? null
+      k = scrollKeyFor(container);
+      const cached = scroll_cache.get(k);
+      appendScrollLog('scroll:restore_attempt', {
+        k,
+        why,
+        cachedScrollTop: cached?.scrollTop ?? null,
+        cachedScrollLeft: cached?.scrollLeft ?? null
+      });
+      if (!cached) {
+        appendScrollLog('scroll:restore_no_scroll', {
+          k,
+          why
         });
-        if (!cached) {
-            appendScrollLog('scroll:restore_no_scroll', {
-                k,
-                why
-            });
-            return;
-        }
-        if (cached.scrollTop != null)
-            c_element.scrollTop = cached.scrollTop;
-        if (cached.scrollLeft != null)
-            c_element.scrollLeft = cached.scrollLeft;
-        appendScrollLog('scroll:restore_applied', {
-            k,
-            why,
-            scrollTop: cached.scrollTop ?? null,
-            scrollLeft: cached.scrollLeft ?? null,
-            scrollTopFinal: c_element.scrollTop,
-            scrollLeftFinal: c_element.scrollLeft
-        });
+        return;
+      }
+      if (cached.scrollTop != null)
+        c_element.scrollTop = cached.scrollTop;
+      if (cached.scrollLeft != null)
+        c_element.scrollLeft = cached.scrollLeft;
+      appendScrollLog('scroll:restore_applied', {
+        k,
+        why,
+        scrollTop: cached.scrollTop ?? null,
+        scrollLeft: cached.scrollLeft ?? null,
+        scrollTopFinal: c_element.scrollTop,
+        scrollLeftFinal: c_element.scrollLeft
+      });
     };
     const setScroll = (why = 'setScroll') => {
-        if (scrollToCellIfPossible(why))
-            return;
-        restoreFromCache(why);
+      if (scrollToCellIfPossible(why))
+        return;
+      restoreFromCache(why);
     };
     const retryFrames = 6;
     for (let i = 0; i < retryFrames; i++) {
-        requestAnimationFrame(() => {
-            k = scrollKeyFor(container);
-            appendScrollLog('fix_scroll:raf_retry', {
-                i,
-                k,
-                title: container?.title ?? null
-            });
-            setScroll(`raf:${ i }`);
+      requestAnimationFrame(() => {
+        k = scrollKeyFor(container);
+        appendScrollLog('fix_scroll:raf_retry', {
+          i,
+          k,
+          title: container?.title ?? null
         });
+        setScroll(`raf:${ i }`);
+      });
     }
     appendScrollLog('fix_scroll:exit', {
-        k,
-        title: container?.title ?? null
+      k,
+      title: container?.title ?? null
     });
-}
-)};
+  };
+};
 const _arfw00 = function _scroll_fix_sync_layout(sync_layout_to_url,layout,appendScrollLog,modulePanel)
 {
     sync_layout_to_url;
@@ -15719,7 +15780,7 @@ export default function define(runtime, observer) {
   $def("_1we0ggl", "reload", ["Generators","viewof reload"], _1we0ggl);  
   $def("_plefwg", "onLoadConfig", ["parseGoldenDSL","URLSearchParams","location"], _plefwg);  
   $def("_1nzpnqy", "visualizer_cache", ["reload"], _1nzpnqy);  
-  $def("_1l35721", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1l35721);  
+  $def("_1ojown8", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1ojown8);  
   $def("_1gm4gbf", "blobPanel", [], _1gm4gbf);  
   $def("_lxv2e2", "settings", [], _lxv2e2);  
   $def("_lp1ggk", "is_mobile", ["width"], _lp1ggk);  
@@ -15740,7 +15801,7 @@ export default function define(runtime, observer) {
   $def("_1dyz4o0", "scrollLog", ["mutable scrollLog"], _1dyz4o0);  
   $def("_1d1nkw9", "scrollKeyFor", ["appendScrollLog"], _1d1nkw9);  
   $def("_tb217h", "scroll_cache", [], _tb217h);  
-  $def("_5tyvpe", "fix_scroll", ["scrollKeyFor","appendScrollLog","scroll_cache"], _5tyvpe);  
+  $def("_12p8mg7", "fix_scroll", ["scroll_cache","scrollKeyFor","appendScrollLog"], _12p8mg7);  
   $def("_arfw00", "scroll_fix_sync_layout", ["sync_layout_to_url","layout","appendScrollLog","modulePanel"], _arfw00);  
   $def("_3nwpp4", "URLrouting", ["md"], _3nwpp4);  
   $def("_14te9pl", "sync_layout_from_url", ["reload","resize","URLSearchParams","hash","appendScrollLog","parseGoldenDSL","gl","layout","serializeGoldenDSL","treeSyncGolden","invalidation"], _14te9pl);  

--- a/notebooks/@tomlarkworthy_cell-map.html
+++ b/notebooks/@tomlarkworthy_cell-map.html
@@ -14013,138 +14013,196 @@ const _1nzpnqy = function _visualizer_cache(reload)
     reload;
     return new Map();
 };
-const _1l35721 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
+const _1ojown8 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
 {
-    return function (container, component) {
-        appendScrollLog('modulePanel:enter', {
-            title: container?.title ?? null,
-            componentCell: component?.cell ?? null
-        });
-        const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
-        if (!moduleInfo) {
-            // Fall through to file attachment: titles like @user/notebook/path.ext
-            // resolve via the lopecode bootloader's contentSync DOM lookup.
-            const title = container?.title ?? null;
-            if (title) {
-                let node = file_attachment_cache.get(title);
-                if (!node) {
-                    const r = window.lopecode?.contentSync?.(title);
-                    if (r && r.status === 200 && r.bytes) {
-                        node = renderFileAttachment(r.mime, r.bytes);
-                        file_attachment_cache.set(title, node);
-                        appendScrollLog('modulePanel:file_attachment_create', {
-                            title,
-                            mime: r.mime
-                        });
-                    }
-                }
-                if (node) {
-                    const c_element = container.getElement();
-                    if (node.parentNode !== c_element)
-                        c_element.appendChild(node);
-                    appendScrollLog('modulePanel:file_attachment_mount', { title });
-                    return;
-                }
-            }
-            appendScrollLog('modulePanel:missing_moduleInfo', { title });
-            return;
-        }
-        const module = moduleInfo.module;
-        let node;
-        if (!visualizer_cache.has(module)) {
-            appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
-            node = visualizer(runtime, {
-                invalidation: new Promise(r => {
-                }),
-                module,
-                detachNodes: isOnObservableCom(),
-                filter: (cell_name, variables) => {
-                    if (variables[0]._type !== 1)
-                        return false;
-                    if (typeof cell_name == 'string') {
-                        if (cell_name.startsWith('dynamic '))
-                            return false;
-                    }
-                    return true;
-                }
+  return function (container, component) {
+    appendScrollLog('modulePanel:enter', {
+      title: container?.title ?? null,
+      componentCell: component?.cell ?? null
+    });
+    const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
+    if (!moduleInfo) {
+      // Fall through to file attachment: titles like @user/notebook/path.ext
+      // resolve via the lopecode bootloader's contentSync DOM lookup.
+      const title = container?.title ?? null;
+      if (title) {
+        let node = file_attachment_cache.get(title);
+        if (!node) {
+          const r = window.lopecode?.contentSync?.(title);
+          if (r && r.status === 200 && r.bytes) {
+            node = renderFileAttachment(r.mime, r.bytes);
+            file_attachment_cache.set(title, node);
+            appendScrollLog('modulePanel:file_attachment_create', {
+              title,
+              mime: r.mime
             });
-            visualizer_cache.set(module, node);
-        } else {
-            node = visualizer_cache.get(module);
-            appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+          }
         }
-        const cell = module._scope.get(component.cell);
-        const scrollKey = scrollKeyFor(container);
-        fix_scroll(container, node, cell, scrollKey);
-        const el = container.getElement();
-        if (!el.__lope_scroll_bound) {
-            el.__lope_scroll_bound = true;
-            appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
-            el.addEventListener('scroll', () => {
-                const k = scrollKeyFor(container);
-                const scrollTop = el.scrollTop;
-                const scrollLeft = el.scrollLeft;
-                if (scrollTop == 0) {
-                    appendScrollLog('modulePanel:skip 0 scroll', {
-                        title: container?.title ?? null,
-                        scrollKey
-                    });
-                    return;
-                }
-                scroll_cache.set(k, {
-                    scrollTop,
-                    scrollLeft,
-                    t: Date.now()
-                });
-                appendScrollLog('scroll:event', {
-                    k,
-                    title: container?.title ?? null,
-                    scrollTop,
-                    scrollLeft
-                });
-            }, { passive: true });
+        if (node) {
+          const c_element = container.getElement();
+          if (node.parentNode !== c_element)
+            c_element.appendChild(node);
+          appendScrollLog('modulePanel:file_attachment_mount', { title });
+          return;
         }
-        // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
-        if (!container.__lope_destroy_bound) {
-            container.__lope_destroy_bound = true;
-            container.on('destroy', () => {
-                try {
-                    const k = scrollKeyFor(container);
-                    const scrollTop = el?.scrollTop;
-                    const scrollLeft = el?.scrollLeft;
-                    if (scrollTop == 0) {
-                        appendScrollLog('scroll:skip 0 scroll', {
-                            k,
-                            key: container?.title ?? null,
-                            scrollKey
-                        });
-                        return;
-                    }
-                    // do not skip 0 here: if the user is at top, preserve that state
-                    scroll_cache.set(k, {
-                        scrollTop,
-                        scrollLeft,
-                        t: Date.now()
-                    });
-                    appendScrollLog('scroll:destroy_capture', {
-                        k,
-                        title: container?.title ?? null,
-                        scrollTop,
-                        scrollLeft
-                    });
-                } catch (e) {
-                    appendScrollLog('scroll:destroy_capture:error', {
-                        title: container?.title ?? null,
-                        error: String(e)
-                    });
-                }
-            });
+      }
+      appendScrollLog('modulePanel:missing_moduleInfo', { title });
+      return;
+    }
+    const module = moduleInfo.module;
+    let node;
+    if (!visualizer_cache.has(module)) {
+      appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
+      node = visualizer(runtime, {
+        invalidation: new Promise(r => {
+        }),
+        module,
+        detachNodes: isOnObservableCom(),
+        filter: (cell_name, variables) => {
+          if (variables[0]._type !== 1)
+            return false;
+          if (typeof cell_name == 'string') {
+            if (cell_name.startsWith('dynamic '))
+              return false;
+          }
+          return true;
         }
-        appendScrollLog('modulePanel:exit', {
+      });
+      visualizer_cache.set(module, node);
+    } else {
+      node = visualizer_cache.get(module);
+      appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+    }
+    const cell = module._scope.get(component.cell);
+    const scrollKey = scrollKeyFor(container);
+    fix_scroll(container, node, cell, scrollKey);
+    const el = container.getElement();
+    if (!el.__lope_scroll_bound) {
+      el.__lope_scroll_bound = true;
+      appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
+      const markUserScroll = () => {
+        el.__lope_user_scroll_at = Date.now();
+      };
+      el.addEventListener('wheel', markUserScroll, { passive: true });
+      el.addEventListener('touchmove', markUserScroll, { passive: true });
+      el.addEventListener('keydown', markUserScroll, { passive: true });
+      el.addEventListener('scroll', () => {
+        if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+          appendScrollLog('scroll:skip_reflow', { title: container?.title ?? null });
+          return;
+        }
+        // Only cache scrolls following a genuine user gesture; reflow-induced
+        // scroll events (e.g. closing an adjacent panel) carry stale scrollTops.
+        if (Date.now() - (el.__lope_user_scroll_at || 0) > 400) {
+          appendScrollLog('scroll:skip_nonuser', { title: container?.title ?? null });
+          return;
+        }
+        const k = scrollKeyFor(container);
+        const scrollTop = el.scrollTop;
+        const scrollLeft = el.scrollLeft;
+        if (scrollTop == 0) {
+          appendScrollLog('modulePanel:skip 0 scroll', {
             title: container?.title ?? null,
             scrollKey
+          });
+          return;
+        }
+        scroll_cache.set(k, {
+          scrollTop,
+          scrollLeft,
+          t: Date.now()
         });
-    };
+        appendScrollLog('scroll:event', {
+          k,
+          title: container?.title ?? null,
+          scrollTop,
+          scrollLeft
+        });
+      }, { passive: true });
+    }
+    // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
+    if (!container.__lope_destroy_bound) {
+      container.__lope_destroy_bound = true;
+      container.on('destroy', () => {
+        try {
+          if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+            appendScrollLog('scroll:destroy_skip_reflow', { title: container?.title ?? null });
+            return;
+          }
+          const k = scrollKeyFor(container);
+          const scrollTop = el?.scrollTop;
+          const scrollLeft = el?.scrollLeft;
+          if (scrollTop == 0) {
+            appendScrollLog('scroll:skip 0 scroll', {
+              k,
+              key: container?.title ?? null,
+              scrollKey
+            });
+            return;
+          }
+          // do not skip 0 here: if the user is at top, preserve that state
+          scroll_cache.set(k, {
+            scrollTop,
+            scrollLeft,
+            t: Date.now()
+          });
+          appendScrollLog('scroll:destroy_capture', {
+            k,
+            title: container?.title ?? null,
+            scrollTop,
+            scrollLeft
+          });
+        } catch (e) {
+          appendScrollLog('scroll:destroy_capture:error', {
+            title: container?.title ?? null,
+            error: String(e)
+          });
+        }
+      });
+    }
+    // When GoldenLayout resizes this panel (e.g. an adjacent panel is closed) the
+    // browser can shift scrollTop; re-apply the user's cached position after the reflow.
+    if (!container.__lope_resize_bound) {
+      container.__lope_resize_bound = true;
+      container.on('resize', () => {
+        const rk = scrollKeyFor(container);
+        const cached = scroll_cache.get(rk);
+        if (!cached || cached.scrollTop == null)
+          return;
+        const c_el = container.getElement();
+        const at = Date.now();
+        scroll_cache.__reflowUntil = at + 800;
+        // The reflow can shift scrollTop in several passes (content relayout
+        // settles ~300ms later), so re-apply over a window. Bail if the user scrolls.
+        const apply = () => {
+          if ((c_el.__lope_user_scroll_at || 0) > at)
+            return;
+          if (c_el.scrollTop !== cached.scrollTop)
+            c_el.scrollTop = cached.scrollTop;
+          if (cached.scrollLeft != null && c_el.scrollLeft !== cached.scrollLeft)
+            c_el.scrollLeft = cached.scrollLeft;
+        };
+        requestAnimationFrame(apply);
+        for (const d of [
+            60,
+            150,
+            300,
+            450,
+            600
+          ])
+          setTimeout(apply, d);
+        appendScrollLog('scroll:resize_restore', {
+          k: rk,
+          title: container?.title ?? null,
+          scrollTop: cached.scrollTop
+        });
+      });
+    }
+    appendScrollLog('modulePanel:exit', {
+      title: container?.title ?? null,
+      scrollKey
+    });
+  };
 };
 const _1gm4gbf = function _blobPanel(){return(
 function (container, component) {
@@ -14262,112 +14320,115 @@ const _1d1nkw9 = function _scrollKeyFor(appendScrollLog)
 const _tb217h = function _scroll_cache(){return(
 new Map()
 )};
-const _5tyvpe = function _fix_scroll(scrollKeyFor,appendScrollLog,scroll_cache){return(
-function (container, node, cell_variable, key) {
+const _12p8mg7 = function _fix_scroll(scroll_cache,scrollKeyFor,appendScrollLog)
+{
+  return function (container, node, cell_variable, key) {
+    scroll_cache.__reflowUntil = Date.now() + 600;
+    // suppress reflow-induced scroll events that clobber the cache
     const c_element = container.getElement();
     let k = scrollKeyFor(container);
     appendScrollLog('fix_scroll:enter', {
-        title: container?.title ?? null,
-        k,
-        cell: cell_variable?._name ?? null
+      title: container?.title ?? null,
+      k,
+      cell: cell_variable?._name ?? null
     });
     if (node && node.parentNode !== c_element) {
-        c_element.appendChild(node);
-        appendScrollLog('fix_scroll:append_node', {
-            title: container?.title ?? null,
-            k
-        });
+      c_element.appendChild(node);
+      appendScrollLog('fix_scroll:append_node', {
+        title: container?.title ?? null,
+        k
+      });
     }
     const writeCache = (scrollTop, scrollLeft, why) => {
-        scroll_cache.set(k, {
-            scrollTop,
-            scrollLeft,
-            t: Date.now()
-        });
-        appendScrollLog('scroll_cache:write', {
-            k,
-            scrollTop,
-            scrollLeft,
-            why
-        });
+      scroll_cache.set(k, {
+        scrollTop,
+        scrollLeft,
+        t: Date.now()
+      });
+      appendScrollLog('scroll_cache:write', {
+        k,
+        scrollTop,
+        scrollLeft,
+        why
+      });
     };
     const scrollToCellIfPossible = why => {
-        if (!cell_variable)
-            return false;
-        const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
-        if (!dom) {
-            appendScrollLog('scroll:cell_dom_not_found', {
-                k,
-                why,
-                cell: cell_variable?._name ?? null
-            });
-            return false;
-        }
-        const top = dom.offsetTop - c_element.offsetTop;
-        const left = c_element.scrollLeft;
-        c_element.scrollTop = top;
-        appendScrollLog('scroll:set', {
-            k,
-            why: `${ why }:cell`,
-            scrollTop: top,
-            scrollLeft: left,
-            cell: cell_variable?._name ?? null
+      if (!cell_variable)
+        return false;
+      const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
+      if (!dom) {
+        appendScrollLog('scroll:cell_dom_not_found', {
+          k,
+          why,
+          cell: cell_variable?._name ?? null
         });
-        writeCache(top, left, `${ why }:cell`);
-        return true;
+        return false;
+      }
+      const top = dom.offsetTop - c_element.offsetTop;
+      const left = c_element.scrollLeft;
+      c_element.scrollTop = top;
+      appendScrollLog('scroll:set', {
+        k,
+        why: `${ why }:cell`,
+        scrollTop: top,
+        scrollLeft: left,
+        cell: cell_variable?._name ?? null
+      });
+      writeCache(top, left, `${ why }:cell`);
+      return true;
     };
     const restoreFromCache = why => {
-        k = scrollKeyFor(container);
-        const cached = scroll_cache.get(k);
-        appendScrollLog('scroll:restore_attempt', {
-            k,
-            why,
-            cachedScrollTop: cached?.scrollTop ?? null,
-            cachedScrollLeft: cached?.scrollLeft ?? null
+      k = scrollKeyFor(container);
+      const cached = scroll_cache.get(k);
+      appendScrollLog('scroll:restore_attempt', {
+        k,
+        why,
+        cachedScrollTop: cached?.scrollTop ?? null,
+        cachedScrollLeft: cached?.scrollLeft ?? null
+      });
+      if (!cached) {
+        appendScrollLog('scroll:restore_no_scroll', {
+          k,
+          why
         });
-        if (!cached) {
-            appendScrollLog('scroll:restore_no_scroll', {
-                k,
-                why
-            });
-            return;
-        }
-        if (cached.scrollTop != null)
-            c_element.scrollTop = cached.scrollTop;
-        if (cached.scrollLeft != null)
-            c_element.scrollLeft = cached.scrollLeft;
-        appendScrollLog('scroll:restore_applied', {
-            k,
-            why,
-            scrollTop: cached.scrollTop ?? null,
-            scrollLeft: cached.scrollLeft ?? null,
-            scrollTopFinal: c_element.scrollTop,
-            scrollLeftFinal: c_element.scrollLeft
-        });
+        return;
+      }
+      if (cached.scrollTop != null)
+        c_element.scrollTop = cached.scrollTop;
+      if (cached.scrollLeft != null)
+        c_element.scrollLeft = cached.scrollLeft;
+      appendScrollLog('scroll:restore_applied', {
+        k,
+        why,
+        scrollTop: cached.scrollTop ?? null,
+        scrollLeft: cached.scrollLeft ?? null,
+        scrollTopFinal: c_element.scrollTop,
+        scrollLeftFinal: c_element.scrollLeft
+      });
     };
     const setScroll = (why = 'setScroll') => {
-        if (scrollToCellIfPossible(why))
-            return;
-        restoreFromCache(why);
+      if (scrollToCellIfPossible(why))
+        return;
+      restoreFromCache(why);
     };
     const retryFrames = 6;
     for (let i = 0; i < retryFrames; i++) {
-        requestAnimationFrame(() => {
-            k = scrollKeyFor(container);
-            appendScrollLog('fix_scroll:raf_retry', {
-                i,
-                k,
-                title: container?.title ?? null
-            });
-            setScroll(`raf:${ i }`);
+      requestAnimationFrame(() => {
+        k = scrollKeyFor(container);
+        appendScrollLog('fix_scroll:raf_retry', {
+          i,
+          k,
+          title: container?.title ?? null
         });
+        setScroll(`raf:${ i }`);
+      });
     }
     appendScrollLog('fix_scroll:exit', {
-        k,
-        title: container?.title ?? null
+      k,
+      title: container?.title ?? null
     });
-}
-)};
+  };
+};
 const _arfw00 = function _scroll_fix_sync_layout(sync_layout_to_url,layout,appendScrollLog,modulePanel)
 {
     sync_layout_to_url;
@@ -15445,7 +15506,7 @@ export default function define(runtime, observer) {
   $def("_1we0ggl", "reload", ["Generators","viewof reload"], _1we0ggl);  
   $def("_plefwg", "onLoadConfig", ["parseGoldenDSL","URLSearchParams","location"], _plefwg);  
   $def("_1nzpnqy", "visualizer_cache", ["reload"], _1nzpnqy);  
-  $def("_1l35721", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1l35721);  
+  $def("_1ojown8", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1ojown8);  
   $def("_1gm4gbf", "blobPanel", [], _1gm4gbf);  
   $def("_lxv2e2", "settings", [], _lxv2e2);  
   $def("_lp1ggk", "is_mobile", ["width"], _lp1ggk);  
@@ -15466,7 +15527,7 @@ export default function define(runtime, observer) {
   $def("_1dyz4o0", "scrollLog", ["mutable scrollLog"], _1dyz4o0);  
   $def("_1d1nkw9", "scrollKeyFor", ["appendScrollLog"], _1d1nkw9);  
   $def("_tb217h", "scroll_cache", [], _tb217h);  
-  $def("_5tyvpe", "fix_scroll", ["scrollKeyFor","appendScrollLog","scroll_cache"], _5tyvpe);  
+  $def("_12p8mg7", "fix_scroll", ["scroll_cache","scrollKeyFor","appendScrollLog"], _12p8mg7);  
   $def("_arfw00", "scroll_fix_sync_layout", ["sync_layout_to_url","layout","appendScrollLog","modulePanel"], _arfw00);  
   $def("_3nwpp4", "URLrouting", ["md"], _3nwpp4);  
   $def("_14te9pl", "sync_layout_from_url", ["reload","resize","URLSearchParams","hash","appendScrollLog","parseGoldenDSL","gl","layout","serializeGoldenDSL","treeSyncGolden","invalidation"], _14te9pl);  

--- a/notebooks/@tomlarkworthy_cells-to-clipboard.html
+++ b/notebooks/@tomlarkworthy_cells-to-clipboard.html
@@ -14037,138 +14037,196 @@ const _1nzpnqy = function _visualizer_cache(reload)
     reload;
     return new Map();
 };
-const _1l35721 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
+const _1ojown8 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
 {
-    return function (container, component) {
-        appendScrollLog('modulePanel:enter', {
-            title: container?.title ?? null,
-            componentCell: component?.cell ?? null
-        });
-        const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
-        if (!moduleInfo) {
-            // Fall through to file attachment: titles like @user/notebook/path.ext
-            // resolve via the lopecode bootloader's contentSync DOM lookup.
-            const title = container?.title ?? null;
-            if (title) {
-                let node = file_attachment_cache.get(title);
-                if (!node) {
-                    const r = window.lopecode?.contentSync?.(title);
-                    if (r && r.status === 200 && r.bytes) {
-                        node = renderFileAttachment(r.mime, r.bytes);
-                        file_attachment_cache.set(title, node);
-                        appendScrollLog('modulePanel:file_attachment_create', {
-                            title,
-                            mime: r.mime
-                        });
-                    }
-                }
-                if (node) {
-                    const c_element = container.getElement();
-                    if (node.parentNode !== c_element)
-                        c_element.appendChild(node);
-                    appendScrollLog('modulePanel:file_attachment_mount', { title });
-                    return;
-                }
-            }
-            appendScrollLog('modulePanel:missing_moduleInfo', { title });
-            return;
-        }
-        const module = moduleInfo.module;
-        let node;
-        if (!visualizer_cache.has(module)) {
-            appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
-            node = visualizer(runtime, {
-                invalidation: new Promise(r => {
-                }),
-                module,
-                detachNodes: isOnObservableCom(),
-                filter: (cell_name, variables) => {
-                    if (variables[0]._type !== 1)
-                        return false;
-                    if (typeof cell_name == 'string') {
-                        if (cell_name.startsWith('dynamic '))
-                            return false;
-                    }
-                    return true;
-                }
+  return function (container, component) {
+    appendScrollLog('modulePanel:enter', {
+      title: container?.title ?? null,
+      componentCell: component?.cell ?? null
+    });
+    const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
+    if (!moduleInfo) {
+      // Fall through to file attachment: titles like @user/notebook/path.ext
+      // resolve via the lopecode bootloader's contentSync DOM lookup.
+      const title = container?.title ?? null;
+      if (title) {
+        let node = file_attachment_cache.get(title);
+        if (!node) {
+          const r = window.lopecode?.contentSync?.(title);
+          if (r && r.status === 200 && r.bytes) {
+            node = renderFileAttachment(r.mime, r.bytes);
+            file_attachment_cache.set(title, node);
+            appendScrollLog('modulePanel:file_attachment_create', {
+              title,
+              mime: r.mime
             });
-            visualizer_cache.set(module, node);
-        } else {
-            node = visualizer_cache.get(module);
-            appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+          }
         }
-        const cell = module._scope.get(component.cell);
-        const scrollKey = scrollKeyFor(container);
-        fix_scroll(container, node, cell, scrollKey);
-        const el = container.getElement();
-        if (!el.__lope_scroll_bound) {
-            el.__lope_scroll_bound = true;
-            appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
-            el.addEventListener('scroll', () => {
-                const k = scrollKeyFor(container);
-                const scrollTop = el.scrollTop;
-                const scrollLeft = el.scrollLeft;
-                if (scrollTop == 0) {
-                    appendScrollLog('modulePanel:skip 0 scroll', {
-                        title: container?.title ?? null,
-                        scrollKey
-                    });
-                    return;
-                }
-                scroll_cache.set(k, {
-                    scrollTop,
-                    scrollLeft,
-                    t: Date.now()
-                });
-                appendScrollLog('scroll:event', {
-                    k,
-                    title: container?.title ?? null,
-                    scrollTop,
-                    scrollLeft
-                });
-            }, { passive: true });
+        if (node) {
+          const c_element = container.getElement();
+          if (node.parentNode !== c_element)
+            c_element.appendChild(node);
+          appendScrollLog('modulePanel:file_attachment_mount', { title });
+          return;
         }
-        // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
-        if (!container.__lope_destroy_bound) {
-            container.__lope_destroy_bound = true;
-            container.on('destroy', () => {
-                try {
-                    const k = scrollKeyFor(container);
-                    const scrollTop = el?.scrollTop;
-                    const scrollLeft = el?.scrollLeft;
-                    if (scrollTop == 0) {
-                        appendScrollLog('scroll:skip 0 scroll', {
-                            k,
-                            key: container?.title ?? null,
-                            scrollKey
-                        });
-                        return;
-                    }
-                    // do not skip 0 here: if the user is at top, preserve that state
-                    scroll_cache.set(k, {
-                        scrollTop,
-                        scrollLeft,
-                        t: Date.now()
-                    });
-                    appendScrollLog('scroll:destroy_capture', {
-                        k,
-                        title: container?.title ?? null,
-                        scrollTop,
-                        scrollLeft
-                    });
-                } catch (e) {
-                    appendScrollLog('scroll:destroy_capture:error', {
-                        title: container?.title ?? null,
-                        error: String(e)
-                    });
-                }
-            });
+      }
+      appendScrollLog('modulePanel:missing_moduleInfo', { title });
+      return;
+    }
+    const module = moduleInfo.module;
+    let node;
+    if (!visualizer_cache.has(module)) {
+      appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
+      node = visualizer(runtime, {
+        invalidation: new Promise(r => {
+        }),
+        module,
+        detachNodes: isOnObservableCom(),
+        filter: (cell_name, variables) => {
+          if (variables[0]._type !== 1)
+            return false;
+          if (typeof cell_name == 'string') {
+            if (cell_name.startsWith('dynamic '))
+              return false;
+          }
+          return true;
         }
-        appendScrollLog('modulePanel:exit', {
+      });
+      visualizer_cache.set(module, node);
+    } else {
+      node = visualizer_cache.get(module);
+      appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+    }
+    const cell = module._scope.get(component.cell);
+    const scrollKey = scrollKeyFor(container);
+    fix_scroll(container, node, cell, scrollKey);
+    const el = container.getElement();
+    if (!el.__lope_scroll_bound) {
+      el.__lope_scroll_bound = true;
+      appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
+      const markUserScroll = () => {
+        el.__lope_user_scroll_at = Date.now();
+      };
+      el.addEventListener('wheel', markUserScroll, { passive: true });
+      el.addEventListener('touchmove', markUserScroll, { passive: true });
+      el.addEventListener('keydown', markUserScroll, { passive: true });
+      el.addEventListener('scroll', () => {
+        if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+          appendScrollLog('scroll:skip_reflow', { title: container?.title ?? null });
+          return;
+        }
+        // Only cache scrolls following a genuine user gesture; reflow-induced
+        // scroll events (e.g. closing an adjacent panel) carry stale scrollTops.
+        if (Date.now() - (el.__lope_user_scroll_at || 0) > 400) {
+          appendScrollLog('scroll:skip_nonuser', { title: container?.title ?? null });
+          return;
+        }
+        const k = scrollKeyFor(container);
+        const scrollTop = el.scrollTop;
+        const scrollLeft = el.scrollLeft;
+        if (scrollTop == 0) {
+          appendScrollLog('modulePanel:skip 0 scroll', {
             title: container?.title ?? null,
             scrollKey
+          });
+          return;
+        }
+        scroll_cache.set(k, {
+          scrollTop,
+          scrollLeft,
+          t: Date.now()
         });
-    };
+        appendScrollLog('scroll:event', {
+          k,
+          title: container?.title ?? null,
+          scrollTop,
+          scrollLeft
+        });
+      }, { passive: true });
+    }
+    // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
+    if (!container.__lope_destroy_bound) {
+      container.__lope_destroy_bound = true;
+      container.on('destroy', () => {
+        try {
+          if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+            appendScrollLog('scroll:destroy_skip_reflow', { title: container?.title ?? null });
+            return;
+          }
+          const k = scrollKeyFor(container);
+          const scrollTop = el?.scrollTop;
+          const scrollLeft = el?.scrollLeft;
+          if (scrollTop == 0) {
+            appendScrollLog('scroll:skip 0 scroll', {
+              k,
+              key: container?.title ?? null,
+              scrollKey
+            });
+            return;
+          }
+          // do not skip 0 here: if the user is at top, preserve that state
+          scroll_cache.set(k, {
+            scrollTop,
+            scrollLeft,
+            t: Date.now()
+          });
+          appendScrollLog('scroll:destroy_capture', {
+            k,
+            title: container?.title ?? null,
+            scrollTop,
+            scrollLeft
+          });
+        } catch (e) {
+          appendScrollLog('scroll:destroy_capture:error', {
+            title: container?.title ?? null,
+            error: String(e)
+          });
+        }
+      });
+    }
+    // When GoldenLayout resizes this panel (e.g. an adjacent panel is closed) the
+    // browser can shift scrollTop; re-apply the user's cached position after the reflow.
+    if (!container.__lope_resize_bound) {
+      container.__lope_resize_bound = true;
+      container.on('resize', () => {
+        const rk = scrollKeyFor(container);
+        const cached = scroll_cache.get(rk);
+        if (!cached || cached.scrollTop == null)
+          return;
+        const c_el = container.getElement();
+        const at = Date.now();
+        scroll_cache.__reflowUntil = at + 800;
+        // The reflow can shift scrollTop in several passes (content relayout
+        // settles ~300ms later), so re-apply over a window. Bail if the user scrolls.
+        const apply = () => {
+          if ((c_el.__lope_user_scroll_at || 0) > at)
+            return;
+          if (c_el.scrollTop !== cached.scrollTop)
+            c_el.scrollTop = cached.scrollTop;
+          if (cached.scrollLeft != null && c_el.scrollLeft !== cached.scrollLeft)
+            c_el.scrollLeft = cached.scrollLeft;
+        };
+        requestAnimationFrame(apply);
+        for (const d of [
+            60,
+            150,
+            300,
+            450,
+            600
+          ])
+          setTimeout(apply, d);
+        appendScrollLog('scroll:resize_restore', {
+          k: rk,
+          title: container?.title ?? null,
+          scrollTop: cached.scrollTop
+        });
+      });
+    }
+    appendScrollLog('modulePanel:exit', {
+      title: container?.title ?? null,
+      scrollKey
+    });
+  };
 };
 const _1gm4gbf = function _blobPanel(){return(
 function (container, component) {
@@ -14286,112 +14344,115 @@ const _1d1nkw9 = function _scrollKeyFor(appendScrollLog)
 const _tb217h = function _scroll_cache(){return(
 new Map()
 )};
-const _5tyvpe = function _fix_scroll(scrollKeyFor,appendScrollLog,scroll_cache){return(
-function (container, node, cell_variable, key) {
+const _12p8mg7 = function _fix_scroll(scroll_cache,scrollKeyFor,appendScrollLog)
+{
+  return function (container, node, cell_variable, key) {
+    scroll_cache.__reflowUntil = Date.now() + 600;
+    // suppress reflow-induced scroll events that clobber the cache
     const c_element = container.getElement();
     let k = scrollKeyFor(container);
     appendScrollLog('fix_scroll:enter', {
-        title: container?.title ?? null,
-        k,
-        cell: cell_variable?._name ?? null
+      title: container?.title ?? null,
+      k,
+      cell: cell_variable?._name ?? null
     });
     if (node && node.parentNode !== c_element) {
-        c_element.appendChild(node);
-        appendScrollLog('fix_scroll:append_node', {
-            title: container?.title ?? null,
-            k
-        });
+      c_element.appendChild(node);
+      appendScrollLog('fix_scroll:append_node', {
+        title: container?.title ?? null,
+        k
+      });
     }
     const writeCache = (scrollTop, scrollLeft, why) => {
-        scroll_cache.set(k, {
-            scrollTop,
-            scrollLeft,
-            t: Date.now()
-        });
-        appendScrollLog('scroll_cache:write', {
-            k,
-            scrollTop,
-            scrollLeft,
-            why
-        });
+      scroll_cache.set(k, {
+        scrollTop,
+        scrollLeft,
+        t: Date.now()
+      });
+      appendScrollLog('scroll_cache:write', {
+        k,
+        scrollTop,
+        scrollLeft,
+        why
+      });
     };
     const scrollToCellIfPossible = why => {
-        if (!cell_variable)
-            return false;
-        const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
-        if (!dom) {
-            appendScrollLog('scroll:cell_dom_not_found', {
-                k,
-                why,
-                cell: cell_variable?._name ?? null
-            });
-            return false;
-        }
-        const top = dom.offsetTop - c_element.offsetTop;
-        const left = c_element.scrollLeft;
-        c_element.scrollTop = top;
-        appendScrollLog('scroll:set', {
-            k,
-            why: `${ why }:cell`,
-            scrollTop: top,
-            scrollLeft: left,
-            cell: cell_variable?._name ?? null
+      if (!cell_variable)
+        return false;
+      const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
+      if (!dom) {
+        appendScrollLog('scroll:cell_dom_not_found', {
+          k,
+          why,
+          cell: cell_variable?._name ?? null
         });
-        writeCache(top, left, `${ why }:cell`);
-        return true;
+        return false;
+      }
+      const top = dom.offsetTop - c_element.offsetTop;
+      const left = c_element.scrollLeft;
+      c_element.scrollTop = top;
+      appendScrollLog('scroll:set', {
+        k,
+        why: `${ why }:cell`,
+        scrollTop: top,
+        scrollLeft: left,
+        cell: cell_variable?._name ?? null
+      });
+      writeCache(top, left, `${ why }:cell`);
+      return true;
     };
     const restoreFromCache = why => {
-        k = scrollKeyFor(container);
-        const cached = scroll_cache.get(k);
-        appendScrollLog('scroll:restore_attempt', {
-            k,
-            why,
-            cachedScrollTop: cached?.scrollTop ?? null,
-            cachedScrollLeft: cached?.scrollLeft ?? null
+      k = scrollKeyFor(container);
+      const cached = scroll_cache.get(k);
+      appendScrollLog('scroll:restore_attempt', {
+        k,
+        why,
+        cachedScrollTop: cached?.scrollTop ?? null,
+        cachedScrollLeft: cached?.scrollLeft ?? null
+      });
+      if (!cached) {
+        appendScrollLog('scroll:restore_no_scroll', {
+          k,
+          why
         });
-        if (!cached) {
-            appendScrollLog('scroll:restore_no_scroll', {
-                k,
-                why
-            });
-            return;
-        }
-        if (cached.scrollTop != null)
-            c_element.scrollTop = cached.scrollTop;
-        if (cached.scrollLeft != null)
-            c_element.scrollLeft = cached.scrollLeft;
-        appendScrollLog('scroll:restore_applied', {
-            k,
-            why,
-            scrollTop: cached.scrollTop ?? null,
-            scrollLeft: cached.scrollLeft ?? null,
-            scrollTopFinal: c_element.scrollTop,
-            scrollLeftFinal: c_element.scrollLeft
-        });
+        return;
+      }
+      if (cached.scrollTop != null)
+        c_element.scrollTop = cached.scrollTop;
+      if (cached.scrollLeft != null)
+        c_element.scrollLeft = cached.scrollLeft;
+      appendScrollLog('scroll:restore_applied', {
+        k,
+        why,
+        scrollTop: cached.scrollTop ?? null,
+        scrollLeft: cached.scrollLeft ?? null,
+        scrollTopFinal: c_element.scrollTop,
+        scrollLeftFinal: c_element.scrollLeft
+      });
     };
     const setScroll = (why = 'setScroll') => {
-        if (scrollToCellIfPossible(why))
-            return;
-        restoreFromCache(why);
+      if (scrollToCellIfPossible(why))
+        return;
+      restoreFromCache(why);
     };
     const retryFrames = 6;
     for (let i = 0; i < retryFrames; i++) {
-        requestAnimationFrame(() => {
-            k = scrollKeyFor(container);
-            appendScrollLog('fix_scroll:raf_retry', {
-                i,
-                k,
-                title: container?.title ?? null
-            });
-            setScroll(`raf:${ i }`);
+      requestAnimationFrame(() => {
+        k = scrollKeyFor(container);
+        appendScrollLog('fix_scroll:raf_retry', {
+          i,
+          k,
+          title: container?.title ?? null
         });
+        setScroll(`raf:${ i }`);
+      });
     }
     appendScrollLog('fix_scroll:exit', {
-        k,
-        title: container?.title ?? null
+      k,
+      title: container?.title ?? null
     });
-}
-)};
+  };
+};
 const _arfw00 = function _scroll_fix_sync_layout(sync_layout_to_url,layout,appendScrollLog,modulePanel)
 {
     sync_layout_to_url;
@@ -15469,7 +15530,7 @@ export default function define(runtime, observer) {
   $def("_1we0ggl", "reload", ["Generators","viewof reload"], _1we0ggl);  
   $def("_plefwg", "onLoadConfig", ["parseGoldenDSL","URLSearchParams","location"], _plefwg);  
   $def("_1nzpnqy", "visualizer_cache", ["reload"], _1nzpnqy);  
-  $def("_1l35721", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1l35721);  
+  $def("_1ojown8", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1ojown8);  
   $def("_1gm4gbf", "blobPanel", [], _1gm4gbf);  
   $def("_lxv2e2", "settings", [], _lxv2e2);  
   $def("_lp1ggk", "is_mobile", ["width"], _lp1ggk);  
@@ -15490,7 +15551,7 @@ export default function define(runtime, observer) {
   $def("_1dyz4o0", "scrollLog", ["mutable scrollLog"], _1dyz4o0);  
   $def("_1d1nkw9", "scrollKeyFor", ["appendScrollLog"], _1d1nkw9);  
   $def("_tb217h", "scroll_cache", [], _tb217h);  
-  $def("_5tyvpe", "fix_scroll", ["scrollKeyFor","appendScrollLog","scroll_cache"], _5tyvpe);  
+  $def("_12p8mg7", "fix_scroll", ["scroll_cache","scrollKeyFor","appendScrollLog"], _12p8mg7);  
   $def("_arfw00", "scroll_fix_sync_layout", ["sync_layout_to_url","layout","appendScrollLog","modulePanel"], _arfw00);  
   $def("_3nwpp4", "URLrouting", ["md"], _3nwpp4);  
   $def("_14te9pl", "sync_layout_from_url", ["reload","resize","URLSearchParams","hash","appendScrollLog","parseGoldenDSL","gl","layout","serializeGoldenDSL","treeSyncGolden","invalidation"], _14te9pl);  

--- a/notebooks/@tomlarkworthy_claude-code-pairing.html
+++ b/notebooks/@tomlarkworthy_claude-code-pairing.html
@@ -14037,138 +14037,196 @@ const _1nzpnqy = function _visualizer_cache(reload)
     reload;
     return new Map();
 };
-const _1l35721 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
+const _1ojown8 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
 {
-    return function (container, component) {
-        appendScrollLog('modulePanel:enter', {
-            title: container?.title ?? null,
-            componentCell: component?.cell ?? null
-        });
-        const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
-        if (!moduleInfo) {
-            // Fall through to file attachment: titles like @user/notebook/path.ext
-            // resolve via the lopecode bootloader's contentSync DOM lookup.
-            const title = container?.title ?? null;
-            if (title) {
-                let node = file_attachment_cache.get(title);
-                if (!node) {
-                    const r = window.lopecode?.contentSync?.(title);
-                    if (r && r.status === 200 && r.bytes) {
-                        node = renderFileAttachment(r.mime, r.bytes);
-                        file_attachment_cache.set(title, node);
-                        appendScrollLog('modulePanel:file_attachment_create', {
-                            title,
-                            mime: r.mime
-                        });
-                    }
-                }
-                if (node) {
-                    const c_element = container.getElement();
-                    if (node.parentNode !== c_element)
-                        c_element.appendChild(node);
-                    appendScrollLog('modulePanel:file_attachment_mount', { title });
-                    return;
-                }
-            }
-            appendScrollLog('modulePanel:missing_moduleInfo', { title });
-            return;
-        }
-        const module = moduleInfo.module;
-        let node;
-        if (!visualizer_cache.has(module)) {
-            appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
-            node = visualizer(runtime, {
-                invalidation: new Promise(r => {
-                }),
-                module,
-                detachNodes: isOnObservableCom(),
-                filter: (cell_name, variables) => {
-                    if (variables[0]._type !== 1)
-                        return false;
-                    if (typeof cell_name == 'string') {
-                        if (cell_name.startsWith('dynamic '))
-                            return false;
-                    }
-                    return true;
-                }
+  return function (container, component) {
+    appendScrollLog('modulePanel:enter', {
+      title: container?.title ?? null,
+      componentCell: component?.cell ?? null
+    });
+    const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
+    if (!moduleInfo) {
+      // Fall through to file attachment: titles like @user/notebook/path.ext
+      // resolve via the lopecode bootloader's contentSync DOM lookup.
+      const title = container?.title ?? null;
+      if (title) {
+        let node = file_attachment_cache.get(title);
+        if (!node) {
+          const r = window.lopecode?.contentSync?.(title);
+          if (r && r.status === 200 && r.bytes) {
+            node = renderFileAttachment(r.mime, r.bytes);
+            file_attachment_cache.set(title, node);
+            appendScrollLog('modulePanel:file_attachment_create', {
+              title,
+              mime: r.mime
             });
-            visualizer_cache.set(module, node);
-        } else {
-            node = visualizer_cache.get(module);
-            appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+          }
         }
-        const cell = module._scope.get(component.cell);
-        const scrollKey = scrollKeyFor(container);
-        fix_scroll(container, node, cell, scrollKey);
-        const el = container.getElement();
-        if (!el.__lope_scroll_bound) {
-            el.__lope_scroll_bound = true;
-            appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
-            el.addEventListener('scroll', () => {
-                const k = scrollKeyFor(container);
-                const scrollTop = el.scrollTop;
-                const scrollLeft = el.scrollLeft;
-                if (scrollTop == 0) {
-                    appendScrollLog('modulePanel:skip 0 scroll', {
-                        title: container?.title ?? null,
-                        scrollKey
-                    });
-                    return;
-                }
-                scroll_cache.set(k, {
-                    scrollTop,
-                    scrollLeft,
-                    t: Date.now()
-                });
-                appendScrollLog('scroll:event', {
-                    k,
-                    title: container?.title ?? null,
-                    scrollTop,
-                    scrollLeft
-                });
-            }, { passive: true });
+        if (node) {
+          const c_element = container.getElement();
+          if (node.parentNode !== c_element)
+            c_element.appendChild(node);
+          appendScrollLog('modulePanel:file_attachment_mount', { title });
+          return;
         }
-        // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
-        if (!container.__lope_destroy_bound) {
-            container.__lope_destroy_bound = true;
-            container.on('destroy', () => {
-                try {
-                    const k = scrollKeyFor(container);
-                    const scrollTop = el?.scrollTop;
-                    const scrollLeft = el?.scrollLeft;
-                    if (scrollTop == 0) {
-                        appendScrollLog('scroll:skip 0 scroll', {
-                            k,
-                            key: container?.title ?? null,
-                            scrollKey
-                        });
-                        return;
-                    }
-                    // do not skip 0 here: if the user is at top, preserve that state
-                    scroll_cache.set(k, {
-                        scrollTop,
-                        scrollLeft,
-                        t: Date.now()
-                    });
-                    appendScrollLog('scroll:destroy_capture', {
-                        k,
-                        title: container?.title ?? null,
-                        scrollTop,
-                        scrollLeft
-                    });
-                } catch (e) {
-                    appendScrollLog('scroll:destroy_capture:error', {
-                        title: container?.title ?? null,
-                        error: String(e)
-                    });
-                }
-            });
+      }
+      appendScrollLog('modulePanel:missing_moduleInfo', { title });
+      return;
+    }
+    const module = moduleInfo.module;
+    let node;
+    if (!visualizer_cache.has(module)) {
+      appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
+      node = visualizer(runtime, {
+        invalidation: new Promise(r => {
+        }),
+        module,
+        detachNodes: isOnObservableCom(),
+        filter: (cell_name, variables) => {
+          if (variables[0]._type !== 1)
+            return false;
+          if (typeof cell_name == 'string') {
+            if (cell_name.startsWith('dynamic '))
+              return false;
+          }
+          return true;
         }
-        appendScrollLog('modulePanel:exit', {
+      });
+      visualizer_cache.set(module, node);
+    } else {
+      node = visualizer_cache.get(module);
+      appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+    }
+    const cell = module._scope.get(component.cell);
+    const scrollKey = scrollKeyFor(container);
+    fix_scroll(container, node, cell, scrollKey);
+    const el = container.getElement();
+    if (!el.__lope_scroll_bound) {
+      el.__lope_scroll_bound = true;
+      appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
+      const markUserScroll = () => {
+        el.__lope_user_scroll_at = Date.now();
+      };
+      el.addEventListener('wheel', markUserScroll, { passive: true });
+      el.addEventListener('touchmove', markUserScroll, { passive: true });
+      el.addEventListener('keydown', markUserScroll, { passive: true });
+      el.addEventListener('scroll', () => {
+        if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+          appendScrollLog('scroll:skip_reflow', { title: container?.title ?? null });
+          return;
+        }
+        // Only cache scrolls following a genuine user gesture; reflow-induced
+        // scroll events (e.g. closing an adjacent panel) carry stale scrollTops.
+        if (Date.now() - (el.__lope_user_scroll_at || 0) > 400) {
+          appendScrollLog('scroll:skip_nonuser', { title: container?.title ?? null });
+          return;
+        }
+        const k = scrollKeyFor(container);
+        const scrollTop = el.scrollTop;
+        const scrollLeft = el.scrollLeft;
+        if (scrollTop == 0) {
+          appendScrollLog('modulePanel:skip 0 scroll', {
             title: container?.title ?? null,
             scrollKey
+          });
+          return;
+        }
+        scroll_cache.set(k, {
+          scrollTop,
+          scrollLeft,
+          t: Date.now()
         });
-    };
+        appendScrollLog('scroll:event', {
+          k,
+          title: container?.title ?? null,
+          scrollTop,
+          scrollLeft
+        });
+      }, { passive: true });
+    }
+    // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
+    if (!container.__lope_destroy_bound) {
+      container.__lope_destroy_bound = true;
+      container.on('destroy', () => {
+        try {
+          if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+            appendScrollLog('scroll:destroy_skip_reflow', { title: container?.title ?? null });
+            return;
+          }
+          const k = scrollKeyFor(container);
+          const scrollTop = el?.scrollTop;
+          const scrollLeft = el?.scrollLeft;
+          if (scrollTop == 0) {
+            appendScrollLog('scroll:skip 0 scroll', {
+              k,
+              key: container?.title ?? null,
+              scrollKey
+            });
+            return;
+          }
+          // do not skip 0 here: if the user is at top, preserve that state
+          scroll_cache.set(k, {
+            scrollTop,
+            scrollLeft,
+            t: Date.now()
+          });
+          appendScrollLog('scroll:destroy_capture', {
+            k,
+            title: container?.title ?? null,
+            scrollTop,
+            scrollLeft
+          });
+        } catch (e) {
+          appendScrollLog('scroll:destroy_capture:error', {
+            title: container?.title ?? null,
+            error: String(e)
+          });
+        }
+      });
+    }
+    // When GoldenLayout resizes this panel (e.g. an adjacent panel is closed) the
+    // browser can shift scrollTop; re-apply the user's cached position after the reflow.
+    if (!container.__lope_resize_bound) {
+      container.__lope_resize_bound = true;
+      container.on('resize', () => {
+        const rk = scrollKeyFor(container);
+        const cached = scroll_cache.get(rk);
+        if (!cached || cached.scrollTop == null)
+          return;
+        const c_el = container.getElement();
+        const at = Date.now();
+        scroll_cache.__reflowUntil = at + 800;
+        // The reflow can shift scrollTop in several passes (content relayout
+        // settles ~300ms later), so re-apply over a window. Bail if the user scrolls.
+        const apply = () => {
+          if ((c_el.__lope_user_scroll_at || 0) > at)
+            return;
+          if (c_el.scrollTop !== cached.scrollTop)
+            c_el.scrollTop = cached.scrollTop;
+          if (cached.scrollLeft != null && c_el.scrollLeft !== cached.scrollLeft)
+            c_el.scrollLeft = cached.scrollLeft;
+        };
+        requestAnimationFrame(apply);
+        for (const d of [
+            60,
+            150,
+            300,
+            450,
+            600
+          ])
+          setTimeout(apply, d);
+        appendScrollLog('scroll:resize_restore', {
+          k: rk,
+          title: container?.title ?? null,
+          scrollTop: cached.scrollTop
+        });
+      });
+    }
+    appendScrollLog('modulePanel:exit', {
+      title: container?.title ?? null,
+      scrollKey
+    });
+  };
 };
 const _1gm4gbf = function _blobPanel(){return(
 function (container, component) {
@@ -14286,112 +14344,115 @@ const _1d1nkw9 = function _scrollKeyFor(appendScrollLog)
 const _tb217h = function _scroll_cache(){return(
 new Map()
 )};
-const _5tyvpe = function _fix_scroll(scrollKeyFor,appendScrollLog,scroll_cache){return(
-function (container, node, cell_variable, key) {
+const _12p8mg7 = function _fix_scroll(scroll_cache,scrollKeyFor,appendScrollLog)
+{
+  return function (container, node, cell_variable, key) {
+    scroll_cache.__reflowUntil = Date.now() + 600;
+    // suppress reflow-induced scroll events that clobber the cache
     const c_element = container.getElement();
     let k = scrollKeyFor(container);
     appendScrollLog('fix_scroll:enter', {
-        title: container?.title ?? null,
-        k,
-        cell: cell_variable?._name ?? null
+      title: container?.title ?? null,
+      k,
+      cell: cell_variable?._name ?? null
     });
     if (node && node.parentNode !== c_element) {
-        c_element.appendChild(node);
-        appendScrollLog('fix_scroll:append_node', {
-            title: container?.title ?? null,
-            k
-        });
+      c_element.appendChild(node);
+      appendScrollLog('fix_scroll:append_node', {
+        title: container?.title ?? null,
+        k
+      });
     }
     const writeCache = (scrollTop, scrollLeft, why) => {
-        scroll_cache.set(k, {
-            scrollTop,
-            scrollLeft,
-            t: Date.now()
-        });
-        appendScrollLog('scroll_cache:write', {
-            k,
-            scrollTop,
-            scrollLeft,
-            why
-        });
+      scroll_cache.set(k, {
+        scrollTop,
+        scrollLeft,
+        t: Date.now()
+      });
+      appendScrollLog('scroll_cache:write', {
+        k,
+        scrollTop,
+        scrollLeft,
+        why
+      });
     };
     const scrollToCellIfPossible = why => {
-        if (!cell_variable)
-            return false;
-        const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
-        if (!dom) {
-            appendScrollLog('scroll:cell_dom_not_found', {
-                k,
-                why,
-                cell: cell_variable?._name ?? null
-            });
-            return false;
-        }
-        const top = dom.offsetTop - c_element.offsetTop;
-        const left = c_element.scrollLeft;
-        c_element.scrollTop = top;
-        appendScrollLog('scroll:set', {
-            k,
-            why: `${ why }:cell`,
-            scrollTop: top,
-            scrollLeft: left,
-            cell: cell_variable?._name ?? null
+      if (!cell_variable)
+        return false;
+      const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
+      if (!dom) {
+        appendScrollLog('scroll:cell_dom_not_found', {
+          k,
+          why,
+          cell: cell_variable?._name ?? null
         });
-        writeCache(top, left, `${ why }:cell`);
-        return true;
+        return false;
+      }
+      const top = dom.offsetTop - c_element.offsetTop;
+      const left = c_element.scrollLeft;
+      c_element.scrollTop = top;
+      appendScrollLog('scroll:set', {
+        k,
+        why: `${ why }:cell`,
+        scrollTop: top,
+        scrollLeft: left,
+        cell: cell_variable?._name ?? null
+      });
+      writeCache(top, left, `${ why }:cell`);
+      return true;
     };
     const restoreFromCache = why => {
-        k = scrollKeyFor(container);
-        const cached = scroll_cache.get(k);
-        appendScrollLog('scroll:restore_attempt', {
-            k,
-            why,
-            cachedScrollTop: cached?.scrollTop ?? null,
-            cachedScrollLeft: cached?.scrollLeft ?? null
+      k = scrollKeyFor(container);
+      const cached = scroll_cache.get(k);
+      appendScrollLog('scroll:restore_attempt', {
+        k,
+        why,
+        cachedScrollTop: cached?.scrollTop ?? null,
+        cachedScrollLeft: cached?.scrollLeft ?? null
+      });
+      if (!cached) {
+        appendScrollLog('scroll:restore_no_scroll', {
+          k,
+          why
         });
-        if (!cached) {
-            appendScrollLog('scroll:restore_no_scroll', {
-                k,
-                why
-            });
-            return;
-        }
-        if (cached.scrollTop != null)
-            c_element.scrollTop = cached.scrollTop;
-        if (cached.scrollLeft != null)
-            c_element.scrollLeft = cached.scrollLeft;
-        appendScrollLog('scroll:restore_applied', {
-            k,
-            why,
-            scrollTop: cached.scrollTop ?? null,
-            scrollLeft: cached.scrollLeft ?? null,
-            scrollTopFinal: c_element.scrollTop,
-            scrollLeftFinal: c_element.scrollLeft
-        });
+        return;
+      }
+      if (cached.scrollTop != null)
+        c_element.scrollTop = cached.scrollTop;
+      if (cached.scrollLeft != null)
+        c_element.scrollLeft = cached.scrollLeft;
+      appendScrollLog('scroll:restore_applied', {
+        k,
+        why,
+        scrollTop: cached.scrollTop ?? null,
+        scrollLeft: cached.scrollLeft ?? null,
+        scrollTopFinal: c_element.scrollTop,
+        scrollLeftFinal: c_element.scrollLeft
+      });
     };
     const setScroll = (why = 'setScroll') => {
-        if (scrollToCellIfPossible(why))
-            return;
-        restoreFromCache(why);
+      if (scrollToCellIfPossible(why))
+        return;
+      restoreFromCache(why);
     };
     const retryFrames = 6;
     for (let i = 0; i < retryFrames; i++) {
-        requestAnimationFrame(() => {
-            k = scrollKeyFor(container);
-            appendScrollLog('fix_scroll:raf_retry', {
-                i,
-                k,
-                title: container?.title ?? null
-            });
-            setScroll(`raf:${ i }`);
+      requestAnimationFrame(() => {
+        k = scrollKeyFor(container);
+        appendScrollLog('fix_scroll:raf_retry', {
+          i,
+          k,
+          title: container?.title ?? null
         });
+        setScroll(`raf:${ i }`);
+      });
     }
     appendScrollLog('fix_scroll:exit', {
-        k,
-        title: container?.title ?? null
+      k,
+      title: container?.title ?? null
     });
-}
-)};
+  };
+};
 const _arfw00 = function _scroll_fix_sync_layout(sync_layout_to_url,layout,appendScrollLog,modulePanel)
 {
     sync_layout_to_url;
@@ -15469,7 +15530,7 @@ export default function define(runtime, observer) {
   $def("_1we0ggl", "reload", ["Generators","viewof reload"], _1we0ggl);  
   $def("_plefwg", "onLoadConfig", ["parseGoldenDSL","URLSearchParams","location"], _plefwg);  
   $def("_1nzpnqy", "visualizer_cache", ["reload"], _1nzpnqy);  
-  $def("_1l35721", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1l35721);  
+  $def("_1ojown8", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1ojown8);  
   $def("_1gm4gbf", "blobPanel", [], _1gm4gbf);  
   $def("_lxv2e2", "settings", [], _lxv2e2);  
   $def("_lp1ggk", "is_mobile", ["width"], _lp1ggk);  
@@ -15490,7 +15551,7 @@ export default function define(runtime, observer) {
   $def("_1dyz4o0", "scrollLog", ["mutable scrollLog"], _1dyz4o0);  
   $def("_1d1nkw9", "scrollKeyFor", ["appendScrollLog"], _1d1nkw9);  
   $def("_tb217h", "scroll_cache", [], _tb217h);  
-  $def("_5tyvpe", "fix_scroll", ["scrollKeyFor","appendScrollLog","scroll_cache"], _5tyvpe);  
+  $def("_12p8mg7", "fix_scroll", ["scroll_cache","scrollKeyFor","appendScrollLog"], _12p8mg7);  
   $def("_arfw00", "scroll_fix_sync_layout", ["sync_layout_to_url","layout","appendScrollLog","modulePanel"], _arfw00);  
   $def("_3nwpp4", "URLrouting", ["md"], _3nwpp4);  
   $def("_14te9pl", "sync_layout_from_url", ["reload","resize","URLSearchParams","hash","appendScrollLog","parseGoldenDSL","gl","layout","serializeGoldenDSL","treeSyncGolden","invalidation"], _14te9pl);  

--- a/notebooks/@tomlarkworthy_codemirror-6-v2.html
+++ b/notebooks/@tomlarkworthy_codemirror-6-v2.html
@@ -14037,138 +14037,196 @@ const _1nzpnqy = function _visualizer_cache(reload)
     reload;
     return new Map();
 };
-const _1l35721 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
+const _1ojown8 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
 {
-    return function (container, component) {
-        appendScrollLog('modulePanel:enter', {
-            title: container?.title ?? null,
-            componentCell: component?.cell ?? null
-        });
-        const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
-        if (!moduleInfo) {
-            // Fall through to file attachment: titles like @user/notebook/path.ext
-            // resolve via the lopecode bootloader's contentSync DOM lookup.
-            const title = container?.title ?? null;
-            if (title) {
-                let node = file_attachment_cache.get(title);
-                if (!node) {
-                    const r = window.lopecode?.contentSync?.(title);
-                    if (r && r.status === 200 && r.bytes) {
-                        node = renderFileAttachment(r.mime, r.bytes);
-                        file_attachment_cache.set(title, node);
-                        appendScrollLog('modulePanel:file_attachment_create', {
-                            title,
-                            mime: r.mime
-                        });
-                    }
-                }
-                if (node) {
-                    const c_element = container.getElement();
-                    if (node.parentNode !== c_element)
-                        c_element.appendChild(node);
-                    appendScrollLog('modulePanel:file_attachment_mount', { title });
-                    return;
-                }
-            }
-            appendScrollLog('modulePanel:missing_moduleInfo', { title });
-            return;
-        }
-        const module = moduleInfo.module;
-        let node;
-        if (!visualizer_cache.has(module)) {
-            appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
-            node = visualizer(runtime, {
-                invalidation: new Promise(r => {
-                }),
-                module,
-                detachNodes: isOnObservableCom(),
-                filter: (cell_name, variables) => {
-                    if (variables[0]._type !== 1)
-                        return false;
-                    if (typeof cell_name == 'string') {
-                        if (cell_name.startsWith('dynamic '))
-                            return false;
-                    }
-                    return true;
-                }
+  return function (container, component) {
+    appendScrollLog('modulePanel:enter', {
+      title: container?.title ?? null,
+      componentCell: component?.cell ?? null
+    });
+    const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
+    if (!moduleInfo) {
+      // Fall through to file attachment: titles like @user/notebook/path.ext
+      // resolve via the lopecode bootloader's contentSync DOM lookup.
+      const title = container?.title ?? null;
+      if (title) {
+        let node = file_attachment_cache.get(title);
+        if (!node) {
+          const r = window.lopecode?.contentSync?.(title);
+          if (r && r.status === 200 && r.bytes) {
+            node = renderFileAttachment(r.mime, r.bytes);
+            file_attachment_cache.set(title, node);
+            appendScrollLog('modulePanel:file_attachment_create', {
+              title,
+              mime: r.mime
             });
-            visualizer_cache.set(module, node);
-        } else {
-            node = visualizer_cache.get(module);
-            appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+          }
         }
-        const cell = module._scope.get(component.cell);
-        const scrollKey = scrollKeyFor(container);
-        fix_scroll(container, node, cell, scrollKey);
-        const el = container.getElement();
-        if (!el.__lope_scroll_bound) {
-            el.__lope_scroll_bound = true;
-            appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
-            el.addEventListener('scroll', () => {
-                const k = scrollKeyFor(container);
-                const scrollTop = el.scrollTop;
-                const scrollLeft = el.scrollLeft;
-                if (scrollTop == 0) {
-                    appendScrollLog('modulePanel:skip 0 scroll', {
-                        title: container?.title ?? null,
-                        scrollKey
-                    });
-                    return;
-                }
-                scroll_cache.set(k, {
-                    scrollTop,
-                    scrollLeft,
-                    t: Date.now()
-                });
-                appendScrollLog('scroll:event', {
-                    k,
-                    title: container?.title ?? null,
-                    scrollTop,
-                    scrollLeft
-                });
-            }, { passive: true });
+        if (node) {
+          const c_element = container.getElement();
+          if (node.parentNode !== c_element)
+            c_element.appendChild(node);
+          appendScrollLog('modulePanel:file_attachment_mount', { title });
+          return;
         }
-        // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
-        if (!container.__lope_destroy_bound) {
-            container.__lope_destroy_bound = true;
-            container.on('destroy', () => {
-                try {
-                    const k = scrollKeyFor(container);
-                    const scrollTop = el?.scrollTop;
-                    const scrollLeft = el?.scrollLeft;
-                    if (scrollTop == 0) {
-                        appendScrollLog('scroll:skip 0 scroll', {
-                            k,
-                            key: container?.title ?? null,
-                            scrollKey
-                        });
-                        return;
-                    }
-                    // do not skip 0 here: if the user is at top, preserve that state
-                    scroll_cache.set(k, {
-                        scrollTop,
-                        scrollLeft,
-                        t: Date.now()
-                    });
-                    appendScrollLog('scroll:destroy_capture', {
-                        k,
-                        title: container?.title ?? null,
-                        scrollTop,
-                        scrollLeft
-                    });
-                } catch (e) {
-                    appendScrollLog('scroll:destroy_capture:error', {
-                        title: container?.title ?? null,
-                        error: String(e)
-                    });
-                }
-            });
+      }
+      appendScrollLog('modulePanel:missing_moduleInfo', { title });
+      return;
+    }
+    const module = moduleInfo.module;
+    let node;
+    if (!visualizer_cache.has(module)) {
+      appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
+      node = visualizer(runtime, {
+        invalidation: new Promise(r => {
+        }),
+        module,
+        detachNodes: isOnObservableCom(),
+        filter: (cell_name, variables) => {
+          if (variables[0]._type !== 1)
+            return false;
+          if (typeof cell_name == 'string') {
+            if (cell_name.startsWith('dynamic '))
+              return false;
+          }
+          return true;
         }
-        appendScrollLog('modulePanel:exit', {
+      });
+      visualizer_cache.set(module, node);
+    } else {
+      node = visualizer_cache.get(module);
+      appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+    }
+    const cell = module._scope.get(component.cell);
+    const scrollKey = scrollKeyFor(container);
+    fix_scroll(container, node, cell, scrollKey);
+    const el = container.getElement();
+    if (!el.__lope_scroll_bound) {
+      el.__lope_scroll_bound = true;
+      appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
+      const markUserScroll = () => {
+        el.__lope_user_scroll_at = Date.now();
+      };
+      el.addEventListener('wheel', markUserScroll, { passive: true });
+      el.addEventListener('touchmove', markUserScroll, { passive: true });
+      el.addEventListener('keydown', markUserScroll, { passive: true });
+      el.addEventListener('scroll', () => {
+        if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+          appendScrollLog('scroll:skip_reflow', { title: container?.title ?? null });
+          return;
+        }
+        // Only cache scrolls following a genuine user gesture; reflow-induced
+        // scroll events (e.g. closing an adjacent panel) carry stale scrollTops.
+        if (Date.now() - (el.__lope_user_scroll_at || 0) > 400) {
+          appendScrollLog('scroll:skip_nonuser', { title: container?.title ?? null });
+          return;
+        }
+        const k = scrollKeyFor(container);
+        const scrollTop = el.scrollTop;
+        const scrollLeft = el.scrollLeft;
+        if (scrollTop == 0) {
+          appendScrollLog('modulePanel:skip 0 scroll', {
             title: container?.title ?? null,
             scrollKey
+          });
+          return;
+        }
+        scroll_cache.set(k, {
+          scrollTop,
+          scrollLeft,
+          t: Date.now()
         });
-    };
+        appendScrollLog('scroll:event', {
+          k,
+          title: container?.title ?? null,
+          scrollTop,
+          scrollLeft
+        });
+      }, { passive: true });
+    }
+    // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
+    if (!container.__lope_destroy_bound) {
+      container.__lope_destroy_bound = true;
+      container.on('destroy', () => {
+        try {
+          if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+            appendScrollLog('scroll:destroy_skip_reflow', { title: container?.title ?? null });
+            return;
+          }
+          const k = scrollKeyFor(container);
+          const scrollTop = el?.scrollTop;
+          const scrollLeft = el?.scrollLeft;
+          if (scrollTop == 0) {
+            appendScrollLog('scroll:skip 0 scroll', {
+              k,
+              key: container?.title ?? null,
+              scrollKey
+            });
+            return;
+          }
+          // do not skip 0 here: if the user is at top, preserve that state
+          scroll_cache.set(k, {
+            scrollTop,
+            scrollLeft,
+            t: Date.now()
+          });
+          appendScrollLog('scroll:destroy_capture', {
+            k,
+            title: container?.title ?? null,
+            scrollTop,
+            scrollLeft
+          });
+        } catch (e) {
+          appendScrollLog('scroll:destroy_capture:error', {
+            title: container?.title ?? null,
+            error: String(e)
+          });
+        }
+      });
+    }
+    // When GoldenLayout resizes this panel (e.g. an adjacent panel is closed) the
+    // browser can shift scrollTop; re-apply the user's cached position after the reflow.
+    if (!container.__lope_resize_bound) {
+      container.__lope_resize_bound = true;
+      container.on('resize', () => {
+        const rk = scrollKeyFor(container);
+        const cached = scroll_cache.get(rk);
+        if (!cached || cached.scrollTop == null)
+          return;
+        const c_el = container.getElement();
+        const at = Date.now();
+        scroll_cache.__reflowUntil = at + 800;
+        // The reflow can shift scrollTop in several passes (content relayout
+        // settles ~300ms later), so re-apply over a window. Bail if the user scrolls.
+        const apply = () => {
+          if ((c_el.__lope_user_scroll_at || 0) > at)
+            return;
+          if (c_el.scrollTop !== cached.scrollTop)
+            c_el.scrollTop = cached.scrollTop;
+          if (cached.scrollLeft != null && c_el.scrollLeft !== cached.scrollLeft)
+            c_el.scrollLeft = cached.scrollLeft;
+        };
+        requestAnimationFrame(apply);
+        for (const d of [
+            60,
+            150,
+            300,
+            450,
+            600
+          ])
+          setTimeout(apply, d);
+        appendScrollLog('scroll:resize_restore', {
+          k: rk,
+          title: container?.title ?? null,
+          scrollTop: cached.scrollTop
+        });
+      });
+    }
+    appendScrollLog('modulePanel:exit', {
+      title: container?.title ?? null,
+      scrollKey
+    });
+  };
 };
 const _1gm4gbf = function _blobPanel(){return(
 function (container, component) {
@@ -14286,112 +14344,115 @@ const _1d1nkw9 = function _scrollKeyFor(appendScrollLog)
 const _tb217h = function _scroll_cache(){return(
 new Map()
 )};
-const _5tyvpe = function _fix_scroll(scrollKeyFor,appendScrollLog,scroll_cache){return(
-function (container, node, cell_variable, key) {
+const _12p8mg7 = function _fix_scroll(scroll_cache,scrollKeyFor,appendScrollLog)
+{
+  return function (container, node, cell_variable, key) {
+    scroll_cache.__reflowUntil = Date.now() + 600;
+    // suppress reflow-induced scroll events that clobber the cache
     const c_element = container.getElement();
     let k = scrollKeyFor(container);
     appendScrollLog('fix_scroll:enter', {
-        title: container?.title ?? null,
-        k,
-        cell: cell_variable?._name ?? null
+      title: container?.title ?? null,
+      k,
+      cell: cell_variable?._name ?? null
     });
     if (node && node.parentNode !== c_element) {
-        c_element.appendChild(node);
-        appendScrollLog('fix_scroll:append_node', {
-            title: container?.title ?? null,
-            k
-        });
+      c_element.appendChild(node);
+      appendScrollLog('fix_scroll:append_node', {
+        title: container?.title ?? null,
+        k
+      });
     }
     const writeCache = (scrollTop, scrollLeft, why) => {
-        scroll_cache.set(k, {
-            scrollTop,
-            scrollLeft,
-            t: Date.now()
-        });
-        appendScrollLog('scroll_cache:write', {
-            k,
-            scrollTop,
-            scrollLeft,
-            why
-        });
+      scroll_cache.set(k, {
+        scrollTop,
+        scrollLeft,
+        t: Date.now()
+      });
+      appendScrollLog('scroll_cache:write', {
+        k,
+        scrollTop,
+        scrollLeft,
+        why
+      });
     };
     const scrollToCellIfPossible = why => {
-        if (!cell_variable)
-            return false;
-        const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
-        if (!dom) {
-            appendScrollLog('scroll:cell_dom_not_found', {
-                k,
-                why,
-                cell: cell_variable?._name ?? null
-            });
-            return false;
-        }
-        const top = dom.offsetTop - c_element.offsetTop;
-        const left = c_element.scrollLeft;
-        c_element.scrollTop = top;
-        appendScrollLog('scroll:set', {
-            k,
-            why: `${ why }:cell`,
-            scrollTop: top,
-            scrollLeft: left,
-            cell: cell_variable?._name ?? null
+      if (!cell_variable)
+        return false;
+      const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
+      if (!dom) {
+        appendScrollLog('scroll:cell_dom_not_found', {
+          k,
+          why,
+          cell: cell_variable?._name ?? null
         });
-        writeCache(top, left, `${ why }:cell`);
-        return true;
+        return false;
+      }
+      const top = dom.offsetTop - c_element.offsetTop;
+      const left = c_element.scrollLeft;
+      c_element.scrollTop = top;
+      appendScrollLog('scroll:set', {
+        k,
+        why: `${ why }:cell`,
+        scrollTop: top,
+        scrollLeft: left,
+        cell: cell_variable?._name ?? null
+      });
+      writeCache(top, left, `${ why }:cell`);
+      return true;
     };
     const restoreFromCache = why => {
-        k = scrollKeyFor(container);
-        const cached = scroll_cache.get(k);
-        appendScrollLog('scroll:restore_attempt', {
-            k,
-            why,
-            cachedScrollTop: cached?.scrollTop ?? null,
-            cachedScrollLeft: cached?.scrollLeft ?? null
+      k = scrollKeyFor(container);
+      const cached = scroll_cache.get(k);
+      appendScrollLog('scroll:restore_attempt', {
+        k,
+        why,
+        cachedScrollTop: cached?.scrollTop ?? null,
+        cachedScrollLeft: cached?.scrollLeft ?? null
+      });
+      if (!cached) {
+        appendScrollLog('scroll:restore_no_scroll', {
+          k,
+          why
         });
-        if (!cached) {
-            appendScrollLog('scroll:restore_no_scroll', {
-                k,
-                why
-            });
-            return;
-        }
-        if (cached.scrollTop != null)
-            c_element.scrollTop = cached.scrollTop;
-        if (cached.scrollLeft != null)
-            c_element.scrollLeft = cached.scrollLeft;
-        appendScrollLog('scroll:restore_applied', {
-            k,
-            why,
-            scrollTop: cached.scrollTop ?? null,
-            scrollLeft: cached.scrollLeft ?? null,
-            scrollTopFinal: c_element.scrollTop,
-            scrollLeftFinal: c_element.scrollLeft
-        });
+        return;
+      }
+      if (cached.scrollTop != null)
+        c_element.scrollTop = cached.scrollTop;
+      if (cached.scrollLeft != null)
+        c_element.scrollLeft = cached.scrollLeft;
+      appendScrollLog('scroll:restore_applied', {
+        k,
+        why,
+        scrollTop: cached.scrollTop ?? null,
+        scrollLeft: cached.scrollLeft ?? null,
+        scrollTopFinal: c_element.scrollTop,
+        scrollLeftFinal: c_element.scrollLeft
+      });
     };
     const setScroll = (why = 'setScroll') => {
-        if (scrollToCellIfPossible(why))
-            return;
-        restoreFromCache(why);
+      if (scrollToCellIfPossible(why))
+        return;
+      restoreFromCache(why);
     };
     const retryFrames = 6;
     for (let i = 0; i < retryFrames; i++) {
-        requestAnimationFrame(() => {
-            k = scrollKeyFor(container);
-            appendScrollLog('fix_scroll:raf_retry', {
-                i,
-                k,
-                title: container?.title ?? null
-            });
-            setScroll(`raf:${ i }`);
+      requestAnimationFrame(() => {
+        k = scrollKeyFor(container);
+        appendScrollLog('fix_scroll:raf_retry', {
+          i,
+          k,
+          title: container?.title ?? null
         });
+        setScroll(`raf:${ i }`);
+      });
     }
     appendScrollLog('fix_scroll:exit', {
-        k,
-        title: container?.title ?? null
+      k,
+      title: container?.title ?? null
     });
-}
-)};
+  };
+};
 const _arfw00 = function _scroll_fix_sync_layout(sync_layout_to_url,layout,appendScrollLog,modulePanel)
 {
     sync_layout_to_url;
@@ -15469,7 +15530,7 @@ export default function define(runtime, observer) {
   $def("_1we0ggl", "reload", ["Generators","viewof reload"], _1we0ggl);  
   $def("_plefwg", "onLoadConfig", ["parseGoldenDSL","URLSearchParams","location"], _plefwg);  
   $def("_1nzpnqy", "visualizer_cache", ["reload"], _1nzpnqy);  
-  $def("_1l35721", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1l35721);  
+  $def("_1ojown8", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1ojown8);  
   $def("_1gm4gbf", "blobPanel", [], _1gm4gbf);  
   $def("_lxv2e2", "settings", [], _lxv2e2);  
   $def("_lp1ggk", "is_mobile", ["width"], _lp1ggk);  
@@ -15490,7 +15551,7 @@ export default function define(runtime, observer) {
   $def("_1dyz4o0", "scrollLog", ["mutable scrollLog"], _1dyz4o0);  
   $def("_1d1nkw9", "scrollKeyFor", ["appendScrollLog"], _1d1nkw9);  
   $def("_tb217h", "scroll_cache", [], _tb217h);  
-  $def("_5tyvpe", "fix_scroll", ["scrollKeyFor","appendScrollLog","scroll_cache"], _5tyvpe);  
+  $def("_12p8mg7", "fix_scroll", ["scroll_cache","scrollKeyFor","appendScrollLog"], _12p8mg7);  
   $def("_arfw00", "scroll_fix_sync_layout", ["sync_layout_to_url","layout","appendScrollLog","modulePanel"], _arfw00);  
   $def("_3nwpp4", "URLrouting", ["md"], _3nwpp4);  
   $def("_14te9pl", "sync_layout_from_url", ["reload","resize","URLSearchParams","hash","appendScrollLog","parseGoldenDSL","gl","layout","serializeGoldenDSL","treeSyncGolden","invalidation"], _14te9pl);  

--- a/notebooks/@tomlarkworthy_command-palette.html
+++ b/notebooks/@tomlarkworthy_command-palette.html
@@ -14037,138 +14037,196 @@ const _1nzpnqy = function _visualizer_cache(reload)
     reload;
     return new Map();
 };
-const _1l35721 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
+const _1ojown8 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
 {
-    return function (container, component) {
-        appendScrollLog('modulePanel:enter', {
-            title: container?.title ?? null,
-            componentCell: component?.cell ?? null
-        });
-        const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
-        if (!moduleInfo) {
-            // Fall through to file attachment: titles like @user/notebook/path.ext
-            // resolve via the lopecode bootloader's contentSync DOM lookup.
-            const title = container?.title ?? null;
-            if (title) {
-                let node = file_attachment_cache.get(title);
-                if (!node) {
-                    const r = window.lopecode?.contentSync?.(title);
-                    if (r && r.status === 200 && r.bytes) {
-                        node = renderFileAttachment(r.mime, r.bytes);
-                        file_attachment_cache.set(title, node);
-                        appendScrollLog('modulePanel:file_attachment_create', {
-                            title,
-                            mime: r.mime
-                        });
-                    }
-                }
-                if (node) {
-                    const c_element = container.getElement();
-                    if (node.parentNode !== c_element)
-                        c_element.appendChild(node);
-                    appendScrollLog('modulePanel:file_attachment_mount', { title });
-                    return;
-                }
-            }
-            appendScrollLog('modulePanel:missing_moduleInfo', { title });
-            return;
-        }
-        const module = moduleInfo.module;
-        let node;
-        if (!visualizer_cache.has(module)) {
-            appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
-            node = visualizer(runtime, {
-                invalidation: new Promise(r => {
-                }),
-                module,
-                detachNodes: isOnObservableCom(),
-                filter: (cell_name, variables) => {
-                    if (variables[0]._type !== 1)
-                        return false;
-                    if (typeof cell_name == 'string') {
-                        if (cell_name.startsWith('dynamic '))
-                            return false;
-                    }
-                    return true;
-                }
+  return function (container, component) {
+    appendScrollLog('modulePanel:enter', {
+      title: container?.title ?? null,
+      componentCell: component?.cell ?? null
+    });
+    const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
+    if (!moduleInfo) {
+      // Fall through to file attachment: titles like @user/notebook/path.ext
+      // resolve via the lopecode bootloader's contentSync DOM lookup.
+      const title = container?.title ?? null;
+      if (title) {
+        let node = file_attachment_cache.get(title);
+        if (!node) {
+          const r = window.lopecode?.contentSync?.(title);
+          if (r && r.status === 200 && r.bytes) {
+            node = renderFileAttachment(r.mime, r.bytes);
+            file_attachment_cache.set(title, node);
+            appendScrollLog('modulePanel:file_attachment_create', {
+              title,
+              mime: r.mime
             });
-            visualizer_cache.set(module, node);
-        } else {
-            node = visualizer_cache.get(module);
-            appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+          }
         }
-        const cell = module._scope.get(component.cell);
-        const scrollKey = scrollKeyFor(container);
-        fix_scroll(container, node, cell, scrollKey);
-        const el = container.getElement();
-        if (!el.__lope_scroll_bound) {
-            el.__lope_scroll_bound = true;
-            appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
-            el.addEventListener('scroll', () => {
-                const k = scrollKeyFor(container);
-                const scrollTop = el.scrollTop;
-                const scrollLeft = el.scrollLeft;
-                if (scrollTop == 0) {
-                    appendScrollLog('modulePanel:skip 0 scroll', {
-                        title: container?.title ?? null,
-                        scrollKey
-                    });
-                    return;
-                }
-                scroll_cache.set(k, {
-                    scrollTop,
-                    scrollLeft,
-                    t: Date.now()
-                });
-                appendScrollLog('scroll:event', {
-                    k,
-                    title: container?.title ?? null,
-                    scrollTop,
-                    scrollLeft
-                });
-            }, { passive: true });
+        if (node) {
+          const c_element = container.getElement();
+          if (node.parentNode !== c_element)
+            c_element.appendChild(node);
+          appendScrollLog('modulePanel:file_attachment_mount', { title });
+          return;
         }
-        // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
-        if (!container.__lope_destroy_bound) {
-            container.__lope_destroy_bound = true;
-            container.on('destroy', () => {
-                try {
-                    const k = scrollKeyFor(container);
-                    const scrollTop = el?.scrollTop;
-                    const scrollLeft = el?.scrollLeft;
-                    if (scrollTop == 0) {
-                        appendScrollLog('scroll:skip 0 scroll', {
-                            k,
-                            key: container?.title ?? null,
-                            scrollKey
-                        });
-                        return;
-                    }
-                    // do not skip 0 here: if the user is at top, preserve that state
-                    scroll_cache.set(k, {
-                        scrollTop,
-                        scrollLeft,
-                        t: Date.now()
-                    });
-                    appendScrollLog('scroll:destroy_capture', {
-                        k,
-                        title: container?.title ?? null,
-                        scrollTop,
-                        scrollLeft
-                    });
-                } catch (e) {
-                    appendScrollLog('scroll:destroy_capture:error', {
-                        title: container?.title ?? null,
-                        error: String(e)
-                    });
-                }
-            });
+      }
+      appendScrollLog('modulePanel:missing_moduleInfo', { title });
+      return;
+    }
+    const module = moduleInfo.module;
+    let node;
+    if (!visualizer_cache.has(module)) {
+      appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
+      node = visualizer(runtime, {
+        invalidation: new Promise(r => {
+        }),
+        module,
+        detachNodes: isOnObservableCom(),
+        filter: (cell_name, variables) => {
+          if (variables[0]._type !== 1)
+            return false;
+          if (typeof cell_name == 'string') {
+            if (cell_name.startsWith('dynamic '))
+              return false;
+          }
+          return true;
         }
-        appendScrollLog('modulePanel:exit', {
+      });
+      visualizer_cache.set(module, node);
+    } else {
+      node = visualizer_cache.get(module);
+      appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+    }
+    const cell = module._scope.get(component.cell);
+    const scrollKey = scrollKeyFor(container);
+    fix_scroll(container, node, cell, scrollKey);
+    const el = container.getElement();
+    if (!el.__lope_scroll_bound) {
+      el.__lope_scroll_bound = true;
+      appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
+      const markUserScroll = () => {
+        el.__lope_user_scroll_at = Date.now();
+      };
+      el.addEventListener('wheel', markUserScroll, { passive: true });
+      el.addEventListener('touchmove', markUserScroll, { passive: true });
+      el.addEventListener('keydown', markUserScroll, { passive: true });
+      el.addEventListener('scroll', () => {
+        if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+          appendScrollLog('scroll:skip_reflow', { title: container?.title ?? null });
+          return;
+        }
+        // Only cache scrolls following a genuine user gesture; reflow-induced
+        // scroll events (e.g. closing an adjacent panel) carry stale scrollTops.
+        if (Date.now() - (el.__lope_user_scroll_at || 0) > 400) {
+          appendScrollLog('scroll:skip_nonuser', { title: container?.title ?? null });
+          return;
+        }
+        const k = scrollKeyFor(container);
+        const scrollTop = el.scrollTop;
+        const scrollLeft = el.scrollLeft;
+        if (scrollTop == 0) {
+          appendScrollLog('modulePanel:skip 0 scroll', {
             title: container?.title ?? null,
             scrollKey
+          });
+          return;
+        }
+        scroll_cache.set(k, {
+          scrollTop,
+          scrollLeft,
+          t: Date.now()
         });
-    };
+        appendScrollLog('scroll:event', {
+          k,
+          title: container?.title ?? null,
+          scrollTop,
+          scrollLeft
+        });
+      }, { passive: true });
+    }
+    // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
+    if (!container.__lope_destroy_bound) {
+      container.__lope_destroy_bound = true;
+      container.on('destroy', () => {
+        try {
+          if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+            appendScrollLog('scroll:destroy_skip_reflow', { title: container?.title ?? null });
+            return;
+          }
+          const k = scrollKeyFor(container);
+          const scrollTop = el?.scrollTop;
+          const scrollLeft = el?.scrollLeft;
+          if (scrollTop == 0) {
+            appendScrollLog('scroll:skip 0 scroll', {
+              k,
+              key: container?.title ?? null,
+              scrollKey
+            });
+            return;
+          }
+          // do not skip 0 here: if the user is at top, preserve that state
+          scroll_cache.set(k, {
+            scrollTop,
+            scrollLeft,
+            t: Date.now()
+          });
+          appendScrollLog('scroll:destroy_capture', {
+            k,
+            title: container?.title ?? null,
+            scrollTop,
+            scrollLeft
+          });
+        } catch (e) {
+          appendScrollLog('scroll:destroy_capture:error', {
+            title: container?.title ?? null,
+            error: String(e)
+          });
+        }
+      });
+    }
+    // When GoldenLayout resizes this panel (e.g. an adjacent panel is closed) the
+    // browser can shift scrollTop; re-apply the user's cached position after the reflow.
+    if (!container.__lope_resize_bound) {
+      container.__lope_resize_bound = true;
+      container.on('resize', () => {
+        const rk = scrollKeyFor(container);
+        const cached = scroll_cache.get(rk);
+        if (!cached || cached.scrollTop == null)
+          return;
+        const c_el = container.getElement();
+        const at = Date.now();
+        scroll_cache.__reflowUntil = at + 800;
+        // The reflow can shift scrollTop in several passes (content relayout
+        // settles ~300ms later), so re-apply over a window. Bail if the user scrolls.
+        const apply = () => {
+          if ((c_el.__lope_user_scroll_at || 0) > at)
+            return;
+          if (c_el.scrollTop !== cached.scrollTop)
+            c_el.scrollTop = cached.scrollTop;
+          if (cached.scrollLeft != null && c_el.scrollLeft !== cached.scrollLeft)
+            c_el.scrollLeft = cached.scrollLeft;
+        };
+        requestAnimationFrame(apply);
+        for (const d of [
+            60,
+            150,
+            300,
+            450,
+            600
+          ])
+          setTimeout(apply, d);
+        appendScrollLog('scroll:resize_restore', {
+          k: rk,
+          title: container?.title ?? null,
+          scrollTop: cached.scrollTop
+        });
+      });
+    }
+    appendScrollLog('modulePanel:exit', {
+      title: container?.title ?? null,
+      scrollKey
+    });
+  };
 };
 const _1gm4gbf = function _blobPanel(){return(
 function (container, component) {
@@ -14286,112 +14344,115 @@ const _1d1nkw9 = function _scrollKeyFor(appendScrollLog)
 const _tb217h = function _scroll_cache(){return(
 new Map()
 )};
-const _5tyvpe = function _fix_scroll(scrollKeyFor,appendScrollLog,scroll_cache){return(
-function (container, node, cell_variable, key) {
+const _12p8mg7 = function _fix_scroll(scroll_cache,scrollKeyFor,appendScrollLog)
+{
+  return function (container, node, cell_variable, key) {
+    scroll_cache.__reflowUntil = Date.now() + 600;
+    // suppress reflow-induced scroll events that clobber the cache
     const c_element = container.getElement();
     let k = scrollKeyFor(container);
     appendScrollLog('fix_scroll:enter', {
-        title: container?.title ?? null,
-        k,
-        cell: cell_variable?._name ?? null
+      title: container?.title ?? null,
+      k,
+      cell: cell_variable?._name ?? null
     });
     if (node && node.parentNode !== c_element) {
-        c_element.appendChild(node);
-        appendScrollLog('fix_scroll:append_node', {
-            title: container?.title ?? null,
-            k
-        });
+      c_element.appendChild(node);
+      appendScrollLog('fix_scroll:append_node', {
+        title: container?.title ?? null,
+        k
+      });
     }
     const writeCache = (scrollTop, scrollLeft, why) => {
-        scroll_cache.set(k, {
-            scrollTop,
-            scrollLeft,
-            t: Date.now()
-        });
-        appendScrollLog('scroll_cache:write', {
-            k,
-            scrollTop,
-            scrollLeft,
-            why
-        });
+      scroll_cache.set(k, {
+        scrollTop,
+        scrollLeft,
+        t: Date.now()
+      });
+      appendScrollLog('scroll_cache:write', {
+        k,
+        scrollTop,
+        scrollLeft,
+        why
+      });
     };
     const scrollToCellIfPossible = why => {
-        if (!cell_variable)
-            return false;
-        const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
-        if (!dom) {
-            appendScrollLog('scroll:cell_dom_not_found', {
-                k,
-                why,
-                cell: cell_variable?._name ?? null
-            });
-            return false;
-        }
-        const top = dom.offsetTop - c_element.offsetTop;
-        const left = c_element.scrollLeft;
-        c_element.scrollTop = top;
-        appendScrollLog('scroll:set', {
-            k,
-            why: `${ why }:cell`,
-            scrollTop: top,
-            scrollLeft: left,
-            cell: cell_variable?._name ?? null
+      if (!cell_variable)
+        return false;
+      const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
+      if (!dom) {
+        appendScrollLog('scroll:cell_dom_not_found', {
+          k,
+          why,
+          cell: cell_variable?._name ?? null
         });
-        writeCache(top, left, `${ why }:cell`);
-        return true;
+        return false;
+      }
+      const top = dom.offsetTop - c_element.offsetTop;
+      const left = c_element.scrollLeft;
+      c_element.scrollTop = top;
+      appendScrollLog('scroll:set', {
+        k,
+        why: `${ why }:cell`,
+        scrollTop: top,
+        scrollLeft: left,
+        cell: cell_variable?._name ?? null
+      });
+      writeCache(top, left, `${ why }:cell`);
+      return true;
     };
     const restoreFromCache = why => {
-        k = scrollKeyFor(container);
-        const cached = scroll_cache.get(k);
-        appendScrollLog('scroll:restore_attempt', {
-            k,
-            why,
-            cachedScrollTop: cached?.scrollTop ?? null,
-            cachedScrollLeft: cached?.scrollLeft ?? null
+      k = scrollKeyFor(container);
+      const cached = scroll_cache.get(k);
+      appendScrollLog('scroll:restore_attempt', {
+        k,
+        why,
+        cachedScrollTop: cached?.scrollTop ?? null,
+        cachedScrollLeft: cached?.scrollLeft ?? null
+      });
+      if (!cached) {
+        appendScrollLog('scroll:restore_no_scroll', {
+          k,
+          why
         });
-        if (!cached) {
-            appendScrollLog('scroll:restore_no_scroll', {
-                k,
-                why
-            });
-            return;
-        }
-        if (cached.scrollTop != null)
-            c_element.scrollTop = cached.scrollTop;
-        if (cached.scrollLeft != null)
-            c_element.scrollLeft = cached.scrollLeft;
-        appendScrollLog('scroll:restore_applied', {
-            k,
-            why,
-            scrollTop: cached.scrollTop ?? null,
-            scrollLeft: cached.scrollLeft ?? null,
-            scrollTopFinal: c_element.scrollTop,
-            scrollLeftFinal: c_element.scrollLeft
-        });
+        return;
+      }
+      if (cached.scrollTop != null)
+        c_element.scrollTop = cached.scrollTop;
+      if (cached.scrollLeft != null)
+        c_element.scrollLeft = cached.scrollLeft;
+      appendScrollLog('scroll:restore_applied', {
+        k,
+        why,
+        scrollTop: cached.scrollTop ?? null,
+        scrollLeft: cached.scrollLeft ?? null,
+        scrollTopFinal: c_element.scrollTop,
+        scrollLeftFinal: c_element.scrollLeft
+      });
     };
     const setScroll = (why = 'setScroll') => {
-        if (scrollToCellIfPossible(why))
-            return;
-        restoreFromCache(why);
+      if (scrollToCellIfPossible(why))
+        return;
+      restoreFromCache(why);
     };
     const retryFrames = 6;
     for (let i = 0; i < retryFrames; i++) {
-        requestAnimationFrame(() => {
-            k = scrollKeyFor(container);
-            appendScrollLog('fix_scroll:raf_retry', {
-                i,
-                k,
-                title: container?.title ?? null
-            });
-            setScroll(`raf:${ i }`);
+      requestAnimationFrame(() => {
+        k = scrollKeyFor(container);
+        appendScrollLog('fix_scroll:raf_retry', {
+          i,
+          k,
+          title: container?.title ?? null
         });
+        setScroll(`raf:${ i }`);
+      });
     }
     appendScrollLog('fix_scroll:exit', {
-        k,
-        title: container?.title ?? null
+      k,
+      title: container?.title ?? null
     });
-}
-)};
+  };
+};
 const _arfw00 = function _scroll_fix_sync_layout(sync_layout_to_url,layout,appendScrollLog,modulePanel)
 {
     sync_layout_to_url;
@@ -15469,7 +15530,7 @@ export default function define(runtime, observer) {
   $def("_1we0ggl", "reload", ["Generators","viewof reload"], _1we0ggl);  
   $def("_plefwg", "onLoadConfig", ["parseGoldenDSL","URLSearchParams","location"], _plefwg);  
   $def("_1nzpnqy", "visualizer_cache", ["reload"], _1nzpnqy);  
-  $def("_1l35721", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1l35721);  
+  $def("_1ojown8", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1ojown8);  
   $def("_1gm4gbf", "blobPanel", [], _1gm4gbf);  
   $def("_lxv2e2", "settings", [], _lxv2e2);  
   $def("_lp1ggk", "is_mobile", ["width"], _lp1ggk);  
@@ -15490,7 +15551,7 @@ export default function define(runtime, observer) {
   $def("_1dyz4o0", "scrollLog", ["mutable scrollLog"], _1dyz4o0);  
   $def("_1d1nkw9", "scrollKeyFor", ["appendScrollLog"], _1d1nkw9);  
   $def("_tb217h", "scroll_cache", [], _tb217h);  
-  $def("_5tyvpe", "fix_scroll", ["scrollKeyFor","appendScrollLog","scroll_cache"], _5tyvpe);  
+  $def("_12p8mg7", "fix_scroll", ["scroll_cache","scrollKeyFor","appendScrollLog"], _12p8mg7);  
   $def("_arfw00", "scroll_fix_sync_layout", ["sync_layout_to_url","layout","appendScrollLog","modulePanel"], _arfw00);  
   $def("_3nwpp4", "URLrouting", ["md"], _3nwpp4);  
   $def("_14te9pl", "sync_layout_from_url", ["reload","resize","URLSearchParams","hash","appendScrollLog","parseGoldenDSL","gl","layout","serializeGoldenDSL","treeSyncGolden","invalidation"], _14te9pl);  

--- a/notebooks/@tomlarkworthy_dataflow-templating.html
+++ b/notebooks/@tomlarkworthy_dataflow-templating.html
@@ -14037,138 +14037,196 @@ const _1nzpnqy = function _visualizer_cache(reload)
     reload;
     return new Map();
 };
-const _1l35721 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
+const _1ojown8 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
 {
-    return function (container, component) {
-        appendScrollLog('modulePanel:enter', {
-            title: container?.title ?? null,
-            componentCell: component?.cell ?? null
-        });
-        const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
-        if (!moduleInfo) {
-            // Fall through to file attachment: titles like @user/notebook/path.ext
-            // resolve via the lopecode bootloader's contentSync DOM lookup.
-            const title = container?.title ?? null;
-            if (title) {
-                let node = file_attachment_cache.get(title);
-                if (!node) {
-                    const r = window.lopecode?.contentSync?.(title);
-                    if (r && r.status === 200 && r.bytes) {
-                        node = renderFileAttachment(r.mime, r.bytes);
-                        file_attachment_cache.set(title, node);
-                        appendScrollLog('modulePanel:file_attachment_create', {
-                            title,
-                            mime: r.mime
-                        });
-                    }
-                }
-                if (node) {
-                    const c_element = container.getElement();
-                    if (node.parentNode !== c_element)
-                        c_element.appendChild(node);
-                    appendScrollLog('modulePanel:file_attachment_mount', { title });
-                    return;
-                }
-            }
-            appendScrollLog('modulePanel:missing_moduleInfo', { title });
-            return;
-        }
-        const module = moduleInfo.module;
-        let node;
-        if (!visualizer_cache.has(module)) {
-            appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
-            node = visualizer(runtime, {
-                invalidation: new Promise(r => {
-                }),
-                module,
-                detachNodes: isOnObservableCom(),
-                filter: (cell_name, variables) => {
-                    if (variables[0]._type !== 1)
-                        return false;
-                    if (typeof cell_name == 'string') {
-                        if (cell_name.startsWith('dynamic '))
-                            return false;
-                    }
-                    return true;
-                }
+  return function (container, component) {
+    appendScrollLog('modulePanel:enter', {
+      title: container?.title ?? null,
+      componentCell: component?.cell ?? null
+    });
+    const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
+    if (!moduleInfo) {
+      // Fall through to file attachment: titles like @user/notebook/path.ext
+      // resolve via the lopecode bootloader's contentSync DOM lookup.
+      const title = container?.title ?? null;
+      if (title) {
+        let node = file_attachment_cache.get(title);
+        if (!node) {
+          const r = window.lopecode?.contentSync?.(title);
+          if (r && r.status === 200 && r.bytes) {
+            node = renderFileAttachment(r.mime, r.bytes);
+            file_attachment_cache.set(title, node);
+            appendScrollLog('modulePanel:file_attachment_create', {
+              title,
+              mime: r.mime
             });
-            visualizer_cache.set(module, node);
-        } else {
-            node = visualizer_cache.get(module);
-            appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+          }
         }
-        const cell = module._scope.get(component.cell);
-        const scrollKey = scrollKeyFor(container);
-        fix_scroll(container, node, cell, scrollKey);
-        const el = container.getElement();
-        if (!el.__lope_scroll_bound) {
-            el.__lope_scroll_bound = true;
-            appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
-            el.addEventListener('scroll', () => {
-                const k = scrollKeyFor(container);
-                const scrollTop = el.scrollTop;
-                const scrollLeft = el.scrollLeft;
-                if (scrollTop == 0) {
-                    appendScrollLog('modulePanel:skip 0 scroll', {
-                        title: container?.title ?? null,
-                        scrollKey
-                    });
-                    return;
-                }
-                scroll_cache.set(k, {
-                    scrollTop,
-                    scrollLeft,
-                    t: Date.now()
-                });
-                appendScrollLog('scroll:event', {
-                    k,
-                    title: container?.title ?? null,
-                    scrollTop,
-                    scrollLeft
-                });
-            }, { passive: true });
+        if (node) {
+          const c_element = container.getElement();
+          if (node.parentNode !== c_element)
+            c_element.appendChild(node);
+          appendScrollLog('modulePanel:file_attachment_mount', { title });
+          return;
         }
-        // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
-        if (!container.__lope_destroy_bound) {
-            container.__lope_destroy_bound = true;
-            container.on('destroy', () => {
-                try {
-                    const k = scrollKeyFor(container);
-                    const scrollTop = el?.scrollTop;
-                    const scrollLeft = el?.scrollLeft;
-                    if (scrollTop == 0) {
-                        appendScrollLog('scroll:skip 0 scroll', {
-                            k,
-                            key: container?.title ?? null,
-                            scrollKey
-                        });
-                        return;
-                    }
-                    // do not skip 0 here: if the user is at top, preserve that state
-                    scroll_cache.set(k, {
-                        scrollTop,
-                        scrollLeft,
-                        t: Date.now()
-                    });
-                    appendScrollLog('scroll:destroy_capture', {
-                        k,
-                        title: container?.title ?? null,
-                        scrollTop,
-                        scrollLeft
-                    });
-                } catch (e) {
-                    appendScrollLog('scroll:destroy_capture:error', {
-                        title: container?.title ?? null,
-                        error: String(e)
-                    });
-                }
-            });
+      }
+      appendScrollLog('modulePanel:missing_moduleInfo', { title });
+      return;
+    }
+    const module = moduleInfo.module;
+    let node;
+    if (!visualizer_cache.has(module)) {
+      appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
+      node = visualizer(runtime, {
+        invalidation: new Promise(r => {
+        }),
+        module,
+        detachNodes: isOnObservableCom(),
+        filter: (cell_name, variables) => {
+          if (variables[0]._type !== 1)
+            return false;
+          if (typeof cell_name == 'string') {
+            if (cell_name.startsWith('dynamic '))
+              return false;
+          }
+          return true;
         }
-        appendScrollLog('modulePanel:exit', {
+      });
+      visualizer_cache.set(module, node);
+    } else {
+      node = visualizer_cache.get(module);
+      appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+    }
+    const cell = module._scope.get(component.cell);
+    const scrollKey = scrollKeyFor(container);
+    fix_scroll(container, node, cell, scrollKey);
+    const el = container.getElement();
+    if (!el.__lope_scroll_bound) {
+      el.__lope_scroll_bound = true;
+      appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
+      const markUserScroll = () => {
+        el.__lope_user_scroll_at = Date.now();
+      };
+      el.addEventListener('wheel', markUserScroll, { passive: true });
+      el.addEventListener('touchmove', markUserScroll, { passive: true });
+      el.addEventListener('keydown', markUserScroll, { passive: true });
+      el.addEventListener('scroll', () => {
+        if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+          appendScrollLog('scroll:skip_reflow', { title: container?.title ?? null });
+          return;
+        }
+        // Only cache scrolls following a genuine user gesture; reflow-induced
+        // scroll events (e.g. closing an adjacent panel) carry stale scrollTops.
+        if (Date.now() - (el.__lope_user_scroll_at || 0) > 400) {
+          appendScrollLog('scroll:skip_nonuser', { title: container?.title ?? null });
+          return;
+        }
+        const k = scrollKeyFor(container);
+        const scrollTop = el.scrollTop;
+        const scrollLeft = el.scrollLeft;
+        if (scrollTop == 0) {
+          appendScrollLog('modulePanel:skip 0 scroll', {
             title: container?.title ?? null,
             scrollKey
+          });
+          return;
+        }
+        scroll_cache.set(k, {
+          scrollTop,
+          scrollLeft,
+          t: Date.now()
         });
-    };
+        appendScrollLog('scroll:event', {
+          k,
+          title: container?.title ?? null,
+          scrollTop,
+          scrollLeft
+        });
+      }, { passive: true });
+    }
+    // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
+    if (!container.__lope_destroy_bound) {
+      container.__lope_destroy_bound = true;
+      container.on('destroy', () => {
+        try {
+          if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+            appendScrollLog('scroll:destroy_skip_reflow', { title: container?.title ?? null });
+            return;
+          }
+          const k = scrollKeyFor(container);
+          const scrollTop = el?.scrollTop;
+          const scrollLeft = el?.scrollLeft;
+          if (scrollTop == 0) {
+            appendScrollLog('scroll:skip 0 scroll', {
+              k,
+              key: container?.title ?? null,
+              scrollKey
+            });
+            return;
+          }
+          // do not skip 0 here: if the user is at top, preserve that state
+          scroll_cache.set(k, {
+            scrollTop,
+            scrollLeft,
+            t: Date.now()
+          });
+          appendScrollLog('scroll:destroy_capture', {
+            k,
+            title: container?.title ?? null,
+            scrollTop,
+            scrollLeft
+          });
+        } catch (e) {
+          appendScrollLog('scroll:destroy_capture:error', {
+            title: container?.title ?? null,
+            error: String(e)
+          });
+        }
+      });
+    }
+    // When GoldenLayout resizes this panel (e.g. an adjacent panel is closed) the
+    // browser can shift scrollTop; re-apply the user's cached position after the reflow.
+    if (!container.__lope_resize_bound) {
+      container.__lope_resize_bound = true;
+      container.on('resize', () => {
+        const rk = scrollKeyFor(container);
+        const cached = scroll_cache.get(rk);
+        if (!cached || cached.scrollTop == null)
+          return;
+        const c_el = container.getElement();
+        const at = Date.now();
+        scroll_cache.__reflowUntil = at + 800;
+        // The reflow can shift scrollTop in several passes (content relayout
+        // settles ~300ms later), so re-apply over a window. Bail if the user scrolls.
+        const apply = () => {
+          if ((c_el.__lope_user_scroll_at || 0) > at)
+            return;
+          if (c_el.scrollTop !== cached.scrollTop)
+            c_el.scrollTop = cached.scrollTop;
+          if (cached.scrollLeft != null && c_el.scrollLeft !== cached.scrollLeft)
+            c_el.scrollLeft = cached.scrollLeft;
+        };
+        requestAnimationFrame(apply);
+        for (const d of [
+            60,
+            150,
+            300,
+            450,
+            600
+          ])
+          setTimeout(apply, d);
+        appendScrollLog('scroll:resize_restore', {
+          k: rk,
+          title: container?.title ?? null,
+          scrollTop: cached.scrollTop
+        });
+      });
+    }
+    appendScrollLog('modulePanel:exit', {
+      title: container?.title ?? null,
+      scrollKey
+    });
+  };
 };
 const _1gm4gbf = function _blobPanel(){return(
 function (container, component) {
@@ -14286,112 +14344,115 @@ const _1d1nkw9 = function _scrollKeyFor(appendScrollLog)
 const _tb217h = function _scroll_cache(){return(
 new Map()
 )};
-const _5tyvpe = function _fix_scroll(scrollKeyFor,appendScrollLog,scroll_cache){return(
-function (container, node, cell_variable, key) {
+const _12p8mg7 = function _fix_scroll(scroll_cache,scrollKeyFor,appendScrollLog)
+{
+  return function (container, node, cell_variable, key) {
+    scroll_cache.__reflowUntil = Date.now() + 600;
+    // suppress reflow-induced scroll events that clobber the cache
     const c_element = container.getElement();
     let k = scrollKeyFor(container);
     appendScrollLog('fix_scroll:enter', {
-        title: container?.title ?? null,
-        k,
-        cell: cell_variable?._name ?? null
+      title: container?.title ?? null,
+      k,
+      cell: cell_variable?._name ?? null
     });
     if (node && node.parentNode !== c_element) {
-        c_element.appendChild(node);
-        appendScrollLog('fix_scroll:append_node', {
-            title: container?.title ?? null,
-            k
-        });
+      c_element.appendChild(node);
+      appendScrollLog('fix_scroll:append_node', {
+        title: container?.title ?? null,
+        k
+      });
     }
     const writeCache = (scrollTop, scrollLeft, why) => {
-        scroll_cache.set(k, {
-            scrollTop,
-            scrollLeft,
-            t: Date.now()
-        });
-        appendScrollLog('scroll_cache:write', {
-            k,
-            scrollTop,
-            scrollLeft,
-            why
-        });
+      scroll_cache.set(k, {
+        scrollTop,
+        scrollLeft,
+        t: Date.now()
+      });
+      appendScrollLog('scroll_cache:write', {
+        k,
+        scrollTop,
+        scrollLeft,
+        why
+      });
     };
     const scrollToCellIfPossible = why => {
-        if (!cell_variable)
-            return false;
-        const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
-        if (!dom) {
-            appendScrollLog('scroll:cell_dom_not_found', {
-                k,
-                why,
-                cell: cell_variable?._name ?? null
-            });
-            return false;
-        }
-        const top = dom.offsetTop - c_element.offsetTop;
-        const left = c_element.scrollLeft;
-        c_element.scrollTop = top;
-        appendScrollLog('scroll:set', {
-            k,
-            why: `${ why }:cell`,
-            scrollTop: top,
-            scrollLeft: left,
-            cell: cell_variable?._name ?? null
+      if (!cell_variable)
+        return false;
+      const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
+      if (!dom) {
+        appendScrollLog('scroll:cell_dom_not_found', {
+          k,
+          why,
+          cell: cell_variable?._name ?? null
         });
-        writeCache(top, left, `${ why }:cell`);
-        return true;
+        return false;
+      }
+      const top = dom.offsetTop - c_element.offsetTop;
+      const left = c_element.scrollLeft;
+      c_element.scrollTop = top;
+      appendScrollLog('scroll:set', {
+        k,
+        why: `${ why }:cell`,
+        scrollTop: top,
+        scrollLeft: left,
+        cell: cell_variable?._name ?? null
+      });
+      writeCache(top, left, `${ why }:cell`);
+      return true;
     };
     const restoreFromCache = why => {
-        k = scrollKeyFor(container);
-        const cached = scroll_cache.get(k);
-        appendScrollLog('scroll:restore_attempt', {
-            k,
-            why,
-            cachedScrollTop: cached?.scrollTop ?? null,
-            cachedScrollLeft: cached?.scrollLeft ?? null
+      k = scrollKeyFor(container);
+      const cached = scroll_cache.get(k);
+      appendScrollLog('scroll:restore_attempt', {
+        k,
+        why,
+        cachedScrollTop: cached?.scrollTop ?? null,
+        cachedScrollLeft: cached?.scrollLeft ?? null
+      });
+      if (!cached) {
+        appendScrollLog('scroll:restore_no_scroll', {
+          k,
+          why
         });
-        if (!cached) {
-            appendScrollLog('scroll:restore_no_scroll', {
-                k,
-                why
-            });
-            return;
-        }
-        if (cached.scrollTop != null)
-            c_element.scrollTop = cached.scrollTop;
-        if (cached.scrollLeft != null)
-            c_element.scrollLeft = cached.scrollLeft;
-        appendScrollLog('scroll:restore_applied', {
-            k,
-            why,
-            scrollTop: cached.scrollTop ?? null,
-            scrollLeft: cached.scrollLeft ?? null,
-            scrollTopFinal: c_element.scrollTop,
-            scrollLeftFinal: c_element.scrollLeft
-        });
+        return;
+      }
+      if (cached.scrollTop != null)
+        c_element.scrollTop = cached.scrollTop;
+      if (cached.scrollLeft != null)
+        c_element.scrollLeft = cached.scrollLeft;
+      appendScrollLog('scroll:restore_applied', {
+        k,
+        why,
+        scrollTop: cached.scrollTop ?? null,
+        scrollLeft: cached.scrollLeft ?? null,
+        scrollTopFinal: c_element.scrollTop,
+        scrollLeftFinal: c_element.scrollLeft
+      });
     };
     const setScroll = (why = 'setScroll') => {
-        if (scrollToCellIfPossible(why))
-            return;
-        restoreFromCache(why);
+      if (scrollToCellIfPossible(why))
+        return;
+      restoreFromCache(why);
     };
     const retryFrames = 6;
     for (let i = 0; i < retryFrames; i++) {
-        requestAnimationFrame(() => {
-            k = scrollKeyFor(container);
-            appendScrollLog('fix_scroll:raf_retry', {
-                i,
-                k,
-                title: container?.title ?? null
-            });
-            setScroll(`raf:${ i }`);
+      requestAnimationFrame(() => {
+        k = scrollKeyFor(container);
+        appendScrollLog('fix_scroll:raf_retry', {
+          i,
+          k,
+          title: container?.title ?? null
         });
+        setScroll(`raf:${ i }`);
+      });
     }
     appendScrollLog('fix_scroll:exit', {
-        k,
-        title: container?.title ?? null
+      k,
+      title: container?.title ?? null
     });
-}
-)};
+  };
+};
 const _arfw00 = function _scroll_fix_sync_layout(sync_layout_to_url,layout,appendScrollLog,modulePanel)
 {
     sync_layout_to_url;
@@ -15469,7 +15530,7 @@ export default function define(runtime, observer) {
   $def("_1we0ggl", "reload", ["Generators","viewof reload"], _1we0ggl);  
   $def("_plefwg", "onLoadConfig", ["parseGoldenDSL","URLSearchParams","location"], _plefwg);  
   $def("_1nzpnqy", "visualizer_cache", ["reload"], _1nzpnqy);  
-  $def("_1l35721", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1l35721);  
+  $def("_1ojown8", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1ojown8);  
   $def("_1gm4gbf", "blobPanel", [], _1gm4gbf);  
   $def("_lxv2e2", "settings", [], _lxv2e2);  
   $def("_lp1ggk", "is_mobile", ["width"], _lp1ggk);  
@@ -15490,7 +15551,7 @@ export default function define(runtime, observer) {
   $def("_1dyz4o0", "scrollLog", ["mutable scrollLog"], _1dyz4o0);  
   $def("_1d1nkw9", "scrollKeyFor", ["appendScrollLog"], _1d1nkw9);  
   $def("_tb217h", "scroll_cache", [], _tb217h);  
-  $def("_5tyvpe", "fix_scroll", ["scrollKeyFor","appendScrollLog","scroll_cache"], _5tyvpe);  
+  $def("_12p8mg7", "fix_scroll", ["scroll_cache","scrollKeyFor","appendScrollLog"], _12p8mg7);  
   $def("_arfw00", "scroll_fix_sync_layout", ["sync_layout_to_url","layout","appendScrollLog","modulePanel"], _arfw00);  
   $def("_3nwpp4", "URLrouting", ["md"], _3nwpp4);  
   $def("_14te9pl", "sync_layout_from_url", ["reload","resize","URLSearchParams","hash","appendScrollLog","parseGoldenDSL","gl","layout","serializeGoldenDSL","treeSyncGolden","invalidation"], _14te9pl);  

--- a/notebooks/@tomlarkworthy_debugger-2.html
+++ b/notebooks/@tomlarkworthy_debugger-2.html
@@ -15199,138 +15199,196 @@ const _1nzpnqy = function _visualizer_cache(reload)
     reload;
     return new Map();
 };
-const _1l35721 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
+const _1ojown8 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
 {
-    return function (container, component) {
-        appendScrollLog('modulePanel:enter', {
-            title: container?.title ?? null,
-            componentCell: component?.cell ?? null
-        });
-        const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
-        if (!moduleInfo) {
-            // Fall through to file attachment: titles like @user/notebook/path.ext
-            // resolve via the lopecode bootloader's contentSync DOM lookup.
-            const title = container?.title ?? null;
-            if (title) {
-                let node = file_attachment_cache.get(title);
-                if (!node) {
-                    const r = window.lopecode?.contentSync?.(title);
-                    if (r && r.status === 200 && r.bytes) {
-                        node = renderFileAttachment(r.mime, r.bytes);
-                        file_attachment_cache.set(title, node);
-                        appendScrollLog('modulePanel:file_attachment_create', {
-                            title,
-                            mime: r.mime
-                        });
-                    }
-                }
-                if (node) {
-                    const c_element = container.getElement();
-                    if (node.parentNode !== c_element)
-                        c_element.appendChild(node);
-                    appendScrollLog('modulePanel:file_attachment_mount', { title });
-                    return;
-                }
-            }
-            appendScrollLog('modulePanel:missing_moduleInfo', { title });
-            return;
-        }
-        const module = moduleInfo.module;
-        let node;
-        if (!visualizer_cache.has(module)) {
-            appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
-            node = visualizer(runtime, {
-                invalidation: new Promise(r => {
-                }),
-                module,
-                detachNodes: isOnObservableCom(),
-                filter: (cell_name, variables) => {
-                    if (variables[0]._type !== 1)
-                        return false;
-                    if (typeof cell_name == 'string') {
-                        if (cell_name.startsWith('dynamic '))
-                            return false;
-                    }
-                    return true;
-                }
+  return function (container, component) {
+    appendScrollLog('modulePanel:enter', {
+      title: container?.title ?? null,
+      componentCell: component?.cell ?? null
+    });
+    const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
+    if (!moduleInfo) {
+      // Fall through to file attachment: titles like @user/notebook/path.ext
+      // resolve via the lopecode bootloader's contentSync DOM lookup.
+      const title = container?.title ?? null;
+      if (title) {
+        let node = file_attachment_cache.get(title);
+        if (!node) {
+          const r = window.lopecode?.contentSync?.(title);
+          if (r && r.status === 200 && r.bytes) {
+            node = renderFileAttachment(r.mime, r.bytes);
+            file_attachment_cache.set(title, node);
+            appendScrollLog('modulePanel:file_attachment_create', {
+              title,
+              mime: r.mime
             });
-            visualizer_cache.set(module, node);
-        } else {
-            node = visualizer_cache.get(module);
-            appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+          }
         }
-        const cell = module._scope.get(component.cell);
-        const scrollKey = scrollKeyFor(container);
-        fix_scroll(container, node, cell, scrollKey);
-        const el = container.getElement();
-        if (!el.__lope_scroll_bound) {
-            el.__lope_scroll_bound = true;
-            appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
-            el.addEventListener('scroll', () => {
-                const k = scrollKeyFor(container);
-                const scrollTop = el.scrollTop;
-                const scrollLeft = el.scrollLeft;
-                if (scrollTop == 0) {
-                    appendScrollLog('modulePanel:skip 0 scroll', {
-                        title: container?.title ?? null,
-                        scrollKey
-                    });
-                    return;
-                }
-                scroll_cache.set(k, {
-                    scrollTop,
-                    scrollLeft,
-                    t: Date.now()
-                });
-                appendScrollLog('scroll:event', {
-                    k,
-                    title: container?.title ?? null,
-                    scrollTop,
-                    scrollLeft
-                });
-            }, { passive: true });
+        if (node) {
+          const c_element = container.getElement();
+          if (node.parentNode !== c_element)
+            c_element.appendChild(node);
+          appendScrollLog('modulePanel:file_attachment_mount', { title });
+          return;
         }
-        // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
-        if (!container.__lope_destroy_bound) {
-            container.__lope_destroy_bound = true;
-            container.on('destroy', () => {
-                try {
-                    const k = scrollKeyFor(container);
-                    const scrollTop = el?.scrollTop;
-                    const scrollLeft = el?.scrollLeft;
-                    if (scrollTop == 0) {
-                        appendScrollLog('scroll:skip 0 scroll', {
-                            k,
-                            key: container?.title ?? null,
-                            scrollKey
-                        });
-                        return;
-                    }
-                    // do not skip 0 here: if the user is at top, preserve that state
-                    scroll_cache.set(k, {
-                        scrollTop,
-                        scrollLeft,
-                        t: Date.now()
-                    });
-                    appendScrollLog('scroll:destroy_capture', {
-                        k,
-                        title: container?.title ?? null,
-                        scrollTop,
-                        scrollLeft
-                    });
-                } catch (e) {
-                    appendScrollLog('scroll:destroy_capture:error', {
-                        title: container?.title ?? null,
-                        error: String(e)
-                    });
-                }
-            });
+      }
+      appendScrollLog('modulePanel:missing_moduleInfo', { title });
+      return;
+    }
+    const module = moduleInfo.module;
+    let node;
+    if (!visualizer_cache.has(module)) {
+      appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
+      node = visualizer(runtime, {
+        invalidation: new Promise(r => {
+        }),
+        module,
+        detachNodes: isOnObservableCom(),
+        filter: (cell_name, variables) => {
+          if (variables[0]._type !== 1)
+            return false;
+          if (typeof cell_name == 'string') {
+            if (cell_name.startsWith('dynamic '))
+              return false;
+          }
+          return true;
         }
-        appendScrollLog('modulePanel:exit', {
+      });
+      visualizer_cache.set(module, node);
+    } else {
+      node = visualizer_cache.get(module);
+      appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+    }
+    const cell = module._scope.get(component.cell);
+    const scrollKey = scrollKeyFor(container);
+    fix_scroll(container, node, cell, scrollKey);
+    const el = container.getElement();
+    if (!el.__lope_scroll_bound) {
+      el.__lope_scroll_bound = true;
+      appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
+      const markUserScroll = () => {
+        el.__lope_user_scroll_at = Date.now();
+      };
+      el.addEventListener('wheel', markUserScroll, { passive: true });
+      el.addEventListener('touchmove', markUserScroll, { passive: true });
+      el.addEventListener('keydown', markUserScroll, { passive: true });
+      el.addEventListener('scroll', () => {
+        if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+          appendScrollLog('scroll:skip_reflow', { title: container?.title ?? null });
+          return;
+        }
+        // Only cache scrolls following a genuine user gesture; reflow-induced
+        // scroll events (e.g. closing an adjacent panel) carry stale scrollTops.
+        if (Date.now() - (el.__lope_user_scroll_at || 0) > 400) {
+          appendScrollLog('scroll:skip_nonuser', { title: container?.title ?? null });
+          return;
+        }
+        const k = scrollKeyFor(container);
+        const scrollTop = el.scrollTop;
+        const scrollLeft = el.scrollLeft;
+        if (scrollTop == 0) {
+          appendScrollLog('modulePanel:skip 0 scroll', {
             title: container?.title ?? null,
             scrollKey
+          });
+          return;
+        }
+        scroll_cache.set(k, {
+          scrollTop,
+          scrollLeft,
+          t: Date.now()
         });
-    };
+        appendScrollLog('scroll:event', {
+          k,
+          title: container?.title ?? null,
+          scrollTop,
+          scrollLeft
+        });
+      }, { passive: true });
+    }
+    // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
+    if (!container.__lope_destroy_bound) {
+      container.__lope_destroy_bound = true;
+      container.on('destroy', () => {
+        try {
+          if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+            appendScrollLog('scroll:destroy_skip_reflow', { title: container?.title ?? null });
+            return;
+          }
+          const k = scrollKeyFor(container);
+          const scrollTop = el?.scrollTop;
+          const scrollLeft = el?.scrollLeft;
+          if (scrollTop == 0) {
+            appendScrollLog('scroll:skip 0 scroll', {
+              k,
+              key: container?.title ?? null,
+              scrollKey
+            });
+            return;
+          }
+          // do not skip 0 here: if the user is at top, preserve that state
+          scroll_cache.set(k, {
+            scrollTop,
+            scrollLeft,
+            t: Date.now()
+          });
+          appendScrollLog('scroll:destroy_capture', {
+            k,
+            title: container?.title ?? null,
+            scrollTop,
+            scrollLeft
+          });
+        } catch (e) {
+          appendScrollLog('scroll:destroy_capture:error', {
+            title: container?.title ?? null,
+            error: String(e)
+          });
+        }
+      });
+    }
+    // When GoldenLayout resizes this panel (e.g. an adjacent panel is closed) the
+    // browser can shift scrollTop; re-apply the user's cached position after the reflow.
+    if (!container.__lope_resize_bound) {
+      container.__lope_resize_bound = true;
+      container.on('resize', () => {
+        const rk = scrollKeyFor(container);
+        const cached = scroll_cache.get(rk);
+        if (!cached || cached.scrollTop == null)
+          return;
+        const c_el = container.getElement();
+        const at = Date.now();
+        scroll_cache.__reflowUntil = at + 800;
+        // The reflow can shift scrollTop in several passes (content relayout
+        // settles ~300ms later), so re-apply over a window. Bail if the user scrolls.
+        const apply = () => {
+          if ((c_el.__lope_user_scroll_at || 0) > at)
+            return;
+          if (c_el.scrollTop !== cached.scrollTop)
+            c_el.scrollTop = cached.scrollTop;
+          if (cached.scrollLeft != null && c_el.scrollLeft !== cached.scrollLeft)
+            c_el.scrollLeft = cached.scrollLeft;
+        };
+        requestAnimationFrame(apply);
+        for (const d of [
+            60,
+            150,
+            300,
+            450,
+            600
+          ])
+          setTimeout(apply, d);
+        appendScrollLog('scroll:resize_restore', {
+          k: rk,
+          title: container?.title ?? null,
+          scrollTop: cached.scrollTop
+        });
+      });
+    }
+    appendScrollLog('modulePanel:exit', {
+      title: container?.title ?? null,
+      scrollKey
+    });
+  };
 };
 const _1gm4gbf = function _blobPanel(){return(
 function (container, component) {
@@ -15448,112 +15506,115 @@ const _1d1nkw9 = function _scrollKeyFor(appendScrollLog)
 const _tb217h = function _scroll_cache(){return(
 new Map()
 )};
-const _5tyvpe = function _fix_scroll(scrollKeyFor,appendScrollLog,scroll_cache){return(
-function (container, node, cell_variable, key) {
+const _12p8mg7 = function _fix_scroll(scroll_cache,scrollKeyFor,appendScrollLog)
+{
+  return function (container, node, cell_variable, key) {
+    scroll_cache.__reflowUntil = Date.now() + 600;
+    // suppress reflow-induced scroll events that clobber the cache
     const c_element = container.getElement();
     let k = scrollKeyFor(container);
     appendScrollLog('fix_scroll:enter', {
-        title: container?.title ?? null,
-        k,
-        cell: cell_variable?._name ?? null
+      title: container?.title ?? null,
+      k,
+      cell: cell_variable?._name ?? null
     });
     if (node && node.parentNode !== c_element) {
-        c_element.appendChild(node);
-        appendScrollLog('fix_scroll:append_node', {
-            title: container?.title ?? null,
-            k
-        });
+      c_element.appendChild(node);
+      appendScrollLog('fix_scroll:append_node', {
+        title: container?.title ?? null,
+        k
+      });
     }
     const writeCache = (scrollTop, scrollLeft, why) => {
-        scroll_cache.set(k, {
-            scrollTop,
-            scrollLeft,
-            t: Date.now()
-        });
-        appendScrollLog('scroll_cache:write', {
-            k,
-            scrollTop,
-            scrollLeft,
-            why
-        });
+      scroll_cache.set(k, {
+        scrollTop,
+        scrollLeft,
+        t: Date.now()
+      });
+      appendScrollLog('scroll_cache:write', {
+        k,
+        scrollTop,
+        scrollLeft,
+        why
+      });
     };
     const scrollToCellIfPossible = why => {
-        if (!cell_variable)
-            return false;
-        const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
-        if (!dom) {
-            appendScrollLog('scroll:cell_dom_not_found', {
-                k,
-                why,
-                cell: cell_variable?._name ?? null
-            });
-            return false;
-        }
-        const top = dom.offsetTop - c_element.offsetTop;
-        const left = c_element.scrollLeft;
-        c_element.scrollTop = top;
-        appendScrollLog('scroll:set', {
-            k,
-            why: `${ why }:cell`,
-            scrollTop: top,
-            scrollLeft: left,
-            cell: cell_variable?._name ?? null
+      if (!cell_variable)
+        return false;
+      const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
+      if (!dom) {
+        appendScrollLog('scroll:cell_dom_not_found', {
+          k,
+          why,
+          cell: cell_variable?._name ?? null
         });
-        writeCache(top, left, `${ why }:cell`);
-        return true;
+        return false;
+      }
+      const top = dom.offsetTop - c_element.offsetTop;
+      const left = c_element.scrollLeft;
+      c_element.scrollTop = top;
+      appendScrollLog('scroll:set', {
+        k,
+        why: `${ why }:cell`,
+        scrollTop: top,
+        scrollLeft: left,
+        cell: cell_variable?._name ?? null
+      });
+      writeCache(top, left, `${ why }:cell`);
+      return true;
     };
     const restoreFromCache = why => {
-        k = scrollKeyFor(container);
-        const cached = scroll_cache.get(k);
-        appendScrollLog('scroll:restore_attempt', {
-            k,
-            why,
-            cachedScrollTop: cached?.scrollTop ?? null,
-            cachedScrollLeft: cached?.scrollLeft ?? null
+      k = scrollKeyFor(container);
+      const cached = scroll_cache.get(k);
+      appendScrollLog('scroll:restore_attempt', {
+        k,
+        why,
+        cachedScrollTop: cached?.scrollTop ?? null,
+        cachedScrollLeft: cached?.scrollLeft ?? null
+      });
+      if (!cached) {
+        appendScrollLog('scroll:restore_no_scroll', {
+          k,
+          why
         });
-        if (!cached) {
-            appendScrollLog('scroll:restore_no_scroll', {
-                k,
-                why
-            });
-            return;
-        }
-        if (cached.scrollTop != null)
-            c_element.scrollTop = cached.scrollTop;
-        if (cached.scrollLeft != null)
-            c_element.scrollLeft = cached.scrollLeft;
-        appendScrollLog('scroll:restore_applied', {
-            k,
-            why,
-            scrollTop: cached.scrollTop ?? null,
-            scrollLeft: cached.scrollLeft ?? null,
-            scrollTopFinal: c_element.scrollTop,
-            scrollLeftFinal: c_element.scrollLeft
-        });
+        return;
+      }
+      if (cached.scrollTop != null)
+        c_element.scrollTop = cached.scrollTop;
+      if (cached.scrollLeft != null)
+        c_element.scrollLeft = cached.scrollLeft;
+      appendScrollLog('scroll:restore_applied', {
+        k,
+        why,
+        scrollTop: cached.scrollTop ?? null,
+        scrollLeft: cached.scrollLeft ?? null,
+        scrollTopFinal: c_element.scrollTop,
+        scrollLeftFinal: c_element.scrollLeft
+      });
     };
     const setScroll = (why = 'setScroll') => {
-        if (scrollToCellIfPossible(why))
-            return;
-        restoreFromCache(why);
+      if (scrollToCellIfPossible(why))
+        return;
+      restoreFromCache(why);
     };
     const retryFrames = 6;
     for (let i = 0; i < retryFrames; i++) {
-        requestAnimationFrame(() => {
-            k = scrollKeyFor(container);
-            appendScrollLog('fix_scroll:raf_retry', {
-                i,
-                k,
-                title: container?.title ?? null
-            });
-            setScroll(`raf:${ i }`);
+      requestAnimationFrame(() => {
+        k = scrollKeyFor(container);
+        appendScrollLog('fix_scroll:raf_retry', {
+          i,
+          k,
+          title: container?.title ?? null
         });
+        setScroll(`raf:${ i }`);
+      });
     }
     appendScrollLog('fix_scroll:exit', {
-        k,
-        title: container?.title ?? null
+      k,
+      title: container?.title ?? null
     });
-}
-)};
+  };
+};
 const _arfw00 = function _scroll_fix_sync_layout(sync_layout_to_url,layout,appendScrollLog,modulePanel)
 {
     sync_layout_to_url;
@@ -16631,7 +16692,7 @@ export default function define(runtime, observer) {
   $def("_1we0ggl", "reload", ["Generators","viewof reload"], _1we0ggl);  
   $def("_plefwg", "onLoadConfig", ["parseGoldenDSL","URLSearchParams","location"], _plefwg);  
   $def("_1nzpnqy", "visualizer_cache", ["reload"], _1nzpnqy);  
-  $def("_1l35721", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1l35721);  
+  $def("_1ojown8", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1ojown8);  
   $def("_1gm4gbf", "blobPanel", [], _1gm4gbf);  
   $def("_lxv2e2", "settings", [], _lxv2e2);  
   $def("_lp1ggk", "is_mobile", ["width"], _lp1ggk);  
@@ -16652,7 +16713,7 @@ export default function define(runtime, observer) {
   $def("_1dyz4o0", "scrollLog", ["mutable scrollLog"], _1dyz4o0);  
   $def("_1d1nkw9", "scrollKeyFor", ["appendScrollLog"], _1d1nkw9);  
   $def("_tb217h", "scroll_cache", [], _tb217h);  
-  $def("_5tyvpe", "fix_scroll", ["scrollKeyFor","appendScrollLog","scroll_cache"], _5tyvpe);  
+  $def("_12p8mg7", "fix_scroll", ["scroll_cache","scrollKeyFor","appendScrollLog"], _12p8mg7);  
   $def("_arfw00", "scroll_fix_sync_layout", ["sync_layout_to_url","layout","appendScrollLog","modulePanel"], _arfw00);  
   $def("_3nwpp4", "URLrouting", ["md"], _3nwpp4);  
   $def("_14te9pl", "sync_layout_from_url", ["reload","resize","URLSearchParams","hash","appendScrollLog","parseGoldenDSL","gl","layout","serializeGoldenDSL","treeSyncGolden","invalidation"], _14te9pl);  

--- a/notebooks/@tomlarkworthy_debugger.html
+++ b/notebooks/@tomlarkworthy_debugger.html
@@ -14458,138 +14458,196 @@ const _1nzpnqy = function _visualizer_cache(reload)
     reload;
     return new Map();
 };
-const _1l35721 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
+const _1ojown8 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
 {
-    return function (container, component) {
-        appendScrollLog('modulePanel:enter', {
-            title: container?.title ?? null,
-            componentCell: component?.cell ?? null
-        });
-        const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
-        if (!moduleInfo) {
-            // Fall through to file attachment: titles like @user/notebook/path.ext
-            // resolve via the lopecode bootloader's contentSync DOM lookup.
-            const title = container?.title ?? null;
-            if (title) {
-                let node = file_attachment_cache.get(title);
-                if (!node) {
-                    const r = window.lopecode?.contentSync?.(title);
-                    if (r && r.status === 200 && r.bytes) {
-                        node = renderFileAttachment(r.mime, r.bytes);
-                        file_attachment_cache.set(title, node);
-                        appendScrollLog('modulePanel:file_attachment_create', {
-                            title,
-                            mime: r.mime
-                        });
-                    }
-                }
-                if (node) {
-                    const c_element = container.getElement();
-                    if (node.parentNode !== c_element)
-                        c_element.appendChild(node);
-                    appendScrollLog('modulePanel:file_attachment_mount', { title });
-                    return;
-                }
-            }
-            appendScrollLog('modulePanel:missing_moduleInfo', { title });
-            return;
-        }
-        const module = moduleInfo.module;
-        let node;
-        if (!visualizer_cache.has(module)) {
-            appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
-            node = visualizer(runtime, {
-                invalidation: new Promise(r => {
-                }),
-                module,
-                detachNodes: isOnObservableCom(),
-                filter: (cell_name, variables) => {
-                    if (variables[0]._type !== 1)
-                        return false;
-                    if (typeof cell_name == 'string') {
-                        if (cell_name.startsWith('dynamic '))
-                            return false;
-                    }
-                    return true;
-                }
+  return function (container, component) {
+    appendScrollLog('modulePanel:enter', {
+      title: container?.title ?? null,
+      componentCell: component?.cell ?? null
+    });
+    const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
+    if (!moduleInfo) {
+      // Fall through to file attachment: titles like @user/notebook/path.ext
+      // resolve via the lopecode bootloader's contentSync DOM lookup.
+      const title = container?.title ?? null;
+      if (title) {
+        let node = file_attachment_cache.get(title);
+        if (!node) {
+          const r = window.lopecode?.contentSync?.(title);
+          if (r && r.status === 200 && r.bytes) {
+            node = renderFileAttachment(r.mime, r.bytes);
+            file_attachment_cache.set(title, node);
+            appendScrollLog('modulePanel:file_attachment_create', {
+              title,
+              mime: r.mime
             });
-            visualizer_cache.set(module, node);
-        } else {
-            node = visualizer_cache.get(module);
-            appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+          }
         }
-        const cell = module._scope.get(component.cell);
-        const scrollKey = scrollKeyFor(container);
-        fix_scroll(container, node, cell, scrollKey);
-        const el = container.getElement();
-        if (!el.__lope_scroll_bound) {
-            el.__lope_scroll_bound = true;
-            appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
-            el.addEventListener('scroll', () => {
-                const k = scrollKeyFor(container);
-                const scrollTop = el.scrollTop;
-                const scrollLeft = el.scrollLeft;
-                if (scrollTop == 0) {
-                    appendScrollLog('modulePanel:skip 0 scroll', {
-                        title: container?.title ?? null,
-                        scrollKey
-                    });
-                    return;
-                }
-                scroll_cache.set(k, {
-                    scrollTop,
-                    scrollLeft,
-                    t: Date.now()
-                });
-                appendScrollLog('scroll:event', {
-                    k,
-                    title: container?.title ?? null,
-                    scrollTop,
-                    scrollLeft
-                });
-            }, { passive: true });
+        if (node) {
+          const c_element = container.getElement();
+          if (node.parentNode !== c_element)
+            c_element.appendChild(node);
+          appendScrollLog('modulePanel:file_attachment_mount', { title });
+          return;
         }
-        // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
-        if (!container.__lope_destroy_bound) {
-            container.__lope_destroy_bound = true;
-            container.on('destroy', () => {
-                try {
-                    const k = scrollKeyFor(container);
-                    const scrollTop = el?.scrollTop;
-                    const scrollLeft = el?.scrollLeft;
-                    if (scrollTop == 0) {
-                        appendScrollLog('scroll:skip 0 scroll', {
-                            k,
-                            key: container?.title ?? null,
-                            scrollKey
-                        });
-                        return;
-                    }
-                    // do not skip 0 here: if the user is at top, preserve that state
-                    scroll_cache.set(k, {
-                        scrollTop,
-                        scrollLeft,
-                        t: Date.now()
-                    });
-                    appendScrollLog('scroll:destroy_capture', {
-                        k,
-                        title: container?.title ?? null,
-                        scrollTop,
-                        scrollLeft
-                    });
-                } catch (e) {
-                    appendScrollLog('scroll:destroy_capture:error', {
-                        title: container?.title ?? null,
-                        error: String(e)
-                    });
-                }
-            });
+      }
+      appendScrollLog('modulePanel:missing_moduleInfo', { title });
+      return;
+    }
+    const module = moduleInfo.module;
+    let node;
+    if (!visualizer_cache.has(module)) {
+      appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
+      node = visualizer(runtime, {
+        invalidation: new Promise(r => {
+        }),
+        module,
+        detachNodes: isOnObservableCom(),
+        filter: (cell_name, variables) => {
+          if (variables[0]._type !== 1)
+            return false;
+          if (typeof cell_name == 'string') {
+            if (cell_name.startsWith('dynamic '))
+              return false;
+          }
+          return true;
         }
-        appendScrollLog('modulePanel:exit', {
+      });
+      visualizer_cache.set(module, node);
+    } else {
+      node = visualizer_cache.get(module);
+      appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+    }
+    const cell = module._scope.get(component.cell);
+    const scrollKey = scrollKeyFor(container);
+    fix_scroll(container, node, cell, scrollKey);
+    const el = container.getElement();
+    if (!el.__lope_scroll_bound) {
+      el.__lope_scroll_bound = true;
+      appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
+      const markUserScroll = () => {
+        el.__lope_user_scroll_at = Date.now();
+      };
+      el.addEventListener('wheel', markUserScroll, { passive: true });
+      el.addEventListener('touchmove', markUserScroll, { passive: true });
+      el.addEventListener('keydown', markUserScroll, { passive: true });
+      el.addEventListener('scroll', () => {
+        if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+          appendScrollLog('scroll:skip_reflow', { title: container?.title ?? null });
+          return;
+        }
+        // Only cache scrolls following a genuine user gesture; reflow-induced
+        // scroll events (e.g. closing an adjacent panel) carry stale scrollTops.
+        if (Date.now() - (el.__lope_user_scroll_at || 0) > 400) {
+          appendScrollLog('scroll:skip_nonuser', { title: container?.title ?? null });
+          return;
+        }
+        const k = scrollKeyFor(container);
+        const scrollTop = el.scrollTop;
+        const scrollLeft = el.scrollLeft;
+        if (scrollTop == 0) {
+          appendScrollLog('modulePanel:skip 0 scroll', {
             title: container?.title ?? null,
             scrollKey
+          });
+          return;
+        }
+        scroll_cache.set(k, {
+          scrollTop,
+          scrollLeft,
+          t: Date.now()
         });
-    };
+        appendScrollLog('scroll:event', {
+          k,
+          title: container?.title ?? null,
+          scrollTop,
+          scrollLeft
+        });
+      }, { passive: true });
+    }
+    // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
+    if (!container.__lope_destroy_bound) {
+      container.__lope_destroy_bound = true;
+      container.on('destroy', () => {
+        try {
+          if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+            appendScrollLog('scroll:destroy_skip_reflow', { title: container?.title ?? null });
+            return;
+          }
+          const k = scrollKeyFor(container);
+          const scrollTop = el?.scrollTop;
+          const scrollLeft = el?.scrollLeft;
+          if (scrollTop == 0) {
+            appendScrollLog('scroll:skip 0 scroll', {
+              k,
+              key: container?.title ?? null,
+              scrollKey
+            });
+            return;
+          }
+          // do not skip 0 here: if the user is at top, preserve that state
+          scroll_cache.set(k, {
+            scrollTop,
+            scrollLeft,
+            t: Date.now()
+          });
+          appendScrollLog('scroll:destroy_capture', {
+            k,
+            title: container?.title ?? null,
+            scrollTop,
+            scrollLeft
+          });
+        } catch (e) {
+          appendScrollLog('scroll:destroy_capture:error', {
+            title: container?.title ?? null,
+            error: String(e)
+          });
+        }
+      });
+    }
+    // When GoldenLayout resizes this panel (e.g. an adjacent panel is closed) the
+    // browser can shift scrollTop; re-apply the user's cached position after the reflow.
+    if (!container.__lope_resize_bound) {
+      container.__lope_resize_bound = true;
+      container.on('resize', () => {
+        const rk = scrollKeyFor(container);
+        const cached = scroll_cache.get(rk);
+        if (!cached || cached.scrollTop == null)
+          return;
+        const c_el = container.getElement();
+        const at = Date.now();
+        scroll_cache.__reflowUntil = at + 800;
+        // The reflow can shift scrollTop in several passes (content relayout
+        // settles ~300ms later), so re-apply over a window. Bail if the user scrolls.
+        const apply = () => {
+          if ((c_el.__lope_user_scroll_at || 0) > at)
+            return;
+          if (c_el.scrollTop !== cached.scrollTop)
+            c_el.scrollTop = cached.scrollTop;
+          if (cached.scrollLeft != null && c_el.scrollLeft !== cached.scrollLeft)
+            c_el.scrollLeft = cached.scrollLeft;
+        };
+        requestAnimationFrame(apply);
+        for (const d of [
+            60,
+            150,
+            300,
+            450,
+            600
+          ])
+          setTimeout(apply, d);
+        appendScrollLog('scroll:resize_restore', {
+          k: rk,
+          title: container?.title ?? null,
+          scrollTop: cached.scrollTop
+        });
+      });
+    }
+    appendScrollLog('modulePanel:exit', {
+      title: container?.title ?? null,
+      scrollKey
+    });
+  };
 };
 const _1gm4gbf = function _blobPanel(){return(
 function (container, component) {
@@ -14707,112 +14765,115 @@ const _1d1nkw9 = function _scrollKeyFor(appendScrollLog)
 const _tb217h = function _scroll_cache(){return(
 new Map()
 )};
-const _5tyvpe = function _fix_scroll(scrollKeyFor,appendScrollLog,scroll_cache){return(
-function (container, node, cell_variable, key) {
+const _12p8mg7 = function _fix_scroll(scroll_cache,scrollKeyFor,appendScrollLog)
+{
+  return function (container, node, cell_variable, key) {
+    scroll_cache.__reflowUntil = Date.now() + 600;
+    // suppress reflow-induced scroll events that clobber the cache
     const c_element = container.getElement();
     let k = scrollKeyFor(container);
     appendScrollLog('fix_scroll:enter', {
-        title: container?.title ?? null,
-        k,
-        cell: cell_variable?._name ?? null
+      title: container?.title ?? null,
+      k,
+      cell: cell_variable?._name ?? null
     });
     if (node && node.parentNode !== c_element) {
-        c_element.appendChild(node);
-        appendScrollLog('fix_scroll:append_node', {
-            title: container?.title ?? null,
-            k
-        });
+      c_element.appendChild(node);
+      appendScrollLog('fix_scroll:append_node', {
+        title: container?.title ?? null,
+        k
+      });
     }
     const writeCache = (scrollTop, scrollLeft, why) => {
-        scroll_cache.set(k, {
-            scrollTop,
-            scrollLeft,
-            t: Date.now()
-        });
-        appendScrollLog('scroll_cache:write', {
-            k,
-            scrollTop,
-            scrollLeft,
-            why
-        });
+      scroll_cache.set(k, {
+        scrollTop,
+        scrollLeft,
+        t: Date.now()
+      });
+      appendScrollLog('scroll_cache:write', {
+        k,
+        scrollTop,
+        scrollLeft,
+        why
+      });
     };
     const scrollToCellIfPossible = why => {
-        if (!cell_variable)
-            return false;
-        const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
-        if (!dom) {
-            appendScrollLog('scroll:cell_dom_not_found', {
-                k,
-                why,
-                cell: cell_variable?._name ?? null
-            });
-            return false;
-        }
-        const top = dom.offsetTop - c_element.offsetTop;
-        const left = c_element.scrollLeft;
-        c_element.scrollTop = top;
-        appendScrollLog('scroll:set', {
-            k,
-            why: `${ why }:cell`,
-            scrollTop: top,
-            scrollLeft: left,
-            cell: cell_variable?._name ?? null
+      if (!cell_variable)
+        return false;
+      const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
+      if (!dom) {
+        appendScrollLog('scroll:cell_dom_not_found', {
+          k,
+          why,
+          cell: cell_variable?._name ?? null
         });
-        writeCache(top, left, `${ why }:cell`);
-        return true;
+        return false;
+      }
+      const top = dom.offsetTop - c_element.offsetTop;
+      const left = c_element.scrollLeft;
+      c_element.scrollTop = top;
+      appendScrollLog('scroll:set', {
+        k,
+        why: `${ why }:cell`,
+        scrollTop: top,
+        scrollLeft: left,
+        cell: cell_variable?._name ?? null
+      });
+      writeCache(top, left, `${ why }:cell`);
+      return true;
     };
     const restoreFromCache = why => {
-        k = scrollKeyFor(container);
-        const cached = scroll_cache.get(k);
-        appendScrollLog('scroll:restore_attempt', {
-            k,
-            why,
-            cachedScrollTop: cached?.scrollTop ?? null,
-            cachedScrollLeft: cached?.scrollLeft ?? null
+      k = scrollKeyFor(container);
+      const cached = scroll_cache.get(k);
+      appendScrollLog('scroll:restore_attempt', {
+        k,
+        why,
+        cachedScrollTop: cached?.scrollTop ?? null,
+        cachedScrollLeft: cached?.scrollLeft ?? null
+      });
+      if (!cached) {
+        appendScrollLog('scroll:restore_no_scroll', {
+          k,
+          why
         });
-        if (!cached) {
-            appendScrollLog('scroll:restore_no_scroll', {
-                k,
-                why
-            });
-            return;
-        }
-        if (cached.scrollTop != null)
-            c_element.scrollTop = cached.scrollTop;
-        if (cached.scrollLeft != null)
-            c_element.scrollLeft = cached.scrollLeft;
-        appendScrollLog('scroll:restore_applied', {
-            k,
-            why,
-            scrollTop: cached.scrollTop ?? null,
-            scrollLeft: cached.scrollLeft ?? null,
-            scrollTopFinal: c_element.scrollTop,
-            scrollLeftFinal: c_element.scrollLeft
-        });
+        return;
+      }
+      if (cached.scrollTop != null)
+        c_element.scrollTop = cached.scrollTop;
+      if (cached.scrollLeft != null)
+        c_element.scrollLeft = cached.scrollLeft;
+      appendScrollLog('scroll:restore_applied', {
+        k,
+        why,
+        scrollTop: cached.scrollTop ?? null,
+        scrollLeft: cached.scrollLeft ?? null,
+        scrollTopFinal: c_element.scrollTop,
+        scrollLeftFinal: c_element.scrollLeft
+      });
     };
     const setScroll = (why = 'setScroll') => {
-        if (scrollToCellIfPossible(why))
-            return;
-        restoreFromCache(why);
+      if (scrollToCellIfPossible(why))
+        return;
+      restoreFromCache(why);
     };
     const retryFrames = 6;
     for (let i = 0; i < retryFrames; i++) {
-        requestAnimationFrame(() => {
-            k = scrollKeyFor(container);
-            appendScrollLog('fix_scroll:raf_retry', {
-                i,
-                k,
-                title: container?.title ?? null
-            });
-            setScroll(`raf:${ i }`);
+      requestAnimationFrame(() => {
+        k = scrollKeyFor(container);
+        appendScrollLog('fix_scroll:raf_retry', {
+          i,
+          k,
+          title: container?.title ?? null
         });
+        setScroll(`raf:${ i }`);
+      });
     }
     appendScrollLog('fix_scroll:exit', {
-        k,
-        title: container?.title ?? null
+      k,
+      title: container?.title ?? null
     });
-}
-)};
+  };
+};
 const _arfw00 = function _scroll_fix_sync_layout(sync_layout_to_url,layout,appendScrollLog,modulePanel)
 {
     sync_layout_to_url;
@@ -15890,7 +15951,7 @@ export default function define(runtime, observer) {
   $def("_1we0ggl", "reload", ["Generators","viewof reload"], _1we0ggl);  
   $def("_plefwg", "onLoadConfig", ["parseGoldenDSL","URLSearchParams","location"], _plefwg);  
   $def("_1nzpnqy", "visualizer_cache", ["reload"], _1nzpnqy);  
-  $def("_1l35721", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1l35721);  
+  $def("_1ojown8", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1ojown8);  
   $def("_1gm4gbf", "blobPanel", [], _1gm4gbf);  
   $def("_lxv2e2", "settings", [], _lxv2e2);  
   $def("_lp1ggk", "is_mobile", ["width"], _lp1ggk);  
@@ -15911,7 +15972,7 @@ export default function define(runtime, observer) {
   $def("_1dyz4o0", "scrollLog", ["mutable scrollLog"], _1dyz4o0);  
   $def("_1d1nkw9", "scrollKeyFor", ["appendScrollLog"], _1d1nkw9);  
   $def("_tb217h", "scroll_cache", [], _tb217h);  
-  $def("_5tyvpe", "fix_scroll", ["scrollKeyFor","appendScrollLog","scroll_cache"], _5tyvpe);  
+  $def("_12p8mg7", "fix_scroll", ["scroll_cache","scrollKeyFor","appendScrollLog"], _12p8mg7);  
   $def("_arfw00", "scroll_fix_sync_layout", ["sync_layout_to_url","layout","appendScrollLog","modulePanel"], _arfw00);  
   $def("_3nwpp4", "URLrouting", ["md"], _3nwpp4);  
   $def("_14te9pl", "sync_layout_from_url", ["reload","resize","URLSearchParams","hash","appendScrollLog","parseGoldenDSL","gl","layout","serializeGoldenDSL","treeSyncGolden","invalidation"], _14te9pl);  

--- a/notebooks/@tomlarkworthy_dom-view.html
+++ b/notebooks/@tomlarkworthy_dom-view.html
@@ -14037,138 +14037,196 @@ const _1nzpnqy = function _visualizer_cache(reload)
     reload;
     return new Map();
 };
-const _1l35721 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
+const _1ojown8 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
 {
-    return function (container, component) {
-        appendScrollLog('modulePanel:enter', {
-            title: container?.title ?? null,
-            componentCell: component?.cell ?? null
-        });
-        const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
-        if (!moduleInfo) {
-            // Fall through to file attachment: titles like @user/notebook/path.ext
-            // resolve via the lopecode bootloader's contentSync DOM lookup.
-            const title = container?.title ?? null;
-            if (title) {
-                let node = file_attachment_cache.get(title);
-                if (!node) {
-                    const r = window.lopecode?.contentSync?.(title);
-                    if (r && r.status === 200 && r.bytes) {
-                        node = renderFileAttachment(r.mime, r.bytes);
-                        file_attachment_cache.set(title, node);
-                        appendScrollLog('modulePanel:file_attachment_create', {
-                            title,
-                            mime: r.mime
-                        });
-                    }
-                }
-                if (node) {
-                    const c_element = container.getElement();
-                    if (node.parentNode !== c_element)
-                        c_element.appendChild(node);
-                    appendScrollLog('modulePanel:file_attachment_mount', { title });
-                    return;
-                }
-            }
-            appendScrollLog('modulePanel:missing_moduleInfo', { title });
-            return;
-        }
-        const module = moduleInfo.module;
-        let node;
-        if (!visualizer_cache.has(module)) {
-            appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
-            node = visualizer(runtime, {
-                invalidation: new Promise(r => {
-                }),
-                module,
-                detachNodes: isOnObservableCom(),
-                filter: (cell_name, variables) => {
-                    if (variables[0]._type !== 1)
-                        return false;
-                    if (typeof cell_name == 'string') {
-                        if (cell_name.startsWith('dynamic '))
-                            return false;
-                    }
-                    return true;
-                }
+  return function (container, component) {
+    appendScrollLog('modulePanel:enter', {
+      title: container?.title ?? null,
+      componentCell: component?.cell ?? null
+    });
+    const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
+    if (!moduleInfo) {
+      // Fall through to file attachment: titles like @user/notebook/path.ext
+      // resolve via the lopecode bootloader's contentSync DOM lookup.
+      const title = container?.title ?? null;
+      if (title) {
+        let node = file_attachment_cache.get(title);
+        if (!node) {
+          const r = window.lopecode?.contentSync?.(title);
+          if (r && r.status === 200 && r.bytes) {
+            node = renderFileAttachment(r.mime, r.bytes);
+            file_attachment_cache.set(title, node);
+            appendScrollLog('modulePanel:file_attachment_create', {
+              title,
+              mime: r.mime
             });
-            visualizer_cache.set(module, node);
-        } else {
-            node = visualizer_cache.get(module);
-            appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+          }
         }
-        const cell = module._scope.get(component.cell);
-        const scrollKey = scrollKeyFor(container);
-        fix_scroll(container, node, cell, scrollKey);
-        const el = container.getElement();
-        if (!el.__lope_scroll_bound) {
-            el.__lope_scroll_bound = true;
-            appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
-            el.addEventListener('scroll', () => {
-                const k = scrollKeyFor(container);
-                const scrollTop = el.scrollTop;
-                const scrollLeft = el.scrollLeft;
-                if (scrollTop == 0) {
-                    appendScrollLog('modulePanel:skip 0 scroll', {
-                        title: container?.title ?? null,
-                        scrollKey
-                    });
-                    return;
-                }
-                scroll_cache.set(k, {
-                    scrollTop,
-                    scrollLeft,
-                    t: Date.now()
-                });
-                appendScrollLog('scroll:event', {
-                    k,
-                    title: container?.title ?? null,
-                    scrollTop,
-                    scrollLeft
-                });
-            }, { passive: true });
+        if (node) {
+          const c_element = container.getElement();
+          if (node.parentNode !== c_element)
+            c_element.appendChild(node);
+          appendScrollLog('modulePanel:file_attachment_mount', { title });
+          return;
         }
-        // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
-        if (!container.__lope_destroy_bound) {
-            container.__lope_destroy_bound = true;
-            container.on('destroy', () => {
-                try {
-                    const k = scrollKeyFor(container);
-                    const scrollTop = el?.scrollTop;
-                    const scrollLeft = el?.scrollLeft;
-                    if (scrollTop == 0) {
-                        appendScrollLog('scroll:skip 0 scroll', {
-                            k,
-                            key: container?.title ?? null,
-                            scrollKey
-                        });
-                        return;
-                    }
-                    // do not skip 0 here: if the user is at top, preserve that state
-                    scroll_cache.set(k, {
-                        scrollTop,
-                        scrollLeft,
-                        t: Date.now()
-                    });
-                    appendScrollLog('scroll:destroy_capture', {
-                        k,
-                        title: container?.title ?? null,
-                        scrollTop,
-                        scrollLeft
-                    });
-                } catch (e) {
-                    appendScrollLog('scroll:destroy_capture:error', {
-                        title: container?.title ?? null,
-                        error: String(e)
-                    });
-                }
-            });
+      }
+      appendScrollLog('modulePanel:missing_moduleInfo', { title });
+      return;
+    }
+    const module = moduleInfo.module;
+    let node;
+    if (!visualizer_cache.has(module)) {
+      appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
+      node = visualizer(runtime, {
+        invalidation: new Promise(r => {
+        }),
+        module,
+        detachNodes: isOnObservableCom(),
+        filter: (cell_name, variables) => {
+          if (variables[0]._type !== 1)
+            return false;
+          if (typeof cell_name == 'string') {
+            if (cell_name.startsWith('dynamic '))
+              return false;
+          }
+          return true;
         }
-        appendScrollLog('modulePanel:exit', {
+      });
+      visualizer_cache.set(module, node);
+    } else {
+      node = visualizer_cache.get(module);
+      appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+    }
+    const cell = module._scope.get(component.cell);
+    const scrollKey = scrollKeyFor(container);
+    fix_scroll(container, node, cell, scrollKey);
+    const el = container.getElement();
+    if (!el.__lope_scroll_bound) {
+      el.__lope_scroll_bound = true;
+      appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
+      const markUserScroll = () => {
+        el.__lope_user_scroll_at = Date.now();
+      };
+      el.addEventListener('wheel', markUserScroll, { passive: true });
+      el.addEventListener('touchmove', markUserScroll, { passive: true });
+      el.addEventListener('keydown', markUserScroll, { passive: true });
+      el.addEventListener('scroll', () => {
+        if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+          appendScrollLog('scroll:skip_reflow', { title: container?.title ?? null });
+          return;
+        }
+        // Only cache scrolls following a genuine user gesture; reflow-induced
+        // scroll events (e.g. closing an adjacent panel) carry stale scrollTops.
+        if (Date.now() - (el.__lope_user_scroll_at || 0) > 400) {
+          appendScrollLog('scroll:skip_nonuser', { title: container?.title ?? null });
+          return;
+        }
+        const k = scrollKeyFor(container);
+        const scrollTop = el.scrollTop;
+        const scrollLeft = el.scrollLeft;
+        if (scrollTop == 0) {
+          appendScrollLog('modulePanel:skip 0 scroll', {
             title: container?.title ?? null,
             scrollKey
+          });
+          return;
+        }
+        scroll_cache.set(k, {
+          scrollTop,
+          scrollLeft,
+          t: Date.now()
         });
-    };
+        appendScrollLog('scroll:event', {
+          k,
+          title: container?.title ?? null,
+          scrollTop,
+          scrollLeft
+        });
+      }, { passive: true });
+    }
+    // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
+    if (!container.__lope_destroy_bound) {
+      container.__lope_destroy_bound = true;
+      container.on('destroy', () => {
+        try {
+          if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+            appendScrollLog('scroll:destroy_skip_reflow', { title: container?.title ?? null });
+            return;
+          }
+          const k = scrollKeyFor(container);
+          const scrollTop = el?.scrollTop;
+          const scrollLeft = el?.scrollLeft;
+          if (scrollTop == 0) {
+            appendScrollLog('scroll:skip 0 scroll', {
+              k,
+              key: container?.title ?? null,
+              scrollKey
+            });
+            return;
+          }
+          // do not skip 0 here: if the user is at top, preserve that state
+          scroll_cache.set(k, {
+            scrollTop,
+            scrollLeft,
+            t: Date.now()
+          });
+          appendScrollLog('scroll:destroy_capture', {
+            k,
+            title: container?.title ?? null,
+            scrollTop,
+            scrollLeft
+          });
+        } catch (e) {
+          appendScrollLog('scroll:destroy_capture:error', {
+            title: container?.title ?? null,
+            error: String(e)
+          });
+        }
+      });
+    }
+    // When GoldenLayout resizes this panel (e.g. an adjacent panel is closed) the
+    // browser can shift scrollTop; re-apply the user's cached position after the reflow.
+    if (!container.__lope_resize_bound) {
+      container.__lope_resize_bound = true;
+      container.on('resize', () => {
+        const rk = scrollKeyFor(container);
+        const cached = scroll_cache.get(rk);
+        if (!cached || cached.scrollTop == null)
+          return;
+        const c_el = container.getElement();
+        const at = Date.now();
+        scroll_cache.__reflowUntil = at + 800;
+        // The reflow can shift scrollTop in several passes (content relayout
+        // settles ~300ms later), so re-apply over a window. Bail if the user scrolls.
+        const apply = () => {
+          if ((c_el.__lope_user_scroll_at || 0) > at)
+            return;
+          if (c_el.scrollTop !== cached.scrollTop)
+            c_el.scrollTop = cached.scrollTop;
+          if (cached.scrollLeft != null && c_el.scrollLeft !== cached.scrollLeft)
+            c_el.scrollLeft = cached.scrollLeft;
+        };
+        requestAnimationFrame(apply);
+        for (const d of [
+            60,
+            150,
+            300,
+            450,
+            600
+          ])
+          setTimeout(apply, d);
+        appendScrollLog('scroll:resize_restore', {
+          k: rk,
+          title: container?.title ?? null,
+          scrollTop: cached.scrollTop
+        });
+      });
+    }
+    appendScrollLog('modulePanel:exit', {
+      title: container?.title ?? null,
+      scrollKey
+    });
+  };
 };
 const _1gm4gbf = function _blobPanel(){return(
 function (container, component) {
@@ -14286,112 +14344,115 @@ const _1d1nkw9 = function _scrollKeyFor(appendScrollLog)
 const _tb217h = function _scroll_cache(){return(
 new Map()
 )};
-const _5tyvpe = function _fix_scroll(scrollKeyFor,appendScrollLog,scroll_cache){return(
-function (container, node, cell_variable, key) {
+const _12p8mg7 = function _fix_scroll(scroll_cache,scrollKeyFor,appendScrollLog)
+{
+  return function (container, node, cell_variable, key) {
+    scroll_cache.__reflowUntil = Date.now() + 600;
+    // suppress reflow-induced scroll events that clobber the cache
     const c_element = container.getElement();
     let k = scrollKeyFor(container);
     appendScrollLog('fix_scroll:enter', {
-        title: container?.title ?? null,
-        k,
-        cell: cell_variable?._name ?? null
+      title: container?.title ?? null,
+      k,
+      cell: cell_variable?._name ?? null
     });
     if (node && node.parentNode !== c_element) {
-        c_element.appendChild(node);
-        appendScrollLog('fix_scroll:append_node', {
-            title: container?.title ?? null,
-            k
-        });
+      c_element.appendChild(node);
+      appendScrollLog('fix_scroll:append_node', {
+        title: container?.title ?? null,
+        k
+      });
     }
     const writeCache = (scrollTop, scrollLeft, why) => {
-        scroll_cache.set(k, {
-            scrollTop,
-            scrollLeft,
-            t: Date.now()
-        });
-        appendScrollLog('scroll_cache:write', {
-            k,
-            scrollTop,
-            scrollLeft,
-            why
-        });
+      scroll_cache.set(k, {
+        scrollTop,
+        scrollLeft,
+        t: Date.now()
+      });
+      appendScrollLog('scroll_cache:write', {
+        k,
+        scrollTop,
+        scrollLeft,
+        why
+      });
     };
     const scrollToCellIfPossible = why => {
-        if (!cell_variable)
-            return false;
-        const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
-        if (!dom) {
-            appendScrollLog('scroll:cell_dom_not_found', {
-                k,
-                why,
-                cell: cell_variable?._name ?? null
-            });
-            return false;
-        }
-        const top = dom.offsetTop - c_element.offsetTop;
-        const left = c_element.scrollLeft;
-        c_element.scrollTop = top;
-        appendScrollLog('scroll:set', {
-            k,
-            why: `${ why }:cell`,
-            scrollTop: top,
-            scrollLeft: left,
-            cell: cell_variable?._name ?? null
+      if (!cell_variable)
+        return false;
+      const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
+      if (!dom) {
+        appendScrollLog('scroll:cell_dom_not_found', {
+          k,
+          why,
+          cell: cell_variable?._name ?? null
         });
-        writeCache(top, left, `${ why }:cell`);
-        return true;
+        return false;
+      }
+      const top = dom.offsetTop - c_element.offsetTop;
+      const left = c_element.scrollLeft;
+      c_element.scrollTop = top;
+      appendScrollLog('scroll:set', {
+        k,
+        why: `${ why }:cell`,
+        scrollTop: top,
+        scrollLeft: left,
+        cell: cell_variable?._name ?? null
+      });
+      writeCache(top, left, `${ why }:cell`);
+      return true;
     };
     const restoreFromCache = why => {
-        k = scrollKeyFor(container);
-        const cached = scroll_cache.get(k);
-        appendScrollLog('scroll:restore_attempt', {
-            k,
-            why,
-            cachedScrollTop: cached?.scrollTop ?? null,
-            cachedScrollLeft: cached?.scrollLeft ?? null
+      k = scrollKeyFor(container);
+      const cached = scroll_cache.get(k);
+      appendScrollLog('scroll:restore_attempt', {
+        k,
+        why,
+        cachedScrollTop: cached?.scrollTop ?? null,
+        cachedScrollLeft: cached?.scrollLeft ?? null
+      });
+      if (!cached) {
+        appendScrollLog('scroll:restore_no_scroll', {
+          k,
+          why
         });
-        if (!cached) {
-            appendScrollLog('scroll:restore_no_scroll', {
-                k,
-                why
-            });
-            return;
-        }
-        if (cached.scrollTop != null)
-            c_element.scrollTop = cached.scrollTop;
-        if (cached.scrollLeft != null)
-            c_element.scrollLeft = cached.scrollLeft;
-        appendScrollLog('scroll:restore_applied', {
-            k,
-            why,
-            scrollTop: cached.scrollTop ?? null,
-            scrollLeft: cached.scrollLeft ?? null,
-            scrollTopFinal: c_element.scrollTop,
-            scrollLeftFinal: c_element.scrollLeft
-        });
+        return;
+      }
+      if (cached.scrollTop != null)
+        c_element.scrollTop = cached.scrollTop;
+      if (cached.scrollLeft != null)
+        c_element.scrollLeft = cached.scrollLeft;
+      appendScrollLog('scroll:restore_applied', {
+        k,
+        why,
+        scrollTop: cached.scrollTop ?? null,
+        scrollLeft: cached.scrollLeft ?? null,
+        scrollTopFinal: c_element.scrollTop,
+        scrollLeftFinal: c_element.scrollLeft
+      });
     };
     const setScroll = (why = 'setScroll') => {
-        if (scrollToCellIfPossible(why))
-            return;
-        restoreFromCache(why);
+      if (scrollToCellIfPossible(why))
+        return;
+      restoreFromCache(why);
     };
     const retryFrames = 6;
     for (let i = 0; i < retryFrames; i++) {
-        requestAnimationFrame(() => {
-            k = scrollKeyFor(container);
-            appendScrollLog('fix_scroll:raf_retry', {
-                i,
-                k,
-                title: container?.title ?? null
-            });
-            setScroll(`raf:${ i }`);
+      requestAnimationFrame(() => {
+        k = scrollKeyFor(container);
+        appendScrollLog('fix_scroll:raf_retry', {
+          i,
+          k,
+          title: container?.title ?? null
         });
+        setScroll(`raf:${ i }`);
+      });
     }
     appendScrollLog('fix_scroll:exit', {
-        k,
-        title: container?.title ?? null
+      k,
+      title: container?.title ?? null
     });
-}
-)};
+  };
+};
 const _arfw00 = function _scroll_fix_sync_layout(sync_layout_to_url,layout,appendScrollLog,modulePanel)
 {
     sync_layout_to_url;
@@ -15469,7 +15530,7 @@ export default function define(runtime, observer) {
   $def("_1we0ggl", "reload", ["Generators","viewof reload"], _1we0ggl);  
   $def("_plefwg", "onLoadConfig", ["parseGoldenDSL","URLSearchParams","location"], _plefwg);  
   $def("_1nzpnqy", "visualizer_cache", ["reload"], _1nzpnqy);  
-  $def("_1l35721", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1l35721);  
+  $def("_1ojown8", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1ojown8);  
   $def("_1gm4gbf", "blobPanel", [], _1gm4gbf);  
   $def("_lxv2e2", "settings", [], _lxv2e2);  
   $def("_lp1ggk", "is_mobile", ["width"], _lp1ggk);  
@@ -15490,7 +15551,7 @@ export default function define(runtime, observer) {
   $def("_1dyz4o0", "scrollLog", ["mutable scrollLog"], _1dyz4o0);  
   $def("_1d1nkw9", "scrollKeyFor", ["appendScrollLog"], _1d1nkw9);  
   $def("_tb217h", "scroll_cache", [], _tb217h);  
-  $def("_5tyvpe", "fix_scroll", ["scrollKeyFor","appendScrollLog","scroll_cache"], _5tyvpe);  
+  $def("_12p8mg7", "fix_scroll", ["scroll_cache","scrollKeyFor","appendScrollLog"], _12p8mg7);  
   $def("_arfw00", "scroll_fix_sync_layout", ["sync_layout_to_url","layout","appendScrollLog","modulePanel"], _arfw00);  
   $def("_3nwpp4", "URLrouting", ["md"], _3nwpp4);  
   $def("_14te9pl", "sync_layout_from_url", ["reload","resize","URLSearchParams","hash","appendScrollLog","parseGoldenDSL","gl","layout","serializeGoldenDSL","treeSyncGolden","invalidation"], _14te9pl);  

--- a/notebooks/@tomlarkworthy_editor-5.html
+++ b/notebooks/@tomlarkworthy_editor-5.html
@@ -14035,138 +14035,196 @@ const _1nzpnqy = function _visualizer_cache(reload)
     reload;
     return new Map();
 };
-const _1l35721 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
+const _1ojown8 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
 {
-    return function (container, component) {
-        appendScrollLog('modulePanel:enter', {
-            title: container?.title ?? null,
-            componentCell: component?.cell ?? null
-        });
-        const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
-        if (!moduleInfo) {
-            // Fall through to file attachment: titles like @user/notebook/path.ext
-            // resolve via the lopecode bootloader's contentSync DOM lookup.
-            const title = container?.title ?? null;
-            if (title) {
-                let node = file_attachment_cache.get(title);
-                if (!node) {
-                    const r = window.lopecode?.contentSync?.(title);
-                    if (r && r.status === 200 && r.bytes) {
-                        node = renderFileAttachment(r.mime, r.bytes);
-                        file_attachment_cache.set(title, node);
-                        appendScrollLog('modulePanel:file_attachment_create', {
-                            title,
-                            mime: r.mime
-                        });
-                    }
-                }
-                if (node) {
-                    const c_element = container.getElement();
-                    if (node.parentNode !== c_element)
-                        c_element.appendChild(node);
-                    appendScrollLog('modulePanel:file_attachment_mount', { title });
-                    return;
-                }
-            }
-            appendScrollLog('modulePanel:missing_moduleInfo', { title });
-            return;
-        }
-        const module = moduleInfo.module;
-        let node;
-        if (!visualizer_cache.has(module)) {
-            appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
-            node = visualizer(runtime, {
-                invalidation: new Promise(r => {
-                }),
-                module,
-                detachNodes: isOnObservableCom(),
-                filter: (cell_name, variables) => {
-                    if (variables[0]._type !== 1)
-                        return false;
-                    if (typeof cell_name == 'string') {
-                        if (cell_name.startsWith('dynamic '))
-                            return false;
-                    }
-                    return true;
-                }
+  return function (container, component) {
+    appendScrollLog('modulePanel:enter', {
+      title: container?.title ?? null,
+      componentCell: component?.cell ?? null
+    });
+    const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
+    if (!moduleInfo) {
+      // Fall through to file attachment: titles like @user/notebook/path.ext
+      // resolve via the lopecode bootloader's contentSync DOM lookup.
+      const title = container?.title ?? null;
+      if (title) {
+        let node = file_attachment_cache.get(title);
+        if (!node) {
+          const r = window.lopecode?.contentSync?.(title);
+          if (r && r.status === 200 && r.bytes) {
+            node = renderFileAttachment(r.mime, r.bytes);
+            file_attachment_cache.set(title, node);
+            appendScrollLog('modulePanel:file_attachment_create', {
+              title,
+              mime: r.mime
             });
-            visualizer_cache.set(module, node);
-        } else {
-            node = visualizer_cache.get(module);
-            appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+          }
         }
-        const cell = module._scope.get(component.cell);
-        const scrollKey = scrollKeyFor(container);
-        fix_scroll(container, node, cell, scrollKey);
-        const el = container.getElement();
-        if (!el.__lope_scroll_bound) {
-            el.__lope_scroll_bound = true;
-            appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
-            el.addEventListener('scroll', () => {
-                const k = scrollKeyFor(container);
-                const scrollTop = el.scrollTop;
-                const scrollLeft = el.scrollLeft;
-                if (scrollTop == 0) {
-                    appendScrollLog('modulePanel:skip 0 scroll', {
-                        title: container?.title ?? null,
-                        scrollKey
-                    });
-                    return;
-                }
-                scroll_cache.set(k, {
-                    scrollTop,
-                    scrollLeft,
-                    t: Date.now()
-                });
-                appendScrollLog('scroll:event', {
-                    k,
-                    title: container?.title ?? null,
-                    scrollTop,
-                    scrollLeft
-                });
-            }, { passive: true });
+        if (node) {
+          const c_element = container.getElement();
+          if (node.parentNode !== c_element)
+            c_element.appendChild(node);
+          appendScrollLog('modulePanel:file_attachment_mount', { title });
+          return;
         }
-        // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
-        if (!container.__lope_destroy_bound) {
-            container.__lope_destroy_bound = true;
-            container.on('destroy', () => {
-                try {
-                    const k = scrollKeyFor(container);
-                    const scrollTop = el?.scrollTop;
-                    const scrollLeft = el?.scrollLeft;
-                    if (scrollTop == 0) {
-                        appendScrollLog('scroll:skip 0 scroll', {
-                            k,
-                            key: container?.title ?? null,
-                            scrollKey
-                        });
-                        return;
-                    }
-                    // do not skip 0 here: if the user is at top, preserve that state
-                    scroll_cache.set(k, {
-                        scrollTop,
-                        scrollLeft,
-                        t: Date.now()
-                    });
-                    appendScrollLog('scroll:destroy_capture', {
-                        k,
-                        title: container?.title ?? null,
-                        scrollTop,
-                        scrollLeft
-                    });
-                } catch (e) {
-                    appendScrollLog('scroll:destroy_capture:error', {
-                        title: container?.title ?? null,
-                        error: String(e)
-                    });
-                }
-            });
+      }
+      appendScrollLog('modulePanel:missing_moduleInfo', { title });
+      return;
+    }
+    const module = moduleInfo.module;
+    let node;
+    if (!visualizer_cache.has(module)) {
+      appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
+      node = visualizer(runtime, {
+        invalidation: new Promise(r => {
+        }),
+        module,
+        detachNodes: isOnObservableCom(),
+        filter: (cell_name, variables) => {
+          if (variables[0]._type !== 1)
+            return false;
+          if (typeof cell_name == 'string') {
+            if (cell_name.startsWith('dynamic '))
+              return false;
+          }
+          return true;
         }
-        appendScrollLog('modulePanel:exit', {
+      });
+      visualizer_cache.set(module, node);
+    } else {
+      node = visualizer_cache.get(module);
+      appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+    }
+    const cell = module._scope.get(component.cell);
+    const scrollKey = scrollKeyFor(container);
+    fix_scroll(container, node, cell, scrollKey);
+    const el = container.getElement();
+    if (!el.__lope_scroll_bound) {
+      el.__lope_scroll_bound = true;
+      appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
+      const markUserScroll = () => {
+        el.__lope_user_scroll_at = Date.now();
+      };
+      el.addEventListener('wheel', markUserScroll, { passive: true });
+      el.addEventListener('touchmove', markUserScroll, { passive: true });
+      el.addEventListener('keydown', markUserScroll, { passive: true });
+      el.addEventListener('scroll', () => {
+        if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+          appendScrollLog('scroll:skip_reflow', { title: container?.title ?? null });
+          return;
+        }
+        // Only cache scrolls following a genuine user gesture; reflow-induced
+        // scroll events (e.g. closing an adjacent panel) carry stale scrollTops.
+        if (Date.now() - (el.__lope_user_scroll_at || 0) > 400) {
+          appendScrollLog('scroll:skip_nonuser', { title: container?.title ?? null });
+          return;
+        }
+        const k = scrollKeyFor(container);
+        const scrollTop = el.scrollTop;
+        const scrollLeft = el.scrollLeft;
+        if (scrollTop == 0) {
+          appendScrollLog('modulePanel:skip 0 scroll', {
             title: container?.title ?? null,
             scrollKey
+          });
+          return;
+        }
+        scroll_cache.set(k, {
+          scrollTop,
+          scrollLeft,
+          t: Date.now()
         });
-    };
+        appendScrollLog('scroll:event', {
+          k,
+          title: container?.title ?? null,
+          scrollTop,
+          scrollLeft
+        });
+      }, { passive: true });
+    }
+    // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
+    if (!container.__lope_destroy_bound) {
+      container.__lope_destroy_bound = true;
+      container.on('destroy', () => {
+        try {
+          if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+            appendScrollLog('scroll:destroy_skip_reflow', { title: container?.title ?? null });
+            return;
+          }
+          const k = scrollKeyFor(container);
+          const scrollTop = el?.scrollTop;
+          const scrollLeft = el?.scrollLeft;
+          if (scrollTop == 0) {
+            appendScrollLog('scroll:skip 0 scroll', {
+              k,
+              key: container?.title ?? null,
+              scrollKey
+            });
+            return;
+          }
+          // do not skip 0 here: if the user is at top, preserve that state
+          scroll_cache.set(k, {
+            scrollTop,
+            scrollLeft,
+            t: Date.now()
+          });
+          appendScrollLog('scroll:destroy_capture', {
+            k,
+            title: container?.title ?? null,
+            scrollTop,
+            scrollLeft
+          });
+        } catch (e) {
+          appendScrollLog('scroll:destroy_capture:error', {
+            title: container?.title ?? null,
+            error: String(e)
+          });
+        }
+      });
+    }
+    // When GoldenLayout resizes this panel (e.g. an adjacent panel is closed) the
+    // browser can shift scrollTop; re-apply the user's cached position after the reflow.
+    if (!container.__lope_resize_bound) {
+      container.__lope_resize_bound = true;
+      container.on('resize', () => {
+        const rk = scrollKeyFor(container);
+        const cached = scroll_cache.get(rk);
+        if (!cached || cached.scrollTop == null)
+          return;
+        const c_el = container.getElement();
+        const at = Date.now();
+        scroll_cache.__reflowUntil = at + 800;
+        // The reflow can shift scrollTop in several passes (content relayout
+        // settles ~300ms later), so re-apply over a window. Bail if the user scrolls.
+        const apply = () => {
+          if ((c_el.__lope_user_scroll_at || 0) > at)
+            return;
+          if (c_el.scrollTop !== cached.scrollTop)
+            c_el.scrollTop = cached.scrollTop;
+          if (cached.scrollLeft != null && c_el.scrollLeft !== cached.scrollLeft)
+            c_el.scrollLeft = cached.scrollLeft;
+        };
+        requestAnimationFrame(apply);
+        for (const d of [
+            60,
+            150,
+            300,
+            450,
+            600
+          ])
+          setTimeout(apply, d);
+        appendScrollLog('scroll:resize_restore', {
+          k: rk,
+          title: container?.title ?? null,
+          scrollTop: cached.scrollTop
+        });
+      });
+    }
+    appendScrollLog('modulePanel:exit', {
+      title: container?.title ?? null,
+      scrollKey
+    });
+  };
 };
 const _1gm4gbf = function _blobPanel(){return(
 function (container, component) {
@@ -14284,112 +14342,115 @@ const _1d1nkw9 = function _scrollKeyFor(appendScrollLog)
 const _tb217h = function _scroll_cache(){return(
 new Map()
 )};
-const _5tyvpe = function _fix_scroll(scrollKeyFor,appendScrollLog,scroll_cache){return(
-function (container, node, cell_variable, key) {
+const _12p8mg7 = function _fix_scroll(scroll_cache,scrollKeyFor,appendScrollLog)
+{
+  return function (container, node, cell_variable, key) {
+    scroll_cache.__reflowUntil = Date.now() + 600;
+    // suppress reflow-induced scroll events that clobber the cache
     const c_element = container.getElement();
     let k = scrollKeyFor(container);
     appendScrollLog('fix_scroll:enter', {
-        title: container?.title ?? null,
-        k,
-        cell: cell_variable?._name ?? null
+      title: container?.title ?? null,
+      k,
+      cell: cell_variable?._name ?? null
     });
     if (node && node.parentNode !== c_element) {
-        c_element.appendChild(node);
-        appendScrollLog('fix_scroll:append_node', {
-            title: container?.title ?? null,
-            k
-        });
+      c_element.appendChild(node);
+      appendScrollLog('fix_scroll:append_node', {
+        title: container?.title ?? null,
+        k
+      });
     }
     const writeCache = (scrollTop, scrollLeft, why) => {
-        scroll_cache.set(k, {
-            scrollTop,
-            scrollLeft,
-            t: Date.now()
-        });
-        appendScrollLog('scroll_cache:write', {
-            k,
-            scrollTop,
-            scrollLeft,
-            why
-        });
+      scroll_cache.set(k, {
+        scrollTop,
+        scrollLeft,
+        t: Date.now()
+      });
+      appendScrollLog('scroll_cache:write', {
+        k,
+        scrollTop,
+        scrollLeft,
+        why
+      });
     };
     const scrollToCellIfPossible = why => {
-        if (!cell_variable)
-            return false;
-        const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
-        if (!dom) {
-            appendScrollLog('scroll:cell_dom_not_found', {
-                k,
-                why,
-                cell: cell_variable?._name ?? null
-            });
-            return false;
-        }
-        const top = dom.offsetTop - c_element.offsetTop;
-        const left = c_element.scrollLeft;
-        c_element.scrollTop = top;
-        appendScrollLog('scroll:set', {
-            k,
-            why: `${ why }:cell`,
-            scrollTop: top,
-            scrollLeft: left,
-            cell: cell_variable?._name ?? null
+      if (!cell_variable)
+        return false;
+      const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
+      if (!dom) {
+        appendScrollLog('scroll:cell_dom_not_found', {
+          k,
+          why,
+          cell: cell_variable?._name ?? null
         });
-        writeCache(top, left, `${ why }:cell`);
-        return true;
+        return false;
+      }
+      const top = dom.offsetTop - c_element.offsetTop;
+      const left = c_element.scrollLeft;
+      c_element.scrollTop = top;
+      appendScrollLog('scroll:set', {
+        k,
+        why: `${ why }:cell`,
+        scrollTop: top,
+        scrollLeft: left,
+        cell: cell_variable?._name ?? null
+      });
+      writeCache(top, left, `${ why }:cell`);
+      return true;
     };
     const restoreFromCache = why => {
-        k = scrollKeyFor(container);
-        const cached = scroll_cache.get(k);
-        appendScrollLog('scroll:restore_attempt', {
-            k,
-            why,
-            cachedScrollTop: cached?.scrollTop ?? null,
-            cachedScrollLeft: cached?.scrollLeft ?? null
+      k = scrollKeyFor(container);
+      const cached = scroll_cache.get(k);
+      appendScrollLog('scroll:restore_attempt', {
+        k,
+        why,
+        cachedScrollTop: cached?.scrollTop ?? null,
+        cachedScrollLeft: cached?.scrollLeft ?? null
+      });
+      if (!cached) {
+        appendScrollLog('scroll:restore_no_scroll', {
+          k,
+          why
         });
-        if (!cached) {
-            appendScrollLog('scroll:restore_no_scroll', {
-                k,
-                why
-            });
-            return;
-        }
-        if (cached.scrollTop != null)
-            c_element.scrollTop = cached.scrollTop;
-        if (cached.scrollLeft != null)
-            c_element.scrollLeft = cached.scrollLeft;
-        appendScrollLog('scroll:restore_applied', {
-            k,
-            why,
-            scrollTop: cached.scrollTop ?? null,
-            scrollLeft: cached.scrollLeft ?? null,
-            scrollTopFinal: c_element.scrollTop,
-            scrollLeftFinal: c_element.scrollLeft
-        });
+        return;
+      }
+      if (cached.scrollTop != null)
+        c_element.scrollTop = cached.scrollTop;
+      if (cached.scrollLeft != null)
+        c_element.scrollLeft = cached.scrollLeft;
+      appendScrollLog('scroll:restore_applied', {
+        k,
+        why,
+        scrollTop: cached.scrollTop ?? null,
+        scrollLeft: cached.scrollLeft ?? null,
+        scrollTopFinal: c_element.scrollTop,
+        scrollLeftFinal: c_element.scrollLeft
+      });
     };
     const setScroll = (why = 'setScroll') => {
-        if (scrollToCellIfPossible(why))
-            return;
-        restoreFromCache(why);
+      if (scrollToCellIfPossible(why))
+        return;
+      restoreFromCache(why);
     };
     const retryFrames = 6;
     for (let i = 0; i < retryFrames; i++) {
-        requestAnimationFrame(() => {
-            k = scrollKeyFor(container);
-            appendScrollLog('fix_scroll:raf_retry', {
-                i,
-                k,
-                title: container?.title ?? null
-            });
-            setScroll(`raf:${ i }`);
+      requestAnimationFrame(() => {
+        k = scrollKeyFor(container);
+        appendScrollLog('fix_scroll:raf_retry', {
+          i,
+          k,
+          title: container?.title ?? null
         });
+        setScroll(`raf:${ i }`);
+      });
     }
     appendScrollLog('fix_scroll:exit', {
-        k,
-        title: container?.title ?? null
+      k,
+      title: container?.title ?? null
     });
-}
-)};
+  };
+};
 const _arfw00 = function _scroll_fix_sync_layout(sync_layout_to_url,layout,appendScrollLog,modulePanel)
 {
     sync_layout_to_url;
@@ -15467,7 +15528,7 @@ export default function define(runtime, observer) {
   $def("_1we0ggl", "reload", ["Generators","viewof reload"], _1we0ggl);  
   $def("_plefwg", "onLoadConfig", ["parseGoldenDSL","URLSearchParams","location"], _plefwg);  
   $def("_1nzpnqy", "visualizer_cache", ["reload"], _1nzpnqy);  
-  $def("_1l35721", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1l35721);  
+  $def("_1ojown8", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1ojown8);  
   $def("_1gm4gbf", "blobPanel", [], _1gm4gbf);  
   $def("_lxv2e2", "settings", [], _lxv2e2);  
   $def("_lp1ggk", "is_mobile", ["width"], _lp1ggk);  
@@ -15488,7 +15549,7 @@ export default function define(runtime, observer) {
   $def("_1dyz4o0", "scrollLog", ["mutable scrollLog"], _1dyz4o0);  
   $def("_1d1nkw9", "scrollKeyFor", ["appendScrollLog"], _1d1nkw9);  
   $def("_tb217h", "scroll_cache", [], _tb217h);  
-  $def("_5tyvpe", "fix_scroll", ["scrollKeyFor","appendScrollLog","scroll_cache"], _5tyvpe);  
+  $def("_12p8mg7", "fix_scroll", ["scroll_cache","scrollKeyFor","appendScrollLog"], _12p8mg7);  
   $def("_arfw00", "scroll_fix_sync_layout", ["sync_layout_to_url","layout","appendScrollLog","modulePanel"], _arfw00);  
   $def("_3nwpp4", "URLrouting", ["md"], _3nwpp4);  
   $def("_14te9pl", "sync_layout_from_url", ["reload","resize","URLSearchParams","hash","appendScrollLog","parseGoldenDSL","gl","layout","serializeGoldenDSL","treeSyncGolden","invalidation"], _14te9pl);  

--- a/notebooks/@tomlarkworthy_exporter-2.html
+++ b/notebooks/@tomlarkworthy_exporter-2.html
@@ -16083,138 +16083,196 @@ const _1nzpnqy = function _visualizer_cache(reload)
     reload;
     return new Map();
 };
-const _1l35721 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
+const _1ojown8 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
 {
-    return function (container, component) {
-        appendScrollLog('modulePanel:enter', {
-            title: container?.title ?? null,
-            componentCell: component?.cell ?? null
-        });
-        const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
-        if (!moduleInfo) {
-            // Fall through to file attachment: titles like @user/notebook/path.ext
-            // resolve via the lopecode bootloader's contentSync DOM lookup.
-            const title = container?.title ?? null;
-            if (title) {
-                let node = file_attachment_cache.get(title);
-                if (!node) {
-                    const r = window.lopecode?.contentSync?.(title);
-                    if (r && r.status === 200 && r.bytes) {
-                        node = renderFileAttachment(r.mime, r.bytes);
-                        file_attachment_cache.set(title, node);
-                        appendScrollLog('modulePanel:file_attachment_create', {
-                            title,
-                            mime: r.mime
-                        });
-                    }
-                }
-                if (node) {
-                    const c_element = container.getElement();
-                    if (node.parentNode !== c_element)
-                        c_element.appendChild(node);
-                    appendScrollLog('modulePanel:file_attachment_mount', { title });
-                    return;
-                }
-            }
-            appendScrollLog('modulePanel:missing_moduleInfo', { title });
-            return;
-        }
-        const module = moduleInfo.module;
-        let node;
-        if (!visualizer_cache.has(module)) {
-            appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
-            node = visualizer(runtime, {
-                invalidation: new Promise(r => {
-                }),
-                module,
-                detachNodes: isOnObservableCom(),
-                filter: (cell_name, variables) => {
-                    if (variables[0]._type !== 1)
-                        return false;
-                    if (typeof cell_name == 'string') {
-                        if (cell_name.startsWith('dynamic '))
-                            return false;
-                    }
-                    return true;
-                }
+  return function (container, component) {
+    appendScrollLog('modulePanel:enter', {
+      title: container?.title ?? null,
+      componentCell: component?.cell ?? null
+    });
+    const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
+    if (!moduleInfo) {
+      // Fall through to file attachment: titles like @user/notebook/path.ext
+      // resolve via the lopecode bootloader's contentSync DOM lookup.
+      const title = container?.title ?? null;
+      if (title) {
+        let node = file_attachment_cache.get(title);
+        if (!node) {
+          const r = window.lopecode?.contentSync?.(title);
+          if (r && r.status === 200 && r.bytes) {
+            node = renderFileAttachment(r.mime, r.bytes);
+            file_attachment_cache.set(title, node);
+            appendScrollLog('modulePanel:file_attachment_create', {
+              title,
+              mime: r.mime
             });
-            visualizer_cache.set(module, node);
-        } else {
-            node = visualizer_cache.get(module);
-            appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+          }
         }
-        const cell = module._scope.get(component.cell);
-        const scrollKey = scrollKeyFor(container);
-        fix_scroll(container, node, cell, scrollKey);
-        const el = container.getElement();
-        if (!el.__lope_scroll_bound) {
-            el.__lope_scroll_bound = true;
-            appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
-            el.addEventListener('scroll', () => {
-                const k = scrollKeyFor(container);
-                const scrollTop = el.scrollTop;
-                const scrollLeft = el.scrollLeft;
-                if (scrollTop == 0) {
-                    appendScrollLog('modulePanel:skip 0 scroll', {
-                        title: container?.title ?? null,
-                        scrollKey
-                    });
-                    return;
-                }
-                scroll_cache.set(k, {
-                    scrollTop,
-                    scrollLeft,
-                    t: Date.now()
-                });
-                appendScrollLog('scroll:event', {
-                    k,
-                    title: container?.title ?? null,
-                    scrollTop,
-                    scrollLeft
-                });
-            }, { passive: true });
+        if (node) {
+          const c_element = container.getElement();
+          if (node.parentNode !== c_element)
+            c_element.appendChild(node);
+          appendScrollLog('modulePanel:file_attachment_mount', { title });
+          return;
         }
-        // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
-        if (!container.__lope_destroy_bound) {
-            container.__lope_destroy_bound = true;
-            container.on('destroy', () => {
-                try {
-                    const k = scrollKeyFor(container);
-                    const scrollTop = el?.scrollTop;
-                    const scrollLeft = el?.scrollLeft;
-                    if (scrollTop == 0) {
-                        appendScrollLog('scroll:skip 0 scroll', {
-                            k,
-                            key: container?.title ?? null,
-                            scrollKey
-                        });
-                        return;
-                    }
-                    // do not skip 0 here: if the user is at top, preserve that state
-                    scroll_cache.set(k, {
-                        scrollTop,
-                        scrollLeft,
-                        t: Date.now()
-                    });
-                    appendScrollLog('scroll:destroy_capture', {
-                        k,
-                        title: container?.title ?? null,
-                        scrollTop,
-                        scrollLeft
-                    });
-                } catch (e) {
-                    appendScrollLog('scroll:destroy_capture:error', {
-                        title: container?.title ?? null,
-                        error: String(e)
-                    });
-                }
-            });
+      }
+      appendScrollLog('modulePanel:missing_moduleInfo', { title });
+      return;
+    }
+    const module = moduleInfo.module;
+    let node;
+    if (!visualizer_cache.has(module)) {
+      appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
+      node = visualizer(runtime, {
+        invalidation: new Promise(r => {
+        }),
+        module,
+        detachNodes: isOnObservableCom(),
+        filter: (cell_name, variables) => {
+          if (variables[0]._type !== 1)
+            return false;
+          if (typeof cell_name == 'string') {
+            if (cell_name.startsWith('dynamic '))
+              return false;
+          }
+          return true;
         }
-        appendScrollLog('modulePanel:exit', {
+      });
+      visualizer_cache.set(module, node);
+    } else {
+      node = visualizer_cache.get(module);
+      appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+    }
+    const cell = module._scope.get(component.cell);
+    const scrollKey = scrollKeyFor(container);
+    fix_scroll(container, node, cell, scrollKey);
+    const el = container.getElement();
+    if (!el.__lope_scroll_bound) {
+      el.__lope_scroll_bound = true;
+      appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
+      const markUserScroll = () => {
+        el.__lope_user_scroll_at = Date.now();
+      };
+      el.addEventListener('wheel', markUserScroll, { passive: true });
+      el.addEventListener('touchmove', markUserScroll, { passive: true });
+      el.addEventListener('keydown', markUserScroll, { passive: true });
+      el.addEventListener('scroll', () => {
+        if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+          appendScrollLog('scroll:skip_reflow', { title: container?.title ?? null });
+          return;
+        }
+        // Only cache scrolls following a genuine user gesture; reflow-induced
+        // scroll events (e.g. closing an adjacent panel) carry stale scrollTops.
+        if (Date.now() - (el.__lope_user_scroll_at || 0) > 400) {
+          appendScrollLog('scroll:skip_nonuser', { title: container?.title ?? null });
+          return;
+        }
+        const k = scrollKeyFor(container);
+        const scrollTop = el.scrollTop;
+        const scrollLeft = el.scrollLeft;
+        if (scrollTop == 0) {
+          appendScrollLog('modulePanel:skip 0 scroll', {
             title: container?.title ?? null,
             scrollKey
+          });
+          return;
+        }
+        scroll_cache.set(k, {
+          scrollTop,
+          scrollLeft,
+          t: Date.now()
         });
-    };
+        appendScrollLog('scroll:event', {
+          k,
+          title: container?.title ?? null,
+          scrollTop,
+          scrollLeft
+        });
+      }, { passive: true });
+    }
+    // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
+    if (!container.__lope_destroy_bound) {
+      container.__lope_destroy_bound = true;
+      container.on('destroy', () => {
+        try {
+          if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+            appendScrollLog('scroll:destroy_skip_reflow', { title: container?.title ?? null });
+            return;
+          }
+          const k = scrollKeyFor(container);
+          const scrollTop = el?.scrollTop;
+          const scrollLeft = el?.scrollLeft;
+          if (scrollTop == 0) {
+            appendScrollLog('scroll:skip 0 scroll', {
+              k,
+              key: container?.title ?? null,
+              scrollKey
+            });
+            return;
+          }
+          // do not skip 0 here: if the user is at top, preserve that state
+          scroll_cache.set(k, {
+            scrollTop,
+            scrollLeft,
+            t: Date.now()
+          });
+          appendScrollLog('scroll:destroy_capture', {
+            k,
+            title: container?.title ?? null,
+            scrollTop,
+            scrollLeft
+          });
+        } catch (e) {
+          appendScrollLog('scroll:destroy_capture:error', {
+            title: container?.title ?? null,
+            error: String(e)
+          });
+        }
+      });
+    }
+    // When GoldenLayout resizes this panel (e.g. an adjacent panel is closed) the
+    // browser can shift scrollTop; re-apply the user's cached position after the reflow.
+    if (!container.__lope_resize_bound) {
+      container.__lope_resize_bound = true;
+      container.on('resize', () => {
+        const rk = scrollKeyFor(container);
+        const cached = scroll_cache.get(rk);
+        if (!cached || cached.scrollTop == null)
+          return;
+        const c_el = container.getElement();
+        const at = Date.now();
+        scroll_cache.__reflowUntil = at + 800;
+        // The reflow can shift scrollTop in several passes (content relayout
+        // settles ~300ms later), so re-apply over a window. Bail if the user scrolls.
+        const apply = () => {
+          if ((c_el.__lope_user_scroll_at || 0) > at)
+            return;
+          if (c_el.scrollTop !== cached.scrollTop)
+            c_el.scrollTop = cached.scrollTop;
+          if (cached.scrollLeft != null && c_el.scrollLeft !== cached.scrollLeft)
+            c_el.scrollLeft = cached.scrollLeft;
+        };
+        requestAnimationFrame(apply);
+        for (const d of [
+            60,
+            150,
+            300,
+            450,
+            600
+          ])
+          setTimeout(apply, d);
+        appendScrollLog('scroll:resize_restore', {
+          k: rk,
+          title: container?.title ?? null,
+          scrollTop: cached.scrollTop
+        });
+      });
+    }
+    appendScrollLog('modulePanel:exit', {
+      title: container?.title ?? null,
+      scrollKey
+    });
+  };
 };
 const _1gm4gbf = function _blobPanel(){return(
 function (container, component) {
@@ -16332,112 +16390,115 @@ const _1d1nkw9 = function _scrollKeyFor(appendScrollLog)
 const _tb217h = function _scroll_cache(){return(
 new Map()
 )};
-const _5tyvpe = function _fix_scroll(scrollKeyFor,appendScrollLog,scroll_cache){return(
-function (container, node, cell_variable, key) {
+const _12p8mg7 = function _fix_scroll(scroll_cache,scrollKeyFor,appendScrollLog)
+{
+  return function (container, node, cell_variable, key) {
+    scroll_cache.__reflowUntil = Date.now() + 600;
+    // suppress reflow-induced scroll events that clobber the cache
     const c_element = container.getElement();
     let k = scrollKeyFor(container);
     appendScrollLog('fix_scroll:enter', {
-        title: container?.title ?? null,
-        k,
-        cell: cell_variable?._name ?? null
+      title: container?.title ?? null,
+      k,
+      cell: cell_variable?._name ?? null
     });
     if (node && node.parentNode !== c_element) {
-        c_element.appendChild(node);
-        appendScrollLog('fix_scroll:append_node', {
-            title: container?.title ?? null,
-            k
-        });
+      c_element.appendChild(node);
+      appendScrollLog('fix_scroll:append_node', {
+        title: container?.title ?? null,
+        k
+      });
     }
     const writeCache = (scrollTop, scrollLeft, why) => {
-        scroll_cache.set(k, {
-            scrollTop,
-            scrollLeft,
-            t: Date.now()
-        });
-        appendScrollLog('scroll_cache:write', {
-            k,
-            scrollTop,
-            scrollLeft,
-            why
-        });
+      scroll_cache.set(k, {
+        scrollTop,
+        scrollLeft,
+        t: Date.now()
+      });
+      appendScrollLog('scroll_cache:write', {
+        k,
+        scrollTop,
+        scrollLeft,
+        why
+      });
     };
     const scrollToCellIfPossible = why => {
-        if (!cell_variable)
-            return false;
-        const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
-        if (!dom) {
-            appendScrollLog('scroll:cell_dom_not_found', {
-                k,
-                why,
-                cell: cell_variable?._name ?? null
-            });
-            return false;
-        }
-        const top = dom.offsetTop - c_element.offsetTop;
-        const left = c_element.scrollLeft;
-        c_element.scrollTop = top;
-        appendScrollLog('scroll:set', {
-            k,
-            why: `${ why }:cell`,
-            scrollTop: top,
-            scrollLeft: left,
-            cell: cell_variable?._name ?? null
+      if (!cell_variable)
+        return false;
+      const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
+      if (!dom) {
+        appendScrollLog('scroll:cell_dom_not_found', {
+          k,
+          why,
+          cell: cell_variable?._name ?? null
         });
-        writeCache(top, left, `${ why }:cell`);
-        return true;
+        return false;
+      }
+      const top = dom.offsetTop - c_element.offsetTop;
+      const left = c_element.scrollLeft;
+      c_element.scrollTop = top;
+      appendScrollLog('scroll:set', {
+        k,
+        why: `${ why }:cell`,
+        scrollTop: top,
+        scrollLeft: left,
+        cell: cell_variable?._name ?? null
+      });
+      writeCache(top, left, `${ why }:cell`);
+      return true;
     };
     const restoreFromCache = why => {
-        k = scrollKeyFor(container);
-        const cached = scroll_cache.get(k);
-        appendScrollLog('scroll:restore_attempt', {
-            k,
-            why,
-            cachedScrollTop: cached?.scrollTop ?? null,
-            cachedScrollLeft: cached?.scrollLeft ?? null
+      k = scrollKeyFor(container);
+      const cached = scroll_cache.get(k);
+      appendScrollLog('scroll:restore_attempt', {
+        k,
+        why,
+        cachedScrollTop: cached?.scrollTop ?? null,
+        cachedScrollLeft: cached?.scrollLeft ?? null
+      });
+      if (!cached) {
+        appendScrollLog('scroll:restore_no_scroll', {
+          k,
+          why
         });
-        if (!cached) {
-            appendScrollLog('scroll:restore_no_scroll', {
-                k,
-                why
-            });
-            return;
-        }
-        if (cached.scrollTop != null)
-            c_element.scrollTop = cached.scrollTop;
-        if (cached.scrollLeft != null)
-            c_element.scrollLeft = cached.scrollLeft;
-        appendScrollLog('scroll:restore_applied', {
-            k,
-            why,
-            scrollTop: cached.scrollTop ?? null,
-            scrollLeft: cached.scrollLeft ?? null,
-            scrollTopFinal: c_element.scrollTop,
-            scrollLeftFinal: c_element.scrollLeft
-        });
+        return;
+      }
+      if (cached.scrollTop != null)
+        c_element.scrollTop = cached.scrollTop;
+      if (cached.scrollLeft != null)
+        c_element.scrollLeft = cached.scrollLeft;
+      appendScrollLog('scroll:restore_applied', {
+        k,
+        why,
+        scrollTop: cached.scrollTop ?? null,
+        scrollLeft: cached.scrollLeft ?? null,
+        scrollTopFinal: c_element.scrollTop,
+        scrollLeftFinal: c_element.scrollLeft
+      });
     };
     const setScroll = (why = 'setScroll') => {
-        if (scrollToCellIfPossible(why))
-            return;
-        restoreFromCache(why);
+      if (scrollToCellIfPossible(why))
+        return;
+      restoreFromCache(why);
     };
     const retryFrames = 6;
     for (let i = 0; i < retryFrames; i++) {
-        requestAnimationFrame(() => {
-            k = scrollKeyFor(container);
-            appendScrollLog('fix_scroll:raf_retry', {
-                i,
-                k,
-                title: container?.title ?? null
-            });
-            setScroll(`raf:${ i }`);
+      requestAnimationFrame(() => {
+        k = scrollKeyFor(container);
+        appendScrollLog('fix_scroll:raf_retry', {
+          i,
+          k,
+          title: container?.title ?? null
         });
+        setScroll(`raf:${ i }`);
+      });
     }
     appendScrollLog('fix_scroll:exit', {
-        k,
-        title: container?.title ?? null
+      k,
+      title: container?.title ?? null
     });
-}
-)};
+  };
+};
 const _arfw00 = function _scroll_fix_sync_layout(sync_layout_to_url,layout,appendScrollLog,modulePanel)
 {
     sync_layout_to_url;
@@ -17515,7 +17576,7 @@ export default function define(runtime, observer) {
   $def("_1we0ggl", "reload", ["Generators","viewof reload"], _1we0ggl);  
   $def("_plefwg", "onLoadConfig", ["parseGoldenDSL","URLSearchParams","location"], _plefwg);  
   $def("_1nzpnqy", "visualizer_cache", ["reload"], _1nzpnqy);  
-  $def("_1l35721", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1l35721);  
+  $def("_1ojown8", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1ojown8);  
   $def("_1gm4gbf", "blobPanel", [], _1gm4gbf);  
   $def("_lxv2e2", "settings", [], _lxv2e2);  
   $def("_lp1ggk", "is_mobile", ["width"], _lp1ggk);  
@@ -17536,7 +17597,7 @@ export default function define(runtime, observer) {
   $def("_1dyz4o0", "scrollLog", ["mutable scrollLog"], _1dyz4o0);  
   $def("_1d1nkw9", "scrollKeyFor", ["appendScrollLog"], _1d1nkw9);  
   $def("_tb217h", "scroll_cache", [], _tb217h);  
-  $def("_5tyvpe", "fix_scroll", ["scrollKeyFor","appendScrollLog","scroll_cache"], _5tyvpe);  
+  $def("_12p8mg7", "fix_scroll", ["scroll_cache","scrollKeyFor","appendScrollLog"], _12p8mg7);  
   $def("_arfw00", "scroll_fix_sync_layout", ["sync_layout_to_url","layout","appendScrollLog","modulePanel"], _arfw00);  
   $def("_3nwpp4", "URLrouting", ["md"], _3nwpp4);  
   $def("_14te9pl", "sync_layout_from_url", ["reload","resize","URLSearchParams","hash","appendScrollLog","parseGoldenDSL","gl","layout","serializeGoldenDSL","treeSyncGolden","invalidation"], _14te9pl);  

--- a/notebooks/@tomlarkworthy_exporter-3.html
+++ b/notebooks/@tomlarkworthy_exporter-3.html
@@ -14037,138 +14037,196 @@ const _1nzpnqy = function _visualizer_cache(reload)
     reload;
     return new Map();
 };
-const _1l35721 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
+const _1ojown8 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
 {
-    return function (container, component) {
-        appendScrollLog('modulePanel:enter', {
-            title: container?.title ?? null,
-            componentCell: component?.cell ?? null
-        });
-        const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
-        if (!moduleInfo) {
-            // Fall through to file attachment: titles like @user/notebook/path.ext
-            // resolve via the lopecode bootloader's contentSync DOM lookup.
-            const title = container?.title ?? null;
-            if (title) {
-                let node = file_attachment_cache.get(title);
-                if (!node) {
-                    const r = window.lopecode?.contentSync?.(title);
-                    if (r && r.status === 200 && r.bytes) {
-                        node = renderFileAttachment(r.mime, r.bytes);
-                        file_attachment_cache.set(title, node);
-                        appendScrollLog('modulePanel:file_attachment_create', {
-                            title,
-                            mime: r.mime
-                        });
-                    }
-                }
-                if (node) {
-                    const c_element = container.getElement();
-                    if (node.parentNode !== c_element)
-                        c_element.appendChild(node);
-                    appendScrollLog('modulePanel:file_attachment_mount', { title });
-                    return;
-                }
-            }
-            appendScrollLog('modulePanel:missing_moduleInfo', { title });
-            return;
-        }
-        const module = moduleInfo.module;
-        let node;
-        if (!visualizer_cache.has(module)) {
-            appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
-            node = visualizer(runtime, {
-                invalidation: new Promise(r => {
-                }),
-                module,
-                detachNodes: isOnObservableCom(),
-                filter: (cell_name, variables) => {
-                    if (variables[0]._type !== 1)
-                        return false;
-                    if (typeof cell_name == 'string') {
-                        if (cell_name.startsWith('dynamic '))
-                            return false;
-                    }
-                    return true;
-                }
+  return function (container, component) {
+    appendScrollLog('modulePanel:enter', {
+      title: container?.title ?? null,
+      componentCell: component?.cell ?? null
+    });
+    const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
+    if (!moduleInfo) {
+      // Fall through to file attachment: titles like @user/notebook/path.ext
+      // resolve via the lopecode bootloader's contentSync DOM lookup.
+      const title = container?.title ?? null;
+      if (title) {
+        let node = file_attachment_cache.get(title);
+        if (!node) {
+          const r = window.lopecode?.contentSync?.(title);
+          if (r && r.status === 200 && r.bytes) {
+            node = renderFileAttachment(r.mime, r.bytes);
+            file_attachment_cache.set(title, node);
+            appendScrollLog('modulePanel:file_attachment_create', {
+              title,
+              mime: r.mime
             });
-            visualizer_cache.set(module, node);
-        } else {
-            node = visualizer_cache.get(module);
-            appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+          }
         }
-        const cell = module._scope.get(component.cell);
-        const scrollKey = scrollKeyFor(container);
-        fix_scroll(container, node, cell, scrollKey);
-        const el = container.getElement();
-        if (!el.__lope_scroll_bound) {
-            el.__lope_scroll_bound = true;
-            appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
-            el.addEventListener('scroll', () => {
-                const k = scrollKeyFor(container);
-                const scrollTop = el.scrollTop;
-                const scrollLeft = el.scrollLeft;
-                if (scrollTop == 0) {
-                    appendScrollLog('modulePanel:skip 0 scroll', {
-                        title: container?.title ?? null,
-                        scrollKey
-                    });
-                    return;
-                }
-                scroll_cache.set(k, {
-                    scrollTop,
-                    scrollLeft,
-                    t: Date.now()
-                });
-                appendScrollLog('scroll:event', {
-                    k,
-                    title: container?.title ?? null,
-                    scrollTop,
-                    scrollLeft
-                });
-            }, { passive: true });
+        if (node) {
+          const c_element = container.getElement();
+          if (node.parentNode !== c_element)
+            c_element.appendChild(node);
+          appendScrollLog('modulePanel:file_attachment_mount', { title });
+          return;
         }
-        // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
-        if (!container.__lope_destroy_bound) {
-            container.__lope_destroy_bound = true;
-            container.on('destroy', () => {
-                try {
-                    const k = scrollKeyFor(container);
-                    const scrollTop = el?.scrollTop;
-                    const scrollLeft = el?.scrollLeft;
-                    if (scrollTop == 0) {
-                        appendScrollLog('scroll:skip 0 scroll', {
-                            k,
-                            key: container?.title ?? null,
-                            scrollKey
-                        });
-                        return;
-                    }
-                    // do not skip 0 here: if the user is at top, preserve that state
-                    scroll_cache.set(k, {
-                        scrollTop,
-                        scrollLeft,
-                        t: Date.now()
-                    });
-                    appendScrollLog('scroll:destroy_capture', {
-                        k,
-                        title: container?.title ?? null,
-                        scrollTop,
-                        scrollLeft
-                    });
-                } catch (e) {
-                    appendScrollLog('scroll:destroy_capture:error', {
-                        title: container?.title ?? null,
-                        error: String(e)
-                    });
-                }
-            });
+      }
+      appendScrollLog('modulePanel:missing_moduleInfo', { title });
+      return;
+    }
+    const module = moduleInfo.module;
+    let node;
+    if (!visualizer_cache.has(module)) {
+      appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
+      node = visualizer(runtime, {
+        invalidation: new Promise(r => {
+        }),
+        module,
+        detachNodes: isOnObservableCom(),
+        filter: (cell_name, variables) => {
+          if (variables[0]._type !== 1)
+            return false;
+          if (typeof cell_name == 'string') {
+            if (cell_name.startsWith('dynamic '))
+              return false;
+          }
+          return true;
         }
-        appendScrollLog('modulePanel:exit', {
+      });
+      visualizer_cache.set(module, node);
+    } else {
+      node = visualizer_cache.get(module);
+      appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+    }
+    const cell = module._scope.get(component.cell);
+    const scrollKey = scrollKeyFor(container);
+    fix_scroll(container, node, cell, scrollKey);
+    const el = container.getElement();
+    if (!el.__lope_scroll_bound) {
+      el.__lope_scroll_bound = true;
+      appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
+      const markUserScroll = () => {
+        el.__lope_user_scroll_at = Date.now();
+      };
+      el.addEventListener('wheel', markUserScroll, { passive: true });
+      el.addEventListener('touchmove', markUserScroll, { passive: true });
+      el.addEventListener('keydown', markUserScroll, { passive: true });
+      el.addEventListener('scroll', () => {
+        if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+          appendScrollLog('scroll:skip_reflow', { title: container?.title ?? null });
+          return;
+        }
+        // Only cache scrolls following a genuine user gesture; reflow-induced
+        // scroll events (e.g. closing an adjacent panel) carry stale scrollTops.
+        if (Date.now() - (el.__lope_user_scroll_at || 0) > 400) {
+          appendScrollLog('scroll:skip_nonuser', { title: container?.title ?? null });
+          return;
+        }
+        const k = scrollKeyFor(container);
+        const scrollTop = el.scrollTop;
+        const scrollLeft = el.scrollLeft;
+        if (scrollTop == 0) {
+          appendScrollLog('modulePanel:skip 0 scroll', {
             title: container?.title ?? null,
             scrollKey
+          });
+          return;
+        }
+        scroll_cache.set(k, {
+          scrollTop,
+          scrollLeft,
+          t: Date.now()
         });
-    };
+        appendScrollLog('scroll:event', {
+          k,
+          title: container?.title ?? null,
+          scrollTop,
+          scrollLeft
+        });
+      }, { passive: true });
+    }
+    // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
+    if (!container.__lope_destroy_bound) {
+      container.__lope_destroy_bound = true;
+      container.on('destroy', () => {
+        try {
+          if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+            appendScrollLog('scroll:destroy_skip_reflow', { title: container?.title ?? null });
+            return;
+          }
+          const k = scrollKeyFor(container);
+          const scrollTop = el?.scrollTop;
+          const scrollLeft = el?.scrollLeft;
+          if (scrollTop == 0) {
+            appendScrollLog('scroll:skip 0 scroll', {
+              k,
+              key: container?.title ?? null,
+              scrollKey
+            });
+            return;
+          }
+          // do not skip 0 here: if the user is at top, preserve that state
+          scroll_cache.set(k, {
+            scrollTop,
+            scrollLeft,
+            t: Date.now()
+          });
+          appendScrollLog('scroll:destroy_capture', {
+            k,
+            title: container?.title ?? null,
+            scrollTop,
+            scrollLeft
+          });
+        } catch (e) {
+          appendScrollLog('scroll:destroy_capture:error', {
+            title: container?.title ?? null,
+            error: String(e)
+          });
+        }
+      });
+    }
+    // When GoldenLayout resizes this panel (e.g. an adjacent panel is closed) the
+    // browser can shift scrollTop; re-apply the user's cached position after the reflow.
+    if (!container.__lope_resize_bound) {
+      container.__lope_resize_bound = true;
+      container.on('resize', () => {
+        const rk = scrollKeyFor(container);
+        const cached = scroll_cache.get(rk);
+        if (!cached || cached.scrollTop == null)
+          return;
+        const c_el = container.getElement();
+        const at = Date.now();
+        scroll_cache.__reflowUntil = at + 800;
+        // The reflow can shift scrollTop in several passes (content relayout
+        // settles ~300ms later), so re-apply over a window. Bail if the user scrolls.
+        const apply = () => {
+          if ((c_el.__lope_user_scroll_at || 0) > at)
+            return;
+          if (c_el.scrollTop !== cached.scrollTop)
+            c_el.scrollTop = cached.scrollTop;
+          if (cached.scrollLeft != null && c_el.scrollLeft !== cached.scrollLeft)
+            c_el.scrollLeft = cached.scrollLeft;
+        };
+        requestAnimationFrame(apply);
+        for (const d of [
+            60,
+            150,
+            300,
+            450,
+            600
+          ])
+          setTimeout(apply, d);
+        appendScrollLog('scroll:resize_restore', {
+          k: rk,
+          title: container?.title ?? null,
+          scrollTop: cached.scrollTop
+        });
+      });
+    }
+    appendScrollLog('modulePanel:exit', {
+      title: container?.title ?? null,
+      scrollKey
+    });
+  };
 };
 const _1gm4gbf = function _blobPanel(){return(
 function (container, component) {
@@ -14286,112 +14344,115 @@ const _1d1nkw9 = function _scrollKeyFor(appendScrollLog)
 const _tb217h = function _scroll_cache(){return(
 new Map()
 )};
-const _5tyvpe = function _fix_scroll(scrollKeyFor,appendScrollLog,scroll_cache){return(
-function (container, node, cell_variable, key) {
+const _12p8mg7 = function _fix_scroll(scroll_cache,scrollKeyFor,appendScrollLog)
+{
+  return function (container, node, cell_variable, key) {
+    scroll_cache.__reflowUntil = Date.now() + 600;
+    // suppress reflow-induced scroll events that clobber the cache
     const c_element = container.getElement();
     let k = scrollKeyFor(container);
     appendScrollLog('fix_scroll:enter', {
-        title: container?.title ?? null,
-        k,
-        cell: cell_variable?._name ?? null
+      title: container?.title ?? null,
+      k,
+      cell: cell_variable?._name ?? null
     });
     if (node && node.parentNode !== c_element) {
-        c_element.appendChild(node);
-        appendScrollLog('fix_scroll:append_node', {
-            title: container?.title ?? null,
-            k
-        });
+      c_element.appendChild(node);
+      appendScrollLog('fix_scroll:append_node', {
+        title: container?.title ?? null,
+        k
+      });
     }
     const writeCache = (scrollTop, scrollLeft, why) => {
-        scroll_cache.set(k, {
-            scrollTop,
-            scrollLeft,
-            t: Date.now()
-        });
-        appendScrollLog('scroll_cache:write', {
-            k,
-            scrollTop,
-            scrollLeft,
-            why
-        });
+      scroll_cache.set(k, {
+        scrollTop,
+        scrollLeft,
+        t: Date.now()
+      });
+      appendScrollLog('scroll_cache:write', {
+        k,
+        scrollTop,
+        scrollLeft,
+        why
+      });
     };
     const scrollToCellIfPossible = why => {
-        if (!cell_variable)
-            return false;
-        const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
-        if (!dom) {
-            appendScrollLog('scroll:cell_dom_not_found', {
-                k,
-                why,
-                cell: cell_variable?._name ?? null
-            });
-            return false;
-        }
-        const top = dom.offsetTop - c_element.offsetTop;
-        const left = c_element.scrollLeft;
-        c_element.scrollTop = top;
-        appendScrollLog('scroll:set', {
-            k,
-            why: `${ why }:cell`,
-            scrollTop: top,
-            scrollLeft: left,
-            cell: cell_variable?._name ?? null
+      if (!cell_variable)
+        return false;
+      const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
+      if (!dom) {
+        appendScrollLog('scroll:cell_dom_not_found', {
+          k,
+          why,
+          cell: cell_variable?._name ?? null
         });
-        writeCache(top, left, `${ why }:cell`);
-        return true;
+        return false;
+      }
+      const top = dom.offsetTop - c_element.offsetTop;
+      const left = c_element.scrollLeft;
+      c_element.scrollTop = top;
+      appendScrollLog('scroll:set', {
+        k,
+        why: `${ why }:cell`,
+        scrollTop: top,
+        scrollLeft: left,
+        cell: cell_variable?._name ?? null
+      });
+      writeCache(top, left, `${ why }:cell`);
+      return true;
     };
     const restoreFromCache = why => {
-        k = scrollKeyFor(container);
-        const cached = scroll_cache.get(k);
-        appendScrollLog('scroll:restore_attempt', {
-            k,
-            why,
-            cachedScrollTop: cached?.scrollTop ?? null,
-            cachedScrollLeft: cached?.scrollLeft ?? null
+      k = scrollKeyFor(container);
+      const cached = scroll_cache.get(k);
+      appendScrollLog('scroll:restore_attempt', {
+        k,
+        why,
+        cachedScrollTop: cached?.scrollTop ?? null,
+        cachedScrollLeft: cached?.scrollLeft ?? null
+      });
+      if (!cached) {
+        appendScrollLog('scroll:restore_no_scroll', {
+          k,
+          why
         });
-        if (!cached) {
-            appendScrollLog('scroll:restore_no_scroll', {
-                k,
-                why
-            });
-            return;
-        }
-        if (cached.scrollTop != null)
-            c_element.scrollTop = cached.scrollTop;
-        if (cached.scrollLeft != null)
-            c_element.scrollLeft = cached.scrollLeft;
-        appendScrollLog('scroll:restore_applied', {
-            k,
-            why,
-            scrollTop: cached.scrollTop ?? null,
-            scrollLeft: cached.scrollLeft ?? null,
-            scrollTopFinal: c_element.scrollTop,
-            scrollLeftFinal: c_element.scrollLeft
-        });
+        return;
+      }
+      if (cached.scrollTop != null)
+        c_element.scrollTop = cached.scrollTop;
+      if (cached.scrollLeft != null)
+        c_element.scrollLeft = cached.scrollLeft;
+      appendScrollLog('scroll:restore_applied', {
+        k,
+        why,
+        scrollTop: cached.scrollTop ?? null,
+        scrollLeft: cached.scrollLeft ?? null,
+        scrollTopFinal: c_element.scrollTop,
+        scrollLeftFinal: c_element.scrollLeft
+      });
     };
     const setScroll = (why = 'setScroll') => {
-        if (scrollToCellIfPossible(why))
-            return;
-        restoreFromCache(why);
+      if (scrollToCellIfPossible(why))
+        return;
+      restoreFromCache(why);
     };
     const retryFrames = 6;
     for (let i = 0; i < retryFrames; i++) {
-        requestAnimationFrame(() => {
-            k = scrollKeyFor(container);
-            appendScrollLog('fix_scroll:raf_retry', {
-                i,
-                k,
-                title: container?.title ?? null
-            });
-            setScroll(`raf:${ i }`);
+      requestAnimationFrame(() => {
+        k = scrollKeyFor(container);
+        appendScrollLog('fix_scroll:raf_retry', {
+          i,
+          k,
+          title: container?.title ?? null
         });
+        setScroll(`raf:${ i }`);
+      });
     }
     appendScrollLog('fix_scroll:exit', {
-        k,
-        title: container?.title ?? null
+      k,
+      title: container?.title ?? null
     });
-}
-)};
+  };
+};
 const _arfw00 = function _scroll_fix_sync_layout(sync_layout_to_url,layout,appendScrollLog,modulePanel)
 {
     sync_layout_to_url;
@@ -15469,7 +15530,7 @@ export default function define(runtime, observer) {
   $def("_1we0ggl", "reload", ["Generators","viewof reload"], _1we0ggl);  
   $def("_plefwg", "onLoadConfig", ["parseGoldenDSL","URLSearchParams","location"], _plefwg);  
   $def("_1nzpnqy", "visualizer_cache", ["reload"], _1nzpnqy);  
-  $def("_1l35721", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1l35721);  
+  $def("_1ojown8", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1ojown8);  
   $def("_1gm4gbf", "blobPanel", [], _1gm4gbf);  
   $def("_lxv2e2", "settings", [], _lxv2e2);  
   $def("_lp1ggk", "is_mobile", ["width"], _lp1ggk);  
@@ -15490,7 +15551,7 @@ export default function define(runtime, observer) {
   $def("_1dyz4o0", "scrollLog", ["mutable scrollLog"], _1dyz4o0);  
   $def("_1d1nkw9", "scrollKeyFor", ["appendScrollLog"], _1d1nkw9);  
   $def("_tb217h", "scroll_cache", [], _tb217h);  
-  $def("_5tyvpe", "fix_scroll", ["scrollKeyFor","appendScrollLog","scroll_cache"], _5tyvpe);  
+  $def("_12p8mg7", "fix_scroll", ["scroll_cache","scrollKeyFor","appendScrollLog"], _12p8mg7);  
   $def("_arfw00", "scroll_fix_sync_layout", ["sync_layout_to_url","layout","appendScrollLog","modulePanel"], _arfw00);  
   $def("_3nwpp4", "URLrouting", ["md"], _3nwpp4);  
   $def("_14te9pl", "sync_layout_from_url", ["reload","resize","URLSearchParams","hash","appendScrollLog","parseGoldenDSL","gl","layout","serializeGoldenDSL","treeSyncGolden","invalidation"], _14te9pl);  

--- a/notebooks/@tomlarkworthy_fileattachments.html
+++ b/notebooks/@tomlarkworthy_fileattachments.html
@@ -14037,138 +14037,196 @@ const _1nzpnqy = function _visualizer_cache(reload)
     reload;
     return new Map();
 };
-const _1l35721 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
+const _1ojown8 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
 {
-    return function (container, component) {
-        appendScrollLog('modulePanel:enter', {
-            title: container?.title ?? null,
-            componentCell: component?.cell ?? null
-        });
-        const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
-        if (!moduleInfo) {
-            // Fall through to file attachment: titles like @user/notebook/path.ext
-            // resolve via the lopecode bootloader's contentSync DOM lookup.
-            const title = container?.title ?? null;
-            if (title) {
-                let node = file_attachment_cache.get(title);
-                if (!node) {
-                    const r = window.lopecode?.contentSync?.(title);
-                    if (r && r.status === 200 && r.bytes) {
-                        node = renderFileAttachment(r.mime, r.bytes);
-                        file_attachment_cache.set(title, node);
-                        appendScrollLog('modulePanel:file_attachment_create', {
-                            title,
-                            mime: r.mime
-                        });
-                    }
-                }
-                if (node) {
-                    const c_element = container.getElement();
-                    if (node.parentNode !== c_element)
-                        c_element.appendChild(node);
-                    appendScrollLog('modulePanel:file_attachment_mount', { title });
-                    return;
-                }
-            }
-            appendScrollLog('modulePanel:missing_moduleInfo', { title });
-            return;
-        }
-        const module = moduleInfo.module;
-        let node;
-        if (!visualizer_cache.has(module)) {
-            appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
-            node = visualizer(runtime, {
-                invalidation: new Promise(r => {
-                }),
-                module,
-                detachNodes: isOnObservableCom(),
-                filter: (cell_name, variables) => {
-                    if (variables[0]._type !== 1)
-                        return false;
-                    if (typeof cell_name == 'string') {
-                        if (cell_name.startsWith('dynamic '))
-                            return false;
-                    }
-                    return true;
-                }
+  return function (container, component) {
+    appendScrollLog('modulePanel:enter', {
+      title: container?.title ?? null,
+      componentCell: component?.cell ?? null
+    });
+    const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
+    if (!moduleInfo) {
+      // Fall through to file attachment: titles like @user/notebook/path.ext
+      // resolve via the lopecode bootloader's contentSync DOM lookup.
+      const title = container?.title ?? null;
+      if (title) {
+        let node = file_attachment_cache.get(title);
+        if (!node) {
+          const r = window.lopecode?.contentSync?.(title);
+          if (r && r.status === 200 && r.bytes) {
+            node = renderFileAttachment(r.mime, r.bytes);
+            file_attachment_cache.set(title, node);
+            appendScrollLog('modulePanel:file_attachment_create', {
+              title,
+              mime: r.mime
             });
-            visualizer_cache.set(module, node);
-        } else {
-            node = visualizer_cache.get(module);
-            appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+          }
         }
-        const cell = module._scope.get(component.cell);
-        const scrollKey = scrollKeyFor(container);
-        fix_scroll(container, node, cell, scrollKey);
-        const el = container.getElement();
-        if (!el.__lope_scroll_bound) {
-            el.__lope_scroll_bound = true;
-            appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
-            el.addEventListener('scroll', () => {
-                const k = scrollKeyFor(container);
-                const scrollTop = el.scrollTop;
-                const scrollLeft = el.scrollLeft;
-                if (scrollTop == 0) {
-                    appendScrollLog('modulePanel:skip 0 scroll', {
-                        title: container?.title ?? null,
-                        scrollKey
-                    });
-                    return;
-                }
-                scroll_cache.set(k, {
-                    scrollTop,
-                    scrollLeft,
-                    t: Date.now()
-                });
-                appendScrollLog('scroll:event', {
-                    k,
-                    title: container?.title ?? null,
-                    scrollTop,
-                    scrollLeft
-                });
-            }, { passive: true });
+        if (node) {
+          const c_element = container.getElement();
+          if (node.parentNode !== c_element)
+            c_element.appendChild(node);
+          appendScrollLog('modulePanel:file_attachment_mount', { title });
+          return;
         }
-        // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
-        if (!container.__lope_destroy_bound) {
-            container.__lope_destroy_bound = true;
-            container.on('destroy', () => {
-                try {
-                    const k = scrollKeyFor(container);
-                    const scrollTop = el?.scrollTop;
-                    const scrollLeft = el?.scrollLeft;
-                    if (scrollTop == 0) {
-                        appendScrollLog('scroll:skip 0 scroll', {
-                            k,
-                            key: container?.title ?? null,
-                            scrollKey
-                        });
-                        return;
-                    }
-                    // do not skip 0 here: if the user is at top, preserve that state
-                    scroll_cache.set(k, {
-                        scrollTop,
-                        scrollLeft,
-                        t: Date.now()
-                    });
-                    appendScrollLog('scroll:destroy_capture', {
-                        k,
-                        title: container?.title ?? null,
-                        scrollTop,
-                        scrollLeft
-                    });
-                } catch (e) {
-                    appendScrollLog('scroll:destroy_capture:error', {
-                        title: container?.title ?? null,
-                        error: String(e)
-                    });
-                }
-            });
+      }
+      appendScrollLog('modulePanel:missing_moduleInfo', { title });
+      return;
+    }
+    const module = moduleInfo.module;
+    let node;
+    if (!visualizer_cache.has(module)) {
+      appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
+      node = visualizer(runtime, {
+        invalidation: new Promise(r => {
+        }),
+        module,
+        detachNodes: isOnObservableCom(),
+        filter: (cell_name, variables) => {
+          if (variables[0]._type !== 1)
+            return false;
+          if (typeof cell_name == 'string') {
+            if (cell_name.startsWith('dynamic '))
+              return false;
+          }
+          return true;
         }
-        appendScrollLog('modulePanel:exit', {
+      });
+      visualizer_cache.set(module, node);
+    } else {
+      node = visualizer_cache.get(module);
+      appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+    }
+    const cell = module._scope.get(component.cell);
+    const scrollKey = scrollKeyFor(container);
+    fix_scroll(container, node, cell, scrollKey);
+    const el = container.getElement();
+    if (!el.__lope_scroll_bound) {
+      el.__lope_scroll_bound = true;
+      appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
+      const markUserScroll = () => {
+        el.__lope_user_scroll_at = Date.now();
+      };
+      el.addEventListener('wheel', markUserScroll, { passive: true });
+      el.addEventListener('touchmove', markUserScroll, { passive: true });
+      el.addEventListener('keydown', markUserScroll, { passive: true });
+      el.addEventListener('scroll', () => {
+        if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+          appendScrollLog('scroll:skip_reflow', { title: container?.title ?? null });
+          return;
+        }
+        // Only cache scrolls following a genuine user gesture; reflow-induced
+        // scroll events (e.g. closing an adjacent panel) carry stale scrollTops.
+        if (Date.now() - (el.__lope_user_scroll_at || 0) > 400) {
+          appendScrollLog('scroll:skip_nonuser', { title: container?.title ?? null });
+          return;
+        }
+        const k = scrollKeyFor(container);
+        const scrollTop = el.scrollTop;
+        const scrollLeft = el.scrollLeft;
+        if (scrollTop == 0) {
+          appendScrollLog('modulePanel:skip 0 scroll', {
             title: container?.title ?? null,
             scrollKey
+          });
+          return;
+        }
+        scroll_cache.set(k, {
+          scrollTop,
+          scrollLeft,
+          t: Date.now()
         });
-    };
+        appendScrollLog('scroll:event', {
+          k,
+          title: container?.title ?? null,
+          scrollTop,
+          scrollLeft
+        });
+      }, { passive: true });
+    }
+    // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
+    if (!container.__lope_destroy_bound) {
+      container.__lope_destroy_bound = true;
+      container.on('destroy', () => {
+        try {
+          if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+            appendScrollLog('scroll:destroy_skip_reflow', { title: container?.title ?? null });
+            return;
+          }
+          const k = scrollKeyFor(container);
+          const scrollTop = el?.scrollTop;
+          const scrollLeft = el?.scrollLeft;
+          if (scrollTop == 0) {
+            appendScrollLog('scroll:skip 0 scroll', {
+              k,
+              key: container?.title ?? null,
+              scrollKey
+            });
+            return;
+          }
+          // do not skip 0 here: if the user is at top, preserve that state
+          scroll_cache.set(k, {
+            scrollTop,
+            scrollLeft,
+            t: Date.now()
+          });
+          appendScrollLog('scroll:destroy_capture', {
+            k,
+            title: container?.title ?? null,
+            scrollTop,
+            scrollLeft
+          });
+        } catch (e) {
+          appendScrollLog('scroll:destroy_capture:error', {
+            title: container?.title ?? null,
+            error: String(e)
+          });
+        }
+      });
+    }
+    // When GoldenLayout resizes this panel (e.g. an adjacent panel is closed) the
+    // browser can shift scrollTop; re-apply the user's cached position after the reflow.
+    if (!container.__lope_resize_bound) {
+      container.__lope_resize_bound = true;
+      container.on('resize', () => {
+        const rk = scrollKeyFor(container);
+        const cached = scroll_cache.get(rk);
+        if (!cached || cached.scrollTop == null)
+          return;
+        const c_el = container.getElement();
+        const at = Date.now();
+        scroll_cache.__reflowUntil = at + 800;
+        // The reflow can shift scrollTop in several passes (content relayout
+        // settles ~300ms later), so re-apply over a window. Bail if the user scrolls.
+        const apply = () => {
+          if ((c_el.__lope_user_scroll_at || 0) > at)
+            return;
+          if (c_el.scrollTop !== cached.scrollTop)
+            c_el.scrollTop = cached.scrollTop;
+          if (cached.scrollLeft != null && c_el.scrollLeft !== cached.scrollLeft)
+            c_el.scrollLeft = cached.scrollLeft;
+        };
+        requestAnimationFrame(apply);
+        for (const d of [
+            60,
+            150,
+            300,
+            450,
+            600
+          ])
+          setTimeout(apply, d);
+        appendScrollLog('scroll:resize_restore', {
+          k: rk,
+          title: container?.title ?? null,
+          scrollTop: cached.scrollTop
+        });
+      });
+    }
+    appendScrollLog('modulePanel:exit', {
+      title: container?.title ?? null,
+      scrollKey
+    });
+  };
 };
 const _1gm4gbf = function _blobPanel(){return(
 function (container, component) {
@@ -14286,112 +14344,115 @@ const _1d1nkw9 = function _scrollKeyFor(appendScrollLog)
 const _tb217h = function _scroll_cache(){return(
 new Map()
 )};
-const _5tyvpe = function _fix_scroll(scrollKeyFor,appendScrollLog,scroll_cache){return(
-function (container, node, cell_variable, key) {
+const _12p8mg7 = function _fix_scroll(scroll_cache,scrollKeyFor,appendScrollLog)
+{
+  return function (container, node, cell_variable, key) {
+    scroll_cache.__reflowUntil = Date.now() + 600;
+    // suppress reflow-induced scroll events that clobber the cache
     const c_element = container.getElement();
     let k = scrollKeyFor(container);
     appendScrollLog('fix_scroll:enter', {
-        title: container?.title ?? null,
-        k,
-        cell: cell_variable?._name ?? null
+      title: container?.title ?? null,
+      k,
+      cell: cell_variable?._name ?? null
     });
     if (node && node.parentNode !== c_element) {
-        c_element.appendChild(node);
-        appendScrollLog('fix_scroll:append_node', {
-            title: container?.title ?? null,
-            k
-        });
+      c_element.appendChild(node);
+      appendScrollLog('fix_scroll:append_node', {
+        title: container?.title ?? null,
+        k
+      });
     }
     const writeCache = (scrollTop, scrollLeft, why) => {
-        scroll_cache.set(k, {
-            scrollTop,
-            scrollLeft,
-            t: Date.now()
-        });
-        appendScrollLog('scroll_cache:write', {
-            k,
-            scrollTop,
-            scrollLeft,
-            why
-        });
+      scroll_cache.set(k, {
+        scrollTop,
+        scrollLeft,
+        t: Date.now()
+      });
+      appendScrollLog('scroll_cache:write', {
+        k,
+        scrollTop,
+        scrollLeft,
+        why
+      });
     };
     const scrollToCellIfPossible = why => {
-        if (!cell_variable)
-            return false;
-        const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
-        if (!dom) {
-            appendScrollLog('scroll:cell_dom_not_found', {
-                k,
-                why,
-                cell: cell_variable?._name ?? null
-            });
-            return false;
-        }
-        const top = dom.offsetTop - c_element.offsetTop;
-        const left = c_element.scrollLeft;
-        c_element.scrollTop = top;
-        appendScrollLog('scroll:set', {
-            k,
-            why: `${ why }:cell`,
-            scrollTop: top,
-            scrollLeft: left,
-            cell: cell_variable?._name ?? null
+      if (!cell_variable)
+        return false;
+      const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
+      if (!dom) {
+        appendScrollLog('scroll:cell_dom_not_found', {
+          k,
+          why,
+          cell: cell_variable?._name ?? null
         });
-        writeCache(top, left, `${ why }:cell`);
-        return true;
+        return false;
+      }
+      const top = dom.offsetTop - c_element.offsetTop;
+      const left = c_element.scrollLeft;
+      c_element.scrollTop = top;
+      appendScrollLog('scroll:set', {
+        k,
+        why: `${ why }:cell`,
+        scrollTop: top,
+        scrollLeft: left,
+        cell: cell_variable?._name ?? null
+      });
+      writeCache(top, left, `${ why }:cell`);
+      return true;
     };
     const restoreFromCache = why => {
-        k = scrollKeyFor(container);
-        const cached = scroll_cache.get(k);
-        appendScrollLog('scroll:restore_attempt', {
-            k,
-            why,
-            cachedScrollTop: cached?.scrollTop ?? null,
-            cachedScrollLeft: cached?.scrollLeft ?? null
+      k = scrollKeyFor(container);
+      const cached = scroll_cache.get(k);
+      appendScrollLog('scroll:restore_attempt', {
+        k,
+        why,
+        cachedScrollTop: cached?.scrollTop ?? null,
+        cachedScrollLeft: cached?.scrollLeft ?? null
+      });
+      if (!cached) {
+        appendScrollLog('scroll:restore_no_scroll', {
+          k,
+          why
         });
-        if (!cached) {
-            appendScrollLog('scroll:restore_no_scroll', {
-                k,
-                why
-            });
-            return;
-        }
-        if (cached.scrollTop != null)
-            c_element.scrollTop = cached.scrollTop;
-        if (cached.scrollLeft != null)
-            c_element.scrollLeft = cached.scrollLeft;
-        appendScrollLog('scroll:restore_applied', {
-            k,
-            why,
-            scrollTop: cached.scrollTop ?? null,
-            scrollLeft: cached.scrollLeft ?? null,
-            scrollTopFinal: c_element.scrollTop,
-            scrollLeftFinal: c_element.scrollLeft
-        });
+        return;
+      }
+      if (cached.scrollTop != null)
+        c_element.scrollTop = cached.scrollTop;
+      if (cached.scrollLeft != null)
+        c_element.scrollLeft = cached.scrollLeft;
+      appendScrollLog('scroll:restore_applied', {
+        k,
+        why,
+        scrollTop: cached.scrollTop ?? null,
+        scrollLeft: cached.scrollLeft ?? null,
+        scrollTopFinal: c_element.scrollTop,
+        scrollLeftFinal: c_element.scrollLeft
+      });
     };
     const setScroll = (why = 'setScroll') => {
-        if (scrollToCellIfPossible(why))
-            return;
-        restoreFromCache(why);
+      if (scrollToCellIfPossible(why))
+        return;
+      restoreFromCache(why);
     };
     const retryFrames = 6;
     for (let i = 0; i < retryFrames; i++) {
-        requestAnimationFrame(() => {
-            k = scrollKeyFor(container);
-            appendScrollLog('fix_scroll:raf_retry', {
-                i,
-                k,
-                title: container?.title ?? null
-            });
-            setScroll(`raf:${ i }`);
+      requestAnimationFrame(() => {
+        k = scrollKeyFor(container);
+        appendScrollLog('fix_scroll:raf_retry', {
+          i,
+          k,
+          title: container?.title ?? null
         });
+        setScroll(`raf:${ i }`);
+      });
     }
     appendScrollLog('fix_scroll:exit', {
-        k,
-        title: container?.title ?? null
+      k,
+      title: container?.title ?? null
     });
-}
-)};
+  };
+};
 const _arfw00 = function _scroll_fix_sync_layout(sync_layout_to_url,layout,appendScrollLog,modulePanel)
 {
     sync_layout_to_url;
@@ -15469,7 +15530,7 @@ export default function define(runtime, observer) {
   $def("_1we0ggl", "reload", ["Generators","viewof reload"], _1we0ggl);  
   $def("_plefwg", "onLoadConfig", ["parseGoldenDSL","URLSearchParams","location"], _plefwg);  
   $def("_1nzpnqy", "visualizer_cache", ["reload"], _1nzpnqy);  
-  $def("_1l35721", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1l35721);  
+  $def("_1ojown8", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1ojown8);  
   $def("_1gm4gbf", "blobPanel", [], _1gm4gbf);  
   $def("_lxv2e2", "settings", [], _lxv2e2);  
   $def("_lp1ggk", "is_mobile", ["width"], _lp1ggk);  
@@ -15490,7 +15551,7 @@ export default function define(runtime, observer) {
   $def("_1dyz4o0", "scrollLog", ["mutable scrollLog"], _1dyz4o0);  
   $def("_1d1nkw9", "scrollKeyFor", ["appendScrollLog"], _1d1nkw9);  
   $def("_tb217h", "scroll_cache", [], _tb217h);  
-  $def("_5tyvpe", "fix_scroll", ["scrollKeyFor","appendScrollLog","scroll_cache"], _5tyvpe);  
+  $def("_12p8mg7", "fix_scroll", ["scroll_cache","scrollKeyFor","appendScrollLog"], _12p8mg7);  
   $def("_arfw00", "scroll_fix_sync_layout", ["sync_layout_to_url","layout","appendScrollLog","modulePanel"], _arfw00);  
   $def("_3nwpp4", "URLrouting", ["md"], _3nwpp4);  
   $def("_14te9pl", "sync_layout_from_url", ["reload","resize","URLSearchParams","hash","appendScrollLog","parseGoldenDSL","gl","layout","serializeGoldenDSL","treeSyncGolden","invalidation"], _14te9pl);  

--- a/notebooks/@tomlarkworthy_flow-queue.html
+++ b/notebooks/@tomlarkworthy_flow-queue.html
@@ -14037,138 +14037,196 @@ const _1nzpnqy = function _visualizer_cache(reload)
     reload;
     return new Map();
 };
-const _1l35721 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
+const _1ojown8 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
 {
-    return function (container, component) {
-        appendScrollLog('modulePanel:enter', {
-            title: container?.title ?? null,
-            componentCell: component?.cell ?? null
-        });
-        const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
-        if (!moduleInfo) {
-            // Fall through to file attachment: titles like @user/notebook/path.ext
-            // resolve via the lopecode bootloader's contentSync DOM lookup.
-            const title = container?.title ?? null;
-            if (title) {
-                let node = file_attachment_cache.get(title);
-                if (!node) {
-                    const r = window.lopecode?.contentSync?.(title);
-                    if (r && r.status === 200 && r.bytes) {
-                        node = renderFileAttachment(r.mime, r.bytes);
-                        file_attachment_cache.set(title, node);
-                        appendScrollLog('modulePanel:file_attachment_create', {
-                            title,
-                            mime: r.mime
-                        });
-                    }
-                }
-                if (node) {
-                    const c_element = container.getElement();
-                    if (node.parentNode !== c_element)
-                        c_element.appendChild(node);
-                    appendScrollLog('modulePanel:file_attachment_mount', { title });
-                    return;
-                }
-            }
-            appendScrollLog('modulePanel:missing_moduleInfo', { title });
-            return;
-        }
-        const module = moduleInfo.module;
-        let node;
-        if (!visualizer_cache.has(module)) {
-            appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
-            node = visualizer(runtime, {
-                invalidation: new Promise(r => {
-                }),
-                module,
-                detachNodes: isOnObservableCom(),
-                filter: (cell_name, variables) => {
-                    if (variables[0]._type !== 1)
-                        return false;
-                    if (typeof cell_name == 'string') {
-                        if (cell_name.startsWith('dynamic '))
-                            return false;
-                    }
-                    return true;
-                }
+  return function (container, component) {
+    appendScrollLog('modulePanel:enter', {
+      title: container?.title ?? null,
+      componentCell: component?.cell ?? null
+    });
+    const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
+    if (!moduleInfo) {
+      // Fall through to file attachment: titles like @user/notebook/path.ext
+      // resolve via the lopecode bootloader's contentSync DOM lookup.
+      const title = container?.title ?? null;
+      if (title) {
+        let node = file_attachment_cache.get(title);
+        if (!node) {
+          const r = window.lopecode?.contentSync?.(title);
+          if (r && r.status === 200 && r.bytes) {
+            node = renderFileAttachment(r.mime, r.bytes);
+            file_attachment_cache.set(title, node);
+            appendScrollLog('modulePanel:file_attachment_create', {
+              title,
+              mime: r.mime
             });
-            visualizer_cache.set(module, node);
-        } else {
-            node = visualizer_cache.get(module);
-            appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+          }
         }
-        const cell = module._scope.get(component.cell);
-        const scrollKey = scrollKeyFor(container);
-        fix_scroll(container, node, cell, scrollKey);
-        const el = container.getElement();
-        if (!el.__lope_scroll_bound) {
-            el.__lope_scroll_bound = true;
-            appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
-            el.addEventListener('scroll', () => {
-                const k = scrollKeyFor(container);
-                const scrollTop = el.scrollTop;
-                const scrollLeft = el.scrollLeft;
-                if (scrollTop == 0) {
-                    appendScrollLog('modulePanel:skip 0 scroll', {
-                        title: container?.title ?? null,
-                        scrollKey
-                    });
-                    return;
-                }
-                scroll_cache.set(k, {
-                    scrollTop,
-                    scrollLeft,
-                    t: Date.now()
-                });
-                appendScrollLog('scroll:event', {
-                    k,
-                    title: container?.title ?? null,
-                    scrollTop,
-                    scrollLeft
-                });
-            }, { passive: true });
+        if (node) {
+          const c_element = container.getElement();
+          if (node.parentNode !== c_element)
+            c_element.appendChild(node);
+          appendScrollLog('modulePanel:file_attachment_mount', { title });
+          return;
         }
-        // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
-        if (!container.__lope_destroy_bound) {
-            container.__lope_destroy_bound = true;
-            container.on('destroy', () => {
-                try {
-                    const k = scrollKeyFor(container);
-                    const scrollTop = el?.scrollTop;
-                    const scrollLeft = el?.scrollLeft;
-                    if (scrollTop == 0) {
-                        appendScrollLog('scroll:skip 0 scroll', {
-                            k,
-                            key: container?.title ?? null,
-                            scrollKey
-                        });
-                        return;
-                    }
-                    // do not skip 0 here: if the user is at top, preserve that state
-                    scroll_cache.set(k, {
-                        scrollTop,
-                        scrollLeft,
-                        t: Date.now()
-                    });
-                    appendScrollLog('scroll:destroy_capture', {
-                        k,
-                        title: container?.title ?? null,
-                        scrollTop,
-                        scrollLeft
-                    });
-                } catch (e) {
-                    appendScrollLog('scroll:destroy_capture:error', {
-                        title: container?.title ?? null,
-                        error: String(e)
-                    });
-                }
-            });
+      }
+      appendScrollLog('modulePanel:missing_moduleInfo', { title });
+      return;
+    }
+    const module = moduleInfo.module;
+    let node;
+    if (!visualizer_cache.has(module)) {
+      appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
+      node = visualizer(runtime, {
+        invalidation: new Promise(r => {
+        }),
+        module,
+        detachNodes: isOnObservableCom(),
+        filter: (cell_name, variables) => {
+          if (variables[0]._type !== 1)
+            return false;
+          if (typeof cell_name == 'string') {
+            if (cell_name.startsWith('dynamic '))
+              return false;
+          }
+          return true;
         }
-        appendScrollLog('modulePanel:exit', {
+      });
+      visualizer_cache.set(module, node);
+    } else {
+      node = visualizer_cache.get(module);
+      appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+    }
+    const cell = module._scope.get(component.cell);
+    const scrollKey = scrollKeyFor(container);
+    fix_scroll(container, node, cell, scrollKey);
+    const el = container.getElement();
+    if (!el.__lope_scroll_bound) {
+      el.__lope_scroll_bound = true;
+      appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
+      const markUserScroll = () => {
+        el.__lope_user_scroll_at = Date.now();
+      };
+      el.addEventListener('wheel', markUserScroll, { passive: true });
+      el.addEventListener('touchmove', markUserScroll, { passive: true });
+      el.addEventListener('keydown', markUserScroll, { passive: true });
+      el.addEventListener('scroll', () => {
+        if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+          appendScrollLog('scroll:skip_reflow', { title: container?.title ?? null });
+          return;
+        }
+        // Only cache scrolls following a genuine user gesture; reflow-induced
+        // scroll events (e.g. closing an adjacent panel) carry stale scrollTops.
+        if (Date.now() - (el.__lope_user_scroll_at || 0) > 400) {
+          appendScrollLog('scroll:skip_nonuser', { title: container?.title ?? null });
+          return;
+        }
+        const k = scrollKeyFor(container);
+        const scrollTop = el.scrollTop;
+        const scrollLeft = el.scrollLeft;
+        if (scrollTop == 0) {
+          appendScrollLog('modulePanel:skip 0 scroll', {
             title: container?.title ?? null,
             scrollKey
+          });
+          return;
+        }
+        scroll_cache.set(k, {
+          scrollTop,
+          scrollLeft,
+          t: Date.now()
         });
-    };
+        appendScrollLog('scroll:event', {
+          k,
+          title: container?.title ?? null,
+          scrollTop,
+          scrollLeft
+        });
+      }, { passive: true });
+    }
+    // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
+    if (!container.__lope_destroy_bound) {
+      container.__lope_destroy_bound = true;
+      container.on('destroy', () => {
+        try {
+          if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+            appendScrollLog('scroll:destroy_skip_reflow', { title: container?.title ?? null });
+            return;
+          }
+          const k = scrollKeyFor(container);
+          const scrollTop = el?.scrollTop;
+          const scrollLeft = el?.scrollLeft;
+          if (scrollTop == 0) {
+            appendScrollLog('scroll:skip 0 scroll', {
+              k,
+              key: container?.title ?? null,
+              scrollKey
+            });
+            return;
+          }
+          // do not skip 0 here: if the user is at top, preserve that state
+          scroll_cache.set(k, {
+            scrollTop,
+            scrollLeft,
+            t: Date.now()
+          });
+          appendScrollLog('scroll:destroy_capture', {
+            k,
+            title: container?.title ?? null,
+            scrollTop,
+            scrollLeft
+          });
+        } catch (e) {
+          appendScrollLog('scroll:destroy_capture:error', {
+            title: container?.title ?? null,
+            error: String(e)
+          });
+        }
+      });
+    }
+    // When GoldenLayout resizes this panel (e.g. an adjacent panel is closed) the
+    // browser can shift scrollTop; re-apply the user's cached position after the reflow.
+    if (!container.__lope_resize_bound) {
+      container.__lope_resize_bound = true;
+      container.on('resize', () => {
+        const rk = scrollKeyFor(container);
+        const cached = scroll_cache.get(rk);
+        if (!cached || cached.scrollTop == null)
+          return;
+        const c_el = container.getElement();
+        const at = Date.now();
+        scroll_cache.__reflowUntil = at + 800;
+        // The reflow can shift scrollTop in several passes (content relayout
+        // settles ~300ms later), so re-apply over a window. Bail if the user scrolls.
+        const apply = () => {
+          if ((c_el.__lope_user_scroll_at || 0) > at)
+            return;
+          if (c_el.scrollTop !== cached.scrollTop)
+            c_el.scrollTop = cached.scrollTop;
+          if (cached.scrollLeft != null && c_el.scrollLeft !== cached.scrollLeft)
+            c_el.scrollLeft = cached.scrollLeft;
+        };
+        requestAnimationFrame(apply);
+        for (const d of [
+            60,
+            150,
+            300,
+            450,
+            600
+          ])
+          setTimeout(apply, d);
+        appendScrollLog('scroll:resize_restore', {
+          k: rk,
+          title: container?.title ?? null,
+          scrollTop: cached.scrollTop
+        });
+      });
+    }
+    appendScrollLog('modulePanel:exit', {
+      title: container?.title ?? null,
+      scrollKey
+    });
+  };
 };
 const _1gm4gbf = function _blobPanel(){return(
 function (container, component) {
@@ -14286,112 +14344,115 @@ const _1d1nkw9 = function _scrollKeyFor(appendScrollLog)
 const _tb217h = function _scroll_cache(){return(
 new Map()
 )};
-const _5tyvpe = function _fix_scroll(scrollKeyFor,appendScrollLog,scroll_cache){return(
-function (container, node, cell_variable, key) {
+const _12p8mg7 = function _fix_scroll(scroll_cache,scrollKeyFor,appendScrollLog)
+{
+  return function (container, node, cell_variable, key) {
+    scroll_cache.__reflowUntil = Date.now() + 600;
+    // suppress reflow-induced scroll events that clobber the cache
     const c_element = container.getElement();
     let k = scrollKeyFor(container);
     appendScrollLog('fix_scroll:enter', {
-        title: container?.title ?? null,
-        k,
-        cell: cell_variable?._name ?? null
+      title: container?.title ?? null,
+      k,
+      cell: cell_variable?._name ?? null
     });
     if (node && node.parentNode !== c_element) {
-        c_element.appendChild(node);
-        appendScrollLog('fix_scroll:append_node', {
-            title: container?.title ?? null,
-            k
-        });
+      c_element.appendChild(node);
+      appendScrollLog('fix_scroll:append_node', {
+        title: container?.title ?? null,
+        k
+      });
     }
     const writeCache = (scrollTop, scrollLeft, why) => {
-        scroll_cache.set(k, {
-            scrollTop,
-            scrollLeft,
-            t: Date.now()
-        });
-        appendScrollLog('scroll_cache:write', {
-            k,
-            scrollTop,
-            scrollLeft,
-            why
-        });
+      scroll_cache.set(k, {
+        scrollTop,
+        scrollLeft,
+        t: Date.now()
+      });
+      appendScrollLog('scroll_cache:write', {
+        k,
+        scrollTop,
+        scrollLeft,
+        why
+      });
     };
     const scrollToCellIfPossible = why => {
-        if (!cell_variable)
-            return false;
-        const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
-        if (!dom) {
-            appendScrollLog('scroll:cell_dom_not_found', {
-                k,
-                why,
-                cell: cell_variable?._name ?? null
-            });
-            return false;
-        }
-        const top = dom.offsetTop - c_element.offsetTop;
-        const left = c_element.scrollLeft;
-        c_element.scrollTop = top;
-        appendScrollLog('scroll:set', {
-            k,
-            why: `${ why }:cell`,
-            scrollTop: top,
-            scrollLeft: left,
-            cell: cell_variable?._name ?? null
+      if (!cell_variable)
+        return false;
+      const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
+      if (!dom) {
+        appendScrollLog('scroll:cell_dom_not_found', {
+          k,
+          why,
+          cell: cell_variable?._name ?? null
         });
-        writeCache(top, left, `${ why }:cell`);
-        return true;
+        return false;
+      }
+      const top = dom.offsetTop - c_element.offsetTop;
+      const left = c_element.scrollLeft;
+      c_element.scrollTop = top;
+      appendScrollLog('scroll:set', {
+        k,
+        why: `${ why }:cell`,
+        scrollTop: top,
+        scrollLeft: left,
+        cell: cell_variable?._name ?? null
+      });
+      writeCache(top, left, `${ why }:cell`);
+      return true;
     };
     const restoreFromCache = why => {
-        k = scrollKeyFor(container);
-        const cached = scroll_cache.get(k);
-        appendScrollLog('scroll:restore_attempt', {
-            k,
-            why,
-            cachedScrollTop: cached?.scrollTop ?? null,
-            cachedScrollLeft: cached?.scrollLeft ?? null
+      k = scrollKeyFor(container);
+      const cached = scroll_cache.get(k);
+      appendScrollLog('scroll:restore_attempt', {
+        k,
+        why,
+        cachedScrollTop: cached?.scrollTop ?? null,
+        cachedScrollLeft: cached?.scrollLeft ?? null
+      });
+      if (!cached) {
+        appendScrollLog('scroll:restore_no_scroll', {
+          k,
+          why
         });
-        if (!cached) {
-            appendScrollLog('scroll:restore_no_scroll', {
-                k,
-                why
-            });
-            return;
-        }
-        if (cached.scrollTop != null)
-            c_element.scrollTop = cached.scrollTop;
-        if (cached.scrollLeft != null)
-            c_element.scrollLeft = cached.scrollLeft;
-        appendScrollLog('scroll:restore_applied', {
-            k,
-            why,
-            scrollTop: cached.scrollTop ?? null,
-            scrollLeft: cached.scrollLeft ?? null,
-            scrollTopFinal: c_element.scrollTop,
-            scrollLeftFinal: c_element.scrollLeft
-        });
+        return;
+      }
+      if (cached.scrollTop != null)
+        c_element.scrollTop = cached.scrollTop;
+      if (cached.scrollLeft != null)
+        c_element.scrollLeft = cached.scrollLeft;
+      appendScrollLog('scroll:restore_applied', {
+        k,
+        why,
+        scrollTop: cached.scrollTop ?? null,
+        scrollLeft: cached.scrollLeft ?? null,
+        scrollTopFinal: c_element.scrollTop,
+        scrollLeftFinal: c_element.scrollLeft
+      });
     };
     const setScroll = (why = 'setScroll') => {
-        if (scrollToCellIfPossible(why))
-            return;
-        restoreFromCache(why);
+      if (scrollToCellIfPossible(why))
+        return;
+      restoreFromCache(why);
     };
     const retryFrames = 6;
     for (let i = 0; i < retryFrames; i++) {
-        requestAnimationFrame(() => {
-            k = scrollKeyFor(container);
-            appendScrollLog('fix_scroll:raf_retry', {
-                i,
-                k,
-                title: container?.title ?? null
-            });
-            setScroll(`raf:${ i }`);
+      requestAnimationFrame(() => {
+        k = scrollKeyFor(container);
+        appendScrollLog('fix_scroll:raf_retry', {
+          i,
+          k,
+          title: container?.title ?? null
         });
+        setScroll(`raf:${ i }`);
+      });
     }
     appendScrollLog('fix_scroll:exit', {
-        k,
-        title: container?.title ?? null
+      k,
+      title: container?.title ?? null
     });
-}
-)};
+  };
+};
 const _arfw00 = function _scroll_fix_sync_layout(sync_layout_to_url,layout,appendScrollLog,modulePanel)
 {
     sync_layout_to_url;
@@ -15469,7 +15530,7 @@ export default function define(runtime, observer) {
   $def("_1we0ggl", "reload", ["Generators","viewof reload"], _1we0ggl);  
   $def("_plefwg", "onLoadConfig", ["parseGoldenDSL","URLSearchParams","location"], _plefwg);  
   $def("_1nzpnqy", "visualizer_cache", ["reload"], _1nzpnqy);  
-  $def("_1l35721", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1l35721);  
+  $def("_1ojown8", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1ojown8);  
   $def("_1gm4gbf", "blobPanel", [], _1gm4gbf);  
   $def("_lxv2e2", "settings", [], _lxv2e2);  
   $def("_lp1ggk", "is_mobile", ["width"], _lp1ggk);  
@@ -15490,7 +15551,7 @@ export default function define(runtime, observer) {
   $def("_1dyz4o0", "scrollLog", ["mutable scrollLog"], _1dyz4o0);  
   $def("_1d1nkw9", "scrollKeyFor", ["appendScrollLog"], _1d1nkw9);  
   $def("_tb217h", "scroll_cache", [], _tb217h);  
-  $def("_5tyvpe", "fix_scroll", ["scrollKeyFor","appendScrollLog","scroll_cache"], _5tyvpe);  
+  $def("_12p8mg7", "fix_scroll", ["scroll_cache","scrollKeyFor","appendScrollLog"], _12p8mg7);  
   $def("_arfw00", "scroll_fix_sync_layout", ["sync_layout_to_url","layout","appendScrollLog","modulePanel"], _arfw00);  
   $def("_3nwpp4", "URLrouting", ["md"], _3nwpp4);  
   $def("_14te9pl", "sync_layout_from_url", ["reload","resize","URLSearchParams","hash","appendScrollLog","parseGoldenDSL","gl","layout","serializeGoldenDSL","treeSyncGolden","invalidation"], _14te9pl);  

--- a/notebooks/@tomlarkworthy_golden-layout-2-6-0.html
+++ b/notebooks/@tomlarkworthy_golden-layout-2-6-0.html
@@ -14037,138 +14037,196 @@ const _1nzpnqy = function _visualizer_cache(reload)
     reload;
     return new Map();
 };
-const _1l35721 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
+const _1ojown8 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
 {
-    return function (container, component) {
-        appendScrollLog('modulePanel:enter', {
-            title: container?.title ?? null,
-            componentCell: component?.cell ?? null
-        });
-        const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
-        if (!moduleInfo) {
-            // Fall through to file attachment: titles like @user/notebook/path.ext
-            // resolve via the lopecode bootloader's contentSync DOM lookup.
-            const title = container?.title ?? null;
-            if (title) {
-                let node = file_attachment_cache.get(title);
-                if (!node) {
-                    const r = window.lopecode?.contentSync?.(title);
-                    if (r && r.status === 200 && r.bytes) {
-                        node = renderFileAttachment(r.mime, r.bytes);
-                        file_attachment_cache.set(title, node);
-                        appendScrollLog('modulePanel:file_attachment_create', {
-                            title,
-                            mime: r.mime
-                        });
-                    }
-                }
-                if (node) {
-                    const c_element = container.getElement();
-                    if (node.parentNode !== c_element)
-                        c_element.appendChild(node);
-                    appendScrollLog('modulePanel:file_attachment_mount', { title });
-                    return;
-                }
-            }
-            appendScrollLog('modulePanel:missing_moduleInfo', { title });
-            return;
-        }
-        const module = moduleInfo.module;
-        let node;
-        if (!visualizer_cache.has(module)) {
-            appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
-            node = visualizer(runtime, {
-                invalidation: new Promise(r => {
-                }),
-                module,
-                detachNodes: isOnObservableCom(),
-                filter: (cell_name, variables) => {
-                    if (variables[0]._type !== 1)
-                        return false;
-                    if (typeof cell_name == 'string') {
-                        if (cell_name.startsWith('dynamic '))
-                            return false;
-                    }
-                    return true;
-                }
+  return function (container, component) {
+    appendScrollLog('modulePanel:enter', {
+      title: container?.title ?? null,
+      componentCell: component?.cell ?? null
+    });
+    const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
+    if (!moduleInfo) {
+      // Fall through to file attachment: titles like @user/notebook/path.ext
+      // resolve via the lopecode bootloader's contentSync DOM lookup.
+      const title = container?.title ?? null;
+      if (title) {
+        let node = file_attachment_cache.get(title);
+        if (!node) {
+          const r = window.lopecode?.contentSync?.(title);
+          if (r && r.status === 200 && r.bytes) {
+            node = renderFileAttachment(r.mime, r.bytes);
+            file_attachment_cache.set(title, node);
+            appendScrollLog('modulePanel:file_attachment_create', {
+              title,
+              mime: r.mime
             });
-            visualizer_cache.set(module, node);
-        } else {
-            node = visualizer_cache.get(module);
-            appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+          }
         }
-        const cell = module._scope.get(component.cell);
-        const scrollKey = scrollKeyFor(container);
-        fix_scroll(container, node, cell, scrollKey);
-        const el = container.getElement();
-        if (!el.__lope_scroll_bound) {
-            el.__lope_scroll_bound = true;
-            appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
-            el.addEventListener('scroll', () => {
-                const k = scrollKeyFor(container);
-                const scrollTop = el.scrollTop;
-                const scrollLeft = el.scrollLeft;
-                if (scrollTop == 0) {
-                    appendScrollLog('modulePanel:skip 0 scroll', {
-                        title: container?.title ?? null,
-                        scrollKey
-                    });
-                    return;
-                }
-                scroll_cache.set(k, {
-                    scrollTop,
-                    scrollLeft,
-                    t: Date.now()
-                });
-                appendScrollLog('scroll:event', {
-                    k,
-                    title: container?.title ?? null,
-                    scrollTop,
-                    scrollLeft
-                });
-            }, { passive: true });
+        if (node) {
+          const c_element = container.getElement();
+          if (node.parentNode !== c_element)
+            c_element.appendChild(node);
+          appendScrollLog('modulePanel:file_attachment_mount', { title });
+          return;
         }
-        // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
-        if (!container.__lope_destroy_bound) {
-            container.__lope_destroy_bound = true;
-            container.on('destroy', () => {
-                try {
-                    const k = scrollKeyFor(container);
-                    const scrollTop = el?.scrollTop;
-                    const scrollLeft = el?.scrollLeft;
-                    if (scrollTop == 0) {
-                        appendScrollLog('scroll:skip 0 scroll', {
-                            k,
-                            key: container?.title ?? null,
-                            scrollKey
-                        });
-                        return;
-                    }
-                    // do not skip 0 here: if the user is at top, preserve that state
-                    scroll_cache.set(k, {
-                        scrollTop,
-                        scrollLeft,
-                        t: Date.now()
-                    });
-                    appendScrollLog('scroll:destroy_capture', {
-                        k,
-                        title: container?.title ?? null,
-                        scrollTop,
-                        scrollLeft
-                    });
-                } catch (e) {
-                    appendScrollLog('scroll:destroy_capture:error', {
-                        title: container?.title ?? null,
-                        error: String(e)
-                    });
-                }
-            });
+      }
+      appendScrollLog('modulePanel:missing_moduleInfo', { title });
+      return;
+    }
+    const module = moduleInfo.module;
+    let node;
+    if (!visualizer_cache.has(module)) {
+      appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
+      node = visualizer(runtime, {
+        invalidation: new Promise(r => {
+        }),
+        module,
+        detachNodes: isOnObservableCom(),
+        filter: (cell_name, variables) => {
+          if (variables[0]._type !== 1)
+            return false;
+          if (typeof cell_name == 'string') {
+            if (cell_name.startsWith('dynamic '))
+              return false;
+          }
+          return true;
         }
-        appendScrollLog('modulePanel:exit', {
+      });
+      visualizer_cache.set(module, node);
+    } else {
+      node = visualizer_cache.get(module);
+      appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+    }
+    const cell = module._scope.get(component.cell);
+    const scrollKey = scrollKeyFor(container);
+    fix_scroll(container, node, cell, scrollKey);
+    const el = container.getElement();
+    if (!el.__lope_scroll_bound) {
+      el.__lope_scroll_bound = true;
+      appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
+      const markUserScroll = () => {
+        el.__lope_user_scroll_at = Date.now();
+      };
+      el.addEventListener('wheel', markUserScroll, { passive: true });
+      el.addEventListener('touchmove', markUserScroll, { passive: true });
+      el.addEventListener('keydown', markUserScroll, { passive: true });
+      el.addEventListener('scroll', () => {
+        if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+          appendScrollLog('scroll:skip_reflow', { title: container?.title ?? null });
+          return;
+        }
+        // Only cache scrolls following a genuine user gesture; reflow-induced
+        // scroll events (e.g. closing an adjacent panel) carry stale scrollTops.
+        if (Date.now() - (el.__lope_user_scroll_at || 0) > 400) {
+          appendScrollLog('scroll:skip_nonuser', { title: container?.title ?? null });
+          return;
+        }
+        const k = scrollKeyFor(container);
+        const scrollTop = el.scrollTop;
+        const scrollLeft = el.scrollLeft;
+        if (scrollTop == 0) {
+          appendScrollLog('modulePanel:skip 0 scroll', {
             title: container?.title ?? null,
             scrollKey
+          });
+          return;
+        }
+        scroll_cache.set(k, {
+          scrollTop,
+          scrollLeft,
+          t: Date.now()
         });
-    };
+        appendScrollLog('scroll:event', {
+          k,
+          title: container?.title ?? null,
+          scrollTop,
+          scrollLeft
+        });
+      }, { passive: true });
+    }
+    // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
+    if (!container.__lope_destroy_bound) {
+      container.__lope_destroy_bound = true;
+      container.on('destroy', () => {
+        try {
+          if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+            appendScrollLog('scroll:destroy_skip_reflow', { title: container?.title ?? null });
+            return;
+          }
+          const k = scrollKeyFor(container);
+          const scrollTop = el?.scrollTop;
+          const scrollLeft = el?.scrollLeft;
+          if (scrollTop == 0) {
+            appendScrollLog('scroll:skip 0 scroll', {
+              k,
+              key: container?.title ?? null,
+              scrollKey
+            });
+            return;
+          }
+          // do not skip 0 here: if the user is at top, preserve that state
+          scroll_cache.set(k, {
+            scrollTop,
+            scrollLeft,
+            t: Date.now()
+          });
+          appendScrollLog('scroll:destroy_capture', {
+            k,
+            title: container?.title ?? null,
+            scrollTop,
+            scrollLeft
+          });
+        } catch (e) {
+          appendScrollLog('scroll:destroy_capture:error', {
+            title: container?.title ?? null,
+            error: String(e)
+          });
+        }
+      });
+    }
+    // When GoldenLayout resizes this panel (e.g. an adjacent panel is closed) the
+    // browser can shift scrollTop; re-apply the user's cached position after the reflow.
+    if (!container.__lope_resize_bound) {
+      container.__lope_resize_bound = true;
+      container.on('resize', () => {
+        const rk = scrollKeyFor(container);
+        const cached = scroll_cache.get(rk);
+        if (!cached || cached.scrollTop == null)
+          return;
+        const c_el = container.getElement();
+        const at = Date.now();
+        scroll_cache.__reflowUntil = at + 800;
+        // The reflow can shift scrollTop in several passes (content relayout
+        // settles ~300ms later), so re-apply over a window. Bail if the user scrolls.
+        const apply = () => {
+          if ((c_el.__lope_user_scroll_at || 0) > at)
+            return;
+          if (c_el.scrollTop !== cached.scrollTop)
+            c_el.scrollTop = cached.scrollTop;
+          if (cached.scrollLeft != null && c_el.scrollLeft !== cached.scrollLeft)
+            c_el.scrollLeft = cached.scrollLeft;
+        };
+        requestAnimationFrame(apply);
+        for (const d of [
+            60,
+            150,
+            300,
+            450,
+            600
+          ])
+          setTimeout(apply, d);
+        appendScrollLog('scroll:resize_restore', {
+          k: rk,
+          title: container?.title ?? null,
+          scrollTop: cached.scrollTop
+        });
+      });
+    }
+    appendScrollLog('modulePanel:exit', {
+      title: container?.title ?? null,
+      scrollKey
+    });
+  };
 };
 const _1gm4gbf = function _blobPanel(){return(
 function (container, component) {
@@ -14286,112 +14344,115 @@ const _1d1nkw9 = function _scrollKeyFor(appendScrollLog)
 const _tb217h = function _scroll_cache(){return(
 new Map()
 )};
-const _5tyvpe = function _fix_scroll(scrollKeyFor,appendScrollLog,scroll_cache){return(
-function (container, node, cell_variable, key) {
+const _12p8mg7 = function _fix_scroll(scroll_cache,scrollKeyFor,appendScrollLog)
+{
+  return function (container, node, cell_variable, key) {
+    scroll_cache.__reflowUntil = Date.now() + 600;
+    // suppress reflow-induced scroll events that clobber the cache
     const c_element = container.getElement();
     let k = scrollKeyFor(container);
     appendScrollLog('fix_scroll:enter', {
-        title: container?.title ?? null,
-        k,
-        cell: cell_variable?._name ?? null
+      title: container?.title ?? null,
+      k,
+      cell: cell_variable?._name ?? null
     });
     if (node && node.parentNode !== c_element) {
-        c_element.appendChild(node);
-        appendScrollLog('fix_scroll:append_node', {
-            title: container?.title ?? null,
-            k
-        });
+      c_element.appendChild(node);
+      appendScrollLog('fix_scroll:append_node', {
+        title: container?.title ?? null,
+        k
+      });
     }
     const writeCache = (scrollTop, scrollLeft, why) => {
-        scroll_cache.set(k, {
-            scrollTop,
-            scrollLeft,
-            t: Date.now()
-        });
-        appendScrollLog('scroll_cache:write', {
-            k,
-            scrollTop,
-            scrollLeft,
-            why
-        });
+      scroll_cache.set(k, {
+        scrollTop,
+        scrollLeft,
+        t: Date.now()
+      });
+      appendScrollLog('scroll_cache:write', {
+        k,
+        scrollTop,
+        scrollLeft,
+        why
+      });
     };
     const scrollToCellIfPossible = why => {
-        if (!cell_variable)
-            return false;
-        const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
-        if (!dom) {
-            appendScrollLog('scroll:cell_dom_not_found', {
-                k,
-                why,
-                cell: cell_variable?._name ?? null
-            });
-            return false;
-        }
-        const top = dom.offsetTop - c_element.offsetTop;
-        const left = c_element.scrollLeft;
-        c_element.scrollTop = top;
-        appendScrollLog('scroll:set', {
-            k,
-            why: `${ why }:cell`,
-            scrollTop: top,
-            scrollLeft: left,
-            cell: cell_variable?._name ?? null
+      if (!cell_variable)
+        return false;
+      const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
+      if (!dom) {
+        appendScrollLog('scroll:cell_dom_not_found', {
+          k,
+          why,
+          cell: cell_variable?._name ?? null
         });
-        writeCache(top, left, `${ why }:cell`);
-        return true;
+        return false;
+      }
+      const top = dom.offsetTop - c_element.offsetTop;
+      const left = c_element.scrollLeft;
+      c_element.scrollTop = top;
+      appendScrollLog('scroll:set', {
+        k,
+        why: `${ why }:cell`,
+        scrollTop: top,
+        scrollLeft: left,
+        cell: cell_variable?._name ?? null
+      });
+      writeCache(top, left, `${ why }:cell`);
+      return true;
     };
     const restoreFromCache = why => {
-        k = scrollKeyFor(container);
-        const cached = scroll_cache.get(k);
-        appendScrollLog('scroll:restore_attempt', {
-            k,
-            why,
-            cachedScrollTop: cached?.scrollTop ?? null,
-            cachedScrollLeft: cached?.scrollLeft ?? null
+      k = scrollKeyFor(container);
+      const cached = scroll_cache.get(k);
+      appendScrollLog('scroll:restore_attempt', {
+        k,
+        why,
+        cachedScrollTop: cached?.scrollTop ?? null,
+        cachedScrollLeft: cached?.scrollLeft ?? null
+      });
+      if (!cached) {
+        appendScrollLog('scroll:restore_no_scroll', {
+          k,
+          why
         });
-        if (!cached) {
-            appendScrollLog('scroll:restore_no_scroll', {
-                k,
-                why
-            });
-            return;
-        }
-        if (cached.scrollTop != null)
-            c_element.scrollTop = cached.scrollTop;
-        if (cached.scrollLeft != null)
-            c_element.scrollLeft = cached.scrollLeft;
-        appendScrollLog('scroll:restore_applied', {
-            k,
-            why,
-            scrollTop: cached.scrollTop ?? null,
-            scrollLeft: cached.scrollLeft ?? null,
-            scrollTopFinal: c_element.scrollTop,
-            scrollLeftFinal: c_element.scrollLeft
-        });
+        return;
+      }
+      if (cached.scrollTop != null)
+        c_element.scrollTop = cached.scrollTop;
+      if (cached.scrollLeft != null)
+        c_element.scrollLeft = cached.scrollLeft;
+      appendScrollLog('scroll:restore_applied', {
+        k,
+        why,
+        scrollTop: cached.scrollTop ?? null,
+        scrollLeft: cached.scrollLeft ?? null,
+        scrollTopFinal: c_element.scrollTop,
+        scrollLeftFinal: c_element.scrollLeft
+      });
     };
     const setScroll = (why = 'setScroll') => {
-        if (scrollToCellIfPossible(why))
-            return;
-        restoreFromCache(why);
+      if (scrollToCellIfPossible(why))
+        return;
+      restoreFromCache(why);
     };
     const retryFrames = 6;
     for (let i = 0; i < retryFrames; i++) {
-        requestAnimationFrame(() => {
-            k = scrollKeyFor(container);
-            appendScrollLog('fix_scroll:raf_retry', {
-                i,
-                k,
-                title: container?.title ?? null
-            });
-            setScroll(`raf:${ i }`);
+      requestAnimationFrame(() => {
+        k = scrollKeyFor(container);
+        appendScrollLog('fix_scroll:raf_retry', {
+          i,
+          k,
+          title: container?.title ?? null
         });
+        setScroll(`raf:${ i }`);
+      });
     }
     appendScrollLog('fix_scroll:exit', {
-        k,
-        title: container?.title ?? null
+      k,
+      title: container?.title ?? null
     });
-}
-)};
+  };
+};
 const _arfw00 = function _scroll_fix_sync_layout(sync_layout_to_url,layout,appendScrollLog,modulePanel)
 {
     sync_layout_to_url;
@@ -15469,7 +15530,7 @@ export default function define(runtime, observer) {
   $def("_1we0ggl", "reload", ["Generators","viewof reload"], _1we0ggl);  
   $def("_plefwg", "onLoadConfig", ["parseGoldenDSL","URLSearchParams","location"], _plefwg);  
   $def("_1nzpnqy", "visualizer_cache", ["reload"], _1nzpnqy);  
-  $def("_1l35721", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1l35721);  
+  $def("_1ojown8", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1ojown8);  
   $def("_1gm4gbf", "blobPanel", [], _1gm4gbf);  
   $def("_lxv2e2", "settings", [], _lxv2e2);  
   $def("_lp1ggk", "is_mobile", ["width"], _lp1ggk);  
@@ -15490,7 +15551,7 @@ export default function define(runtime, observer) {
   $def("_1dyz4o0", "scrollLog", ["mutable scrollLog"], _1dyz4o0);  
   $def("_1d1nkw9", "scrollKeyFor", ["appendScrollLog"], _1d1nkw9);  
   $def("_tb217h", "scroll_cache", [], _tb217h);  
-  $def("_5tyvpe", "fix_scroll", ["scrollKeyFor","appendScrollLog","scroll_cache"], _5tyvpe);  
+  $def("_12p8mg7", "fix_scroll", ["scroll_cache","scrollKeyFor","appendScrollLog"], _12p8mg7);  
   $def("_arfw00", "scroll_fix_sync_layout", ["sync_layout_to_url","layout","appendScrollLog","modulePanel"], _arfw00);  
   $def("_3nwpp4", "URLrouting", ["md"], _3nwpp4);  
   $def("_14te9pl", "sync_layout_from_url", ["reload","resize","URLSearchParams","hash","appendScrollLog","parseGoldenDSL","gl","layout","serializeGoldenDSL","treeSyncGolden","invalidation"], _14te9pl);  

--- a/notebooks/@tomlarkworthy_import-notebook.html
+++ b/notebooks/@tomlarkworthy_import-notebook.html
@@ -14035,138 +14035,196 @@ const _1nzpnqy = function _visualizer_cache(reload)
     reload;
     return new Map();
 };
-const _1l35721 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
+const _1ojown8 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
 {
-    return function (container, component) {
-        appendScrollLog('modulePanel:enter', {
-            title: container?.title ?? null,
-            componentCell: component?.cell ?? null
-        });
-        const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
-        if (!moduleInfo) {
-            // Fall through to file attachment: titles like @user/notebook/path.ext
-            // resolve via the lopecode bootloader's contentSync DOM lookup.
-            const title = container?.title ?? null;
-            if (title) {
-                let node = file_attachment_cache.get(title);
-                if (!node) {
-                    const r = window.lopecode?.contentSync?.(title);
-                    if (r && r.status === 200 && r.bytes) {
-                        node = renderFileAttachment(r.mime, r.bytes);
-                        file_attachment_cache.set(title, node);
-                        appendScrollLog('modulePanel:file_attachment_create', {
-                            title,
-                            mime: r.mime
-                        });
-                    }
-                }
-                if (node) {
-                    const c_element = container.getElement();
-                    if (node.parentNode !== c_element)
-                        c_element.appendChild(node);
-                    appendScrollLog('modulePanel:file_attachment_mount', { title });
-                    return;
-                }
-            }
-            appendScrollLog('modulePanel:missing_moduleInfo', { title });
-            return;
-        }
-        const module = moduleInfo.module;
-        let node;
-        if (!visualizer_cache.has(module)) {
-            appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
-            node = visualizer(runtime, {
-                invalidation: new Promise(r => {
-                }),
-                module,
-                detachNodes: isOnObservableCom(),
-                filter: (cell_name, variables) => {
-                    if (variables[0]._type !== 1)
-                        return false;
-                    if (typeof cell_name == 'string') {
-                        if (cell_name.startsWith('dynamic '))
-                            return false;
-                    }
-                    return true;
-                }
+  return function (container, component) {
+    appendScrollLog('modulePanel:enter', {
+      title: container?.title ?? null,
+      componentCell: component?.cell ?? null
+    });
+    const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
+    if (!moduleInfo) {
+      // Fall through to file attachment: titles like @user/notebook/path.ext
+      // resolve via the lopecode bootloader's contentSync DOM lookup.
+      const title = container?.title ?? null;
+      if (title) {
+        let node = file_attachment_cache.get(title);
+        if (!node) {
+          const r = window.lopecode?.contentSync?.(title);
+          if (r && r.status === 200 && r.bytes) {
+            node = renderFileAttachment(r.mime, r.bytes);
+            file_attachment_cache.set(title, node);
+            appendScrollLog('modulePanel:file_attachment_create', {
+              title,
+              mime: r.mime
             });
-            visualizer_cache.set(module, node);
-        } else {
-            node = visualizer_cache.get(module);
-            appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+          }
         }
-        const cell = module._scope.get(component.cell);
-        const scrollKey = scrollKeyFor(container);
-        fix_scroll(container, node, cell, scrollKey);
-        const el = container.getElement();
-        if (!el.__lope_scroll_bound) {
-            el.__lope_scroll_bound = true;
-            appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
-            el.addEventListener('scroll', () => {
-                const k = scrollKeyFor(container);
-                const scrollTop = el.scrollTop;
-                const scrollLeft = el.scrollLeft;
-                if (scrollTop == 0) {
-                    appendScrollLog('modulePanel:skip 0 scroll', {
-                        title: container?.title ?? null,
-                        scrollKey
-                    });
-                    return;
-                }
-                scroll_cache.set(k, {
-                    scrollTop,
-                    scrollLeft,
-                    t: Date.now()
-                });
-                appendScrollLog('scroll:event', {
-                    k,
-                    title: container?.title ?? null,
-                    scrollTop,
-                    scrollLeft
-                });
-            }, { passive: true });
+        if (node) {
+          const c_element = container.getElement();
+          if (node.parentNode !== c_element)
+            c_element.appendChild(node);
+          appendScrollLog('modulePanel:file_attachment_mount', { title });
+          return;
         }
-        // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
-        if (!container.__lope_destroy_bound) {
-            container.__lope_destroy_bound = true;
-            container.on('destroy', () => {
-                try {
-                    const k = scrollKeyFor(container);
-                    const scrollTop = el?.scrollTop;
-                    const scrollLeft = el?.scrollLeft;
-                    if (scrollTop == 0) {
-                        appendScrollLog('scroll:skip 0 scroll', {
-                            k,
-                            key: container?.title ?? null,
-                            scrollKey
-                        });
-                        return;
-                    }
-                    // do not skip 0 here: if the user is at top, preserve that state
-                    scroll_cache.set(k, {
-                        scrollTop,
-                        scrollLeft,
-                        t: Date.now()
-                    });
-                    appendScrollLog('scroll:destroy_capture', {
-                        k,
-                        title: container?.title ?? null,
-                        scrollTop,
-                        scrollLeft
-                    });
-                } catch (e) {
-                    appendScrollLog('scroll:destroy_capture:error', {
-                        title: container?.title ?? null,
-                        error: String(e)
-                    });
-                }
-            });
+      }
+      appendScrollLog('modulePanel:missing_moduleInfo', { title });
+      return;
+    }
+    const module = moduleInfo.module;
+    let node;
+    if (!visualizer_cache.has(module)) {
+      appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
+      node = visualizer(runtime, {
+        invalidation: new Promise(r => {
+        }),
+        module,
+        detachNodes: isOnObservableCom(),
+        filter: (cell_name, variables) => {
+          if (variables[0]._type !== 1)
+            return false;
+          if (typeof cell_name == 'string') {
+            if (cell_name.startsWith('dynamic '))
+              return false;
+          }
+          return true;
         }
-        appendScrollLog('modulePanel:exit', {
+      });
+      visualizer_cache.set(module, node);
+    } else {
+      node = visualizer_cache.get(module);
+      appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+    }
+    const cell = module._scope.get(component.cell);
+    const scrollKey = scrollKeyFor(container);
+    fix_scroll(container, node, cell, scrollKey);
+    const el = container.getElement();
+    if (!el.__lope_scroll_bound) {
+      el.__lope_scroll_bound = true;
+      appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
+      const markUserScroll = () => {
+        el.__lope_user_scroll_at = Date.now();
+      };
+      el.addEventListener('wheel', markUserScroll, { passive: true });
+      el.addEventListener('touchmove', markUserScroll, { passive: true });
+      el.addEventListener('keydown', markUserScroll, { passive: true });
+      el.addEventListener('scroll', () => {
+        if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+          appendScrollLog('scroll:skip_reflow', { title: container?.title ?? null });
+          return;
+        }
+        // Only cache scrolls following a genuine user gesture; reflow-induced
+        // scroll events (e.g. closing an adjacent panel) carry stale scrollTops.
+        if (Date.now() - (el.__lope_user_scroll_at || 0) > 400) {
+          appendScrollLog('scroll:skip_nonuser', { title: container?.title ?? null });
+          return;
+        }
+        const k = scrollKeyFor(container);
+        const scrollTop = el.scrollTop;
+        const scrollLeft = el.scrollLeft;
+        if (scrollTop == 0) {
+          appendScrollLog('modulePanel:skip 0 scroll', {
             title: container?.title ?? null,
             scrollKey
+          });
+          return;
+        }
+        scroll_cache.set(k, {
+          scrollTop,
+          scrollLeft,
+          t: Date.now()
         });
-    };
+        appendScrollLog('scroll:event', {
+          k,
+          title: container?.title ?? null,
+          scrollTop,
+          scrollLeft
+        });
+      }, { passive: true });
+    }
+    // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
+    if (!container.__lope_destroy_bound) {
+      container.__lope_destroy_bound = true;
+      container.on('destroy', () => {
+        try {
+          if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+            appendScrollLog('scroll:destroy_skip_reflow', { title: container?.title ?? null });
+            return;
+          }
+          const k = scrollKeyFor(container);
+          const scrollTop = el?.scrollTop;
+          const scrollLeft = el?.scrollLeft;
+          if (scrollTop == 0) {
+            appendScrollLog('scroll:skip 0 scroll', {
+              k,
+              key: container?.title ?? null,
+              scrollKey
+            });
+            return;
+          }
+          // do not skip 0 here: if the user is at top, preserve that state
+          scroll_cache.set(k, {
+            scrollTop,
+            scrollLeft,
+            t: Date.now()
+          });
+          appendScrollLog('scroll:destroy_capture', {
+            k,
+            title: container?.title ?? null,
+            scrollTop,
+            scrollLeft
+          });
+        } catch (e) {
+          appendScrollLog('scroll:destroy_capture:error', {
+            title: container?.title ?? null,
+            error: String(e)
+          });
+        }
+      });
+    }
+    // When GoldenLayout resizes this panel (e.g. an adjacent panel is closed) the
+    // browser can shift scrollTop; re-apply the user's cached position after the reflow.
+    if (!container.__lope_resize_bound) {
+      container.__lope_resize_bound = true;
+      container.on('resize', () => {
+        const rk = scrollKeyFor(container);
+        const cached = scroll_cache.get(rk);
+        if (!cached || cached.scrollTop == null)
+          return;
+        const c_el = container.getElement();
+        const at = Date.now();
+        scroll_cache.__reflowUntil = at + 800;
+        // The reflow can shift scrollTop in several passes (content relayout
+        // settles ~300ms later), so re-apply over a window. Bail if the user scrolls.
+        const apply = () => {
+          if ((c_el.__lope_user_scroll_at || 0) > at)
+            return;
+          if (c_el.scrollTop !== cached.scrollTop)
+            c_el.scrollTop = cached.scrollTop;
+          if (cached.scrollLeft != null && c_el.scrollLeft !== cached.scrollLeft)
+            c_el.scrollLeft = cached.scrollLeft;
+        };
+        requestAnimationFrame(apply);
+        for (const d of [
+            60,
+            150,
+            300,
+            450,
+            600
+          ])
+          setTimeout(apply, d);
+        appendScrollLog('scroll:resize_restore', {
+          k: rk,
+          title: container?.title ?? null,
+          scrollTop: cached.scrollTop
+        });
+      });
+    }
+    appendScrollLog('modulePanel:exit', {
+      title: container?.title ?? null,
+      scrollKey
+    });
+  };
 };
 const _1gm4gbf = function _blobPanel(){return(
 function (container, component) {
@@ -14284,112 +14342,115 @@ const _1d1nkw9 = function _scrollKeyFor(appendScrollLog)
 const _tb217h = function _scroll_cache(){return(
 new Map()
 )};
-const _5tyvpe = function _fix_scroll(scrollKeyFor,appendScrollLog,scroll_cache){return(
-function (container, node, cell_variable, key) {
+const _12p8mg7 = function _fix_scroll(scroll_cache,scrollKeyFor,appendScrollLog)
+{
+  return function (container, node, cell_variable, key) {
+    scroll_cache.__reflowUntil = Date.now() + 600;
+    // suppress reflow-induced scroll events that clobber the cache
     const c_element = container.getElement();
     let k = scrollKeyFor(container);
     appendScrollLog('fix_scroll:enter', {
-        title: container?.title ?? null,
-        k,
-        cell: cell_variable?._name ?? null
+      title: container?.title ?? null,
+      k,
+      cell: cell_variable?._name ?? null
     });
     if (node && node.parentNode !== c_element) {
-        c_element.appendChild(node);
-        appendScrollLog('fix_scroll:append_node', {
-            title: container?.title ?? null,
-            k
-        });
+      c_element.appendChild(node);
+      appendScrollLog('fix_scroll:append_node', {
+        title: container?.title ?? null,
+        k
+      });
     }
     const writeCache = (scrollTop, scrollLeft, why) => {
-        scroll_cache.set(k, {
-            scrollTop,
-            scrollLeft,
-            t: Date.now()
-        });
-        appendScrollLog('scroll_cache:write', {
-            k,
-            scrollTop,
-            scrollLeft,
-            why
-        });
+      scroll_cache.set(k, {
+        scrollTop,
+        scrollLeft,
+        t: Date.now()
+      });
+      appendScrollLog('scroll_cache:write', {
+        k,
+        scrollTop,
+        scrollLeft,
+        why
+      });
     };
     const scrollToCellIfPossible = why => {
-        if (!cell_variable)
-            return false;
-        const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
-        if (!dom) {
-            appendScrollLog('scroll:cell_dom_not_found', {
-                k,
-                why,
-                cell: cell_variable?._name ?? null
-            });
-            return false;
-        }
-        const top = dom.offsetTop - c_element.offsetTop;
-        const left = c_element.scrollLeft;
-        c_element.scrollTop = top;
-        appendScrollLog('scroll:set', {
-            k,
-            why: `${ why }:cell`,
-            scrollTop: top,
-            scrollLeft: left,
-            cell: cell_variable?._name ?? null
+      if (!cell_variable)
+        return false;
+      const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
+      if (!dom) {
+        appendScrollLog('scroll:cell_dom_not_found', {
+          k,
+          why,
+          cell: cell_variable?._name ?? null
         });
-        writeCache(top, left, `${ why }:cell`);
-        return true;
+        return false;
+      }
+      const top = dom.offsetTop - c_element.offsetTop;
+      const left = c_element.scrollLeft;
+      c_element.scrollTop = top;
+      appendScrollLog('scroll:set', {
+        k,
+        why: `${ why }:cell`,
+        scrollTop: top,
+        scrollLeft: left,
+        cell: cell_variable?._name ?? null
+      });
+      writeCache(top, left, `${ why }:cell`);
+      return true;
     };
     const restoreFromCache = why => {
-        k = scrollKeyFor(container);
-        const cached = scroll_cache.get(k);
-        appendScrollLog('scroll:restore_attempt', {
-            k,
-            why,
-            cachedScrollTop: cached?.scrollTop ?? null,
-            cachedScrollLeft: cached?.scrollLeft ?? null
+      k = scrollKeyFor(container);
+      const cached = scroll_cache.get(k);
+      appendScrollLog('scroll:restore_attempt', {
+        k,
+        why,
+        cachedScrollTop: cached?.scrollTop ?? null,
+        cachedScrollLeft: cached?.scrollLeft ?? null
+      });
+      if (!cached) {
+        appendScrollLog('scroll:restore_no_scroll', {
+          k,
+          why
         });
-        if (!cached) {
-            appendScrollLog('scroll:restore_no_scroll', {
-                k,
-                why
-            });
-            return;
-        }
-        if (cached.scrollTop != null)
-            c_element.scrollTop = cached.scrollTop;
-        if (cached.scrollLeft != null)
-            c_element.scrollLeft = cached.scrollLeft;
-        appendScrollLog('scroll:restore_applied', {
-            k,
-            why,
-            scrollTop: cached.scrollTop ?? null,
-            scrollLeft: cached.scrollLeft ?? null,
-            scrollTopFinal: c_element.scrollTop,
-            scrollLeftFinal: c_element.scrollLeft
-        });
+        return;
+      }
+      if (cached.scrollTop != null)
+        c_element.scrollTop = cached.scrollTop;
+      if (cached.scrollLeft != null)
+        c_element.scrollLeft = cached.scrollLeft;
+      appendScrollLog('scroll:restore_applied', {
+        k,
+        why,
+        scrollTop: cached.scrollTop ?? null,
+        scrollLeft: cached.scrollLeft ?? null,
+        scrollTopFinal: c_element.scrollTop,
+        scrollLeftFinal: c_element.scrollLeft
+      });
     };
     const setScroll = (why = 'setScroll') => {
-        if (scrollToCellIfPossible(why))
-            return;
-        restoreFromCache(why);
+      if (scrollToCellIfPossible(why))
+        return;
+      restoreFromCache(why);
     };
     const retryFrames = 6;
     for (let i = 0; i < retryFrames; i++) {
-        requestAnimationFrame(() => {
-            k = scrollKeyFor(container);
-            appendScrollLog('fix_scroll:raf_retry', {
-                i,
-                k,
-                title: container?.title ?? null
-            });
-            setScroll(`raf:${ i }`);
+      requestAnimationFrame(() => {
+        k = scrollKeyFor(container);
+        appendScrollLog('fix_scroll:raf_retry', {
+          i,
+          k,
+          title: container?.title ?? null
         });
+        setScroll(`raf:${ i }`);
+      });
     }
     appendScrollLog('fix_scroll:exit', {
-        k,
-        title: container?.title ?? null
+      k,
+      title: container?.title ?? null
     });
-}
-)};
+  };
+};
 const _arfw00 = function _scroll_fix_sync_layout(sync_layout_to_url,layout,appendScrollLog,modulePanel)
 {
     sync_layout_to_url;
@@ -15467,7 +15528,7 @@ export default function define(runtime, observer) {
   $def("_1we0ggl", "reload", ["Generators","viewof reload"], _1we0ggl);  
   $def("_plefwg", "onLoadConfig", ["parseGoldenDSL","URLSearchParams","location"], _plefwg);  
   $def("_1nzpnqy", "visualizer_cache", ["reload"], _1nzpnqy);  
-  $def("_1l35721", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1l35721);  
+  $def("_1ojown8", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1ojown8);  
   $def("_1gm4gbf", "blobPanel", [], _1gm4gbf);  
   $def("_lxv2e2", "settings", [], _lxv2e2);  
   $def("_lp1ggk", "is_mobile", ["width"], _lp1ggk);  
@@ -15488,7 +15549,7 @@ export default function define(runtime, observer) {
   $def("_1dyz4o0", "scrollLog", ["mutable scrollLog"], _1dyz4o0);  
   $def("_1d1nkw9", "scrollKeyFor", ["appendScrollLog"], _1d1nkw9);  
   $def("_tb217h", "scroll_cache", [], _tb217h);  
-  $def("_5tyvpe", "fix_scroll", ["scrollKeyFor","appendScrollLog","scroll_cache"], _5tyvpe);  
+  $def("_12p8mg7", "fix_scroll", ["scroll_cache","scrollKeyFor","appendScrollLog"], _12p8mg7);  
   $def("_arfw00", "scroll_fix_sync_layout", ["sync_layout_to_url","layout","appendScrollLog","modulePanel"], _arfw00);  
   $def("_3nwpp4", "URLrouting", ["md"], _3nwpp4);  
   $def("_14te9pl", "sync_layout_from_url", ["reload","resize","URLSearchParams","hash","appendScrollLog","parseGoldenDSL","gl","layout","serializeGoldenDSL","treeSyncGolden","invalidation"], _14te9pl);  

--- a/notebooks/@tomlarkworthy_jest-expect-standalone.html
+++ b/notebooks/@tomlarkworthy_jest-expect-standalone.html
@@ -14037,138 +14037,196 @@ const _1nzpnqy = function _visualizer_cache(reload)
     reload;
     return new Map();
 };
-const _1l35721 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
+const _1ojown8 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
 {
-    return function (container, component) {
-        appendScrollLog('modulePanel:enter', {
-            title: container?.title ?? null,
-            componentCell: component?.cell ?? null
-        });
-        const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
-        if (!moduleInfo) {
-            // Fall through to file attachment: titles like @user/notebook/path.ext
-            // resolve via the lopecode bootloader's contentSync DOM lookup.
-            const title = container?.title ?? null;
-            if (title) {
-                let node = file_attachment_cache.get(title);
-                if (!node) {
-                    const r = window.lopecode?.contentSync?.(title);
-                    if (r && r.status === 200 && r.bytes) {
-                        node = renderFileAttachment(r.mime, r.bytes);
-                        file_attachment_cache.set(title, node);
-                        appendScrollLog('modulePanel:file_attachment_create', {
-                            title,
-                            mime: r.mime
-                        });
-                    }
-                }
-                if (node) {
-                    const c_element = container.getElement();
-                    if (node.parentNode !== c_element)
-                        c_element.appendChild(node);
-                    appendScrollLog('modulePanel:file_attachment_mount', { title });
-                    return;
-                }
-            }
-            appendScrollLog('modulePanel:missing_moduleInfo', { title });
-            return;
-        }
-        const module = moduleInfo.module;
-        let node;
-        if (!visualizer_cache.has(module)) {
-            appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
-            node = visualizer(runtime, {
-                invalidation: new Promise(r => {
-                }),
-                module,
-                detachNodes: isOnObservableCom(),
-                filter: (cell_name, variables) => {
-                    if (variables[0]._type !== 1)
-                        return false;
-                    if (typeof cell_name == 'string') {
-                        if (cell_name.startsWith('dynamic '))
-                            return false;
-                    }
-                    return true;
-                }
+  return function (container, component) {
+    appendScrollLog('modulePanel:enter', {
+      title: container?.title ?? null,
+      componentCell: component?.cell ?? null
+    });
+    const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
+    if (!moduleInfo) {
+      // Fall through to file attachment: titles like @user/notebook/path.ext
+      // resolve via the lopecode bootloader's contentSync DOM lookup.
+      const title = container?.title ?? null;
+      if (title) {
+        let node = file_attachment_cache.get(title);
+        if (!node) {
+          const r = window.lopecode?.contentSync?.(title);
+          if (r && r.status === 200 && r.bytes) {
+            node = renderFileAttachment(r.mime, r.bytes);
+            file_attachment_cache.set(title, node);
+            appendScrollLog('modulePanel:file_attachment_create', {
+              title,
+              mime: r.mime
             });
-            visualizer_cache.set(module, node);
-        } else {
-            node = visualizer_cache.get(module);
-            appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+          }
         }
-        const cell = module._scope.get(component.cell);
-        const scrollKey = scrollKeyFor(container);
-        fix_scroll(container, node, cell, scrollKey);
-        const el = container.getElement();
-        if (!el.__lope_scroll_bound) {
-            el.__lope_scroll_bound = true;
-            appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
-            el.addEventListener('scroll', () => {
-                const k = scrollKeyFor(container);
-                const scrollTop = el.scrollTop;
-                const scrollLeft = el.scrollLeft;
-                if (scrollTop == 0) {
-                    appendScrollLog('modulePanel:skip 0 scroll', {
-                        title: container?.title ?? null,
-                        scrollKey
-                    });
-                    return;
-                }
-                scroll_cache.set(k, {
-                    scrollTop,
-                    scrollLeft,
-                    t: Date.now()
-                });
-                appendScrollLog('scroll:event', {
-                    k,
-                    title: container?.title ?? null,
-                    scrollTop,
-                    scrollLeft
-                });
-            }, { passive: true });
+        if (node) {
+          const c_element = container.getElement();
+          if (node.parentNode !== c_element)
+            c_element.appendChild(node);
+          appendScrollLog('modulePanel:file_attachment_mount', { title });
+          return;
         }
-        // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
-        if (!container.__lope_destroy_bound) {
-            container.__lope_destroy_bound = true;
-            container.on('destroy', () => {
-                try {
-                    const k = scrollKeyFor(container);
-                    const scrollTop = el?.scrollTop;
-                    const scrollLeft = el?.scrollLeft;
-                    if (scrollTop == 0) {
-                        appendScrollLog('scroll:skip 0 scroll', {
-                            k,
-                            key: container?.title ?? null,
-                            scrollKey
-                        });
-                        return;
-                    }
-                    // do not skip 0 here: if the user is at top, preserve that state
-                    scroll_cache.set(k, {
-                        scrollTop,
-                        scrollLeft,
-                        t: Date.now()
-                    });
-                    appendScrollLog('scroll:destroy_capture', {
-                        k,
-                        title: container?.title ?? null,
-                        scrollTop,
-                        scrollLeft
-                    });
-                } catch (e) {
-                    appendScrollLog('scroll:destroy_capture:error', {
-                        title: container?.title ?? null,
-                        error: String(e)
-                    });
-                }
-            });
+      }
+      appendScrollLog('modulePanel:missing_moduleInfo', { title });
+      return;
+    }
+    const module = moduleInfo.module;
+    let node;
+    if (!visualizer_cache.has(module)) {
+      appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
+      node = visualizer(runtime, {
+        invalidation: new Promise(r => {
+        }),
+        module,
+        detachNodes: isOnObservableCom(),
+        filter: (cell_name, variables) => {
+          if (variables[0]._type !== 1)
+            return false;
+          if (typeof cell_name == 'string') {
+            if (cell_name.startsWith('dynamic '))
+              return false;
+          }
+          return true;
         }
-        appendScrollLog('modulePanel:exit', {
+      });
+      visualizer_cache.set(module, node);
+    } else {
+      node = visualizer_cache.get(module);
+      appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+    }
+    const cell = module._scope.get(component.cell);
+    const scrollKey = scrollKeyFor(container);
+    fix_scroll(container, node, cell, scrollKey);
+    const el = container.getElement();
+    if (!el.__lope_scroll_bound) {
+      el.__lope_scroll_bound = true;
+      appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
+      const markUserScroll = () => {
+        el.__lope_user_scroll_at = Date.now();
+      };
+      el.addEventListener('wheel', markUserScroll, { passive: true });
+      el.addEventListener('touchmove', markUserScroll, { passive: true });
+      el.addEventListener('keydown', markUserScroll, { passive: true });
+      el.addEventListener('scroll', () => {
+        if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+          appendScrollLog('scroll:skip_reflow', { title: container?.title ?? null });
+          return;
+        }
+        // Only cache scrolls following a genuine user gesture; reflow-induced
+        // scroll events (e.g. closing an adjacent panel) carry stale scrollTops.
+        if (Date.now() - (el.__lope_user_scroll_at || 0) > 400) {
+          appendScrollLog('scroll:skip_nonuser', { title: container?.title ?? null });
+          return;
+        }
+        const k = scrollKeyFor(container);
+        const scrollTop = el.scrollTop;
+        const scrollLeft = el.scrollLeft;
+        if (scrollTop == 0) {
+          appendScrollLog('modulePanel:skip 0 scroll', {
             title: container?.title ?? null,
             scrollKey
+          });
+          return;
+        }
+        scroll_cache.set(k, {
+          scrollTop,
+          scrollLeft,
+          t: Date.now()
         });
-    };
+        appendScrollLog('scroll:event', {
+          k,
+          title: container?.title ?? null,
+          scrollTop,
+          scrollLeft
+        });
+      }, { passive: true });
+    }
+    // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
+    if (!container.__lope_destroy_bound) {
+      container.__lope_destroy_bound = true;
+      container.on('destroy', () => {
+        try {
+          if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+            appendScrollLog('scroll:destroy_skip_reflow', { title: container?.title ?? null });
+            return;
+          }
+          const k = scrollKeyFor(container);
+          const scrollTop = el?.scrollTop;
+          const scrollLeft = el?.scrollLeft;
+          if (scrollTop == 0) {
+            appendScrollLog('scroll:skip 0 scroll', {
+              k,
+              key: container?.title ?? null,
+              scrollKey
+            });
+            return;
+          }
+          // do not skip 0 here: if the user is at top, preserve that state
+          scroll_cache.set(k, {
+            scrollTop,
+            scrollLeft,
+            t: Date.now()
+          });
+          appendScrollLog('scroll:destroy_capture', {
+            k,
+            title: container?.title ?? null,
+            scrollTop,
+            scrollLeft
+          });
+        } catch (e) {
+          appendScrollLog('scroll:destroy_capture:error', {
+            title: container?.title ?? null,
+            error: String(e)
+          });
+        }
+      });
+    }
+    // When GoldenLayout resizes this panel (e.g. an adjacent panel is closed) the
+    // browser can shift scrollTop; re-apply the user's cached position after the reflow.
+    if (!container.__lope_resize_bound) {
+      container.__lope_resize_bound = true;
+      container.on('resize', () => {
+        const rk = scrollKeyFor(container);
+        const cached = scroll_cache.get(rk);
+        if (!cached || cached.scrollTop == null)
+          return;
+        const c_el = container.getElement();
+        const at = Date.now();
+        scroll_cache.__reflowUntil = at + 800;
+        // The reflow can shift scrollTop in several passes (content relayout
+        // settles ~300ms later), so re-apply over a window. Bail if the user scrolls.
+        const apply = () => {
+          if ((c_el.__lope_user_scroll_at || 0) > at)
+            return;
+          if (c_el.scrollTop !== cached.scrollTop)
+            c_el.scrollTop = cached.scrollTop;
+          if (cached.scrollLeft != null && c_el.scrollLeft !== cached.scrollLeft)
+            c_el.scrollLeft = cached.scrollLeft;
+        };
+        requestAnimationFrame(apply);
+        for (const d of [
+            60,
+            150,
+            300,
+            450,
+            600
+          ])
+          setTimeout(apply, d);
+        appendScrollLog('scroll:resize_restore', {
+          k: rk,
+          title: container?.title ?? null,
+          scrollTop: cached.scrollTop
+        });
+      });
+    }
+    appendScrollLog('modulePanel:exit', {
+      title: container?.title ?? null,
+      scrollKey
+    });
+  };
 };
 const _1gm4gbf = function _blobPanel(){return(
 function (container, component) {
@@ -14286,112 +14344,115 @@ const _1d1nkw9 = function _scrollKeyFor(appendScrollLog)
 const _tb217h = function _scroll_cache(){return(
 new Map()
 )};
-const _5tyvpe = function _fix_scroll(scrollKeyFor,appendScrollLog,scroll_cache){return(
-function (container, node, cell_variable, key) {
+const _12p8mg7 = function _fix_scroll(scroll_cache,scrollKeyFor,appendScrollLog)
+{
+  return function (container, node, cell_variable, key) {
+    scroll_cache.__reflowUntil = Date.now() + 600;
+    // suppress reflow-induced scroll events that clobber the cache
     const c_element = container.getElement();
     let k = scrollKeyFor(container);
     appendScrollLog('fix_scroll:enter', {
-        title: container?.title ?? null,
-        k,
-        cell: cell_variable?._name ?? null
+      title: container?.title ?? null,
+      k,
+      cell: cell_variable?._name ?? null
     });
     if (node && node.parentNode !== c_element) {
-        c_element.appendChild(node);
-        appendScrollLog('fix_scroll:append_node', {
-            title: container?.title ?? null,
-            k
-        });
+      c_element.appendChild(node);
+      appendScrollLog('fix_scroll:append_node', {
+        title: container?.title ?? null,
+        k
+      });
     }
     const writeCache = (scrollTop, scrollLeft, why) => {
-        scroll_cache.set(k, {
-            scrollTop,
-            scrollLeft,
-            t: Date.now()
-        });
-        appendScrollLog('scroll_cache:write', {
-            k,
-            scrollTop,
-            scrollLeft,
-            why
-        });
+      scroll_cache.set(k, {
+        scrollTop,
+        scrollLeft,
+        t: Date.now()
+      });
+      appendScrollLog('scroll_cache:write', {
+        k,
+        scrollTop,
+        scrollLeft,
+        why
+      });
     };
     const scrollToCellIfPossible = why => {
-        if (!cell_variable)
-            return false;
-        const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
-        if (!dom) {
-            appendScrollLog('scroll:cell_dom_not_found', {
-                k,
-                why,
-                cell: cell_variable?._name ?? null
-            });
-            return false;
-        }
-        const top = dom.offsetTop - c_element.offsetTop;
-        const left = c_element.scrollLeft;
-        c_element.scrollTop = top;
-        appendScrollLog('scroll:set', {
-            k,
-            why: `${ why }:cell`,
-            scrollTop: top,
-            scrollLeft: left,
-            cell: cell_variable?._name ?? null
+      if (!cell_variable)
+        return false;
+      const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
+      if (!dom) {
+        appendScrollLog('scroll:cell_dom_not_found', {
+          k,
+          why,
+          cell: cell_variable?._name ?? null
         });
-        writeCache(top, left, `${ why }:cell`);
-        return true;
+        return false;
+      }
+      const top = dom.offsetTop - c_element.offsetTop;
+      const left = c_element.scrollLeft;
+      c_element.scrollTop = top;
+      appendScrollLog('scroll:set', {
+        k,
+        why: `${ why }:cell`,
+        scrollTop: top,
+        scrollLeft: left,
+        cell: cell_variable?._name ?? null
+      });
+      writeCache(top, left, `${ why }:cell`);
+      return true;
     };
     const restoreFromCache = why => {
-        k = scrollKeyFor(container);
-        const cached = scroll_cache.get(k);
-        appendScrollLog('scroll:restore_attempt', {
-            k,
-            why,
-            cachedScrollTop: cached?.scrollTop ?? null,
-            cachedScrollLeft: cached?.scrollLeft ?? null
+      k = scrollKeyFor(container);
+      const cached = scroll_cache.get(k);
+      appendScrollLog('scroll:restore_attempt', {
+        k,
+        why,
+        cachedScrollTop: cached?.scrollTop ?? null,
+        cachedScrollLeft: cached?.scrollLeft ?? null
+      });
+      if (!cached) {
+        appendScrollLog('scroll:restore_no_scroll', {
+          k,
+          why
         });
-        if (!cached) {
-            appendScrollLog('scroll:restore_no_scroll', {
-                k,
-                why
-            });
-            return;
-        }
-        if (cached.scrollTop != null)
-            c_element.scrollTop = cached.scrollTop;
-        if (cached.scrollLeft != null)
-            c_element.scrollLeft = cached.scrollLeft;
-        appendScrollLog('scroll:restore_applied', {
-            k,
-            why,
-            scrollTop: cached.scrollTop ?? null,
-            scrollLeft: cached.scrollLeft ?? null,
-            scrollTopFinal: c_element.scrollTop,
-            scrollLeftFinal: c_element.scrollLeft
-        });
+        return;
+      }
+      if (cached.scrollTop != null)
+        c_element.scrollTop = cached.scrollTop;
+      if (cached.scrollLeft != null)
+        c_element.scrollLeft = cached.scrollLeft;
+      appendScrollLog('scroll:restore_applied', {
+        k,
+        why,
+        scrollTop: cached.scrollTop ?? null,
+        scrollLeft: cached.scrollLeft ?? null,
+        scrollTopFinal: c_element.scrollTop,
+        scrollLeftFinal: c_element.scrollLeft
+      });
     };
     const setScroll = (why = 'setScroll') => {
-        if (scrollToCellIfPossible(why))
-            return;
-        restoreFromCache(why);
+      if (scrollToCellIfPossible(why))
+        return;
+      restoreFromCache(why);
     };
     const retryFrames = 6;
     for (let i = 0; i < retryFrames; i++) {
-        requestAnimationFrame(() => {
-            k = scrollKeyFor(container);
-            appendScrollLog('fix_scroll:raf_retry', {
-                i,
-                k,
-                title: container?.title ?? null
-            });
-            setScroll(`raf:${ i }`);
+      requestAnimationFrame(() => {
+        k = scrollKeyFor(container);
+        appendScrollLog('fix_scroll:raf_retry', {
+          i,
+          k,
+          title: container?.title ?? null
         });
+        setScroll(`raf:${ i }`);
+      });
     }
     appendScrollLog('fix_scroll:exit', {
-        k,
-        title: container?.title ?? null
+      k,
+      title: container?.title ?? null
     });
-}
-)};
+  };
+};
 const _arfw00 = function _scroll_fix_sync_layout(sync_layout_to_url,layout,appendScrollLog,modulePanel)
 {
     sync_layout_to_url;
@@ -15469,7 +15530,7 @@ export default function define(runtime, observer) {
   $def("_1we0ggl", "reload", ["Generators","viewof reload"], _1we0ggl);  
   $def("_plefwg", "onLoadConfig", ["parseGoldenDSL","URLSearchParams","location"], _plefwg);  
   $def("_1nzpnqy", "visualizer_cache", ["reload"], _1nzpnqy);  
-  $def("_1l35721", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1l35721);  
+  $def("_1ojown8", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1ojown8);  
   $def("_1gm4gbf", "blobPanel", [], _1gm4gbf);  
   $def("_lxv2e2", "settings", [], _lxv2e2);  
   $def("_lp1ggk", "is_mobile", ["width"], _lp1ggk);  
@@ -15490,7 +15551,7 @@ export default function define(runtime, observer) {
   $def("_1dyz4o0", "scrollLog", ["mutable scrollLog"], _1dyz4o0);  
   $def("_1d1nkw9", "scrollKeyFor", ["appendScrollLog"], _1d1nkw9);  
   $def("_tb217h", "scroll_cache", [], _tb217h);  
-  $def("_5tyvpe", "fix_scroll", ["scrollKeyFor","appendScrollLog","scroll_cache"], _5tyvpe);  
+  $def("_12p8mg7", "fix_scroll", ["scroll_cache","scrollKeyFor","appendScrollLog"], _12p8mg7);  
   $def("_arfw00", "scroll_fix_sync_layout", ["sync_layout_to_url","layout","appendScrollLog","modulePanel"], _arfw00);  
   $def("_3nwpp4", "URLrouting", ["md"], _3nwpp4);  
   $def("_14te9pl", "sync_layout_from_url", ["reload","resize","URLSearchParams","hash","appendScrollLog","parseGoldenDSL","gl","layout","serializeGoldenDSL","treeSyncGolden","invalidation"], _14te9pl);  

--- a/notebooks/@tomlarkworthy_local-change-history.html
+++ b/notebooks/@tomlarkworthy_local-change-history.html
@@ -14037,138 +14037,196 @@ const _1nzpnqy = function _visualizer_cache(reload)
     reload;
     return new Map();
 };
-const _1l35721 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
+const _1ojown8 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
 {
-    return function (container, component) {
-        appendScrollLog('modulePanel:enter', {
-            title: container?.title ?? null,
-            componentCell: component?.cell ?? null
-        });
-        const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
-        if (!moduleInfo) {
-            // Fall through to file attachment: titles like @user/notebook/path.ext
-            // resolve via the lopecode bootloader's contentSync DOM lookup.
-            const title = container?.title ?? null;
-            if (title) {
-                let node = file_attachment_cache.get(title);
-                if (!node) {
-                    const r = window.lopecode?.contentSync?.(title);
-                    if (r && r.status === 200 && r.bytes) {
-                        node = renderFileAttachment(r.mime, r.bytes);
-                        file_attachment_cache.set(title, node);
-                        appendScrollLog('modulePanel:file_attachment_create', {
-                            title,
-                            mime: r.mime
-                        });
-                    }
-                }
-                if (node) {
-                    const c_element = container.getElement();
-                    if (node.parentNode !== c_element)
-                        c_element.appendChild(node);
-                    appendScrollLog('modulePanel:file_attachment_mount', { title });
-                    return;
-                }
-            }
-            appendScrollLog('modulePanel:missing_moduleInfo', { title });
-            return;
-        }
-        const module = moduleInfo.module;
-        let node;
-        if (!visualizer_cache.has(module)) {
-            appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
-            node = visualizer(runtime, {
-                invalidation: new Promise(r => {
-                }),
-                module,
-                detachNodes: isOnObservableCom(),
-                filter: (cell_name, variables) => {
-                    if (variables[0]._type !== 1)
-                        return false;
-                    if (typeof cell_name == 'string') {
-                        if (cell_name.startsWith('dynamic '))
-                            return false;
-                    }
-                    return true;
-                }
+  return function (container, component) {
+    appendScrollLog('modulePanel:enter', {
+      title: container?.title ?? null,
+      componentCell: component?.cell ?? null
+    });
+    const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
+    if (!moduleInfo) {
+      // Fall through to file attachment: titles like @user/notebook/path.ext
+      // resolve via the lopecode bootloader's contentSync DOM lookup.
+      const title = container?.title ?? null;
+      if (title) {
+        let node = file_attachment_cache.get(title);
+        if (!node) {
+          const r = window.lopecode?.contentSync?.(title);
+          if (r && r.status === 200 && r.bytes) {
+            node = renderFileAttachment(r.mime, r.bytes);
+            file_attachment_cache.set(title, node);
+            appendScrollLog('modulePanel:file_attachment_create', {
+              title,
+              mime: r.mime
             });
-            visualizer_cache.set(module, node);
-        } else {
-            node = visualizer_cache.get(module);
-            appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+          }
         }
-        const cell = module._scope.get(component.cell);
-        const scrollKey = scrollKeyFor(container);
-        fix_scroll(container, node, cell, scrollKey);
-        const el = container.getElement();
-        if (!el.__lope_scroll_bound) {
-            el.__lope_scroll_bound = true;
-            appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
-            el.addEventListener('scroll', () => {
-                const k = scrollKeyFor(container);
-                const scrollTop = el.scrollTop;
-                const scrollLeft = el.scrollLeft;
-                if (scrollTop == 0) {
-                    appendScrollLog('modulePanel:skip 0 scroll', {
-                        title: container?.title ?? null,
-                        scrollKey
-                    });
-                    return;
-                }
-                scroll_cache.set(k, {
-                    scrollTop,
-                    scrollLeft,
-                    t: Date.now()
-                });
-                appendScrollLog('scroll:event', {
-                    k,
-                    title: container?.title ?? null,
-                    scrollTop,
-                    scrollLeft
-                });
-            }, { passive: true });
+        if (node) {
+          const c_element = container.getElement();
+          if (node.parentNode !== c_element)
+            c_element.appendChild(node);
+          appendScrollLog('modulePanel:file_attachment_mount', { title });
+          return;
         }
-        // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
-        if (!container.__lope_destroy_bound) {
-            container.__lope_destroy_bound = true;
-            container.on('destroy', () => {
-                try {
-                    const k = scrollKeyFor(container);
-                    const scrollTop = el?.scrollTop;
-                    const scrollLeft = el?.scrollLeft;
-                    if (scrollTop == 0) {
-                        appendScrollLog('scroll:skip 0 scroll', {
-                            k,
-                            key: container?.title ?? null,
-                            scrollKey
-                        });
-                        return;
-                    }
-                    // do not skip 0 here: if the user is at top, preserve that state
-                    scroll_cache.set(k, {
-                        scrollTop,
-                        scrollLeft,
-                        t: Date.now()
-                    });
-                    appendScrollLog('scroll:destroy_capture', {
-                        k,
-                        title: container?.title ?? null,
-                        scrollTop,
-                        scrollLeft
-                    });
-                } catch (e) {
-                    appendScrollLog('scroll:destroy_capture:error', {
-                        title: container?.title ?? null,
-                        error: String(e)
-                    });
-                }
-            });
+      }
+      appendScrollLog('modulePanel:missing_moduleInfo', { title });
+      return;
+    }
+    const module = moduleInfo.module;
+    let node;
+    if (!visualizer_cache.has(module)) {
+      appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
+      node = visualizer(runtime, {
+        invalidation: new Promise(r => {
+        }),
+        module,
+        detachNodes: isOnObservableCom(),
+        filter: (cell_name, variables) => {
+          if (variables[0]._type !== 1)
+            return false;
+          if (typeof cell_name == 'string') {
+            if (cell_name.startsWith('dynamic '))
+              return false;
+          }
+          return true;
         }
-        appendScrollLog('modulePanel:exit', {
+      });
+      visualizer_cache.set(module, node);
+    } else {
+      node = visualizer_cache.get(module);
+      appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+    }
+    const cell = module._scope.get(component.cell);
+    const scrollKey = scrollKeyFor(container);
+    fix_scroll(container, node, cell, scrollKey);
+    const el = container.getElement();
+    if (!el.__lope_scroll_bound) {
+      el.__lope_scroll_bound = true;
+      appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
+      const markUserScroll = () => {
+        el.__lope_user_scroll_at = Date.now();
+      };
+      el.addEventListener('wheel', markUserScroll, { passive: true });
+      el.addEventListener('touchmove', markUserScroll, { passive: true });
+      el.addEventListener('keydown', markUserScroll, { passive: true });
+      el.addEventListener('scroll', () => {
+        if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+          appendScrollLog('scroll:skip_reflow', { title: container?.title ?? null });
+          return;
+        }
+        // Only cache scrolls following a genuine user gesture; reflow-induced
+        // scroll events (e.g. closing an adjacent panel) carry stale scrollTops.
+        if (Date.now() - (el.__lope_user_scroll_at || 0) > 400) {
+          appendScrollLog('scroll:skip_nonuser', { title: container?.title ?? null });
+          return;
+        }
+        const k = scrollKeyFor(container);
+        const scrollTop = el.scrollTop;
+        const scrollLeft = el.scrollLeft;
+        if (scrollTop == 0) {
+          appendScrollLog('modulePanel:skip 0 scroll', {
             title: container?.title ?? null,
             scrollKey
+          });
+          return;
+        }
+        scroll_cache.set(k, {
+          scrollTop,
+          scrollLeft,
+          t: Date.now()
         });
-    };
+        appendScrollLog('scroll:event', {
+          k,
+          title: container?.title ?? null,
+          scrollTop,
+          scrollLeft
+        });
+      }, { passive: true });
+    }
+    // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
+    if (!container.__lope_destroy_bound) {
+      container.__lope_destroy_bound = true;
+      container.on('destroy', () => {
+        try {
+          if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+            appendScrollLog('scroll:destroy_skip_reflow', { title: container?.title ?? null });
+            return;
+          }
+          const k = scrollKeyFor(container);
+          const scrollTop = el?.scrollTop;
+          const scrollLeft = el?.scrollLeft;
+          if (scrollTop == 0) {
+            appendScrollLog('scroll:skip 0 scroll', {
+              k,
+              key: container?.title ?? null,
+              scrollKey
+            });
+            return;
+          }
+          // do not skip 0 here: if the user is at top, preserve that state
+          scroll_cache.set(k, {
+            scrollTop,
+            scrollLeft,
+            t: Date.now()
+          });
+          appendScrollLog('scroll:destroy_capture', {
+            k,
+            title: container?.title ?? null,
+            scrollTop,
+            scrollLeft
+          });
+        } catch (e) {
+          appendScrollLog('scroll:destroy_capture:error', {
+            title: container?.title ?? null,
+            error: String(e)
+          });
+        }
+      });
+    }
+    // When GoldenLayout resizes this panel (e.g. an adjacent panel is closed) the
+    // browser can shift scrollTop; re-apply the user's cached position after the reflow.
+    if (!container.__lope_resize_bound) {
+      container.__lope_resize_bound = true;
+      container.on('resize', () => {
+        const rk = scrollKeyFor(container);
+        const cached = scroll_cache.get(rk);
+        if (!cached || cached.scrollTop == null)
+          return;
+        const c_el = container.getElement();
+        const at = Date.now();
+        scroll_cache.__reflowUntil = at + 800;
+        // The reflow can shift scrollTop in several passes (content relayout
+        // settles ~300ms later), so re-apply over a window. Bail if the user scrolls.
+        const apply = () => {
+          if ((c_el.__lope_user_scroll_at || 0) > at)
+            return;
+          if (c_el.scrollTop !== cached.scrollTop)
+            c_el.scrollTop = cached.scrollTop;
+          if (cached.scrollLeft != null && c_el.scrollLeft !== cached.scrollLeft)
+            c_el.scrollLeft = cached.scrollLeft;
+        };
+        requestAnimationFrame(apply);
+        for (const d of [
+            60,
+            150,
+            300,
+            450,
+            600
+          ])
+          setTimeout(apply, d);
+        appendScrollLog('scroll:resize_restore', {
+          k: rk,
+          title: container?.title ?? null,
+          scrollTop: cached.scrollTop
+        });
+      });
+    }
+    appendScrollLog('modulePanel:exit', {
+      title: container?.title ?? null,
+      scrollKey
+    });
+  };
 };
 const _1gm4gbf = function _blobPanel(){return(
 function (container, component) {
@@ -14286,112 +14344,115 @@ const _1d1nkw9 = function _scrollKeyFor(appendScrollLog)
 const _tb217h = function _scroll_cache(){return(
 new Map()
 )};
-const _5tyvpe = function _fix_scroll(scrollKeyFor,appendScrollLog,scroll_cache){return(
-function (container, node, cell_variable, key) {
+const _12p8mg7 = function _fix_scroll(scroll_cache,scrollKeyFor,appendScrollLog)
+{
+  return function (container, node, cell_variable, key) {
+    scroll_cache.__reflowUntil = Date.now() + 600;
+    // suppress reflow-induced scroll events that clobber the cache
     const c_element = container.getElement();
     let k = scrollKeyFor(container);
     appendScrollLog('fix_scroll:enter', {
-        title: container?.title ?? null,
-        k,
-        cell: cell_variable?._name ?? null
+      title: container?.title ?? null,
+      k,
+      cell: cell_variable?._name ?? null
     });
     if (node && node.parentNode !== c_element) {
-        c_element.appendChild(node);
-        appendScrollLog('fix_scroll:append_node', {
-            title: container?.title ?? null,
-            k
-        });
+      c_element.appendChild(node);
+      appendScrollLog('fix_scroll:append_node', {
+        title: container?.title ?? null,
+        k
+      });
     }
     const writeCache = (scrollTop, scrollLeft, why) => {
-        scroll_cache.set(k, {
-            scrollTop,
-            scrollLeft,
-            t: Date.now()
-        });
-        appendScrollLog('scroll_cache:write', {
-            k,
-            scrollTop,
-            scrollLeft,
-            why
-        });
+      scroll_cache.set(k, {
+        scrollTop,
+        scrollLeft,
+        t: Date.now()
+      });
+      appendScrollLog('scroll_cache:write', {
+        k,
+        scrollTop,
+        scrollLeft,
+        why
+      });
     };
     const scrollToCellIfPossible = why => {
-        if (!cell_variable)
-            return false;
-        const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
-        if (!dom) {
-            appendScrollLog('scroll:cell_dom_not_found', {
-                k,
-                why,
-                cell: cell_variable?._name ?? null
-            });
-            return false;
-        }
-        const top = dom.offsetTop - c_element.offsetTop;
-        const left = c_element.scrollLeft;
-        c_element.scrollTop = top;
-        appendScrollLog('scroll:set', {
-            k,
-            why: `${ why }:cell`,
-            scrollTop: top,
-            scrollLeft: left,
-            cell: cell_variable?._name ?? null
+      if (!cell_variable)
+        return false;
+      const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
+      if (!dom) {
+        appendScrollLog('scroll:cell_dom_not_found', {
+          k,
+          why,
+          cell: cell_variable?._name ?? null
         });
-        writeCache(top, left, `${ why }:cell`);
-        return true;
+        return false;
+      }
+      const top = dom.offsetTop - c_element.offsetTop;
+      const left = c_element.scrollLeft;
+      c_element.scrollTop = top;
+      appendScrollLog('scroll:set', {
+        k,
+        why: `${ why }:cell`,
+        scrollTop: top,
+        scrollLeft: left,
+        cell: cell_variable?._name ?? null
+      });
+      writeCache(top, left, `${ why }:cell`);
+      return true;
     };
     const restoreFromCache = why => {
-        k = scrollKeyFor(container);
-        const cached = scroll_cache.get(k);
-        appendScrollLog('scroll:restore_attempt', {
-            k,
-            why,
-            cachedScrollTop: cached?.scrollTop ?? null,
-            cachedScrollLeft: cached?.scrollLeft ?? null
+      k = scrollKeyFor(container);
+      const cached = scroll_cache.get(k);
+      appendScrollLog('scroll:restore_attempt', {
+        k,
+        why,
+        cachedScrollTop: cached?.scrollTop ?? null,
+        cachedScrollLeft: cached?.scrollLeft ?? null
+      });
+      if (!cached) {
+        appendScrollLog('scroll:restore_no_scroll', {
+          k,
+          why
         });
-        if (!cached) {
-            appendScrollLog('scroll:restore_no_scroll', {
-                k,
-                why
-            });
-            return;
-        }
-        if (cached.scrollTop != null)
-            c_element.scrollTop = cached.scrollTop;
-        if (cached.scrollLeft != null)
-            c_element.scrollLeft = cached.scrollLeft;
-        appendScrollLog('scroll:restore_applied', {
-            k,
-            why,
-            scrollTop: cached.scrollTop ?? null,
-            scrollLeft: cached.scrollLeft ?? null,
-            scrollTopFinal: c_element.scrollTop,
-            scrollLeftFinal: c_element.scrollLeft
-        });
+        return;
+      }
+      if (cached.scrollTop != null)
+        c_element.scrollTop = cached.scrollTop;
+      if (cached.scrollLeft != null)
+        c_element.scrollLeft = cached.scrollLeft;
+      appendScrollLog('scroll:restore_applied', {
+        k,
+        why,
+        scrollTop: cached.scrollTop ?? null,
+        scrollLeft: cached.scrollLeft ?? null,
+        scrollTopFinal: c_element.scrollTop,
+        scrollLeftFinal: c_element.scrollLeft
+      });
     };
     const setScroll = (why = 'setScroll') => {
-        if (scrollToCellIfPossible(why))
-            return;
-        restoreFromCache(why);
+      if (scrollToCellIfPossible(why))
+        return;
+      restoreFromCache(why);
     };
     const retryFrames = 6;
     for (let i = 0; i < retryFrames; i++) {
-        requestAnimationFrame(() => {
-            k = scrollKeyFor(container);
-            appendScrollLog('fix_scroll:raf_retry', {
-                i,
-                k,
-                title: container?.title ?? null
-            });
-            setScroll(`raf:${ i }`);
+      requestAnimationFrame(() => {
+        k = scrollKeyFor(container);
+        appendScrollLog('fix_scroll:raf_retry', {
+          i,
+          k,
+          title: container?.title ?? null
         });
+        setScroll(`raf:${ i }`);
+      });
     }
     appendScrollLog('fix_scroll:exit', {
-        k,
-        title: container?.title ?? null
+      k,
+      title: container?.title ?? null
     });
-}
-)};
+  };
+};
 const _arfw00 = function _scroll_fix_sync_layout(sync_layout_to_url,layout,appendScrollLog,modulePanel)
 {
     sync_layout_to_url;
@@ -15469,7 +15530,7 @@ export default function define(runtime, observer) {
   $def("_1we0ggl", "reload", ["Generators","viewof reload"], _1we0ggl);  
   $def("_plefwg", "onLoadConfig", ["parseGoldenDSL","URLSearchParams","location"], _plefwg);  
   $def("_1nzpnqy", "visualizer_cache", ["reload"], _1nzpnqy);  
-  $def("_1l35721", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1l35721);  
+  $def("_1ojown8", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1ojown8);  
   $def("_1gm4gbf", "blobPanel", [], _1gm4gbf);  
   $def("_lxv2e2", "settings", [], _lxv2e2);  
   $def("_lp1ggk", "is_mobile", ["width"], _lp1ggk);  
@@ -15490,7 +15551,7 @@ export default function define(runtime, observer) {
   $def("_1dyz4o0", "scrollLog", ["mutable scrollLog"], _1dyz4o0);  
   $def("_1d1nkw9", "scrollKeyFor", ["appendScrollLog"], _1d1nkw9);  
   $def("_tb217h", "scroll_cache", [], _tb217h);  
-  $def("_5tyvpe", "fix_scroll", ["scrollKeyFor","appendScrollLog","scroll_cache"], _5tyvpe);  
+  $def("_12p8mg7", "fix_scroll", ["scroll_cache","scrollKeyFor","appendScrollLog"], _12p8mg7);  
   $def("_arfw00", "scroll_fix_sync_layout", ["sync_layout_to_url","layout","appendScrollLog","modulePanel"], _arfw00);  
   $def("_3nwpp4", "URLrouting", ["md"], _3nwpp4);  
   $def("_14te9pl", "sync_layout_from_url", ["reload","resize","URLSearchParams","hash","appendScrollLog","parseGoldenDSL","gl","layout","serializeGoldenDSL","treeSyncGolden","invalidation"], _14te9pl);  

--- a/notebooks/@tomlarkworthy_local-storage-view.html
+++ b/notebooks/@tomlarkworthy_local-storage-view.html
@@ -14037,138 +14037,196 @@ const _1nzpnqy = function _visualizer_cache(reload)
     reload;
     return new Map();
 };
-const _1l35721 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
+const _1ojown8 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
 {
-    return function (container, component) {
-        appendScrollLog('modulePanel:enter', {
-            title: container?.title ?? null,
-            componentCell: component?.cell ?? null
-        });
-        const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
-        if (!moduleInfo) {
-            // Fall through to file attachment: titles like @user/notebook/path.ext
-            // resolve via the lopecode bootloader's contentSync DOM lookup.
-            const title = container?.title ?? null;
-            if (title) {
-                let node = file_attachment_cache.get(title);
-                if (!node) {
-                    const r = window.lopecode?.contentSync?.(title);
-                    if (r && r.status === 200 && r.bytes) {
-                        node = renderFileAttachment(r.mime, r.bytes);
-                        file_attachment_cache.set(title, node);
-                        appendScrollLog('modulePanel:file_attachment_create', {
-                            title,
-                            mime: r.mime
-                        });
-                    }
-                }
-                if (node) {
-                    const c_element = container.getElement();
-                    if (node.parentNode !== c_element)
-                        c_element.appendChild(node);
-                    appendScrollLog('modulePanel:file_attachment_mount', { title });
-                    return;
-                }
-            }
-            appendScrollLog('modulePanel:missing_moduleInfo', { title });
-            return;
-        }
-        const module = moduleInfo.module;
-        let node;
-        if (!visualizer_cache.has(module)) {
-            appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
-            node = visualizer(runtime, {
-                invalidation: new Promise(r => {
-                }),
-                module,
-                detachNodes: isOnObservableCom(),
-                filter: (cell_name, variables) => {
-                    if (variables[0]._type !== 1)
-                        return false;
-                    if (typeof cell_name == 'string') {
-                        if (cell_name.startsWith('dynamic '))
-                            return false;
-                    }
-                    return true;
-                }
+  return function (container, component) {
+    appendScrollLog('modulePanel:enter', {
+      title: container?.title ?? null,
+      componentCell: component?.cell ?? null
+    });
+    const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
+    if (!moduleInfo) {
+      // Fall through to file attachment: titles like @user/notebook/path.ext
+      // resolve via the lopecode bootloader's contentSync DOM lookup.
+      const title = container?.title ?? null;
+      if (title) {
+        let node = file_attachment_cache.get(title);
+        if (!node) {
+          const r = window.lopecode?.contentSync?.(title);
+          if (r && r.status === 200 && r.bytes) {
+            node = renderFileAttachment(r.mime, r.bytes);
+            file_attachment_cache.set(title, node);
+            appendScrollLog('modulePanel:file_attachment_create', {
+              title,
+              mime: r.mime
             });
-            visualizer_cache.set(module, node);
-        } else {
-            node = visualizer_cache.get(module);
-            appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+          }
         }
-        const cell = module._scope.get(component.cell);
-        const scrollKey = scrollKeyFor(container);
-        fix_scroll(container, node, cell, scrollKey);
-        const el = container.getElement();
-        if (!el.__lope_scroll_bound) {
-            el.__lope_scroll_bound = true;
-            appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
-            el.addEventListener('scroll', () => {
-                const k = scrollKeyFor(container);
-                const scrollTop = el.scrollTop;
-                const scrollLeft = el.scrollLeft;
-                if (scrollTop == 0) {
-                    appendScrollLog('modulePanel:skip 0 scroll', {
-                        title: container?.title ?? null,
-                        scrollKey
-                    });
-                    return;
-                }
-                scroll_cache.set(k, {
-                    scrollTop,
-                    scrollLeft,
-                    t: Date.now()
-                });
-                appendScrollLog('scroll:event', {
-                    k,
-                    title: container?.title ?? null,
-                    scrollTop,
-                    scrollLeft
-                });
-            }, { passive: true });
+        if (node) {
+          const c_element = container.getElement();
+          if (node.parentNode !== c_element)
+            c_element.appendChild(node);
+          appendScrollLog('modulePanel:file_attachment_mount', { title });
+          return;
         }
-        // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
-        if (!container.__lope_destroy_bound) {
-            container.__lope_destroy_bound = true;
-            container.on('destroy', () => {
-                try {
-                    const k = scrollKeyFor(container);
-                    const scrollTop = el?.scrollTop;
-                    const scrollLeft = el?.scrollLeft;
-                    if (scrollTop == 0) {
-                        appendScrollLog('scroll:skip 0 scroll', {
-                            k,
-                            key: container?.title ?? null,
-                            scrollKey
-                        });
-                        return;
-                    }
-                    // do not skip 0 here: if the user is at top, preserve that state
-                    scroll_cache.set(k, {
-                        scrollTop,
-                        scrollLeft,
-                        t: Date.now()
-                    });
-                    appendScrollLog('scroll:destroy_capture', {
-                        k,
-                        title: container?.title ?? null,
-                        scrollTop,
-                        scrollLeft
-                    });
-                } catch (e) {
-                    appendScrollLog('scroll:destroy_capture:error', {
-                        title: container?.title ?? null,
-                        error: String(e)
-                    });
-                }
-            });
+      }
+      appendScrollLog('modulePanel:missing_moduleInfo', { title });
+      return;
+    }
+    const module = moduleInfo.module;
+    let node;
+    if (!visualizer_cache.has(module)) {
+      appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
+      node = visualizer(runtime, {
+        invalidation: new Promise(r => {
+        }),
+        module,
+        detachNodes: isOnObservableCom(),
+        filter: (cell_name, variables) => {
+          if (variables[0]._type !== 1)
+            return false;
+          if (typeof cell_name == 'string') {
+            if (cell_name.startsWith('dynamic '))
+              return false;
+          }
+          return true;
         }
-        appendScrollLog('modulePanel:exit', {
+      });
+      visualizer_cache.set(module, node);
+    } else {
+      node = visualizer_cache.get(module);
+      appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+    }
+    const cell = module._scope.get(component.cell);
+    const scrollKey = scrollKeyFor(container);
+    fix_scroll(container, node, cell, scrollKey);
+    const el = container.getElement();
+    if (!el.__lope_scroll_bound) {
+      el.__lope_scroll_bound = true;
+      appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
+      const markUserScroll = () => {
+        el.__lope_user_scroll_at = Date.now();
+      };
+      el.addEventListener('wheel', markUserScroll, { passive: true });
+      el.addEventListener('touchmove', markUserScroll, { passive: true });
+      el.addEventListener('keydown', markUserScroll, { passive: true });
+      el.addEventListener('scroll', () => {
+        if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+          appendScrollLog('scroll:skip_reflow', { title: container?.title ?? null });
+          return;
+        }
+        // Only cache scrolls following a genuine user gesture; reflow-induced
+        // scroll events (e.g. closing an adjacent panel) carry stale scrollTops.
+        if (Date.now() - (el.__lope_user_scroll_at || 0) > 400) {
+          appendScrollLog('scroll:skip_nonuser', { title: container?.title ?? null });
+          return;
+        }
+        const k = scrollKeyFor(container);
+        const scrollTop = el.scrollTop;
+        const scrollLeft = el.scrollLeft;
+        if (scrollTop == 0) {
+          appendScrollLog('modulePanel:skip 0 scroll', {
             title: container?.title ?? null,
             scrollKey
+          });
+          return;
+        }
+        scroll_cache.set(k, {
+          scrollTop,
+          scrollLeft,
+          t: Date.now()
         });
-    };
+        appendScrollLog('scroll:event', {
+          k,
+          title: container?.title ?? null,
+          scrollTop,
+          scrollLeft
+        });
+      }, { passive: true });
+    }
+    // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
+    if (!container.__lope_destroy_bound) {
+      container.__lope_destroy_bound = true;
+      container.on('destroy', () => {
+        try {
+          if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+            appendScrollLog('scroll:destroy_skip_reflow', { title: container?.title ?? null });
+            return;
+          }
+          const k = scrollKeyFor(container);
+          const scrollTop = el?.scrollTop;
+          const scrollLeft = el?.scrollLeft;
+          if (scrollTop == 0) {
+            appendScrollLog('scroll:skip 0 scroll', {
+              k,
+              key: container?.title ?? null,
+              scrollKey
+            });
+            return;
+          }
+          // do not skip 0 here: if the user is at top, preserve that state
+          scroll_cache.set(k, {
+            scrollTop,
+            scrollLeft,
+            t: Date.now()
+          });
+          appendScrollLog('scroll:destroy_capture', {
+            k,
+            title: container?.title ?? null,
+            scrollTop,
+            scrollLeft
+          });
+        } catch (e) {
+          appendScrollLog('scroll:destroy_capture:error', {
+            title: container?.title ?? null,
+            error: String(e)
+          });
+        }
+      });
+    }
+    // When GoldenLayout resizes this panel (e.g. an adjacent panel is closed) the
+    // browser can shift scrollTop; re-apply the user's cached position after the reflow.
+    if (!container.__lope_resize_bound) {
+      container.__lope_resize_bound = true;
+      container.on('resize', () => {
+        const rk = scrollKeyFor(container);
+        const cached = scroll_cache.get(rk);
+        if (!cached || cached.scrollTop == null)
+          return;
+        const c_el = container.getElement();
+        const at = Date.now();
+        scroll_cache.__reflowUntil = at + 800;
+        // The reflow can shift scrollTop in several passes (content relayout
+        // settles ~300ms later), so re-apply over a window. Bail if the user scrolls.
+        const apply = () => {
+          if ((c_el.__lope_user_scroll_at || 0) > at)
+            return;
+          if (c_el.scrollTop !== cached.scrollTop)
+            c_el.scrollTop = cached.scrollTop;
+          if (cached.scrollLeft != null && c_el.scrollLeft !== cached.scrollLeft)
+            c_el.scrollLeft = cached.scrollLeft;
+        };
+        requestAnimationFrame(apply);
+        for (const d of [
+            60,
+            150,
+            300,
+            450,
+            600
+          ])
+          setTimeout(apply, d);
+        appendScrollLog('scroll:resize_restore', {
+          k: rk,
+          title: container?.title ?? null,
+          scrollTop: cached.scrollTop
+        });
+      });
+    }
+    appendScrollLog('modulePanel:exit', {
+      title: container?.title ?? null,
+      scrollKey
+    });
+  };
 };
 const _1gm4gbf = function _blobPanel(){return(
 function (container, component) {
@@ -14286,112 +14344,115 @@ const _1d1nkw9 = function _scrollKeyFor(appendScrollLog)
 const _tb217h = function _scroll_cache(){return(
 new Map()
 )};
-const _5tyvpe = function _fix_scroll(scrollKeyFor,appendScrollLog,scroll_cache){return(
-function (container, node, cell_variable, key) {
+const _12p8mg7 = function _fix_scroll(scroll_cache,scrollKeyFor,appendScrollLog)
+{
+  return function (container, node, cell_variable, key) {
+    scroll_cache.__reflowUntil = Date.now() + 600;
+    // suppress reflow-induced scroll events that clobber the cache
     const c_element = container.getElement();
     let k = scrollKeyFor(container);
     appendScrollLog('fix_scroll:enter', {
-        title: container?.title ?? null,
-        k,
-        cell: cell_variable?._name ?? null
+      title: container?.title ?? null,
+      k,
+      cell: cell_variable?._name ?? null
     });
     if (node && node.parentNode !== c_element) {
-        c_element.appendChild(node);
-        appendScrollLog('fix_scroll:append_node', {
-            title: container?.title ?? null,
-            k
-        });
+      c_element.appendChild(node);
+      appendScrollLog('fix_scroll:append_node', {
+        title: container?.title ?? null,
+        k
+      });
     }
     const writeCache = (scrollTop, scrollLeft, why) => {
-        scroll_cache.set(k, {
-            scrollTop,
-            scrollLeft,
-            t: Date.now()
-        });
-        appendScrollLog('scroll_cache:write', {
-            k,
-            scrollTop,
-            scrollLeft,
-            why
-        });
+      scroll_cache.set(k, {
+        scrollTop,
+        scrollLeft,
+        t: Date.now()
+      });
+      appendScrollLog('scroll_cache:write', {
+        k,
+        scrollTop,
+        scrollLeft,
+        why
+      });
     };
     const scrollToCellIfPossible = why => {
-        if (!cell_variable)
-            return false;
-        const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
-        if (!dom) {
-            appendScrollLog('scroll:cell_dom_not_found', {
-                k,
-                why,
-                cell: cell_variable?._name ?? null
-            });
-            return false;
-        }
-        const top = dom.offsetTop - c_element.offsetTop;
-        const left = c_element.scrollLeft;
-        c_element.scrollTop = top;
-        appendScrollLog('scroll:set', {
-            k,
-            why: `${ why }:cell`,
-            scrollTop: top,
-            scrollLeft: left,
-            cell: cell_variable?._name ?? null
+      if (!cell_variable)
+        return false;
+      const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
+      if (!dom) {
+        appendScrollLog('scroll:cell_dom_not_found', {
+          k,
+          why,
+          cell: cell_variable?._name ?? null
         });
-        writeCache(top, left, `${ why }:cell`);
-        return true;
+        return false;
+      }
+      const top = dom.offsetTop - c_element.offsetTop;
+      const left = c_element.scrollLeft;
+      c_element.scrollTop = top;
+      appendScrollLog('scroll:set', {
+        k,
+        why: `${ why }:cell`,
+        scrollTop: top,
+        scrollLeft: left,
+        cell: cell_variable?._name ?? null
+      });
+      writeCache(top, left, `${ why }:cell`);
+      return true;
     };
     const restoreFromCache = why => {
-        k = scrollKeyFor(container);
-        const cached = scroll_cache.get(k);
-        appendScrollLog('scroll:restore_attempt', {
-            k,
-            why,
-            cachedScrollTop: cached?.scrollTop ?? null,
-            cachedScrollLeft: cached?.scrollLeft ?? null
+      k = scrollKeyFor(container);
+      const cached = scroll_cache.get(k);
+      appendScrollLog('scroll:restore_attempt', {
+        k,
+        why,
+        cachedScrollTop: cached?.scrollTop ?? null,
+        cachedScrollLeft: cached?.scrollLeft ?? null
+      });
+      if (!cached) {
+        appendScrollLog('scroll:restore_no_scroll', {
+          k,
+          why
         });
-        if (!cached) {
-            appendScrollLog('scroll:restore_no_scroll', {
-                k,
-                why
-            });
-            return;
-        }
-        if (cached.scrollTop != null)
-            c_element.scrollTop = cached.scrollTop;
-        if (cached.scrollLeft != null)
-            c_element.scrollLeft = cached.scrollLeft;
-        appendScrollLog('scroll:restore_applied', {
-            k,
-            why,
-            scrollTop: cached.scrollTop ?? null,
-            scrollLeft: cached.scrollLeft ?? null,
-            scrollTopFinal: c_element.scrollTop,
-            scrollLeftFinal: c_element.scrollLeft
-        });
+        return;
+      }
+      if (cached.scrollTop != null)
+        c_element.scrollTop = cached.scrollTop;
+      if (cached.scrollLeft != null)
+        c_element.scrollLeft = cached.scrollLeft;
+      appendScrollLog('scroll:restore_applied', {
+        k,
+        why,
+        scrollTop: cached.scrollTop ?? null,
+        scrollLeft: cached.scrollLeft ?? null,
+        scrollTopFinal: c_element.scrollTop,
+        scrollLeftFinal: c_element.scrollLeft
+      });
     };
     const setScroll = (why = 'setScroll') => {
-        if (scrollToCellIfPossible(why))
-            return;
-        restoreFromCache(why);
+      if (scrollToCellIfPossible(why))
+        return;
+      restoreFromCache(why);
     };
     const retryFrames = 6;
     for (let i = 0; i < retryFrames; i++) {
-        requestAnimationFrame(() => {
-            k = scrollKeyFor(container);
-            appendScrollLog('fix_scroll:raf_retry', {
-                i,
-                k,
-                title: container?.title ?? null
-            });
-            setScroll(`raf:${ i }`);
+      requestAnimationFrame(() => {
+        k = scrollKeyFor(container);
+        appendScrollLog('fix_scroll:raf_retry', {
+          i,
+          k,
+          title: container?.title ?? null
         });
+        setScroll(`raf:${ i }`);
+      });
     }
     appendScrollLog('fix_scroll:exit', {
-        k,
-        title: container?.title ?? null
+      k,
+      title: container?.title ?? null
     });
-}
-)};
+  };
+};
 const _arfw00 = function _scroll_fix_sync_layout(sync_layout_to_url,layout,appendScrollLog,modulePanel)
 {
     sync_layout_to_url;
@@ -15469,7 +15530,7 @@ export default function define(runtime, observer) {
   $def("_1we0ggl", "reload", ["Generators","viewof reload"], _1we0ggl);  
   $def("_plefwg", "onLoadConfig", ["parseGoldenDSL","URLSearchParams","location"], _plefwg);  
   $def("_1nzpnqy", "visualizer_cache", ["reload"], _1nzpnqy);  
-  $def("_1l35721", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1l35721);  
+  $def("_1ojown8", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1ojown8);  
   $def("_1gm4gbf", "blobPanel", [], _1gm4gbf);  
   $def("_lxv2e2", "settings", [], _lxv2e2);  
   $def("_lp1ggk", "is_mobile", ["width"], _lp1ggk);  
@@ -15490,7 +15551,7 @@ export default function define(runtime, observer) {
   $def("_1dyz4o0", "scrollLog", ["mutable scrollLog"], _1dyz4o0);  
   $def("_1d1nkw9", "scrollKeyFor", ["appendScrollLog"], _1d1nkw9);  
   $def("_tb217h", "scroll_cache", [], _tb217h);  
-  $def("_5tyvpe", "fix_scroll", ["scrollKeyFor","appendScrollLog","scroll_cache"], _5tyvpe);  
+  $def("_12p8mg7", "fix_scroll", ["scroll_cache","scrollKeyFor","appendScrollLog"], _12p8mg7);  
   $def("_arfw00", "scroll_fix_sync_layout", ["sync_layout_to_url","layout","appendScrollLog","modulePanel"], _arfw00);  
   $def("_3nwpp4", "URLrouting", ["md"], _3nwpp4);  
   $def("_14te9pl", "sync_layout_from_url", ["reload","resize","URLSearchParams","hash","appendScrollLog","parseGoldenDSL","gl","layout","serializeGoldenDSL","treeSyncGolden","invalidation"], _14te9pl);  

--- a/notebooks/@tomlarkworthy_lopecode-tour.html
+++ b/notebooks/@tomlarkworthy_lopecode-tour.html
@@ -15951,138 +15951,196 @@ const _1nzpnqy = function _visualizer_cache(reload)
     reload;
     return new Map();
 };
-const _1l35721 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
+const _1ojown8 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
 {
-    return function (container, component) {
-        appendScrollLog('modulePanel:enter', {
-            title: container?.title ?? null,
-            componentCell: component?.cell ?? null
-        });
-        const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
-        if (!moduleInfo) {
-            // Fall through to file attachment: titles like @user/notebook/path.ext
-            // resolve via the lopecode bootloader's contentSync DOM lookup.
-            const title = container?.title ?? null;
-            if (title) {
-                let node = file_attachment_cache.get(title);
-                if (!node) {
-                    const r = window.lopecode?.contentSync?.(title);
-                    if (r && r.status === 200 && r.bytes) {
-                        node = renderFileAttachment(r.mime, r.bytes);
-                        file_attachment_cache.set(title, node);
-                        appendScrollLog('modulePanel:file_attachment_create', {
-                            title,
-                            mime: r.mime
-                        });
-                    }
-                }
-                if (node) {
-                    const c_element = container.getElement();
-                    if (node.parentNode !== c_element)
-                        c_element.appendChild(node);
-                    appendScrollLog('modulePanel:file_attachment_mount', { title });
-                    return;
-                }
-            }
-            appendScrollLog('modulePanel:missing_moduleInfo', { title });
-            return;
-        }
-        const module = moduleInfo.module;
-        let node;
-        if (!visualizer_cache.has(module)) {
-            appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
-            node = visualizer(runtime, {
-                invalidation: new Promise(r => {
-                }),
-                module,
-                detachNodes: isOnObservableCom(),
-                filter: (cell_name, variables) => {
-                    if (variables[0]._type !== 1)
-                        return false;
-                    if (typeof cell_name == 'string') {
-                        if (cell_name.startsWith('dynamic '))
-                            return false;
-                    }
-                    return true;
-                }
+  return function (container, component) {
+    appendScrollLog('modulePanel:enter', {
+      title: container?.title ?? null,
+      componentCell: component?.cell ?? null
+    });
+    const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
+    if (!moduleInfo) {
+      // Fall through to file attachment: titles like @user/notebook/path.ext
+      // resolve via the lopecode bootloader's contentSync DOM lookup.
+      const title = container?.title ?? null;
+      if (title) {
+        let node = file_attachment_cache.get(title);
+        if (!node) {
+          const r = window.lopecode?.contentSync?.(title);
+          if (r && r.status === 200 && r.bytes) {
+            node = renderFileAttachment(r.mime, r.bytes);
+            file_attachment_cache.set(title, node);
+            appendScrollLog('modulePanel:file_attachment_create', {
+              title,
+              mime: r.mime
             });
-            visualizer_cache.set(module, node);
-        } else {
-            node = visualizer_cache.get(module);
-            appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+          }
         }
-        const cell = module._scope.get(component.cell);
-        const scrollKey = scrollKeyFor(container);
-        fix_scroll(container, node, cell, scrollKey);
-        const el = container.getElement();
-        if (!el.__lope_scroll_bound) {
-            el.__lope_scroll_bound = true;
-            appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
-            el.addEventListener('scroll', () => {
-                const k = scrollKeyFor(container);
-                const scrollTop = el.scrollTop;
-                const scrollLeft = el.scrollLeft;
-                if (scrollTop == 0) {
-                    appendScrollLog('modulePanel:skip 0 scroll', {
-                        title: container?.title ?? null,
-                        scrollKey
-                    });
-                    return;
-                }
-                scroll_cache.set(k, {
-                    scrollTop,
-                    scrollLeft,
-                    t: Date.now()
-                });
-                appendScrollLog('scroll:event', {
-                    k,
-                    title: container?.title ?? null,
-                    scrollTop,
-                    scrollLeft
-                });
-            }, { passive: true });
+        if (node) {
+          const c_element = container.getElement();
+          if (node.parentNode !== c_element)
+            c_element.appendChild(node);
+          appendScrollLog('modulePanel:file_attachment_mount', { title });
+          return;
         }
-        // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
-        if (!container.__lope_destroy_bound) {
-            container.__lope_destroy_bound = true;
-            container.on('destroy', () => {
-                try {
-                    const k = scrollKeyFor(container);
-                    const scrollTop = el?.scrollTop;
-                    const scrollLeft = el?.scrollLeft;
-                    if (scrollTop == 0) {
-                        appendScrollLog('scroll:skip 0 scroll', {
-                            k,
-                            key: container?.title ?? null,
-                            scrollKey
-                        });
-                        return;
-                    }
-                    // do not skip 0 here: if the user is at top, preserve that state
-                    scroll_cache.set(k, {
-                        scrollTop,
-                        scrollLeft,
-                        t: Date.now()
-                    });
-                    appendScrollLog('scroll:destroy_capture', {
-                        k,
-                        title: container?.title ?? null,
-                        scrollTop,
-                        scrollLeft
-                    });
-                } catch (e) {
-                    appendScrollLog('scroll:destroy_capture:error', {
-                        title: container?.title ?? null,
-                        error: String(e)
-                    });
-                }
-            });
+      }
+      appendScrollLog('modulePanel:missing_moduleInfo', { title });
+      return;
+    }
+    const module = moduleInfo.module;
+    let node;
+    if (!visualizer_cache.has(module)) {
+      appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
+      node = visualizer(runtime, {
+        invalidation: new Promise(r => {
+        }),
+        module,
+        detachNodes: isOnObservableCom(),
+        filter: (cell_name, variables) => {
+          if (variables[0]._type !== 1)
+            return false;
+          if (typeof cell_name == 'string') {
+            if (cell_name.startsWith('dynamic '))
+              return false;
+          }
+          return true;
         }
-        appendScrollLog('modulePanel:exit', {
+      });
+      visualizer_cache.set(module, node);
+    } else {
+      node = visualizer_cache.get(module);
+      appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+    }
+    const cell = module._scope.get(component.cell);
+    const scrollKey = scrollKeyFor(container);
+    fix_scroll(container, node, cell, scrollKey);
+    const el = container.getElement();
+    if (!el.__lope_scroll_bound) {
+      el.__lope_scroll_bound = true;
+      appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
+      const markUserScroll = () => {
+        el.__lope_user_scroll_at = Date.now();
+      };
+      el.addEventListener('wheel', markUserScroll, { passive: true });
+      el.addEventListener('touchmove', markUserScroll, { passive: true });
+      el.addEventListener('keydown', markUserScroll, { passive: true });
+      el.addEventListener('scroll', () => {
+        if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+          appendScrollLog('scroll:skip_reflow', { title: container?.title ?? null });
+          return;
+        }
+        // Only cache scrolls following a genuine user gesture; reflow-induced
+        // scroll events (e.g. closing an adjacent panel) carry stale scrollTops.
+        if (Date.now() - (el.__lope_user_scroll_at || 0) > 400) {
+          appendScrollLog('scroll:skip_nonuser', { title: container?.title ?? null });
+          return;
+        }
+        const k = scrollKeyFor(container);
+        const scrollTop = el.scrollTop;
+        const scrollLeft = el.scrollLeft;
+        if (scrollTop == 0) {
+          appendScrollLog('modulePanel:skip 0 scroll', {
             title: container?.title ?? null,
             scrollKey
+          });
+          return;
+        }
+        scroll_cache.set(k, {
+          scrollTop,
+          scrollLeft,
+          t: Date.now()
         });
-    };
+        appendScrollLog('scroll:event', {
+          k,
+          title: container?.title ?? null,
+          scrollTop,
+          scrollLeft
+        });
+      }, { passive: true });
+    }
+    // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
+    if (!container.__lope_destroy_bound) {
+      container.__lope_destroy_bound = true;
+      container.on('destroy', () => {
+        try {
+          if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+            appendScrollLog('scroll:destroy_skip_reflow', { title: container?.title ?? null });
+            return;
+          }
+          const k = scrollKeyFor(container);
+          const scrollTop = el?.scrollTop;
+          const scrollLeft = el?.scrollLeft;
+          if (scrollTop == 0) {
+            appendScrollLog('scroll:skip 0 scroll', {
+              k,
+              key: container?.title ?? null,
+              scrollKey
+            });
+            return;
+          }
+          // do not skip 0 here: if the user is at top, preserve that state
+          scroll_cache.set(k, {
+            scrollTop,
+            scrollLeft,
+            t: Date.now()
+          });
+          appendScrollLog('scroll:destroy_capture', {
+            k,
+            title: container?.title ?? null,
+            scrollTop,
+            scrollLeft
+          });
+        } catch (e) {
+          appendScrollLog('scroll:destroy_capture:error', {
+            title: container?.title ?? null,
+            error: String(e)
+          });
+        }
+      });
+    }
+    // When GoldenLayout resizes this panel (e.g. an adjacent panel is closed) the
+    // browser can shift scrollTop; re-apply the user's cached position after the reflow.
+    if (!container.__lope_resize_bound) {
+      container.__lope_resize_bound = true;
+      container.on('resize', () => {
+        const rk = scrollKeyFor(container);
+        const cached = scroll_cache.get(rk);
+        if (!cached || cached.scrollTop == null)
+          return;
+        const c_el = container.getElement();
+        const at = Date.now();
+        scroll_cache.__reflowUntil = at + 800;
+        // The reflow can shift scrollTop in several passes (content relayout
+        // settles ~300ms later), so re-apply over a window. Bail if the user scrolls.
+        const apply = () => {
+          if ((c_el.__lope_user_scroll_at || 0) > at)
+            return;
+          if (c_el.scrollTop !== cached.scrollTop)
+            c_el.scrollTop = cached.scrollTop;
+          if (cached.scrollLeft != null && c_el.scrollLeft !== cached.scrollLeft)
+            c_el.scrollLeft = cached.scrollLeft;
+        };
+        requestAnimationFrame(apply);
+        for (const d of [
+            60,
+            150,
+            300,
+            450,
+            600
+          ])
+          setTimeout(apply, d);
+        appendScrollLog('scroll:resize_restore', {
+          k: rk,
+          title: container?.title ?? null,
+          scrollTop: cached.scrollTop
+        });
+      });
+    }
+    appendScrollLog('modulePanel:exit', {
+      title: container?.title ?? null,
+      scrollKey
+    });
+  };
 };
 const _1gm4gbf = function _blobPanel(){return(
 function (container, component) {
@@ -16200,112 +16258,115 @@ const _1d1nkw9 = function _scrollKeyFor(appendScrollLog)
 const _tb217h = function _scroll_cache(){return(
 new Map()
 )};
-const _5tyvpe = function _fix_scroll(scrollKeyFor,appendScrollLog,scroll_cache){return(
-function (container, node, cell_variable, key) {
+const _12p8mg7 = function _fix_scroll(scroll_cache,scrollKeyFor,appendScrollLog)
+{
+  return function (container, node, cell_variable, key) {
+    scroll_cache.__reflowUntil = Date.now() + 600;
+    // suppress reflow-induced scroll events that clobber the cache
     const c_element = container.getElement();
     let k = scrollKeyFor(container);
     appendScrollLog('fix_scroll:enter', {
-        title: container?.title ?? null,
-        k,
-        cell: cell_variable?._name ?? null
+      title: container?.title ?? null,
+      k,
+      cell: cell_variable?._name ?? null
     });
     if (node && node.parentNode !== c_element) {
-        c_element.appendChild(node);
-        appendScrollLog('fix_scroll:append_node', {
-            title: container?.title ?? null,
-            k
-        });
+      c_element.appendChild(node);
+      appendScrollLog('fix_scroll:append_node', {
+        title: container?.title ?? null,
+        k
+      });
     }
     const writeCache = (scrollTop, scrollLeft, why) => {
-        scroll_cache.set(k, {
-            scrollTop,
-            scrollLeft,
-            t: Date.now()
-        });
-        appendScrollLog('scroll_cache:write', {
-            k,
-            scrollTop,
-            scrollLeft,
-            why
-        });
+      scroll_cache.set(k, {
+        scrollTop,
+        scrollLeft,
+        t: Date.now()
+      });
+      appendScrollLog('scroll_cache:write', {
+        k,
+        scrollTop,
+        scrollLeft,
+        why
+      });
     };
     const scrollToCellIfPossible = why => {
-        if (!cell_variable)
-            return false;
-        const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
-        if (!dom) {
-            appendScrollLog('scroll:cell_dom_not_found', {
-                k,
-                why,
-                cell: cell_variable?._name ?? null
-            });
-            return false;
-        }
-        const top = dom.offsetTop - c_element.offsetTop;
-        const left = c_element.scrollLeft;
-        c_element.scrollTop = top;
-        appendScrollLog('scroll:set', {
-            k,
-            why: `${ why }:cell`,
-            scrollTop: top,
-            scrollLeft: left,
-            cell: cell_variable?._name ?? null
+      if (!cell_variable)
+        return false;
+      const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
+      if (!dom) {
+        appendScrollLog('scroll:cell_dom_not_found', {
+          k,
+          why,
+          cell: cell_variable?._name ?? null
         });
-        writeCache(top, left, `${ why }:cell`);
-        return true;
+        return false;
+      }
+      const top = dom.offsetTop - c_element.offsetTop;
+      const left = c_element.scrollLeft;
+      c_element.scrollTop = top;
+      appendScrollLog('scroll:set', {
+        k,
+        why: `${ why }:cell`,
+        scrollTop: top,
+        scrollLeft: left,
+        cell: cell_variable?._name ?? null
+      });
+      writeCache(top, left, `${ why }:cell`);
+      return true;
     };
     const restoreFromCache = why => {
-        k = scrollKeyFor(container);
-        const cached = scroll_cache.get(k);
-        appendScrollLog('scroll:restore_attempt', {
-            k,
-            why,
-            cachedScrollTop: cached?.scrollTop ?? null,
-            cachedScrollLeft: cached?.scrollLeft ?? null
+      k = scrollKeyFor(container);
+      const cached = scroll_cache.get(k);
+      appendScrollLog('scroll:restore_attempt', {
+        k,
+        why,
+        cachedScrollTop: cached?.scrollTop ?? null,
+        cachedScrollLeft: cached?.scrollLeft ?? null
+      });
+      if (!cached) {
+        appendScrollLog('scroll:restore_no_scroll', {
+          k,
+          why
         });
-        if (!cached) {
-            appendScrollLog('scroll:restore_no_scroll', {
-                k,
-                why
-            });
-            return;
-        }
-        if (cached.scrollTop != null)
-            c_element.scrollTop = cached.scrollTop;
-        if (cached.scrollLeft != null)
-            c_element.scrollLeft = cached.scrollLeft;
-        appendScrollLog('scroll:restore_applied', {
-            k,
-            why,
-            scrollTop: cached.scrollTop ?? null,
-            scrollLeft: cached.scrollLeft ?? null,
-            scrollTopFinal: c_element.scrollTop,
-            scrollLeftFinal: c_element.scrollLeft
-        });
+        return;
+      }
+      if (cached.scrollTop != null)
+        c_element.scrollTop = cached.scrollTop;
+      if (cached.scrollLeft != null)
+        c_element.scrollLeft = cached.scrollLeft;
+      appendScrollLog('scroll:restore_applied', {
+        k,
+        why,
+        scrollTop: cached.scrollTop ?? null,
+        scrollLeft: cached.scrollLeft ?? null,
+        scrollTopFinal: c_element.scrollTop,
+        scrollLeftFinal: c_element.scrollLeft
+      });
     };
     const setScroll = (why = 'setScroll') => {
-        if (scrollToCellIfPossible(why))
-            return;
-        restoreFromCache(why);
+      if (scrollToCellIfPossible(why))
+        return;
+      restoreFromCache(why);
     };
     const retryFrames = 6;
     for (let i = 0; i < retryFrames; i++) {
-        requestAnimationFrame(() => {
-            k = scrollKeyFor(container);
-            appendScrollLog('fix_scroll:raf_retry', {
-                i,
-                k,
-                title: container?.title ?? null
-            });
-            setScroll(`raf:${ i }`);
+      requestAnimationFrame(() => {
+        k = scrollKeyFor(container);
+        appendScrollLog('fix_scroll:raf_retry', {
+          i,
+          k,
+          title: container?.title ?? null
         });
+        setScroll(`raf:${ i }`);
+      });
     }
     appendScrollLog('fix_scroll:exit', {
-        k,
-        title: container?.title ?? null
+      k,
+      title: container?.title ?? null
     });
-}
-)};
+  };
+};
 const _arfw00 = function _scroll_fix_sync_layout(sync_layout_to_url,layout,appendScrollLog,modulePanel)
 {
     sync_layout_to_url;
@@ -17383,7 +17444,7 @@ export default function define(runtime, observer) {
   $def("_1we0ggl", "reload", ["Generators","viewof reload"], _1we0ggl);  
   $def("_plefwg", "onLoadConfig", ["parseGoldenDSL","URLSearchParams","location"], _plefwg);  
   $def("_1nzpnqy", "visualizer_cache", ["reload"], _1nzpnqy);  
-  $def("_1l35721", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1l35721);  
+  $def("_1ojown8", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1ojown8);  
   $def("_1gm4gbf", "blobPanel", [], _1gm4gbf);  
   $def("_lxv2e2", "settings", [], _lxv2e2);  
   $def("_lp1ggk", "is_mobile", ["width"], _lp1ggk);  
@@ -17404,7 +17465,7 @@ export default function define(runtime, observer) {
   $def("_1dyz4o0", "scrollLog", ["mutable scrollLog"], _1dyz4o0);  
   $def("_1d1nkw9", "scrollKeyFor", ["appendScrollLog"], _1d1nkw9);  
   $def("_tb217h", "scroll_cache", [], _tb217h);  
-  $def("_5tyvpe", "fix_scroll", ["scrollKeyFor","appendScrollLog","scroll_cache"], _5tyvpe);  
+  $def("_12p8mg7", "fix_scroll", ["scroll_cache","scrollKeyFor","appendScrollLog"], _12p8mg7);  
   $def("_arfw00", "scroll_fix_sync_layout", ["sync_layout_to_url","layout","appendScrollLog","modulePanel"], _arfw00);  
   $def("_3nwpp4", "URLrouting", ["md"], _3nwpp4);  
   $def("_14te9pl", "sync_layout_from_url", ["reload","resize","URLSearchParams","hash","appendScrollLog","parseGoldenDSL","gl","layout","serializeGoldenDSL","treeSyncGolden","invalidation"], _14te9pl);  

--- a/notebooks/@tomlarkworthy_lopecode-vision.html
+++ b/notebooks/@tomlarkworthy_lopecode-vision.html
@@ -15263,138 +15263,196 @@ const _1nzpnqy = function _visualizer_cache(reload)
     reload;
     return new Map();
 };
-const _1l35721 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
+const _1ojown8 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
 {
-    return function (container, component) {
-        appendScrollLog('modulePanel:enter', {
-            title: container?.title ?? null,
-            componentCell: component?.cell ?? null
-        });
-        const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
-        if (!moduleInfo) {
-            // Fall through to file attachment: titles like @user/notebook/path.ext
-            // resolve via the lopecode bootloader's contentSync DOM lookup.
-            const title = container?.title ?? null;
-            if (title) {
-                let node = file_attachment_cache.get(title);
-                if (!node) {
-                    const r = window.lopecode?.contentSync?.(title);
-                    if (r && r.status === 200 && r.bytes) {
-                        node = renderFileAttachment(r.mime, r.bytes);
-                        file_attachment_cache.set(title, node);
-                        appendScrollLog('modulePanel:file_attachment_create', {
-                            title,
-                            mime: r.mime
-                        });
-                    }
-                }
-                if (node) {
-                    const c_element = container.getElement();
-                    if (node.parentNode !== c_element)
-                        c_element.appendChild(node);
-                    appendScrollLog('modulePanel:file_attachment_mount', { title });
-                    return;
-                }
-            }
-            appendScrollLog('modulePanel:missing_moduleInfo', { title });
-            return;
-        }
-        const module = moduleInfo.module;
-        let node;
-        if (!visualizer_cache.has(module)) {
-            appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
-            node = visualizer(runtime, {
-                invalidation: new Promise(r => {
-                }),
-                module,
-                detachNodes: isOnObservableCom(),
-                filter: (cell_name, variables) => {
-                    if (variables[0]._type !== 1)
-                        return false;
-                    if (typeof cell_name == 'string') {
-                        if (cell_name.startsWith('dynamic '))
-                            return false;
-                    }
-                    return true;
-                }
+  return function (container, component) {
+    appendScrollLog('modulePanel:enter', {
+      title: container?.title ?? null,
+      componentCell: component?.cell ?? null
+    });
+    const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
+    if (!moduleInfo) {
+      // Fall through to file attachment: titles like @user/notebook/path.ext
+      // resolve via the lopecode bootloader's contentSync DOM lookup.
+      const title = container?.title ?? null;
+      if (title) {
+        let node = file_attachment_cache.get(title);
+        if (!node) {
+          const r = window.lopecode?.contentSync?.(title);
+          if (r && r.status === 200 && r.bytes) {
+            node = renderFileAttachment(r.mime, r.bytes);
+            file_attachment_cache.set(title, node);
+            appendScrollLog('modulePanel:file_attachment_create', {
+              title,
+              mime: r.mime
             });
-            visualizer_cache.set(module, node);
-        } else {
-            node = visualizer_cache.get(module);
-            appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+          }
         }
-        const cell = module._scope.get(component.cell);
-        const scrollKey = scrollKeyFor(container);
-        fix_scroll(container, node, cell, scrollKey);
-        const el = container.getElement();
-        if (!el.__lope_scroll_bound) {
-            el.__lope_scroll_bound = true;
-            appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
-            el.addEventListener('scroll', () => {
-                const k = scrollKeyFor(container);
-                const scrollTop = el.scrollTop;
-                const scrollLeft = el.scrollLeft;
-                if (scrollTop == 0) {
-                    appendScrollLog('modulePanel:skip 0 scroll', {
-                        title: container?.title ?? null,
-                        scrollKey
-                    });
-                    return;
-                }
-                scroll_cache.set(k, {
-                    scrollTop,
-                    scrollLeft,
-                    t: Date.now()
-                });
-                appendScrollLog('scroll:event', {
-                    k,
-                    title: container?.title ?? null,
-                    scrollTop,
-                    scrollLeft
-                });
-            }, { passive: true });
+        if (node) {
+          const c_element = container.getElement();
+          if (node.parentNode !== c_element)
+            c_element.appendChild(node);
+          appendScrollLog('modulePanel:file_attachment_mount', { title });
+          return;
         }
-        // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
-        if (!container.__lope_destroy_bound) {
-            container.__lope_destroy_bound = true;
-            container.on('destroy', () => {
-                try {
-                    const k = scrollKeyFor(container);
-                    const scrollTop = el?.scrollTop;
-                    const scrollLeft = el?.scrollLeft;
-                    if (scrollTop == 0) {
-                        appendScrollLog('scroll:skip 0 scroll', {
-                            k,
-                            key: container?.title ?? null,
-                            scrollKey
-                        });
-                        return;
-                    }
-                    // do not skip 0 here: if the user is at top, preserve that state
-                    scroll_cache.set(k, {
-                        scrollTop,
-                        scrollLeft,
-                        t: Date.now()
-                    });
-                    appendScrollLog('scroll:destroy_capture', {
-                        k,
-                        title: container?.title ?? null,
-                        scrollTop,
-                        scrollLeft
-                    });
-                } catch (e) {
-                    appendScrollLog('scroll:destroy_capture:error', {
-                        title: container?.title ?? null,
-                        error: String(e)
-                    });
-                }
-            });
+      }
+      appendScrollLog('modulePanel:missing_moduleInfo', { title });
+      return;
+    }
+    const module = moduleInfo.module;
+    let node;
+    if (!visualizer_cache.has(module)) {
+      appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
+      node = visualizer(runtime, {
+        invalidation: new Promise(r => {
+        }),
+        module,
+        detachNodes: isOnObservableCom(),
+        filter: (cell_name, variables) => {
+          if (variables[0]._type !== 1)
+            return false;
+          if (typeof cell_name == 'string') {
+            if (cell_name.startsWith('dynamic '))
+              return false;
+          }
+          return true;
         }
-        appendScrollLog('modulePanel:exit', {
+      });
+      visualizer_cache.set(module, node);
+    } else {
+      node = visualizer_cache.get(module);
+      appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+    }
+    const cell = module._scope.get(component.cell);
+    const scrollKey = scrollKeyFor(container);
+    fix_scroll(container, node, cell, scrollKey);
+    const el = container.getElement();
+    if (!el.__lope_scroll_bound) {
+      el.__lope_scroll_bound = true;
+      appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
+      const markUserScroll = () => {
+        el.__lope_user_scroll_at = Date.now();
+      };
+      el.addEventListener('wheel', markUserScroll, { passive: true });
+      el.addEventListener('touchmove', markUserScroll, { passive: true });
+      el.addEventListener('keydown', markUserScroll, { passive: true });
+      el.addEventListener('scroll', () => {
+        if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+          appendScrollLog('scroll:skip_reflow', { title: container?.title ?? null });
+          return;
+        }
+        // Only cache scrolls following a genuine user gesture; reflow-induced
+        // scroll events (e.g. closing an adjacent panel) carry stale scrollTops.
+        if (Date.now() - (el.__lope_user_scroll_at || 0) > 400) {
+          appendScrollLog('scroll:skip_nonuser', { title: container?.title ?? null });
+          return;
+        }
+        const k = scrollKeyFor(container);
+        const scrollTop = el.scrollTop;
+        const scrollLeft = el.scrollLeft;
+        if (scrollTop == 0) {
+          appendScrollLog('modulePanel:skip 0 scroll', {
             title: container?.title ?? null,
             scrollKey
+          });
+          return;
+        }
+        scroll_cache.set(k, {
+          scrollTop,
+          scrollLeft,
+          t: Date.now()
         });
-    };
+        appendScrollLog('scroll:event', {
+          k,
+          title: container?.title ?? null,
+          scrollTop,
+          scrollLeft
+        });
+      }, { passive: true });
+    }
+    // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
+    if (!container.__lope_destroy_bound) {
+      container.__lope_destroy_bound = true;
+      container.on('destroy', () => {
+        try {
+          if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+            appendScrollLog('scroll:destroy_skip_reflow', { title: container?.title ?? null });
+            return;
+          }
+          const k = scrollKeyFor(container);
+          const scrollTop = el?.scrollTop;
+          const scrollLeft = el?.scrollLeft;
+          if (scrollTop == 0) {
+            appendScrollLog('scroll:skip 0 scroll', {
+              k,
+              key: container?.title ?? null,
+              scrollKey
+            });
+            return;
+          }
+          // do not skip 0 here: if the user is at top, preserve that state
+          scroll_cache.set(k, {
+            scrollTop,
+            scrollLeft,
+            t: Date.now()
+          });
+          appendScrollLog('scroll:destroy_capture', {
+            k,
+            title: container?.title ?? null,
+            scrollTop,
+            scrollLeft
+          });
+        } catch (e) {
+          appendScrollLog('scroll:destroy_capture:error', {
+            title: container?.title ?? null,
+            error: String(e)
+          });
+        }
+      });
+    }
+    // When GoldenLayout resizes this panel (e.g. an adjacent panel is closed) the
+    // browser can shift scrollTop; re-apply the user's cached position after the reflow.
+    if (!container.__lope_resize_bound) {
+      container.__lope_resize_bound = true;
+      container.on('resize', () => {
+        const rk = scrollKeyFor(container);
+        const cached = scroll_cache.get(rk);
+        if (!cached || cached.scrollTop == null)
+          return;
+        const c_el = container.getElement();
+        const at = Date.now();
+        scroll_cache.__reflowUntil = at + 800;
+        // The reflow can shift scrollTop in several passes (content relayout
+        // settles ~300ms later), so re-apply over a window. Bail if the user scrolls.
+        const apply = () => {
+          if ((c_el.__lope_user_scroll_at || 0) > at)
+            return;
+          if (c_el.scrollTop !== cached.scrollTop)
+            c_el.scrollTop = cached.scrollTop;
+          if (cached.scrollLeft != null && c_el.scrollLeft !== cached.scrollLeft)
+            c_el.scrollLeft = cached.scrollLeft;
+        };
+        requestAnimationFrame(apply);
+        for (const d of [
+            60,
+            150,
+            300,
+            450,
+            600
+          ])
+          setTimeout(apply, d);
+        appendScrollLog('scroll:resize_restore', {
+          k: rk,
+          title: container?.title ?? null,
+          scrollTop: cached.scrollTop
+        });
+      });
+    }
+    appendScrollLog('modulePanel:exit', {
+      title: container?.title ?? null,
+      scrollKey
+    });
+  };
 };
 const _1gm4gbf = function _blobPanel(){return(
 function (container, component) {
@@ -15512,112 +15570,115 @@ const _1d1nkw9 = function _scrollKeyFor(appendScrollLog)
 const _tb217h = function _scroll_cache(){return(
 new Map()
 )};
-const _5tyvpe = function _fix_scroll(scrollKeyFor,appendScrollLog,scroll_cache){return(
-function (container, node, cell_variable, key) {
+const _12p8mg7 = function _fix_scroll(scroll_cache,scrollKeyFor,appendScrollLog)
+{
+  return function (container, node, cell_variable, key) {
+    scroll_cache.__reflowUntil = Date.now() + 600;
+    // suppress reflow-induced scroll events that clobber the cache
     const c_element = container.getElement();
     let k = scrollKeyFor(container);
     appendScrollLog('fix_scroll:enter', {
-        title: container?.title ?? null,
-        k,
-        cell: cell_variable?._name ?? null
+      title: container?.title ?? null,
+      k,
+      cell: cell_variable?._name ?? null
     });
     if (node && node.parentNode !== c_element) {
-        c_element.appendChild(node);
-        appendScrollLog('fix_scroll:append_node', {
-            title: container?.title ?? null,
-            k
-        });
+      c_element.appendChild(node);
+      appendScrollLog('fix_scroll:append_node', {
+        title: container?.title ?? null,
+        k
+      });
     }
     const writeCache = (scrollTop, scrollLeft, why) => {
-        scroll_cache.set(k, {
-            scrollTop,
-            scrollLeft,
-            t: Date.now()
-        });
-        appendScrollLog('scroll_cache:write', {
-            k,
-            scrollTop,
-            scrollLeft,
-            why
-        });
+      scroll_cache.set(k, {
+        scrollTop,
+        scrollLeft,
+        t: Date.now()
+      });
+      appendScrollLog('scroll_cache:write', {
+        k,
+        scrollTop,
+        scrollLeft,
+        why
+      });
     };
     const scrollToCellIfPossible = why => {
-        if (!cell_variable)
-            return false;
-        const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
-        if (!dom) {
-            appendScrollLog('scroll:cell_dom_not_found', {
-                k,
-                why,
-                cell: cell_variable?._name ?? null
-            });
-            return false;
-        }
-        const top = dom.offsetTop - c_element.offsetTop;
-        const left = c_element.scrollLeft;
-        c_element.scrollTop = top;
-        appendScrollLog('scroll:set', {
-            k,
-            why: `${ why }:cell`,
-            scrollTop: top,
-            scrollLeft: left,
-            cell: cell_variable?._name ?? null
+      if (!cell_variable)
+        return false;
+      const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
+      if (!dom) {
+        appendScrollLog('scroll:cell_dom_not_found', {
+          k,
+          why,
+          cell: cell_variable?._name ?? null
         });
-        writeCache(top, left, `${ why }:cell`);
-        return true;
+        return false;
+      }
+      const top = dom.offsetTop - c_element.offsetTop;
+      const left = c_element.scrollLeft;
+      c_element.scrollTop = top;
+      appendScrollLog('scroll:set', {
+        k,
+        why: `${ why }:cell`,
+        scrollTop: top,
+        scrollLeft: left,
+        cell: cell_variable?._name ?? null
+      });
+      writeCache(top, left, `${ why }:cell`);
+      return true;
     };
     const restoreFromCache = why => {
-        k = scrollKeyFor(container);
-        const cached = scroll_cache.get(k);
-        appendScrollLog('scroll:restore_attempt', {
-            k,
-            why,
-            cachedScrollTop: cached?.scrollTop ?? null,
-            cachedScrollLeft: cached?.scrollLeft ?? null
+      k = scrollKeyFor(container);
+      const cached = scroll_cache.get(k);
+      appendScrollLog('scroll:restore_attempt', {
+        k,
+        why,
+        cachedScrollTop: cached?.scrollTop ?? null,
+        cachedScrollLeft: cached?.scrollLeft ?? null
+      });
+      if (!cached) {
+        appendScrollLog('scroll:restore_no_scroll', {
+          k,
+          why
         });
-        if (!cached) {
-            appendScrollLog('scroll:restore_no_scroll', {
-                k,
-                why
-            });
-            return;
-        }
-        if (cached.scrollTop != null)
-            c_element.scrollTop = cached.scrollTop;
-        if (cached.scrollLeft != null)
-            c_element.scrollLeft = cached.scrollLeft;
-        appendScrollLog('scroll:restore_applied', {
-            k,
-            why,
-            scrollTop: cached.scrollTop ?? null,
-            scrollLeft: cached.scrollLeft ?? null,
-            scrollTopFinal: c_element.scrollTop,
-            scrollLeftFinal: c_element.scrollLeft
-        });
+        return;
+      }
+      if (cached.scrollTop != null)
+        c_element.scrollTop = cached.scrollTop;
+      if (cached.scrollLeft != null)
+        c_element.scrollLeft = cached.scrollLeft;
+      appendScrollLog('scroll:restore_applied', {
+        k,
+        why,
+        scrollTop: cached.scrollTop ?? null,
+        scrollLeft: cached.scrollLeft ?? null,
+        scrollTopFinal: c_element.scrollTop,
+        scrollLeftFinal: c_element.scrollLeft
+      });
     };
     const setScroll = (why = 'setScroll') => {
-        if (scrollToCellIfPossible(why))
-            return;
-        restoreFromCache(why);
+      if (scrollToCellIfPossible(why))
+        return;
+      restoreFromCache(why);
     };
     const retryFrames = 6;
     for (let i = 0; i < retryFrames; i++) {
-        requestAnimationFrame(() => {
-            k = scrollKeyFor(container);
-            appendScrollLog('fix_scroll:raf_retry', {
-                i,
-                k,
-                title: container?.title ?? null
-            });
-            setScroll(`raf:${ i }`);
+      requestAnimationFrame(() => {
+        k = scrollKeyFor(container);
+        appendScrollLog('fix_scroll:raf_retry', {
+          i,
+          k,
+          title: container?.title ?? null
         });
+        setScroll(`raf:${ i }`);
+      });
     }
     appendScrollLog('fix_scroll:exit', {
-        k,
-        title: container?.title ?? null
+      k,
+      title: container?.title ?? null
     });
-}
-)};
+  };
+};
 const _arfw00 = function _scroll_fix_sync_layout(sync_layout_to_url,layout,appendScrollLog,modulePanel)
 {
     sync_layout_to_url;
@@ -16695,7 +16756,7 @@ export default function define(runtime, observer) {
   $def("_1we0ggl", "reload", ["Generators","viewof reload"], _1we0ggl);  
   $def("_plefwg", "onLoadConfig", ["parseGoldenDSL","URLSearchParams","location"], _plefwg);  
   $def("_1nzpnqy", "visualizer_cache", ["reload"], _1nzpnqy);  
-  $def("_1l35721", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1l35721);  
+  $def("_1ojown8", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1ojown8);  
   $def("_1gm4gbf", "blobPanel", [], _1gm4gbf);  
   $def("_lxv2e2", "settings", [], _lxv2e2);  
   $def("_lp1ggk", "is_mobile", ["width"], _lp1ggk);  
@@ -16716,7 +16777,7 @@ export default function define(runtime, observer) {
   $def("_1dyz4o0", "scrollLog", ["mutable scrollLog"], _1dyz4o0);  
   $def("_1d1nkw9", "scrollKeyFor", ["appendScrollLog"], _1d1nkw9);  
   $def("_tb217h", "scroll_cache", [], _tb217h);  
-  $def("_5tyvpe", "fix_scroll", ["scrollKeyFor","appendScrollLog","scroll_cache"], _5tyvpe);  
+  $def("_12p8mg7", "fix_scroll", ["scroll_cache","scrollKeyFor","appendScrollLog"], _12p8mg7);  
   $def("_arfw00", "scroll_fix_sync_layout", ["sync_layout_to_url","layout","appendScrollLog","modulePanel"], _arfw00);  
   $def("_3nwpp4", "URLrouting", ["md"], _3nwpp4);  
   $def("_14te9pl", "sync_layout_from_url", ["reload","resize","URLSearchParams","hash","appendScrollLog","parseGoldenDSL","gl","layout","serializeGoldenDSL","treeSyncGolden","invalidation"], _14te9pl);  

--- a/notebooks/@tomlarkworthy_lopepage-urls.html
+++ b/notebooks/@tomlarkworthy_lopepage-urls.html
@@ -14037,138 +14037,196 @@ const _1nzpnqy = function _visualizer_cache(reload)
     reload;
     return new Map();
 };
-const _1l35721 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
+const _1ojown8 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
 {
-    return function (container, component) {
-        appendScrollLog('modulePanel:enter', {
-            title: container?.title ?? null,
-            componentCell: component?.cell ?? null
-        });
-        const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
-        if (!moduleInfo) {
-            // Fall through to file attachment: titles like @user/notebook/path.ext
-            // resolve via the lopecode bootloader's contentSync DOM lookup.
-            const title = container?.title ?? null;
-            if (title) {
-                let node = file_attachment_cache.get(title);
-                if (!node) {
-                    const r = window.lopecode?.contentSync?.(title);
-                    if (r && r.status === 200 && r.bytes) {
-                        node = renderFileAttachment(r.mime, r.bytes);
-                        file_attachment_cache.set(title, node);
-                        appendScrollLog('modulePanel:file_attachment_create', {
-                            title,
-                            mime: r.mime
-                        });
-                    }
-                }
-                if (node) {
-                    const c_element = container.getElement();
-                    if (node.parentNode !== c_element)
-                        c_element.appendChild(node);
-                    appendScrollLog('modulePanel:file_attachment_mount', { title });
-                    return;
-                }
-            }
-            appendScrollLog('modulePanel:missing_moduleInfo', { title });
-            return;
-        }
-        const module = moduleInfo.module;
-        let node;
-        if (!visualizer_cache.has(module)) {
-            appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
-            node = visualizer(runtime, {
-                invalidation: new Promise(r => {
-                }),
-                module,
-                detachNodes: isOnObservableCom(),
-                filter: (cell_name, variables) => {
-                    if (variables[0]._type !== 1)
-                        return false;
-                    if (typeof cell_name == 'string') {
-                        if (cell_name.startsWith('dynamic '))
-                            return false;
-                    }
-                    return true;
-                }
+  return function (container, component) {
+    appendScrollLog('modulePanel:enter', {
+      title: container?.title ?? null,
+      componentCell: component?.cell ?? null
+    });
+    const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
+    if (!moduleInfo) {
+      // Fall through to file attachment: titles like @user/notebook/path.ext
+      // resolve via the lopecode bootloader's contentSync DOM lookup.
+      const title = container?.title ?? null;
+      if (title) {
+        let node = file_attachment_cache.get(title);
+        if (!node) {
+          const r = window.lopecode?.contentSync?.(title);
+          if (r && r.status === 200 && r.bytes) {
+            node = renderFileAttachment(r.mime, r.bytes);
+            file_attachment_cache.set(title, node);
+            appendScrollLog('modulePanel:file_attachment_create', {
+              title,
+              mime: r.mime
             });
-            visualizer_cache.set(module, node);
-        } else {
-            node = visualizer_cache.get(module);
-            appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+          }
         }
-        const cell = module._scope.get(component.cell);
-        const scrollKey = scrollKeyFor(container);
-        fix_scroll(container, node, cell, scrollKey);
-        const el = container.getElement();
-        if (!el.__lope_scroll_bound) {
-            el.__lope_scroll_bound = true;
-            appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
-            el.addEventListener('scroll', () => {
-                const k = scrollKeyFor(container);
-                const scrollTop = el.scrollTop;
-                const scrollLeft = el.scrollLeft;
-                if (scrollTop == 0) {
-                    appendScrollLog('modulePanel:skip 0 scroll', {
-                        title: container?.title ?? null,
-                        scrollKey
-                    });
-                    return;
-                }
-                scroll_cache.set(k, {
-                    scrollTop,
-                    scrollLeft,
-                    t: Date.now()
-                });
-                appendScrollLog('scroll:event', {
-                    k,
-                    title: container?.title ?? null,
-                    scrollTop,
-                    scrollLeft
-                });
-            }, { passive: true });
+        if (node) {
+          const c_element = container.getElement();
+          if (node.parentNode !== c_element)
+            c_element.appendChild(node);
+          appendScrollLog('modulePanel:file_attachment_mount', { title });
+          return;
         }
-        // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
-        if (!container.__lope_destroy_bound) {
-            container.__lope_destroy_bound = true;
-            container.on('destroy', () => {
-                try {
-                    const k = scrollKeyFor(container);
-                    const scrollTop = el?.scrollTop;
-                    const scrollLeft = el?.scrollLeft;
-                    if (scrollTop == 0) {
-                        appendScrollLog('scroll:skip 0 scroll', {
-                            k,
-                            key: container?.title ?? null,
-                            scrollKey
-                        });
-                        return;
-                    }
-                    // do not skip 0 here: if the user is at top, preserve that state
-                    scroll_cache.set(k, {
-                        scrollTop,
-                        scrollLeft,
-                        t: Date.now()
-                    });
-                    appendScrollLog('scroll:destroy_capture', {
-                        k,
-                        title: container?.title ?? null,
-                        scrollTop,
-                        scrollLeft
-                    });
-                } catch (e) {
-                    appendScrollLog('scroll:destroy_capture:error', {
-                        title: container?.title ?? null,
-                        error: String(e)
-                    });
-                }
-            });
+      }
+      appendScrollLog('modulePanel:missing_moduleInfo', { title });
+      return;
+    }
+    const module = moduleInfo.module;
+    let node;
+    if (!visualizer_cache.has(module)) {
+      appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
+      node = visualizer(runtime, {
+        invalidation: new Promise(r => {
+        }),
+        module,
+        detachNodes: isOnObservableCom(),
+        filter: (cell_name, variables) => {
+          if (variables[0]._type !== 1)
+            return false;
+          if (typeof cell_name == 'string') {
+            if (cell_name.startsWith('dynamic '))
+              return false;
+          }
+          return true;
         }
-        appendScrollLog('modulePanel:exit', {
+      });
+      visualizer_cache.set(module, node);
+    } else {
+      node = visualizer_cache.get(module);
+      appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+    }
+    const cell = module._scope.get(component.cell);
+    const scrollKey = scrollKeyFor(container);
+    fix_scroll(container, node, cell, scrollKey);
+    const el = container.getElement();
+    if (!el.__lope_scroll_bound) {
+      el.__lope_scroll_bound = true;
+      appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
+      const markUserScroll = () => {
+        el.__lope_user_scroll_at = Date.now();
+      };
+      el.addEventListener('wheel', markUserScroll, { passive: true });
+      el.addEventListener('touchmove', markUserScroll, { passive: true });
+      el.addEventListener('keydown', markUserScroll, { passive: true });
+      el.addEventListener('scroll', () => {
+        if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+          appendScrollLog('scroll:skip_reflow', { title: container?.title ?? null });
+          return;
+        }
+        // Only cache scrolls following a genuine user gesture; reflow-induced
+        // scroll events (e.g. closing an adjacent panel) carry stale scrollTops.
+        if (Date.now() - (el.__lope_user_scroll_at || 0) > 400) {
+          appendScrollLog('scroll:skip_nonuser', { title: container?.title ?? null });
+          return;
+        }
+        const k = scrollKeyFor(container);
+        const scrollTop = el.scrollTop;
+        const scrollLeft = el.scrollLeft;
+        if (scrollTop == 0) {
+          appendScrollLog('modulePanel:skip 0 scroll', {
             title: container?.title ?? null,
             scrollKey
+          });
+          return;
+        }
+        scroll_cache.set(k, {
+          scrollTop,
+          scrollLeft,
+          t: Date.now()
         });
-    };
+        appendScrollLog('scroll:event', {
+          k,
+          title: container?.title ?? null,
+          scrollTop,
+          scrollLeft
+        });
+      }, { passive: true });
+    }
+    // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
+    if (!container.__lope_destroy_bound) {
+      container.__lope_destroy_bound = true;
+      container.on('destroy', () => {
+        try {
+          if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+            appendScrollLog('scroll:destroy_skip_reflow', { title: container?.title ?? null });
+            return;
+          }
+          const k = scrollKeyFor(container);
+          const scrollTop = el?.scrollTop;
+          const scrollLeft = el?.scrollLeft;
+          if (scrollTop == 0) {
+            appendScrollLog('scroll:skip 0 scroll', {
+              k,
+              key: container?.title ?? null,
+              scrollKey
+            });
+            return;
+          }
+          // do not skip 0 here: if the user is at top, preserve that state
+          scroll_cache.set(k, {
+            scrollTop,
+            scrollLeft,
+            t: Date.now()
+          });
+          appendScrollLog('scroll:destroy_capture', {
+            k,
+            title: container?.title ?? null,
+            scrollTop,
+            scrollLeft
+          });
+        } catch (e) {
+          appendScrollLog('scroll:destroy_capture:error', {
+            title: container?.title ?? null,
+            error: String(e)
+          });
+        }
+      });
+    }
+    // When GoldenLayout resizes this panel (e.g. an adjacent panel is closed) the
+    // browser can shift scrollTop; re-apply the user's cached position after the reflow.
+    if (!container.__lope_resize_bound) {
+      container.__lope_resize_bound = true;
+      container.on('resize', () => {
+        const rk = scrollKeyFor(container);
+        const cached = scroll_cache.get(rk);
+        if (!cached || cached.scrollTop == null)
+          return;
+        const c_el = container.getElement();
+        const at = Date.now();
+        scroll_cache.__reflowUntil = at + 800;
+        // The reflow can shift scrollTop in several passes (content relayout
+        // settles ~300ms later), so re-apply over a window. Bail if the user scrolls.
+        const apply = () => {
+          if ((c_el.__lope_user_scroll_at || 0) > at)
+            return;
+          if (c_el.scrollTop !== cached.scrollTop)
+            c_el.scrollTop = cached.scrollTop;
+          if (cached.scrollLeft != null && c_el.scrollLeft !== cached.scrollLeft)
+            c_el.scrollLeft = cached.scrollLeft;
+        };
+        requestAnimationFrame(apply);
+        for (const d of [
+            60,
+            150,
+            300,
+            450,
+            600
+          ])
+          setTimeout(apply, d);
+        appendScrollLog('scroll:resize_restore', {
+          k: rk,
+          title: container?.title ?? null,
+          scrollTop: cached.scrollTop
+        });
+      });
+    }
+    appendScrollLog('modulePanel:exit', {
+      title: container?.title ?? null,
+      scrollKey
+    });
+  };
 };
 const _1gm4gbf = function _blobPanel(){return(
 function (container, component) {
@@ -14286,112 +14344,115 @@ const _1d1nkw9 = function _scrollKeyFor(appendScrollLog)
 const _tb217h = function _scroll_cache(){return(
 new Map()
 )};
-const _5tyvpe = function _fix_scroll(scrollKeyFor,appendScrollLog,scroll_cache){return(
-function (container, node, cell_variable, key) {
+const _12p8mg7 = function _fix_scroll(scroll_cache,scrollKeyFor,appendScrollLog)
+{
+  return function (container, node, cell_variable, key) {
+    scroll_cache.__reflowUntil = Date.now() + 600;
+    // suppress reflow-induced scroll events that clobber the cache
     const c_element = container.getElement();
     let k = scrollKeyFor(container);
     appendScrollLog('fix_scroll:enter', {
-        title: container?.title ?? null,
-        k,
-        cell: cell_variable?._name ?? null
+      title: container?.title ?? null,
+      k,
+      cell: cell_variable?._name ?? null
     });
     if (node && node.parentNode !== c_element) {
-        c_element.appendChild(node);
-        appendScrollLog('fix_scroll:append_node', {
-            title: container?.title ?? null,
-            k
-        });
+      c_element.appendChild(node);
+      appendScrollLog('fix_scroll:append_node', {
+        title: container?.title ?? null,
+        k
+      });
     }
     const writeCache = (scrollTop, scrollLeft, why) => {
-        scroll_cache.set(k, {
-            scrollTop,
-            scrollLeft,
-            t: Date.now()
-        });
-        appendScrollLog('scroll_cache:write', {
-            k,
-            scrollTop,
-            scrollLeft,
-            why
-        });
+      scroll_cache.set(k, {
+        scrollTop,
+        scrollLeft,
+        t: Date.now()
+      });
+      appendScrollLog('scroll_cache:write', {
+        k,
+        scrollTop,
+        scrollLeft,
+        why
+      });
     };
     const scrollToCellIfPossible = why => {
-        if (!cell_variable)
-            return false;
-        const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
-        if (!dom) {
-            appendScrollLog('scroll:cell_dom_not_found', {
-                k,
-                why,
-                cell: cell_variable?._name ?? null
-            });
-            return false;
-        }
-        const top = dom.offsetTop - c_element.offsetTop;
-        const left = c_element.scrollLeft;
-        c_element.scrollTop = top;
-        appendScrollLog('scroll:set', {
-            k,
-            why: `${ why }:cell`,
-            scrollTop: top,
-            scrollLeft: left,
-            cell: cell_variable?._name ?? null
+      if (!cell_variable)
+        return false;
+      const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
+      if (!dom) {
+        appendScrollLog('scroll:cell_dom_not_found', {
+          k,
+          why,
+          cell: cell_variable?._name ?? null
         });
-        writeCache(top, left, `${ why }:cell`);
-        return true;
+        return false;
+      }
+      const top = dom.offsetTop - c_element.offsetTop;
+      const left = c_element.scrollLeft;
+      c_element.scrollTop = top;
+      appendScrollLog('scroll:set', {
+        k,
+        why: `${ why }:cell`,
+        scrollTop: top,
+        scrollLeft: left,
+        cell: cell_variable?._name ?? null
+      });
+      writeCache(top, left, `${ why }:cell`);
+      return true;
     };
     const restoreFromCache = why => {
-        k = scrollKeyFor(container);
-        const cached = scroll_cache.get(k);
-        appendScrollLog('scroll:restore_attempt', {
-            k,
-            why,
-            cachedScrollTop: cached?.scrollTop ?? null,
-            cachedScrollLeft: cached?.scrollLeft ?? null
+      k = scrollKeyFor(container);
+      const cached = scroll_cache.get(k);
+      appendScrollLog('scroll:restore_attempt', {
+        k,
+        why,
+        cachedScrollTop: cached?.scrollTop ?? null,
+        cachedScrollLeft: cached?.scrollLeft ?? null
+      });
+      if (!cached) {
+        appendScrollLog('scroll:restore_no_scroll', {
+          k,
+          why
         });
-        if (!cached) {
-            appendScrollLog('scroll:restore_no_scroll', {
-                k,
-                why
-            });
-            return;
-        }
-        if (cached.scrollTop != null)
-            c_element.scrollTop = cached.scrollTop;
-        if (cached.scrollLeft != null)
-            c_element.scrollLeft = cached.scrollLeft;
-        appendScrollLog('scroll:restore_applied', {
-            k,
-            why,
-            scrollTop: cached.scrollTop ?? null,
-            scrollLeft: cached.scrollLeft ?? null,
-            scrollTopFinal: c_element.scrollTop,
-            scrollLeftFinal: c_element.scrollLeft
-        });
+        return;
+      }
+      if (cached.scrollTop != null)
+        c_element.scrollTop = cached.scrollTop;
+      if (cached.scrollLeft != null)
+        c_element.scrollLeft = cached.scrollLeft;
+      appendScrollLog('scroll:restore_applied', {
+        k,
+        why,
+        scrollTop: cached.scrollTop ?? null,
+        scrollLeft: cached.scrollLeft ?? null,
+        scrollTopFinal: c_element.scrollTop,
+        scrollLeftFinal: c_element.scrollLeft
+      });
     };
     const setScroll = (why = 'setScroll') => {
-        if (scrollToCellIfPossible(why))
-            return;
-        restoreFromCache(why);
+      if (scrollToCellIfPossible(why))
+        return;
+      restoreFromCache(why);
     };
     const retryFrames = 6;
     for (let i = 0; i < retryFrames; i++) {
-        requestAnimationFrame(() => {
-            k = scrollKeyFor(container);
-            appendScrollLog('fix_scroll:raf_retry', {
-                i,
-                k,
-                title: container?.title ?? null
-            });
-            setScroll(`raf:${ i }`);
+      requestAnimationFrame(() => {
+        k = scrollKeyFor(container);
+        appendScrollLog('fix_scroll:raf_retry', {
+          i,
+          k,
+          title: container?.title ?? null
         });
+        setScroll(`raf:${ i }`);
+      });
     }
     appendScrollLog('fix_scroll:exit', {
-        k,
-        title: container?.title ?? null
+      k,
+      title: container?.title ?? null
     });
-}
-)};
+  };
+};
 const _arfw00 = function _scroll_fix_sync_layout(sync_layout_to_url,layout,appendScrollLog,modulePanel)
 {
     sync_layout_to_url;
@@ -15469,7 +15530,7 @@ export default function define(runtime, observer) {
   $def("_1we0ggl", "reload", ["Generators","viewof reload"], _1we0ggl);  
   $def("_plefwg", "onLoadConfig", ["parseGoldenDSL","URLSearchParams","location"], _plefwg);  
   $def("_1nzpnqy", "visualizer_cache", ["reload"], _1nzpnqy);  
-  $def("_1l35721", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1l35721);  
+  $def("_1ojown8", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1ojown8);  
   $def("_1gm4gbf", "blobPanel", [], _1gm4gbf);  
   $def("_lxv2e2", "settings", [], _lxv2e2);  
   $def("_lp1ggk", "is_mobile", ["width"], _lp1ggk);  
@@ -15490,7 +15551,7 @@ export default function define(runtime, observer) {
   $def("_1dyz4o0", "scrollLog", ["mutable scrollLog"], _1dyz4o0);  
   $def("_1d1nkw9", "scrollKeyFor", ["appendScrollLog"], _1d1nkw9);  
   $def("_tb217h", "scroll_cache", [], _tb217h);  
-  $def("_5tyvpe", "fix_scroll", ["scrollKeyFor","appendScrollLog","scroll_cache"], _5tyvpe);  
+  $def("_12p8mg7", "fix_scroll", ["scroll_cache","scrollKeyFor","appendScrollLog"], _12p8mg7);  
   $def("_arfw00", "scroll_fix_sync_layout", ["sync_layout_to_url","layout","appendScrollLog","modulePanel"], _arfw00);  
   $def("_3nwpp4", "URLrouting", ["md"], _3nwpp4);  
   $def("_14te9pl", "sync_layout_from_url", ["reload","resize","URLSearchParams","hash","appendScrollLog","parseGoldenDSL","gl","layout","serializeGoldenDSL","treeSyncGolden","invalidation"], _14te9pl);  

--- a/notebooks/@tomlarkworthy_lopepage.html
+++ b/notebooks/@tomlarkworthy_lopepage.html
@@ -1943,10 +1943,9 @@ const _1hybsm8 = function _coverage_failures(runtime_variables,liveCellMap,modul
   }
   return failures;
 };
-const _4tg5tm = function _test_cell_map_covers_all_runtime_variables(coverage_failures)
+const _1p0qclg = function _test_cell_map_covers_all_runtime_variables(coverage_failures)
 {
   if (coverage_failures.length) {
-    debugger;
     throw JSON.stringify(coverage_failures);
   }
   return "pass";
@@ -2188,7 +2187,7 @@ export default function define(runtime, observer) {
   $def("_1rtpyzk", "cellMapVizView", ["viewof cellMapViz"], _1rtpyzk);  
   $def("_1srzrzc", null, ["md"], _1srzrzc);  
   $def("_1hybsm8", "coverage_failures", ["runtime_variables","liveCellMap","modules"], _1hybsm8);  
-  $def("_4tg5tm", "test_cell_map_covers_all_runtime_variables", ["coverage_failures"], _4tg5tm);  
+  $def("_1p0qclg", "test_cell_map_covers_all_runtime_variables", ["coverage_failures"], _1p0qclg);  
   $def("_1a18z7a", "test_cell_map_no_variable_in_more_than_one_cell", ["runtime_variables","liveCellMap","modules"], _1a18z7a);  
   $def("_8nkqnx", null, ["md"], _8nkqnx);  
   $def("_2h3a9s", "importedModule", [], _2h3a9s);  
@@ -2246,17 +2245,29 @@ const _1i8jhrq = function _copyCellButton(Inputs,cellsToClipboard){return(
 (cells) =>
   Inputs.button("Copy cells", { reduce: () => cellsToClipboard(cells) })
 )};
-const _1imaqds = function _makeCell($0,defaultJS,defaultOther){return(
-(value) => {
+const _1ud4fa1 = function _makeCell($0,defaultJS,defaultOther){return(
+value => {
   const id = $0.value++;
-  debugger;
-  if (typeof value === "string") {
-    return { ...defaultJS, id, value };
-  } else if (typeof value === "object") {
-    if (value.type === "js") return { ...defaultJS, id, ...value };
-    return { ...defaultOther, id, ...value };
+  if (typeof value === 'string') {
+    return {
+      ...defaultJS,
+      id,
+      value
+    };
+  } else if (typeof value === 'object') {
+    if (value.type === 'js')
+      return {
+        ...defaultJS,
+        id,
+        ...value
+      };
+    return {
+      ...defaultOther,
+      id,
+      ...value
+    };
   } else {
-    throw new Error("Value must be string or object");
+    throw new Error('Value must be string or object');
   }
 }
 )};
@@ -2299,7 +2310,7 @@ export default function define(runtime, observer) {
   $def("_10uloef", null, ["md"], _10uloef);  
   $def("_1seifpc", "cellsToClipboard", ["makeCell"], _1seifpc);  
   $def("_1i8jhrq", "copyCellButton", ["Inputs","cellsToClipboard"], _1i8jhrq);  
-  $def("_1imaqds", "makeCell", ["mutable id","defaultJS","defaultOther"], _1imaqds);  
+  $def("_1ud4fa1", "makeCell", ["mutable id","defaultJS","defaultOther"], _1ud4fa1);  
   $def("_h1t91h", "defaultJS", [], _h1t91h);  
   $def("_but2s9", "defaultOther", [], _but2s9);  
   $def("_lj7470", "initial id", [], _lj7470);  
@@ -14037,188 +14048,196 @@ const _1nzpnqy = function _visualizer_cache(reload)
     reload;
     return new Map();
 };
-const _1l35721 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
+const _1ojown8 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
 {
-    return function (container, component) {
-        appendScrollLog('modulePanel:enter', {
-            title: container?.title ?? null,
-            componentCell: component?.cell ?? null
-        });
-        const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
-        if (!moduleInfo) {
-            // Fall through to file attachment: titles like @user/notebook/path.ext
-            // resolve via the lopecode bootloader's contentSync DOM lookup.
-            const title = container?.title ?? null;
-            if (title) {
-                let node = file_attachment_cache.get(title);
-                if (!node) {
-                    const r = window.lopecode?.contentSync?.(title);
-                    if (r && r.status === 200 && r.bytes) {
-                        node = renderFileAttachment(r.mime, r.bytes);
-                        file_attachment_cache.set(title, node);
-                        appendScrollLog('modulePanel:file_attachment_create', {
-                            title,
-                            mime: r.mime
-                        });
-                    }
-                }
-                if (node) {
-                    const c_element = container.getElement();
-                    if (node.parentNode !== c_element)
-                        c_element.appendChild(node);
-                    appendScrollLog('modulePanel:file_attachment_mount', { title });
-                    return;
-                }
-            }
-            appendScrollLog('modulePanel:missing_moduleInfo', { title });
-            return;
-        }
-        const module = moduleInfo.module;
-        let node;
-        if (!visualizer_cache.has(module)) {
-            appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
-            node = visualizer(runtime, {
-                invalidation: new Promise(r => {
-                }),
-                module,
-                detachNodes: isOnObservableCom(),
-                filter: (cell_name, variables) => {
-                    if (variables[0]._type !== 1)
-                        return false;
-                    if (typeof cell_name == 'string') {
-                        if (cell_name.startsWith('dynamic '))
-                            return false;
-                    }
-                    return true;
-                }
+  return function (container, component) {
+    appendScrollLog('modulePanel:enter', {
+      title: container?.title ?? null,
+      componentCell: component?.cell ?? null
+    });
+    const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
+    if (!moduleInfo) {
+      // Fall through to file attachment: titles like @user/notebook/path.ext
+      // resolve via the lopecode bootloader's contentSync DOM lookup.
+      const title = container?.title ?? null;
+      if (title) {
+        let node = file_attachment_cache.get(title);
+        if (!node) {
+          const r = window.lopecode?.contentSync?.(title);
+          if (r && r.status === 200 && r.bytes) {
+            node = renderFileAttachment(r.mime, r.bytes);
+            file_attachment_cache.set(title, node);
+            appendScrollLog('modulePanel:file_attachment_create', {
+              title,
+              mime: r.mime
             });
-            visualizer_cache.set(module, node);
-        } else {
-            node = visualizer_cache.get(module);
-            appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+          }
         }
-        const cell = module._scope.get(component.cell);
-        const scrollKey = scrollKeyFor(container);
-        fix_scroll(container, node, cell, scrollKey);
-        const el = container.getElement();
-        if (!el.__lope_scroll_bound) {
-            el.__lope_scroll_bound = true;
-            appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
-            const markUserScroll = () => { el.__lope_user_scroll_at = Date.now(); };
-            el.addEventListener('wheel', markUserScroll, { passive: true });
-            el.addEventListener('touchmove', markUserScroll, { passive: true });
-            el.addEventListener('keydown', markUserScroll, { passive: true });
-            el.addEventListener('scroll', () => {
-                if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
-                    appendScrollLog('scroll:skip_reflow', { title: container?.title ?? null });
-                    return;
-                }
-                // Only cache scrolls following a genuine user gesture; reflow-induced
-                // scroll events (e.g. closing an adjacent panel) carry stale scrollTops.
-                if (Date.now() - (el.__lope_user_scroll_at || 0) > 400) {
-                    appendScrollLog('scroll:skip_nonuser', { title: container?.title ?? null });
-                    return;
-                }
-                const k = scrollKeyFor(container);
-                const scrollTop = el.scrollTop;
-                const scrollLeft = el.scrollLeft;
-                if (scrollTop == 0) {
-                    appendScrollLog('modulePanel:skip 0 scroll', {
-                        title: container?.title ?? null,
-                        scrollKey
-                    });
-                    return;
-                }
-                scroll_cache.set(k, {
-                    scrollTop,
-                    scrollLeft,
-                    t: Date.now()
-                });
-                appendScrollLog('scroll:event', {
-                    k,
-                    title: container?.title ?? null,
-                    scrollTop,
-                    scrollLeft
-                });
-            }, { passive: true });
+        if (node) {
+          const c_element = container.getElement();
+          if (node.parentNode !== c_element)
+            c_element.appendChild(node);
+          appendScrollLog('modulePanel:file_attachment_mount', { title });
+          return;
         }
-        // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
-        if (!container.__lope_destroy_bound) {
-            container.__lope_destroy_bound = true;
-            container.on('destroy', () => {
-                try {
-                    if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
-                        appendScrollLog('scroll:destroy_skip_reflow', { title: container?.title ?? null });
-                        return;
-                    }
-                    const k = scrollKeyFor(container);
-                    const scrollTop = el?.scrollTop;
-                    const scrollLeft = el?.scrollLeft;
-                    if (scrollTop == 0) {
-                        appendScrollLog('scroll:skip 0 scroll', {
-                            k,
-                            key: container?.title ?? null,
-                            scrollKey
-                        });
-                        return;
-                    }
-                    // do not skip 0 here: if the user is at top, preserve that state
-                    scroll_cache.set(k, {
-                        scrollTop,
-                        scrollLeft,
-                        t: Date.now()
-                    });
-                    appendScrollLog('scroll:destroy_capture', {
-                        k,
-                        title: container?.title ?? null,
-                        scrollTop,
-                        scrollLeft
-                    });
-                } catch (e) {
-                    appendScrollLog('scroll:destroy_capture:error', {
-                        title: container?.title ?? null,
-                        error: String(e)
-                    });
-                }
-            });
+      }
+      appendScrollLog('modulePanel:missing_moduleInfo', { title });
+      return;
+    }
+    const module = moduleInfo.module;
+    let node;
+    if (!visualizer_cache.has(module)) {
+      appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
+      node = visualizer(runtime, {
+        invalidation: new Promise(r => {
+        }),
+        module,
+        detachNodes: isOnObservableCom(),
+        filter: (cell_name, variables) => {
+          if (variables[0]._type !== 1)
+            return false;
+          if (typeof cell_name == 'string') {
+            if (cell_name.startsWith('dynamic '))
+              return false;
+          }
+          return true;
         }
-        // When GoldenLayout resizes this panel (e.g. an adjacent panel is closed) the
-        // browser can shift scrollTop; re-apply the user's cached position after the reflow.
-        if (!container.__lope_resize_bound) {
-            container.__lope_resize_bound = true;
-            container.on('resize', () => {
-                const rk = scrollKeyFor(container);
-                const cached = scroll_cache.get(rk);
-                if (!cached || cached.scrollTop == null)
-                    return;
-                const c_el = container.getElement();
-                const at = Date.now();
-                scroll_cache.__reflowUntil = at + 800;
-                // The reflow can shift scrollTop in several passes (content relayout
-                // settles ~300ms later), so re-apply over a window. Bail if the user scrolls.
-                const apply = () => {
-                    if ((c_el.__lope_user_scroll_at || 0) > at)
-                        return;
-                    if (c_el.scrollTop !== cached.scrollTop)
-                        c_el.scrollTop = cached.scrollTop;
-                    if (cached.scrollLeft != null && c_el.scrollLeft !== cached.scrollLeft)
-                        c_el.scrollLeft = cached.scrollLeft;
-                };
-                requestAnimationFrame(apply);
-                for (const d of [60, 150, 300, 450, 600])
-                    setTimeout(apply, d);
-                appendScrollLog('scroll:resize_restore', {
-                    k: rk,
-                    title: container?.title ?? null,
-                    scrollTop: cached.scrollTop
-                });
-            });
+      });
+      visualizer_cache.set(module, node);
+    } else {
+      node = visualizer_cache.get(module);
+      appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+    }
+    const cell = module._scope.get(component.cell);
+    const scrollKey = scrollKeyFor(container);
+    fix_scroll(container, node, cell, scrollKey);
+    const el = container.getElement();
+    if (!el.__lope_scroll_bound) {
+      el.__lope_scroll_bound = true;
+      appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
+      const markUserScroll = () => {
+        el.__lope_user_scroll_at = Date.now();
+      };
+      el.addEventListener('wheel', markUserScroll, { passive: true });
+      el.addEventListener('touchmove', markUserScroll, { passive: true });
+      el.addEventListener('keydown', markUserScroll, { passive: true });
+      el.addEventListener('scroll', () => {
+        if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+          appendScrollLog('scroll:skip_reflow', { title: container?.title ?? null });
+          return;
         }
-        appendScrollLog('modulePanel:exit', {
+        // Only cache scrolls following a genuine user gesture; reflow-induced
+        // scroll events (e.g. closing an adjacent panel) carry stale scrollTops.
+        if (Date.now() - (el.__lope_user_scroll_at || 0) > 400) {
+          appendScrollLog('scroll:skip_nonuser', { title: container?.title ?? null });
+          return;
+        }
+        const k = scrollKeyFor(container);
+        const scrollTop = el.scrollTop;
+        const scrollLeft = el.scrollLeft;
+        if (scrollTop == 0) {
+          appendScrollLog('modulePanel:skip 0 scroll', {
             title: container?.title ?? null,
             scrollKey
+          });
+          return;
+        }
+        scroll_cache.set(k, {
+          scrollTop,
+          scrollLeft,
+          t: Date.now()
         });
-    };
+        appendScrollLog('scroll:event', {
+          k,
+          title: container?.title ?? null,
+          scrollTop,
+          scrollLeft
+        });
+      }, { passive: true });
+    }
+    // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
+    if (!container.__lope_destroy_bound) {
+      container.__lope_destroy_bound = true;
+      container.on('destroy', () => {
+        try {
+          if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+            appendScrollLog('scroll:destroy_skip_reflow', { title: container?.title ?? null });
+            return;
+          }
+          const k = scrollKeyFor(container);
+          const scrollTop = el?.scrollTop;
+          const scrollLeft = el?.scrollLeft;
+          if (scrollTop == 0) {
+            appendScrollLog('scroll:skip 0 scroll', {
+              k,
+              key: container?.title ?? null,
+              scrollKey
+            });
+            return;
+          }
+          // do not skip 0 here: if the user is at top, preserve that state
+          scroll_cache.set(k, {
+            scrollTop,
+            scrollLeft,
+            t: Date.now()
+          });
+          appendScrollLog('scroll:destroy_capture', {
+            k,
+            title: container?.title ?? null,
+            scrollTop,
+            scrollLeft
+          });
+        } catch (e) {
+          appendScrollLog('scroll:destroy_capture:error', {
+            title: container?.title ?? null,
+            error: String(e)
+          });
+        }
+      });
+    }
+    // When GoldenLayout resizes this panel (e.g. an adjacent panel is closed) the
+    // browser can shift scrollTop; re-apply the user's cached position after the reflow.
+    if (!container.__lope_resize_bound) {
+      container.__lope_resize_bound = true;
+      container.on('resize', () => {
+        const rk = scrollKeyFor(container);
+        const cached = scroll_cache.get(rk);
+        if (!cached || cached.scrollTop == null)
+          return;
+        const c_el = container.getElement();
+        const at = Date.now();
+        scroll_cache.__reflowUntil = at + 800;
+        // The reflow can shift scrollTop in several passes (content relayout
+        // settles ~300ms later), so re-apply over a window. Bail if the user scrolls.
+        const apply = () => {
+          if ((c_el.__lope_user_scroll_at || 0) > at)
+            return;
+          if (c_el.scrollTop !== cached.scrollTop)
+            c_el.scrollTop = cached.scrollTop;
+          if (cached.scrollLeft != null && c_el.scrollLeft !== cached.scrollLeft)
+            c_el.scrollLeft = cached.scrollLeft;
+        };
+        requestAnimationFrame(apply);
+        for (const d of [
+            60,
+            150,
+            300,
+            450,
+            600
+          ])
+          setTimeout(apply, d);
+        appendScrollLog('scroll:resize_restore', {
+          k: rk,
+          title: container?.title ?? null,
+          scrollTop: cached.scrollTop
+        });
+      });
+    }
+    appendScrollLog('modulePanel:exit', {
+      title: container?.title ?? null,
+      scrollKey
+    });
+  };
 };
 const _1gm4gbf = function _blobPanel(){return(
 function (container, component) {
@@ -14336,113 +14355,115 @@ const _1d1nkw9 = function _scrollKeyFor(appendScrollLog)
 const _tb217h = function _scroll_cache(){return(
 new Map()
 )};
-const _5tyvpe = function _fix_scroll(scrollKeyFor,appendScrollLog,scroll_cache){return(
-function (container, node, cell_variable, key) {
-    scroll_cache.__reflowUntil = Date.now() + 600; // suppress reflow-induced scroll events that clobber the cache
+const _12p8mg7 = function _fix_scroll(scroll_cache,scrollKeyFor,appendScrollLog)
+{
+  return function (container, node, cell_variable, key) {
+    scroll_cache.__reflowUntil = Date.now() + 600;
+    // suppress reflow-induced scroll events that clobber the cache
     const c_element = container.getElement();
     let k = scrollKeyFor(container);
     appendScrollLog('fix_scroll:enter', {
-        title: container?.title ?? null,
-        k,
-        cell: cell_variable?._name ?? null
+      title: container?.title ?? null,
+      k,
+      cell: cell_variable?._name ?? null
     });
     if (node && node.parentNode !== c_element) {
-        c_element.appendChild(node);
-        appendScrollLog('fix_scroll:append_node', {
-            title: container?.title ?? null,
-            k
-        });
+      c_element.appendChild(node);
+      appendScrollLog('fix_scroll:append_node', {
+        title: container?.title ?? null,
+        k
+      });
     }
     const writeCache = (scrollTop, scrollLeft, why) => {
-        scroll_cache.set(k, {
-            scrollTop,
-            scrollLeft,
-            t: Date.now()
-        });
-        appendScrollLog('scroll_cache:write', {
-            k,
-            scrollTop,
-            scrollLeft,
-            why
-        });
+      scroll_cache.set(k, {
+        scrollTop,
+        scrollLeft,
+        t: Date.now()
+      });
+      appendScrollLog('scroll_cache:write', {
+        k,
+        scrollTop,
+        scrollLeft,
+        why
+      });
     };
     const scrollToCellIfPossible = why => {
-        if (!cell_variable)
-            return false;
-        const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
-        if (!dom) {
-            appendScrollLog('scroll:cell_dom_not_found', {
-                k,
-                why,
-                cell: cell_variable?._name ?? null
-            });
-            return false;
-        }
-        const top = dom.offsetTop - c_element.offsetTop;
-        const left = c_element.scrollLeft;
-        c_element.scrollTop = top;
-        appendScrollLog('scroll:set', {
-            k,
-            why: `${ why }:cell`,
-            scrollTop: top,
-            scrollLeft: left,
-            cell: cell_variable?._name ?? null
+      if (!cell_variable)
+        return false;
+      const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
+      if (!dom) {
+        appendScrollLog('scroll:cell_dom_not_found', {
+          k,
+          why,
+          cell: cell_variable?._name ?? null
         });
-        writeCache(top, left, `${ why }:cell`);
-        return true;
+        return false;
+      }
+      const top = dom.offsetTop - c_element.offsetTop;
+      const left = c_element.scrollLeft;
+      c_element.scrollTop = top;
+      appendScrollLog('scroll:set', {
+        k,
+        why: `${ why }:cell`,
+        scrollTop: top,
+        scrollLeft: left,
+        cell: cell_variable?._name ?? null
+      });
+      writeCache(top, left, `${ why }:cell`);
+      return true;
     };
     const restoreFromCache = why => {
-        k = scrollKeyFor(container);
-        const cached = scroll_cache.get(k);
-        appendScrollLog('scroll:restore_attempt', {
-            k,
-            why,
-            cachedScrollTop: cached?.scrollTop ?? null,
-            cachedScrollLeft: cached?.scrollLeft ?? null
+      k = scrollKeyFor(container);
+      const cached = scroll_cache.get(k);
+      appendScrollLog('scroll:restore_attempt', {
+        k,
+        why,
+        cachedScrollTop: cached?.scrollTop ?? null,
+        cachedScrollLeft: cached?.scrollLeft ?? null
+      });
+      if (!cached) {
+        appendScrollLog('scroll:restore_no_scroll', {
+          k,
+          why
         });
-        if (!cached) {
-            appendScrollLog('scroll:restore_no_scroll', {
-                k,
-                why
-            });
-            return;
-        }
-        if (cached.scrollTop != null)
-            c_element.scrollTop = cached.scrollTop;
-        if (cached.scrollLeft != null)
-            c_element.scrollLeft = cached.scrollLeft;
-        appendScrollLog('scroll:restore_applied', {
-            k,
-            why,
-            scrollTop: cached.scrollTop ?? null,
-            scrollLeft: cached.scrollLeft ?? null,
-            scrollTopFinal: c_element.scrollTop,
-            scrollLeftFinal: c_element.scrollLeft
-        });
+        return;
+      }
+      if (cached.scrollTop != null)
+        c_element.scrollTop = cached.scrollTop;
+      if (cached.scrollLeft != null)
+        c_element.scrollLeft = cached.scrollLeft;
+      appendScrollLog('scroll:restore_applied', {
+        k,
+        why,
+        scrollTop: cached.scrollTop ?? null,
+        scrollLeft: cached.scrollLeft ?? null,
+        scrollTopFinal: c_element.scrollTop,
+        scrollLeftFinal: c_element.scrollLeft
+      });
     };
     const setScroll = (why = 'setScroll') => {
-        if (scrollToCellIfPossible(why))
-            return;
-        restoreFromCache(why);
+      if (scrollToCellIfPossible(why))
+        return;
+      restoreFromCache(why);
     };
     const retryFrames = 6;
     for (let i = 0; i < retryFrames; i++) {
-        requestAnimationFrame(() => {
-            k = scrollKeyFor(container);
-            appendScrollLog('fix_scroll:raf_retry', {
-                i,
-                k,
-                title: container?.title ?? null
-            });
-            setScroll(`raf:${ i }`);
+      requestAnimationFrame(() => {
+        k = scrollKeyFor(container);
+        appendScrollLog('fix_scroll:raf_retry', {
+          i,
+          k,
+          title: container?.title ?? null
         });
+        setScroll(`raf:${ i }`);
+      });
     }
     appendScrollLog('fix_scroll:exit', {
-        k,
-        title: container?.title ?? null
+      k,
+      title: container?.title ?? null
     });
-}
-)};
+  };
+};
 const _arfw00 = function _scroll_fix_sync_layout(sync_layout_to_url,layout,appendScrollLog,modulePanel)
 {
     sync_layout_to_url;
@@ -15520,7 +15541,7 @@ export default function define(runtime, observer) {
   $def("_1we0ggl", "reload", ["Generators","viewof reload"], _1we0ggl);  
   $def("_plefwg", "onLoadConfig", ["parseGoldenDSL","URLSearchParams","location"], _plefwg);  
   $def("_1nzpnqy", "visualizer_cache", ["reload"], _1nzpnqy);  
-  $def("_1l35721", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1l35721);  
+  $def("_1ojown8", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1ojown8);  
   $def("_1gm4gbf", "blobPanel", [], _1gm4gbf);  
   $def("_lxv2e2", "settings", [], _lxv2e2);  
   $def("_lp1ggk", "is_mobile", ["width"], _lp1ggk);  
@@ -15541,7 +15562,7 @@ export default function define(runtime, observer) {
   $def("_1dyz4o0", "scrollLog", ["mutable scrollLog"], _1dyz4o0);  
   $def("_1d1nkw9", "scrollKeyFor", ["appendScrollLog"], _1d1nkw9);  
   $def("_tb217h", "scroll_cache", [], _tb217h);  
-  $def("_5tyvpe", "fix_scroll", ["scrollKeyFor","appendScrollLog","scroll_cache"], _5tyvpe);  
+  $def("_12p8mg7", "fix_scroll", ["scroll_cache","scrollKeyFor","appendScrollLog"], _12p8mg7);  
   $def("_arfw00", "scroll_fix_sync_layout", ["sync_layout_to_url","layout","appendScrollLog","modulePanel"], _arfw00);  
   $def("_3nwpp4", "URLrouting", ["md"], _3nwpp4);  
   $def("_14te9pl", "sync_layout_from_url", ["reload","resize","URLSearchParams","hash","appendScrollLog","parseGoldenDSL","gl","layout","serializeGoldenDSL","treeSyncGolden","invalidation"], _14te9pl);  
@@ -23686,11 +23707,13 @@ md`### interval
 
 https://rxjs.dev/api/index/function/interval`
 )};
-const _bz8ib5 = function _interval(Inputs,Event){return(
+const _px7gfx = function _interval(Inputs,Event){return(
 function interval({period = 0, invalidation}) {
   const result = Inputs.input();
   let count = 0;
+  debugger;
   const onTick = () => {
+    debugger;
     result.value = count++;
     result.dispatchEvent(new Event('input'));
   };
@@ -23883,7 +23906,7 @@ export default function define(runtime, observer) {
   $def("_xvoqqz", null, ["md"], _xvoqqz);  
   $def("_1sychb7", null, ["md"], _1sychb7);  
   $def("_1a3sdj9", null, ["md"], _1a3sdj9);  
-  $def("_bz8ib5", "interval", ["Inputs","Event"], _bz8ib5);  
+  $def("_px7gfx", "interval", ["Inputs","Event"], _px7gfx);  
   $def("_11meps1", null, ["md"], _11meps1);  
   $def("_sdzl0o", "map", ["Inputs","Event"], _sdzl0o);  
   $def("_zawuyh", null, ["md"], _zawuyh);  
@@ -24381,138 +24404,138 @@ import {themes, theme_properties, css} from "@tomlarkworthy/themes"
 \`\`\`
 `
 )};
-const _1clcodb = function _theme_assets(Inputs,themes,current_theme){return(
+const _x91dc7 = function _theme_assets(Inputs,themes,current_theme){return(
 Inputs.select(themes, {
-    label: 'Theme',
-    value: current_theme || themes.get('near-midnight')
+  label: 'Theme',
+  value: current_theme || themes.get('near-midnight')
 })
 )};
 const _1sdw5pf = (G, _) => G.input(_);
 const _1wzah21 = function _theme_name(themes,theme_assets){return(
 [...themes.entries()].find(([, assets]) => assets === theme_assets)?.[0] ?? 'unknown'
 )};
-const _nz55m5 = function _4(css,themes,theme_assets,html)
+const _zy6iu8 = function _apply_theme(css,themes,theme_assets,html)
 {
-    const view = document.defaultView;
-    const sheets = [];
-    for (const [url, text] of css) {
-        if (typeof text !== 'string')
-            continue;
-        try {
-            const sheet = new view.CSSStyleSheet();
-            sheet.replaceSync(text);
-            sheets.push(sheet);
-        } catch (e) {
-            console.warn('Could not adopt stylesheet', url, e);
-        }
+  const view = document.defaultView;
+  const sheets = [];
+  for (const [url, text] of css) {
+    if (typeof text !== 'string')
+      continue;
+    try {
+      const sheet = new view.CSSStyleSheet();
+      sheet.replaceSync(text);
+      sheets.push(sheet);
+    } catch (e) {
+      console.warn('Could not adopt stylesheet', url, e);
     }
-    document.adoptedStyleSheets = sheets;
-    // Sync embedded <script id="<url>" data-mime="text/css"> cache blocks so
-    // current_theme (which sniffs by document.getElementById) and the next
-    // export reflect the live selection. Only touches blocks that belong to
-    // known theme URLs — leaves unrelated CSS asset blocks alone.
-    const knownThemeUrls = new Set();
-    for (const list of themes.values())
-        for (const u of list)
-            knownThemeUrls.add(u);
-    for (const u of knownThemeUrls) {
-        if (!theme_assets.includes(u))
-            document.getElementById(u)?.remove();
+  }
+  document.adoptedStyleSheets = sheets;
+  // Sync embedded <script id="<url>" data-mime="text/css"> cache blocks so
+  // current_theme (which sniffs by document.getElementById) and the next
+  // export reflect the live selection. Only touches blocks that belong to
+  // known theme URLs — leaves unrelated CSS asset blocks alone.
+  const knownThemeUrls = new Set();
+  for (const list of themes.values())
+    for (const u of list)
+      knownThemeUrls.add(u);
+  for (const u of knownThemeUrls) {
+    if (!theme_assets.includes(u))
+      document.getElementById(u)?.remove();
+  }
+  for (const [url, text] of css) {
+    if (!url || !url.startsWith('http'))
+      continue;
+    if (!theme_assets.includes(url))
+      continue;
+    let s = document.getElementById(url);
+    if (!s) {
+      s = document.createElement('script');
+      s.id = url;
+      s.type = 'text/plain';
+      s.setAttribute('data-mime', 'text/css');
+      document.head.appendChild(s);
     }
-    for (const [url, text] of css) {
-        if (!url || !url.startsWith('http'))
-            continue;
-        if (!theme_assets.includes(url))
-            continue;
-        let s = document.getElementById(url);
-        if (!s) {
-            s = document.createElement('script');
-            s.id = url;
-            s.type = 'text/plain';
-            s.setAttribute('data-mime', 'text/css');
-            document.head.appendChild(s);
-        }
-        // Always replace text so a freshly-fetched theme overwrites stale cache.
-        if (!s.hasAttribute('data-encoding'))
-            s.textContent = text;
-    }
-    return html`<div style="font:11px/1.4 var(--monospace, ui-monospace, monospace);color:var(--theme-foreground-muted);padding:6px 10px;border:1px solid var(--theme-foreground-faintest);border-radius:4px;display:inline-block">Applied ${ sheets.length } stylesheets to the page.</div>`;
+    // Always replace text so a freshly-fetched theme overwrites stale cache.
+    if (!s.hasAttribute('data-encoding'))
+      s.textContent = text;
+  }
+  return html`<div style="font:11px/1.4 var(--monospace, ui-monospace, monospace);color:var(--theme-foreground-muted);padding:6px 10px;border:1px solid var(--theme-foreground-faintest);border-radius:4px;display:inline-block">Applied ${ sheets.length } stylesheets to the page.</div>`;
 };
-const _11pe38r = function _5(theme_properties,html,htl,theme_name){return(
+const _10zmng3 = function _5(theme_properties,html,htl,theme_name){return(
 (() => {
-    const props = theme_properties;
-    const get = k => props[k] || '';
-    const groups = {
-        Background: [
-            '--theme-background',
-            '--theme-background-a',
-            '--theme-background-b',
-            '--theme-background-raised'
-        ],
-        Foreground: [
-            '--theme-foreground',
-            '--theme-foreground-muted',
-            '--theme-foreground-faint',
-            '--theme-foreground-fainter',
-            '--theme-foreground-faintest',
-            '--theme-foreground-focus',
-            '--theme-foreground-error'
-        ],
-        Syntax: [
-            '--syntax-keyword',
-            '--syntax-string',
-            '--syntax-comment',
-            '--syntax-literal',
-            '--syntax-atom',
-            '--syntax-variable',
-            '--syntax-definition'
-        ]
-    };
-    const fonts = [
-        [
-            '--serif',
-            'Serif'
-        ],
-        [
-            '--sans-serif',
-            'Sans-serif'
-        ],
-        [
-            '--monospace',
-            'Monospace'
-        ]
-    ].filter(([k]) => props[k]);
-    const swatch = key => {
-        const value = get(key);
-        if (!value)
-            return '';
-        return html`<div style="display:flex;align-items:center;gap:8px;padding:4px 6px;border-radius:4px;font:12px/1.4 var(--monospace, ui-monospace, monospace)">
+  const props = theme_properties;
+  const get = k => props[k] || '';
+  const groups = {
+    Background: [
+      '--theme-background',
+      '--theme-background-a',
+      '--theme-background-b',
+      '--theme-background-raised'
+    ],
+    Foreground: [
+      '--theme-foreground',
+      '--theme-foreground-muted',
+      '--theme-foreground-faint',
+      '--theme-foreground-fainter',
+      '--theme-foreground-faintest',
+      '--theme-foreground-focus',
+      '--theme-foreground-error'
+    ],
+    Syntax: [
+      '--syntax-keyword',
+      '--syntax-string',
+      '--syntax-comment',
+      '--syntax-literal',
+      '--syntax-atom',
+      '--syntax-variable',
+      '--syntax-definition'
+    ]
+  };
+  const fonts = [
+    [
+      '--serif',
+      'Serif'
+    ],
+    [
+      '--sans-serif',
+      'Sans-serif'
+    ],
+    [
+      '--monospace',
+      'Monospace'
+    ]
+  ].filter(([k]) => props[k]);
+  const swatch = key => {
+    const value = get(key);
+    if (!value)
+      return '';
+    return html`<div style="display:flex;align-items:center;gap:8px;padding:4px 6px;border-radius:4px;font:12px/1.4 var(--monospace, ui-monospace, monospace)">
             <span style="width:28px;height:28px;border-radius:4px;border:1px solid var(--theme-foreground-faintest);background:var(${ key });flex:none"></span>
             <div style="display:flex;flex-direction:column;min-width:0;flex:1">
                 <code style="color:var(--theme-foreground)">${ key }</code>
                 <span style="color:var(--theme-foreground-muted);overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${ value }</span>
             </div>
         </div>`;
-    };
-    const fontSample = ([key, label]) => {
-        const family = get(key);
-        const isMono = /mono/i.test(label) || /mono/i.test(key);
-        return html`<div style="padding:10px 12px;border:1px solid var(--theme-foreground-faintest);border-radius:6px;background:var(--theme-background-a, var(--theme-background))">
+  };
+  const fontSample = ([key, label]) => {
+    const family = get(key);
+    const isMono = /mono/i.test(label) || /mono/i.test(key);
+    return html`<div style="padding:10px 12px;border:1px solid var(--theme-foreground-faintest);border-radius:6px;background:var(--theme-background-a, var(--theme-background))">
             <div style="font:11px/1.2 var(--sans-serif, ui-sans-serif, system-ui);color:var(--theme-foreground-muted);margin-bottom:6px;letter-spacing:0.04em;text-transform:uppercase">${ label }</div>
             <div style="font-family:${ family };font-size:${ isMono ? '14px' : '22px' };line-height:1.3;color:var(--theme-foreground)">
                 ${ isMono ? html`<code>const greeting = "Hello, world";</code>` : 'The quick brown fox jumps over the lazy dog' }
             </div>
             <div style="font:11px/1.4 var(--monospace, ui-monospace, monospace);color:var(--theme-foreground-faint);margin-top:6px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${ family }</div>
         </div>`;
-    };
-    const codeSample = html`<pre style="margin:0;padding:12px;border-radius:6px;background:var(--theme-background-a, var(--theme-background));border:1px solid var(--theme-foreground-faintest);font:13px/1.5 var(--monospace, ui-monospace, monospace);color:var(--theme-foreground);overflow-x:auto"><span style="color:var(--syntax-comment)">// fibonacci</span>
+  };
+  const codeSample = html`<pre style="margin:0;padding:12px;border-radius:6px;background:var(--theme-background-a, var(--theme-background));border:1px solid var(--theme-foreground-faintest);font:13px/1.5 var(--monospace, ui-monospace, monospace);color:var(--theme-foreground);overflow-x:auto"><span style="color:var(--syntax-comment)">// fibonacci</span>
 <span style="color:var(--syntax-keyword)">function</span> <span style="color:var(--syntax-definition)">fib</span>(<span style="color:var(--syntax-variable)">n</span>) {
   <span style="color:var(--syntax-keyword)">if</span> (n &lt; <span style="color:var(--syntax-literal)">2</span>) <span style="color:var(--syntax-keyword)">return</span> n;
   <span style="color:var(--syntax-keyword)">return</span> <span style="color:var(--syntax-string)">\`fib(\${n})\`</span>;
 }
 <span style="color:var(--syntax-keyword)">const</span> result = fib(<span style="color:var(--syntax-literal)">10</span>);
 <span style="color:var(--syntax-keyword)">return</span> <span style="color:var(--syntax-atom)">null</span>;</pre>`;
-    return htl.html`<div style="background:var(--theme-background);color:var(--theme-foreground);padding:16px;border-radius:8px;font-family:var(--serif, var(--sans-serif, ui-sans-serif, system-ui))">
+  return htl.html`<div style="background:var(--theme-background);color:var(--theme-foreground);padding:16px;border-radius:8px;font-family:var(--serif, var(--sans-serif, ui-sans-serif, system-ui))">
         <div style="display:flex;align-items:baseline;gap:12px;margin-bottom:14px">
             <h3 style="margin:0;font-family:var(--serif, var(--sans-serif, ui-sans-serif));color:var(--theme-foreground)">${ theme_name }</h3>
             <span style="font:12px/1 var(--monospace, ui-monospace, monospace);color:var(--theme-foreground-muted)">theme preview</span>
@@ -24542,190 +24565,190 @@ md`## All CSS variables
 
 Every CSS custom property parsed from the active theme. \`theme_properties\` is exported as a plain JS object so other notebooks can consume theme values programmatically (canvas colors, chart palettes, inline styles) without parsing CSS.`
 )};
-const _1hu8vay = function _7(htl,theme_properties,html){return(
+const _18nx47m = function _7(htl,theme_properties,html){return(
 htl.html`<details style="background: var(--theme-background); color: var(--theme-foreground); padding: 12px; border-radius: 6px;">
 <summary style="cursor:pointer;font-weight:600">Show all ${ Object.keys(theme_properties).length } properties</summary>
 
 ${ Object.entries(theme_properties).map(([key, value]) => {
-    const isColor = /^(#|rgb|hsl|color-mix)/.test(value) || /^var\(--theme-(foreground|background|error)/.test(value);
-    return html`<p style="margin:4px 0"><span style="width: 16px; height: 16px; border-radius: 3px; border: 1px solid var(--theme-foreground-faintest); background: ${ isColor ? 'var(' + key + ')' : 'transparent' }; display: inline-block; vertical-align: middle;"></span> <code>${ key }</code> <span style="color: var(--theme-foreground-muted)">${ value }</span></p>`;
+  const isColor = /^(#|rgb|hsl|color-mix)/.test(value) || /^var\(--theme-(foreground|background|error)/.test(value);
+  return html`<p style="margin:4px 0"><span style="width: 16px; height: 16px; border-radius: 3px; border: 1px solid var(--theme-foreground-faintest); background: ${ isColor ? 'var(' + key + ')' : 'transparent' }; display: inline-block; vertical-align: middle;"></span> <code>${ key }</code> <span style="color: var(--theme-foreground-muted)">${ value }</span></p>`;
 }) }
 
 </details>
 `
 )};
-const _1k4keny = function _theme_properties(css){return(
+const _ebjyl2 = function _theme_properties(css){return(
 (() => {
-    const props = {};
-    for (const [url, text] of css) {
-        if (typeof text !== 'string')
-            continue;
-        for (const match of text.matchAll(/^\s+(--[a-z0-9-]+)\s*:\s*([^;]+);/gm)) {
-            props[match[1]] = match[2].trim();
-        }
+  const props = {};
+  for (const [url, text] of css) {
+    if (typeof text !== 'string')
+      continue;
+    for (const match of text.matchAll(/^\s+(--[a-z0-9-]+)\s*:\s*([^;]+);/gm)) {
+      props[match[1]] = match[2].trim();
     }
-    return props;
+  }
+  return props;
 })()
 )};
 const _iny180 = function _9(md){return(
 md`## Implementation`
 )};
-const _vhnhz5 = function _themes()
+const _p0at3d = function _themes()
 {
-    const baseURL = 'https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/';
-    return new Map(Object.entries({
-        air: [
-            baseURL + 'global.css',
-            baseURL + 'inspector.css',
-            baseURL + 'highlight.css',
-            baseURL + 'plot.css',
-            baseURL + 'index.css',
-            baseURL + 'theme-air.css',
-            baseURL + 'abstract-light.css',
-            baseURL + 'syntax-light.css'
-        ],
-        coffee: [
-            baseURL + 'global.css',
-            baseURL + 'inspector.css',
-            baseURL + 'highlight.css',
-            baseURL + 'plot.css',
-            baseURL + 'index.css',
-            baseURL + 'theme-coffee.css',
-            baseURL + 'abstract-dark.css',
-            baseURL + 'syntax-dark.css'
-        ],
-        cotton: [
-            baseURL + 'global.css',
-            baseURL + 'inspector.css',
-            baseURL + 'highlight.css',
-            baseURL + 'plot.css',
-            baseURL + 'index.css',
-            baseURL + 'theme-cotton.css',
-            baseURL + 'abstract-light.css',
-            baseURL + 'syntax-light.css'
-        ],
-        'deep-space': [
-            baseURL + 'global.css',
-            baseURL + 'inspector.css',
-            baseURL + 'highlight.css',
-            baseURL + 'plot.css',
-            baseURL + 'index.css',
-            baseURL + 'theme-deep-space.css',
-            baseURL + 'syntax-dark.css'
-        ],
-        glacier: [
-            baseURL + 'global.css',
-            baseURL + 'inspector.css',
-            baseURL + 'highlight.css',
-            baseURL + 'plot.css',
-            baseURL + 'index.css',
-            baseURL + 'theme-glacier.css',
-            baseURL + 'abstract-light.css',
-            baseURL + 'syntax-light.css'
-        ],
-        ink: [
-            baseURL + 'global.css',
-            baseURL + 'inspector.css',
-            baseURL + 'highlight.css',
-            baseURL + 'plot.css',
-            baseURL + 'index.css',
-            baseURL + 'theme-ink.css',
-            baseURL + 'abstract-dark.css',
-            baseURL + 'syntax-dark.css'
-        ],
-        midnight: [
-            baseURL + 'global.css',
-            baseURL + 'inspector.css',
-            baseURL + 'highlight.css',
-            baseURL + 'plot.css',
-            baseURL + 'index.css',
-            baseURL + 'theme-midnight.css',
-            baseURL + 'abstract-dark.css',
-            baseURL + 'syntax-dark.css'
-        ],
-        'near-midnight': [
-            baseURL + 'global.css',
-            baseURL + 'inspector.css',
-            baseURL + 'highlight.css',
-            baseURL + 'plot.css',
-            baseURL + 'index.css',
-            baseURL + 'theme-near-midnight.css',
-            baseURL + 'abstract-dark.css',
-            baseURL + 'syntax-dark.css'
-        ],
-        'ocean-floor': [
-            baseURL + 'global.css',
-            baseURL + 'inspector.css',
-            baseURL + 'highlight.css',
-            baseURL + 'plot.css',
-            baseURL + 'index.css',
-            baseURL + 'theme-ocean-floor.css',
-            baseURL + 'abstract-dark.css',
-            baseURL + 'syntax-dark.css'
-        ],
-        parchment: [
-            baseURL + 'global.css',
-            baseURL + 'inspector.css',
-            baseURL + 'highlight.css',
-            baseURL + 'plot.css',
-            baseURL + 'index.css',
-            baseURL + 'theme-parchment.css',
-            baseURL + 'abstract-light.css',
-            baseURL + 'syntax-light.css'
-        ],
-        slate: [
-            baseURL + 'global.css',
-            baseURL + 'inspector.css',
-            baseURL + 'highlight.css',
-            baseURL + 'plot.css',
-            baseURL + 'index.css',
-            baseURL + 'theme-slate.css',
-            baseURL + 'abstract-dark.css',
-            baseURL + 'syntax-dark.css'
-        ],
-        stark: [
-            baseURL + 'global.css',
-            baseURL + 'inspector.css',
-            baseURL + 'highlight.css',
-            baseURL + 'plot.css',
-            baseURL + 'index.css',
-            baseURL + 'theme-stark.css',
-            baseURL + 'syntax-dark.css'
-        ],
-        'sun-faded': [
-            baseURL + 'global.css',
-            baseURL + 'inspector.css',
-            baseURL + 'highlight.css',
-            baseURL + 'plot.css',
-            baseURL + 'index.css',
-            baseURL + 'theme-sun-faded.css',
-            baseURL + 'abstract-dark.css',
-            baseURL + 'syntax-dark.css'
-        ]
-    }));
+  const baseURL = 'https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/';
+  return new Map(Object.entries({
+    air: [
+      baseURL + 'global.css',
+      baseURL + 'inspector.css',
+      baseURL + 'highlight.css',
+      baseURL + 'plot.css',
+      baseURL + 'index.css',
+      baseURL + 'theme-air.css',
+      baseURL + 'abstract-light.css',
+      baseURL + 'syntax-light.css'
+    ],
+    coffee: [
+      baseURL + 'global.css',
+      baseURL + 'inspector.css',
+      baseURL + 'highlight.css',
+      baseURL + 'plot.css',
+      baseURL + 'index.css',
+      baseURL + 'theme-coffee.css',
+      baseURL + 'abstract-dark.css',
+      baseURL + 'syntax-dark.css'
+    ],
+    cotton: [
+      baseURL + 'global.css',
+      baseURL + 'inspector.css',
+      baseURL + 'highlight.css',
+      baseURL + 'plot.css',
+      baseURL + 'index.css',
+      baseURL + 'theme-cotton.css',
+      baseURL + 'abstract-light.css',
+      baseURL + 'syntax-light.css'
+    ],
+    'deep-space': [
+      baseURL + 'global.css',
+      baseURL + 'inspector.css',
+      baseURL + 'highlight.css',
+      baseURL + 'plot.css',
+      baseURL + 'index.css',
+      baseURL + 'theme-deep-space.css',
+      baseURL + 'syntax-dark.css'
+    ],
+    glacier: [
+      baseURL + 'global.css',
+      baseURL + 'inspector.css',
+      baseURL + 'highlight.css',
+      baseURL + 'plot.css',
+      baseURL + 'index.css',
+      baseURL + 'theme-glacier.css',
+      baseURL + 'abstract-light.css',
+      baseURL + 'syntax-light.css'
+    ],
+    ink: [
+      baseURL + 'global.css',
+      baseURL + 'inspector.css',
+      baseURL + 'highlight.css',
+      baseURL + 'plot.css',
+      baseURL + 'index.css',
+      baseURL + 'theme-ink.css',
+      baseURL + 'abstract-dark.css',
+      baseURL + 'syntax-dark.css'
+    ],
+    midnight: [
+      baseURL + 'global.css',
+      baseURL + 'inspector.css',
+      baseURL + 'highlight.css',
+      baseURL + 'plot.css',
+      baseURL + 'index.css',
+      baseURL + 'theme-midnight.css',
+      baseURL + 'abstract-dark.css',
+      baseURL + 'syntax-dark.css'
+    ],
+    'near-midnight': [
+      baseURL + 'global.css',
+      baseURL + 'inspector.css',
+      baseURL + 'highlight.css',
+      baseURL + 'plot.css',
+      baseURL + 'index.css',
+      baseURL + 'theme-near-midnight.css',
+      baseURL + 'abstract-dark.css',
+      baseURL + 'syntax-dark.css'
+    ],
+    'ocean-floor': [
+      baseURL + 'global.css',
+      baseURL + 'inspector.css',
+      baseURL + 'highlight.css',
+      baseURL + 'plot.css',
+      baseURL + 'index.css',
+      baseURL + 'theme-ocean-floor.css',
+      baseURL + 'abstract-dark.css',
+      baseURL + 'syntax-dark.css'
+    ],
+    parchment: [
+      baseURL + 'global.css',
+      baseURL + 'inspector.css',
+      baseURL + 'highlight.css',
+      baseURL + 'plot.css',
+      baseURL + 'index.css',
+      baseURL + 'theme-parchment.css',
+      baseURL + 'abstract-light.css',
+      baseURL + 'syntax-light.css'
+    ],
+    slate: [
+      baseURL + 'global.css',
+      baseURL + 'inspector.css',
+      baseURL + 'highlight.css',
+      baseURL + 'plot.css',
+      baseURL + 'index.css',
+      baseURL + 'theme-slate.css',
+      baseURL + 'abstract-dark.css',
+      baseURL + 'syntax-dark.css'
+    ],
+    stark: [
+      baseURL + 'global.css',
+      baseURL + 'inspector.css',
+      baseURL + 'highlight.css',
+      baseURL + 'plot.css',
+      baseURL + 'index.css',
+      baseURL + 'theme-stark.css',
+      baseURL + 'syntax-dark.css'
+    ],
+    'sun-faded': [
+      baseURL + 'global.css',
+      baseURL + 'inspector.css',
+      baseURL + 'highlight.css',
+      baseURL + 'plot.css',
+      baseURL + 'index.css',
+      baseURL + 'theme-sun-faded.css',
+      baseURL + 'abstract-dark.css',
+      baseURL + 'syntax-dark.css'
+    ]
+  }));
 };
-const _iq48k6 = function _cssForTheme(themes,extra_css){return(
+const _m8taeu = function _cssForTheme(themes,extra_css){return(
 async theme => [
-    ...await Promise.all(themes.get(theme).map(async url => [
-        url,
-        await (await fetch(url)).text()
-    ])),
-    extra_css
+  ...await Promise.all(themes.get(theme).map(async url => [
+    url,
+    await (await fetch(url)).text()
+  ])),
+  extra_css
 ]
 )};
-const _e3ckjw = async function _css(theme_assets,extra_css){return(
+const _yqy56c = async function _css(theme_assets,extra_css){return(
 [
-    ...await Promise.all(theme_assets.map(async url => [
-        url,
-        await (await fetch(url)).text()
-    ])),
-    extra_css
+  ...await Promise.all(theme_assets.map(async url => [
+    url,
+    await (await fetch(url)).text()
+  ])),
+  extra_css
 ]
 )};
-const _d7mxvx = function _extra_css(){return(
+const _16bhmn1 = function _extra_css(){return(
 [
-    'file://syntax.css',
-    `
+  'file://syntax.css',
+  `
 /* Center page */
 .lopecode-visualizer {
     max-width: 1200px;
@@ -24797,19 +24820,19 @@ export default function define(runtime, observer) {
   };
 
   $def("_1yy5rbo", null, ["md"], _1yy5rbo);  
-  $def("_1clcodb", "viewof theme_assets", ["Inputs","themes","current_theme"], _1clcodb);  
+  $def("_x91dc7", "viewof theme_assets", ["Inputs","themes","current_theme"], _x91dc7);  
   $def("_1sdw5pf", "theme_assets", ["Generators","viewof theme_assets"], _1sdw5pf);  
   $def("_1wzah21", "theme_name", ["themes","theme_assets"], _1wzah21);  
-  $def("_nz55m5", null, ["css","themes","theme_assets","html"], _nz55m5);  
-  $def("_11pe38r", null, ["theme_properties","html","htl","theme_name"], _11pe38r);  
+  $def("_zy6iu8", "apply_theme", ["css","themes","theme_assets","html"], _zy6iu8);  
+  $def("_10zmng3", null, ["theme_properties","html","htl","theme_name"], _10zmng3);  
   $def("_1txjoje", null, ["md"], _1txjoje);  
-  $def("_1hu8vay", null, ["htl","theme_properties","html"], _1hu8vay);  
-  $def("_1k4keny", "theme_properties", ["css"], _1k4keny);  
+  $def("_18nx47m", null, ["htl","theme_properties","html"], _18nx47m);  
+  $def("_ebjyl2", "theme_properties", ["css"], _ebjyl2);  
   $def("_iny180", null, ["md"], _iny180);  
-  $def("_vhnhz5", "themes", [], _vhnhz5);  
-  $def("_iq48k6", "cssForTheme", ["themes","extra_css"], _iq48k6);  
-  $def("_e3ckjw", "css", ["theme_assets","extra_css"], _e3ckjw);  
-  $def("_d7mxvx", "extra_css", [], _d7mxvx);  
+  $def("_p0at3d", "themes", [], _p0at3d);  
+  $def("_m8taeu", "cssForTheme", ["themes","extra_css"], _m8taeu);  
+  $def("_yqy56c", "css", ["theme_assets","extra_css"], _yqy56c);  
+  $def("_16bhmn1", "extra_css", [], _16bhmn1);  
   $def("_rijq1n", "current_theme", ["themes"], _rijq1n);
   return main;
 }</script>

--- a/notebooks/@tomlarkworthy_lopepage.html
+++ b/notebooks/@tomlarkworthy_lopepage.html
@@ -14104,7 +14104,21 @@ const _1l35721 = function _modulePanel(appendScrollLog,currentModules,file_attac
         if (!el.__lope_scroll_bound) {
             el.__lope_scroll_bound = true;
             appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
+            const markUserScroll = () => { el.__lope_user_scroll_at = Date.now(); };
+            el.addEventListener('wheel', markUserScroll, { passive: true });
+            el.addEventListener('touchmove', markUserScroll, { passive: true });
+            el.addEventListener('keydown', markUserScroll, { passive: true });
             el.addEventListener('scroll', () => {
+                if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+                    appendScrollLog('scroll:skip_reflow', { title: container?.title ?? null });
+                    return;
+                }
+                // Only cache scrolls following a genuine user gesture; reflow-induced
+                // scroll events (e.g. closing an adjacent panel) carry stale scrollTops.
+                if (Date.now() - (el.__lope_user_scroll_at || 0) > 400) {
+                    appendScrollLog('scroll:skip_nonuser', { title: container?.title ?? null });
+                    return;
+                }
                 const k = scrollKeyFor(container);
                 const scrollTop = el.scrollTop;
                 const scrollLeft = el.scrollLeft;
@@ -14133,6 +14147,10 @@ const _1l35721 = function _modulePanel(appendScrollLog,currentModules,file_attac
             container.__lope_destroy_bound = true;
             container.on('destroy', () => {
                 try {
+                    if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+                        appendScrollLog('scroll:destroy_skip_reflow', { title: container?.title ?? null });
+                        return;
+                    }
                     const k = scrollKeyFor(container);
                     const scrollTop = el?.scrollTop;
                     const scrollLeft = el?.scrollLeft;
@@ -14162,6 +14180,38 @@ const _1l35721 = function _modulePanel(appendScrollLog,currentModules,file_attac
                         error: String(e)
                     });
                 }
+            });
+        }
+        // When GoldenLayout resizes this panel (e.g. an adjacent panel is closed) the
+        // browser can shift scrollTop; re-apply the user's cached position after the reflow.
+        if (!container.__lope_resize_bound) {
+            container.__lope_resize_bound = true;
+            container.on('resize', () => {
+                const rk = scrollKeyFor(container);
+                const cached = scroll_cache.get(rk);
+                if (!cached || cached.scrollTop == null)
+                    return;
+                const c_el = container.getElement();
+                const at = Date.now();
+                scroll_cache.__reflowUntil = at + 800;
+                // The reflow can shift scrollTop in several passes (content relayout
+                // settles ~300ms later), so re-apply over a window. Bail if the user scrolls.
+                const apply = () => {
+                    if ((c_el.__lope_user_scroll_at || 0) > at)
+                        return;
+                    if (c_el.scrollTop !== cached.scrollTop)
+                        c_el.scrollTop = cached.scrollTop;
+                    if (cached.scrollLeft != null && c_el.scrollLeft !== cached.scrollLeft)
+                        c_el.scrollLeft = cached.scrollLeft;
+                };
+                requestAnimationFrame(apply);
+                for (const d of [60, 150, 300, 450, 600])
+                    setTimeout(apply, d);
+                appendScrollLog('scroll:resize_restore', {
+                    k: rk,
+                    title: container?.title ?? null,
+                    scrollTop: cached.scrollTop
+                });
             });
         }
         appendScrollLog('modulePanel:exit', {
@@ -14288,6 +14338,7 @@ new Map()
 )};
 const _5tyvpe = function _fix_scroll(scrollKeyFor,appendScrollLog,scroll_cache){return(
 function (container, node, cell_variable, key) {
+    scroll_cache.__reflowUntil = Date.now() + 600; // suppress reflow-induced scroll events that clobber the cache
     const c_element = container.getElement();
     let k = scrollKeyFor(container);
     appendScrollLog('fix_scroll:enter', {

--- a/notebooks/@tomlarkworthy_lopepage.json
+++ b/notebooks/@tomlarkworthy_lopepage.json
@@ -43,7 +43,7 @@
       ]
     },
     "@tomlarkworthy/cell-map": {
-      "hash": "c8281cd25de378ac872c7e289b0b715a",
+      "hash": "a58cde1f33bf1d60ba83caa866a03be1",
       "dependsOn": [
         "@tomlarkworthy/lopepage-urls",
         "@tomlarkworthy/module-map",
@@ -62,7 +62,7 @@
       ]
     },
     "@tomlarkworthy/cells-to-clipboard": {
-      "hash": "f245a2a1ad646c1f9430b0ecdf9b0cbc",
+      "hash": "7af7898b237728b52ea24b568ad2fd32",
       "dependedBy": [
         "@tomlarkworthy/editor-5"
       ]
@@ -123,7 +123,7 @@
       ]
     },
     "@tomlarkworthy/editor-5": {
-      "hash": "fb8e916ca128e007c27542f4ce86ed4b",
+      "hash": "4a9c313ccb5746d004530926cdca27ca",
       "files": [
         "cell_options.json"
       ],
@@ -229,7 +229,7 @@
       ]
     },
     "@tomlarkworthy/import-notebook": {
-      "hash": "b6c52cc7de8b52cdf491eb76049236cc",
+      "hash": "b6b75803b1a4b7006005a06e0495ee65",
       "dependsOn": [
         "@tomlarkworthy/runtime-sdk"
       ],
@@ -316,7 +316,7 @@
       ]
     },
     "@tomlarkworthy/lopepage": {
-      "hash": "58fc5d7eb298cc0fe3d8ffd2debe9e36",
+      "hash": "633f78d13e1da2ee746dc2c8598b5a24",
       "dependsOn": [
         "@tomlarkworthy/golden-layout-2-6-0",
         "@tomlarkworthy/visualizer",
@@ -331,7 +331,7 @@
       ]
     },
     "@tomlarkworthy/lopepage-urls": {
-      "hash": "eee5c7951f9edd92f8fd1dba8442609b",
+      "hash": "28f1a31190b2a69e3c9d3ac522c41bd4",
       "dependsOn": [
         "@tomlarkworthy/runtime-sdk",
         "@tomlarkworthy/tests"
@@ -408,7 +408,7 @@
       ]
     },
     "@tomlarkworthy/observablejs-toolchain": {
-      "hash": "c966316acf0555f9b3780691ef4ce73c",
+      "hash": "d9a90e9fe4112061bbce4824bd88b307",
       "files": [
         "acorn-walk-8.3.2.js.gz",
         "parser-6.1.0.js.gz"
@@ -473,7 +473,7 @@
       ]
     },
     "@tomlarkworthy/stream-operators": {
-      "hash": "60e01583a36fc0e1abe3f5fa7b71efd7",
+      "hash": "e36abaedab4dca730a68bbd8fa2a72f5",
       "dependedBy": [
         "@tomlarkworthy/tests"
       ]
@@ -503,7 +503,7 @@
       ]
     },
     "@tomlarkworthy/themes": {
-      "hash": "2d0e95ad9db0f2e04ca5afa81cbdd089",
+      "hash": "0fe84814f727b3cc5f0f012ff9e556e9",
       "dependedBy": [
         "@tomlarkworthy/command-palette",
         "@tomlarkworthy/exporter-3"
@@ -541,6 +541,6 @@
       "@tomlarkworthy/lopepage": "https://observablehq.com/@tomlarkworthy/lopepage"
     }
   },
-  "observable_version": 3419,
-  "observable_update_time": "2026-05-17T19:16:18.724Z"
+  "observable_version": 3421,
+  "observable_update_time": "2026-05-24T12:26:33.293Z"
 }

--- a/notebooks/@tomlarkworthy_modern-screenshot.html
+++ b/notebooks/@tomlarkworthy_modern-screenshot.html
@@ -14037,138 +14037,196 @@ const _1nzpnqy = function _visualizer_cache(reload)
     reload;
     return new Map();
 };
-const _1l35721 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
+const _1ojown8 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
 {
-    return function (container, component) {
-        appendScrollLog('modulePanel:enter', {
-            title: container?.title ?? null,
-            componentCell: component?.cell ?? null
-        });
-        const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
-        if (!moduleInfo) {
-            // Fall through to file attachment: titles like @user/notebook/path.ext
-            // resolve via the lopecode bootloader's contentSync DOM lookup.
-            const title = container?.title ?? null;
-            if (title) {
-                let node = file_attachment_cache.get(title);
-                if (!node) {
-                    const r = window.lopecode?.contentSync?.(title);
-                    if (r && r.status === 200 && r.bytes) {
-                        node = renderFileAttachment(r.mime, r.bytes);
-                        file_attachment_cache.set(title, node);
-                        appendScrollLog('modulePanel:file_attachment_create', {
-                            title,
-                            mime: r.mime
-                        });
-                    }
-                }
-                if (node) {
-                    const c_element = container.getElement();
-                    if (node.parentNode !== c_element)
-                        c_element.appendChild(node);
-                    appendScrollLog('modulePanel:file_attachment_mount', { title });
-                    return;
-                }
-            }
-            appendScrollLog('modulePanel:missing_moduleInfo', { title });
-            return;
-        }
-        const module = moduleInfo.module;
-        let node;
-        if (!visualizer_cache.has(module)) {
-            appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
-            node = visualizer(runtime, {
-                invalidation: new Promise(r => {
-                }),
-                module,
-                detachNodes: isOnObservableCom(),
-                filter: (cell_name, variables) => {
-                    if (variables[0]._type !== 1)
-                        return false;
-                    if (typeof cell_name == 'string') {
-                        if (cell_name.startsWith('dynamic '))
-                            return false;
-                    }
-                    return true;
-                }
+  return function (container, component) {
+    appendScrollLog('modulePanel:enter', {
+      title: container?.title ?? null,
+      componentCell: component?.cell ?? null
+    });
+    const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
+    if (!moduleInfo) {
+      // Fall through to file attachment: titles like @user/notebook/path.ext
+      // resolve via the lopecode bootloader's contentSync DOM lookup.
+      const title = container?.title ?? null;
+      if (title) {
+        let node = file_attachment_cache.get(title);
+        if (!node) {
+          const r = window.lopecode?.contentSync?.(title);
+          if (r && r.status === 200 && r.bytes) {
+            node = renderFileAttachment(r.mime, r.bytes);
+            file_attachment_cache.set(title, node);
+            appendScrollLog('modulePanel:file_attachment_create', {
+              title,
+              mime: r.mime
             });
-            visualizer_cache.set(module, node);
-        } else {
-            node = visualizer_cache.get(module);
-            appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+          }
         }
-        const cell = module._scope.get(component.cell);
-        const scrollKey = scrollKeyFor(container);
-        fix_scroll(container, node, cell, scrollKey);
-        const el = container.getElement();
-        if (!el.__lope_scroll_bound) {
-            el.__lope_scroll_bound = true;
-            appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
-            el.addEventListener('scroll', () => {
-                const k = scrollKeyFor(container);
-                const scrollTop = el.scrollTop;
-                const scrollLeft = el.scrollLeft;
-                if (scrollTop == 0) {
-                    appendScrollLog('modulePanel:skip 0 scroll', {
-                        title: container?.title ?? null,
-                        scrollKey
-                    });
-                    return;
-                }
-                scroll_cache.set(k, {
-                    scrollTop,
-                    scrollLeft,
-                    t: Date.now()
-                });
-                appendScrollLog('scroll:event', {
-                    k,
-                    title: container?.title ?? null,
-                    scrollTop,
-                    scrollLeft
-                });
-            }, { passive: true });
+        if (node) {
+          const c_element = container.getElement();
+          if (node.parentNode !== c_element)
+            c_element.appendChild(node);
+          appendScrollLog('modulePanel:file_attachment_mount', { title });
+          return;
         }
-        // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
-        if (!container.__lope_destroy_bound) {
-            container.__lope_destroy_bound = true;
-            container.on('destroy', () => {
-                try {
-                    const k = scrollKeyFor(container);
-                    const scrollTop = el?.scrollTop;
-                    const scrollLeft = el?.scrollLeft;
-                    if (scrollTop == 0) {
-                        appendScrollLog('scroll:skip 0 scroll', {
-                            k,
-                            key: container?.title ?? null,
-                            scrollKey
-                        });
-                        return;
-                    }
-                    // do not skip 0 here: if the user is at top, preserve that state
-                    scroll_cache.set(k, {
-                        scrollTop,
-                        scrollLeft,
-                        t: Date.now()
-                    });
-                    appendScrollLog('scroll:destroy_capture', {
-                        k,
-                        title: container?.title ?? null,
-                        scrollTop,
-                        scrollLeft
-                    });
-                } catch (e) {
-                    appendScrollLog('scroll:destroy_capture:error', {
-                        title: container?.title ?? null,
-                        error: String(e)
-                    });
-                }
-            });
+      }
+      appendScrollLog('modulePanel:missing_moduleInfo', { title });
+      return;
+    }
+    const module = moduleInfo.module;
+    let node;
+    if (!visualizer_cache.has(module)) {
+      appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
+      node = visualizer(runtime, {
+        invalidation: new Promise(r => {
+        }),
+        module,
+        detachNodes: isOnObservableCom(),
+        filter: (cell_name, variables) => {
+          if (variables[0]._type !== 1)
+            return false;
+          if (typeof cell_name == 'string') {
+            if (cell_name.startsWith('dynamic '))
+              return false;
+          }
+          return true;
         }
-        appendScrollLog('modulePanel:exit', {
+      });
+      visualizer_cache.set(module, node);
+    } else {
+      node = visualizer_cache.get(module);
+      appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+    }
+    const cell = module._scope.get(component.cell);
+    const scrollKey = scrollKeyFor(container);
+    fix_scroll(container, node, cell, scrollKey);
+    const el = container.getElement();
+    if (!el.__lope_scroll_bound) {
+      el.__lope_scroll_bound = true;
+      appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
+      const markUserScroll = () => {
+        el.__lope_user_scroll_at = Date.now();
+      };
+      el.addEventListener('wheel', markUserScroll, { passive: true });
+      el.addEventListener('touchmove', markUserScroll, { passive: true });
+      el.addEventListener('keydown', markUserScroll, { passive: true });
+      el.addEventListener('scroll', () => {
+        if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+          appendScrollLog('scroll:skip_reflow', { title: container?.title ?? null });
+          return;
+        }
+        // Only cache scrolls following a genuine user gesture; reflow-induced
+        // scroll events (e.g. closing an adjacent panel) carry stale scrollTops.
+        if (Date.now() - (el.__lope_user_scroll_at || 0) > 400) {
+          appendScrollLog('scroll:skip_nonuser', { title: container?.title ?? null });
+          return;
+        }
+        const k = scrollKeyFor(container);
+        const scrollTop = el.scrollTop;
+        const scrollLeft = el.scrollLeft;
+        if (scrollTop == 0) {
+          appendScrollLog('modulePanel:skip 0 scroll', {
             title: container?.title ?? null,
             scrollKey
+          });
+          return;
+        }
+        scroll_cache.set(k, {
+          scrollTop,
+          scrollLeft,
+          t: Date.now()
         });
-    };
+        appendScrollLog('scroll:event', {
+          k,
+          title: container?.title ?? null,
+          scrollTop,
+          scrollLeft
+        });
+      }, { passive: true });
+    }
+    // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
+    if (!container.__lope_destroy_bound) {
+      container.__lope_destroy_bound = true;
+      container.on('destroy', () => {
+        try {
+          if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+            appendScrollLog('scroll:destroy_skip_reflow', { title: container?.title ?? null });
+            return;
+          }
+          const k = scrollKeyFor(container);
+          const scrollTop = el?.scrollTop;
+          const scrollLeft = el?.scrollLeft;
+          if (scrollTop == 0) {
+            appendScrollLog('scroll:skip 0 scroll', {
+              k,
+              key: container?.title ?? null,
+              scrollKey
+            });
+            return;
+          }
+          // do not skip 0 here: if the user is at top, preserve that state
+          scroll_cache.set(k, {
+            scrollTop,
+            scrollLeft,
+            t: Date.now()
+          });
+          appendScrollLog('scroll:destroy_capture', {
+            k,
+            title: container?.title ?? null,
+            scrollTop,
+            scrollLeft
+          });
+        } catch (e) {
+          appendScrollLog('scroll:destroy_capture:error', {
+            title: container?.title ?? null,
+            error: String(e)
+          });
+        }
+      });
+    }
+    // When GoldenLayout resizes this panel (e.g. an adjacent panel is closed) the
+    // browser can shift scrollTop; re-apply the user's cached position after the reflow.
+    if (!container.__lope_resize_bound) {
+      container.__lope_resize_bound = true;
+      container.on('resize', () => {
+        const rk = scrollKeyFor(container);
+        const cached = scroll_cache.get(rk);
+        if (!cached || cached.scrollTop == null)
+          return;
+        const c_el = container.getElement();
+        const at = Date.now();
+        scroll_cache.__reflowUntil = at + 800;
+        // The reflow can shift scrollTop in several passes (content relayout
+        // settles ~300ms later), so re-apply over a window. Bail if the user scrolls.
+        const apply = () => {
+          if ((c_el.__lope_user_scroll_at || 0) > at)
+            return;
+          if (c_el.scrollTop !== cached.scrollTop)
+            c_el.scrollTop = cached.scrollTop;
+          if (cached.scrollLeft != null && c_el.scrollLeft !== cached.scrollLeft)
+            c_el.scrollLeft = cached.scrollLeft;
+        };
+        requestAnimationFrame(apply);
+        for (const d of [
+            60,
+            150,
+            300,
+            450,
+            600
+          ])
+          setTimeout(apply, d);
+        appendScrollLog('scroll:resize_restore', {
+          k: rk,
+          title: container?.title ?? null,
+          scrollTop: cached.scrollTop
+        });
+      });
+    }
+    appendScrollLog('modulePanel:exit', {
+      title: container?.title ?? null,
+      scrollKey
+    });
+  };
 };
 const _1gm4gbf = function _blobPanel(){return(
 function (container, component) {
@@ -14286,112 +14344,115 @@ const _1d1nkw9 = function _scrollKeyFor(appendScrollLog)
 const _tb217h = function _scroll_cache(){return(
 new Map()
 )};
-const _5tyvpe = function _fix_scroll(scrollKeyFor,appendScrollLog,scroll_cache){return(
-function (container, node, cell_variable, key) {
+const _12p8mg7 = function _fix_scroll(scroll_cache,scrollKeyFor,appendScrollLog)
+{
+  return function (container, node, cell_variable, key) {
+    scroll_cache.__reflowUntil = Date.now() + 600;
+    // suppress reflow-induced scroll events that clobber the cache
     const c_element = container.getElement();
     let k = scrollKeyFor(container);
     appendScrollLog('fix_scroll:enter', {
-        title: container?.title ?? null,
-        k,
-        cell: cell_variable?._name ?? null
+      title: container?.title ?? null,
+      k,
+      cell: cell_variable?._name ?? null
     });
     if (node && node.parentNode !== c_element) {
-        c_element.appendChild(node);
-        appendScrollLog('fix_scroll:append_node', {
-            title: container?.title ?? null,
-            k
-        });
+      c_element.appendChild(node);
+      appendScrollLog('fix_scroll:append_node', {
+        title: container?.title ?? null,
+        k
+      });
     }
     const writeCache = (scrollTop, scrollLeft, why) => {
-        scroll_cache.set(k, {
-            scrollTop,
-            scrollLeft,
-            t: Date.now()
-        });
-        appendScrollLog('scroll_cache:write', {
-            k,
-            scrollTop,
-            scrollLeft,
-            why
-        });
+      scroll_cache.set(k, {
+        scrollTop,
+        scrollLeft,
+        t: Date.now()
+      });
+      appendScrollLog('scroll_cache:write', {
+        k,
+        scrollTop,
+        scrollLeft,
+        why
+      });
     };
     const scrollToCellIfPossible = why => {
-        if (!cell_variable)
-            return false;
-        const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
-        if (!dom) {
-            appendScrollLog('scroll:cell_dom_not_found', {
-                k,
-                why,
-                cell: cell_variable?._name ?? null
-            });
-            return false;
-        }
-        const top = dom.offsetTop - c_element.offsetTop;
-        const left = c_element.scrollLeft;
-        c_element.scrollTop = top;
-        appendScrollLog('scroll:set', {
-            k,
-            why: `${ why }:cell`,
-            scrollTop: top,
-            scrollLeft: left,
-            cell: cell_variable?._name ?? null
+      if (!cell_variable)
+        return false;
+      const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
+      if (!dom) {
+        appendScrollLog('scroll:cell_dom_not_found', {
+          k,
+          why,
+          cell: cell_variable?._name ?? null
         });
-        writeCache(top, left, `${ why }:cell`);
-        return true;
+        return false;
+      }
+      const top = dom.offsetTop - c_element.offsetTop;
+      const left = c_element.scrollLeft;
+      c_element.scrollTop = top;
+      appendScrollLog('scroll:set', {
+        k,
+        why: `${ why }:cell`,
+        scrollTop: top,
+        scrollLeft: left,
+        cell: cell_variable?._name ?? null
+      });
+      writeCache(top, left, `${ why }:cell`);
+      return true;
     };
     const restoreFromCache = why => {
-        k = scrollKeyFor(container);
-        const cached = scroll_cache.get(k);
-        appendScrollLog('scroll:restore_attempt', {
-            k,
-            why,
-            cachedScrollTop: cached?.scrollTop ?? null,
-            cachedScrollLeft: cached?.scrollLeft ?? null
+      k = scrollKeyFor(container);
+      const cached = scroll_cache.get(k);
+      appendScrollLog('scroll:restore_attempt', {
+        k,
+        why,
+        cachedScrollTop: cached?.scrollTop ?? null,
+        cachedScrollLeft: cached?.scrollLeft ?? null
+      });
+      if (!cached) {
+        appendScrollLog('scroll:restore_no_scroll', {
+          k,
+          why
         });
-        if (!cached) {
-            appendScrollLog('scroll:restore_no_scroll', {
-                k,
-                why
-            });
-            return;
-        }
-        if (cached.scrollTop != null)
-            c_element.scrollTop = cached.scrollTop;
-        if (cached.scrollLeft != null)
-            c_element.scrollLeft = cached.scrollLeft;
-        appendScrollLog('scroll:restore_applied', {
-            k,
-            why,
-            scrollTop: cached.scrollTop ?? null,
-            scrollLeft: cached.scrollLeft ?? null,
-            scrollTopFinal: c_element.scrollTop,
-            scrollLeftFinal: c_element.scrollLeft
-        });
+        return;
+      }
+      if (cached.scrollTop != null)
+        c_element.scrollTop = cached.scrollTop;
+      if (cached.scrollLeft != null)
+        c_element.scrollLeft = cached.scrollLeft;
+      appendScrollLog('scroll:restore_applied', {
+        k,
+        why,
+        scrollTop: cached.scrollTop ?? null,
+        scrollLeft: cached.scrollLeft ?? null,
+        scrollTopFinal: c_element.scrollTop,
+        scrollLeftFinal: c_element.scrollLeft
+      });
     };
     const setScroll = (why = 'setScroll') => {
-        if (scrollToCellIfPossible(why))
-            return;
-        restoreFromCache(why);
+      if (scrollToCellIfPossible(why))
+        return;
+      restoreFromCache(why);
     };
     const retryFrames = 6;
     for (let i = 0; i < retryFrames; i++) {
-        requestAnimationFrame(() => {
-            k = scrollKeyFor(container);
-            appendScrollLog('fix_scroll:raf_retry', {
-                i,
-                k,
-                title: container?.title ?? null
-            });
-            setScroll(`raf:${ i }`);
+      requestAnimationFrame(() => {
+        k = scrollKeyFor(container);
+        appendScrollLog('fix_scroll:raf_retry', {
+          i,
+          k,
+          title: container?.title ?? null
         });
+        setScroll(`raf:${ i }`);
+      });
     }
     appendScrollLog('fix_scroll:exit', {
-        k,
-        title: container?.title ?? null
+      k,
+      title: container?.title ?? null
     });
-}
-)};
+  };
+};
 const _arfw00 = function _scroll_fix_sync_layout(sync_layout_to_url,layout,appendScrollLog,modulePanel)
 {
     sync_layout_to_url;
@@ -15469,7 +15530,7 @@ export default function define(runtime, observer) {
   $def("_1we0ggl", "reload", ["Generators","viewof reload"], _1we0ggl);  
   $def("_plefwg", "onLoadConfig", ["parseGoldenDSL","URLSearchParams","location"], _plefwg);  
   $def("_1nzpnqy", "visualizer_cache", ["reload"], _1nzpnqy);  
-  $def("_1l35721", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1l35721);  
+  $def("_1ojown8", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1ojown8);  
   $def("_1gm4gbf", "blobPanel", [], _1gm4gbf);  
   $def("_lxv2e2", "settings", [], _lxv2e2);  
   $def("_lp1ggk", "is_mobile", ["width"], _lp1ggk);  
@@ -15490,7 +15551,7 @@ export default function define(runtime, observer) {
   $def("_1dyz4o0", "scrollLog", ["mutable scrollLog"], _1dyz4o0);  
   $def("_1d1nkw9", "scrollKeyFor", ["appendScrollLog"], _1d1nkw9);  
   $def("_tb217h", "scroll_cache", [], _tb217h);  
-  $def("_5tyvpe", "fix_scroll", ["scrollKeyFor","appendScrollLog","scroll_cache"], _5tyvpe);  
+  $def("_12p8mg7", "fix_scroll", ["scroll_cache","scrollKeyFor","appendScrollLog"], _12p8mg7);  
   $def("_arfw00", "scroll_fix_sync_layout", ["sync_layout_to_url","layout","appendScrollLog","modulePanel"], _arfw00);  
   $def("_3nwpp4", "URLrouting", ["md"], _3nwpp4);  
   $def("_14te9pl", "sync_layout_from_url", ["reload","resize","URLSearchParams","hash","appendScrollLog","parseGoldenDSL","gl","layout","serializeGoldenDSL","treeSyncGolden","invalidation"], _14te9pl);  

--- a/notebooks/@tomlarkworthy_module-selection.html
+++ b/notebooks/@tomlarkworthy_module-selection.html
@@ -14037,138 +14037,196 @@ const _1nzpnqy = function _visualizer_cache(reload)
     reload;
     return new Map();
 };
-const _1l35721 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
+const _1ojown8 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
 {
-    return function (container, component) {
-        appendScrollLog('modulePanel:enter', {
-            title: container?.title ?? null,
-            componentCell: component?.cell ?? null
-        });
-        const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
-        if (!moduleInfo) {
-            // Fall through to file attachment: titles like @user/notebook/path.ext
-            // resolve via the lopecode bootloader's contentSync DOM lookup.
-            const title = container?.title ?? null;
-            if (title) {
-                let node = file_attachment_cache.get(title);
-                if (!node) {
-                    const r = window.lopecode?.contentSync?.(title);
-                    if (r && r.status === 200 && r.bytes) {
-                        node = renderFileAttachment(r.mime, r.bytes);
-                        file_attachment_cache.set(title, node);
-                        appendScrollLog('modulePanel:file_attachment_create', {
-                            title,
-                            mime: r.mime
-                        });
-                    }
-                }
-                if (node) {
-                    const c_element = container.getElement();
-                    if (node.parentNode !== c_element)
-                        c_element.appendChild(node);
-                    appendScrollLog('modulePanel:file_attachment_mount', { title });
-                    return;
-                }
-            }
-            appendScrollLog('modulePanel:missing_moduleInfo', { title });
-            return;
-        }
-        const module = moduleInfo.module;
-        let node;
-        if (!visualizer_cache.has(module)) {
-            appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
-            node = visualizer(runtime, {
-                invalidation: new Promise(r => {
-                }),
-                module,
-                detachNodes: isOnObservableCom(),
-                filter: (cell_name, variables) => {
-                    if (variables[0]._type !== 1)
-                        return false;
-                    if (typeof cell_name == 'string') {
-                        if (cell_name.startsWith('dynamic '))
-                            return false;
-                    }
-                    return true;
-                }
+  return function (container, component) {
+    appendScrollLog('modulePanel:enter', {
+      title: container?.title ?? null,
+      componentCell: component?.cell ?? null
+    });
+    const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
+    if (!moduleInfo) {
+      // Fall through to file attachment: titles like @user/notebook/path.ext
+      // resolve via the lopecode bootloader's contentSync DOM lookup.
+      const title = container?.title ?? null;
+      if (title) {
+        let node = file_attachment_cache.get(title);
+        if (!node) {
+          const r = window.lopecode?.contentSync?.(title);
+          if (r && r.status === 200 && r.bytes) {
+            node = renderFileAttachment(r.mime, r.bytes);
+            file_attachment_cache.set(title, node);
+            appendScrollLog('modulePanel:file_attachment_create', {
+              title,
+              mime: r.mime
             });
-            visualizer_cache.set(module, node);
-        } else {
-            node = visualizer_cache.get(module);
-            appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+          }
         }
-        const cell = module._scope.get(component.cell);
-        const scrollKey = scrollKeyFor(container);
-        fix_scroll(container, node, cell, scrollKey);
-        const el = container.getElement();
-        if (!el.__lope_scroll_bound) {
-            el.__lope_scroll_bound = true;
-            appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
-            el.addEventListener('scroll', () => {
-                const k = scrollKeyFor(container);
-                const scrollTop = el.scrollTop;
-                const scrollLeft = el.scrollLeft;
-                if (scrollTop == 0) {
-                    appendScrollLog('modulePanel:skip 0 scroll', {
-                        title: container?.title ?? null,
-                        scrollKey
-                    });
-                    return;
-                }
-                scroll_cache.set(k, {
-                    scrollTop,
-                    scrollLeft,
-                    t: Date.now()
-                });
-                appendScrollLog('scroll:event', {
-                    k,
-                    title: container?.title ?? null,
-                    scrollTop,
-                    scrollLeft
-                });
-            }, { passive: true });
+        if (node) {
+          const c_element = container.getElement();
+          if (node.parentNode !== c_element)
+            c_element.appendChild(node);
+          appendScrollLog('modulePanel:file_attachment_mount', { title });
+          return;
         }
-        // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
-        if (!container.__lope_destroy_bound) {
-            container.__lope_destroy_bound = true;
-            container.on('destroy', () => {
-                try {
-                    const k = scrollKeyFor(container);
-                    const scrollTop = el?.scrollTop;
-                    const scrollLeft = el?.scrollLeft;
-                    if (scrollTop == 0) {
-                        appendScrollLog('scroll:skip 0 scroll', {
-                            k,
-                            key: container?.title ?? null,
-                            scrollKey
-                        });
-                        return;
-                    }
-                    // do not skip 0 here: if the user is at top, preserve that state
-                    scroll_cache.set(k, {
-                        scrollTop,
-                        scrollLeft,
-                        t: Date.now()
-                    });
-                    appendScrollLog('scroll:destroy_capture', {
-                        k,
-                        title: container?.title ?? null,
-                        scrollTop,
-                        scrollLeft
-                    });
-                } catch (e) {
-                    appendScrollLog('scroll:destroy_capture:error', {
-                        title: container?.title ?? null,
-                        error: String(e)
-                    });
-                }
-            });
+      }
+      appendScrollLog('modulePanel:missing_moduleInfo', { title });
+      return;
+    }
+    const module = moduleInfo.module;
+    let node;
+    if (!visualizer_cache.has(module)) {
+      appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
+      node = visualizer(runtime, {
+        invalidation: new Promise(r => {
+        }),
+        module,
+        detachNodes: isOnObservableCom(),
+        filter: (cell_name, variables) => {
+          if (variables[0]._type !== 1)
+            return false;
+          if (typeof cell_name == 'string') {
+            if (cell_name.startsWith('dynamic '))
+              return false;
+          }
+          return true;
         }
-        appendScrollLog('modulePanel:exit', {
+      });
+      visualizer_cache.set(module, node);
+    } else {
+      node = visualizer_cache.get(module);
+      appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+    }
+    const cell = module._scope.get(component.cell);
+    const scrollKey = scrollKeyFor(container);
+    fix_scroll(container, node, cell, scrollKey);
+    const el = container.getElement();
+    if (!el.__lope_scroll_bound) {
+      el.__lope_scroll_bound = true;
+      appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
+      const markUserScroll = () => {
+        el.__lope_user_scroll_at = Date.now();
+      };
+      el.addEventListener('wheel', markUserScroll, { passive: true });
+      el.addEventListener('touchmove', markUserScroll, { passive: true });
+      el.addEventListener('keydown', markUserScroll, { passive: true });
+      el.addEventListener('scroll', () => {
+        if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+          appendScrollLog('scroll:skip_reflow', { title: container?.title ?? null });
+          return;
+        }
+        // Only cache scrolls following a genuine user gesture; reflow-induced
+        // scroll events (e.g. closing an adjacent panel) carry stale scrollTops.
+        if (Date.now() - (el.__lope_user_scroll_at || 0) > 400) {
+          appendScrollLog('scroll:skip_nonuser', { title: container?.title ?? null });
+          return;
+        }
+        const k = scrollKeyFor(container);
+        const scrollTop = el.scrollTop;
+        const scrollLeft = el.scrollLeft;
+        if (scrollTop == 0) {
+          appendScrollLog('modulePanel:skip 0 scroll', {
             title: container?.title ?? null,
             scrollKey
+          });
+          return;
+        }
+        scroll_cache.set(k, {
+          scrollTop,
+          scrollLeft,
+          t: Date.now()
         });
-    };
+        appendScrollLog('scroll:event', {
+          k,
+          title: container?.title ?? null,
+          scrollTop,
+          scrollLeft
+        });
+      }, { passive: true });
+    }
+    // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
+    if (!container.__lope_destroy_bound) {
+      container.__lope_destroy_bound = true;
+      container.on('destroy', () => {
+        try {
+          if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+            appendScrollLog('scroll:destroy_skip_reflow', { title: container?.title ?? null });
+            return;
+          }
+          const k = scrollKeyFor(container);
+          const scrollTop = el?.scrollTop;
+          const scrollLeft = el?.scrollLeft;
+          if (scrollTop == 0) {
+            appendScrollLog('scroll:skip 0 scroll', {
+              k,
+              key: container?.title ?? null,
+              scrollKey
+            });
+            return;
+          }
+          // do not skip 0 here: if the user is at top, preserve that state
+          scroll_cache.set(k, {
+            scrollTop,
+            scrollLeft,
+            t: Date.now()
+          });
+          appendScrollLog('scroll:destroy_capture', {
+            k,
+            title: container?.title ?? null,
+            scrollTop,
+            scrollLeft
+          });
+        } catch (e) {
+          appendScrollLog('scroll:destroy_capture:error', {
+            title: container?.title ?? null,
+            error: String(e)
+          });
+        }
+      });
+    }
+    // When GoldenLayout resizes this panel (e.g. an adjacent panel is closed) the
+    // browser can shift scrollTop; re-apply the user's cached position after the reflow.
+    if (!container.__lope_resize_bound) {
+      container.__lope_resize_bound = true;
+      container.on('resize', () => {
+        const rk = scrollKeyFor(container);
+        const cached = scroll_cache.get(rk);
+        if (!cached || cached.scrollTop == null)
+          return;
+        const c_el = container.getElement();
+        const at = Date.now();
+        scroll_cache.__reflowUntil = at + 800;
+        // The reflow can shift scrollTop in several passes (content relayout
+        // settles ~300ms later), so re-apply over a window. Bail if the user scrolls.
+        const apply = () => {
+          if ((c_el.__lope_user_scroll_at || 0) > at)
+            return;
+          if (c_el.scrollTop !== cached.scrollTop)
+            c_el.scrollTop = cached.scrollTop;
+          if (cached.scrollLeft != null && c_el.scrollLeft !== cached.scrollLeft)
+            c_el.scrollLeft = cached.scrollLeft;
+        };
+        requestAnimationFrame(apply);
+        for (const d of [
+            60,
+            150,
+            300,
+            450,
+            600
+          ])
+          setTimeout(apply, d);
+        appendScrollLog('scroll:resize_restore', {
+          k: rk,
+          title: container?.title ?? null,
+          scrollTop: cached.scrollTop
+        });
+      });
+    }
+    appendScrollLog('modulePanel:exit', {
+      title: container?.title ?? null,
+      scrollKey
+    });
+  };
 };
 const _1gm4gbf = function _blobPanel(){return(
 function (container, component) {
@@ -14286,112 +14344,115 @@ const _1d1nkw9 = function _scrollKeyFor(appendScrollLog)
 const _tb217h = function _scroll_cache(){return(
 new Map()
 )};
-const _5tyvpe = function _fix_scroll(scrollKeyFor,appendScrollLog,scroll_cache){return(
-function (container, node, cell_variable, key) {
+const _12p8mg7 = function _fix_scroll(scroll_cache,scrollKeyFor,appendScrollLog)
+{
+  return function (container, node, cell_variable, key) {
+    scroll_cache.__reflowUntil = Date.now() + 600;
+    // suppress reflow-induced scroll events that clobber the cache
     const c_element = container.getElement();
     let k = scrollKeyFor(container);
     appendScrollLog('fix_scroll:enter', {
-        title: container?.title ?? null,
-        k,
-        cell: cell_variable?._name ?? null
+      title: container?.title ?? null,
+      k,
+      cell: cell_variable?._name ?? null
     });
     if (node && node.parentNode !== c_element) {
-        c_element.appendChild(node);
-        appendScrollLog('fix_scroll:append_node', {
-            title: container?.title ?? null,
-            k
-        });
+      c_element.appendChild(node);
+      appendScrollLog('fix_scroll:append_node', {
+        title: container?.title ?? null,
+        k
+      });
     }
     const writeCache = (scrollTop, scrollLeft, why) => {
-        scroll_cache.set(k, {
-            scrollTop,
-            scrollLeft,
-            t: Date.now()
-        });
-        appendScrollLog('scroll_cache:write', {
-            k,
-            scrollTop,
-            scrollLeft,
-            why
-        });
+      scroll_cache.set(k, {
+        scrollTop,
+        scrollLeft,
+        t: Date.now()
+      });
+      appendScrollLog('scroll_cache:write', {
+        k,
+        scrollTop,
+        scrollLeft,
+        why
+      });
     };
     const scrollToCellIfPossible = why => {
-        if (!cell_variable)
-            return false;
-        const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
-        if (!dom) {
-            appendScrollLog('scroll:cell_dom_not_found', {
-                k,
-                why,
-                cell: cell_variable?._name ?? null
-            });
-            return false;
-        }
-        const top = dom.offsetTop - c_element.offsetTop;
-        const left = c_element.scrollLeft;
-        c_element.scrollTop = top;
-        appendScrollLog('scroll:set', {
-            k,
-            why: `${ why }:cell`,
-            scrollTop: top,
-            scrollLeft: left,
-            cell: cell_variable?._name ?? null
+      if (!cell_variable)
+        return false;
+      const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
+      if (!dom) {
+        appendScrollLog('scroll:cell_dom_not_found', {
+          k,
+          why,
+          cell: cell_variable?._name ?? null
         });
-        writeCache(top, left, `${ why }:cell`);
-        return true;
+        return false;
+      }
+      const top = dom.offsetTop - c_element.offsetTop;
+      const left = c_element.scrollLeft;
+      c_element.scrollTop = top;
+      appendScrollLog('scroll:set', {
+        k,
+        why: `${ why }:cell`,
+        scrollTop: top,
+        scrollLeft: left,
+        cell: cell_variable?._name ?? null
+      });
+      writeCache(top, left, `${ why }:cell`);
+      return true;
     };
     const restoreFromCache = why => {
-        k = scrollKeyFor(container);
-        const cached = scroll_cache.get(k);
-        appendScrollLog('scroll:restore_attempt', {
-            k,
-            why,
-            cachedScrollTop: cached?.scrollTop ?? null,
-            cachedScrollLeft: cached?.scrollLeft ?? null
+      k = scrollKeyFor(container);
+      const cached = scroll_cache.get(k);
+      appendScrollLog('scroll:restore_attempt', {
+        k,
+        why,
+        cachedScrollTop: cached?.scrollTop ?? null,
+        cachedScrollLeft: cached?.scrollLeft ?? null
+      });
+      if (!cached) {
+        appendScrollLog('scroll:restore_no_scroll', {
+          k,
+          why
         });
-        if (!cached) {
-            appendScrollLog('scroll:restore_no_scroll', {
-                k,
-                why
-            });
-            return;
-        }
-        if (cached.scrollTop != null)
-            c_element.scrollTop = cached.scrollTop;
-        if (cached.scrollLeft != null)
-            c_element.scrollLeft = cached.scrollLeft;
-        appendScrollLog('scroll:restore_applied', {
-            k,
-            why,
-            scrollTop: cached.scrollTop ?? null,
-            scrollLeft: cached.scrollLeft ?? null,
-            scrollTopFinal: c_element.scrollTop,
-            scrollLeftFinal: c_element.scrollLeft
-        });
+        return;
+      }
+      if (cached.scrollTop != null)
+        c_element.scrollTop = cached.scrollTop;
+      if (cached.scrollLeft != null)
+        c_element.scrollLeft = cached.scrollLeft;
+      appendScrollLog('scroll:restore_applied', {
+        k,
+        why,
+        scrollTop: cached.scrollTop ?? null,
+        scrollLeft: cached.scrollLeft ?? null,
+        scrollTopFinal: c_element.scrollTop,
+        scrollLeftFinal: c_element.scrollLeft
+      });
     };
     const setScroll = (why = 'setScroll') => {
-        if (scrollToCellIfPossible(why))
-            return;
-        restoreFromCache(why);
+      if (scrollToCellIfPossible(why))
+        return;
+      restoreFromCache(why);
     };
     const retryFrames = 6;
     for (let i = 0; i < retryFrames; i++) {
-        requestAnimationFrame(() => {
-            k = scrollKeyFor(container);
-            appendScrollLog('fix_scroll:raf_retry', {
-                i,
-                k,
-                title: container?.title ?? null
-            });
-            setScroll(`raf:${ i }`);
+      requestAnimationFrame(() => {
+        k = scrollKeyFor(container);
+        appendScrollLog('fix_scroll:raf_retry', {
+          i,
+          k,
+          title: container?.title ?? null
         });
+        setScroll(`raf:${ i }`);
+      });
     }
     appendScrollLog('fix_scroll:exit', {
-        k,
-        title: container?.title ?? null
+      k,
+      title: container?.title ?? null
     });
-}
-)};
+  };
+};
 const _arfw00 = function _scroll_fix_sync_layout(sync_layout_to_url,layout,appendScrollLog,modulePanel)
 {
     sync_layout_to_url;
@@ -15469,7 +15530,7 @@ export default function define(runtime, observer) {
   $def("_1we0ggl", "reload", ["Generators","viewof reload"], _1we0ggl);  
   $def("_plefwg", "onLoadConfig", ["parseGoldenDSL","URLSearchParams","location"], _plefwg);  
   $def("_1nzpnqy", "visualizer_cache", ["reload"], _1nzpnqy);  
-  $def("_1l35721", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1l35721);  
+  $def("_1ojown8", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1ojown8);  
   $def("_1gm4gbf", "blobPanel", [], _1gm4gbf);  
   $def("_lxv2e2", "settings", [], _lxv2e2);  
   $def("_lp1ggk", "is_mobile", ["width"], _lp1ggk);  
@@ -15490,7 +15551,7 @@ export default function define(runtime, observer) {
   $def("_1dyz4o0", "scrollLog", ["mutable scrollLog"], _1dyz4o0);  
   $def("_1d1nkw9", "scrollKeyFor", ["appendScrollLog"], _1d1nkw9);  
   $def("_tb217h", "scroll_cache", [], _tb217h);  
-  $def("_5tyvpe", "fix_scroll", ["scrollKeyFor","appendScrollLog","scroll_cache"], _5tyvpe);  
+  $def("_12p8mg7", "fix_scroll", ["scroll_cache","scrollKeyFor","appendScrollLog"], _12p8mg7);  
   $def("_arfw00", "scroll_fix_sync_layout", ["sync_layout_to_url","layout","appendScrollLog","modulePanel"], _arfw00);  
   $def("_3nwpp4", "URLrouting", ["md"], _3nwpp4);  
   $def("_14te9pl", "sync_layout_from_url", ["reload","resize","URLSearchParams","hash","appendScrollLog","parseGoldenDSL","gl","layout","serializeGoldenDSL","treeSyncGolden","invalidation"], _14te9pl);  

--- a/notebooks/@tomlarkworthy_notes.html
+++ b/notebooks/@tomlarkworthy_notes.html
@@ -14083,138 +14083,196 @@ const _1nzpnqy = function _visualizer_cache(reload)
     reload;
     return new Map();
 };
-const _1l35721 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
+const _1ojown8 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
 {
-    return function (container, component) {
-        appendScrollLog('modulePanel:enter', {
-            title: container?.title ?? null,
-            componentCell: component?.cell ?? null
-        });
-        const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
-        if (!moduleInfo) {
-            // Fall through to file attachment: titles like @user/notebook/path.ext
-            // resolve via the lopecode bootloader's contentSync DOM lookup.
-            const title = container?.title ?? null;
-            if (title) {
-                let node = file_attachment_cache.get(title);
-                if (!node) {
-                    const r = window.lopecode?.contentSync?.(title);
-                    if (r && r.status === 200 && r.bytes) {
-                        node = renderFileAttachment(r.mime, r.bytes);
-                        file_attachment_cache.set(title, node);
-                        appendScrollLog('modulePanel:file_attachment_create', {
-                            title,
-                            mime: r.mime
-                        });
-                    }
-                }
-                if (node) {
-                    const c_element = container.getElement();
-                    if (node.parentNode !== c_element)
-                        c_element.appendChild(node);
-                    appendScrollLog('modulePanel:file_attachment_mount', { title });
-                    return;
-                }
-            }
-            appendScrollLog('modulePanel:missing_moduleInfo', { title });
-            return;
-        }
-        const module = moduleInfo.module;
-        let node;
-        if (!visualizer_cache.has(module)) {
-            appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
-            node = visualizer(runtime, {
-                invalidation: new Promise(r => {
-                }),
-                module,
-                detachNodes: isOnObservableCom(),
-                filter: (cell_name, variables) => {
-                    if (variables[0]._type !== 1)
-                        return false;
-                    if (typeof cell_name == 'string') {
-                        if (cell_name.startsWith('dynamic '))
-                            return false;
-                    }
-                    return true;
-                }
+  return function (container, component) {
+    appendScrollLog('modulePanel:enter', {
+      title: container?.title ?? null,
+      componentCell: component?.cell ?? null
+    });
+    const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
+    if (!moduleInfo) {
+      // Fall through to file attachment: titles like @user/notebook/path.ext
+      // resolve via the lopecode bootloader's contentSync DOM lookup.
+      const title = container?.title ?? null;
+      if (title) {
+        let node = file_attachment_cache.get(title);
+        if (!node) {
+          const r = window.lopecode?.contentSync?.(title);
+          if (r && r.status === 200 && r.bytes) {
+            node = renderFileAttachment(r.mime, r.bytes);
+            file_attachment_cache.set(title, node);
+            appendScrollLog('modulePanel:file_attachment_create', {
+              title,
+              mime: r.mime
             });
-            visualizer_cache.set(module, node);
-        } else {
-            node = visualizer_cache.get(module);
-            appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+          }
         }
-        const cell = module._scope.get(component.cell);
-        const scrollKey = scrollKeyFor(container);
-        fix_scroll(container, node, cell, scrollKey);
-        const el = container.getElement();
-        if (!el.__lope_scroll_bound) {
-            el.__lope_scroll_bound = true;
-            appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
-            el.addEventListener('scroll', () => {
-                const k = scrollKeyFor(container);
-                const scrollTop = el.scrollTop;
-                const scrollLeft = el.scrollLeft;
-                if (scrollTop == 0) {
-                    appendScrollLog('modulePanel:skip 0 scroll', {
-                        title: container?.title ?? null,
-                        scrollKey
-                    });
-                    return;
-                }
-                scroll_cache.set(k, {
-                    scrollTop,
-                    scrollLeft,
-                    t: Date.now()
-                });
-                appendScrollLog('scroll:event', {
-                    k,
-                    title: container?.title ?? null,
-                    scrollTop,
-                    scrollLeft
-                });
-            }, { passive: true });
+        if (node) {
+          const c_element = container.getElement();
+          if (node.parentNode !== c_element)
+            c_element.appendChild(node);
+          appendScrollLog('modulePanel:file_attachment_mount', { title });
+          return;
         }
-        // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
-        if (!container.__lope_destroy_bound) {
-            container.__lope_destroy_bound = true;
-            container.on('destroy', () => {
-                try {
-                    const k = scrollKeyFor(container);
-                    const scrollTop = el?.scrollTop;
-                    const scrollLeft = el?.scrollLeft;
-                    if (scrollTop == 0) {
-                        appendScrollLog('scroll:skip 0 scroll', {
-                            k,
-                            key: container?.title ?? null,
-                            scrollKey
-                        });
-                        return;
-                    }
-                    // do not skip 0 here: if the user is at top, preserve that state
-                    scroll_cache.set(k, {
-                        scrollTop,
-                        scrollLeft,
-                        t: Date.now()
-                    });
-                    appendScrollLog('scroll:destroy_capture', {
-                        k,
-                        title: container?.title ?? null,
-                        scrollTop,
-                        scrollLeft
-                    });
-                } catch (e) {
-                    appendScrollLog('scroll:destroy_capture:error', {
-                        title: container?.title ?? null,
-                        error: String(e)
-                    });
-                }
-            });
+      }
+      appendScrollLog('modulePanel:missing_moduleInfo', { title });
+      return;
+    }
+    const module = moduleInfo.module;
+    let node;
+    if (!visualizer_cache.has(module)) {
+      appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
+      node = visualizer(runtime, {
+        invalidation: new Promise(r => {
+        }),
+        module,
+        detachNodes: isOnObservableCom(),
+        filter: (cell_name, variables) => {
+          if (variables[0]._type !== 1)
+            return false;
+          if (typeof cell_name == 'string') {
+            if (cell_name.startsWith('dynamic '))
+              return false;
+          }
+          return true;
         }
-        appendScrollLog('modulePanel:exit', {
+      });
+      visualizer_cache.set(module, node);
+    } else {
+      node = visualizer_cache.get(module);
+      appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+    }
+    const cell = module._scope.get(component.cell);
+    const scrollKey = scrollKeyFor(container);
+    fix_scroll(container, node, cell, scrollKey);
+    const el = container.getElement();
+    if (!el.__lope_scroll_bound) {
+      el.__lope_scroll_bound = true;
+      appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
+      const markUserScroll = () => {
+        el.__lope_user_scroll_at = Date.now();
+      };
+      el.addEventListener('wheel', markUserScroll, { passive: true });
+      el.addEventListener('touchmove', markUserScroll, { passive: true });
+      el.addEventListener('keydown', markUserScroll, { passive: true });
+      el.addEventListener('scroll', () => {
+        if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+          appendScrollLog('scroll:skip_reflow', { title: container?.title ?? null });
+          return;
+        }
+        // Only cache scrolls following a genuine user gesture; reflow-induced
+        // scroll events (e.g. closing an adjacent panel) carry stale scrollTops.
+        if (Date.now() - (el.__lope_user_scroll_at || 0) > 400) {
+          appendScrollLog('scroll:skip_nonuser', { title: container?.title ?? null });
+          return;
+        }
+        const k = scrollKeyFor(container);
+        const scrollTop = el.scrollTop;
+        const scrollLeft = el.scrollLeft;
+        if (scrollTop == 0) {
+          appendScrollLog('modulePanel:skip 0 scroll', {
             title: container?.title ?? null,
             scrollKey
+          });
+          return;
+        }
+        scroll_cache.set(k, {
+          scrollTop,
+          scrollLeft,
+          t: Date.now()
         });
-    };
+        appendScrollLog('scroll:event', {
+          k,
+          title: container?.title ?? null,
+          scrollTop,
+          scrollLeft
+        });
+      }, { passive: true });
+    }
+    // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
+    if (!container.__lope_destroy_bound) {
+      container.__lope_destroy_bound = true;
+      container.on('destroy', () => {
+        try {
+          if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+            appendScrollLog('scroll:destroy_skip_reflow', { title: container?.title ?? null });
+            return;
+          }
+          const k = scrollKeyFor(container);
+          const scrollTop = el?.scrollTop;
+          const scrollLeft = el?.scrollLeft;
+          if (scrollTop == 0) {
+            appendScrollLog('scroll:skip 0 scroll', {
+              k,
+              key: container?.title ?? null,
+              scrollKey
+            });
+            return;
+          }
+          // do not skip 0 here: if the user is at top, preserve that state
+          scroll_cache.set(k, {
+            scrollTop,
+            scrollLeft,
+            t: Date.now()
+          });
+          appendScrollLog('scroll:destroy_capture', {
+            k,
+            title: container?.title ?? null,
+            scrollTop,
+            scrollLeft
+          });
+        } catch (e) {
+          appendScrollLog('scroll:destroy_capture:error', {
+            title: container?.title ?? null,
+            error: String(e)
+          });
+        }
+      });
+    }
+    // When GoldenLayout resizes this panel (e.g. an adjacent panel is closed) the
+    // browser can shift scrollTop; re-apply the user's cached position after the reflow.
+    if (!container.__lope_resize_bound) {
+      container.__lope_resize_bound = true;
+      container.on('resize', () => {
+        const rk = scrollKeyFor(container);
+        const cached = scroll_cache.get(rk);
+        if (!cached || cached.scrollTop == null)
+          return;
+        const c_el = container.getElement();
+        const at = Date.now();
+        scroll_cache.__reflowUntil = at + 800;
+        // The reflow can shift scrollTop in several passes (content relayout
+        // settles ~300ms later), so re-apply over a window. Bail if the user scrolls.
+        const apply = () => {
+          if ((c_el.__lope_user_scroll_at || 0) > at)
+            return;
+          if (c_el.scrollTop !== cached.scrollTop)
+            c_el.scrollTop = cached.scrollTop;
+          if (cached.scrollLeft != null && c_el.scrollLeft !== cached.scrollLeft)
+            c_el.scrollLeft = cached.scrollLeft;
+        };
+        requestAnimationFrame(apply);
+        for (const d of [
+            60,
+            150,
+            300,
+            450,
+            600
+          ])
+          setTimeout(apply, d);
+        appendScrollLog('scroll:resize_restore', {
+          k: rk,
+          title: container?.title ?? null,
+          scrollTop: cached.scrollTop
+        });
+      });
+    }
+    appendScrollLog('modulePanel:exit', {
+      title: container?.title ?? null,
+      scrollKey
+    });
+  };
 };
 const _1gm4gbf = function _blobPanel(){return(
 function (container, component) {
@@ -14332,112 +14390,115 @@ const _1d1nkw9 = function _scrollKeyFor(appendScrollLog)
 const _tb217h = function _scroll_cache(){return(
 new Map()
 )};
-const _5tyvpe = function _fix_scroll(scrollKeyFor,appendScrollLog,scroll_cache){return(
-function (container, node, cell_variable, key) {
+const _12p8mg7 = function _fix_scroll(scroll_cache,scrollKeyFor,appendScrollLog)
+{
+  return function (container, node, cell_variable, key) {
+    scroll_cache.__reflowUntil = Date.now() + 600;
+    // suppress reflow-induced scroll events that clobber the cache
     const c_element = container.getElement();
     let k = scrollKeyFor(container);
     appendScrollLog('fix_scroll:enter', {
-        title: container?.title ?? null,
-        k,
-        cell: cell_variable?._name ?? null
+      title: container?.title ?? null,
+      k,
+      cell: cell_variable?._name ?? null
     });
     if (node && node.parentNode !== c_element) {
-        c_element.appendChild(node);
-        appendScrollLog('fix_scroll:append_node', {
-            title: container?.title ?? null,
-            k
-        });
+      c_element.appendChild(node);
+      appendScrollLog('fix_scroll:append_node', {
+        title: container?.title ?? null,
+        k
+      });
     }
     const writeCache = (scrollTop, scrollLeft, why) => {
-        scroll_cache.set(k, {
-            scrollTop,
-            scrollLeft,
-            t: Date.now()
-        });
-        appendScrollLog('scroll_cache:write', {
-            k,
-            scrollTop,
-            scrollLeft,
-            why
-        });
+      scroll_cache.set(k, {
+        scrollTop,
+        scrollLeft,
+        t: Date.now()
+      });
+      appendScrollLog('scroll_cache:write', {
+        k,
+        scrollTop,
+        scrollLeft,
+        why
+      });
     };
     const scrollToCellIfPossible = why => {
-        if (!cell_variable)
-            return false;
-        const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
-        if (!dom) {
-            appendScrollLog('scroll:cell_dom_not_found', {
-                k,
-                why,
-                cell: cell_variable?._name ?? null
-            });
-            return false;
-        }
-        const top = dom.offsetTop - c_element.offsetTop;
-        const left = c_element.scrollLeft;
-        c_element.scrollTop = top;
-        appendScrollLog('scroll:set', {
-            k,
-            why: `${ why }:cell`,
-            scrollTop: top,
-            scrollLeft: left,
-            cell: cell_variable?._name ?? null
+      if (!cell_variable)
+        return false;
+      const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
+      if (!dom) {
+        appendScrollLog('scroll:cell_dom_not_found', {
+          k,
+          why,
+          cell: cell_variable?._name ?? null
         });
-        writeCache(top, left, `${ why }:cell`);
-        return true;
+        return false;
+      }
+      const top = dom.offsetTop - c_element.offsetTop;
+      const left = c_element.scrollLeft;
+      c_element.scrollTop = top;
+      appendScrollLog('scroll:set', {
+        k,
+        why: `${ why }:cell`,
+        scrollTop: top,
+        scrollLeft: left,
+        cell: cell_variable?._name ?? null
+      });
+      writeCache(top, left, `${ why }:cell`);
+      return true;
     };
     const restoreFromCache = why => {
-        k = scrollKeyFor(container);
-        const cached = scroll_cache.get(k);
-        appendScrollLog('scroll:restore_attempt', {
-            k,
-            why,
-            cachedScrollTop: cached?.scrollTop ?? null,
-            cachedScrollLeft: cached?.scrollLeft ?? null
+      k = scrollKeyFor(container);
+      const cached = scroll_cache.get(k);
+      appendScrollLog('scroll:restore_attempt', {
+        k,
+        why,
+        cachedScrollTop: cached?.scrollTop ?? null,
+        cachedScrollLeft: cached?.scrollLeft ?? null
+      });
+      if (!cached) {
+        appendScrollLog('scroll:restore_no_scroll', {
+          k,
+          why
         });
-        if (!cached) {
-            appendScrollLog('scroll:restore_no_scroll', {
-                k,
-                why
-            });
-            return;
-        }
-        if (cached.scrollTop != null)
-            c_element.scrollTop = cached.scrollTop;
-        if (cached.scrollLeft != null)
-            c_element.scrollLeft = cached.scrollLeft;
-        appendScrollLog('scroll:restore_applied', {
-            k,
-            why,
-            scrollTop: cached.scrollTop ?? null,
-            scrollLeft: cached.scrollLeft ?? null,
-            scrollTopFinal: c_element.scrollTop,
-            scrollLeftFinal: c_element.scrollLeft
-        });
+        return;
+      }
+      if (cached.scrollTop != null)
+        c_element.scrollTop = cached.scrollTop;
+      if (cached.scrollLeft != null)
+        c_element.scrollLeft = cached.scrollLeft;
+      appendScrollLog('scroll:restore_applied', {
+        k,
+        why,
+        scrollTop: cached.scrollTop ?? null,
+        scrollLeft: cached.scrollLeft ?? null,
+        scrollTopFinal: c_element.scrollTop,
+        scrollLeftFinal: c_element.scrollLeft
+      });
     };
     const setScroll = (why = 'setScroll') => {
-        if (scrollToCellIfPossible(why))
-            return;
-        restoreFromCache(why);
+      if (scrollToCellIfPossible(why))
+        return;
+      restoreFromCache(why);
     };
     const retryFrames = 6;
     for (let i = 0; i < retryFrames; i++) {
-        requestAnimationFrame(() => {
-            k = scrollKeyFor(container);
-            appendScrollLog('fix_scroll:raf_retry', {
-                i,
-                k,
-                title: container?.title ?? null
-            });
-            setScroll(`raf:${ i }`);
+      requestAnimationFrame(() => {
+        k = scrollKeyFor(container);
+        appendScrollLog('fix_scroll:raf_retry', {
+          i,
+          k,
+          title: container?.title ?? null
         });
+        setScroll(`raf:${ i }`);
+      });
     }
     appendScrollLog('fix_scroll:exit', {
-        k,
-        title: container?.title ?? null
+      k,
+      title: container?.title ?? null
     });
-}
-)};
+  };
+};
 const _arfw00 = function _scroll_fix_sync_layout(sync_layout_to_url,layout,appendScrollLog,modulePanel)
 {
     sync_layout_to_url;
@@ -15515,7 +15576,7 @@ export default function define(runtime, observer) {
   $def("_1we0ggl", "reload", ["Generators","viewof reload"], _1we0ggl);  
   $def("_plefwg", "onLoadConfig", ["parseGoldenDSL","URLSearchParams","location"], _plefwg);  
   $def("_1nzpnqy", "visualizer_cache", ["reload"], _1nzpnqy);  
-  $def("_1l35721", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1l35721);  
+  $def("_1ojown8", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1ojown8);  
   $def("_1gm4gbf", "blobPanel", [], _1gm4gbf);  
   $def("_lxv2e2", "settings", [], _lxv2e2);  
   $def("_lp1ggk", "is_mobile", ["width"], _lp1ggk);  
@@ -15536,7 +15597,7 @@ export default function define(runtime, observer) {
   $def("_1dyz4o0", "scrollLog", ["mutable scrollLog"], _1dyz4o0);  
   $def("_1d1nkw9", "scrollKeyFor", ["appendScrollLog"], _1d1nkw9);  
   $def("_tb217h", "scroll_cache", [], _tb217h);  
-  $def("_5tyvpe", "fix_scroll", ["scrollKeyFor","appendScrollLog","scroll_cache"], _5tyvpe);  
+  $def("_12p8mg7", "fix_scroll", ["scroll_cache","scrollKeyFor","appendScrollLog"], _12p8mg7);  
   $def("_arfw00", "scroll_fix_sync_layout", ["sync_layout_to_url","layout","appendScrollLog","modulePanel"], _arfw00);  
   $def("_3nwpp4", "URLrouting", ["md"], _3nwpp4);  
   $def("_14te9pl", "sync_layout_from_url", ["reload","resize","URLSearchParams","hash","appendScrollLog","parseGoldenDSL","gl","layout","serializeGoldenDSL","treeSyncGolden","invalidation"], _14te9pl);  

--- a/notebooks/@tomlarkworthy_observablehq-lezer.html
+++ b/notebooks/@tomlarkworthy_observablehq-lezer.html
@@ -14037,138 +14037,196 @@ const _1nzpnqy = function _visualizer_cache(reload)
     reload;
     return new Map();
 };
-const _1l35721 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
+const _1ojown8 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
 {
-    return function (container, component) {
-        appendScrollLog('modulePanel:enter', {
-            title: container?.title ?? null,
-            componentCell: component?.cell ?? null
-        });
-        const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
-        if (!moduleInfo) {
-            // Fall through to file attachment: titles like @user/notebook/path.ext
-            // resolve via the lopecode bootloader's contentSync DOM lookup.
-            const title = container?.title ?? null;
-            if (title) {
-                let node = file_attachment_cache.get(title);
-                if (!node) {
-                    const r = window.lopecode?.contentSync?.(title);
-                    if (r && r.status === 200 && r.bytes) {
-                        node = renderFileAttachment(r.mime, r.bytes);
-                        file_attachment_cache.set(title, node);
-                        appendScrollLog('modulePanel:file_attachment_create', {
-                            title,
-                            mime: r.mime
-                        });
-                    }
-                }
-                if (node) {
-                    const c_element = container.getElement();
-                    if (node.parentNode !== c_element)
-                        c_element.appendChild(node);
-                    appendScrollLog('modulePanel:file_attachment_mount', { title });
-                    return;
-                }
-            }
-            appendScrollLog('modulePanel:missing_moduleInfo', { title });
-            return;
-        }
-        const module = moduleInfo.module;
-        let node;
-        if (!visualizer_cache.has(module)) {
-            appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
-            node = visualizer(runtime, {
-                invalidation: new Promise(r => {
-                }),
-                module,
-                detachNodes: isOnObservableCom(),
-                filter: (cell_name, variables) => {
-                    if (variables[0]._type !== 1)
-                        return false;
-                    if (typeof cell_name == 'string') {
-                        if (cell_name.startsWith('dynamic '))
-                            return false;
-                    }
-                    return true;
-                }
+  return function (container, component) {
+    appendScrollLog('modulePanel:enter', {
+      title: container?.title ?? null,
+      componentCell: component?.cell ?? null
+    });
+    const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
+    if (!moduleInfo) {
+      // Fall through to file attachment: titles like @user/notebook/path.ext
+      // resolve via the lopecode bootloader's contentSync DOM lookup.
+      const title = container?.title ?? null;
+      if (title) {
+        let node = file_attachment_cache.get(title);
+        if (!node) {
+          const r = window.lopecode?.contentSync?.(title);
+          if (r && r.status === 200 && r.bytes) {
+            node = renderFileAttachment(r.mime, r.bytes);
+            file_attachment_cache.set(title, node);
+            appendScrollLog('modulePanel:file_attachment_create', {
+              title,
+              mime: r.mime
             });
-            visualizer_cache.set(module, node);
-        } else {
-            node = visualizer_cache.get(module);
-            appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+          }
         }
-        const cell = module._scope.get(component.cell);
-        const scrollKey = scrollKeyFor(container);
-        fix_scroll(container, node, cell, scrollKey);
-        const el = container.getElement();
-        if (!el.__lope_scroll_bound) {
-            el.__lope_scroll_bound = true;
-            appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
-            el.addEventListener('scroll', () => {
-                const k = scrollKeyFor(container);
-                const scrollTop = el.scrollTop;
-                const scrollLeft = el.scrollLeft;
-                if (scrollTop == 0) {
-                    appendScrollLog('modulePanel:skip 0 scroll', {
-                        title: container?.title ?? null,
-                        scrollKey
-                    });
-                    return;
-                }
-                scroll_cache.set(k, {
-                    scrollTop,
-                    scrollLeft,
-                    t: Date.now()
-                });
-                appendScrollLog('scroll:event', {
-                    k,
-                    title: container?.title ?? null,
-                    scrollTop,
-                    scrollLeft
-                });
-            }, { passive: true });
+        if (node) {
+          const c_element = container.getElement();
+          if (node.parentNode !== c_element)
+            c_element.appendChild(node);
+          appendScrollLog('modulePanel:file_attachment_mount', { title });
+          return;
         }
-        // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
-        if (!container.__lope_destroy_bound) {
-            container.__lope_destroy_bound = true;
-            container.on('destroy', () => {
-                try {
-                    const k = scrollKeyFor(container);
-                    const scrollTop = el?.scrollTop;
-                    const scrollLeft = el?.scrollLeft;
-                    if (scrollTop == 0) {
-                        appendScrollLog('scroll:skip 0 scroll', {
-                            k,
-                            key: container?.title ?? null,
-                            scrollKey
-                        });
-                        return;
-                    }
-                    // do not skip 0 here: if the user is at top, preserve that state
-                    scroll_cache.set(k, {
-                        scrollTop,
-                        scrollLeft,
-                        t: Date.now()
-                    });
-                    appendScrollLog('scroll:destroy_capture', {
-                        k,
-                        title: container?.title ?? null,
-                        scrollTop,
-                        scrollLeft
-                    });
-                } catch (e) {
-                    appendScrollLog('scroll:destroy_capture:error', {
-                        title: container?.title ?? null,
-                        error: String(e)
-                    });
-                }
-            });
+      }
+      appendScrollLog('modulePanel:missing_moduleInfo', { title });
+      return;
+    }
+    const module = moduleInfo.module;
+    let node;
+    if (!visualizer_cache.has(module)) {
+      appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
+      node = visualizer(runtime, {
+        invalidation: new Promise(r => {
+        }),
+        module,
+        detachNodes: isOnObservableCom(),
+        filter: (cell_name, variables) => {
+          if (variables[0]._type !== 1)
+            return false;
+          if (typeof cell_name == 'string') {
+            if (cell_name.startsWith('dynamic '))
+              return false;
+          }
+          return true;
         }
-        appendScrollLog('modulePanel:exit', {
+      });
+      visualizer_cache.set(module, node);
+    } else {
+      node = visualizer_cache.get(module);
+      appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+    }
+    const cell = module._scope.get(component.cell);
+    const scrollKey = scrollKeyFor(container);
+    fix_scroll(container, node, cell, scrollKey);
+    const el = container.getElement();
+    if (!el.__lope_scroll_bound) {
+      el.__lope_scroll_bound = true;
+      appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
+      const markUserScroll = () => {
+        el.__lope_user_scroll_at = Date.now();
+      };
+      el.addEventListener('wheel', markUserScroll, { passive: true });
+      el.addEventListener('touchmove', markUserScroll, { passive: true });
+      el.addEventListener('keydown', markUserScroll, { passive: true });
+      el.addEventListener('scroll', () => {
+        if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+          appendScrollLog('scroll:skip_reflow', { title: container?.title ?? null });
+          return;
+        }
+        // Only cache scrolls following a genuine user gesture; reflow-induced
+        // scroll events (e.g. closing an adjacent panel) carry stale scrollTops.
+        if (Date.now() - (el.__lope_user_scroll_at || 0) > 400) {
+          appendScrollLog('scroll:skip_nonuser', { title: container?.title ?? null });
+          return;
+        }
+        const k = scrollKeyFor(container);
+        const scrollTop = el.scrollTop;
+        const scrollLeft = el.scrollLeft;
+        if (scrollTop == 0) {
+          appendScrollLog('modulePanel:skip 0 scroll', {
             title: container?.title ?? null,
             scrollKey
+          });
+          return;
+        }
+        scroll_cache.set(k, {
+          scrollTop,
+          scrollLeft,
+          t: Date.now()
         });
-    };
+        appendScrollLog('scroll:event', {
+          k,
+          title: container?.title ?? null,
+          scrollTop,
+          scrollLeft
+        });
+      }, { passive: true });
+    }
+    // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
+    if (!container.__lope_destroy_bound) {
+      container.__lope_destroy_bound = true;
+      container.on('destroy', () => {
+        try {
+          if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+            appendScrollLog('scroll:destroy_skip_reflow', { title: container?.title ?? null });
+            return;
+          }
+          const k = scrollKeyFor(container);
+          const scrollTop = el?.scrollTop;
+          const scrollLeft = el?.scrollLeft;
+          if (scrollTop == 0) {
+            appendScrollLog('scroll:skip 0 scroll', {
+              k,
+              key: container?.title ?? null,
+              scrollKey
+            });
+            return;
+          }
+          // do not skip 0 here: if the user is at top, preserve that state
+          scroll_cache.set(k, {
+            scrollTop,
+            scrollLeft,
+            t: Date.now()
+          });
+          appendScrollLog('scroll:destroy_capture', {
+            k,
+            title: container?.title ?? null,
+            scrollTop,
+            scrollLeft
+          });
+        } catch (e) {
+          appendScrollLog('scroll:destroy_capture:error', {
+            title: container?.title ?? null,
+            error: String(e)
+          });
+        }
+      });
+    }
+    // When GoldenLayout resizes this panel (e.g. an adjacent panel is closed) the
+    // browser can shift scrollTop; re-apply the user's cached position after the reflow.
+    if (!container.__lope_resize_bound) {
+      container.__lope_resize_bound = true;
+      container.on('resize', () => {
+        const rk = scrollKeyFor(container);
+        const cached = scroll_cache.get(rk);
+        if (!cached || cached.scrollTop == null)
+          return;
+        const c_el = container.getElement();
+        const at = Date.now();
+        scroll_cache.__reflowUntil = at + 800;
+        // The reflow can shift scrollTop in several passes (content relayout
+        // settles ~300ms later), so re-apply over a window. Bail if the user scrolls.
+        const apply = () => {
+          if ((c_el.__lope_user_scroll_at || 0) > at)
+            return;
+          if (c_el.scrollTop !== cached.scrollTop)
+            c_el.scrollTop = cached.scrollTop;
+          if (cached.scrollLeft != null && c_el.scrollLeft !== cached.scrollLeft)
+            c_el.scrollLeft = cached.scrollLeft;
+        };
+        requestAnimationFrame(apply);
+        for (const d of [
+            60,
+            150,
+            300,
+            450,
+            600
+          ])
+          setTimeout(apply, d);
+        appendScrollLog('scroll:resize_restore', {
+          k: rk,
+          title: container?.title ?? null,
+          scrollTop: cached.scrollTop
+        });
+      });
+    }
+    appendScrollLog('modulePanel:exit', {
+      title: container?.title ?? null,
+      scrollKey
+    });
+  };
 };
 const _1gm4gbf = function _blobPanel(){return(
 function (container, component) {
@@ -14286,112 +14344,115 @@ const _1d1nkw9 = function _scrollKeyFor(appendScrollLog)
 const _tb217h = function _scroll_cache(){return(
 new Map()
 )};
-const _5tyvpe = function _fix_scroll(scrollKeyFor,appendScrollLog,scroll_cache){return(
-function (container, node, cell_variable, key) {
+const _12p8mg7 = function _fix_scroll(scroll_cache,scrollKeyFor,appendScrollLog)
+{
+  return function (container, node, cell_variable, key) {
+    scroll_cache.__reflowUntil = Date.now() + 600;
+    // suppress reflow-induced scroll events that clobber the cache
     const c_element = container.getElement();
     let k = scrollKeyFor(container);
     appendScrollLog('fix_scroll:enter', {
-        title: container?.title ?? null,
-        k,
-        cell: cell_variable?._name ?? null
+      title: container?.title ?? null,
+      k,
+      cell: cell_variable?._name ?? null
     });
     if (node && node.parentNode !== c_element) {
-        c_element.appendChild(node);
-        appendScrollLog('fix_scroll:append_node', {
-            title: container?.title ?? null,
-            k
-        });
+      c_element.appendChild(node);
+      appendScrollLog('fix_scroll:append_node', {
+        title: container?.title ?? null,
+        k
+      });
     }
     const writeCache = (scrollTop, scrollLeft, why) => {
-        scroll_cache.set(k, {
-            scrollTop,
-            scrollLeft,
-            t: Date.now()
-        });
-        appendScrollLog('scroll_cache:write', {
-            k,
-            scrollTop,
-            scrollLeft,
-            why
-        });
+      scroll_cache.set(k, {
+        scrollTop,
+        scrollLeft,
+        t: Date.now()
+      });
+      appendScrollLog('scroll_cache:write', {
+        k,
+        scrollTop,
+        scrollLeft,
+        why
+      });
     };
     const scrollToCellIfPossible = why => {
-        if (!cell_variable)
-            return false;
-        const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
-        if (!dom) {
-            appendScrollLog('scroll:cell_dom_not_found', {
-                k,
-                why,
-                cell: cell_variable?._name ?? null
-            });
-            return false;
-        }
-        const top = dom.offsetTop - c_element.offsetTop;
-        const left = c_element.scrollLeft;
-        c_element.scrollTop = top;
-        appendScrollLog('scroll:set', {
-            k,
-            why: `${ why }:cell`,
-            scrollTop: top,
-            scrollLeft: left,
-            cell: cell_variable?._name ?? null
+      if (!cell_variable)
+        return false;
+      const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
+      if (!dom) {
+        appendScrollLog('scroll:cell_dom_not_found', {
+          k,
+          why,
+          cell: cell_variable?._name ?? null
         });
-        writeCache(top, left, `${ why }:cell`);
-        return true;
+        return false;
+      }
+      const top = dom.offsetTop - c_element.offsetTop;
+      const left = c_element.scrollLeft;
+      c_element.scrollTop = top;
+      appendScrollLog('scroll:set', {
+        k,
+        why: `${ why }:cell`,
+        scrollTop: top,
+        scrollLeft: left,
+        cell: cell_variable?._name ?? null
+      });
+      writeCache(top, left, `${ why }:cell`);
+      return true;
     };
     const restoreFromCache = why => {
-        k = scrollKeyFor(container);
-        const cached = scroll_cache.get(k);
-        appendScrollLog('scroll:restore_attempt', {
-            k,
-            why,
-            cachedScrollTop: cached?.scrollTop ?? null,
-            cachedScrollLeft: cached?.scrollLeft ?? null
+      k = scrollKeyFor(container);
+      const cached = scroll_cache.get(k);
+      appendScrollLog('scroll:restore_attempt', {
+        k,
+        why,
+        cachedScrollTop: cached?.scrollTop ?? null,
+        cachedScrollLeft: cached?.scrollLeft ?? null
+      });
+      if (!cached) {
+        appendScrollLog('scroll:restore_no_scroll', {
+          k,
+          why
         });
-        if (!cached) {
-            appendScrollLog('scroll:restore_no_scroll', {
-                k,
-                why
-            });
-            return;
-        }
-        if (cached.scrollTop != null)
-            c_element.scrollTop = cached.scrollTop;
-        if (cached.scrollLeft != null)
-            c_element.scrollLeft = cached.scrollLeft;
-        appendScrollLog('scroll:restore_applied', {
-            k,
-            why,
-            scrollTop: cached.scrollTop ?? null,
-            scrollLeft: cached.scrollLeft ?? null,
-            scrollTopFinal: c_element.scrollTop,
-            scrollLeftFinal: c_element.scrollLeft
-        });
+        return;
+      }
+      if (cached.scrollTop != null)
+        c_element.scrollTop = cached.scrollTop;
+      if (cached.scrollLeft != null)
+        c_element.scrollLeft = cached.scrollLeft;
+      appendScrollLog('scroll:restore_applied', {
+        k,
+        why,
+        scrollTop: cached.scrollTop ?? null,
+        scrollLeft: cached.scrollLeft ?? null,
+        scrollTopFinal: c_element.scrollTop,
+        scrollLeftFinal: c_element.scrollLeft
+      });
     };
     const setScroll = (why = 'setScroll') => {
-        if (scrollToCellIfPossible(why))
-            return;
-        restoreFromCache(why);
+      if (scrollToCellIfPossible(why))
+        return;
+      restoreFromCache(why);
     };
     const retryFrames = 6;
     for (let i = 0; i < retryFrames; i++) {
-        requestAnimationFrame(() => {
-            k = scrollKeyFor(container);
-            appendScrollLog('fix_scroll:raf_retry', {
-                i,
-                k,
-                title: container?.title ?? null
-            });
-            setScroll(`raf:${ i }`);
+      requestAnimationFrame(() => {
+        k = scrollKeyFor(container);
+        appendScrollLog('fix_scroll:raf_retry', {
+          i,
+          k,
+          title: container?.title ?? null
         });
+        setScroll(`raf:${ i }`);
+      });
     }
     appendScrollLog('fix_scroll:exit', {
-        k,
-        title: container?.title ?? null
+      k,
+      title: container?.title ?? null
     });
-}
-)};
+  };
+};
 const _arfw00 = function _scroll_fix_sync_layout(sync_layout_to_url,layout,appendScrollLog,modulePanel)
 {
     sync_layout_to_url;
@@ -15469,7 +15530,7 @@ export default function define(runtime, observer) {
   $def("_1we0ggl", "reload", ["Generators","viewof reload"], _1we0ggl);  
   $def("_plefwg", "onLoadConfig", ["parseGoldenDSL","URLSearchParams","location"], _plefwg);  
   $def("_1nzpnqy", "visualizer_cache", ["reload"], _1nzpnqy);  
-  $def("_1l35721", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1l35721);  
+  $def("_1ojown8", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1ojown8);  
   $def("_1gm4gbf", "blobPanel", [], _1gm4gbf);  
   $def("_lxv2e2", "settings", [], _lxv2e2);  
   $def("_lp1ggk", "is_mobile", ["width"], _lp1ggk);  
@@ -15490,7 +15551,7 @@ export default function define(runtime, observer) {
   $def("_1dyz4o0", "scrollLog", ["mutable scrollLog"], _1dyz4o0);  
   $def("_1d1nkw9", "scrollKeyFor", ["appendScrollLog"], _1d1nkw9);  
   $def("_tb217h", "scroll_cache", [], _tb217h);  
-  $def("_5tyvpe", "fix_scroll", ["scrollKeyFor","appendScrollLog","scroll_cache"], _5tyvpe);  
+  $def("_12p8mg7", "fix_scroll", ["scroll_cache","scrollKeyFor","appendScrollLog"], _12p8mg7);  
   $def("_arfw00", "scroll_fix_sync_layout", ["sync_layout_to_url","layout","appendScrollLog","modulePanel"], _arfw00);  
   $def("_3nwpp4", "URLrouting", ["md"], _3nwpp4);  
   $def("_14te9pl", "sync_layout_from_url", ["reload","resize","URLSearchParams","hash","appendScrollLog","parseGoldenDSL","gl","layout","serializeGoldenDSL","treeSyncGolden","invalidation"], _14te9pl);  

--- a/notebooks/@tomlarkworthy_observablejs-toolchain.html
+++ b/notebooks/@tomlarkworthy_observablejs-toolchain.html
@@ -14035,138 +14035,196 @@ const _1nzpnqy = function _visualizer_cache(reload)
     reload;
     return new Map();
 };
-const _1l35721 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
+const _1ojown8 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
 {
-    return function (container, component) {
-        appendScrollLog('modulePanel:enter', {
-            title: container?.title ?? null,
-            componentCell: component?.cell ?? null
-        });
-        const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
-        if (!moduleInfo) {
-            // Fall through to file attachment: titles like @user/notebook/path.ext
-            // resolve via the lopecode bootloader's contentSync DOM lookup.
-            const title = container?.title ?? null;
-            if (title) {
-                let node = file_attachment_cache.get(title);
-                if (!node) {
-                    const r = window.lopecode?.contentSync?.(title);
-                    if (r && r.status === 200 && r.bytes) {
-                        node = renderFileAttachment(r.mime, r.bytes);
-                        file_attachment_cache.set(title, node);
-                        appendScrollLog('modulePanel:file_attachment_create', {
-                            title,
-                            mime: r.mime
-                        });
-                    }
-                }
-                if (node) {
-                    const c_element = container.getElement();
-                    if (node.parentNode !== c_element)
-                        c_element.appendChild(node);
-                    appendScrollLog('modulePanel:file_attachment_mount', { title });
-                    return;
-                }
-            }
-            appendScrollLog('modulePanel:missing_moduleInfo', { title });
-            return;
-        }
-        const module = moduleInfo.module;
-        let node;
-        if (!visualizer_cache.has(module)) {
-            appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
-            node = visualizer(runtime, {
-                invalidation: new Promise(r => {
-                }),
-                module,
-                detachNodes: isOnObservableCom(),
-                filter: (cell_name, variables) => {
-                    if (variables[0]._type !== 1)
-                        return false;
-                    if (typeof cell_name == 'string') {
-                        if (cell_name.startsWith('dynamic '))
-                            return false;
-                    }
-                    return true;
-                }
+  return function (container, component) {
+    appendScrollLog('modulePanel:enter', {
+      title: container?.title ?? null,
+      componentCell: component?.cell ?? null
+    });
+    const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
+    if (!moduleInfo) {
+      // Fall through to file attachment: titles like @user/notebook/path.ext
+      // resolve via the lopecode bootloader's contentSync DOM lookup.
+      const title = container?.title ?? null;
+      if (title) {
+        let node = file_attachment_cache.get(title);
+        if (!node) {
+          const r = window.lopecode?.contentSync?.(title);
+          if (r && r.status === 200 && r.bytes) {
+            node = renderFileAttachment(r.mime, r.bytes);
+            file_attachment_cache.set(title, node);
+            appendScrollLog('modulePanel:file_attachment_create', {
+              title,
+              mime: r.mime
             });
-            visualizer_cache.set(module, node);
-        } else {
-            node = visualizer_cache.get(module);
-            appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+          }
         }
-        const cell = module._scope.get(component.cell);
-        const scrollKey = scrollKeyFor(container);
-        fix_scroll(container, node, cell, scrollKey);
-        const el = container.getElement();
-        if (!el.__lope_scroll_bound) {
-            el.__lope_scroll_bound = true;
-            appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
-            el.addEventListener('scroll', () => {
-                const k = scrollKeyFor(container);
-                const scrollTop = el.scrollTop;
-                const scrollLeft = el.scrollLeft;
-                if (scrollTop == 0) {
-                    appendScrollLog('modulePanel:skip 0 scroll', {
-                        title: container?.title ?? null,
-                        scrollKey
-                    });
-                    return;
-                }
-                scroll_cache.set(k, {
-                    scrollTop,
-                    scrollLeft,
-                    t: Date.now()
-                });
-                appendScrollLog('scroll:event', {
-                    k,
-                    title: container?.title ?? null,
-                    scrollTop,
-                    scrollLeft
-                });
-            }, { passive: true });
+        if (node) {
+          const c_element = container.getElement();
+          if (node.parentNode !== c_element)
+            c_element.appendChild(node);
+          appendScrollLog('modulePanel:file_attachment_mount', { title });
+          return;
         }
-        // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
-        if (!container.__lope_destroy_bound) {
-            container.__lope_destroy_bound = true;
-            container.on('destroy', () => {
-                try {
-                    const k = scrollKeyFor(container);
-                    const scrollTop = el?.scrollTop;
-                    const scrollLeft = el?.scrollLeft;
-                    if (scrollTop == 0) {
-                        appendScrollLog('scroll:skip 0 scroll', {
-                            k,
-                            key: container?.title ?? null,
-                            scrollKey
-                        });
-                        return;
-                    }
-                    // do not skip 0 here: if the user is at top, preserve that state
-                    scroll_cache.set(k, {
-                        scrollTop,
-                        scrollLeft,
-                        t: Date.now()
-                    });
-                    appendScrollLog('scroll:destroy_capture', {
-                        k,
-                        title: container?.title ?? null,
-                        scrollTop,
-                        scrollLeft
-                    });
-                } catch (e) {
-                    appendScrollLog('scroll:destroy_capture:error', {
-                        title: container?.title ?? null,
-                        error: String(e)
-                    });
-                }
-            });
+      }
+      appendScrollLog('modulePanel:missing_moduleInfo', { title });
+      return;
+    }
+    const module = moduleInfo.module;
+    let node;
+    if (!visualizer_cache.has(module)) {
+      appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
+      node = visualizer(runtime, {
+        invalidation: new Promise(r => {
+        }),
+        module,
+        detachNodes: isOnObservableCom(),
+        filter: (cell_name, variables) => {
+          if (variables[0]._type !== 1)
+            return false;
+          if (typeof cell_name == 'string') {
+            if (cell_name.startsWith('dynamic '))
+              return false;
+          }
+          return true;
         }
-        appendScrollLog('modulePanel:exit', {
+      });
+      visualizer_cache.set(module, node);
+    } else {
+      node = visualizer_cache.get(module);
+      appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+    }
+    const cell = module._scope.get(component.cell);
+    const scrollKey = scrollKeyFor(container);
+    fix_scroll(container, node, cell, scrollKey);
+    const el = container.getElement();
+    if (!el.__lope_scroll_bound) {
+      el.__lope_scroll_bound = true;
+      appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
+      const markUserScroll = () => {
+        el.__lope_user_scroll_at = Date.now();
+      };
+      el.addEventListener('wheel', markUserScroll, { passive: true });
+      el.addEventListener('touchmove', markUserScroll, { passive: true });
+      el.addEventListener('keydown', markUserScroll, { passive: true });
+      el.addEventListener('scroll', () => {
+        if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+          appendScrollLog('scroll:skip_reflow', { title: container?.title ?? null });
+          return;
+        }
+        // Only cache scrolls following a genuine user gesture; reflow-induced
+        // scroll events (e.g. closing an adjacent panel) carry stale scrollTops.
+        if (Date.now() - (el.__lope_user_scroll_at || 0) > 400) {
+          appendScrollLog('scroll:skip_nonuser', { title: container?.title ?? null });
+          return;
+        }
+        const k = scrollKeyFor(container);
+        const scrollTop = el.scrollTop;
+        const scrollLeft = el.scrollLeft;
+        if (scrollTop == 0) {
+          appendScrollLog('modulePanel:skip 0 scroll', {
             title: container?.title ?? null,
             scrollKey
+          });
+          return;
+        }
+        scroll_cache.set(k, {
+          scrollTop,
+          scrollLeft,
+          t: Date.now()
         });
-    };
+        appendScrollLog('scroll:event', {
+          k,
+          title: container?.title ?? null,
+          scrollTop,
+          scrollLeft
+        });
+      }, { passive: true });
+    }
+    // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
+    if (!container.__lope_destroy_bound) {
+      container.__lope_destroy_bound = true;
+      container.on('destroy', () => {
+        try {
+          if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+            appendScrollLog('scroll:destroy_skip_reflow', { title: container?.title ?? null });
+            return;
+          }
+          const k = scrollKeyFor(container);
+          const scrollTop = el?.scrollTop;
+          const scrollLeft = el?.scrollLeft;
+          if (scrollTop == 0) {
+            appendScrollLog('scroll:skip 0 scroll', {
+              k,
+              key: container?.title ?? null,
+              scrollKey
+            });
+            return;
+          }
+          // do not skip 0 here: if the user is at top, preserve that state
+          scroll_cache.set(k, {
+            scrollTop,
+            scrollLeft,
+            t: Date.now()
+          });
+          appendScrollLog('scroll:destroy_capture', {
+            k,
+            title: container?.title ?? null,
+            scrollTop,
+            scrollLeft
+          });
+        } catch (e) {
+          appendScrollLog('scroll:destroy_capture:error', {
+            title: container?.title ?? null,
+            error: String(e)
+          });
+        }
+      });
+    }
+    // When GoldenLayout resizes this panel (e.g. an adjacent panel is closed) the
+    // browser can shift scrollTop; re-apply the user's cached position after the reflow.
+    if (!container.__lope_resize_bound) {
+      container.__lope_resize_bound = true;
+      container.on('resize', () => {
+        const rk = scrollKeyFor(container);
+        const cached = scroll_cache.get(rk);
+        if (!cached || cached.scrollTop == null)
+          return;
+        const c_el = container.getElement();
+        const at = Date.now();
+        scroll_cache.__reflowUntil = at + 800;
+        // The reflow can shift scrollTop in several passes (content relayout
+        // settles ~300ms later), so re-apply over a window. Bail if the user scrolls.
+        const apply = () => {
+          if ((c_el.__lope_user_scroll_at || 0) > at)
+            return;
+          if (c_el.scrollTop !== cached.scrollTop)
+            c_el.scrollTop = cached.scrollTop;
+          if (cached.scrollLeft != null && c_el.scrollLeft !== cached.scrollLeft)
+            c_el.scrollLeft = cached.scrollLeft;
+        };
+        requestAnimationFrame(apply);
+        for (const d of [
+            60,
+            150,
+            300,
+            450,
+            600
+          ])
+          setTimeout(apply, d);
+        appendScrollLog('scroll:resize_restore', {
+          k: rk,
+          title: container?.title ?? null,
+          scrollTop: cached.scrollTop
+        });
+      });
+    }
+    appendScrollLog('modulePanel:exit', {
+      title: container?.title ?? null,
+      scrollKey
+    });
+  };
 };
 const _1gm4gbf = function _blobPanel(){return(
 function (container, component) {
@@ -14284,112 +14342,115 @@ const _1d1nkw9 = function _scrollKeyFor(appendScrollLog)
 const _tb217h = function _scroll_cache(){return(
 new Map()
 )};
-const _5tyvpe = function _fix_scroll(scrollKeyFor,appendScrollLog,scroll_cache){return(
-function (container, node, cell_variable, key) {
+const _12p8mg7 = function _fix_scroll(scroll_cache,scrollKeyFor,appendScrollLog)
+{
+  return function (container, node, cell_variable, key) {
+    scroll_cache.__reflowUntil = Date.now() + 600;
+    // suppress reflow-induced scroll events that clobber the cache
     const c_element = container.getElement();
     let k = scrollKeyFor(container);
     appendScrollLog('fix_scroll:enter', {
-        title: container?.title ?? null,
-        k,
-        cell: cell_variable?._name ?? null
+      title: container?.title ?? null,
+      k,
+      cell: cell_variable?._name ?? null
     });
     if (node && node.parentNode !== c_element) {
-        c_element.appendChild(node);
-        appendScrollLog('fix_scroll:append_node', {
-            title: container?.title ?? null,
-            k
-        });
+      c_element.appendChild(node);
+      appendScrollLog('fix_scroll:append_node', {
+        title: container?.title ?? null,
+        k
+      });
     }
     const writeCache = (scrollTop, scrollLeft, why) => {
-        scroll_cache.set(k, {
-            scrollTop,
-            scrollLeft,
-            t: Date.now()
-        });
-        appendScrollLog('scroll_cache:write', {
-            k,
-            scrollTop,
-            scrollLeft,
-            why
-        });
+      scroll_cache.set(k, {
+        scrollTop,
+        scrollLeft,
+        t: Date.now()
+      });
+      appendScrollLog('scroll_cache:write', {
+        k,
+        scrollTop,
+        scrollLeft,
+        why
+      });
     };
     const scrollToCellIfPossible = why => {
-        if (!cell_variable)
-            return false;
-        const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
-        if (!dom) {
-            appendScrollLog('scroll:cell_dom_not_found', {
-                k,
-                why,
-                cell: cell_variable?._name ?? null
-            });
-            return false;
-        }
-        const top = dom.offsetTop - c_element.offsetTop;
-        const left = c_element.scrollLeft;
-        c_element.scrollTop = top;
-        appendScrollLog('scroll:set', {
-            k,
-            why: `${ why }:cell`,
-            scrollTop: top,
-            scrollLeft: left,
-            cell: cell_variable?._name ?? null
+      if (!cell_variable)
+        return false;
+      const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
+      if (!dom) {
+        appendScrollLog('scroll:cell_dom_not_found', {
+          k,
+          why,
+          cell: cell_variable?._name ?? null
         });
-        writeCache(top, left, `${ why }:cell`);
-        return true;
+        return false;
+      }
+      const top = dom.offsetTop - c_element.offsetTop;
+      const left = c_element.scrollLeft;
+      c_element.scrollTop = top;
+      appendScrollLog('scroll:set', {
+        k,
+        why: `${ why }:cell`,
+        scrollTop: top,
+        scrollLeft: left,
+        cell: cell_variable?._name ?? null
+      });
+      writeCache(top, left, `${ why }:cell`);
+      return true;
     };
     const restoreFromCache = why => {
-        k = scrollKeyFor(container);
-        const cached = scroll_cache.get(k);
-        appendScrollLog('scroll:restore_attempt', {
-            k,
-            why,
-            cachedScrollTop: cached?.scrollTop ?? null,
-            cachedScrollLeft: cached?.scrollLeft ?? null
+      k = scrollKeyFor(container);
+      const cached = scroll_cache.get(k);
+      appendScrollLog('scroll:restore_attempt', {
+        k,
+        why,
+        cachedScrollTop: cached?.scrollTop ?? null,
+        cachedScrollLeft: cached?.scrollLeft ?? null
+      });
+      if (!cached) {
+        appendScrollLog('scroll:restore_no_scroll', {
+          k,
+          why
         });
-        if (!cached) {
-            appendScrollLog('scroll:restore_no_scroll', {
-                k,
-                why
-            });
-            return;
-        }
-        if (cached.scrollTop != null)
-            c_element.scrollTop = cached.scrollTop;
-        if (cached.scrollLeft != null)
-            c_element.scrollLeft = cached.scrollLeft;
-        appendScrollLog('scroll:restore_applied', {
-            k,
-            why,
-            scrollTop: cached.scrollTop ?? null,
-            scrollLeft: cached.scrollLeft ?? null,
-            scrollTopFinal: c_element.scrollTop,
-            scrollLeftFinal: c_element.scrollLeft
-        });
+        return;
+      }
+      if (cached.scrollTop != null)
+        c_element.scrollTop = cached.scrollTop;
+      if (cached.scrollLeft != null)
+        c_element.scrollLeft = cached.scrollLeft;
+      appendScrollLog('scroll:restore_applied', {
+        k,
+        why,
+        scrollTop: cached.scrollTop ?? null,
+        scrollLeft: cached.scrollLeft ?? null,
+        scrollTopFinal: c_element.scrollTop,
+        scrollLeftFinal: c_element.scrollLeft
+      });
     };
     const setScroll = (why = 'setScroll') => {
-        if (scrollToCellIfPossible(why))
-            return;
-        restoreFromCache(why);
+      if (scrollToCellIfPossible(why))
+        return;
+      restoreFromCache(why);
     };
     const retryFrames = 6;
     for (let i = 0; i < retryFrames; i++) {
-        requestAnimationFrame(() => {
-            k = scrollKeyFor(container);
-            appendScrollLog('fix_scroll:raf_retry', {
-                i,
-                k,
-                title: container?.title ?? null
-            });
-            setScroll(`raf:${ i }`);
+      requestAnimationFrame(() => {
+        k = scrollKeyFor(container);
+        appendScrollLog('fix_scroll:raf_retry', {
+          i,
+          k,
+          title: container?.title ?? null
         });
+        setScroll(`raf:${ i }`);
+      });
     }
     appendScrollLog('fix_scroll:exit', {
-        k,
-        title: container?.title ?? null
+      k,
+      title: container?.title ?? null
     });
-}
-)};
+  };
+};
 const _arfw00 = function _scroll_fix_sync_layout(sync_layout_to_url,layout,appendScrollLog,modulePanel)
 {
     sync_layout_to_url;
@@ -15467,7 +15528,7 @@ export default function define(runtime, observer) {
   $def("_1we0ggl", "reload", ["Generators","viewof reload"], _1we0ggl);  
   $def("_plefwg", "onLoadConfig", ["parseGoldenDSL","URLSearchParams","location"], _plefwg);  
   $def("_1nzpnqy", "visualizer_cache", ["reload"], _1nzpnqy);  
-  $def("_1l35721", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1l35721);  
+  $def("_1ojown8", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1ojown8);  
   $def("_1gm4gbf", "blobPanel", [], _1gm4gbf);  
   $def("_lxv2e2", "settings", [], _lxv2e2);  
   $def("_lp1ggk", "is_mobile", ["width"], _lp1ggk);  
@@ -15488,7 +15549,7 @@ export default function define(runtime, observer) {
   $def("_1dyz4o0", "scrollLog", ["mutable scrollLog"], _1dyz4o0);  
   $def("_1d1nkw9", "scrollKeyFor", ["appendScrollLog"], _1d1nkw9);  
   $def("_tb217h", "scroll_cache", [], _tb217h);  
-  $def("_5tyvpe", "fix_scroll", ["scrollKeyFor","appendScrollLog","scroll_cache"], _5tyvpe);  
+  $def("_12p8mg7", "fix_scroll", ["scroll_cache","scrollKeyFor","appendScrollLog"], _12p8mg7);  
   $def("_arfw00", "scroll_fix_sync_layout", ["sync_layout_to_url","layout","appendScrollLog","modulePanel"], _arfw00);  
   $def("_3nwpp4", "URLrouting", ["md"], _3nwpp4);  
   $def("_14te9pl", "sync_layout_from_url", ["reload","resize","URLSearchParams","hash","appendScrollLog","parseGoldenDSL","gl","layout","serializeGoldenDSL","treeSyncGolden","invalidation"], _14te9pl);  

--- a/notebooks/@tomlarkworthy_openai-responses-api.html
+++ b/notebooks/@tomlarkworthy_openai-responses-api.html
@@ -14037,138 +14037,196 @@ const _1nzpnqy = function _visualizer_cache(reload)
     reload;
     return new Map();
 };
-const _1l35721 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
+const _1ojown8 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
 {
-    return function (container, component) {
-        appendScrollLog('modulePanel:enter', {
-            title: container?.title ?? null,
-            componentCell: component?.cell ?? null
-        });
-        const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
-        if (!moduleInfo) {
-            // Fall through to file attachment: titles like @user/notebook/path.ext
-            // resolve via the lopecode bootloader's contentSync DOM lookup.
-            const title = container?.title ?? null;
-            if (title) {
-                let node = file_attachment_cache.get(title);
-                if (!node) {
-                    const r = window.lopecode?.contentSync?.(title);
-                    if (r && r.status === 200 && r.bytes) {
-                        node = renderFileAttachment(r.mime, r.bytes);
-                        file_attachment_cache.set(title, node);
-                        appendScrollLog('modulePanel:file_attachment_create', {
-                            title,
-                            mime: r.mime
-                        });
-                    }
-                }
-                if (node) {
-                    const c_element = container.getElement();
-                    if (node.parentNode !== c_element)
-                        c_element.appendChild(node);
-                    appendScrollLog('modulePanel:file_attachment_mount', { title });
-                    return;
-                }
-            }
-            appendScrollLog('modulePanel:missing_moduleInfo', { title });
-            return;
-        }
-        const module = moduleInfo.module;
-        let node;
-        if (!visualizer_cache.has(module)) {
-            appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
-            node = visualizer(runtime, {
-                invalidation: new Promise(r => {
-                }),
-                module,
-                detachNodes: isOnObservableCom(),
-                filter: (cell_name, variables) => {
-                    if (variables[0]._type !== 1)
-                        return false;
-                    if (typeof cell_name == 'string') {
-                        if (cell_name.startsWith('dynamic '))
-                            return false;
-                    }
-                    return true;
-                }
+  return function (container, component) {
+    appendScrollLog('modulePanel:enter', {
+      title: container?.title ?? null,
+      componentCell: component?.cell ?? null
+    });
+    const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
+    if (!moduleInfo) {
+      // Fall through to file attachment: titles like @user/notebook/path.ext
+      // resolve via the lopecode bootloader's contentSync DOM lookup.
+      const title = container?.title ?? null;
+      if (title) {
+        let node = file_attachment_cache.get(title);
+        if (!node) {
+          const r = window.lopecode?.contentSync?.(title);
+          if (r && r.status === 200 && r.bytes) {
+            node = renderFileAttachment(r.mime, r.bytes);
+            file_attachment_cache.set(title, node);
+            appendScrollLog('modulePanel:file_attachment_create', {
+              title,
+              mime: r.mime
             });
-            visualizer_cache.set(module, node);
-        } else {
-            node = visualizer_cache.get(module);
-            appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+          }
         }
-        const cell = module._scope.get(component.cell);
-        const scrollKey = scrollKeyFor(container);
-        fix_scroll(container, node, cell, scrollKey);
-        const el = container.getElement();
-        if (!el.__lope_scroll_bound) {
-            el.__lope_scroll_bound = true;
-            appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
-            el.addEventListener('scroll', () => {
-                const k = scrollKeyFor(container);
-                const scrollTop = el.scrollTop;
-                const scrollLeft = el.scrollLeft;
-                if (scrollTop == 0) {
-                    appendScrollLog('modulePanel:skip 0 scroll', {
-                        title: container?.title ?? null,
-                        scrollKey
-                    });
-                    return;
-                }
-                scroll_cache.set(k, {
-                    scrollTop,
-                    scrollLeft,
-                    t: Date.now()
-                });
-                appendScrollLog('scroll:event', {
-                    k,
-                    title: container?.title ?? null,
-                    scrollTop,
-                    scrollLeft
-                });
-            }, { passive: true });
+        if (node) {
+          const c_element = container.getElement();
+          if (node.parentNode !== c_element)
+            c_element.appendChild(node);
+          appendScrollLog('modulePanel:file_attachment_mount', { title });
+          return;
         }
-        // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
-        if (!container.__lope_destroy_bound) {
-            container.__lope_destroy_bound = true;
-            container.on('destroy', () => {
-                try {
-                    const k = scrollKeyFor(container);
-                    const scrollTop = el?.scrollTop;
-                    const scrollLeft = el?.scrollLeft;
-                    if (scrollTop == 0) {
-                        appendScrollLog('scroll:skip 0 scroll', {
-                            k,
-                            key: container?.title ?? null,
-                            scrollKey
-                        });
-                        return;
-                    }
-                    // do not skip 0 here: if the user is at top, preserve that state
-                    scroll_cache.set(k, {
-                        scrollTop,
-                        scrollLeft,
-                        t: Date.now()
-                    });
-                    appendScrollLog('scroll:destroy_capture', {
-                        k,
-                        title: container?.title ?? null,
-                        scrollTop,
-                        scrollLeft
-                    });
-                } catch (e) {
-                    appendScrollLog('scroll:destroy_capture:error', {
-                        title: container?.title ?? null,
-                        error: String(e)
-                    });
-                }
-            });
+      }
+      appendScrollLog('modulePanel:missing_moduleInfo', { title });
+      return;
+    }
+    const module = moduleInfo.module;
+    let node;
+    if (!visualizer_cache.has(module)) {
+      appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
+      node = visualizer(runtime, {
+        invalidation: new Promise(r => {
+        }),
+        module,
+        detachNodes: isOnObservableCom(),
+        filter: (cell_name, variables) => {
+          if (variables[0]._type !== 1)
+            return false;
+          if (typeof cell_name == 'string') {
+            if (cell_name.startsWith('dynamic '))
+              return false;
+          }
+          return true;
         }
-        appendScrollLog('modulePanel:exit', {
+      });
+      visualizer_cache.set(module, node);
+    } else {
+      node = visualizer_cache.get(module);
+      appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+    }
+    const cell = module._scope.get(component.cell);
+    const scrollKey = scrollKeyFor(container);
+    fix_scroll(container, node, cell, scrollKey);
+    const el = container.getElement();
+    if (!el.__lope_scroll_bound) {
+      el.__lope_scroll_bound = true;
+      appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
+      const markUserScroll = () => {
+        el.__lope_user_scroll_at = Date.now();
+      };
+      el.addEventListener('wheel', markUserScroll, { passive: true });
+      el.addEventListener('touchmove', markUserScroll, { passive: true });
+      el.addEventListener('keydown', markUserScroll, { passive: true });
+      el.addEventListener('scroll', () => {
+        if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+          appendScrollLog('scroll:skip_reflow', { title: container?.title ?? null });
+          return;
+        }
+        // Only cache scrolls following a genuine user gesture; reflow-induced
+        // scroll events (e.g. closing an adjacent panel) carry stale scrollTops.
+        if (Date.now() - (el.__lope_user_scroll_at || 0) > 400) {
+          appendScrollLog('scroll:skip_nonuser', { title: container?.title ?? null });
+          return;
+        }
+        const k = scrollKeyFor(container);
+        const scrollTop = el.scrollTop;
+        const scrollLeft = el.scrollLeft;
+        if (scrollTop == 0) {
+          appendScrollLog('modulePanel:skip 0 scroll', {
             title: container?.title ?? null,
             scrollKey
+          });
+          return;
+        }
+        scroll_cache.set(k, {
+          scrollTop,
+          scrollLeft,
+          t: Date.now()
         });
-    };
+        appendScrollLog('scroll:event', {
+          k,
+          title: container?.title ?? null,
+          scrollTop,
+          scrollLeft
+        });
+      }, { passive: true });
+    }
+    // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
+    if (!container.__lope_destroy_bound) {
+      container.__lope_destroy_bound = true;
+      container.on('destroy', () => {
+        try {
+          if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+            appendScrollLog('scroll:destroy_skip_reflow', { title: container?.title ?? null });
+            return;
+          }
+          const k = scrollKeyFor(container);
+          const scrollTop = el?.scrollTop;
+          const scrollLeft = el?.scrollLeft;
+          if (scrollTop == 0) {
+            appendScrollLog('scroll:skip 0 scroll', {
+              k,
+              key: container?.title ?? null,
+              scrollKey
+            });
+            return;
+          }
+          // do not skip 0 here: if the user is at top, preserve that state
+          scroll_cache.set(k, {
+            scrollTop,
+            scrollLeft,
+            t: Date.now()
+          });
+          appendScrollLog('scroll:destroy_capture', {
+            k,
+            title: container?.title ?? null,
+            scrollTop,
+            scrollLeft
+          });
+        } catch (e) {
+          appendScrollLog('scroll:destroy_capture:error', {
+            title: container?.title ?? null,
+            error: String(e)
+          });
+        }
+      });
+    }
+    // When GoldenLayout resizes this panel (e.g. an adjacent panel is closed) the
+    // browser can shift scrollTop; re-apply the user's cached position after the reflow.
+    if (!container.__lope_resize_bound) {
+      container.__lope_resize_bound = true;
+      container.on('resize', () => {
+        const rk = scrollKeyFor(container);
+        const cached = scroll_cache.get(rk);
+        if (!cached || cached.scrollTop == null)
+          return;
+        const c_el = container.getElement();
+        const at = Date.now();
+        scroll_cache.__reflowUntil = at + 800;
+        // The reflow can shift scrollTop in several passes (content relayout
+        // settles ~300ms later), so re-apply over a window. Bail if the user scrolls.
+        const apply = () => {
+          if ((c_el.__lope_user_scroll_at || 0) > at)
+            return;
+          if (c_el.scrollTop !== cached.scrollTop)
+            c_el.scrollTop = cached.scrollTop;
+          if (cached.scrollLeft != null && c_el.scrollLeft !== cached.scrollLeft)
+            c_el.scrollLeft = cached.scrollLeft;
+        };
+        requestAnimationFrame(apply);
+        for (const d of [
+            60,
+            150,
+            300,
+            450,
+            600
+          ])
+          setTimeout(apply, d);
+        appendScrollLog('scroll:resize_restore', {
+          k: rk,
+          title: container?.title ?? null,
+          scrollTop: cached.scrollTop
+        });
+      });
+    }
+    appendScrollLog('modulePanel:exit', {
+      title: container?.title ?? null,
+      scrollKey
+    });
+  };
 };
 const _1gm4gbf = function _blobPanel(){return(
 function (container, component) {
@@ -14286,112 +14344,115 @@ const _1d1nkw9 = function _scrollKeyFor(appendScrollLog)
 const _tb217h = function _scroll_cache(){return(
 new Map()
 )};
-const _5tyvpe = function _fix_scroll(scrollKeyFor,appendScrollLog,scroll_cache){return(
-function (container, node, cell_variable, key) {
+const _12p8mg7 = function _fix_scroll(scroll_cache,scrollKeyFor,appendScrollLog)
+{
+  return function (container, node, cell_variable, key) {
+    scroll_cache.__reflowUntil = Date.now() + 600;
+    // suppress reflow-induced scroll events that clobber the cache
     const c_element = container.getElement();
     let k = scrollKeyFor(container);
     appendScrollLog('fix_scroll:enter', {
-        title: container?.title ?? null,
-        k,
-        cell: cell_variable?._name ?? null
+      title: container?.title ?? null,
+      k,
+      cell: cell_variable?._name ?? null
     });
     if (node && node.parentNode !== c_element) {
-        c_element.appendChild(node);
-        appendScrollLog('fix_scroll:append_node', {
-            title: container?.title ?? null,
-            k
-        });
+      c_element.appendChild(node);
+      appendScrollLog('fix_scroll:append_node', {
+        title: container?.title ?? null,
+        k
+      });
     }
     const writeCache = (scrollTop, scrollLeft, why) => {
-        scroll_cache.set(k, {
-            scrollTop,
-            scrollLeft,
-            t: Date.now()
-        });
-        appendScrollLog('scroll_cache:write', {
-            k,
-            scrollTop,
-            scrollLeft,
-            why
-        });
+      scroll_cache.set(k, {
+        scrollTop,
+        scrollLeft,
+        t: Date.now()
+      });
+      appendScrollLog('scroll_cache:write', {
+        k,
+        scrollTop,
+        scrollLeft,
+        why
+      });
     };
     const scrollToCellIfPossible = why => {
-        if (!cell_variable)
-            return false;
-        const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
-        if (!dom) {
-            appendScrollLog('scroll:cell_dom_not_found', {
-                k,
-                why,
-                cell: cell_variable?._name ?? null
-            });
-            return false;
-        }
-        const top = dom.offsetTop - c_element.offsetTop;
-        const left = c_element.scrollLeft;
-        c_element.scrollTop = top;
-        appendScrollLog('scroll:set', {
-            k,
-            why: `${ why }:cell`,
-            scrollTop: top,
-            scrollLeft: left,
-            cell: cell_variable?._name ?? null
+      if (!cell_variable)
+        return false;
+      const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
+      if (!dom) {
+        appendScrollLog('scroll:cell_dom_not_found', {
+          k,
+          why,
+          cell: cell_variable?._name ?? null
         });
-        writeCache(top, left, `${ why }:cell`);
-        return true;
+        return false;
+      }
+      const top = dom.offsetTop - c_element.offsetTop;
+      const left = c_element.scrollLeft;
+      c_element.scrollTop = top;
+      appendScrollLog('scroll:set', {
+        k,
+        why: `${ why }:cell`,
+        scrollTop: top,
+        scrollLeft: left,
+        cell: cell_variable?._name ?? null
+      });
+      writeCache(top, left, `${ why }:cell`);
+      return true;
     };
     const restoreFromCache = why => {
-        k = scrollKeyFor(container);
-        const cached = scroll_cache.get(k);
-        appendScrollLog('scroll:restore_attempt', {
-            k,
-            why,
-            cachedScrollTop: cached?.scrollTop ?? null,
-            cachedScrollLeft: cached?.scrollLeft ?? null
+      k = scrollKeyFor(container);
+      const cached = scroll_cache.get(k);
+      appendScrollLog('scroll:restore_attempt', {
+        k,
+        why,
+        cachedScrollTop: cached?.scrollTop ?? null,
+        cachedScrollLeft: cached?.scrollLeft ?? null
+      });
+      if (!cached) {
+        appendScrollLog('scroll:restore_no_scroll', {
+          k,
+          why
         });
-        if (!cached) {
-            appendScrollLog('scroll:restore_no_scroll', {
-                k,
-                why
-            });
-            return;
-        }
-        if (cached.scrollTop != null)
-            c_element.scrollTop = cached.scrollTop;
-        if (cached.scrollLeft != null)
-            c_element.scrollLeft = cached.scrollLeft;
-        appendScrollLog('scroll:restore_applied', {
-            k,
-            why,
-            scrollTop: cached.scrollTop ?? null,
-            scrollLeft: cached.scrollLeft ?? null,
-            scrollTopFinal: c_element.scrollTop,
-            scrollLeftFinal: c_element.scrollLeft
-        });
+        return;
+      }
+      if (cached.scrollTop != null)
+        c_element.scrollTop = cached.scrollTop;
+      if (cached.scrollLeft != null)
+        c_element.scrollLeft = cached.scrollLeft;
+      appendScrollLog('scroll:restore_applied', {
+        k,
+        why,
+        scrollTop: cached.scrollTop ?? null,
+        scrollLeft: cached.scrollLeft ?? null,
+        scrollTopFinal: c_element.scrollTop,
+        scrollLeftFinal: c_element.scrollLeft
+      });
     };
     const setScroll = (why = 'setScroll') => {
-        if (scrollToCellIfPossible(why))
-            return;
-        restoreFromCache(why);
+      if (scrollToCellIfPossible(why))
+        return;
+      restoreFromCache(why);
     };
     const retryFrames = 6;
     for (let i = 0; i < retryFrames; i++) {
-        requestAnimationFrame(() => {
-            k = scrollKeyFor(container);
-            appendScrollLog('fix_scroll:raf_retry', {
-                i,
-                k,
-                title: container?.title ?? null
-            });
-            setScroll(`raf:${ i }`);
+      requestAnimationFrame(() => {
+        k = scrollKeyFor(container);
+        appendScrollLog('fix_scroll:raf_retry', {
+          i,
+          k,
+          title: container?.title ?? null
         });
+        setScroll(`raf:${ i }`);
+      });
     }
     appendScrollLog('fix_scroll:exit', {
-        k,
-        title: container?.title ?? null
+      k,
+      title: container?.title ?? null
     });
-}
-)};
+  };
+};
 const _arfw00 = function _scroll_fix_sync_layout(sync_layout_to_url,layout,appendScrollLog,modulePanel)
 {
     sync_layout_to_url;
@@ -15469,7 +15530,7 @@ export default function define(runtime, observer) {
   $def("_1we0ggl", "reload", ["Generators","viewof reload"], _1we0ggl);  
   $def("_plefwg", "onLoadConfig", ["parseGoldenDSL","URLSearchParams","location"], _plefwg);  
   $def("_1nzpnqy", "visualizer_cache", ["reload"], _1nzpnqy);  
-  $def("_1l35721", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1l35721);  
+  $def("_1ojown8", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1ojown8);  
   $def("_1gm4gbf", "blobPanel", [], _1gm4gbf);  
   $def("_lxv2e2", "settings", [], _lxv2e2);  
   $def("_lp1ggk", "is_mobile", ["width"], _lp1ggk);  
@@ -15490,7 +15551,7 @@ export default function define(runtime, observer) {
   $def("_1dyz4o0", "scrollLog", ["mutable scrollLog"], _1dyz4o0);  
   $def("_1d1nkw9", "scrollKeyFor", ["appendScrollLog"], _1d1nkw9);  
   $def("_tb217h", "scroll_cache", [], _tb217h);  
-  $def("_5tyvpe", "fix_scroll", ["scrollKeyFor","appendScrollLog","scroll_cache"], _5tyvpe);  
+  $def("_12p8mg7", "fix_scroll", ["scroll_cache","scrollKeyFor","appendScrollLog"], _12p8mg7);  
   $def("_arfw00", "scroll_fix_sync_layout", ["sync_layout_to_url","layout","appendScrollLog","modulePanel"], _arfw00);  
   $def("_3nwpp4", "URLrouting", ["md"], _3nwpp4);  
   $def("_14te9pl", "sync_layout_from_url", ["reload","resize","URLSearchParams","hash","appendScrollLog","parseGoldenDSL","gl","layout","serializeGoldenDSL","treeSyncGolden","invalidation"], _14te9pl);  

--- a/notebooks/@tomlarkworthy_reversible-attachment.html
+++ b/notebooks/@tomlarkworthy_reversible-attachment.html
@@ -14037,138 +14037,196 @@ const _1nzpnqy = function _visualizer_cache(reload)
     reload;
     return new Map();
 };
-const _1l35721 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
+const _1ojown8 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
 {
-    return function (container, component) {
-        appendScrollLog('modulePanel:enter', {
-            title: container?.title ?? null,
-            componentCell: component?.cell ?? null
-        });
-        const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
-        if (!moduleInfo) {
-            // Fall through to file attachment: titles like @user/notebook/path.ext
-            // resolve via the lopecode bootloader's contentSync DOM lookup.
-            const title = container?.title ?? null;
-            if (title) {
-                let node = file_attachment_cache.get(title);
-                if (!node) {
-                    const r = window.lopecode?.contentSync?.(title);
-                    if (r && r.status === 200 && r.bytes) {
-                        node = renderFileAttachment(r.mime, r.bytes);
-                        file_attachment_cache.set(title, node);
-                        appendScrollLog('modulePanel:file_attachment_create', {
-                            title,
-                            mime: r.mime
-                        });
-                    }
-                }
-                if (node) {
-                    const c_element = container.getElement();
-                    if (node.parentNode !== c_element)
-                        c_element.appendChild(node);
-                    appendScrollLog('modulePanel:file_attachment_mount', { title });
-                    return;
-                }
-            }
-            appendScrollLog('modulePanel:missing_moduleInfo', { title });
-            return;
-        }
-        const module = moduleInfo.module;
-        let node;
-        if (!visualizer_cache.has(module)) {
-            appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
-            node = visualizer(runtime, {
-                invalidation: new Promise(r => {
-                }),
-                module,
-                detachNodes: isOnObservableCom(),
-                filter: (cell_name, variables) => {
-                    if (variables[0]._type !== 1)
-                        return false;
-                    if (typeof cell_name == 'string') {
-                        if (cell_name.startsWith('dynamic '))
-                            return false;
-                    }
-                    return true;
-                }
+  return function (container, component) {
+    appendScrollLog('modulePanel:enter', {
+      title: container?.title ?? null,
+      componentCell: component?.cell ?? null
+    });
+    const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
+    if (!moduleInfo) {
+      // Fall through to file attachment: titles like @user/notebook/path.ext
+      // resolve via the lopecode bootloader's contentSync DOM lookup.
+      const title = container?.title ?? null;
+      if (title) {
+        let node = file_attachment_cache.get(title);
+        if (!node) {
+          const r = window.lopecode?.contentSync?.(title);
+          if (r && r.status === 200 && r.bytes) {
+            node = renderFileAttachment(r.mime, r.bytes);
+            file_attachment_cache.set(title, node);
+            appendScrollLog('modulePanel:file_attachment_create', {
+              title,
+              mime: r.mime
             });
-            visualizer_cache.set(module, node);
-        } else {
-            node = visualizer_cache.get(module);
-            appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+          }
         }
-        const cell = module._scope.get(component.cell);
-        const scrollKey = scrollKeyFor(container);
-        fix_scroll(container, node, cell, scrollKey);
-        const el = container.getElement();
-        if (!el.__lope_scroll_bound) {
-            el.__lope_scroll_bound = true;
-            appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
-            el.addEventListener('scroll', () => {
-                const k = scrollKeyFor(container);
-                const scrollTop = el.scrollTop;
-                const scrollLeft = el.scrollLeft;
-                if (scrollTop == 0) {
-                    appendScrollLog('modulePanel:skip 0 scroll', {
-                        title: container?.title ?? null,
-                        scrollKey
-                    });
-                    return;
-                }
-                scroll_cache.set(k, {
-                    scrollTop,
-                    scrollLeft,
-                    t: Date.now()
-                });
-                appendScrollLog('scroll:event', {
-                    k,
-                    title: container?.title ?? null,
-                    scrollTop,
-                    scrollLeft
-                });
-            }, { passive: true });
+        if (node) {
+          const c_element = container.getElement();
+          if (node.parentNode !== c_element)
+            c_element.appendChild(node);
+          appendScrollLog('modulePanel:file_attachment_mount', { title });
+          return;
         }
-        // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
-        if (!container.__lope_destroy_bound) {
-            container.__lope_destroy_bound = true;
-            container.on('destroy', () => {
-                try {
-                    const k = scrollKeyFor(container);
-                    const scrollTop = el?.scrollTop;
-                    const scrollLeft = el?.scrollLeft;
-                    if (scrollTop == 0) {
-                        appendScrollLog('scroll:skip 0 scroll', {
-                            k,
-                            key: container?.title ?? null,
-                            scrollKey
-                        });
-                        return;
-                    }
-                    // do not skip 0 here: if the user is at top, preserve that state
-                    scroll_cache.set(k, {
-                        scrollTop,
-                        scrollLeft,
-                        t: Date.now()
-                    });
-                    appendScrollLog('scroll:destroy_capture', {
-                        k,
-                        title: container?.title ?? null,
-                        scrollTop,
-                        scrollLeft
-                    });
-                } catch (e) {
-                    appendScrollLog('scroll:destroy_capture:error', {
-                        title: container?.title ?? null,
-                        error: String(e)
-                    });
-                }
-            });
+      }
+      appendScrollLog('modulePanel:missing_moduleInfo', { title });
+      return;
+    }
+    const module = moduleInfo.module;
+    let node;
+    if (!visualizer_cache.has(module)) {
+      appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
+      node = visualizer(runtime, {
+        invalidation: new Promise(r => {
+        }),
+        module,
+        detachNodes: isOnObservableCom(),
+        filter: (cell_name, variables) => {
+          if (variables[0]._type !== 1)
+            return false;
+          if (typeof cell_name == 'string') {
+            if (cell_name.startsWith('dynamic '))
+              return false;
+          }
+          return true;
         }
-        appendScrollLog('modulePanel:exit', {
+      });
+      visualizer_cache.set(module, node);
+    } else {
+      node = visualizer_cache.get(module);
+      appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+    }
+    const cell = module._scope.get(component.cell);
+    const scrollKey = scrollKeyFor(container);
+    fix_scroll(container, node, cell, scrollKey);
+    const el = container.getElement();
+    if (!el.__lope_scroll_bound) {
+      el.__lope_scroll_bound = true;
+      appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
+      const markUserScroll = () => {
+        el.__lope_user_scroll_at = Date.now();
+      };
+      el.addEventListener('wheel', markUserScroll, { passive: true });
+      el.addEventListener('touchmove', markUserScroll, { passive: true });
+      el.addEventListener('keydown', markUserScroll, { passive: true });
+      el.addEventListener('scroll', () => {
+        if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+          appendScrollLog('scroll:skip_reflow', { title: container?.title ?? null });
+          return;
+        }
+        // Only cache scrolls following a genuine user gesture; reflow-induced
+        // scroll events (e.g. closing an adjacent panel) carry stale scrollTops.
+        if (Date.now() - (el.__lope_user_scroll_at || 0) > 400) {
+          appendScrollLog('scroll:skip_nonuser', { title: container?.title ?? null });
+          return;
+        }
+        const k = scrollKeyFor(container);
+        const scrollTop = el.scrollTop;
+        const scrollLeft = el.scrollLeft;
+        if (scrollTop == 0) {
+          appendScrollLog('modulePanel:skip 0 scroll', {
             title: container?.title ?? null,
             scrollKey
+          });
+          return;
+        }
+        scroll_cache.set(k, {
+          scrollTop,
+          scrollLeft,
+          t: Date.now()
         });
-    };
+        appendScrollLog('scroll:event', {
+          k,
+          title: container?.title ?? null,
+          scrollTop,
+          scrollLeft
+        });
+      }, { passive: true });
+    }
+    // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
+    if (!container.__lope_destroy_bound) {
+      container.__lope_destroy_bound = true;
+      container.on('destroy', () => {
+        try {
+          if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+            appendScrollLog('scroll:destroy_skip_reflow', { title: container?.title ?? null });
+            return;
+          }
+          const k = scrollKeyFor(container);
+          const scrollTop = el?.scrollTop;
+          const scrollLeft = el?.scrollLeft;
+          if (scrollTop == 0) {
+            appendScrollLog('scroll:skip 0 scroll', {
+              k,
+              key: container?.title ?? null,
+              scrollKey
+            });
+            return;
+          }
+          // do not skip 0 here: if the user is at top, preserve that state
+          scroll_cache.set(k, {
+            scrollTop,
+            scrollLeft,
+            t: Date.now()
+          });
+          appendScrollLog('scroll:destroy_capture', {
+            k,
+            title: container?.title ?? null,
+            scrollTop,
+            scrollLeft
+          });
+        } catch (e) {
+          appendScrollLog('scroll:destroy_capture:error', {
+            title: container?.title ?? null,
+            error: String(e)
+          });
+        }
+      });
+    }
+    // When GoldenLayout resizes this panel (e.g. an adjacent panel is closed) the
+    // browser can shift scrollTop; re-apply the user's cached position after the reflow.
+    if (!container.__lope_resize_bound) {
+      container.__lope_resize_bound = true;
+      container.on('resize', () => {
+        const rk = scrollKeyFor(container);
+        const cached = scroll_cache.get(rk);
+        if (!cached || cached.scrollTop == null)
+          return;
+        const c_el = container.getElement();
+        const at = Date.now();
+        scroll_cache.__reflowUntil = at + 800;
+        // The reflow can shift scrollTop in several passes (content relayout
+        // settles ~300ms later), so re-apply over a window. Bail if the user scrolls.
+        const apply = () => {
+          if ((c_el.__lope_user_scroll_at || 0) > at)
+            return;
+          if (c_el.scrollTop !== cached.scrollTop)
+            c_el.scrollTop = cached.scrollTop;
+          if (cached.scrollLeft != null && c_el.scrollLeft !== cached.scrollLeft)
+            c_el.scrollLeft = cached.scrollLeft;
+        };
+        requestAnimationFrame(apply);
+        for (const d of [
+            60,
+            150,
+            300,
+            450,
+            600
+          ])
+          setTimeout(apply, d);
+        appendScrollLog('scroll:resize_restore', {
+          k: rk,
+          title: container?.title ?? null,
+          scrollTop: cached.scrollTop
+        });
+      });
+    }
+    appendScrollLog('modulePanel:exit', {
+      title: container?.title ?? null,
+      scrollKey
+    });
+  };
 };
 const _1gm4gbf = function _blobPanel(){return(
 function (container, component) {
@@ -14286,112 +14344,115 @@ const _1d1nkw9 = function _scrollKeyFor(appendScrollLog)
 const _tb217h = function _scroll_cache(){return(
 new Map()
 )};
-const _5tyvpe = function _fix_scroll(scrollKeyFor,appendScrollLog,scroll_cache){return(
-function (container, node, cell_variable, key) {
+const _12p8mg7 = function _fix_scroll(scroll_cache,scrollKeyFor,appendScrollLog)
+{
+  return function (container, node, cell_variable, key) {
+    scroll_cache.__reflowUntil = Date.now() + 600;
+    // suppress reflow-induced scroll events that clobber the cache
     const c_element = container.getElement();
     let k = scrollKeyFor(container);
     appendScrollLog('fix_scroll:enter', {
-        title: container?.title ?? null,
-        k,
-        cell: cell_variable?._name ?? null
+      title: container?.title ?? null,
+      k,
+      cell: cell_variable?._name ?? null
     });
     if (node && node.parentNode !== c_element) {
-        c_element.appendChild(node);
-        appendScrollLog('fix_scroll:append_node', {
-            title: container?.title ?? null,
-            k
-        });
+      c_element.appendChild(node);
+      appendScrollLog('fix_scroll:append_node', {
+        title: container?.title ?? null,
+        k
+      });
     }
     const writeCache = (scrollTop, scrollLeft, why) => {
-        scroll_cache.set(k, {
-            scrollTop,
-            scrollLeft,
-            t: Date.now()
-        });
-        appendScrollLog('scroll_cache:write', {
-            k,
-            scrollTop,
-            scrollLeft,
-            why
-        });
+      scroll_cache.set(k, {
+        scrollTop,
+        scrollLeft,
+        t: Date.now()
+      });
+      appendScrollLog('scroll_cache:write', {
+        k,
+        scrollTop,
+        scrollLeft,
+        why
+      });
     };
     const scrollToCellIfPossible = why => {
-        if (!cell_variable)
-            return false;
-        const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
-        if (!dom) {
-            appendScrollLog('scroll:cell_dom_not_found', {
-                k,
-                why,
-                cell: cell_variable?._name ?? null
-            });
-            return false;
-        }
-        const top = dom.offsetTop - c_element.offsetTop;
-        const left = c_element.scrollLeft;
-        c_element.scrollTop = top;
-        appendScrollLog('scroll:set', {
-            k,
-            why: `${ why }:cell`,
-            scrollTop: top,
-            scrollLeft: left,
-            cell: cell_variable?._name ?? null
+      if (!cell_variable)
+        return false;
+      const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
+      if (!dom) {
+        appendScrollLog('scroll:cell_dom_not_found', {
+          k,
+          why,
+          cell: cell_variable?._name ?? null
         });
-        writeCache(top, left, `${ why }:cell`);
-        return true;
+        return false;
+      }
+      const top = dom.offsetTop - c_element.offsetTop;
+      const left = c_element.scrollLeft;
+      c_element.scrollTop = top;
+      appendScrollLog('scroll:set', {
+        k,
+        why: `${ why }:cell`,
+        scrollTop: top,
+        scrollLeft: left,
+        cell: cell_variable?._name ?? null
+      });
+      writeCache(top, left, `${ why }:cell`);
+      return true;
     };
     const restoreFromCache = why => {
-        k = scrollKeyFor(container);
-        const cached = scroll_cache.get(k);
-        appendScrollLog('scroll:restore_attempt', {
-            k,
-            why,
-            cachedScrollTop: cached?.scrollTop ?? null,
-            cachedScrollLeft: cached?.scrollLeft ?? null
+      k = scrollKeyFor(container);
+      const cached = scroll_cache.get(k);
+      appendScrollLog('scroll:restore_attempt', {
+        k,
+        why,
+        cachedScrollTop: cached?.scrollTop ?? null,
+        cachedScrollLeft: cached?.scrollLeft ?? null
+      });
+      if (!cached) {
+        appendScrollLog('scroll:restore_no_scroll', {
+          k,
+          why
         });
-        if (!cached) {
-            appendScrollLog('scroll:restore_no_scroll', {
-                k,
-                why
-            });
-            return;
-        }
-        if (cached.scrollTop != null)
-            c_element.scrollTop = cached.scrollTop;
-        if (cached.scrollLeft != null)
-            c_element.scrollLeft = cached.scrollLeft;
-        appendScrollLog('scroll:restore_applied', {
-            k,
-            why,
-            scrollTop: cached.scrollTop ?? null,
-            scrollLeft: cached.scrollLeft ?? null,
-            scrollTopFinal: c_element.scrollTop,
-            scrollLeftFinal: c_element.scrollLeft
-        });
+        return;
+      }
+      if (cached.scrollTop != null)
+        c_element.scrollTop = cached.scrollTop;
+      if (cached.scrollLeft != null)
+        c_element.scrollLeft = cached.scrollLeft;
+      appendScrollLog('scroll:restore_applied', {
+        k,
+        why,
+        scrollTop: cached.scrollTop ?? null,
+        scrollLeft: cached.scrollLeft ?? null,
+        scrollTopFinal: c_element.scrollTop,
+        scrollLeftFinal: c_element.scrollLeft
+      });
     };
     const setScroll = (why = 'setScroll') => {
-        if (scrollToCellIfPossible(why))
-            return;
-        restoreFromCache(why);
+      if (scrollToCellIfPossible(why))
+        return;
+      restoreFromCache(why);
     };
     const retryFrames = 6;
     for (let i = 0; i < retryFrames; i++) {
-        requestAnimationFrame(() => {
-            k = scrollKeyFor(container);
-            appendScrollLog('fix_scroll:raf_retry', {
-                i,
-                k,
-                title: container?.title ?? null
-            });
-            setScroll(`raf:${ i }`);
+      requestAnimationFrame(() => {
+        k = scrollKeyFor(container);
+        appendScrollLog('fix_scroll:raf_retry', {
+          i,
+          k,
+          title: container?.title ?? null
         });
+        setScroll(`raf:${ i }`);
+      });
     }
     appendScrollLog('fix_scroll:exit', {
-        k,
-        title: container?.title ?? null
+      k,
+      title: container?.title ?? null
     });
-}
-)};
+  };
+};
 const _arfw00 = function _scroll_fix_sync_layout(sync_layout_to_url,layout,appendScrollLog,modulePanel)
 {
     sync_layout_to_url;
@@ -15469,7 +15530,7 @@ export default function define(runtime, observer) {
   $def("_1we0ggl", "reload", ["Generators","viewof reload"], _1we0ggl);  
   $def("_plefwg", "onLoadConfig", ["parseGoldenDSL","URLSearchParams","location"], _plefwg);  
   $def("_1nzpnqy", "visualizer_cache", ["reload"], _1nzpnqy);  
-  $def("_1l35721", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1l35721);  
+  $def("_1ojown8", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1ojown8);  
   $def("_1gm4gbf", "blobPanel", [], _1gm4gbf);  
   $def("_lxv2e2", "settings", [], _lxv2e2);  
   $def("_lp1ggk", "is_mobile", ["width"], _lp1ggk);  
@@ -15490,7 +15551,7 @@ export default function define(runtime, observer) {
   $def("_1dyz4o0", "scrollLog", ["mutable scrollLog"], _1dyz4o0);  
   $def("_1d1nkw9", "scrollKeyFor", ["appendScrollLog"], _1d1nkw9);  
   $def("_tb217h", "scroll_cache", [], _tb217h);  
-  $def("_5tyvpe", "fix_scroll", ["scrollKeyFor","appendScrollLog","scroll_cache"], _5tyvpe);  
+  $def("_12p8mg7", "fix_scroll", ["scroll_cache","scrollKeyFor","appendScrollLog"], _12p8mg7);  
   $def("_arfw00", "scroll_fix_sync_layout", ["sync_layout_to_url","layout","appendScrollLog","modulePanel"], _arfw00);  
   $def("_3nwpp4", "URLrouting", ["md"], _3nwpp4);  
   $def("_14te9pl", "sync_layout_from_url", ["reload","resize","URLSearchParams","hash","appendScrollLog","parseGoldenDSL","gl","layout","serializeGoldenDSL","treeSyncGolden","invalidation"], _14te9pl);  

--- a/notebooks/@tomlarkworthy_robocoop-2.html
+++ b/notebooks/@tomlarkworthy_robocoop-2.html
@@ -14037,138 +14037,196 @@ const _1nzpnqy = function _visualizer_cache(reload)
     reload;
     return new Map();
 };
-const _1l35721 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
+const _1ojown8 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
 {
-    return function (container, component) {
-        appendScrollLog('modulePanel:enter', {
-            title: container?.title ?? null,
-            componentCell: component?.cell ?? null
-        });
-        const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
-        if (!moduleInfo) {
-            // Fall through to file attachment: titles like @user/notebook/path.ext
-            // resolve via the lopecode bootloader's contentSync DOM lookup.
-            const title = container?.title ?? null;
-            if (title) {
-                let node = file_attachment_cache.get(title);
-                if (!node) {
-                    const r = window.lopecode?.contentSync?.(title);
-                    if (r && r.status === 200 && r.bytes) {
-                        node = renderFileAttachment(r.mime, r.bytes);
-                        file_attachment_cache.set(title, node);
-                        appendScrollLog('modulePanel:file_attachment_create', {
-                            title,
-                            mime: r.mime
-                        });
-                    }
-                }
-                if (node) {
-                    const c_element = container.getElement();
-                    if (node.parentNode !== c_element)
-                        c_element.appendChild(node);
-                    appendScrollLog('modulePanel:file_attachment_mount', { title });
-                    return;
-                }
-            }
-            appendScrollLog('modulePanel:missing_moduleInfo', { title });
-            return;
-        }
-        const module = moduleInfo.module;
-        let node;
-        if (!visualizer_cache.has(module)) {
-            appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
-            node = visualizer(runtime, {
-                invalidation: new Promise(r => {
-                }),
-                module,
-                detachNodes: isOnObservableCom(),
-                filter: (cell_name, variables) => {
-                    if (variables[0]._type !== 1)
-                        return false;
-                    if (typeof cell_name == 'string') {
-                        if (cell_name.startsWith('dynamic '))
-                            return false;
-                    }
-                    return true;
-                }
+  return function (container, component) {
+    appendScrollLog('modulePanel:enter', {
+      title: container?.title ?? null,
+      componentCell: component?.cell ?? null
+    });
+    const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
+    if (!moduleInfo) {
+      // Fall through to file attachment: titles like @user/notebook/path.ext
+      // resolve via the lopecode bootloader's contentSync DOM lookup.
+      const title = container?.title ?? null;
+      if (title) {
+        let node = file_attachment_cache.get(title);
+        if (!node) {
+          const r = window.lopecode?.contentSync?.(title);
+          if (r && r.status === 200 && r.bytes) {
+            node = renderFileAttachment(r.mime, r.bytes);
+            file_attachment_cache.set(title, node);
+            appendScrollLog('modulePanel:file_attachment_create', {
+              title,
+              mime: r.mime
             });
-            visualizer_cache.set(module, node);
-        } else {
-            node = visualizer_cache.get(module);
-            appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+          }
         }
-        const cell = module._scope.get(component.cell);
-        const scrollKey = scrollKeyFor(container);
-        fix_scroll(container, node, cell, scrollKey);
-        const el = container.getElement();
-        if (!el.__lope_scroll_bound) {
-            el.__lope_scroll_bound = true;
-            appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
-            el.addEventListener('scroll', () => {
-                const k = scrollKeyFor(container);
-                const scrollTop = el.scrollTop;
-                const scrollLeft = el.scrollLeft;
-                if (scrollTop == 0) {
-                    appendScrollLog('modulePanel:skip 0 scroll', {
-                        title: container?.title ?? null,
-                        scrollKey
-                    });
-                    return;
-                }
-                scroll_cache.set(k, {
-                    scrollTop,
-                    scrollLeft,
-                    t: Date.now()
-                });
-                appendScrollLog('scroll:event', {
-                    k,
-                    title: container?.title ?? null,
-                    scrollTop,
-                    scrollLeft
-                });
-            }, { passive: true });
+        if (node) {
+          const c_element = container.getElement();
+          if (node.parentNode !== c_element)
+            c_element.appendChild(node);
+          appendScrollLog('modulePanel:file_attachment_mount', { title });
+          return;
         }
-        // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
-        if (!container.__lope_destroy_bound) {
-            container.__lope_destroy_bound = true;
-            container.on('destroy', () => {
-                try {
-                    const k = scrollKeyFor(container);
-                    const scrollTop = el?.scrollTop;
-                    const scrollLeft = el?.scrollLeft;
-                    if (scrollTop == 0) {
-                        appendScrollLog('scroll:skip 0 scroll', {
-                            k,
-                            key: container?.title ?? null,
-                            scrollKey
-                        });
-                        return;
-                    }
-                    // do not skip 0 here: if the user is at top, preserve that state
-                    scroll_cache.set(k, {
-                        scrollTop,
-                        scrollLeft,
-                        t: Date.now()
-                    });
-                    appendScrollLog('scroll:destroy_capture', {
-                        k,
-                        title: container?.title ?? null,
-                        scrollTop,
-                        scrollLeft
-                    });
-                } catch (e) {
-                    appendScrollLog('scroll:destroy_capture:error', {
-                        title: container?.title ?? null,
-                        error: String(e)
-                    });
-                }
-            });
+      }
+      appendScrollLog('modulePanel:missing_moduleInfo', { title });
+      return;
+    }
+    const module = moduleInfo.module;
+    let node;
+    if (!visualizer_cache.has(module)) {
+      appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
+      node = visualizer(runtime, {
+        invalidation: new Promise(r => {
+        }),
+        module,
+        detachNodes: isOnObservableCom(),
+        filter: (cell_name, variables) => {
+          if (variables[0]._type !== 1)
+            return false;
+          if (typeof cell_name == 'string') {
+            if (cell_name.startsWith('dynamic '))
+              return false;
+          }
+          return true;
         }
-        appendScrollLog('modulePanel:exit', {
+      });
+      visualizer_cache.set(module, node);
+    } else {
+      node = visualizer_cache.get(module);
+      appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+    }
+    const cell = module._scope.get(component.cell);
+    const scrollKey = scrollKeyFor(container);
+    fix_scroll(container, node, cell, scrollKey);
+    const el = container.getElement();
+    if (!el.__lope_scroll_bound) {
+      el.__lope_scroll_bound = true;
+      appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
+      const markUserScroll = () => {
+        el.__lope_user_scroll_at = Date.now();
+      };
+      el.addEventListener('wheel', markUserScroll, { passive: true });
+      el.addEventListener('touchmove', markUserScroll, { passive: true });
+      el.addEventListener('keydown', markUserScroll, { passive: true });
+      el.addEventListener('scroll', () => {
+        if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+          appendScrollLog('scroll:skip_reflow', { title: container?.title ?? null });
+          return;
+        }
+        // Only cache scrolls following a genuine user gesture; reflow-induced
+        // scroll events (e.g. closing an adjacent panel) carry stale scrollTops.
+        if (Date.now() - (el.__lope_user_scroll_at || 0) > 400) {
+          appendScrollLog('scroll:skip_nonuser', { title: container?.title ?? null });
+          return;
+        }
+        const k = scrollKeyFor(container);
+        const scrollTop = el.scrollTop;
+        const scrollLeft = el.scrollLeft;
+        if (scrollTop == 0) {
+          appendScrollLog('modulePanel:skip 0 scroll', {
             title: container?.title ?? null,
             scrollKey
+          });
+          return;
+        }
+        scroll_cache.set(k, {
+          scrollTop,
+          scrollLeft,
+          t: Date.now()
         });
-    };
+        appendScrollLog('scroll:event', {
+          k,
+          title: container?.title ?? null,
+          scrollTop,
+          scrollLeft
+        });
+      }, { passive: true });
+    }
+    // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
+    if (!container.__lope_destroy_bound) {
+      container.__lope_destroy_bound = true;
+      container.on('destroy', () => {
+        try {
+          if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+            appendScrollLog('scroll:destroy_skip_reflow', { title: container?.title ?? null });
+            return;
+          }
+          const k = scrollKeyFor(container);
+          const scrollTop = el?.scrollTop;
+          const scrollLeft = el?.scrollLeft;
+          if (scrollTop == 0) {
+            appendScrollLog('scroll:skip 0 scroll', {
+              k,
+              key: container?.title ?? null,
+              scrollKey
+            });
+            return;
+          }
+          // do not skip 0 here: if the user is at top, preserve that state
+          scroll_cache.set(k, {
+            scrollTop,
+            scrollLeft,
+            t: Date.now()
+          });
+          appendScrollLog('scroll:destroy_capture', {
+            k,
+            title: container?.title ?? null,
+            scrollTop,
+            scrollLeft
+          });
+        } catch (e) {
+          appendScrollLog('scroll:destroy_capture:error', {
+            title: container?.title ?? null,
+            error: String(e)
+          });
+        }
+      });
+    }
+    // When GoldenLayout resizes this panel (e.g. an adjacent panel is closed) the
+    // browser can shift scrollTop; re-apply the user's cached position after the reflow.
+    if (!container.__lope_resize_bound) {
+      container.__lope_resize_bound = true;
+      container.on('resize', () => {
+        const rk = scrollKeyFor(container);
+        const cached = scroll_cache.get(rk);
+        if (!cached || cached.scrollTop == null)
+          return;
+        const c_el = container.getElement();
+        const at = Date.now();
+        scroll_cache.__reflowUntil = at + 800;
+        // The reflow can shift scrollTop in several passes (content relayout
+        // settles ~300ms later), so re-apply over a window. Bail if the user scrolls.
+        const apply = () => {
+          if ((c_el.__lope_user_scroll_at || 0) > at)
+            return;
+          if (c_el.scrollTop !== cached.scrollTop)
+            c_el.scrollTop = cached.scrollTop;
+          if (cached.scrollLeft != null && c_el.scrollLeft !== cached.scrollLeft)
+            c_el.scrollLeft = cached.scrollLeft;
+        };
+        requestAnimationFrame(apply);
+        for (const d of [
+            60,
+            150,
+            300,
+            450,
+            600
+          ])
+          setTimeout(apply, d);
+        appendScrollLog('scroll:resize_restore', {
+          k: rk,
+          title: container?.title ?? null,
+          scrollTop: cached.scrollTop
+        });
+      });
+    }
+    appendScrollLog('modulePanel:exit', {
+      title: container?.title ?? null,
+      scrollKey
+    });
+  };
 };
 const _1gm4gbf = function _blobPanel(){return(
 function (container, component) {
@@ -14286,112 +14344,115 @@ const _1d1nkw9 = function _scrollKeyFor(appendScrollLog)
 const _tb217h = function _scroll_cache(){return(
 new Map()
 )};
-const _5tyvpe = function _fix_scroll(scrollKeyFor,appendScrollLog,scroll_cache){return(
-function (container, node, cell_variable, key) {
+const _12p8mg7 = function _fix_scroll(scroll_cache,scrollKeyFor,appendScrollLog)
+{
+  return function (container, node, cell_variable, key) {
+    scroll_cache.__reflowUntil = Date.now() + 600;
+    // suppress reflow-induced scroll events that clobber the cache
     const c_element = container.getElement();
     let k = scrollKeyFor(container);
     appendScrollLog('fix_scroll:enter', {
-        title: container?.title ?? null,
-        k,
-        cell: cell_variable?._name ?? null
+      title: container?.title ?? null,
+      k,
+      cell: cell_variable?._name ?? null
     });
     if (node && node.parentNode !== c_element) {
-        c_element.appendChild(node);
-        appendScrollLog('fix_scroll:append_node', {
-            title: container?.title ?? null,
-            k
-        });
+      c_element.appendChild(node);
+      appendScrollLog('fix_scroll:append_node', {
+        title: container?.title ?? null,
+        k
+      });
     }
     const writeCache = (scrollTop, scrollLeft, why) => {
-        scroll_cache.set(k, {
-            scrollTop,
-            scrollLeft,
-            t: Date.now()
-        });
-        appendScrollLog('scroll_cache:write', {
-            k,
-            scrollTop,
-            scrollLeft,
-            why
-        });
+      scroll_cache.set(k, {
+        scrollTop,
+        scrollLeft,
+        t: Date.now()
+      });
+      appendScrollLog('scroll_cache:write', {
+        k,
+        scrollTop,
+        scrollLeft,
+        why
+      });
     };
     const scrollToCellIfPossible = why => {
-        if (!cell_variable)
-            return false;
-        const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
-        if (!dom) {
-            appendScrollLog('scroll:cell_dom_not_found', {
-                k,
-                why,
-                cell: cell_variable?._name ?? null
-            });
-            return false;
-        }
-        const top = dom.offsetTop - c_element.offsetTop;
-        const left = c_element.scrollLeft;
-        c_element.scrollTop = top;
-        appendScrollLog('scroll:set', {
-            k,
-            why: `${ why }:cell`,
-            scrollTop: top,
-            scrollLeft: left,
-            cell: cell_variable?._name ?? null
+      if (!cell_variable)
+        return false;
+      const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
+      if (!dom) {
+        appendScrollLog('scroll:cell_dom_not_found', {
+          k,
+          why,
+          cell: cell_variable?._name ?? null
         });
-        writeCache(top, left, `${ why }:cell`);
-        return true;
+        return false;
+      }
+      const top = dom.offsetTop - c_element.offsetTop;
+      const left = c_element.scrollLeft;
+      c_element.scrollTop = top;
+      appendScrollLog('scroll:set', {
+        k,
+        why: `${ why }:cell`,
+        scrollTop: top,
+        scrollLeft: left,
+        cell: cell_variable?._name ?? null
+      });
+      writeCache(top, left, `${ why }:cell`);
+      return true;
     };
     const restoreFromCache = why => {
-        k = scrollKeyFor(container);
-        const cached = scroll_cache.get(k);
-        appendScrollLog('scroll:restore_attempt', {
-            k,
-            why,
-            cachedScrollTop: cached?.scrollTop ?? null,
-            cachedScrollLeft: cached?.scrollLeft ?? null
+      k = scrollKeyFor(container);
+      const cached = scroll_cache.get(k);
+      appendScrollLog('scroll:restore_attempt', {
+        k,
+        why,
+        cachedScrollTop: cached?.scrollTop ?? null,
+        cachedScrollLeft: cached?.scrollLeft ?? null
+      });
+      if (!cached) {
+        appendScrollLog('scroll:restore_no_scroll', {
+          k,
+          why
         });
-        if (!cached) {
-            appendScrollLog('scroll:restore_no_scroll', {
-                k,
-                why
-            });
-            return;
-        }
-        if (cached.scrollTop != null)
-            c_element.scrollTop = cached.scrollTop;
-        if (cached.scrollLeft != null)
-            c_element.scrollLeft = cached.scrollLeft;
-        appendScrollLog('scroll:restore_applied', {
-            k,
-            why,
-            scrollTop: cached.scrollTop ?? null,
-            scrollLeft: cached.scrollLeft ?? null,
-            scrollTopFinal: c_element.scrollTop,
-            scrollLeftFinal: c_element.scrollLeft
-        });
+        return;
+      }
+      if (cached.scrollTop != null)
+        c_element.scrollTop = cached.scrollTop;
+      if (cached.scrollLeft != null)
+        c_element.scrollLeft = cached.scrollLeft;
+      appendScrollLog('scroll:restore_applied', {
+        k,
+        why,
+        scrollTop: cached.scrollTop ?? null,
+        scrollLeft: cached.scrollLeft ?? null,
+        scrollTopFinal: c_element.scrollTop,
+        scrollLeftFinal: c_element.scrollLeft
+      });
     };
     const setScroll = (why = 'setScroll') => {
-        if (scrollToCellIfPossible(why))
-            return;
-        restoreFromCache(why);
+      if (scrollToCellIfPossible(why))
+        return;
+      restoreFromCache(why);
     };
     const retryFrames = 6;
     for (let i = 0; i < retryFrames; i++) {
-        requestAnimationFrame(() => {
-            k = scrollKeyFor(container);
-            appendScrollLog('fix_scroll:raf_retry', {
-                i,
-                k,
-                title: container?.title ?? null
-            });
-            setScroll(`raf:${ i }`);
+      requestAnimationFrame(() => {
+        k = scrollKeyFor(container);
+        appendScrollLog('fix_scroll:raf_retry', {
+          i,
+          k,
+          title: container?.title ?? null
         });
+        setScroll(`raf:${ i }`);
+      });
     }
     appendScrollLog('fix_scroll:exit', {
-        k,
-        title: container?.title ?? null
+      k,
+      title: container?.title ?? null
     });
-}
-)};
+  };
+};
 const _arfw00 = function _scroll_fix_sync_layout(sync_layout_to_url,layout,appendScrollLog,modulePanel)
 {
     sync_layout_to_url;
@@ -15469,7 +15530,7 @@ export default function define(runtime, observer) {
   $def("_1we0ggl", "reload", ["Generators","viewof reload"], _1we0ggl);  
   $def("_plefwg", "onLoadConfig", ["parseGoldenDSL","URLSearchParams","location"], _plefwg);  
   $def("_1nzpnqy", "visualizer_cache", ["reload"], _1nzpnqy);  
-  $def("_1l35721", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1l35721);  
+  $def("_1ojown8", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1ojown8);  
   $def("_1gm4gbf", "blobPanel", [], _1gm4gbf);  
   $def("_lxv2e2", "settings", [], _lxv2e2);  
   $def("_lp1ggk", "is_mobile", ["width"], _lp1ggk);  
@@ -15490,7 +15551,7 @@ export default function define(runtime, observer) {
   $def("_1dyz4o0", "scrollLog", ["mutable scrollLog"], _1dyz4o0);  
   $def("_1d1nkw9", "scrollKeyFor", ["appendScrollLog"], _1d1nkw9);  
   $def("_tb217h", "scroll_cache", [], _tb217h);  
-  $def("_5tyvpe", "fix_scroll", ["scrollKeyFor","appendScrollLog","scroll_cache"], _5tyvpe);  
+  $def("_12p8mg7", "fix_scroll", ["scroll_cache","scrollKeyFor","appendScrollLog"], _12p8mg7);  
   $def("_arfw00", "scroll_fix_sync_layout", ["sync_layout_to_url","layout","appendScrollLog","modulePanel"], _arfw00);  
   $def("_3nwpp4", "URLrouting", ["md"], _3nwpp4);  
   $def("_14te9pl", "sync_layout_from_url", ["reload","resize","URLSearchParams","hash","appendScrollLog","parseGoldenDSL","gl","layout","serializeGoldenDSL","treeSyncGolden","invalidation"], _14te9pl);  

--- a/notebooks/@tomlarkworthy_robocoop-3.html
+++ b/notebooks/@tomlarkworthy_robocoop-3.html
@@ -14037,138 +14037,196 @@ const _1nzpnqy = function _visualizer_cache(reload)
     reload;
     return new Map();
 };
-const _1l35721 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
+const _1ojown8 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
 {
-    return function (container, component) {
-        appendScrollLog('modulePanel:enter', {
-            title: container?.title ?? null,
-            componentCell: component?.cell ?? null
-        });
-        const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
-        if (!moduleInfo) {
-            // Fall through to file attachment: titles like @user/notebook/path.ext
-            // resolve via the lopecode bootloader's contentSync DOM lookup.
-            const title = container?.title ?? null;
-            if (title) {
-                let node = file_attachment_cache.get(title);
-                if (!node) {
-                    const r = window.lopecode?.contentSync?.(title);
-                    if (r && r.status === 200 && r.bytes) {
-                        node = renderFileAttachment(r.mime, r.bytes);
-                        file_attachment_cache.set(title, node);
-                        appendScrollLog('modulePanel:file_attachment_create', {
-                            title,
-                            mime: r.mime
-                        });
-                    }
-                }
-                if (node) {
-                    const c_element = container.getElement();
-                    if (node.parentNode !== c_element)
-                        c_element.appendChild(node);
-                    appendScrollLog('modulePanel:file_attachment_mount', { title });
-                    return;
-                }
-            }
-            appendScrollLog('modulePanel:missing_moduleInfo', { title });
-            return;
-        }
-        const module = moduleInfo.module;
-        let node;
-        if (!visualizer_cache.has(module)) {
-            appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
-            node = visualizer(runtime, {
-                invalidation: new Promise(r => {
-                }),
-                module,
-                detachNodes: isOnObservableCom(),
-                filter: (cell_name, variables) => {
-                    if (variables[0]._type !== 1)
-                        return false;
-                    if (typeof cell_name == 'string') {
-                        if (cell_name.startsWith('dynamic '))
-                            return false;
-                    }
-                    return true;
-                }
+  return function (container, component) {
+    appendScrollLog('modulePanel:enter', {
+      title: container?.title ?? null,
+      componentCell: component?.cell ?? null
+    });
+    const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
+    if (!moduleInfo) {
+      // Fall through to file attachment: titles like @user/notebook/path.ext
+      // resolve via the lopecode bootloader's contentSync DOM lookup.
+      const title = container?.title ?? null;
+      if (title) {
+        let node = file_attachment_cache.get(title);
+        if (!node) {
+          const r = window.lopecode?.contentSync?.(title);
+          if (r && r.status === 200 && r.bytes) {
+            node = renderFileAttachment(r.mime, r.bytes);
+            file_attachment_cache.set(title, node);
+            appendScrollLog('modulePanel:file_attachment_create', {
+              title,
+              mime: r.mime
             });
-            visualizer_cache.set(module, node);
-        } else {
-            node = visualizer_cache.get(module);
-            appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+          }
         }
-        const cell = module._scope.get(component.cell);
-        const scrollKey = scrollKeyFor(container);
-        fix_scroll(container, node, cell, scrollKey);
-        const el = container.getElement();
-        if (!el.__lope_scroll_bound) {
-            el.__lope_scroll_bound = true;
-            appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
-            el.addEventListener('scroll', () => {
-                const k = scrollKeyFor(container);
-                const scrollTop = el.scrollTop;
-                const scrollLeft = el.scrollLeft;
-                if (scrollTop == 0) {
-                    appendScrollLog('modulePanel:skip 0 scroll', {
-                        title: container?.title ?? null,
-                        scrollKey
-                    });
-                    return;
-                }
-                scroll_cache.set(k, {
-                    scrollTop,
-                    scrollLeft,
-                    t: Date.now()
-                });
-                appendScrollLog('scroll:event', {
-                    k,
-                    title: container?.title ?? null,
-                    scrollTop,
-                    scrollLeft
-                });
-            }, { passive: true });
+        if (node) {
+          const c_element = container.getElement();
+          if (node.parentNode !== c_element)
+            c_element.appendChild(node);
+          appendScrollLog('modulePanel:file_attachment_mount', { title });
+          return;
         }
-        // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
-        if (!container.__lope_destroy_bound) {
-            container.__lope_destroy_bound = true;
-            container.on('destroy', () => {
-                try {
-                    const k = scrollKeyFor(container);
-                    const scrollTop = el?.scrollTop;
-                    const scrollLeft = el?.scrollLeft;
-                    if (scrollTop == 0) {
-                        appendScrollLog('scroll:skip 0 scroll', {
-                            k,
-                            key: container?.title ?? null,
-                            scrollKey
-                        });
-                        return;
-                    }
-                    // do not skip 0 here: if the user is at top, preserve that state
-                    scroll_cache.set(k, {
-                        scrollTop,
-                        scrollLeft,
-                        t: Date.now()
-                    });
-                    appendScrollLog('scroll:destroy_capture', {
-                        k,
-                        title: container?.title ?? null,
-                        scrollTop,
-                        scrollLeft
-                    });
-                } catch (e) {
-                    appendScrollLog('scroll:destroy_capture:error', {
-                        title: container?.title ?? null,
-                        error: String(e)
-                    });
-                }
-            });
+      }
+      appendScrollLog('modulePanel:missing_moduleInfo', { title });
+      return;
+    }
+    const module = moduleInfo.module;
+    let node;
+    if (!visualizer_cache.has(module)) {
+      appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
+      node = visualizer(runtime, {
+        invalidation: new Promise(r => {
+        }),
+        module,
+        detachNodes: isOnObservableCom(),
+        filter: (cell_name, variables) => {
+          if (variables[0]._type !== 1)
+            return false;
+          if (typeof cell_name == 'string') {
+            if (cell_name.startsWith('dynamic '))
+              return false;
+          }
+          return true;
         }
-        appendScrollLog('modulePanel:exit', {
+      });
+      visualizer_cache.set(module, node);
+    } else {
+      node = visualizer_cache.get(module);
+      appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+    }
+    const cell = module._scope.get(component.cell);
+    const scrollKey = scrollKeyFor(container);
+    fix_scroll(container, node, cell, scrollKey);
+    const el = container.getElement();
+    if (!el.__lope_scroll_bound) {
+      el.__lope_scroll_bound = true;
+      appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
+      const markUserScroll = () => {
+        el.__lope_user_scroll_at = Date.now();
+      };
+      el.addEventListener('wheel', markUserScroll, { passive: true });
+      el.addEventListener('touchmove', markUserScroll, { passive: true });
+      el.addEventListener('keydown', markUserScroll, { passive: true });
+      el.addEventListener('scroll', () => {
+        if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+          appendScrollLog('scroll:skip_reflow', { title: container?.title ?? null });
+          return;
+        }
+        // Only cache scrolls following a genuine user gesture; reflow-induced
+        // scroll events (e.g. closing an adjacent panel) carry stale scrollTops.
+        if (Date.now() - (el.__lope_user_scroll_at || 0) > 400) {
+          appendScrollLog('scroll:skip_nonuser', { title: container?.title ?? null });
+          return;
+        }
+        const k = scrollKeyFor(container);
+        const scrollTop = el.scrollTop;
+        const scrollLeft = el.scrollLeft;
+        if (scrollTop == 0) {
+          appendScrollLog('modulePanel:skip 0 scroll', {
             title: container?.title ?? null,
             scrollKey
+          });
+          return;
+        }
+        scroll_cache.set(k, {
+          scrollTop,
+          scrollLeft,
+          t: Date.now()
         });
-    };
+        appendScrollLog('scroll:event', {
+          k,
+          title: container?.title ?? null,
+          scrollTop,
+          scrollLeft
+        });
+      }, { passive: true });
+    }
+    // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
+    if (!container.__lope_destroy_bound) {
+      container.__lope_destroy_bound = true;
+      container.on('destroy', () => {
+        try {
+          if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+            appendScrollLog('scroll:destroy_skip_reflow', { title: container?.title ?? null });
+            return;
+          }
+          const k = scrollKeyFor(container);
+          const scrollTop = el?.scrollTop;
+          const scrollLeft = el?.scrollLeft;
+          if (scrollTop == 0) {
+            appendScrollLog('scroll:skip 0 scroll', {
+              k,
+              key: container?.title ?? null,
+              scrollKey
+            });
+            return;
+          }
+          // do not skip 0 here: if the user is at top, preserve that state
+          scroll_cache.set(k, {
+            scrollTop,
+            scrollLeft,
+            t: Date.now()
+          });
+          appendScrollLog('scroll:destroy_capture', {
+            k,
+            title: container?.title ?? null,
+            scrollTop,
+            scrollLeft
+          });
+        } catch (e) {
+          appendScrollLog('scroll:destroy_capture:error', {
+            title: container?.title ?? null,
+            error: String(e)
+          });
+        }
+      });
+    }
+    // When GoldenLayout resizes this panel (e.g. an adjacent panel is closed) the
+    // browser can shift scrollTop; re-apply the user's cached position after the reflow.
+    if (!container.__lope_resize_bound) {
+      container.__lope_resize_bound = true;
+      container.on('resize', () => {
+        const rk = scrollKeyFor(container);
+        const cached = scroll_cache.get(rk);
+        if (!cached || cached.scrollTop == null)
+          return;
+        const c_el = container.getElement();
+        const at = Date.now();
+        scroll_cache.__reflowUntil = at + 800;
+        // The reflow can shift scrollTop in several passes (content relayout
+        // settles ~300ms later), so re-apply over a window. Bail if the user scrolls.
+        const apply = () => {
+          if ((c_el.__lope_user_scroll_at || 0) > at)
+            return;
+          if (c_el.scrollTop !== cached.scrollTop)
+            c_el.scrollTop = cached.scrollTop;
+          if (cached.scrollLeft != null && c_el.scrollLeft !== cached.scrollLeft)
+            c_el.scrollLeft = cached.scrollLeft;
+        };
+        requestAnimationFrame(apply);
+        for (const d of [
+            60,
+            150,
+            300,
+            450,
+            600
+          ])
+          setTimeout(apply, d);
+        appendScrollLog('scroll:resize_restore', {
+          k: rk,
+          title: container?.title ?? null,
+          scrollTop: cached.scrollTop
+        });
+      });
+    }
+    appendScrollLog('modulePanel:exit', {
+      title: container?.title ?? null,
+      scrollKey
+    });
+  };
 };
 const _1gm4gbf = function _blobPanel(){return(
 function (container, component) {
@@ -14286,112 +14344,115 @@ const _1d1nkw9 = function _scrollKeyFor(appendScrollLog)
 const _tb217h = function _scroll_cache(){return(
 new Map()
 )};
-const _5tyvpe = function _fix_scroll(scrollKeyFor,appendScrollLog,scroll_cache){return(
-function (container, node, cell_variable, key) {
+const _12p8mg7 = function _fix_scroll(scroll_cache,scrollKeyFor,appendScrollLog)
+{
+  return function (container, node, cell_variable, key) {
+    scroll_cache.__reflowUntil = Date.now() + 600;
+    // suppress reflow-induced scroll events that clobber the cache
     const c_element = container.getElement();
     let k = scrollKeyFor(container);
     appendScrollLog('fix_scroll:enter', {
-        title: container?.title ?? null,
-        k,
-        cell: cell_variable?._name ?? null
+      title: container?.title ?? null,
+      k,
+      cell: cell_variable?._name ?? null
     });
     if (node && node.parentNode !== c_element) {
-        c_element.appendChild(node);
-        appendScrollLog('fix_scroll:append_node', {
-            title: container?.title ?? null,
-            k
-        });
+      c_element.appendChild(node);
+      appendScrollLog('fix_scroll:append_node', {
+        title: container?.title ?? null,
+        k
+      });
     }
     const writeCache = (scrollTop, scrollLeft, why) => {
-        scroll_cache.set(k, {
-            scrollTop,
-            scrollLeft,
-            t: Date.now()
-        });
-        appendScrollLog('scroll_cache:write', {
-            k,
-            scrollTop,
-            scrollLeft,
-            why
-        });
+      scroll_cache.set(k, {
+        scrollTop,
+        scrollLeft,
+        t: Date.now()
+      });
+      appendScrollLog('scroll_cache:write', {
+        k,
+        scrollTop,
+        scrollLeft,
+        why
+      });
     };
     const scrollToCellIfPossible = why => {
-        if (!cell_variable)
-            return false;
-        const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
-        if (!dom) {
-            appendScrollLog('scroll:cell_dom_not_found', {
-                k,
-                why,
-                cell: cell_variable?._name ?? null
-            });
-            return false;
-        }
-        const top = dom.offsetTop - c_element.offsetTop;
-        const left = c_element.scrollLeft;
-        c_element.scrollTop = top;
-        appendScrollLog('scroll:set', {
-            k,
-            why: `${ why }:cell`,
-            scrollTop: top,
-            scrollLeft: left,
-            cell: cell_variable?._name ?? null
+      if (!cell_variable)
+        return false;
+      const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
+      if (!dom) {
+        appendScrollLog('scroll:cell_dom_not_found', {
+          k,
+          why,
+          cell: cell_variable?._name ?? null
         });
-        writeCache(top, left, `${ why }:cell`);
-        return true;
+        return false;
+      }
+      const top = dom.offsetTop - c_element.offsetTop;
+      const left = c_element.scrollLeft;
+      c_element.scrollTop = top;
+      appendScrollLog('scroll:set', {
+        k,
+        why: `${ why }:cell`,
+        scrollTop: top,
+        scrollLeft: left,
+        cell: cell_variable?._name ?? null
+      });
+      writeCache(top, left, `${ why }:cell`);
+      return true;
     };
     const restoreFromCache = why => {
-        k = scrollKeyFor(container);
-        const cached = scroll_cache.get(k);
-        appendScrollLog('scroll:restore_attempt', {
-            k,
-            why,
-            cachedScrollTop: cached?.scrollTop ?? null,
-            cachedScrollLeft: cached?.scrollLeft ?? null
+      k = scrollKeyFor(container);
+      const cached = scroll_cache.get(k);
+      appendScrollLog('scroll:restore_attempt', {
+        k,
+        why,
+        cachedScrollTop: cached?.scrollTop ?? null,
+        cachedScrollLeft: cached?.scrollLeft ?? null
+      });
+      if (!cached) {
+        appendScrollLog('scroll:restore_no_scroll', {
+          k,
+          why
         });
-        if (!cached) {
-            appendScrollLog('scroll:restore_no_scroll', {
-                k,
-                why
-            });
-            return;
-        }
-        if (cached.scrollTop != null)
-            c_element.scrollTop = cached.scrollTop;
-        if (cached.scrollLeft != null)
-            c_element.scrollLeft = cached.scrollLeft;
-        appendScrollLog('scroll:restore_applied', {
-            k,
-            why,
-            scrollTop: cached.scrollTop ?? null,
-            scrollLeft: cached.scrollLeft ?? null,
-            scrollTopFinal: c_element.scrollTop,
-            scrollLeftFinal: c_element.scrollLeft
-        });
+        return;
+      }
+      if (cached.scrollTop != null)
+        c_element.scrollTop = cached.scrollTop;
+      if (cached.scrollLeft != null)
+        c_element.scrollLeft = cached.scrollLeft;
+      appendScrollLog('scroll:restore_applied', {
+        k,
+        why,
+        scrollTop: cached.scrollTop ?? null,
+        scrollLeft: cached.scrollLeft ?? null,
+        scrollTopFinal: c_element.scrollTop,
+        scrollLeftFinal: c_element.scrollLeft
+      });
     };
     const setScroll = (why = 'setScroll') => {
-        if (scrollToCellIfPossible(why))
-            return;
-        restoreFromCache(why);
+      if (scrollToCellIfPossible(why))
+        return;
+      restoreFromCache(why);
     };
     const retryFrames = 6;
     for (let i = 0; i < retryFrames; i++) {
-        requestAnimationFrame(() => {
-            k = scrollKeyFor(container);
-            appendScrollLog('fix_scroll:raf_retry', {
-                i,
-                k,
-                title: container?.title ?? null
-            });
-            setScroll(`raf:${ i }`);
+      requestAnimationFrame(() => {
+        k = scrollKeyFor(container);
+        appendScrollLog('fix_scroll:raf_retry', {
+          i,
+          k,
+          title: container?.title ?? null
         });
+        setScroll(`raf:${ i }`);
+      });
     }
     appendScrollLog('fix_scroll:exit', {
-        k,
-        title: container?.title ?? null
+      k,
+      title: container?.title ?? null
     });
-}
-)};
+  };
+};
 const _arfw00 = function _scroll_fix_sync_layout(sync_layout_to_url,layout,appendScrollLog,modulePanel)
 {
     sync_layout_to_url;
@@ -15469,7 +15530,7 @@ export default function define(runtime, observer) {
   $def("_1we0ggl", "reload", ["Generators","viewof reload"], _1we0ggl);  
   $def("_plefwg", "onLoadConfig", ["parseGoldenDSL","URLSearchParams","location"], _plefwg);  
   $def("_1nzpnqy", "visualizer_cache", ["reload"], _1nzpnqy);  
-  $def("_1l35721", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1l35721);  
+  $def("_1ojown8", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1ojown8);  
   $def("_1gm4gbf", "blobPanel", [], _1gm4gbf);  
   $def("_lxv2e2", "settings", [], _lxv2e2);  
   $def("_lp1ggk", "is_mobile", ["width"], _lp1ggk);  
@@ -15490,7 +15551,7 @@ export default function define(runtime, observer) {
   $def("_1dyz4o0", "scrollLog", ["mutable scrollLog"], _1dyz4o0);  
   $def("_1d1nkw9", "scrollKeyFor", ["appendScrollLog"], _1d1nkw9);  
   $def("_tb217h", "scroll_cache", [], _tb217h);  
-  $def("_5tyvpe", "fix_scroll", ["scrollKeyFor","appendScrollLog","scroll_cache"], _5tyvpe);  
+  $def("_12p8mg7", "fix_scroll", ["scroll_cache","scrollKeyFor","appendScrollLog"], _12p8mg7);  
   $def("_arfw00", "scroll_fix_sync_layout", ["sync_layout_to_url","layout","appendScrollLog","modulePanel"], _arfw00);  
   $def("_3nwpp4", "URLrouting", ["md"], _3nwpp4);  
   $def("_14te9pl", "sync_layout_from_url", ["reload","resize","URLSearchParams","hash","appendScrollLog","parseGoldenDSL","gl","layout","serializeGoldenDSL","treeSyncGolden","invalidation"], _14te9pl);  

--- a/notebooks/@tomlarkworthy_runtime-sdk.html
+++ b/notebooks/@tomlarkworthy_runtime-sdk.html
@@ -14037,138 +14037,196 @@ const _1nzpnqy = function _visualizer_cache(reload)
     reload;
     return new Map();
 };
-const _1l35721 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
+const _1ojown8 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
 {
-    return function (container, component) {
-        appendScrollLog('modulePanel:enter', {
-            title: container?.title ?? null,
-            componentCell: component?.cell ?? null
-        });
-        const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
-        if (!moduleInfo) {
-            // Fall through to file attachment: titles like @user/notebook/path.ext
-            // resolve via the lopecode bootloader's contentSync DOM lookup.
-            const title = container?.title ?? null;
-            if (title) {
-                let node = file_attachment_cache.get(title);
-                if (!node) {
-                    const r = window.lopecode?.contentSync?.(title);
-                    if (r && r.status === 200 && r.bytes) {
-                        node = renderFileAttachment(r.mime, r.bytes);
-                        file_attachment_cache.set(title, node);
-                        appendScrollLog('modulePanel:file_attachment_create', {
-                            title,
-                            mime: r.mime
-                        });
-                    }
-                }
-                if (node) {
-                    const c_element = container.getElement();
-                    if (node.parentNode !== c_element)
-                        c_element.appendChild(node);
-                    appendScrollLog('modulePanel:file_attachment_mount', { title });
-                    return;
-                }
-            }
-            appendScrollLog('modulePanel:missing_moduleInfo', { title });
-            return;
-        }
-        const module = moduleInfo.module;
-        let node;
-        if (!visualizer_cache.has(module)) {
-            appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
-            node = visualizer(runtime, {
-                invalidation: new Promise(r => {
-                }),
-                module,
-                detachNodes: isOnObservableCom(),
-                filter: (cell_name, variables) => {
-                    if (variables[0]._type !== 1)
-                        return false;
-                    if (typeof cell_name == 'string') {
-                        if (cell_name.startsWith('dynamic '))
-                            return false;
-                    }
-                    return true;
-                }
+  return function (container, component) {
+    appendScrollLog('modulePanel:enter', {
+      title: container?.title ?? null,
+      componentCell: component?.cell ?? null
+    });
+    const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
+    if (!moduleInfo) {
+      // Fall through to file attachment: titles like @user/notebook/path.ext
+      // resolve via the lopecode bootloader's contentSync DOM lookup.
+      const title = container?.title ?? null;
+      if (title) {
+        let node = file_attachment_cache.get(title);
+        if (!node) {
+          const r = window.lopecode?.contentSync?.(title);
+          if (r && r.status === 200 && r.bytes) {
+            node = renderFileAttachment(r.mime, r.bytes);
+            file_attachment_cache.set(title, node);
+            appendScrollLog('modulePanel:file_attachment_create', {
+              title,
+              mime: r.mime
             });
-            visualizer_cache.set(module, node);
-        } else {
-            node = visualizer_cache.get(module);
-            appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+          }
         }
-        const cell = module._scope.get(component.cell);
-        const scrollKey = scrollKeyFor(container);
-        fix_scroll(container, node, cell, scrollKey);
-        const el = container.getElement();
-        if (!el.__lope_scroll_bound) {
-            el.__lope_scroll_bound = true;
-            appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
-            el.addEventListener('scroll', () => {
-                const k = scrollKeyFor(container);
-                const scrollTop = el.scrollTop;
-                const scrollLeft = el.scrollLeft;
-                if (scrollTop == 0) {
-                    appendScrollLog('modulePanel:skip 0 scroll', {
-                        title: container?.title ?? null,
-                        scrollKey
-                    });
-                    return;
-                }
-                scroll_cache.set(k, {
-                    scrollTop,
-                    scrollLeft,
-                    t: Date.now()
-                });
-                appendScrollLog('scroll:event', {
-                    k,
-                    title: container?.title ?? null,
-                    scrollTop,
-                    scrollLeft
-                });
-            }, { passive: true });
+        if (node) {
+          const c_element = container.getElement();
+          if (node.parentNode !== c_element)
+            c_element.appendChild(node);
+          appendScrollLog('modulePanel:file_attachment_mount', { title });
+          return;
         }
-        // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
-        if (!container.__lope_destroy_bound) {
-            container.__lope_destroy_bound = true;
-            container.on('destroy', () => {
-                try {
-                    const k = scrollKeyFor(container);
-                    const scrollTop = el?.scrollTop;
-                    const scrollLeft = el?.scrollLeft;
-                    if (scrollTop == 0) {
-                        appendScrollLog('scroll:skip 0 scroll', {
-                            k,
-                            key: container?.title ?? null,
-                            scrollKey
-                        });
-                        return;
-                    }
-                    // do not skip 0 here: if the user is at top, preserve that state
-                    scroll_cache.set(k, {
-                        scrollTop,
-                        scrollLeft,
-                        t: Date.now()
-                    });
-                    appendScrollLog('scroll:destroy_capture', {
-                        k,
-                        title: container?.title ?? null,
-                        scrollTop,
-                        scrollLeft
-                    });
-                } catch (e) {
-                    appendScrollLog('scroll:destroy_capture:error', {
-                        title: container?.title ?? null,
-                        error: String(e)
-                    });
-                }
-            });
+      }
+      appendScrollLog('modulePanel:missing_moduleInfo', { title });
+      return;
+    }
+    const module = moduleInfo.module;
+    let node;
+    if (!visualizer_cache.has(module)) {
+      appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
+      node = visualizer(runtime, {
+        invalidation: new Promise(r => {
+        }),
+        module,
+        detachNodes: isOnObservableCom(),
+        filter: (cell_name, variables) => {
+          if (variables[0]._type !== 1)
+            return false;
+          if (typeof cell_name == 'string') {
+            if (cell_name.startsWith('dynamic '))
+              return false;
+          }
+          return true;
         }
-        appendScrollLog('modulePanel:exit', {
+      });
+      visualizer_cache.set(module, node);
+    } else {
+      node = visualizer_cache.get(module);
+      appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+    }
+    const cell = module._scope.get(component.cell);
+    const scrollKey = scrollKeyFor(container);
+    fix_scroll(container, node, cell, scrollKey);
+    const el = container.getElement();
+    if (!el.__lope_scroll_bound) {
+      el.__lope_scroll_bound = true;
+      appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
+      const markUserScroll = () => {
+        el.__lope_user_scroll_at = Date.now();
+      };
+      el.addEventListener('wheel', markUserScroll, { passive: true });
+      el.addEventListener('touchmove', markUserScroll, { passive: true });
+      el.addEventListener('keydown', markUserScroll, { passive: true });
+      el.addEventListener('scroll', () => {
+        if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+          appendScrollLog('scroll:skip_reflow', { title: container?.title ?? null });
+          return;
+        }
+        // Only cache scrolls following a genuine user gesture; reflow-induced
+        // scroll events (e.g. closing an adjacent panel) carry stale scrollTops.
+        if (Date.now() - (el.__lope_user_scroll_at || 0) > 400) {
+          appendScrollLog('scroll:skip_nonuser', { title: container?.title ?? null });
+          return;
+        }
+        const k = scrollKeyFor(container);
+        const scrollTop = el.scrollTop;
+        const scrollLeft = el.scrollLeft;
+        if (scrollTop == 0) {
+          appendScrollLog('modulePanel:skip 0 scroll', {
             title: container?.title ?? null,
             scrollKey
+          });
+          return;
+        }
+        scroll_cache.set(k, {
+          scrollTop,
+          scrollLeft,
+          t: Date.now()
         });
-    };
+        appendScrollLog('scroll:event', {
+          k,
+          title: container?.title ?? null,
+          scrollTop,
+          scrollLeft
+        });
+      }, { passive: true });
+    }
+    // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
+    if (!container.__lope_destroy_bound) {
+      container.__lope_destroy_bound = true;
+      container.on('destroy', () => {
+        try {
+          if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+            appendScrollLog('scroll:destroy_skip_reflow', { title: container?.title ?? null });
+            return;
+          }
+          const k = scrollKeyFor(container);
+          const scrollTop = el?.scrollTop;
+          const scrollLeft = el?.scrollLeft;
+          if (scrollTop == 0) {
+            appendScrollLog('scroll:skip 0 scroll', {
+              k,
+              key: container?.title ?? null,
+              scrollKey
+            });
+            return;
+          }
+          // do not skip 0 here: if the user is at top, preserve that state
+          scroll_cache.set(k, {
+            scrollTop,
+            scrollLeft,
+            t: Date.now()
+          });
+          appendScrollLog('scroll:destroy_capture', {
+            k,
+            title: container?.title ?? null,
+            scrollTop,
+            scrollLeft
+          });
+        } catch (e) {
+          appendScrollLog('scroll:destroy_capture:error', {
+            title: container?.title ?? null,
+            error: String(e)
+          });
+        }
+      });
+    }
+    // When GoldenLayout resizes this panel (e.g. an adjacent panel is closed) the
+    // browser can shift scrollTop; re-apply the user's cached position after the reflow.
+    if (!container.__lope_resize_bound) {
+      container.__lope_resize_bound = true;
+      container.on('resize', () => {
+        const rk = scrollKeyFor(container);
+        const cached = scroll_cache.get(rk);
+        if (!cached || cached.scrollTop == null)
+          return;
+        const c_el = container.getElement();
+        const at = Date.now();
+        scroll_cache.__reflowUntil = at + 800;
+        // The reflow can shift scrollTop in several passes (content relayout
+        // settles ~300ms later), so re-apply over a window. Bail if the user scrolls.
+        const apply = () => {
+          if ((c_el.__lope_user_scroll_at || 0) > at)
+            return;
+          if (c_el.scrollTop !== cached.scrollTop)
+            c_el.scrollTop = cached.scrollTop;
+          if (cached.scrollLeft != null && c_el.scrollLeft !== cached.scrollLeft)
+            c_el.scrollLeft = cached.scrollLeft;
+        };
+        requestAnimationFrame(apply);
+        for (const d of [
+            60,
+            150,
+            300,
+            450,
+            600
+          ])
+          setTimeout(apply, d);
+        appendScrollLog('scroll:resize_restore', {
+          k: rk,
+          title: container?.title ?? null,
+          scrollTop: cached.scrollTop
+        });
+      });
+    }
+    appendScrollLog('modulePanel:exit', {
+      title: container?.title ?? null,
+      scrollKey
+    });
+  };
 };
 const _1gm4gbf = function _blobPanel(){return(
 function (container, component) {
@@ -14286,112 +14344,115 @@ const _1d1nkw9 = function _scrollKeyFor(appendScrollLog)
 const _tb217h = function _scroll_cache(){return(
 new Map()
 )};
-const _5tyvpe = function _fix_scroll(scrollKeyFor,appendScrollLog,scroll_cache){return(
-function (container, node, cell_variable, key) {
+const _12p8mg7 = function _fix_scroll(scroll_cache,scrollKeyFor,appendScrollLog)
+{
+  return function (container, node, cell_variable, key) {
+    scroll_cache.__reflowUntil = Date.now() + 600;
+    // suppress reflow-induced scroll events that clobber the cache
     const c_element = container.getElement();
     let k = scrollKeyFor(container);
     appendScrollLog('fix_scroll:enter', {
-        title: container?.title ?? null,
-        k,
-        cell: cell_variable?._name ?? null
+      title: container?.title ?? null,
+      k,
+      cell: cell_variable?._name ?? null
     });
     if (node && node.parentNode !== c_element) {
-        c_element.appendChild(node);
-        appendScrollLog('fix_scroll:append_node', {
-            title: container?.title ?? null,
-            k
-        });
+      c_element.appendChild(node);
+      appendScrollLog('fix_scroll:append_node', {
+        title: container?.title ?? null,
+        k
+      });
     }
     const writeCache = (scrollTop, scrollLeft, why) => {
-        scroll_cache.set(k, {
-            scrollTop,
-            scrollLeft,
-            t: Date.now()
-        });
-        appendScrollLog('scroll_cache:write', {
-            k,
-            scrollTop,
-            scrollLeft,
-            why
-        });
+      scroll_cache.set(k, {
+        scrollTop,
+        scrollLeft,
+        t: Date.now()
+      });
+      appendScrollLog('scroll_cache:write', {
+        k,
+        scrollTop,
+        scrollLeft,
+        why
+      });
     };
     const scrollToCellIfPossible = why => {
-        if (!cell_variable)
-            return false;
-        const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
-        if (!dom) {
-            appendScrollLog('scroll:cell_dom_not_found', {
-                k,
-                why,
-                cell: cell_variable?._name ?? null
-            });
-            return false;
-        }
-        const top = dom.offsetTop - c_element.offsetTop;
-        const left = c_element.scrollLeft;
-        c_element.scrollTop = top;
-        appendScrollLog('scroll:set', {
-            k,
-            why: `${ why }:cell`,
-            scrollTop: top,
-            scrollLeft: left,
-            cell: cell_variable?._name ?? null
+      if (!cell_variable)
+        return false;
+      const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
+      if (!dom) {
+        appendScrollLog('scroll:cell_dom_not_found', {
+          k,
+          why,
+          cell: cell_variable?._name ?? null
         });
-        writeCache(top, left, `${ why }:cell`);
-        return true;
+        return false;
+      }
+      const top = dom.offsetTop - c_element.offsetTop;
+      const left = c_element.scrollLeft;
+      c_element.scrollTop = top;
+      appendScrollLog('scroll:set', {
+        k,
+        why: `${ why }:cell`,
+        scrollTop: top,
+        scrollLeft: left,
+        cell: cell_variable?._name ?? null
+      });
+      writeCache(top, left, `${ why }:cell`);
+      return true;
     };
     const restoreFromCache = why => {
-        k = scrollKeyFor(container);
-        const cached = scroll_cache.get(k);
-        appendScrollLog('scroll:restore_attempt', {
-            k,
-            why,
-            cachedScrollTop: cached?.scrollTop ?? null,
-            cachedScrollLeft: cached?.scrollLeft ?? null
+      k = scrollKeyFor(container);
+      const cached = scroll_cache.get(k);
+      appendScrollLog('scroll:restore_attempt', {
+        k,
+        why,
+        cachedScrollTop: cached?.scrollTop ?? null,
+        cachedScrollLeft: cached?.scrollLeft ?? null
+      });
+      if (!cached) {
+        appendScrollLog('scroll:restore_no_scroll', {
+          k,
+          why
         });
-        if (!cached) {
-            appendScrollLog('scroll:restore_no_scroll', {
-                k,
-                why
-            });
-            return;
-        }
-        if (cached.scrollTop != null)
-            c_element.scrollTop = cached.scrollTop;
-        if (cached.scrollLeft != null)
-            c_element.scrollLeft = cached.scrollLeft;
-        appendScrollLog('scroll:restore_applied', {
-            k,
-            why,
-            scrollTop: cached.scrollTop ?? null,
-            scrollLeft: cached.scrollLeft ?? null,
-            scrollTopFinal: c_element.scrollTop,
-            scrollLeftFinal: c_element.scrollLeft
-        });
+        return;
+      }
+      if (cached.scrollTop != null)
+        c_element.scrollTop = cached.scrollTop;
+      if (cached.scrollLeft != null)
+        c_element.scrollLeft = cached.scrollLeft;
+      appendScrollLog('scroll:restore_applied', {
+        k,
+        why,
+        scrollTop: cached.scrollTop ?? null,
+        scrollLeft: cached.scrollLeft ?? null,
+        scrollTopFinal: c_element.scrollTop,
+        scrollLeftFinal: c_element.scrollLeft
+      });
     };
     const setScroll = (why = 'setScroll') => {
-        if (scrollToCellIfPossible(why))
-            return;
-        restoreFromCache(why);
+      if (scrollToCellIfPossible(why))
+        return;
+      restoreFromCache(why);
     };
     const retryFrames = 6;
     for (let i = 0; i < retryFrames; i++) {
-        requestAnimationFrame(() => {
-            k = scrollKeyFor(container);
-            appendScrollLog('fix_scroll:raf_retry', {
-                i,
-                k,
-                title: container?.title ?? null
-            });
-            setScroll(`raf:${ i }`);
+      requestAnimationFrame(() => {
+        k = scrollKeyFor(container);
+        appendScrollLog('fix_scroll:raf_retry', {
+          i,
+          k,
+          title: container?.title ?? null
         });
+        setScroll(`raf:${ i }`);
+      });
     }
     appendScrollLog('fix_scroll:exit', {
-        k,
-        title: container?.title ?? null
+      k,
+      title: container?.title ?? null
     });
-}
-)};
+  };
+};
 const _arfw00 = function _scroll_fix_sync_layout(sync_layout_to_url,layout,appendScrollLog,modulePanel)
 {
     sync_layout_to_url;
@@ -15469,7 +15530,7 @@ export default function define(runtime, observer) {
   $def("_1we0ggl", "reload", ["Generators","viewof reload"], _1we0ggl);  
   $def("_plefwg", "onLoadConfig", ["parseGoldenDSL","URLSearchParams","location"], _plefwg);  
   $def("_1nzpnqy", "visualizer_cache", ["reload"], _1nzpnqy);  
-  $def("_1l35721", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1l35721);  
+  $def("_1ojown8", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1ojown8);  
   $def("_1gm4gbf", "blobPanel", [], _1gm4gbf);  
   $def("_lxv2e2", "settings", [], _lxv2e2);  
   $def("_lp1ggk", "is_mobile", ["width"], _lp1ggk);  
@@ -15490,7 +15551,7 @@ export default function define(runtime, observer) {
   $def("_1dyz4o0", "scrollLog", ["mutable scrollLog"], _1dyz4o0);  
   $def("_1d1nkw9", "scrollKeyFor", ["appendScrollLog"], _1d1nkw9);  
   $def("_tb217h", "scroll_cache", [], _tb217h);  
-  $def("_5tyvpe", "fix_scroll", ["scrollKeyFor","appendScrollLog","scroll_cache"], _5tyvpe);  
+  $def("_12p8mg7", "fix_scroll", ["scroll_cache","scrollKeyFor","appendScrollLog"], _12p8mg7);  
   $def("_arfw00", "scroll_fix_sync_layout", ["sync_layout_to_url","layout","appendScrollLog","modulePanel"], _arfw00);  
   $def("_3nwpp4", "URLrouting", ["md"], _3nwpp4);  
   $def("_14te9pl", "sync_layout_from_url", ["reload","resize","URLSearchParams","hash","appendScrollLog","parseGoldenDSL","gl","layout","serializeGoldenDSL","treeSyncGolden","invalidation"], _14te9pl);  

--- a/notebooks/@tomlarkworthy_secrets.html
+++ b/notebooks/@tomlarkworthy_secrets.html
@@ -14037,138 +14037,196 @@ const _1nzpnqy = function _visualizer_cache(reload)
     reload;
     return new Map();
 };
-const _1l35721 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
+const _1ojown8 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
 {
-    return function (container, component) {
-        appendScrollLog('modulePanel:enter', {
-            title: container?.title ?? null,
-            componentCell: component?.cell ?? null
-        });
-        const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
-        if (!moduleInfo) {
-            // Fall through to file attachment: titles like @user/notebook/path.ext
-            // resolve via the lopecode bootloader's contentSync DOM lookup.
-            const title = container?.title ?? null;
-            if (title) {
-                let node = file_attachment_cache.get(title);
-                if (!node) {
-                    const r = window.lopecode?.contentSync?.(title);
-                    if (r && r.status === 200 && r.bytes) {
-                        node = renderFileAttachment(r.mime, r.bytes);
-                        file_attachment_cache.set(title, node);
-                        appendScrollLog('modulePanel:file_attachment_create', {
-                            title,
-                            mime: r.mime
-                        });
-                    }
-                }
-                if (node) {
-                    const c_element = container.getElement();
-                    if (node.parentNode !== c_element)
-                        c_element.appendChild(node);
-                    appendScrollLog('modulePanel:file_attachment_mount', { title });
-                    return;
-                }
-            }
-            appendScrollLog('modulePanel:missing_moduleInfo', { title });
-            return;
-        }
-        const module = moduleInfo.module;
-        let node;
-        if (!visualizer_cache.has(module)) {
-            appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
-            node = visualizer(runtime, {
-                invalidation: new Promise(r => {
-                }),
-                module,
-                detachNodes: isOnObservableCom(),
-                filter: (cell_name, variables) => {
-                    if (variables[0]._type !== 1)
-                        return false;
-                    if (typeof cell_name == 'string') {
-                        if (cell_name.startsWith('dynamic '))
-                            return false;
-                    }
-                    return true;
-                }
+  return function (container, component) {
+    appendScrollLog('modulePanel:enter', {
+      title: container?.title ?? null,
+      componentCell: component?.cell ?? null
+    });
+    const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
+    if (!moduleInfo) {
+      // Fall through to file attachment: titles like @user/notebook/path.ext
+      // resolve via the lopecode bootloader's contentSync DOM lookup.
+      const title = container?.title ?? null;
+      if (title) {
+        let node = file_attachment_cache.get(title);
+        if (!node) {
+          const r = window.lopecode?.contentSync?.(title);
+          if (r && r.status === 200 && r.bytes) {
+            node = renderFileAttachment(r.mime, r.bytes);
+            file_attachment_cache.set(title, node);
+            appendScrollLog('modulePanel:file_attachment_create', {
+              title,
+              mime: r.mime
             });
-            visualizer_cache.set(module, node);
-        } else {
-            node = visualizer_cache.get(module);
-            appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+          }
         }
-        const cell = module._scope.get(component.cell);
-        const scrollKey = scrollKeyFor(container);
-        fix_scroll(container, node, cell, scrollKey);
-        const el = container.getElement();
-        if (!el.__lope_scroll_bound) {
-            el.__lope_scroll_bound = true;
-            appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
-            el.addEventListener('scroll', () => {
-                const k = scrollKeyFor(container);
-                const scrollTop = el.scrollTop;
-                const scrollLeft = el.scrollLeft;
-                if (scrollTop == 0) {
-                    appendScrollLog('modulePanel:skip 0 scroll', {
-                        title: container?.title ?? null,
-                        scrollKey
-                    });
-                    return;
-                }
-                scroll_cache.set(k, {
-                    scrollTop,
-                    scrollLeft,
-                    t: Date.now()
-                });
-                appendScrollLog('scroll:event', {
-                    k,
-                    title: container?.title ?? null,
-                    scrollTop,
-                    scrollLeft
-                });
-            }, { passive: true });
+        if (node) {
+          const c_element = container.getElement();
+          if (node.parentNode !== c_element)
+            c_element.appendChild(node);
+          appendScrollLog('modulePanel:file_attachment_mount', { title });
+          return;
         }
-        // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
-        if (!container.__lope_destroy_bound) {
-            container.__lope_destroy_bound = true;
-            container.on('destroy', () => {
-                try {
-                    const k = scrollKeyFor(container);
-                    const scrollTop = el?.scrollTop;
-                    const scrollLeft = el?.scrollLeft;
-                    if (scrollTop == 0) {
-                        appendScrollLog('scroll:skip 0 scroll', {
-                            k,
-                            key: container?.title ?? null,
-                            scrollKey
-                        });
-                        return;
-                    }
-                    // do not skip 0 here: if the user is at top, preserve that state
-                    scroll_cache.set(k, {
-                        scrollTop,
-                        scrollLeft,
-                        t: Date.now()
-                    });
-                    appendScrollLog('scroll:destroy_capture', {
-                        k,
-                        title: container?.title ?? null,
-                        scrollTop,
-                        scrollLeft
-                    });
-                } catch (e) {
-                    appendScrollLog('scroll:destroy_capture:error', {
-                        title: container?.title ?? null,
-                        error: String(e)
-                    });
-                }
-            });
+      }
+      appendScrollLog('modulePanel:missing_moduleInfo', { title });
+      return;
+    }
+    const module = moduleInfo.module;
+    let node;
+    if (!visualizer_cache.has(module)) {
+      appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
+      node = visualizer(runtime, {
+        invalidation: new Promise(r => {
+        }),
+        module,
+        detachNodes: isOnObservableCom(),
+        filter: (cell_name, variables) => {
+          if (variables[0]._type !== 1)
+            return false;
+          if (typeof cell_name == 'string') {
+            if (cell_name.startsWith('dynamic '))
+              return false;
+          }
+          return true;
         }
-        appendScrollLog('modulePanel:exit', {
+      });
+      visualizer_cache.set(module, node);
+    } else {
+      node = visualizer_cache.get(module);
+      appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+    }
+    const cell = module._scope.get(component.cell);
+    const scrollKey = scrollKeyFor(container);
+    fix_scroll(container, node, cell, scrollKey);
+    const el = container.getElement();
+    if (!el.__lope_scroll_bound) {
+      el.__lope_scroll_bound = true;
+      appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
+      const markUserScroll = () => {
+        el.__lope_user_scroll_at = Date.now();
+      };
+      el.addEventListener('wheel', markUserScroll, { passive: true });
+      el.addEventListener('touchmove', markUserScroll, { passive: true });
+      el.addEventListener('keydown', markUserScroll, { passive: true });
+      el.addEventListener('scroll', () => {
+        if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+          appendScrollLog('scroll:skip_reflow', { title: container?.title ?? null });
+          return;
+        }
+        // Only cache scrolls following a genuine user gesture; reflow-induced
+        // scroll events (e.g. closing an adjacent panel) carry stale scrollTops.
+        if (Date.now() - (el.__lope_user_scroll_at || 0) > 400) {
+          appendScrollLog('scroll:skip_nonuser', { title: container?.title ?? null });
+          return;
+        }
+        const k = scrollKeyFor(container);
+        const scrollTop = el.scrollTop;
+        const scrollLeft = el.scrollLeft;
+        if (scrollTop == 0) {
+          appendScrollLog('modulePanel:skip 0 scroll', {
             title: container?.title ?? null,
             scrollKey
+          });
+          return;
+        }
+        scroll_cache.set(k, {
+          scrollTop,
+          scrollLeft,
+          t: Date.now()
         });
-    };
+        appendScrollLog('scroll:event', {
+          k,
+          title: container?.title ?? null,
+          scrollTop,
+          scrollLeft
+        });
+      }, { passive: true });
+    }
+    // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
+    if (!container.__lope_destroy_bound) {
+      container.__lope_destroy_bound = true;
+      container.on('destroy', () => {
+        try {
+          if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+            appendScrollLog('scroll:destroy_skip_reflow', { title: container?.title ?? null });
+            return;
+          }
+          const k = scrollKeyFor(container);
+          const scrollTop = el?.scrollTop;
+          const scrollLeft = el?.scrollLeft;
+          if (scrollTop == 0) {
+            appendScrollLog('scroll:skip 0 scroll', {
+              k,
+              key: container?.title ?? null,
+              scrollKey
+            });
+            return;
+          }
+          // do not skip 0 here: if the user is at top, preserve that state
+          scroll_cache.set(k, {
+            scrollTop,
+            scrollLeft,
+            t: Date.now()
+          });
+          appendScrollLog('scroll:destroy_capture', {
+            k,
+            title: container?.title ?? null,
+            scrollTop,
+            scrollLeft
+          });
+        } catch (e) {
+          appendScrollLog('scroll:destroy_capture:error', {
+            title: container?.title ?? null,
+            error: String(e)
+          });
+        }
+      });
+    }
+    // When GoldenLayout resizes this panel (e.g. an adjacent panel is closed) the
+    // browser can shift scrollTop; re-apply the user's cached position after the reflow.
+    if (!container.__lope_resize_bound) {
+      container.__lope_resize_bound = true;
+      container.on('resize', () => {
+        const rk = scrollKeyFor(container);
+        const cached = scroll_cache.get(rk);
+        if (!cached || cached.scrollTop == null)
+          return;
+        const c_el = container.getElement();
+        const at = Date.now();
+        scroll_cache.__reflowUntil = at + 800;
+        // The reflow can shift scrollTop in several passes (content relayout
+        // settles ~300ms later), so re-apply over a window. Bail if the user scrolls.
+        const apply = () => {
+          if ((c_el.__lope_user_scroll_at || 0) > at)
+            return;
+          if (c_el.scrollTop !== cached.scrollTop)
+            c_el.scrollTop = cached.scrollTop;
+          if (cached.scrollLeft != null && c_el.scrollLeft !== cached.scrollLeft)
+            c_el.scrollLeft = cached.scrollLeft;
+        };
+        requestAnimationFrame(apply);
+        for (const d of [
+            60,
+            150,
+            300,
+            450,
+            600
+          ])
+          setTimeout(apply, d);
+        appendScrollLog('scroll:resize_restore', {
+          k: rk,
+          title: container?.title ?? null,
+          scrollTop: cached.scrollTop
+        });
+      });
+    }
+    appendScrollLog('modulePanel:exit', {
+      title: container?.title ?? null,
+      scrollKey
+    });
+  };
 };
 const _1gm4gbf = function _blobPanel(){return(
 function (container, component) {
@@ -14286,112 +14344,115 @@ const _1d1nkw9 = function _scrollKeyFor(appendScrollLog)
 const _tb217h = function _scroll_cache(){return(
 new Map()
 )};
-const _5tyvpe = function _fix_scroll(scrollKeyFor,appendScrollLog,scroll_cache){return(
-function (container, node, cell_variable, key) {
+const _12p8mg7 = function _fix_scroll(scroll_cache,scrollKeyFor,appendScrollLog)
+{
+  return function (container, node, cell_variable, key) {
+    scroll_cache.__reflowUntil = Date.now() + 600;
+    // suppress reflow-induced scroll events that clobber the cache
     const c_element = container.getElement();
     let k = scrollKeyFor(container);
     appendScrollLog('fix_scroll:enter', {
-        title: container?.title ?? null,
-        k,
-        cell: cell_variable?._name ?? null
+      title: container?.title ?? null,
+      k,
+      cell: cell_variable?._name ?? null
     });
     if (node && node.parentNode !== c_element) {
-        c_element.appendChild(node);
-        appendScrollLog('fix_scroll:append_node', {
-            title: container?.title ?? null,
-            k
-        });
+      c_element.appendChild(node);
+      appendScrollLog('fix_scroll:append_node', {
+        title: container?.title ?? null,
+        k
+      });
     }
     const writeCache = (scrollTop, scrollLeft, why) => {
-        scroll_cache.set(k, {
-            scrollTop,
-            scrollLeft,
-            t: Date.now()
-        });
-        appendScrollLog('scroll_cache:write', {
-            k,
-            scrollTop,
-            scrollLeft,
-            why
-        });
+      scroll_cache.set(k, {
+        scrollTop,
+        scrollLeft,
+        t: Date.now()
+      });
+      appendScrollLog('scroll_cache:write', {
+        k,
+        scrollTop,
+        scrollLeft,
+        why
+      });
     };
     const scrollToCellIfPossible = why => {
-        if (!cell_variable)
-            return false;
-        const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
-        if (!dom) {
-            appendScrollLog('scroll:cell_dom_not_found', {
-                k,
-                why,
-                cell: cell_variable?._name ?? null
-            });
-            return false;
-        }
-        const top = dom.offsetTop - c_element.offsetTop;
-        const left = c_element.scrollLeft;
-        c_element.scrollTop = top;
-        appendScrollLog('scroll:set', {
-            k,
-            why: `${ why }:cell`,
-            scrollTop: top,
-            scrollLeft: left,
-            cell: cell_variable?._name ?? null
+      if (!cell_variable)
+        return false;
+      const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
+      if (!dom) {
+        appendScrollLog('scroll:cell_dom_not_found', {
+          k,
+          why,
+          cell: cell_variable?._name ?? null
         });
-        writeCache(top, left, `${ why }:cell`);
-        return true;
+        return false;
+      }
+      const top = dom.offsetTop - c_element.offsetTop;
+      const left = c_element.scrollLeft;
+      c_element.scrollTop = top;
+      appendScrollLog('scroll:set', {
+        k,
+        why: `${ why }:cell`,
+        scrollTop: top,
+        scrollLeft: left,
+        cell: cell_variable?._name ?? null
+      });
+      writeCache(top, left, `${ why }:cell`);
+      return true;
     };
     const restoreFromCache = why => {
-        k = scrollKeyFor(container);
-        const cached = scroll_cache.get(k);
-        appendScrollLog('scroll:restore_attempt', {
-            k,
-            why,
-            cachedScrollTop: cached?.scrollTop ?? null,
-            cachedScrollLeft: cached?.scrollLeft ?? null
+      k = scrollKeyFor(container);
+      const cached = scroll_cache.get(k);
+      appendScrollLog('scroll:restore_attempt', {
+        k,
+        why,
+        cachedScrollTop: cached?.scrollTop ?? null,
+        cachedScrollLeft: cached?.scrollLeft ?? null
+      });
+      if (!cached) {
+        appendScrollLog('scroll:restore_no_scroll', {
+          k,
+          why
         });
-        if (!cached) {
-            appendScrollLog('scroll:restore_no_scroll', {
-                k,
-                why
-            });
-            return;
-        }
-        if (cached.scrollTop != null)
-            c_element.scrollTop = cached.scrollTop;
-        if (cached.scrollLeft != null)
-            c_element.scrollLeft = cached.scrollLeft;
-        appendScrollLog('scroll:restore_applied', {
-            k,
-            why,
-            scrollTop: cached.scrollTop ?? null,
-            scrollLeft: cached.scrollLeft ?? null,
-            scrollTopFinal: c_element.scrollTop,
-            scrollLeftFinal: c_element.scrollLeft
-        });
+        return;
+      }
+      if (cached.scrollTop != null)
+        c_element.scrollTop = cached.scrollTop;
+      if (cached.scrollLeft != null)
+        c_element.scrollLeft = cached.scrollLeft;
+      appendScrollLog('scroll:restore_applied', {
+        k,
+        why,
+        scrollTop: cached.scrollTop ?? null,
+        scrollLeft: cached.scrollLeft ?? null,
+        scrollTopFinal: c_element.scrollTop,
+        scrollLeftFinal: c_element.scrollLeft
+      });
     };
     const setScroll = (why = 'setScroll') => {
-        if (scrollToCellIfPossible(why))
-            return;
-        restoreFromCache(why);
+      if (scrollToCellIfPossible(why))
+        return;
+      restoreFromCache(why);
     };
     const retryFrames = 6;
     for (let i = 0; i < retryFrames; i++) {
-        requestAnimationFrame(() => {
-            k = scrollKeyFor(container);
-            appendScrollLog('fix_scroll:raf_retry', {
-                i,
-                k,
-                title: container?.title ?? null
-            });
-            setScroll(`raf:${ i }`);
+      requestAnimationFrame(() => {
+        k = scrollKeyFor(container);
+        appendScrollLog('fix_scroll:raf_retry', {
+          i,
+          k,
+          title: container?.title ?? null
         });
+        setScroll(`raf:${ i }`);
+      });
     }
     appendScrollLog('fix_scroll:exit', {
-        k,
-        title: container?.title ?? null
+      k,
+      title: container?.title ?? null
     });
-}
-)};
+  };
+};
 const _arfw00 = function _scroll_fix_sync_layout(sync_layout_to_url,layout,appendScrollLog,modulePanel)
 {
     sync_layout_to_url;
@@ -15469,7 +15530,7 @@ export default function define(runtime, observer) {
   $def("_1we0ggl", "reload", ["Generators","viewof reload"], _1we0ggl);  
   $def("_plefwg", "onLoadConfig", ["parseGoldenDSL","URLSearchParams","location"], _plefwg);  
   $def("_1nzpnqy", "visualizer_cache", ["reload"], _1nzpnqy);  
-  $def("_1l35721", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1l35721);  
+  $def("_1ojown8", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1ojown8);  
   $def("_1gm4gbf", "blobPanel", [], _1gm4gbf);  
   $def("_lxv2e2", "settings", [], _lxv2e2);  
   $def("_lp1ggk", "is_mobile", ["width"], _lp1ggk);  
@@ -15490,7 +15551,7 @@ export default function define(runtime, observer) {
   $def("_1dyz4o0", "scrollLog", ["mutable scrollLog"], _1dyz4o0);  
   $def("_1d1nkw9", "scrollKeyFor", ["appendScrollLog"], _1d1nkw9);  
   $def("_tb217h", "scroll_cache", [], _tb217h);  
-  $def("_5tyvpe", "fix_scroll", ["scrollKeyFor","appendScrollLog","scroll_cache"], _5tyvpe);  
+  $def("_12p8mg7", "fix_scroll", ["scroll_cache","scrollKeyFor","appendScrollLog"], _12p8mg7);  
   $def("_arfw00", "scroll_fix_sync_layout", ["sync_layout_to_url","layout","appendScrollLog","modulePanel"], _arfw00);  
   $def("_3nwpp4", "URLrouting", ["md"], _3nwpp4);  
   $def("_14te9pl", "sync_layout_from_url", ["reload","resize","URLSearchParams","hash","appendScrollLog","parseGoldenDSL","gl","layout","serializeGoldenDSL","treeSyncGolden","invalidation"], _14te9pl);  

--- a/notebooks/@tomlarkworthy_tests.html
+++ b/notebooks/@tomlarkworthy_tests.html
@@ -14037,138 +14037,196 @@ const _1nzpnqy = function _visualizer_cache(reload)
     reload;
     return new Map();
 };
-const _1l35721 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
+const _1ojown8 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
 {
-    return function (container, component) {
-        appendScrollLog('modulePanel:enter', {
-            title: container?.title ?? null,
-            componentCell: component?.cell ?? null
-        });
-        const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
-        if (!moduleInfo) {
-            // Fall through to file attachment: titles like @user/notebook/path.ext
-            // resolve via the lopecode bootloader's contentSync DOM lookup.
-            const title = container?.title ?? null;
-            if (title) {
-                let node = file_attachment_cache.get(title);
-                if (!node) {
-                    const r = window.lopecode?.contentSync?.(title);
-                    if (r && r.status === 200 && r.bytes) {
-                        node = renderFileAttachment(r.mime, r.bytes);
-                        file_attachment_cache.set(title, node);
-                        appendScrollLog('modulePanel:file_attachment_create', {
-                            title,
-                            mime: r.mime
-                        });
-                    }
-                }
-                if (node) {
-                    const c_element = container.getElement();
-                    if (node.parentNode !== c_element)
-                        c_element.appendChild(node);
-                    appendScrollLog('modulePanel:file_attachment_mount', { title });
-                    return;
-                }
-            }
-            appendScrollLog('modulePanel:missing_moduleInfo', { title });
-            return;
-        }
-        const module = moduleInfo.module;
-        let node;
-        if (!visualizer_cache.has(module)) {
-            appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
-            node = visualizer(runtime, {
-                invalidation: new Promise(r => {
-                }),
-                module,
-                detachNodes: isOnObservableCom(),
-                filter: (cell_name, variables) => {
-                    if (variables[0]._type !== 1)
-                        return false;
-                    if (typeof cell_name == 'string') {
-                        if (cell_name.startsWith('dynamic '))
-                            return false;
-                    }
-                    return true;
-                }
+  return function (container, component) {
+    appendScrollLog('modulePanel:enter', {
+      title: container?.title ?? null,
+      componentCell: component?.cell ?? null
+    });
+    const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
+    if (!moduleInfo) {
+      // Fall through to file attachment: titles like @user/notebook/path.ext
+      // resolve via the lopecode bootloader's contentSync DOM lookup.
+      const title = container?.title ?? null;
+      if (title) {
+        let node = file_attachment_cache.get(title);
+        if (!node) {
+          const r = window.lopecode?.contentSync?.(title);
+          if (r && r.status === 200 && r.bytes) {
+            node = renderFileAttachment(r.mime, r.bytes);
+            file_attachment_cache.set(title, node);
+            appendScrollLog('modulePanel:file_attachment_create', {
+              title,
+              mime: r.mime
             });
-            visualizer_cache.set(module, node);
-        } else {
-            node = visualizer_cache.get(module);
-            appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+          }
         }
-        const cell = module._scope.get(component.cell);
-        const scrollKey = scrollKeyFor(container);
-        fix_scroll(container, node, cell, scrollKey);
-        const el = container.getElement();
-        if (!el.__lope_scroll_bound) {
-            el.__lope_scroll_bound = true;
-            appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
-            el.addEventListener('scroll', () => {
-                const k = scrollKeyFor(container);
-                const scrollTop = el.scrollTop;
-                const scrollLeft = el.scrollLeft;
-                if (scrollTop == 0) {
-                    appendScrollLog('modulePanel:skip 0 scroll', {
-                        title: container?.title ?? null,
-                        scrollKey
-                    });
-                    return;
-                }
-                scroll_cache.set(k, {
-                    scrollTop,
-                    scrollLeft,
-                    t: Date.now()
-                });
-                appendScrollLog('scroll:event', {
-                    k,
-                    title: container?.title ?? null,
-                    scrollTop,
-                    scrollLeft
-                });
-            }, { passive: true });
+        if (node) {
+          const c_element = container.getElement();
+          if (node.parentNode !== c_element)
+            c_element.appendChild(node);
+          appendScrollLog('modulePanel:file_attachment_mount', { title });
+          return;
         }
-        // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
-        if (!container.__lope_destroy_bound) {
-            container.__lope_destroy_bound = true;
-            container.on('destroy', () => {
-                try {
-                    const k = scrollKeyFor(container);
-                    const scrollTop = el?.scrollTop;
-                    const scrollLeft = el?.scrollLeft;
-                    if (scrollTop == 0) {
-                        appendScrollLog('scroll:skip 0 scroll', {
-                            k,
-                            key: container?.title ?? null,
-                            scrollKey
-                        });
-                        return;
-                    }
-                    // do not skip 0 here: if the user is at top, preserve that state
-                    scroll_cache.set(k, {
-                        scrollTop,
-                        scrollLeft,
-                        t: Date.now()
-                    });
-                    appendScrollLog('scroll:destroy_capture', {
-                        k,
-                        title: container?.title ?? null,
-                        scrollTop,
-                        scrollLeft
-                    });
-                } catch (e) {
-                    appendScrollLog('scroll:destroy_capture:error', {
-                        title: container?.title ?? null,
-                        error: String(e)
-                    });
-                }
-            });
+      }
+      appendScrollLog('modulePanel:missing_moduleInfo', { title });
+      return;
+    }
+    const module = moduleInfo.module;
+    let node;
+    if (!visualizer_cache.has(module)) {
+      appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
+      node = visualizer(runtime, {
+        invalidation: new Promise(r => {
+        }),
+        module,
+        detachNodes: isOnObservableCom(),
+        filter: (cell_name, variables) => {
+          if (variables[0]._type !== 1)
+            return false;
+          if (typeof cell_name == 'string') {
+            if (cell_name.startsWith('dynamic '))
+              return false;
+          }
+          return true;
         }
-        appendScrollLog('modulePanel:exit', {
+      });
+      visualizer_cache.set(module, node);
+    } else {
+      node = visualizer_cache.get(module);
+      appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+    }
+    const cell = module._scope.get(component.cell);
+    const scrollKey = scrollKeyFor(container);
+    fix_scroll(container, node, cell, scrollKey);
+    const el = container.getElement();
+    if (!el.__lope_scroll_bound) {
+      el.__lope_scroll_bound = true;
+      appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
+      const markUserScroll = () => {
+        el.__lope_user_scroll_at = Date.now();
+      };
+      el.addEventListener('wheel', markUserScroll, { passive: true });
+      el.addEventListener('touchmove', markUserScroll, { passive: true });
+      el.addEventListener('keydown', markUserScroll, { passive: true });
+      el.addEventListener('scroll', () => {
+        if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+          appendScrollLog('scroll:skip_reflow', { title: container?.title ?? null });
+          return;
+        }
+        // Only cache scrolls following a genuine user gesture; reflow-induced
+        // scroll events (e.g. closing an adjacent panel) carry stale scrollTops.
+        if (Date.now() - (el.__lope_user_scroll_at || 0) > 400) {
+          appendScrollLog('scroll:skip_nonuser', { title: container?.title ?? null });
+          return;
+        }
+        const k = scrollKeyFor(container);
+        const scrollTop = el.scrollTop;
+        const scrollLeft = el.scrollLeft;
+        if (scrollTop == 0) {
+          appendScrollLog('modulePanel:skip 0 scroll', {
             title: container?.title ?? null,
             scrollKey
+          });
+          return;
+        }
+        scroll_cache.set(k, {
+          scrollTop,
+          scrollLeft,
+          t: Date.now()
         });
-    };
+        appendScrollLog('scroll:event', {
+          k,
+          title: container?.title ?? null,
+          scrollTop,
+          scrollLeft
+        });
+      }, { passive: true });
+    }
+    // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
+    if (!container.__lope_destroy_bound) {
+      container.__lope_destroy_bound = true;
+      container.on('destroy', () => {
+        try {
+          if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+            appendScrollLog('scroll:destroy_skip_reflow', { title: container?.title ?? null });
+            return;
+          }
+          const k = scrollKeyFor(container);
+          const scrollTop = el?.scrollTop;
+          const scrollLeft = el?.scrollLeft;
+          if (scrollTop == 0) {
+            appendScrollLog('scroll:skip 0 scroll', {
+              k,
+              key: container?.title ?? null,
+              scrollKey
+            });
+            return;
+          }
+          // do not skip 0 here: if the user is at top, preserve that state
+          scroll_cache.set(k, {
+            scrollTop,
+            scrollLeft,
+            t: Date.now()
+          });
+          appendScrollLog('scroll:destroy_capture', {
+            k,
+            title: container?.title ?? null,
+            scrollTop,
+            scrollLeft
+          });
+        } catch (e) {
+          appendScrollLog('scroll:destroy_capture:error', {
+            title: container?.title ?? null,
+            error: String(e)
+          });
+        }
+      });
+    }
+    // When GoldenLayout resizes this panel (e.g. an adjacent panel is closed) the
+    // browser can shift scrollTop; re-apply the user's cached position after the reflow.
+    if (!container.__lope_resize_bound) {
+      container.__lope_resize_bound = true;
+      container.on('resize', () => {
+        const rk = scrollKeyFor(container);
+        const cached = scroll_cache.get(rk);
+        if (!cached || cached.scrollTop == null)
+          return;
+        const c_el = container.getElement();
+        const at = Date.now();
+        scroll_cache.__reflowUntil = at + 800;
+        // The reflow can shift scrollTop in several passes (content relayout
+        // settles ~300ms later), so re-apply over a window. Bail if the user scrolls.
+        const apply = () => {
+          if ((c_el.__lope_user_scroll_at || 0) > at)
+            return;
+          if (c_el.scrollTop !== cached.scrollTop)
+            c_el.scrollTop = cached.scrollTop;
+          if (cached.scrollLeft != null && c_el.scrollLeft !== cached.scrollLeft)
+            c_el.scrollLeft = cached.scrollLeft;
+        };
+        requestAnimationFrame(apply);
+        for (const d of [
+            60,
+            150,
+            300,
+            450,
+            600
+          ])
+          setTimeout(apply, d);
+        appendScrollLog('scroll:resize_restore', {
+          k: rk,
+          title: container?.title ?? null,
+          scrollTop: cached.scrollTop
+        });
+      });
+    }
+    appendScrollLog('modulePanel:exit', {
+      title: container?.title ?? null,
+      scrollKey
+    });
+  };
 };
 const _1gm4gbf = function _blobPanel(){return(
 function (container, component) {
@@ -14286,112 +14344,115 @@ const _1d1nkw9 = function _scrollKeyFor(appendScrollLog)
 const _tb217h = function _scroll_cache(){return(
 new Map()
 )};
-const _5tyvpe = function _fix_scroll(scrollKeyFor,appendScrollLog,scroll_cache){return(
-function (container, node, cell_variable, key) {
+const _12p8mg7 = function _fix_scroll(scroll_cache,scrollKeyFor,appendScrollLog)
+{
+  return function (container, node, cell_variable, key) {
+    scroll_cache.__reflowUntil = Date.now() + 600;
+    // suppress reflow-induced scroll events that clobber the cache
     const c_element = container.getElement();
     let k = scrollKeyFor(container);
     appendScrollLog('fix_scroll:enter', {
-        title: container?.title ?? null,
-        k,
-        cell: cell_variable?._name ?? null
+      title: container?.title ?? null,
+      k,
+      cell: cell_variable?._name ?? null
     });
     if (node && node.parentNode !== c_element) {
-        c_element.appendChild(node);
-        appendScrollLog('fix_scroll:append_node', {
-            title: container?.title ?? null,
-            k
-        });
+      c_element.appendChild(node);
+      appendScrollLog('fix_scroll:append_node', {
+        title: container?.title ?? null,
+        k
+      });
     }
     const writeCache = (scrollTop, scrollLeft, why) => {
-        scroll_cache.set(k, {
-            scrollTop,
-            scrollLeft,
-            t: Date.now()
-        });
-        appendScrollLog('scroll_cache:write', {
-            k,
-            scrollTop,
-            scrollLeft,
-            why
-        });
+      scroll_cache.set(k, {
+        scrollTop,
+        scrollLeft,
+        t: Date.now()
+      });
+      appendScrollLog('scroll_cache:write', {
+        k,
+        scrollTop,
+        scrollLeft,
+        why
+      });
     };
     const scrollToCellIfPossible = why => {
-        if (!cell_variable)
-            return false;
-        const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
-        if (!dom) {
-            appendScrollLog('scroll:cell_dom_not_found', {
-                k,
-                why,
-                cell: cell_variable?._name ?? null
-            });
-            return false;
-        }
-        const top = dom.offsetTop - c_element.offsetTop;
-        const left = c_element.scrollLeft;
-        c_element.scrollTop = top;
-        appendScrollLog('scroll:set', {
-            k,
-            why: `${ why }:cell`,
-            scrollTop: top,
-            scrollLeft: left,
-            cell: cell_variable?._name ?? null
+      if (!cell_variable)
+        return false;
+      const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
+      if (!dom) {
+        appendScrollLog('scroll:cell_dom_not_found', {
+          k,
+          why,
+          cell: cell_variable?._name ?? null
         });
-        writeCache(top, left, `${ why }:cell`);
-        return true;
+        return false;
+      }
+      const top = dom.offsetTop - c_element.offsetTop;
+      const left = c_element.scrollLeft;
+      c_element.scrollTop = top;
+      appendScrollLog('scroll:set', {
+        k,
+        why: `${ why }:cell`,
+        scrollTop: top,
+        scrollLeft: left,
+        cell: cell_variable?._name ?? null
+      });
+      writeCache(top, left, `${ why }:cell`);
+      return true;
     };
     const restoreFromCache = why => {
-        k = scrollKeyFor(container);
-        const cached = scroll_cache.get(k);
-        appendScrollLog('scroll:restore_attempt', {
-            k,
-            why,
-            cachedScrollTop: cached?.scrollTop ?? null,
-            cachedScrollLeft: cached?.scrollLeft ?? null
+      k = scrollKeyFor(container);
+      const cached = scroll_cache.get(k);
+      appendScrollLog('scroll:restore_attempt', {
+        k,
+        why,
+        cachedScrollTop: cached?.scrollTop ?? null,
+        cachedScrollLeft: cached?.scrollLeft ?? null
+      });
+      if (!cached) {
+        appendScrollLog('scroll:restore_no_scroll', {
+          k,
+          why
         });
-        if (!cached) {
-            appendScrollLog('scroll:restore_no_scroll', {
-                k,
-                why
-            });
-            return;
-        }
-        if (cached.scrollTop != null)
-            c_element.scrollTop = cached.scrollTop;
-        if (cached.scrollLeft != null)
-            c_element.scrollLeft = cached.scrollLeft;
-        appendScrollLog('scroll:restore_applied', {
-            k,
-            why,
-            scrollTop: cached.scrollTop ?? null,
-            scrollLeft: cached.scrollLeft ?? null,
-            scrollTopFinal: c_element.scrollTop,
-            scrollLeftFinal: c_element.scrollLeft
-        });
+        return;
+      }
+      if (cached.scrollTop != null)
+        c_element.scrollTop = cached.scrollTop;
+      if (cached.scrollLeft != null)
+        c_element.scrollLeft = cached.scrollLeft;
+      appendScrollLog('scroll:restore_applied', {
+        k,
+        why,
+        scrollTop: cached.scrollTop ?? null,
+        scrollLeft: cached.scrollLeft ?? null,
+        scrollTopFinal: c_element.scrollTop,
+        scrollLeftFinal: c_element.scrollLeft
+      });
     };
     const setScroll = (why = 'setScroll') => {
-        if (scrollToCellIfPossible(why))
-            return;
-        restoreFromCache(why);
+      if (scrollToCellIfPossible(why))
+        return;
+      restoreFromCache(why);
     };
     const retryFrames = 6;
     for (let i = 0; i < retryFrames; i++) {
-        requestAnimationFrame(() => {
-            k = scrollKeyFor(container);
-            appendScrollLog('fix_scroll:raf_retry', {
-                i,
-                k,
-                title: container?.title ?? null
-            });
-            setScroll(`raf:${ i }`);
+      requestAnimationFrame(() => {
+        k = scrollKeyFor(container);
+        appendScrollLog('fix_scroll:raf_retry', {
+          i,
+          k,
+          title: container?.title ?? null
         });
+        setScroll(`raf:${ i }`);
+      });
     }
     appendScrollLog('fix_scroll:exit', {
-        k,
-        title: container?.title ?? null
+      k,
+      title: container?.title ?? null
     });
-}
-)};
+  };
+};
 const _arfw00 = function _scroll_fix_sync_layout(sync_layout_to_url,layout,appendScrollLog,modulePanel)
 {
     sync_layout_to_url;
@@ -15469,7 +15530,7 @@ export default function define(runtime, observer) {
   $def("_1we0ggl", "reload", ["Generators","viewof reload"], _1we0ggl);  
   $def("_plefwg", "onLoadConfig", ["parseGoldenDSL","URLSearchParams","location"], _plefwg);  
   $def("_1nzpnqy", "visualizer_cache", ["reload"], _1nzpnqy);  
-  $def("_1l35721", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1l35721);  
+  $def("_1ojown8", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1ojown8);  
   $def("_1gm4gbf", "blobPanel", [], _1gm4gbf);  
   $def("_lxv2e2", "settings", [], _lxv2e2);  
   $def("_lp1ggk", "is_mobile", ["width"], _lp1ggk);  
@@ -15490,7 +15551,7 @@ export default function define(runtime, observer) {
   $def("_1dyz4o0", "scrollLog", ["mutable scrollLog"], _1dyz4o0);  
   $def("_1d1nkw9", "scrollKeyFor", ["appendScrollLog"], _1d1nkw9);  
   $def("_tb217h", "scroll_cache", [], _tb217h);  
-  $def("_5tyvpe", "fix_scroll", ["scrollKeyFor","appendScrollLog","scroll_cache"], _5tyvpe);  
+  $def("_12p8mg7", "fix_scroll", ["scroll_cache","scrollKeyFor","appendScrollLog"], _12p8mg7);  
   $def("_arfw00", "scroll_fix_sync_layout", ["sync_layout_to_url","layout","appendScrollLog","modulePanel"], _arfw00);  
   $def("_3nwpp4", "URLrouting", ["md"], _3nwpp4);  
   $def("_14te9pl", "sync_layout_from_url", ["reload","resize","URLSearchParams","hash","appendScrollLog","parseGoldenDSL","gl","layout","serializeGoldenDSL","treeSyncGolden","invalidation"], _14te9pl);  

--- a/notebooks/@tomlarkworthy_themes.html
+++ b/notebooks/@tomlarkworthy_themes.html
@@ -14037,138 +14037,196 @@ const _1nzpnqy = function _visualizer_cache(reload)
     reload;
     return new Map();
 };
-const _1l35721 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
+const _1ojown8 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
 {
-    return function (container, component) {
-        appendScrollLog('modulePanel:enter', {
-            title: container?.title ?? null,
-            componentCell: component?.cell ?? null
-        });
-        const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
-        if (!moduleInfo) {
-            // Fall through to file attachment: titles like @user/notebook/path.ext
-            // resolve via the lopecode bootloader's contentSync DOM lookup.
-            const title = container?.title ?? null;
-            if (title) {
-                let node = file_attachment_cache.get(title);
-                if (!node) {
-                    const r = window.lopecode?.contentSync?.(title);
-                    if (r && r.status === 200 && r.bytes) {
-                        node = renderFileAttachment(r.mime, r.bytes);
-                        file_attachment_cache.set(title, node);
-                        appendScrollLog('modulePanel:file_attachment_create', {
-                            title,
-                            mime: r.mime
-                        });
-                    }
-                }
-                if (node) {
-                    const c_element = container.getElement();
-                    if (node.parentNode !== c_element)
-                        c_element.appendChild(node);
-                    appendScrollLog('modulePanel:file_attachment_mount', { title });
-                    return;
-                }
-            }
-            appendScrollLog('modulePanel:missing_moduleInfo', { title });
-            return;
-        }
-        const module = moduleInfo.module;
-        let node;
-        if (!visualizer_cache.has(module)) {
-            appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
-            node = visualizer(runtime, {
-                invalidation: new Promise(r => {
-                }),
-                module,
-                detachNodes: isOnObservableCom(),
-                filter: (cell_name, variables) => {
-                    if (variables[0]._type !== 1)
-                        return false;
-                    if (typeof cell_name == 'string') {
-                        if (cell_name.startsWith('dynamic '))
-                            return false;
-                    }
-                    return true;
-                }
+  return function (container, component) {
+    appendScrollLog('modulePanel:enter', {
+      title: container?.title ?? null,
+      componentCell: component?.cell ?? null
+    });
+    const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
+    if (!moduleInfo) {
+      // Fall through to file attachment: titles like @user/notebook/path.ext
+      // resolve via the lopecode bootloader's contentSync DOM lookup.
+      const title = container?.title ?? null;
+      if (title) {
+        let node = file_attachment_cache.get(title);
+        if (!node) {
+          const r = window.lopecode?.contentSync?.(title);
+          if (r && r.status === 200 && r.bytes) {
+            node = renderFileAttachment(r.mime, r.bytes);
+            file_attachment_cache.set(title, node);
+            appendScrollLog('modulePanel:file_attachment_create', {
+              title,
+              mime: r.mime
             });
-            visualizer_cache.set(module, node);
-        } else {
-            node = visualizer_cache.get(module);
-            appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+          }
         }
-        const cell = module._scope.get(component.cell);
-        const scrollKey = scrollKeyFor(container);
-        fix_scroll(container, node, cell, scrollKey);
-        const el = container.getElement();
-        if (!el.__lope_scroll_bound) {
-            el.__lope_scroll_bound = true;
-            appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
-            el.addEventListener('scroll', () => {
-                const k = scrollKeyFor(container);
-                const scrollTop = el.scrollTop;
-                const scrollLeft = el.scrollLeft;
-                if (scrollTop == 0) {
-                    appendScrollLog('modulePanel:skip 0 scroll', {
-                        title: container?.title ?? null,
-                        scrollKey
-                    });
-                    return;
-                }
-                scroll_cache.set(k, {
-                    scrollTop,
-                    scrollLeft,
-                    t: Date.now()
-                });
-                appendScrollLog('scroll:event', {
-                    k,
-                    title: container?.title ?? null,
-                    scrollTop,
-                    scrollLeft
-                });
-            }, { passive: true });
+        if (node) {
+          const c_element = container.getElement();
+          if (node.parentNode !== c_element)
+            c_element.appendChild(node);
+          appendScrollLog('modulePanel:file_attachment_mount', { title });
+          return;
         }
-        // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
-        if (!container.__lope_destroy_bound) {
-            container.__lope_destroy_bound = true;
-            container.on('destroy', () => {
-                try {
-                    const k = scrollKeyFor(container);
-                    const scrollTop = el?.scrollTop;
-                    const scrollLeft = el?.scrollLeft;
-                    if (scrollTop == 0) {
-                        appendScrollLog('scroll:skip 0 scroll', {
-                            k,
-                            key: container?.title ?? null,
-                            scrollKey
-                        });
-                        return;
-                    }
-                    // do not skip 0 here: if the user is at top, preserve that state
-                    scroll_cache.set(k, {
-                        scrollTop,
-                        scrollLeft,
-                        t: Date.now()
-                    });
-                    appendScrollLog('scroll:destroy_capture', {
-                        k,
-                        title: container?.title ?? null,
-                        scrollTop,
-                        scrollLeft
-                    });
-                } catch (e) {
-                    appendScrollLog('scroll:destroy_capture:error', {
-                        title: container?.title ?? null,
-                        error: String(e)
-                    });
-                }
-            });
+      }
+      appendScrollLog('modulePanel:missing_moduleInfo', { title });
+      return;
+    }
+    const module = moduleInfo.module;
+    let node;
+    if (!visualizer_cache.has(module)) {
+      appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
+      node = visualizer(runtime, {
+        invalidation: new Promise(r => {
+        }),
+        module,
+        detachNodes: isOnObservableCom(),
+        filter: (cell_name, variables) => {
+          if (variables[0]._type !== 1)
+            return false;
+          if (typeof cell_name == 'string') {
+            if (cell_name.startsWith('dynamic '))
+              return false;
+          }
+          return true;
         }
-        appendScrollLog('modulePanel:exit', {
+      });
+      visualizer_cache.set(module, node);
+    } else {
+      node = visualizer_cache.get(module);
+      appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+    }
+    const cell = module._scope.get(component.cell);
+    const scrollKey = scrollKeyFor(container);
+    fix_scroll(container, node, cell, scrollKey);
+    const el = container.getElement();
+    if (!el.__lope_scroll_bound) {
+      el.__lope_scroll_bound = true;
+      appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
+      const markUserScroll = () => {
+        el.__lope_user_scroll_at = Date.now();
+      };
+      el.addEventListener('wheel', markUserScroll, { passive: true });
+      el.addEventListener('touchmove', markUserScroll, { passive: true });
+      el.addEventListener('keydown', markUserScroll, { passive: true });
+      el.addEventListener('scroll', () => {
+        if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+          appendScrollLog('scroll:skip_reflow', { title: container?.title ?? null });
+          return;
+        }
+        // Only cache scrolls following a genuine user gesture; reflow-induced
+        // scroll events (e.g. closing an adjacent panel) carry stale scrollTops.
+        if (Date.now() - (el.__lope_user_scroll_at || 0) > 400) {
+          appendScrollLog('scroll:skip_nonuser', { title: container?.title ?? null });
+          return;
+        }
+        const k = scrollKeyFor(container);
+        const scrollTop = el.scrollTop;
+        const scrollLeft = el.scrollLeft;
+        if (scrollTop == 0) {
+          appendScrollLog('modulePanel:skip 0 scroll', {
             title: container?.title ?? null,
             scrollKey
+          });
+          return;
+        }
+        scroll_cache.set(k, {
+          scrollTop,
+          scrollLeft,
+          t: Date.now()
         });
-    };
+        appendScrollLog('scroll:event', {
+          k,
+          title: container?.title ?? null,
+          scrollTop,
+          scrollLeft
+        });
+      }, { passive: true });
+    }
+    // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
+    if (!container.__lope_destroy_bound) {
+      container.__lope_destroy_bound = true;
+      container.on('destroy', () => {
+        try {
+          if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+            appendScrollLog('scroll:destroy_skip_reflow', { title: container?.title ?? null });
+            return;
+          }
+          const k = scrollKeyFor(container);
+          const scrollTop = el?.scrollTop;
+          const scrollLeft = el?.scrollLeft;
+          if (scrollTop == 0) {
+            appendScrollLog('scroll:skip 0 scroll', {
+              k,
+              key: container?.title ?? null,
+              scrollKey
+            });
+            return;
+          }
+          // do not skip 0 here: if the user is at top, preserve that state
+          scroll_cache.set(k, {
+            scrollTop,
+            scrollLeft,
+            t: Date.now()
+          });
+          appendScrollLog('scroll:destroy_capture', {
+            k,
+            title: container?.title ?? null,
+            scrollTop,
+            scrollLeft
+          });
+        } catch (e) {
+          appendScrollLog('scroll:destroy_capture:error', {
+            title: container?.title ?? null,
+            error: String(e)
+          });
+        }
+      });
+    }
+    // When GoldenLayout resizes this panel (e.g. an adjacent panel is closed) the
+    // browser can shift scrollTop; re-apply the user's cached position after the reflow.
+    if (!container.__lope_resize_bound) {
+      container.__lope_resize_bound = true;
+      container.on('resize', () => {
+        const rk = scrollKeyFor(container);
+        const cached = scroll_cache.get(rk);
+        if (!cached || cached.scrollTop == null)
+          return;
+        const c_el = container.getElement();
+        const at = Date.now();
+        scroll_cache.__reflowUntil = at + 800;
+        // The reflow can shift scrollTop in several passes (content relayout
+        // settles ~300ms later), so re-apply over a window. Bail if the user scrolls.
+        const apply = () => {
+          if ((c_el.__lope_user_scroll_at || 0) > at)
+            return;
+          if (c_el.scrollTop !== cached.scrollTop)
+            c_el.scrollTop = cached.scrollTop;
+          if (cached.scrollLeft != null && c_el.scrollLeft !== cached.scrollLeft)
+            c_el.scrollLeft = cached.scrollLeft;
+        };
+        requestAnimationFrame(apply);
+        for (const d of [
+            60,
+            150,
+            300,
+            450,
+            600
+          ])
+          setTimeout(apply, d);
+        appendScrollLog('scroll:resize_restore', {
+          k: rk,
+          title: container?.title ?? null,
+          scrollTop: cached.scrollTop
+        });
+      });
+    }
+    appendScrollLog('modulePanel:exit', {
+      title: container?.title ?? null,
+      scrollKey
+    });
+  };
 };
 const _1gm4gbf = function _blobPanel(){return(
 function (container, component) {
@@ -14286,112 +14344,115 @@ const _1d1nkw9 = function _scrollKeyFor(appendScrollLog)
 const _tb217h = function _scroll_cache(){return(
 new Map()
 )};
-const _5tyvpe = function _fix_scroll(scrollKeyFor,appendScrollLog,scroll_cache){return(
-function (container, node, cell_variable, key) {
+const _12p8mg7 = function _fix_scroll(scroll_cache,scrollKeyFor,appendScrollLog)
+{
+  return function (container, node, cell_variable, key) {
+    scroll_cache.__reflowUntil = Date.now() + 600;
+    // suppress reflow-induced scroll events that clobber the cache
     const c_element = container.getElement();
     let k = scrollKeyFor(container);
     appendScrollLog('fix_scroll:enter', {
-        title: container?.title ?? null,
-        k,
-        cell: cell_variable?._name ?? null
+      title: container?.title ?? null,
+      k,
+      cell: cell_variable?._name ?? null
     });
     if (node && node.parentNode !== c_element) {
-        c_element.appendChild(node);
-        appendScrollLog('fix_scroll:append_node', {
-            title: container?.title ?? null,
-            k
-        });
+      c_element.appendChild(node);
+      appendScrollLog('fix_scroll:append_node', {
+        title: container?.title ?? null,
+        k
+      });
     }
     const writeCache = (scrollTop, scrollLeft, why) => {
-        scroll_cache.set(k, {
-            scrollTop,
-            scrollLeft,
-            t: Date.now()
-        });
-        appendScrollLog('scroll_cache:write', {
-            k,
-            scrollTop,
-            scrollLeft,
-            why
-        });
+      scroll_cache.set(k, {
+        scrollTop,
+        scrollLeft,
+        t: Date.now()
+      });
+      appendScrollLog('scroll_cache:write', {
+        k,
+        scrollTop,
+        scrollLeft,
+        why
+      });
     };
     const scrollToCellIfPossible = why => {
-        if (!cell_variable)
-            return false;
-        const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
-        if (!dom) {
-            appendScrollLog('scroll:cell_dom_not_found', {
-                k,
-                why,
-                cell: cell_variable?._name ?? null
-            });
-            return false;
-        }
-        const top = dom.offsetTop - c_element.offsetTop;
-        const left = c_element.scrollLeft;
-        c_element.scrollTop = top;
-        appendScrollLog('scroll:set', {
-            k,
-            why: `${ why }:cell`,
-            scrollTop: top,
-            scrollLeft: left,
-            cell: cell_variable?._name ?? null
+      if (!cell_variable)
+        return false;
+      const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
+      if (!dom) {
+        appendScrollLog('scroll:cell_dom_not_found', {
+          k,
+          why,
+          cell: cell_variable?._name ?? null
         });
-        writeCache(top, left, `${ why }:cell`);
-        return true;
+        return false;
+      }
+      const top = dom.offsetTop - c_element.offsetTop;
+      const left = c_element.scrollLeft;
+      c_element.scrollTop = top;
+      appendScrollLog('scroll:set', {
+        k,
+        why: `${ why }:cell`,
+        scrollTop: top,
+        scrollLeft: left,
+        cell: cell_variable?._name ?? null
+      });
+      writeCache(top, left, `${ why }:cell`);
+      return true;
     };
     const restoreFromCache = why => {
-        k = scrollKeyFor(container);
-        const cached = scroll_cache.get(k);
-        appendScrollLog('scroll:restore_attempt', {
-            k,
-            why,
-            cachedScrollTop: cached?.scrollTop ?? null,
-            cachedScrollLeft: cached?.scrollLeft ?? null
+      k = scrollKeyFor(container);
+      const cached = scroll_cache.get(k);
+      appendScrollLog('scroll:restore_attempt', {
+        k,
+        why,
+        cachedScrollTop: cached?.scrollTop ?? null,
+        cachedScrollLeft: cached?.scrollLeft ?? null
+      });
+      if (!cached) {
+        appendScrollLog('scroll:restore_no_scroll', {
+          k,
+          why
         });
-        if (!cached) {
-            appendScrollLog('scroll:restore_no_scroll', {
-                k,
-                why
-            });
-            return;
-        }
-        if (cached.scrollTop != null)
-            c_element.scrollTop = cached.scrollTop;
-        if (cached.scrollLeft != null)
-            c_element.scrollLeft = cached.scrollLeft;
-        appendScrollLog('scroll:restore_applied', {
-            k,
-            why,
-            scrollTop: cached.scrollTop ?? null,
-            scrollLeft: cached.scrollLeft ?? null,
-            scrollTopFinal: c_element.scrollTop,
-            scrollLeftFinal: c_element.scrollLeft
-        });
+        return;
+      }
+      if (cached.scrollTop != null)
+        c_element.scrollTop = cached.scrollTop;
+      if (cached.scrollLeft != null)
+        c_element.scrollLeft = cached.scrollLeft;
+      appendScrollLog('scroll:restore_applied', {
+        k,
+        why,
+        scrollTop: cached.scrollTop ?? null,
+        scrollLeft: cached.scrollLeft ?? null,
+        scrollTopFinal: c_element.scrollTop,
+        scrollLeftFinal: c_element.scrollLeft
+      });
     };
     const setScroll = (why = 'setScroll') => {
-        if (scrollToCellIfPossible(why))
-            return;
-        restoreFromCache(why);
+      if (scrollToCellIfPossible(why))
+        return;
+      restoreFromCache(why);
     };
     const retryFrames = 6;
     for (let i = 0; i < retryFrames; i++) {
-        requestAnimationFrame(() => {
-            k = scrollKeyFor(container);
-            appendScrollLog('fix_scroll:raf_retry', {
-                i,
-                k,
-                title: container?.title ?? null
-            });
-            setScroll(`raf:${ i }`);
+      requestAnimationFrame(() => {
+        k = scrollKeyFor(container);
+        appendScrollLog('fix_scroll:raf_retry', {
+          i,
+          k,
+          title: container?.title ?? null
         });
+        setScroll(`raf:${ i }`);
+      });
     }
     appendScrollLog('fix_scroll:exit', {
-        k,
-        title: container?.title ?? null
+      k,
+      title: container?.title ?? null
     });
-}
-)};
+  };
+};
 const _arfw00 = function _scroll_fix_sync_layout(sync_layout_to_url,layout,appendScrollLog,modulePanel)
 {
     sync_layout_to_url;
@@ -15469,7 +15530,7 @@ export default function define(runtime, observer) {
   $def("_1we0ggl", "reload", ["Generators","viewof reload"], _1we0ggl);  
   $def("_plefwg", "onLoadConfig", ["parseGoldenDSL","URLSearchParams","location"], _plefwg);  
   $def("_1nzpnqy", "visualizer_cache", ["reload"], _1nzpnqy);  
-  $def("_1l35721", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1l35721);  
+  $def("_1ojown8", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1ojown8);  
   $def("_1gm4gbf", "blobPanel", [], _1gm4gbf);  
   $def("_lxv2e2", "settings", [], _lxv2e2);  
   $def("_lp1ggk", "is_mobile", ["width"], _lp1ggk);  
@@ -15490,7 +15551,7 @@ export default function define(runtime, observer) {
   $def("_1dyz4o0", "scrollLog", ["mutable scrollLog"], _1dyz4o0);  
   $def("_1d1nkw9", "scrollKeyFor", ["appendScrollLog"], _1d1nkw9);  
   $def("_tb217h", "scroll_cache", [], _tb217h);  
-  $def("_5tyvpe", "fix_scroll", ["scrollKeyFor","appendScrollLog","scroll_cache"], _5tyvpe);  
+  $def("_12p8mg7", "fix_scroll", ["scroll_cache","scrollKeyFor","appendScrollLog"], _12p8mg7);  
   $def("_arfw00", "scroll_fix_sync_layout", ["sync_layout_to_url","layout","appendScrollLog","modulePanel"], _arfw00);  
   $def("_3nwpp4", "URLrouting", ["md"], _3nwpp4);  
   $def("_14te9pl", "sync_layout_from_url", ["reload","resize","URLSearchParams","hash","appendScrollLog","parseGoldenDSL","gl","layout","serializeGoldenDSL","treeSyncGolden","invalidation"], _14te9pl);  

--- a/notebooks/@tomlarkworthy_visualizer.html
+++ b/notebooks/@tomlarkworthy_visualizer.html
@@ -14037,138 +14037,196 @@ const _1nzpnqy = function _visualizer_cache(reload)
     reload;
     return new Map();
 };
-const _1l35721 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
+const _1ojown8 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
 {
-    return function (container, component) {
-        appendScrollLog('modulePanel:enter', {
-            title: container?.title ?? null,
-            componentCell: component?.cell ?? null
-        });
-        const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
-        if (!moduleInfo) {
-            // Fall through to file attachment: titles like @user/notebook/path.ext
-            // resolve via the lopecode bootloader's contentSync DOM lookup.
-            const title = container?.title ?? null;
-            if (title) {
-                let node = file_attachment_cache.get(title);
-                if (!node) {
-                    const r = window.lopecode?.contentSync?.(title);
-                    if (r && r.status === 200 && r.bytes) {
-                        node = renderFileAttachment(r.mime, r.bytes);
-                        file_attachment_cache.set(title, node);
-                        appendScrollLog('modulePanel:file_attachment_create', {
-                            title,
-                            mime: r.mime
-                        });
-                    }
-                }
-                if (node) {
-                    const c_element = container.getElement();
-                    if (node.parentNode !== c_element)
-                        c_element.appendChild(node);
-                    appendScrollLog('modulePanel:file_attachment_mount', { title });
-                    return;
-                }
-            }
-            appendScrollLog('modulePanel:missing_moduleInfo', { title });
-            return;
-        }
-        const module = moduleInfo.module;
-        let node;
-        if (!visualizer_cache.has(module)) {
-            appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
-            node = visualizer(runtime, {
-                invalidation: new Promise(r => {
-                }),
-                module,
-                detachNodes: isOnObservableCom(),
-                filter: (cell_name, variables) => {
-                    if (variables[0]._type !== 1)
-                        return false;
-                    if (typeof cell_name == 'string') {
-                        if (cell_name.startsWith('dynamic '))
-                            return false;
-                    }
-                    return true;
-                }
+  return function (container, component) {
+    appendScrollLog('modulePanel:enter', {
+      title: container?.title ?? null,
+      componentCell: component?.cell ?? null
+    });
+    const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
+    if (!moduleInfo) {
+      // Fall through to file attachment: titles like @user/notebook/path.ext
+      // resolve via the lopecode bootloader's contentSync DOM lookup.
+      const title = container?.title ?? null;
+      if (title) {
+        let node = file_attachment_cache.get(title);
+        if (!node) {
+          const r = window.lopecode?.contentSync?.(title);
+          if (r && r.status === 200 && r.bytes) {
+            node = renderFileAttachment(r.mime, r.bytes);
+            file_attachment_cache.set(title, node);
+            appendScrollLog('modulePanel:file_attachment_create', {
+              title,
+              mime: r.mime
             });
-            visualizer_cache.set(module, node);
-        } else {
-            node = visualizer_cache.get(module);
-            appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+          }
         }
-        const cell = module._scope.get(component.cell);
-        const scrollKey = scrollKeyFor(container);
-        fix_scroll(container, node, cell, scrollKey);
-        const el = container.getElement();
-        if (!el.__lope_scroll_bound) {
-            el.__lope_scroll_bound = true;
-            appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
-            el.addEventListener('scroll', () => {
-                const k = scrollKeyFor(container);
-                const scrollTop = el.scrollTop;
-                const scrollLeft = el.scrollLeft;
-                if (scrollTop == 0) {
-                    appendScrollLog('modulePanel:skip 0 scroll', {
-                        title: container?.title ?? null,
-                        scrollKey
-                    });
-                    return;
-                }
-                scroll_cache.set(k, {
-                    scrollTop,
-                    scrollLeft,
-                    t: Date.now()
-                });
-                appendScrollLog('scroll:event', {
-                    k,
-                    title: container?.title ?? null,
-                    scrollTop,
-                    scrollLeft
-                });
-            }, { passive: true });
+        if (node) {
+          const c_element = container.getElement();
+          if (node.parentNode !== c_element)
+            c_element.appendChild(node);
+          appendScrollLog('modulePanel:file_attachment_mount', { title });
+          return;
         }
-        // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
-        if (!container.__lope_destroy_bound) {
-            container.__lope_destroy_bound = true;
-            container.on('destroy', () => {
-                try {
-                    const k = scrollKeyFor(container);
-                    const scrollTop = el?.scrollTop;
-                    const scrollLeft = el?.scrollLeft;
-                    if (scrollTop == 0) {
-                        appendScrollLog('scroll:skip 0 scroll', {
-                            k,
-                            key: container?.title ?? null,
-                            scrollKey
-                        });
-                        return;
-                    }
-                    // do not skip 0 here: if the user is at top, preserve that state
-                    scroll_cache.set(k, {
-                        scrollTop,
-                        scrollLeft,
-                        t: Date.now()
-                    });
-                    appendScrollLog('scroll:destroy_capture', {
-                        k,
-                        title: container?.title ?? null,
-                        scrollTop,
-                        scrollLeft
-                    });
-                } catch (e) {
-                    appendScrollLog('scroll:destroy_capture:error', {
-                        title: container?.title ?? null,
-                        error: String(e)
-                    });
-                }
-            });
+      }
+      appendScrollLog('modulePanel:missing_moduleInfo', { title });
+      return;
+    }
+    const module = moduleInfo.module;
+    let node;
+    if (!visualizer_cache.has(module)) {
+      appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
+      node = visualizer(runtime, {
+        invalidation: new Promise(r => {
+        }),
+        module,
+        detachNodes: isOnObservableCom(),
+        filter: (cell_name, variables) => {
+          if (variables[0]._type !== 1)
+            return false;
+          if (typeof cell_name == 'string') {
+            if (cell_name.startsWith('dynamic '))
+              return false;
+          }
+          return true;
         }
-        appendScrollLog('modulePanel:exit', {
+      });
+      visualizer_cache.set(module, node);
+    } else {
+      node = visualizer_cache.get(module);
+      appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+    }
+    const cell = module._scope.get(component.cell);
+    const scrollKey = scrollKeyFor(container);
+    fix_scroll(container, node, cell, scrollKey);
+    const el = container.getElement();
+    if (!el.__lope_scroll_bound) {
+      el.__lope_scroll_bound = true;
+      appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
+      const markUserScroll = () => {
+        el.__lope_user_scroll_at = Date.now();
+      };
+      el.addEventListener('wheel', markUserScroll, { passive: true });
+      el.addEventListener('touchmove', markUserScroll, { passive: true });
+      el.addEventListener('keydown', markUserScroll, { passive: true });
+      el.addEventListener('scroll', () => {
+        if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+          appendScrollLog('scroll:skip_reflow', { title: container?.title ?? null });
+          return;
+        }
+        // Only cache scrolls following a genuine user gesture; reflow-induced
+        // scroll events (e.g. closing an adjacent panel) carry stale scrollTops.
+        if (Date.now() - (el.__lope_user_scroll_at || 0) > 400) {
+          appendScrollLog('scroll:skip_nonuser', { title: container?.title ?? null });
+          return;
+        }
+        const k = scrollKeyFor(container);
+        const scrollTop = el.scrollTop;
+        const scrollLeft = el.scrollLeft;
+        if (scrollTop == 0) {
+          appendScrollLog('modulePanel:skip 0 scroll', {
             title: container?.title ?? null,
             scrollKey
+          });
+          return;
+        }
+        scroll_cache.set(k, {
+          scrollTop,
+          scrollLeft,
+          t: Date.now()
         });
-    };
+        appendScrollLog('scroll:event', {
+          k,
+          title: container?.title ?? null,
+          scrollTop,
+          scrollLeft
+        });
+      }, { passive: true });
+    }
+    // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
+    if (!container.__lope_destroy_bound) {
+      container.__lope_destroy_bound = true;
+      container.on('destroy', () => {
+        try {
+          if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+            appendScrollLog('scroll:destroy_skip_reflow', { title: container?.title ?? null });
+            return;
+          }
+          const k = scrollKeyFor(container);
+          const scrollTop = el?.scrollTop;
+          const scrollLeft = el?.scrollLeft;
+          if (scrollTop == 0) {
+            appendScrollLog('scroll:skip 0 scroll', {
+              k,
+              key: container?.title ?? null,
+              scrollKey
+            });
+            return;
+          }
+          // do not skip 0 here: if the user is at top, preserve that state
+          scroll_cache.set(k, {
+            scrollTop,
+            scrollLeft,
+            t: Date.now()
+          });
+          appendScrollLog('scroll:destroy_capture', {
+            k,
+            title: container?.title ?? null,
+            scrollTop,
+            scrollLeft
+          });
+        } catch (e) {
+          appendScrollLog('scroll:destroy_capture:error', {
+            title: container?.title ?? null,
+            error: String(e)
+          });
+        }
+      });
+    }
+    // When GoldenLayout resizes this panel (e.g. an adjacent panel is closed) the
+    // browser can shift scrollTop; re-apply the user's cached position after the reflow.
+    if (!container.__lope_resize_bound) {
+      container.__lope_resize_bound = true;
+      container.on('resize', () => {
+        const rk = scrollKeyFor(container);
+        const cached = scroll_cache.get(rk);
+        if (!cached || cached.scrollTop == null)
+          return;
+        const c_el = container.getElement();
+        const at = Date.now();
+        scroll_cache.__reflowUntil = at + 800;
+        // The reflow can shift scrollTop in several passes (content relayout
+        // settles ~300ms later), so re-apply over a window. Bail if the user scrolls.
+        const apply = () => {
+          if ((c_el.__lope_user_scroll_at || 0) > at)
+            return;
+          if (c_el.scrollTop !== cached.scrollTop)
+            c_el.scrollTop = cached.scrollTop;
+          if (cached.scrollLeft != null && c_el.scrollLeft !== cached.scrollLeft)
+            c_el.scrollLeft = cached.scrollLeft;
+        };
+        requestAnimationFrame(apply);
+        for (const d of [
+            60,
+            150,
+            300,
+            450,
+            600
+          ])
+          setTimeout(apply, d);
+        appendScrollLog('scroll:resize_restore', {
+          k: rk,
+          title: container?.title ?? null,
+          scrollTop: cached.scrollTop
+        });
+      });
+    }
+    appendScrollLog('modulePanel:exit', {
+      title: container?.title ?? null,
+      scrollKey
+    });
+  };
 };
 const _1gm4gbf = function _blobPanel(){return(
 function (container, component) {
@@ -14286,112 +14344,115 @@ const _1d1nkw9 = function _scrollKeyFor(appendScrollLog)
 const _tb217h = function _scroll_cache(){return(
 new Map()
 )};
-const _5tyvpe = function _fix_scroll(scrollKeyFor,appendScrollLog,scroll_cache){return(
-function (container, node, cell_variable, key) {
+const _12p8mg7 = function _fix_scroll(scroll_cache,scrollKeyFor,appendScrollLog)
+{
+  return function (container, node, cell_variable, key) {
+    scroll_cache.__reflowUntil = Date.now() + 600;
+    // suppress reflow-induced scroll events that clobber the cache
     const c_element = container.getElement();
     let k = scrollKeyFor(container);
     appendScrollLog('fix_scroll:enter', {
-        title: container?.title ?? null,
-        k,
-        cell: cell_variable?._name ?? null
+      title: container?.title ?? null,
+      k,
+      cell: cell_variable?._name ?? null
     });
     if (node && node.parentNode !== c_element) {
-        c_element.appendChild(node);
-        appendScrollLog('fix_scroll:append_node', {
-            title: container?.title ?? null,
-            k
-        });
+      c_element.appendChild(node);
+      appendScrollLog('fix_scroll:append_node', {
+        title: container?.title ?? null,
+        k
+      });
     }
     const writeCache = (scrollTop, scrollLeft, why) => {
-        scroll_cache.set(k, {
-            scrollTop,
-            scrollLeft,
-            t: Date.now()
-        });
-        appendScrollLog('scroll_cache:write', {
-            k,
-            scrollTop,
-            scrollLeft,
-            why
-        });
+      scroll_cache.set(k, {
+        scrollTop,
+        scrollLeft,
+        t: Date.now()
+      });
+      appendScrollLog('scroll_cache:write', {
+        k,
+        scrollTop,
+        scrollLeft,
+        why
+      });
     };
     const scrollToCellIfPossible = why => {
-        if (!cell_variable)
-            return false;
-        const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
-        if (!dom) {
-            appendScrollLog('scroll:cell_dom_not_found', {
-                k,
-                why,
-                cell: cell_variable?._name ?? null
-            });
-            return false;
-        }
-        const top = dom.offsetTop - c_element.offsetTop;
-        const left = c_element.scrollLeft;
-        c_element.scrollTop = top;
-        appendScrollLog('scroll:set', {
-            k,
-            why: `${ why }:cell`,
-            scrollTop: top,
-            scrollLeft: left,
-            cell: cell_variable?._name ?? null
+      if (!cell_variable)
+        return false;
+      const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
+      if (!dom) {
+        appendScrollLog('scroll:cell_dom_not_found', {
+          k,
+          why,
+          cell: cell_variable?._name ?? null
         });
-        writeCache(top, left, `${ why }:cell`);
-        return true;
+        return false;
+      }
+      const top = dom.offsetTop - c_element.offsetTop;
+      const left = c_element.scrollLeft;
+      c_element.scrollTop = top;
+      appendScrollLog('scroll:set', {
+        k,
+        why: `${ why }:cell`,
+        scrollTop: top,
+        scrollLeft: left,
+        cell: cell_variable?._name ?? null
+      });
+      writeCache(top, left, `${ why }:cell`);
+      return true;
     };
     const restoreFromCache = why => {
-        k = scrollKeyFor(container);
-        const cached = scroll_cache.get(k);
-        appendScrollLog('scroll:restore_attempt', {
-            k,
-            why,
-            cachedScrollTop: cached?.scrollTop ?? null,
-            cachedScrollLeft: cached?.scrollLeft ?? null
+      k = scrollKeyFor(container);
+      const cached = scroll_cache.get(k);
+      appendScrollLog('scroll:restore_attempt', {
+        k,
+        why,
+        cachedScrollTop: cached?.scrollTop ?? null,
+        cachedScrollLeft: cached?.scrollLeft ?? null
+      });
+      if (!cached) {
+        appendScrollLog('scroll:restore_no_scroll', {
+          k,
+          why
         });
-        if (!cached) {
-            appendScrollLog('scroll:restore_no_scroll', {
-                k,
-                why
-            });
-            return;
-        }
-        if (cached.scrollTop != null)
-            c_element.scrollTop = cached.scrollTop;
-        if (cached.scrollLeft != null)
-            c_element.scrollLeft = cached.scrollLeft;
-        appendScrollLog('scroll:restore_applied', {
-            k,
-            why,
-            scrollTop: cached.scrollTop ?? null,
-            scrollLeft: cached.scrollLeft ?? null,
-            scrollTopFinal: c_element.scrollTop,
-            scrollLeftFinal: c_element.scrollLeft
-        });
+        return;
+      }
+      if (cached.scrollTop != null)
+        c_element.scrollTop = cached.scrollTop;
+      if (cached.scrollLeft != null)
+        c_element.scrollLeft = cached.scrollLeft;
+      appendScrollLog('scroll:restore_applied', {
+        k,
+        why,
+        scrollTop: cached.scrollTop ?? null,
+        scrollLeft: cached.scrollLeft ?? null,
+        scrollTopFinal: c_element.scrollTop,
+        scrollLeftFinal: c_element.scrollLeft
+      });
     };
     const setScroll = (why = 'setScroll') => {
-        if (scrollToCellIfPossible(why))
-            return;
-        restoreFromCache(why);
+      if (scrollToCellIfPossible(why))
+        return;
+      restoreFromCache(why);
     };
     const retryFrames = 6;
     for (let i = 0; i < retryFrames; i++) {
-        requestAnimationFrame(() => {
-            k = scrollKeyFor(container);
-            appendScrollLog('fix_scroll:raf_retry', {
-                i,
-                k,
-                title: container?.title ?? null
-            });
-            setScroll(`raf:${ i }`);
+      requestAnimationFrame(() => {
+        k = scrollKeyFor(container);
+        appendScrollLog('fix_scroll:raf_retry', {
+          i,
+          k,
+          title: container?.title ?? null
         });
+        setScroll(`raf:${ i }`);
+      });
     }
     appendScrollLog('fix_scroll:exit', {
-        k,
-        title: container?.title ?? null
+      k,
+      title: container?.title ?? null
     });
-}
-)};
+  };
+};
 const _arfw00 = function _scroll_fix_sync_layout(sync_layout_to_url,layout,appendScrollLog,modulePanel)
 {
     sync_layout_to_url;
@@ -15469,7 +15530,7 @@ export default function define(runtime, observer) {
   $def("_1we0ggl", "reload", ["Generators","viewof reload"], _1we0ggl);  
   $def("_plefwg", "onLoadConfig", ["parseGoldenDSL","URLSearchParams","location"], _plefwg);  
   $def("_1nzpnqy", "visualizer_cache", ["reload"], _1nzpnqy);  
-  $def("_1l35721", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1l35721);  
+  $def("_1ojown8", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1ojown8);  
   $def("_1gm4gbf", "blobPanel", [], _1gm4gbf);  
   $def("_lxv2e2", "settings", [], _lxv2e2);  
   $def("_lp1ggk", "is_mobile", ["width"], _lp1ggk);  
@@ -15490,7 +15551,7 @@ export default function define(runtime, observer) {
   $def("_1dyz4o0", "scrollLog", ["mutable scrollLog"], _1dyz4o0);  
   $def("_1d1nkw9", "scrollKeyFor", ["appendScrollLog"], _1d1nkw9);  
   $def("_tb217h", "scroll_cache", [], _tb217h);  
-  $def("_5tyvpe", "fix_scroll", ["scrollKeyFor","appendScrollLog","scroll_cache"], _5tyvpe);  
+  $def("_12p8mg7", "fix_scroll", ["scroll_cache","scrollKeyFor","appendScrollLog"], _12p8mg7);  
   $def("_arfw00", "scroll_fix_sync_layout", ["sync_layout_to_url","layout","appendScrollLog","modulePanel"], _arfw00);  
   $def("_3nwpp4", "URLrouting", ["md"], _3nwpp4);  
   $def("_14te9pl", "sync_layout_from_url", ["reload","resize","URLSearchParams","hash","appendScrollLog","parseGoldenDSL","gl","layout","serializeGoldenDSL","treeSyncGolden","invalidation"], _14te9pl);  

--- a/notebooks/atproto.html
+++ b/notebooks/atproto.html
@@ -16717,138 +16717,196 @@ const _1nzpnqy = function _visualizer_cache(reload)
     reload;
     return new Map();
 };
-const _1l35721 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
+const _1ojown8 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
 {
-    return function (container, component) {
-        appendScrollLog('modulePanel:enter', {
-            title: container?.title ?? null,
-            componentCell: component?.cell ?? null
-        });
-        const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
-        if (!moduleInfo) {
-            // Fall through to file attachment: titles like @user/notebook/path.ext
-            // resolve via the lopecode bootloader's contentSync DOM lookup.
-            const title = container?.title ?? null;
-            if (title) {
-                let node = file_attachment_cache.get(title);
-                if (!node) {
-                    const r = window.lopecode?.contentSync?.(title);
-                    if (r && r.status === 200 && r.bytes) {
-                        node = renderFileAttachment(r.mime, r.bytes);
-                        file_attachment_cache.set(title, node);
-                        appendScrollLog('modulePanel:file_attachment_create', {
-                            title,
-                            mime: r.mime
-                        });
-                    }
-                }
-                if (node) {
-                    const c_element = container.getElement();
-                    if (node.parentNode !== c_element)
-                        c_element.appendChild(node);
-                    appendScrollLog('modulePanel:file_attachment_mount', { title });
-                    return;
-                }
-            }
-            appendScrollLog('modulePanel:missing_moduleInfo', { title });
-            return;
-        }
-        const module = moduleInfo.module;
-        let node;
-        if (!visualizer_cache.has(module)) {
-            appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
-            node = visualizer(runtime, {
-                invalidation: new Promise(r => {
-                }),
-                module,
-                detachNodes: isOnObservableCom(),
-                filter: (cell_name, variables) => {
-                    if (variables[0]._type !== 1)
-                        return false;
-                    if (typeof cell_name == 'string') {
-                        if (cell_name.startsWith('dynamic '))
-                            return false;
-                    }
-                    return true;
-                }
+  return function (container, component) {
+    appendScrollLog('modulePanel:enter', {
+      title: container?.title ?? null,
+      componentCell: component?.cell ?? null
+    });
+    const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
+    if (!moduleInfo) {
+      // Fall through to file attachment: titles like @user/notebook/path.ext
+      // resolve via the lopecode bootloader's contentSync DOM lookup.
+      const title = container?.title ?? null;
+      if (title) {
+        let node = file_attachment_cache.get(title);
+        if (!node) {
+          const r = window.lopecode?.contentSync?.(title);
+          if (r && r.status === 200 && r.bytes) {
+            node = renderFileAttachment(r.mime, r.bytes);
+            file_attachment_cache.set(title, node);
+            appendScrollLog('modulePanel:file_attachment_create', {
+              title,
+              mime: r.mime
             });
-            visualizer_cache.set(module, node);
-        } else {
-            node = visualizer_cache.get(module);
-            appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+          }
         }
-        const cell = module._scope.get(component.cell);
-        const scrollKey = scrollKeyFor(container);
-        fix_scroll(container, node, cell, scrollKey);
-        const el = container.getElement();
-        if (!el.__lope_scroll_bound) {
-            el.__lope_scroll_bound = true;
-            appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
-            el.addEventListener('scroll', () => {
-                const k = scrollKeyFor(container);
-                const scrollTop = el.scrollTop;
-                const scrollLeft = el.scrollLeft;
-                if (scrollTop == 0) {
-                    appendScrollLog('modulePanel:skip 0 scroll', {
-                        title: container?.title ?? null,
-                        scrollKey
-                    });
-                    return;
-                }
-                scroll_cache.set(k, {
-                    scrollTop,
-                    scrollLeft,
-                    t: Date.now()
-                });
-                appendScrollLog('scroll:event', {
-                    k,
-                    title: container?.title ?? null,
-                    scrollTop,
-                    scrollLeft
-                });
-            }, { passive: true });
+        if (node) {
+          const c_element = container.getElement();
+          if (node.parentNode !== c_element)
+            c_element.appendChild(node);
+          appendScrollLog('modulePanel:file_attachment_mount', { title });
+          return;
         }
-        // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
-        if (!container.__lope_destroy_bound) {
-            container.__lope_destroy_bound = true;
-            container.on('destroy', () => {
-                try {
-                    const k = scrollKeyFor(container);
-                    const scrollTop = el?.scrollTop;
-                    const scrollLeft = el?.scrollLeft;
-                    if (scrollTop == 0) {
-                        appendScrollLog('scroll:skip 0 scroll', {
-                            k,
-                            key: container?.title ?? null,
-                            scrollKey
-                        });
-                        return;
-                    }
-                    // do not skip 0 here: if the user is at top, preserve that state
-                    scroll_cache.set(k, {
-                        scrollTop,
-                        scrollLeft,
-                        t: Date.now()
-                    });
-                    appendScrollLog('scroll:destroy_capture', {
-                        k,
-                        title: container?.title ?? null,
-                        scrollTop,
-                        scrollLeft
-                    });
-                } catch (e) {
-                    appendScrollLog('scroll:destroy_capture:error', {
-                        title: container?.title ?? null,
-                        error: String(e)
-                    });
-                }
-            });
+      }
+      appendScrollLog('modulePanel:missing_moduleInfo', { title });
+      return;
+    }
+    const module = moduleInfo.module;
+    let node;
+    if (!visualizer_cache.has(module)) {
+      appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
+      node = visualizer(runtime, {
+        invalidation: new Promise(r => {
+        }),
+        module,
+        detachNodes: isOnObservableCom(),
+        filter: (cell_name, variables) => {
+          if (variables[0]._type !== 1)
+            return false;
+          if (typeof cell_name == 'string') {
+            if (cell_name.startsWith('dynamic '))
+              return false;
+          }
+          return true;
         }
-        appendScrollLog('modulePanel:exit', {
+      });
+      visualizer_cache.set(module, node);
+    } else {
+      node = visualizer_cache.get(module);
+      appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+    }
+    const cell = module._scope.get(component.cell);
+    const scrollKey = scrollKeyFor(container);
+    fix_scroll(container, node, cell, scrollKey);
+    const el = container.getElement();
+    if (!el.__lope_scroll_bound) {
+      el.__lope_scroll_bound = true;
+      appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
+      const markUserScroll = () => {
+        el.__lope_user_scroll_at = Date.now();
+      };
+      el.addEventListener('wheel', markUserScroll, { passive: true });
+      el.addEventListener('touchmove', markUserScroll, { passive: true });
+      el.addEventListener('keydown', markUserScroll, { passive: true });
+      el.addEventListener('scroll', () => {
+        if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+          appendScrollLog('scroll:skip_reflow', { title: container?.title ?? null });
+          return;
+        }
+        // Only cache scrolls following a genuine user gesture; reflow-induced
+        // scroll events (e.g. closing an adjacent panel) carry stale scrollTops.
+        if (Date.now() - (el.__lope_user_scroll_at || 0) > 400) {
+          appendScrollLog('scroll:skip_nonuser', { title: container?.title ?? null });
+          return;
+        }
+        const k = scrollKeyFor(container);
+        const scrollTop = el.scrollTop;
+        const scrollLeft = el.scrollLeft;
+        if (scrollTop == 0) {
+          appendScrollLog('modulePanel:skip 0 scroll', {
             title: container?.title ?? null,
             scrollKey
+          });
+          return;
+        }
+        scroll_cache.set(k, {
+          scrollTop,
+          scrollLeft,
+          t: Date.now()
         });
-    };
+        appendScrollLog('scroll:event', {
+          k,
+          title: container?.title ?? null,
+          scrollTop,
+          scrollLeft
+        });
+      }, { passive: true });
+    }
+    // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
+    if (!container.__lope_destroy_bound) {
+      container.__lope_destroy_bound = true;
+      container.on('destroy', () => {
+        try {
+          if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+            appendScrollLog('scroll:destroy_skip_reflow', { title: container?.title ?? null });
+            return;
+          }
+          const k = scrollKeyFor(container);
+          const scrollTop = el?.scrollTop;
+          const scrollLeft = el?.scrollLeft;
+          if (scrollTop == 0) {
+            appendScrollLog('scroll:skip 0 scroll', {
+              k,
+              key: container?.title ?? null,
+              scrollKey
+            });
+            return;
+          }
+          // do not skip 0 here: if the user is at top, preserve that state
+          scroll_cache.set(k, {
+            scrollTop,
+            scrollLeft,
+            t: Date.now()
+          });
+          appendScrollLog('scroll:destroy_capture', {
+            k,
+            title: container?.title ?? null,
+            scrollTop,
+            scrollLeft
+          });
+        } catch (e) {
+          appendScrollLog('scroll:destroy_capture:error', {
+            title: container?.title ?? null,
+            error: String(e)
+          });
+        }
+      });
+    }
+    // When GoldenLayout resizes this panel (e.g. an adjacent panel is closed) the
+    // browser can shift scrollTop; re-apply the user's cached position after the reflow.
+    if (!container.__lope_resize_bound) {
+      container.__lope_resize_bound = true;
+      container.on('resize', () => {
+        const rk = scrollKeyFor(container);
+        const cached = scroll_cache.get(rk);
+        if (!cached || cached.scrollTop == null)
+          return;
+        const c_el = container.getElement();
+        const at = Date.now();
+        scroll_cache.__reflowUntil = at + 800;
+        // The reflow can shift scrollTop in several passes (content relayout
+        // settles ~300ms later), so re-apply over a window. Bail if the user scrolls.
+        const apply = () => {
+          if ((c_el.__lope_user_scroll_at || 0) > at)
+            return;
+          if (c_el.scrollTop !== cached.scrollTop)
+            c_el.scrollTop = cached.scrollTop;
+          if (cached.scrollLeft != null && c_el.scrollLeft !== cached.scrollLeft)
+            c_el.scrollLeft = cached.scrollLeft;
+        };
+        requestAnimationFrame(apply);
+        for (const d of [
+            60,
+            150,
+            300,
+            450,
+            600
+          ])
+          setTimeout(apply, d);
+        appendScrollLog('scroll:resize_restore', {
+          k: rk,
+          title: container?.title ?? null,
+          scrollTop: cached.scrollTop
+        });
+      });
+    }
+    appendScrollLog('modulePanel:exit', {
+      title: container?.title ?? null,
+      scrollKey
+    });
+  };
 };
 const _1gm4gbf = function _blobPanel(){return(
 function (container, component) {
@@ -16966,112 +17024,115 @@ const _1d1nkw9 = function _scrollKeyFor(appendScrollLog)
 const _tb217h = function _scroll_cache(){return(
 new Map()
 )};
-const _5tyvpe = function _fix_scroll(scrollKeyFor,appendScrollLog,scroll_cache){return(
-function (container, node, cell_variable, key) {
+const _12p8mg7 = function _fix_scroll(scroll_cache,scrollKeyFor,appendScrollLog)
+{
+  return function (container, node, cell_variable, key) {
+    scroll_cache.__reflowUntil = Date.now() + 600;
+    // suppress reflow-induced scroll events that clobber the cache
     const c_element = container.getElement();
     let k = scrollKeyFor(container);
     appendScrollLog('fix_scroll:enter', {
-        title: container?.title ?? null,
-        k,
-        cell: cell_variable?._name ?? null
+      title: container?.title ?? null,
+      k,
+      cell: cell_variable?._name ?? null
     });
     if (node && node.parentNode !== c_element) {
-        c_element.appendChild(node);
-        appendScrollLog('fix_scroll:append_node', {
-            title: container?.title ?? null,
-            k
-        });
+      c_element.appendChild(node);
+      appendScrollLog('fix_scroll:append_node', {
+        title: container?.title ?? null,
+        k
+      });
     }
     const writeCache = (scrollTop, scrollLeft, why) => {
-        scroll_cache.set(k, {
-            scrollTop,
-            scrollLeft,
-            t: Date.now()
-        });
-        appendScrollLog('scroll_cache:write', {
-            k,
-            scrollTop,
-            scrollLeft,
-            why
-        });
+      scroll_cache.set(k, {
+        scrollTop,
+        scrollLeft,
+        t: Date.now()
+      });
+      appendScrollLog('scroll_cache:write', {
+        k,
+        scrollTop,
+        scrollLeft,
+        why
+      });
     };
     const scrollToCellIfPossible = why => {
-        if (!cell_variable)
-            return false;
-        const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
-        if (!dom) {
-            appendScrollLog('scroll:cell_dom_not_found', {
-                k,
-                why,
-                cell: cell_variable?._name ?? null
-            });
-            return false;
-        }
-        const top = dom.offsetTop - c_element.offsetTop;
-        const left = c_element.scrollLeft;
-        c_element.scrollTop = top;
-        appendScrollLog('scroll:set', {
-            k,
-            why: `${ why }:cell`,
-            scrollTop: top,
-            scrollLeft: left,
-            cell: cell_variable?._name ?? null
+      if (!cell_variable)
+        return false;
+      const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
+      if (!dom) {
+        appendScrollLog('scroll:cell_dom_not_found', {
+          k,
+          why,
+          cell: cell_variable?._name ?? null
         });
-        writeCache(top, left, `${ why }:cell`);
-        return true;
+        return false;
+      }
+      const top = dom.offsetTop - c_element.offsetTop;
+      const left = c_element.scrollLeft;
+      c_element.scrollTop = top;
+      appendScrollLog('scroll:set', {
+        k,
+        why: `${ why }:cell`,
+        scrollTop: top,
+        scrollLeft: left,
+        cell: cell_variable?._name ?? null
+      });
+      writeCache(top, left, `${ why }:cell`);
+      return true;
     };
     const restoreFromCache = why => {
-        k = scrollKeyFor(container);
-        const cached = scroll_cache.get(k);
-        appendScrollLog('scroll:restore_attempt', {
-            k,
-            why,
-            cachedScrollTop: cached?.scrollTop ?? null,
-            cachedScrollLeft: cached?.scrollLeft ?? null
+      k = scrollKeyFor(container);
+      const cached = scroll_cache.get(k);
+      appendScrollLog('scroll:restore_attempt', {
+        k,
+        why,
+        cachedScrollTop: cached?.scrollTop ?? null,
+        cachedScrollLeft: cached?.scrollLeft ?? null
+      });
+      if (!cached) {
+        appendScrollLog('scroll:restore_no_scroll', {
+          k,
+          why
         });
-        if (!cached) {
-            appendScrollLog('scroll:restore_no_scroll', {
-                k,
-                why
-            });
-            return;
-        }
-        if (cached.scrollTop != null)
-            c_element.scrollTop = cached.scrollTop;
-        if (cached.scrollLeft != null)
-            c_element.scrollLeft = cached.scrollLeft;
-        appendScrollLog('scroll:restore_applied', {
-            k,
-            why,
-            scrollTop: cached.scrollTop ?? null,
-            scrollLeft: cached.scrollLeft ?? null,
-            scrollTopFinal: c_element.scrollTop,
-            scrollLeftFinal: c_element.scrollLeft
-        });
+        return;
+      }
+      if (cached.scrollTop != null)
+        c_element.scrollTop = cached.scrollTop;
+      if (cached.scrollLeft != null)
+        c_element.scrollLeft = cached.scrollLeft;
+      appendScrollLog('scroll:restore_applied', {
+        k,
+        why,
+        scrollTop: cached.scrollTop ?? null,
+        scrollLeft: cached.scrollLeft ?? null,
+        scrollTopFinal: c_element.scrollTop,
+        scrollLeftFinal: c_element.scrollLeft
+      });
     };
     const setScroll = (why = 'setScroll') => {
-        if (scrollToCellIfPossible(why))
-            return;
-        restoreFromCache(why);
+      if (scrollToCellIfPossible(why))
+        return;
+      restoreFromCache(why);
     };
     const retryFrames = 6;
     for (let i = 0; i < retryFrames; i++) {
-        requestAnimationFrame(() => {
-            k = scrollKeyFor(container);
-            appendScrollLog('fix_scroll:raf_retry', {
-                i,
-                k,
-                title: container?.title ?? null
-            });
-            setScroll(`raf:${ i }`);
+      requestAnimationFrame(() => {
+        k = scrollKeyFor(container);
+        appendScrollLog('fix_scroll:raf_retry', {
+          i,
+          k,
+          title: container?.title ?? null
         });
+        setScroll(`raf:${ i }`);
+      });
     }
     appendScrollLog('fix_scroll:exit', {
-        k,
-        title: container?.title ?? null
+      k,
+      title: container?.title ?? null
     });
-}
-)};
+  };
+};
 const _arfw00 = function _scroll_fix_sync_layout(sync_layout_to_url,layout,appendScrollLog,modulePanel)
 {
     sync_layout_to_url;
@@ -18149,7 +18210,7 @@ export default function define(runtime, observer) {
   $def("_1we0ggl", "reload", ["Generators","viewof reload"], _1we0ggl);  
   $def("_plefwg", "onLoadConfig", ["parseGoldenDSL","URLSearchParams","location"], _plefwg);  
   $def("_1nzpnqy", "visualizer_cache", ["reload"], _1nzpnqy);  
-  $def("_1l35721", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1l35721);  
+  $def("_1ojown8", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1ojown8);  
   $def("_1gm4gbf", "blobPanel", [], _1gm4gbf);  
   $def("_lxv2e2", "settings", [], _lxv2e2);  
   $def("_lp1ggk", "is_mobile", ["width"], _lp1ggk);  
@@ -18170,7 +18231,7 @@ export default function define(runtime, observer) {
   $def("_1dyz4o0", "scrollLog", ["mutable scrollLog"], _1dyz4o0);  
   $def("_1d1nkw9", "scrollKeyFor", ["appendScrollLog"], _1d1nkw9);  
   $def("_tb217h", "scroll_cache", [], _tb217h);  
-  $def("_5tyvpe", "fix_scroll", ["scrollKeyFor","appendScrollLog","scroll_cache"], _5tyvpe);  
+  $def("_12p8mg7", "fix_scroll", ["scroll_cache","scrollKeyFor","appendScrollLog"], _12p8mg7);  
   $def("_arfw00", "scroll_fix_sync_layout", ["sync_layout_to_url","layout","appendScrollLog","modulePanel"], _arfw00);  
   $def("_3nwpp4", "URLrouting", ["md"], _3nwpp4);  
   $def("_14te9pl", "sync_layout_from_url", ["reload","resize","URLSearchParams","hash","appendScrollLog","parseGoldenDSL","gl","layout","serializeGoldenDSL","treeSyncGolden","invalidation"], _14te9pl);  

--- a/notebooks/jumpgates.html
+++ b/notebooks/jumpgates.html
@@ -15427,138 +15427,196 @@ const _1nzpnqy = function _visualizer_cache(reload)
     reload;
     return new Map();
 };
-const _1l35721 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
+const _1ojown8 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
 {
-    return function (container, component) {
-        appendScrollLog('modulePanel:enter', {
-            title: container?.title ?? null,
-            componentCell: component?.cell ?? null
-        });
-        const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
-        if (!moduleInfo) {
-            // Fall through to file attachment: titles like @user/notebook/path.ext
-            // resolve via the lopecode bootloader's contentSync DOM lookup.
-            const title = container?.title ?? null;
-            if (title) {
-                let node = file_attachment_cache.get(title);
-                if (!node) {
-                    const r = window.lopecode?.contentSync?.(title);
-                    if (r && r.status === 200 && r.bytes) {
-                        node = renderFileAttachment(r.mime, r.bytes);
-                        file_attachment_cache.set(title, node);
-                        appendScrollLog('modulePanel:file_attachment_create', {
-                            title,
-                            mime: r.mime
-                        });
-                    }
-                }
-                if (node) {
-                    const c_element = container.getElement();
-                    if (node.parentNode !== c_element)
-                        c_element.appendChild(node);
-                    appendScrollLog('modulePanel:file_attachment_mount', { title });
-                    return;
-                }
-            }
-            appendScrollLog('modulePanel:missing_moduleInfo', { title });
-            return;
-        }
-        const module = moduleInfo.module;
-        let node;
-        if (!visualizer_cache.has(module)) {
-            appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
-            node = visualizer(runtime, {
-                invalidation: new Promise(r => {
-                }),
-                module,
-                detachNodes: isOnObservableCom(),
-                filter: (cell_name, variables) => {
-                    if (variables[0]._type !== 1)
-                        return false;
-                    if (typeof cell_name == 'string') {
-                        if (cell_name.startsWith('dynamic '))
-                            return false;
-                    }
-                    return true;
-                }
+  return function (container, component) {
+    appendScrollLog('modulePanel:enter', {
+      title: container?.title ?? null,
+      componentCell: component?.cell ?? null
+    });
+    const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
+    if (!moduleInfo) {
+      // Fall through to file attachment: titles like @user/notebook/path.ext
+      // resolve via the lopecode bootloader's contentSync DOM lookup.
+      const title = container?.title ?? null;
+      if (title) {
+        let node = file_attachment_cache.get(title);
+        if (!node) {
+          const r = window.lopecode?.contentSync?.(title);
+          if (r && r.status === 200 && r.bytes) {
+            node = renderFileAttachment(r.mime, r.bytes);
+            file_attachment_cache.set(title, node);
+            appendScrollLog('modulePanel:file_attachment_create', {
+              title,
+              mime: r.mime
             });
-            visualizer_cache.set(module, node);
-        } else {
-            node = visualizer_cache.get(module);
-            appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+          }
         }
-        const cell = module._scope.get(component.cell);
-        const scrollKey = scrollKeyFor(container);
-        fix_scroll(container, node, cell, scrollKey);
-        const el = container.getElement();
-        if (!el.__lope_scroll_bound) {
-            el.__lope_scroll_bound = true;
-            appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
-            el.addEventListener('scroll', () => {
-                const k = scrollKeyFor(container);
-                const scrollTop = el.scrollTop;
-                const scrollLeft = el.scrollLeft;
-                if (scrollTop == 0) {
-                    appendScrollLog('modulePanel:skip 0 scroll', {
-                        title: container?.title ?? null,
-                        scrollKey
-                    });
-                    return;
-                }
-                scroll_cache.set(k, {
-                    scrollTop,
-                    scrollLeft,
-                    t: Date.now()
-                });
-                appendScrollLog('scroll:event', {
-                    k,
-                    title: container?.title ?? null,
-                    scrollTop,
-                    scrollLeft
-                });
-            }, { passive: true });
+        if (node) {
+          const c_element = container.getElement();
+          if (node.parentNode !== c_element)
+            c_element.appendChild(node);
+          appendScrollLog('modulePanel:file_attachment_mount', { title });
+          return;
         }
-        // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
-        if (!container.__lope_destroy_bound) {
-            container.__lope_destroy_bound = true;
-            container.on('destroy', () => {
-                try {
-                    const k = scrollKeyFor(container);
-                    const scrollTop = el?.scrollTop;
-                    const scrollLeft = el?.scrollLeft;
-                    if (scrollTop == 0) {
-                        appendScrollLog('scroll:skip 0 scroll', {
-                            k,
-                            key: container?.title ?? null,
-                            scrollKey
-                        });
-                        return;
-                    }
-                    // do not skip 0 here: if the user is at top, preserve that state
-                    scroll_cache.set(k, {
-                        scrollTop,
-                        scrollLeft,
-                        t: Date.now()
-                    });
-                    appendScrollLog('scroll:destroy_capture', {
-                        k,
-                        title: container?.title ?? null,
-                        scrollTop,
-                        scrollLeft
-                    });
-                } catch (e) {
-                    appendScrollLog('scroll:destroy_capture:error', {
-                        title: container?.title ?? null,
-                        error: String(e)
-                    });
-                }
-            });
+      }
+      appendScrollLog('modulePanel:missing_moduleInfo', { title });
+      return;
+    }
+    const module = moduleInfo.module;
+    let node;
+    if (!visualizer_cache.has(module)) {
+      appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
+      node = visualizer(runtime, {
+        invalidation: new Promise(r => {
+        }),
+        module,
+        detachNodes: isOnObservableCom(),
+        filter: (cell_name, variables) => {
+          if (variables[0]._type !== 1)
+            return false;
+          if (typeof cell_name == 'string') {
+            if (cell_name.startsWith('dynamic '))
+              return false;
+          }
+          return true;
         }
-        appendScrollLog('modulePanel:exit', {
+      });
+      visualizer_cache.set(module, node);
+    } else {
+      node = visualizer_cache.get(module);
+      appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+    }
+    const cell = module._scope.get(component.cell);
+    const scrollKey = scrollKeyFor(container);
+    fix_scroll(container, node, cell, scrollKey);
+    const el = container.getElement();
+    if (!el.__lope_scroll_bound) {
+      el.__lope_scroll_bound = true;
+      appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
+      const markUserScroll = () => {
+        el.__lope_user_scroll_at = Date.now();
+      };
+      el.addEventListener('wheel', markUserScroll, { passive: true });
+      el.addEventListener('touchmove', markUserScroll, { passive: true });
+      el.addEventListener('keydown', markUserScroll, { passive: true });
+      el.addEventListener('scroll', () => {
+        if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+          appendScrollLog('scroll:skip_reflow', { title: container?.title ?? null });
+          return;
+        }
+        // Only cache scrolls following a genuine user gesture; reflow-induced
+        // scroll events (e.g. closing an adjacent panel) carry stale scrollTops.
+        if (Date.now() - (el.__lope_user_scroll_at || 0) > 400) {
+          appendScrollLog('scroll:skip_nonuser', { title: container?.title ?? null });
+          return;
+        }
+        const k = scrollKeyFor(container);
+        const scrollTop = el.scrollTop;
+        const scrollLeft = el.scrollLeft;
+        if (scrollTop == 0) {
+          appendScrollLog('modulePanel:skip 0 scroll', {
             title: container?.title ?? null,
             scrollKey
+          });
+          return;
+        }
+        scroll_cache.set(k, {
+          scrollTop,
+          scrollLeft,
+          t: Date.now()
         });
-    };
+        appendScrollLog('scroll:event', {
+          k,
+          title: container?.title ?? null,
+          scrollTop,
+          scrollLeft
+        });
+      }, { passive: true });
+    }
+    // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
+    if (!container.__lope_destroy_bound) {
+      container.__lope_destroy_bound = true;
+      container.on('destroy', () => {
+        try {
+          if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+            appendScrollLog('scroll:destroy_skip_reflow', { title: container?.title ?? null });
+            return;
+          }
+          const k = scrollKeyFor(container);
+          const scrollTop = el?.scrollTop;
+          const scrollLeft = el?.scrollLeft;
+          if (scrollTop == 0) {
+            appendScrollLog('scroll:skip 0 scroll', {
+              k,
+              key: container?.title ?? null,
+              scrollKey
+            });
+            return;
+          }
+          // do not skip 0 here: if the user is at top, preserve that state
+          scroll_cache.set(k, {
+            scrollTop,
+            scrollLeft,
+            t: Date.now()
+          });
+          appendScrollLog('scroll:destroy_capture', {
+            k,
+            title: container?.title ?? null,
+            scrollTop,
+            scrollLeft
+          });
+        } catch (e) {
+          appendScrollLog('scroll:destroy_capture:error', {
+            title: container?.title ?? null,
+            error: String(e)
+          });
+        }
+      });
+    }
+    // When GoldenLayout resizes this panel (e.g. an adjacent panel is closed) the
+    // browser can shift scrollTop; re-apply the user's cached position after the reflow.
+    if (!container.__lope_resize_bound) {
+      container.__lope_resize_bound = true;
+      container.on('resize', () => {
+        const rk = scrollKeyFor(container);
+        const cached = scroll_cache.get(rk);
+        if (!cached || cached.scrollTop == null)
+          return;
+        const c_el = container.getElement();
+        const at = Date.now();
+        scroll_cache.__reflowUntil = at + 800;
+        // The reflow can shift scrollTop in several passes (content relayout
+        // settles ~300ms later), so re-apply over a window. Bail if the user scrolls.
+        const apply = () => {
+          if ((c_el.__lope_user_scroll_at || 0) > at)
+            return;
+          if (c_el.scrollTop !== cached.scrollTop)
+            c_el.scrollTop = cached.scrollTop;
+          if (cached.scrollLeft != null && c_el.scrollLeft !== cached.scrollLeft)
+            c_el.scrollLeft = cached.scrollLeft;
+        };
+        requestAnimationFrame(apply);
+        for (const d of [
+            60,
+            150,
+            300,
+            450,
+            600
+          ])
+          setTimeout(apply, d);
+        appendScrollLog('scroll:resize_restore', {
+          k: rk,
+          title: container?.title ?? null,
+          scrollTop: cached.scrollTop
+        });
+      });
+    }
+    appendScrollLog('modulePanel:exit', {
+      title: container?.title ?? null,
+      scrollKey
+    });
+  };
 };
 const _1gm4gbf = function _blobPanel(){return(
 function (container, component) {
@@ -15676,112 +15734,115 @@ const _1d1nkw9 = function _scrollKeyFor(appendScrollLog)
 const _tb217h = function _scroll_cache(){return(
 new Map()
 )};
-const _5tyvpe = function _fix_scroll(scrollKeyFor,appendScrollLog,scroll_cache){return(
-function (container, node, cell_variable, key) {
+const _12p8mg7 = function _fix_scroll(scroll_cache,scrollKeyFor,appendScrollLog)
+{
+  return function (container, node, cell_variable, key) {
+    scroll_cache.__reflowUntil = Date.now() + 600;
+    // suppress reflow-induced scroll events that clobber the cache
     const c_element = container.getElement();
     let k = scrollKeyFor(container);
     appendScrollLog('fix_scroll:enter', {
-        title: container?.title ?? null,
-        k,
-        cell: cell_variable?._name ?? null
+      title: container?.title ?? null,
+      k,
+      cell: cell_variable?._name ?? null
     });
     if (node && node.parentNode !== c_element) {
-        c_element.appendChild(node);
-        appendScrollLog('fix_scroll:append_node', {
-            title: container?.title ?? null,
-            k
-        });
+      c_element.appendChild(node);
+      appendScrollLog('fix_scroll:append_node', {
+        title: container?.title ?? null,
+        k
+      });
     }
     const writeCache = (scrollTop, scrollLeft, why) => {
-        scroll_cache.set(k, {
-            scrollTop,
-            scrollLeft,
-            t: Date.now()
-        });
-        appendScrollLog('scroll_cache:write', {
-            k,
-            scrollTop,
-            scrollLeft,
-            why
-        });
+      scroll_cache.set(k, {
+        scrollTop,
+        scrollLeft,
+        t: Date.now()
+      });
+      appendScrollLog('scroll_cache:write', {
+        k,
+        scrollTop,
+        scrollLeft,
+        why
+      });
     };
     const scrollToCellIfPossible = why => {
-        if (!cell_variable)
-            return false;
-        const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
-        if (!dom) {
-            appendScrollLog('scroll:cell_dom_not_found', {
-                k,
-                why,
-                cell: cell_variable?._name ?? null
-            });
-            return false;
-        }
-        const top = dom.offsetTop - c_element.offsetTop;
-        const left = c_element.scrollLeft;
-        c_element.scrollTop = top;
-        appendScrollLog('scroll:set', {
-            k,
-            why: `${ why }:cell`,
-            scrollTop: top,
-            scrollLeft: left,
-            cell: cell_variable?._name ?? null
+      if (!cell_variable)
+        return false;
+      const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
+      if (!dom) {
+        appendScrollLog('scroll:cell_dom_not_found', {
+          k,
+          why,
+          cell: cell_variable?._name ?? null
         });
-        writeCache(top, left, `${ why }:cell`);
-        return true;
+        return false;
+      }
+      const top = dom.offsetTop - c_element.offsetTop;
+      const left = c_element.scrollLeft;
+      c_element.scrollTop = top;
+      appendScrollLog('scroll:set', {
+        k,
+        why: `${ why }:cell`,
+        scrollTop: top,
+        scrollLeft: left,
+        cell: cell_variable?._name ?? null
+      });
+      writeCache(top, left, `${ why }:cell`);
+      return true;
     };
     const restoreFromCache = why => {
-        k = scrollKeyFor(container);
-        const cached = scroll_cache.get(k);
-        appendScrollLog('scroll:restore_attempt', {
-            k,
-            why,
-            cachedScrollTop: cached?.scrollTop ?? null,
-            cachedScrollLeft: cached?.scrollLeft ?? null
+      k = scrollKeyFor(container);
+      const cached = scroll_cache.get(k);
+      appendScrollLog('scroll:restore_attempt', {
+        k,
+        why,
+        cachedScrollTop: cached?.scrollTop ?? null,
+        cachedScrollLeft: cached?.scrollLeft ?? null
+      });
+      if (!cached) {
+        appendScrollLog('scroll:restore_no_scroll', {
+          k,
+          why
         });
-        if (!cached) {
-            appendScrollLog('scroll:restore_no_scroll', {
-                k,
-                why
-            });
-            return;
-        }
-        if (cached.scrollTop != null)
-            c_element.scrollTop = cached.scrollTop;
-        if (cached.scrollLeft != null)
-            c_element.scrollLeft = cached.scrollLeft;
-        appendScrollLog('scroll:restore_applied', {
-            k,
-            why,
-            scrollTop: cached.scrollTop ?? null,
-            scrollLeft: cached.scrollLeft ?? null,
-            scrollTopFinal: c_element.scrollTop,
-            scrollLeftFinal: c_element.scrollLeft
-        });
+        return;
+      }
+      if (cached.scrollTop != null)
+        c_element.scrollTop = cached.scrollTop;
+      if (cached.scrollLeft != null)
+        c_element.scrollLeft = cached.scrollLeft;
+      appendScrollLog('scroll:restore_applied', {
+        k,
+        why,
+        scrollTop: cached.scrollTop ?? null,
+        scrollLeft: cached.scrollLeft ?? null,
+        scrollTopFinal: c_element.scrollTop,
+        scrollLeftFinal: c_element.scrollLeft
+      });
     };
     const setScroll = (why = 'setScroll') => {
-        if (scrollToCellIfPossible(why))
-            return;
-        restoreFromCache(why);
+      if (scrollToCellIfPossible(why))
+        return;
+      restoreFromCache(why);
     };
     const retryFrames = 6;
     for (let i = 0; i < retryFrames; i++) {
-        requestAnimationFrame(() => {
-            k = scrollKeyFor(container);
-            appendScrollLog('fix_scroll:raf_retry', {
-                i,
-                k,
-                title: container?.title ?? null
-            });
-            setScroll(`raf:${ i }`);
+      requestAnimationFrame(() => {
+        k = scrollKeyFor(container);
+        appendScrollLog('fix_scroll:raf_retry', {
+          i,
+          k,
+          title: container?.title ?? null
         });
+        setScroll(`raf:${ i }`);
+      });
     }
     appendScrollLog('fix_scroll:exit', {
-        k,
-        title: container?.title ?? null
+      k,
+      title: container?.title ?? null
     });
-}
-)};
+  };
+};
 const _arfw00 = function _scroll_fix_sync_layout(sync_layout_to_url,layout,appendScrollLog,modulePanel)
 {
     sync_layout_to_url;
@@ -16859,7 +16920,7 @@ export default function define(runtime, observer) {
   $def("_1we0ggl", "reload", ["Generators","viewof reload"], _1we0ggl);  
   $def("_plefwg", "onLoadConfig", ["parseGoldenDSL","URLSearchParams","location"], _plefwg);  
   $def("_1nzpnqy", "visualizer_cache", ["reload"], _1nzpnqy);  
-  $def("_1l35721", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1l35721);  
+  $def("_1ojown8", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1ojown8);  
   $def("_1gm4gbf", "blobPanel", [], _1gm4gbf);  
   $def("_lxv2e2", "settings", [], _lxv2e2);  
   $def("_lp1ggk", "is_mobile", ["width"], _lp1ggk);  
@@ -16880,7 +16941,7 @@ export default function define(runtime, observer) {
   $def("_1dyz4o0", "scrollLog", ["mutable scrollLog"], _1dyz4o0);  
   $def("_1d1nkw9", "scrollKeyFor", ["appendScrollLog"], _1d1nkw9);  
   $def("_tb217h", "scroll_cache", [], _tb217h);  
-  $def("_5tyvpe", "fix_scroll", ["scrollKeyFor","appendScrollLog","scroll_cache"], _5tyvpe);  
+  $def("_12p8mg7", "fix_scroll", ["scroll_cache","scrollKeyFor","appendScrollLog"], _12p8mg7);  
   $def("_arfw00", "scroll_fix_sync_layout", ["sync_layout_to_url","layout","appendScrollLog","modulePanel"], _arfw00);  
   $def("_3nwpp4", "URLrouting", ["md"], _3nwpp4);  
   $def("_14te9pl", "sync_layout_from_url", ["reload","resize","URLSearchParams","hash","appendScrollLog","parseGoldenDSL","gl","layout","serializeGoldenDSL","treeSyncGolden","invalidation"], _14te9pl);  

--- a/notebooks/ledger.html
+++ b/notebooks/ledger.html
@@ -17800,138 +17800,196 @@ const _1nzpnqy = function _visualizer_cache(reload)
     reload;
     return new Map();
 };
-const _1l35721 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
+const _1ojown8 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
 {
-    return function (container, component) {
-        appendScrollLog('modulePanel:enter', {
-            title: container?.title ?? null,
-            componentCell: component?.cell ?? null
-        });
-        const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
-        if (!moduleInfo) {
-            // Fall through to file attachment: titles like @user/notebook/path.ext
-            // resolve via the lopecode bootloader's contentSync DOM lookup.
-            const title = container?.title ?? null;
-            if (title) {
-                let node = file_attachment_cache.get(title);
-                if (!node) {
-                    const r = window.lopecode?.contentSync?.(title);
-                    if (r && r.status === 200 && r.bytes) {
-                        node = renderFileAttachment(r.mime, r.bytes);
-                        file_attachment_cache.set(title, node);
-                        appendScrollLog('modulePanel:file_attachment_create', {
-                            title,
-                            mime: r.mime
-                        });
-                    }
-                }
-                if (node) {
-                    const c_element = container.getElement();
-                    if (node.parentNode !== c_element)
-                        c_element.appendChild(node);
-                    appendScrollLog('modulePanel:file_attachment_mount', { title });
-                    return;
-                }
-            }
-            appendScrollLog('modulePanel:missing_moduleInfo', { title });
-            return;
-        }
-        const module = moduleInfo.module;
-        let node;
-        if (!visualizer_cache.has(module)) {
-            appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
-            node = visualizer(runtime, {
-                invalidation: new Promise(r => {
-                }),
-                module,
-                detachNodes: isOnObservableCom(),
-                filter: (cell_name, variables) => {
-                    if (variables[0]._type !== 1)
-                        return false;
-                    if (typeof cell_name == 'string') {
-                        if (cell_name.startsWith('dynamic '))
-                            return false;
-                    }
-                    return true;
-                }
+  return function (container, component) {
+    appendScrollLog('modulePanel:enter', {
+      title: container?.title ?? null,
+      componentCell: component?.cell ?? null
+    });
+    const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
+    if (!moduleInfo) {
+      // Fall through to file attachment: titles like @user/notebook/path.ext
+      // resolve via the lopecode bootloader's contentSync DOM lookup.
+      const title = container?.title ?? null;
+      if (title) {
+        let node = file_attachment_cache.get(title);
+        if (!node) {
+          const r = window.lopecode?.contentSync?.(title);
+          if (r && r.status === 200 && r.bytes) {
+            node = renderFileAttachment(r.mime, r.bytes);
+            file_attachment_cache.set(title, node);
+            appendScrollLog('modulePanel:file_attachment_create', {
+              title,
+              mime: r.mime
             });
-            visualizer_cache.set(module, node);
-        } else {
-            node = visualizer_cache.get(module);
-            appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+          }
         }
-        const cell = module._scope.get(component.cell);
-        const scrollKey = scrollKeyFor(container);
-        fix_scroll(container, node, cell, scrollKey);
-        const el = container.getElement();
-        if (!el.__lope_scroll_bound) {
-            el.__lope_scroll_bound = true;
-            appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
-            el.addEventListener('scroll', () => {
-                const k = scrollKeyFor(container);
-                const scrollTop = el.scrollTop;
-                const scrollLeft = el.scrollLeft;
-                if (scrollTop == 0) {
-                    appendScrollLog('modulePanel:skip 0 scroll', {
-                        title: container?.title ?? null,
-                        scrollKey
-                    });
-                    return;
-                }
-                scroll_cache.set(k, {
-                    scrollTop,
-                    scrollLeft,
-                    t: Date.now()
-                });
-                appendScrollLog('scroll:event', {
-                    k,
-                    title: container?.title ?? null,
-                    scrollTop,
-                    scrollLeft
-                });
-            }, { passive: true });
+        if (node) {
+          const c_element = container.getElement();
+          if (node.parentNode !== c_element)
+            c_element.appendChild(node);
+          appendScrollLog('modulePanel:file_attachment_mount', { title });
+          return;
         }
-        // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
-        if (!container.__lope_destroy_bound) {
-            container.__lope_destroy_bound = true;
-            container.on('destroy', () => {
-                try {
-                    const k = scrollKeyFor(container);
-                    const scrollTop = el?.scrollTop;
-                    const scrollLeft = el?.scrollLeft;
-                    if (scrollTop == 0) {
-                        appendScrollLog('scroll:skip 0 scroll', {
-                            k,
-                            key: container?.title ?? null,
-                            scrollKey
-                        });
-                        return;
-                    }
-                    // do not skip 0 here: if the user is at top, preserve that state
-                    scroll_cache.set(k, {
-                        scrollTop,
-                        scrollLeft,
-                        t: Date.now()
-                    });
-                    appendScrollLog('scroll:destroy_capture', {
-                        k,
-                        title: container?.title ?? null,
-                        scrollTop,
-                        scrollLeft
-                    });
-                } catch (e) {
-                    appendScrollLog('scroll:destroy_capture:error', {
-                        title: container?.title ?? null,
-                        error: String(e)
-                    });
-                }
-            });
+      }
+      appendScrollLog('modulePanel:missing_moduleInfo', { title });
+      return;
+    }
+    const module = moduleInfo.module;
+    let node;
+    if (!visualizer_cache.has(module)) {
+      appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
+      node = visualizer(runtime, {
+        invalidation: new Promise(r => {
+        }),
+        module,
+        detachNodes: isOnObservableCom(),
+        filter: (cell_name, variables) => {
+          if (variables[0]._type !== 1)
+            return false;
+          if (typeof cell_name == 'string') {
+            if (cell_name.startsWith('dynamic '))
+              return false;
+          }
+          return true;
         }
-        appendScrollLog('modulePanel:exit', {
+      });
+      visualizer_cache.set(module, node);
+    } else {
+      node = visualizer_cache.get(module);
+      appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+    }
+    const cell = module._scope.get(component.cell);
+    const scrollKey = scrollKeyFor(container);
+    fix_scroll(container, node, cell, scrollKey);
+    const el = container.getElement();
+    if (!el.__lope_scroll_bound) {
+      el.__lope_scroll_bound = true;
+      appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
+      const markUserScroll = () => {
+        el.__lope_user_scroll_at = Date.now();
+      };
+      el.addEventListener('wheel', markUserScroll, { passive: true });
+      el.addEventListener('touchmove', markUserScroll, { passive: true });
+      el.addEventListener('keydown', markUserScroll, { passive: true });
+      el.addEventListener('scroll', () => {
+        if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+          appendScrollLog('scroll:skip_reflow', { title: container?.title ?? null });
+          return;
+        }
+        // Only cache scrolls following a genuine user gesture; reflow-induced
+        // scroll events (e.g. closing an adjacent panel) carry stale scrollTops.
+        if (Date.now() - (el.__lope_user_scroll_at || 0) > 400) {
+          appendScrollLog('scroll:skip_nonuser', { title: container?.title ?? null });
+          return;
+        }
+        const k = scrollKeyFor(container);
+        const scrollTop = el.scrollTop;
+        const scrollLeft = el.scrollLeft;
+        if (scrollTop == 0) {
+          appendScrollLog('modulePanel:skip 0 scroll', {
             title: container?.title ?? null,
             scrollKey
+          });
+          return;
+        }
+        scroll_cache.set(k, {
+          scrollTop,
+          scrollLeft,
+          t: Date.now()
         });
-    };
+        appendScrollLog('scroll:event', {
+          k,
+          title: container?.title ?? null,
+          scrollTop,
+          scrollLeft
+        });
+      }, { passive: true });
+    }
+    // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
+    if (!container.__lope_destroy_bound) {
+      container.__lope_destroy_bound = true;
+      container.on('destroy', () => {
+        try {
+          if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+            appendScrollLog('scroll:destroy_skip_reflow', { title: container?.title ?? null });
+            return;
+          }
+          const k = scrollKeyFor(container);
+          const scrollTop = el?.scrollTop;
+          const scrollLeft = el?.scrollLeft;
+          if (scrollTop == 0) {
+            appendScrollLog('scroll:skip 0 scroll', {
+              k,
+              key: container?.title ?? null,
+              scrollKey
+            });
+            return;
+          }
+          // do not skip 0 here: if the user is at top, preserve that state
+          scroll_cache.set(k, {
+            scrollTop,
+            scrollLeft,
+            t: Date.now()
+          });
+          appendScrollLog('scroll:destroy_capture', {
+            k,
+            title: container?.title ?? null,
+            scrollTop,
+            scrollLeft
+          });
+        } catch (e) {
+          appendScrollLog('scroll:destroy_capture:error', {
+            title: container?.title ?? null,
+            error: String(e)
+          });
+        }
+      });
+    }
+    // When GoldenLayout resizes this panel (e.g. an adjacent panel is closed) the
+    // browser can shift scrollTop; re-apply the user's cached position after the reflow.
+    if (!container.__lope_resize_bound) {
+      container.__lope_resize_bound = true;
+      container.on('resize', () => {
+        const rk = scrollKeyFor(container);
+        const cached = scroll_cache.get(rk);
+        if (!cached || cached.scrollTop == null)
+          return;
+        const c_el = container.getElement();
+        const at = Date.now();
+        scroll_cache.__reflowUntil = at + 800;
+        // The reflow can shift scrollTop in several passes (content relayout
+        // settles ~300ms later), so re-apply over a window. Bail if the user scrolls.
+        const apply = () => {
+          if ((c_el.__lope_user_scroll_at || 0) > at)
+            return;
+          if (c_el.scrollTop !== cached.scrollTop)
+            c_el.scrollTop = cached.scrollTop;
+          if (cached.scrollLeft != null && c_el.scrollLeft !== cached.scrollLeft)
+            c_el.scrollLeft = cached.scrollLeft;
+        };
+        requestAnimationFrame(apply);
+        for (const d of [
+            60,
+            150,
+            300,
+            450,
+            600
+          ])
+          setTimeout(apply, d);
+        appendScrollLog('scroll:resize_restore', {
+          k: rk,
+          title: container?.title ?? null,
+          scrollTop: cached.scrollTop
+        });
+      });
+    }
+    appendScrollLog('modulePanel:exit', {
+      title: container?.title ?? null,
+      scrollKey
+    });
+  };
 };
 const _1gm4gbf = function _blobPanel(){return(
 function (container, component) {
@@ -18049,112 +18107,115 @@ const _1d1nkw9 = function _scrollKeyFor(appendScrollLog)
 const _tb217h = function _scroll_cache(){return(
 new Map()
 )};
-const _5tyvpe = function _fix_scroll(scrollKeyFor,appendScrollLog,scroll_cache){return(
-function (container, node, cell_variable, key) {
+const _12p8mg7 = function _fix_scroll(scroll_cache,scrollKeyFor,appendScrollLog)
+{
+  return function (container, node, cell_variable, key) {
+    scroll_cache.__reflowUntil = Date.now() + 600;
+    // suppress reflow-induced scroll events that clobber the cache
     const c_element = container.getElement();
     let k = scrollKeyFor(container);
     appendScrollLog('fix_scroll:enter', {
-        title: container?.title ?? null,
-        k,
-        cell: cell_variable?._name ?? null
+      title: container?.title ?? null,
+      k,
+      cell: cell_variable?._name ?? null
     });
     if (node && node.parentNode !== c_element) {
-        c_element.appendChild(node);
-        appendScrollLog('fix_scroll:append_node', {
-            title: container?.title ?? null,
-            k
-        });
+      c_element.appendChild(node);
+      appendScrollLog('fix_scroll:append_node', {
+        title: container?.title ?? null,
+        k
+      });
     }
     const writeCache = (scrollTop, scrollLeft, why) => {
-        scroll_cache.set(k, {
-            scrollTop,
-            scrollLeft,
-            t: Date.now()
-        });
-        appendScrollLog('scroll_cache:write', {
-            k,
-            scrollTop,
-            scrollLeft,
-            why
-        });
+      scroll_cache.set(k, {
+        scrollTop,
+        scrollLeft,
+        t: Date.now()
+      });
+      appendScrollLog('scroll_cache:write', {
+        k,
+        scrollTop,
+        scrollLeft,
+        why
+      });
     };
     const scrollToCellIfPossible = why => {
-        if (!cell_variable)
-            return false;
-        const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
-        if (!dom) {
-            appendScrollLog('scroll:cell_dom_not_found', {
-                k,
-                why,
-                cell: cell_variable?._name ?? null
-            });
-            return false;
-        }
-        const top = dom.offsetTop - c_element.offsetTop;
-        const left = c_element.scrollLeft;
-        c_element.scrollTop = top;
-        appendScrollLog('scroll:set', {
-            k,
-            why: `${ why }:cell`,
-            scrollTop: top,
-            scrollLeft: left,
-            cell: cell_variable?._name ?? null
+      if (!cell_variable)
+        return false;
+      const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
+      if (!dom) {
+        appendScrollLog('scroll:cell_dom_not_found', {
+          k,
+          why,
+          cell: cell_variable?._name ?? null
         });
-        writeCache(top, left, `${ why }:cell`);
-        return true;
+        return false;
+      }
+      const top = dom.offsetTop - c_element.offsetTop;
+      const left = c_element.scrollLeft;
+      c_element.scrollTop = top;
+      appendScrollLog('scroll:set', {
+        k,
+        why: `${ why }:cell`,
+        scrollTop: top,
+        scrollLeft: left,
+        cell: cell_variable?._name ?? null
+      });
+      writeCache(top, left, `${ why }:cell`);
+      return true;
     };
     const restoreFromCache = why => {
-        k = scrollKeyFor(container);
-        const cached = scroll_cache.get(k);
-        appendScrollLog('scroll:restore_attempt', {
-            k,
-            why,
-            cachedScrollTop: cached?.scrollTop ?? null,
-            cachedScrollLeft: cached?.scrollLeft ?? null
+      k = scrollKeyFor(container);
+      const cached = scroll_cache.get(k);
+      appendScrollLog('scroll:restore_attempt', {
+        k,
+        why,
+        cachedScrollTop: cached?.scrollTop ?? null,
+        cachedScrollLeft: cached?.scrollLeft ?? null
+      });
+      if (!cached) {
+        appendScrollLog('scroll:restore_no_scroll', {
+          k,
+          why
         });
-        if (!cached) {
-            appendScrollLog('scroll:restore_no_scroll', {
-                k,
-                why
-            });
-            return;
-        }
-        if (cached.scrollTop != null)
-            c_element.scrollTop = cached.scrollTop;
-        if (cached.scrollLeft != null)
-            c_element.scrollLeft = cached.scrollLeft;
-        appendScrollLog('scroll:restore_applied', {
-            k,
-            why,
-            scrollTop: cached.scrollTop ?? null,
-            scrollLeft: cached.scrollLeft ?? null,
-            scrollTopFinal: c_element.scrollTop,
-            scrollLeftFinal: c_element.scrollLeft
-        });
+        return;
+      }
+      if (cached.scrollTop != null)
+        c_element.scrollTop = cached.scrollTop;
+      if (cached.scrollLeft != null)
+        c_element.scrollLeft = cached.scrollLeft;
+      appendScrollLog('scroll:restore_applied', {
+        k,
+        why,
+        scrollTop: cached.scrollTop ?? null,
+        scrollLeft: cached.scrollLeft ?? null,
+        scrollTopFinal: c_element.scrollTop,
+        scrollLeftFinal: c_element.scrollLeft
+      });
     };
     const setScroll = (why = 'setScroll') => {
-        if (scrollToCellIfPossible(why))
-            return;
-        restoreFromCache(why);
+      if (scrollToCellIfPossible(why))
+        return;
+      restoreFromCache(why);
     };
     const retryFrames = 6;
     for (let i = 0; i < retryFrames; i++) {
-        requestAnimationFrame(() => {
-            k = scrollKeyFor(container);
-            appendScrollLog('fix_scroll:raf_retry', {
-                i,
-                k,
-                title: container?.title ?? null
-            });
-            setScroll(`raf:${ i }`);
+      requestAnimationFrame(() => {
+        k = scrollKeyFor(container);
+        appendScrollLog('fix_scroll:raf_retry', {
+          i,
+          k,
+          title: container?.title ?? null
         });
+        setScroll(`raf:${ i }`);
+      });
     }
     appendScrollLog('fix_scroll:exit', {
-        k,
-        title: container?.title ?? null
+      k,
+      title: container?.title ?? null
     });
-}
-)};
+  };
+};
 const _arfw00 = function _scroll_fix_sync_layout(sync_layout_to_url,layout,appendScrollLog,modulePanel)
 {
     sync_layout_to_url;
@@ -19232,7 +19293,7 @@ export default function define(runtime, observer) {
   $def("_1we0ggl", "reload", ["Generators","viewof reload"], _1we0ggl);  
   $def("_plefwg", "onLoadConfig", ["parseGoldenDSL","URLSearchParams","location"], _plefwg);  
   $def("_1nzpnqy", "visualizer_cache", ["reload"], _1nzpnqy);  
-  $def("_1l35721", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1l35721);  
+  $def("_1ojown8", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1ojown8);  
   $def("_1gm4gbf", "blobPanel", [], _1gm4gbf);  
   $def("_lxv2e2", "settings", [], _lxv2e2);  
   $def("_lp1ggk", "is_mobile", ["width"], _lp1ggk);  
@@ -19253,7 +19314,7 @@ export default function define(runtime, observer) {
   $def("_1dyz4o0", "scrollLog", ["mutable scrollLog"], _1dyz4o0);  
   $def("_1d1nkw9", "scrollKeyFor", ["appendScrollLog"], _1d1nkw9);  
   $def("_tb217h", "scroll_cache", [], _tb217h);  
-  $def("_5tyvpe", "fix_scroll", ["scrollKeyFor","appendScrollLog","scroll_cache"], _5tyvpe);  
+  $def("_12p8mg7", "fix_scroll", ["scroll_cache","scrollKeyFor","appendScrollLog"], _12p8mg7);  
   $def("_arfw00", "scroll_fix_sync_layout", ["sync_layout_to_url","layout","appendScrollLog","modulePanel"], _arfw00);  
   $def("_3nwpp4", "URLrouting", ["md"], _3nwpp4);  
   $def("_14te9pl", "sync_layout_from_url", ["reload","resize","URLSearchParams","hash","appendScrollLog","parseGoldenDSL","gl","layout","serializeGoldenDSL","treeSyncGolden","invalidation"], _14te9pl);  

--- a/notebooks/lopefeed.html
+++ b/notebooks/lopefeed.html
@@ -16871,138 +16871,196 @@ const _1nzpnqy = function _visualizer_cache(reload)
     reload;
     return new Map();
 };
-const _1l35721 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
+const _1ojown8 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
 {
-    return function (container, component) {
-        appendScrollLog('modulePanel:enter', {
-            title: container?.title ?? null,
-            componentCell: component?.cell ?? null
-        });
-        const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
-        if (!moduleInfo) {
-            // Fall through to file attachment: titles like @user/notebook/path.ext
-            // resolve via the lopecode bootloader's contentSync DOM lookup.
-            const title = container?.title ?? null;
-            if (title) {
-                let node = file_attachment_cache.get(title);
-                if (!node) {
-                    const r = window.lopecode?.contentSync?.(title);
-                    if (r && r.status === 200 && r.bytes) {
-                        node = renderFileAttachment(r.mime, r.bytes);
-                        file_attachment_cache.set(title, node);
-                        appendScrollLog('modulePanel:file_attachment_create', {
-                            title,
-                            mime: r.mime
-                        });
-                    }
-                }
-                if (node) {
-                    const c_element = container.getElement();
-                    if (node.parentNode !== c_element)
-                        c_element.appendChild(node);
-                    appendScrollLog('modulePanel:file_attachment_mount', { title });
-                    return;
-                }
-            }
-            appendScrollLog('modulePanel:missing_moduleInfo', { title });
-            return;
-        }
-        const module = moduleInfo.module;
-        let node;
-        if (!visualizer_cache.has(module)) {
-            appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
-            node = visualizer(runtime, {
-                invalidation: new Promise(r => {
-                }),
-                module,
-                detachNodes: isOnObservableCom(),
-                filter: (cell_name, variables) => {
-                    if (variables[0]._type !== 1)
-                        return false;
-                    if (typeof cell_name == 'string') {
-                        if (cell_name.startsWith('dynamic '))
-                            return false;
-                    }
-                    return true;
-                }
+  return function (container, component) {
+    appendScrollLog('modulePanel:enter', {
+      title: container?.title ?? null,
+      componentCell: component?.cell ?? null
+    });
+    const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
+    if (!moduleInfo) {
+      // Fall through to file attachment: titles like @user/notebook/path.ext
+      // resolve via the lopecode bootloader's contentSync DOM lookup.
+      const title = container?.title ?? null;
+      if (title) {
+        let node = file_attachment_cache.get(title);
+        if (!node) {
+          const r = window.lopecode?.contentSync?.(title);
+          if (r && r.status === 200 && r.bytes) {
+            node = renderFileAttachment(r.mime, r.bytes);
+            file_attachment_cache.set(title, node);
+            appendScrollLog('modulePanel:file_attachment_create', {
+              title,
+              mime: r.mime
             });
-            visualizer_cache.set(module, node);
-        } else {
-            node = visualizer_cache.get(module);
-            appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+          }
         }
-        const cell = module._scope.get(component.cell);
-        const scrollKey = scrollKeyFor(container);
-        fix_scroll(container, node, cell, scrollKey);
-        const el = container.getElement();
-        if (!el.__lope_scroll_bound) {
-            el.__lope_scroll_bound = true;
-            appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
-            el.addEventListener('scroll', () => {
-                const k = scrollKeyFor(container);
-                const scrollTop = el.scrollTop;
-                const scrollLeft = el.scrollLeft;
-                if (scrollTop == 0) {
-                    appendScrollLog('modulePanel:skip 0 scroll', {
-                        title: container?.title ?? null,
-                        scrollKey
-                    });
-                    return;
-                }
-                scroll_cache.set(k, {
-                    scrollTop,
-                    scrollLeft,
-                    t: Date.now()
-                });
-                appendScrollLog('scroll:event', {
-                    k,
-                    title: container?.title ?? null,
-                    scrollTop,
-                    scrollLeft
-                });
-            }, { passive: true });
+        if (node) {
+          const c_element = container.getElement();
+          if (node.parentNode !== c_element)
+            c_element.appendChild(node);
+          appendScrollLog('modulePanel:file_attachment_mount', { title });
+          return;
         }
-        // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
-        if (!container.__lope_destroy_bound) {
-            container.__lope_destroy_bound = true;
-            container.on('destroy', () => {
-                try {
-                    const k = scrollKeyFor(container);
-                    const scrollTop = el?.scrollTop;
-                    const scrollLeft = el?.scrollLeft;
-                    if (scrollTop == 0) {
-                        appendScrollLog('scroll:skip 0 scroll', {
-                            k,
-                            key: container?.title ?? null,
-                            scrollKey
-                        });
-                        return;
-                    }
-                    // do not skip 0 here: if the user is at top, preserve that state
-                    scroll_cache.set(k, {
-                        scrollTop,
-                        scrollLeft,
-                        t: Date.now()
-                    });
-                    appendScrollLog('scroll:destroy_capture', {
-                        k,
-                        title: container?.title ?? null,
-                        scrollTop,
-                        scrollLeft
-                    });
-                } catch (e) {
-                    appendScrollLog('scroll:destroy_capture:error', {
-                        title: container?.title ?? null,
-                        error: String(e)
-                    });
-                }
-            });
+      }
+      appendScrollLog('modulePanel:missing_moduleInfo', { title });
+      return;
+    }
+    const module = moduleInfo.module;
+    let node;
+    if (!visualizer_cache.has(module)) {
+      appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
+      node = visualizer(runtime, {
+        invalidation: new Promise(r => {
+        }),
+        module,
+        detachNodes: isOnObservableCom(),
+        filter: (cell_name, variables) => {
+          if (variables[0]._type !== 1)
+            return false;
+          if (typeof cell_name == 'string') {
+            if (cell_name.startsWith('dynamic '))
+              return false;
+          }
+          return true;
         }
-        appendScrollLog('modulePanel:exit', {
+      });
+      visualizer_cache.set(module, node);
+    } else {
+      node = visualizer_cache.get(module);
+      appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+    }
+    const cell = module._scope.get(component.cell);
+    const scrollKey = scrollKeyFor(container);
+    fix_scroll(container, node, cell, scrollKey);
+    const el = container.getElement();
+    if (!el.__lope_scroll_bound) {
+      el.__lope_scroll_bound = true;
+      appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
+      const markUserScroll = () => {
+        el.__lope_user_scroll_at = Date.now();
+      };
+      el.addEventListener('wheel', markUserScroll, { passive: true });
+      el.addEventListener('touchmove', markUserScroll, { passive: true });
+      el.addEventListener('keydown', markUserScroll, { passive: true });
+      el.addEventListener('scroll', () => {
+        if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+          appendScrollLog('scroll:skip_reflow', { title: container?.title ?? null });
+          return;
+        }
+        // Only cache scrolls following a genuine user gesture; reflow-induced
+        // scroll events (e.g. closing an adjacent panel) carry stale scrollTops.
+        if (Date.now() - (el.__lope_user_scroll_at || 0) > 400) {
+          appendScrollLog('scroll:skip_nonuser', { title: container?.title ?? null });
+          return;
+        }
+        const k = scrollKeyFor(container);
+        const scrollTop = el.scrollTop;
+        const scrollLeft = el.scrollLeft;
+        if (scrollTop == 0) {
+          appendScrollLog('modulePanel:skip 0 scroll', {
             title: container?.title ?? null,
             scrollKey
+          });
+          return;
+        }
+        scroll_cache.set(k, {
+          scrollTop,
+          scrollLeft,
+          t: Date.now()
         });
-    };
+        appendScrollLog('scroll:event', {
+          k,
+          title: container?.title ?? null,
+          scrollTop,
+          scrollLeft
+        });
+      }, { passive: true });
+    }
+    // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
+    if (!container.__lope_destroy_bound) {
+      container.__lope_destroy_bound = true;
+      container.on('destroy', () => {
+        try {
+          if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+            appendScrollLog('scroll:destroy_skip_reflow', { title: container?.title ?? null });
+            return;
+          }
+          const k = scrollKeyFor(container);
+          const scrollTop = el?.scrollTop;
+          const scrollLeft = el?.scrollLeft;
+          if (scrollTop == 0) {
+            appendScrollLog('scroll:skip 0 scroll', {
+              k,
+              key: container?.title ?? null,
+              scrollKey
+            });
+            return;
+          }
+          // do not skip 0 here: if the user is at top, preserve that state
+          scroll_cache.set(k, {
+            scrollTop,
+            scrollLeft,
+            t: Date.now()
+          });
+          appendScrollLog('scroll:destroy_capture', {
+            k,
+            title: container?.title ?? null,
+            scrollTop,
+            scrollLeft
+          });
+        } catch (e) {
+          appendScrollLog('scroll:destroy_capture:error', {
+            title: container?.title ?? null,
+            error: String(e)
+          });
+        }
+      });
+    }
+    // When GoldenLayout resizes this panel (e.g. an adjacent panel is closed) the
+    // browser can shift scrollTop; re-apply the user's cached position after the reflow.
+    if (!container.__lope_resize_bound) {
+      container.__lope_resize_bound = true;
+      container.on('resize', () => {
+        const rk = scrollKeyFor(container);
+        const cached = scroll_cache.get(rk);
+        if (!cached || cached.scrollTop == null)
+          return;
+        const c_el = container.getElement();
+        const at = Date.now();
+        scroll_cache.__reflowUntil = at + 800;
+        // The reflow can shift scrollTop in several passes (content relayout
+        // settles ~300ms later), so re-apply over a window. Bail if the user scrolls.
+        const apply = () => {
+          if ((c_el.__lope_user_scroll_at || 0) > at)
+            return;
+          if (c_el.scrollTop !== cached.scrollTop)
+            c_el.scrollTop = cached.scrollTop;
+          if (cached.scrollLeft != null && c_el.scrollLeft !== cached.scrollLeft)
+            c_el.scrollLeft = cached.scrollLeft;
+        };
+        requestAnimationFrame(apply);
+        for (const d of [
+            60,
+            150,
+            300,
+            450,
+            600
+          ])
+          setTimeout(apply, d);
+        appendScrollLog('scroll:resize_restore', {
+          k: rk,
+          title: container?.title ?? null,
+          scrollTop: cached.scrollTop
+        });
+      });
+    }
+    appendScrollLog('modulePanel:exit', {
+      title: container?.title ?? null,
+      scrollKey
+    });
+  };
 };
 const _1gm4gbf = function _blobPanel(){return(
 function (container, component) {
@@ -17120,112 +17178,115 @@ const _1d1nkw9 = function _scrollKeyFor(appendScrollLog)
 const _tb217h = function _scroll_cache(){return(
 new Map()
 )};
-const _5tyvpe = function _fix_scroll(scrollKeyFor,appendScrollLog,scroll_cache){return(
-function (container, node, cell_variable, key) {
+const _12p8mg7 = function _fix_scroll(scroll_cache,scrollKeyFor,appendScrollLog)
+{
+  return function (container, node, cell_variable, key) {
+    scroll_cache.__reflowUntil = Date.now() + 600;
+    // suppress reflow-induced scroll events that clobber the cache
     const c_element = container.getElement();
     let k = scrollKeyFor(container);
     appendScrollLog('fix_scroll:enter', {
-        title: container?.title ?? null,
-        k,
-        cell: cell_variable?._name ?? null
+      title: container?.title ?? null,
+      k,
+      cell: cell_variable?._name ?? null
     });
     if (node && node.parentNode !== c_element) {
-        c_element.appendChild(node);
-        appendScrollLog('fix_scroll:append_node', {
-            title: container?.title ?? null,
-            k
-        });
+      c_element.appendChild(node);
+      appendScrollLog('fix_scroll:append_node', {
+        title: container?.title ?? null,
+        k
+      });
     }
     const writeCache = (scrollTop, scrollLeft, why) => {
-        scroll_cache.set(k, {
-            scrollTop,
-            scrollLeft,
-            t: Date.now()
-        });
-        appendScrollLog('scroll_cache:write', {
-            k,
-            scrollTop,
-            scrollLeft,
-            why
-        });
+      scroll_cache.set(k, {
+        scrollTop,
+        scrollLeft,
+        t: Date.now()
+      });
+      appendScrollLog('scroll_cache:write', {
+        k,
+        scrollTop,
+        scrollLeft,
+        why
+      });
     };
     const scrollToCellIfPossible = why => {
-        if (!cell_variable)
-            return false;
-        const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
-        if (!dom) {
-            appendScrollLog('scroll:cell_dom_not_found', {
-                k,
-                why,
-                cell: cell_variable?._name ?? null
-            });
-            return false;
-        }
-        const top = dom.offsetTop - c_element.offsetTop;
-        const left = c_element.scrollLeft;
-        c_element.scrollTop = top;
-        appendScrollLog('scroll:set', {
-            k,
-            why: `${ why }:cell`,
-            scrollTop: top,
-            scrollLeft: left,
-            cell: cell_variable?._name ?? null
+      if (!cell_variable)
+        return false;
+      const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
+      if (!dom) {
+        appendScrollLog('scroll:cell_dom_not_found', {
+          k,
+          why,
+          cell: cell_variable?._name ?? null
         });
-        writeCache(top, left, `${ why }:cell`);
-        return true;
+        return false;
+      }
+      const top = dom.offsetTop - c_element.offsetTop;
+      const left = c_element.scrollLeft;
+      c_element.scrollTop = top;
+      appendScrollLog('scroll:set', {
+        k,
+        why: `${ why }:cell`,
+        scrollTop: top,
+        scrollLeft: left,
+        cell: cell_variable?._name ?? null
+      });
+      writeCache(top, left, `${ why }:cell`);
+      return true;
     };
     const restoreFromCache = why => {
-        k = scrollKeyFor(container);
-        const cached = scroll_cache.get(k);
-        appendScrollLog('scroll:restore_attempt', {
-            k,
-            why,
-            cachedScrollTop: cached?.scrollTop ?? null,
-            cachedScrollLeft: cached?.scrollLeft ?? null
+      k = scrollKeyFor(container);
+      const cached = scroll_cache.get(k);
+      appendScrollLog('scroll:restore_attempt', {
+        k,
+        why,
+        cachedScrollTop: cached?.scrollTop ?? null,
+        cachedScrollLeft: cached?.scrollLeft ?? null
+      });
+      if (!cached) {
+        appendScrollLog('scroll:restore_no_scroll', {
+          k,
+          why
         });
-        if (!cached) {
-            appendScrollLog('scroll:restore_no_scroll', {
-                k,
-                why
-            });
-            return;
-        }
-        if (cached.scrollTop != null)
-            c_element.scrollTop = cached.scrollTop;
-        if (cached.scrollLeft != null)
-            c_element.scrollLeft = cached.scrollLeft;
-        appendScrollLog('scroll:restore_applied', {
-            k,
-            why,
-            scrollTop: cached.scrollTop ?? null,
-            scrollLeft: cached.scrollLeft ?? null,
-            scrollTopFinal: c_element.scrollTop,
-            scrollLeftFinal: c_element.scrollLeft
-        });
+        return;
+      }
+      if (cached.scrollTop != null)
+        c_element.scrollTop = cached.scrollTop;
+      if (cached.scrollLeft != null)
+        c_element.scrollLeft = cached.scrollLeft;
+      appendScrollLog('scroll:restore_applied', {
+        k,
+        why,
+        scrollTop: cached.scrollTop ?? null,
+        scrollLeft: cached.scrollLeft ?? null,
+        scrollTopFinal: c_element.scrollTop,
+        scrollLeftFinal: c_element.scrollLeft
+      });
     };
     const setScroll = (why = 'setScroll') => {
-        if (scrollToCellIfPossible(why))
-            return;
-        restoreFromCache(why);
+      if (scrollToCellIfPossible(why))
+        return;
+      restoreFromCache(why);
     };
     const retryFrames = 6;
     for (let i = 0; i < retryFrames; i++) {
-        requestAnimationFrame(() => {
-            k = scrollKeyFor(container);
-            appendScrollLog('fix_scroll:raf_retry', {
-                i,
-                k,
-                title: container?.title ?? null
-            });
-            setScroll(`raf:${ i }`);
+      requestAnimationFrame(() => {
+        k = scrollKeyFor(container);
+        appendScrollLog('fix_scroll:raf_retry', {
+          i,
+          k,
+          title: container?.title ?? null
         });
+        setScroll(`raf:${ i }`);
+      });
     }
     appendScrollLog('fix_scroll:exit', {
-        k,
-        title: container?.title ?? null
+      k,
+      title: container?.title ?? null
     });
-}
-)};
+  };
+};
 const _arfw00 = function _scroll_fix_sync_layout(sync_layout_to_url,layout,appendScrollLog,modulePanel)
 {
     sync_layout_to_url;
@@ -18303,7 +18364,7 @@ export default function define(runtime, observer) {
   $def("_1we0ggl", "reload", ["Generators","viewof reload"], _1we0ggl);  
   $def("_plefwg", "onLoadConfig", ["parseGoldenDSL","URLSearchParams","location"], _plefwg);  
   $def("_1nzpnqy", "visualizer_cache", ["reload"], _1nzpnqy);  
-  $def("_1l35721", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1l35721);  
+  $def("_1ojown8", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1ojown8);  
   $def("_1gm4gbf", "blobPanel", [], _1gm4gbf);  
   $def("_lxv2e2", "settings", [], _lxv2e2);  
   $def("_lp1ggk", "is_mobile", ["width"], _lp1ggk);  
@@ -18324,7 +18385,7 @@ export default function define(runtime, observer) {
   $def("_1dyz4o0", "scrollLog", ["mutable scrollLog"], _1dyz4o0);  
   $def("_1d1nkw9", "scrollKeyFor", ["appendScrollLog"], _1d1nkw9);  
   $def("_tb217h", "scroll_cache", [], _tb217h);  
-  $def("_5tyvpe", "fix_scroll", ["scrollKeyFor","appendScrollLog","scroll_cache"], _5tyvpe);  
+  $def("_12p8mg7", "fix_scroll", ["scroll_cache","scrollKeyFor","appendScrollLog"], _12p8mg7);  
   $def("_arfw00", "scroll_fix_sync_layout", ["sync_layout_to_url","layout","appendScrollLog","modulePanel"], _arfw00);  
   $def("_3nwpp4", "URLrouting", ["md"], _3nwpp4);  
   $def("_14te9pl", "sync_layout_from_url", ["reload","resize","URLSearchParams","hash","appendScrollLog","parseGoldenDSL","gl","layout","serializeGoldenDSL","treeSyncGolden","invalidation"], _14te9pl);  


### PR DESCRIPTION
**This PR is a proposal** — the canonical `@tomlarkworthy/lopepage` HTML has been updated with the fix, but ObservableHQ has not been pushed and consumer notebooks have not been re-synced yet. After approval, those steps will run and additional commits will be pushed to this branch.

## Reported symptom
In `@tomlarkworthy_lopecode-newsletter-001`, scroll a notebook panel down, click an "aside" link (e.g. `claude-code-pairing`) which opens that module in a side panel, then close that panel. The original panel's scroll position is lost — it jumps to an unrelated position.

## Root cause
`@tomlarkworthy/lopepage`'s `modulePanel` caches each panel's scroll position (`scroll_cache`, keyed by title) on every non-zero `scroll` event, and `fix_scroll` restores it after a reflow. When GoldenLayout resizes the surviving panel (because the adjacent one was closed), the browser fires **spurious `scroll` events** carrying a stale `scrollTop`. Two failures resulted:

1. The scroll listener wrote those garbage values into `scroll_cache`, overwriting the user's real position.
2. On the close path nothing re-applied the cached position to the resized panel (`fix_scroll` only runs on hash-driven reflows, not on a GoldenLayout close-button resize), so the panel kept whatever scrollTop the reflow left it at. The content also relayouts in several passes (settling ~300 ms later), re-corrupting the position.

## Fix (all in `modulePanel` / `fix_scroll`)
- **Gesture-gate the cache writes:** only record a `scroll` event into `scroll_cache` if it follows a genuine user gesture (`wheel`/`touchmove`/`keydown`) within 400 ms. Reflow-induced scrolls have no preceding gesture, so they no longer clobber the cache.
- **Reflow-suppression window:** `fix_scroll` sets `scroll_cache.__reflowUntil`; the scroll listener and the destroy-capture skip writes during that window (defense for programmatic restores).
- **Restore on resize:** bind a GoldenLayout `container.on('resize')` handler that re-applies the cached scroll position over a short window (rAF + a few timeouts, to outlast the multi-pass content relayout), bailing if the user starts scrolling.

## Targeted QA (live runtime, fixed bundle reloaded clean)
- Genuine wheel scroll → position cached ✅
- Open aside panel → original panel scroll preserved ✅
- Close aside panel → original panel scroll preserved (was: lost) ✅ — brief sub-second flicker that self-corrects to the user's position
- Console: no new errors (pre-existing newsletter `<rect>`/`@import` noise only)