### PR TITLE
Fix: replayGitCommits treats renamed/absent module as base-mismatch (#185)

### DIFF
--- a/notebooks/@tomlarkworthy_atlas.html
+++ b/notebooks/@tomlarkworthy_atlas.html
@@ -13444,7 +13444,7 @@ async function replayGitEntries(gitEntries, {
   return results;
 }
 )};
-const _oha4mi = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
+const _7hpmkx = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
 async function replayGitCommits(commits, {repo = config?.repo, branch = config?.branch, order = 'oldest-first'} = {}) {
   const list = Array.isArray(commits) ? commits : [];
   const ordered = order === 'newest-first' ? list.slice() : order === 'oldest-first' ? list.slice().reverse() : list.slice();
@@ -13473,10 +13473,10 @@ async function replayGitCommits(commits, {repo = config?.repo, branch = config?.
       const moduleName = p.module ?? 'main';
       if (baseHashes && baseHashes[moduleName]) {
         const currentHash = moduleBaseHash(moduleName);
-        if (currentHash && currentHash !== baseHashes[moduleName]) {
+        if (!currentHash || currentHash !== baseHashes[moduleName]) {
           if (!skippedModules.has(moduleName)) {
             skippedModules.add(moduleName);
-            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed`);
+            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed or module absent`);
           }
           continue;
         }
@@ -14671,7 +14671,7 @@ export default function define(runtime, observer) {
   $def("_1r7lx5s", "GitEntry", ["ensure_repo","git","fs"], _1r7lx5s);  
   $def("_yngfrp", "replay_pid_map", [], _yngfrp);  
   $def("_19c2k49", "replayGitEntries", ["modules","getVariableByPersistentId","runtime","replay_pid_map","GitEntry","realize","tag"], _19c2k49);  
-  $def("_oha4mi", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _oha4mi);  
+  $def("_7hpmkx", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _7hpmkx);  
   $def("_1ail6g2", "replay_git", ["isOnObservableCom","modules","replayGitCommits","relevant_git_commits"], _1ail6g2);  
   $def("_1rm7oy4", null, ["md"], _1rm7oy4);  
   $def("_m77twl", null, ["Inputs","exportToZip","fs","config","getCompactISODate"], _m77twl);  

--- a/notebooks/@tomlarkworthy_atproto-comments.html
+++ b/notebooks/@tomlarkworthy_atproto-comments.html
@@ -12615,7 +12615,7 @@ async function replayGitEntries(gitEntries, {
   return results;
 }
 )};
-const _oha4mi = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
+const _7hpmkx = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
 async function replayGitCommits(commits, {repo = config?.repo, branch = config?.branch, order = 'oldest-first'} = {}) {
   const list = Array.isArray(commits) ? commits : [];
   const ordered = order === 'newest-first' ? list.slice() : order === 'oldest-first' ? list.slice().reverse() : list.slice();
@@ -12644,10 +12644,10 @@ async function replayGitCommits(commits, {repo = config?.repo, branch = config?.
       const moduleName = p.module ?? 'main';
       if (baseHashes && baseHashes[moduleName]) {
         const currentHash = moduleBaseHash(moduleName);
-        if (currentHash && currentHash !== baseHashes[moduleName]) {
+        if (!currentHash || currentHash !== baseHashes[moduleName]) {
           if (!skippedModules.has(moduleName)) {
             skippedModules.add(moduleName);
-            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed`);
+            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed or module absent`);
           }
           continue;
         }
@@ -13842,7 +13842,7 @@ export default function define(runtime, observer) {
   $def("_1r7lx5s", "GitEntry", ["ensure_repo","git","fs"], _1r7lx5s);  
   $def("_yngfrp", "replay_pid_map", [], _yngfrp);  
   $def("_19c2k49", "replayGitEntries", ["modules","getVariableByPersistentId","runtime","replay_pid_map","GitEntry","realize","tag"], _19c2k49);  
-  $def("_oha4mi", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _oha4mi);  
+  $def("_7hpmkx", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _7hpmkx);  
   $def("_1ail6g2", "replay_git", ["isOnObservableCom","modules","replayGitCommits","relevant_git_commits"], _1ail6g2);  
   $def("_1rm7oy4", null, ["md"], _1rm7oy4);  
   $def("_m77twl", null, ["Inputs","exportToZip","fs","config","getCompactISODate"], _m77twl);  

--- a/notebooks/@tomlarkworthy_blank-notebook.html
+++ b/notebooks/@tomlarkworthy_blank-notebook.html
@@ -12506,7 +12506,7 @@ async function replayGitEntries(gitEntries, {
   return results;
 }
 )};
-const _oha4mi = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
+const _7hpmkx = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
 async function replayGitCommits(commits, {repo = config?.repo, branch = config?.branch, order = 'oldest-first'} = {}) {
   const list = Array.isArray(commits) ? commits : [];
   const ordered = order === 'newest-first' ? list.slice() : order === 'oldest-first' ? list.slice().reverse() : list.slice();
@@ -12535,10 +12535,10 @@ async function replayGitCommits(commits, {repo = config?.repo, branch = config?.
       const moduleName = p.module ?? 'main';
       if (baseHashes && baseHashes[moduleName]) {
         const currentHash = moduleBaseHash(moduleName);
-        if (currentHash && currentHash !== baseHashes[moduleName]) {
+        if (!currentHash || currentHash !== baseHashes[moduleName]) {
           if (!skippedModules.has(moduleName)) {
             skippedModules.add(moduleName);
-            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed`);
+            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed or module absent`);
           }
           continue;
         }
@@ -13733,7 +13733,7 @@ export default function define(runtime, observer) {
   $def("_1r7lx5s", "GitEntry", ["ensure_repo","git","fs"], _1r7lx5s);  
   $def("_yngfrp", "replay_pid_map", [], _yngfrp);  
   $def("_19c2k49", "replayGitEntries", ["modules","getVariableByPersistentId","runtime","replay_pid_map","GitEntry","realize","tag"], _19c2k49);  
-  $def("_oha4mi", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _oha4mi);  
+  $def("_7hpmkx", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _7hpmkx);  
   $def("_1ail6g2", "replay_git", ["isOnObservableCom","modules","replayGitCommits","relevant_git_commits"], _1ail6g2);  
   $def("_1rm7oy4", null, ["md"], _1rm7oy4);  
   $def("_m77twl", null, ["Inputs","exportToZip","fs","config","getCompactISODate"], _m77twl);  

--- a/notebooks/@tomlarkworthy_bootloader.html
+++ b/notebooks/@tomlarkworthy_bootloader.html
@@ -12723,7 +12723,7 @@ async function replayGitEntries(gitEntries, {
   return results;
 }
 )};
-const _oha4mi = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
+const _7hpmkx = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
 async function replayGitCommits(commits, {repo = config?.repo, branch = config?.branch, order = 'oldest-first'} = {}) {
   const list = Array.isArray(commits) ? commits : [];
   const ordered = order === 'newest-first' ? list.slice() : order === 'oldest-first' ? list.slice().reverse() : list.slice();
@@ -12752,10 +12752,10 @@ async function replayGitCommits(commits, {repo = config?.repo, branch = config?.
       const moduleName = p.module ?? 'main';
       if (baseHashes && baseHashes[moduleName]) {
         const currentHash = moduleBaseHash(moduleName);
-        if (currentHash && currentHash !== baseHashes[moduleName]) {
+        if (!currentHash || currentHash !== baseHashes[moduleName]) {
           if (!skippedModules.has(moduleName)) {
             skippedModules.add(moduleName);
-            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed`);
+            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed or module absent`);
           }
           continue;
         }
@@ -13950,7 +13950,7 @@ export default function define(runtime, observer) {
   $def("_1r7lx5s", "GitEntry", ["ensure_repo","git","fs"], _1r7lx5s);  
   $def("_yngfrp", "replay_pid_map", [], _yngfrp);  
   $def("_19c2k49", "replayGitEntries", ["modules","getVariableByPersistentId","runtime","replay_pid_map","GitEntry","realize","tag"], _19c2k49);  
-  $def("_oha4mi", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _oha4mi);  
+  $def("_7hpmkx", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _7hpmkx);  
   $def("_1ail6g2", "replay_git", ["isOnObservableCom","modules","replayGitCommits","relevant_git_commits"], _1ail6g2);  
   $def("_1rm7oy4", null, ["md"], _1rm7oy4);  
   $def("_m77twl", null, ["Inputs","exportToZip","fs","config","getCompactISODate"], _m77twl);  

--- a/notebooks/@tomlarkworthy_cell-map.html
+++ b/notebooks/@tomlarkworthy_cell-map.html
@@ -12449,7 +12449,7 @@ async function replayGitEntries(gitEntries, {
   return results;
 }
 )};
-const _oha4mi = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
+const _7hpmkx = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
 async function replayGitCommits(commits, {repo = config?.repo, branch = config?.branch, order = 'oldest-first'} = {}) {
   const list = Array.isArray(commits) ? commits : [];
   const ordered = order === 'newest-first' ? list.slice() : order === 'oldest-first' ? list.slice().reverse() : list.slice();
@@ -12478,10 +12478,10 @@ async function replayGitCommits(commits, {repo = config?.repo, branch = config?.
       const moduleName = p.module ?? 'main';
       if (baseHashes && baseHashes[moduleName]) {
         const currentHash = moduleBaseHash(moduleName);
-        if (currentHash && currentHash !== baseHashes[moduleName]) {
+        if (!currentHash || currentHash !== baseHashes[moduleName]) {
           if (!skippedModules.has(moduleName)) {
             skippedModules.add(moduleName);
-            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed`);
+            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed or module absent`);
           }
           continue;
         }
@@ -13676,7 +13676,7 @@ export default function define(runtime, observer) {
   $def("_1r7lx5s", "GitEntry", ["ensure_repo","git","fs"], _1r7lx5s);  
   $def("_yngfrp", "replay_pid_map", [], _yngfrp);  
   $def("_19c2k49", "replayGitEntries", ["modules","getVariableByPersistentId","runtime","replay_pid_map","GitEntry","realize","tag"], _19c2k49);  
-  $def("_oha4mi", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _oha4mi);  
+  $def("_7hpmkx", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _7hpmkx);  
   $def("_1ail6g2", "replay_git", ["isOnObservableCom","modules","replayGitCommits","relevant_git_commits"], _1ail6g2);  
   $def("_1rm7oy4", null, ["md"], _1rm7oy4);  
   $def("_m77twl", null, ["Inputs","exportToZip","fs","config","getCompactISODate"], _m77twl);  

--- a/notebooks/@tomlarkworthy_cells-to-clipboard.html
+++ b/notebooks/@tomlarkworthy_cells-to-clipboard.html
@@ -12484,7 +12484,7 @@ async function replayGitEntries(gitEntries, {
   return results;
 }
 )};
-const _oha4mi = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
+const _7hpmkx = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
 async function replayGitCommits(commits, {repo = config?.repo, branch = config?.branch, order = 'oldest-first'} = {}) {
   const list = Array.isArray(commits) ? commits : [];
   const ordered = order === 'newest-first' ? list.slice() : order === 'oldest-first' ? list.slice().reverse() : list.slice();
@@ -12513,10 +12513,10 @@ async function replayGitCommits(commits, {repo = config?.repo, branch = config?.
       const moduleName = p.module ?? 'main';
       if (baseHashes && baseHashes[moduleName]) {
         const currentHash = moduleBaseHash(moduleName);
-        if (currentHash && currentHash !== baseHashes[moduleName]) {
+        if (!currentHash || currentHash !== baseHashes[moduleName]) {
           if (!skippedModules.has(moduleName)) {
             skippedModules.add(moduleName);
-            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed`);
+            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed or module absent`);
           }
           continue;
         }
@@ -13711,7 +13711,7 @@ export default function define(runtime, observer) {
   $def("_1r7lx5s", "GitEntry", ["ensure_repo","git","fs"], _1r7lx5s);  
   $def("_yngfrp", "replay_pid_map", [], _yngfrp);  
   $def("_19c2k49", "replayGitEntries", ["modules","getVariableByPersistentId","runtime","replay_pid_map","GitEntry","realize","tag"], _19c2k49);  
-  $def("_oha4mi", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _oha4mi);  
+  $def("_7hpmkx", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _7hpmkx);  
   $def("_1ail6g2", "replay_git", ["isOnObservableCom","modules","replayGitCommits","relevant_git_commits"], _1ail6g2);  
   $def("_1rm7oy4", null, ["md"], _1rm7oy4);  
   $def("_m77twl", null, ["Inputs","exportToZip","fs","config","getCompactISODate"], _m77twl);  

--- a/notebooks/@tomlarkworthy_claude-code-pairing.html
+++ b/notebooks/@tomlarkworthy_claude-code-pairing.html
@@ -12473,7 +12473,7 @@ async function replayGitEntries(gitEntries, {
   return results;
 }
 )};
-const _oha4mi = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
+const _7hpmkx = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
 async function replayGitCommits(commits, {repo = config?.repo, branch = config?.branch, order = 'oldest-first'} = {}) {
   const list = Array.isArray(commits) ? commits : [];
   const ordered = order === 'newest-first' ? list.slice() : order === 'oldest-first' ? list.slice().reverse() : list.slice();
@@ -12502,10 +12502,10 @@ async function replayGitCommits(commits, {repo = config?.repo, branch = config?.
       const moduleName = p.module ?? 'main';
       if (baseHashes && baseHashes[moduleName]) {
         const currentHash = moduleBaseHash(moduleName);
-        if (currentHash && currentHash !== baseHashes[moduleName]) {
+        if (!currentHash || currentHash !== baseHashes[moduleName]) {
           if (!skippedModules.has(moduleName)) {
             skippedModules.add(moduleName);
-            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed`);
+            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed or module absent`);
           }
           continue;
         }
@@ -13700,7 +13700,7 @@ export default function define(runtime, observer) {
   $def("_1r7lx5s", "GitEntry", ["ensure_repo","git","fs"], _1r7lx5s);  
   $def("_yngfrp", "replay_pid_map", [], _yngfrp);  
   $def("_19c2k49", "replayGitEntries", ["modules","getVariableByPersistentId","runtime","replay_pid_map","GitEntry","realize","tag"], _19c2k49);  
-  $def("_oha4mi", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _oha4mi);  
+  $def("_7hpmkx", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _7hpmkx);  
   $def("_1ail6g2", "replay_git", ["isOnObservableCom","modules","replayGitCommits","relevant_git_commits"], _1ail6g2);  
   $def("_1rm7oy4", null, ["md"], _1rm7oy4);  
   $def("_m77twl", null, ["Inputs","exportToZip","fs","config","getCompactISODate"], _m77twl);  

--- a/notebooks/@tomlarkworthy_codemirror-6-v2.html
+++ b/notebooks/@tomlarkworthy_codemirror-6-v2.html
@@ -12473,7 +12473,7 @@ async function replayGitEntries(gitEntries, {
   return results;
 }
 )};
-const _oha4mi = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
+const _7hpmkx = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
 async function replayGitCommits(commits, {repo = config?.repo, branch = config?.branch, order = 'oldest-first'} = {}) {
   const list = Array.isArray(commits) ? commits : [];
   const ordered = order === 'newest-first' ? list.slice() : order === 'oldest-first' ? list.slice().reverse() : list.slice();
@@ -12502,10 +12502,10 @@ async function replayGitCommits(commits, {repo = config?.repo, branch = config?.
       const moduleName = p.module ?? 'main';
       if (baseHashes && baseHashes[moduleName]) {
         const currentHash = moduleBaseHash(moduleName);
-        if (currentHash && currentHash !== baseHashes[moduleName]) {
+        if (!currentHash || currentHash !== baseHashes[moduleName]) {
           if (!skippedModules.has(moduleName)) {
             skippedModules.add(moduleName);
-            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed`);
+            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed or module absent`);
           }
           continue;
         }
@@ -13700,7 +13700,7 @@ export default function define(runtime, observer) {
   $def("_1r7lx5s", "GitEntry", ["ensure_repo","git","fs"], _1r7lx5s);  
   $def("_yngfrp", "replay_pid_map", [], _yngfrp);  
   $def("_19c2k49", "replayGitEntries", ["modules","getVariableByPersistentId","runtime","replay_pid_map","GitEntry","realize","tag"], _19c2k49);  
-  $def("_oha4mi", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _oha4mi);  
+  $def("_7hpmkx", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _7hpmkx);  
   $def("_1ail6g2", "replay_git", ["isOnObservableCom","modules","replayGitCommits","relevant_git_commits"], _1ail6g2);  
   $def("_1rm7oy4", null, ["md"], _1rm7oy4);  
   $def("_m77twl", null, ["Inputs","exportToZip","fs","config","getCompactISODate"], _m77twl);  

--- a/notebooks/@tomlarkworthy_command-palette.html
+++ b/notebooks/@tomlarkworthy_command-palette.html
@@ -12473,7 +12473,7 @@ async function replayGitEntries(gitEntries, {
   return results;
 }
 )};
-const _oha4mi = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
+const _7hpmkx = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
 async function replayGitCommits(commits, {repo = config?.repo, branch = config?.branch, order = 'oldest-first'} = {}) {
   const list = Array.isArray(commits) ? commits : [];
   const ordered = order === 'newest-first' ? list.slice() : order === 'oldest-first' ? list.slice().reverse() : list.slice();
@@ -12502,10 +12502,10 @@ async function replayGitCommits(commits, {repo = config?.repo, branch = config?.
       const moduleName = p.module ?? 'main';
       if (baseHashes && baseHashes[moduleName]) {
         const currentHash = moduleBaseHash(moduleName);
-        if (currentHash && currentHash !== baseHashes[moduleName]) {
+        if (!currentHash || currentHash !== baseHashes[moduleName]) {
           if (!skippedModules.has(moduleName)) {
             skippedModules.add(moduleName);
-            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed`);
+            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed or module absent`);
           }
           continue;
         }
@@ -13700,7 +13700,7 @@ export default function define(runtime, observer) {
   $def("_1r7lx5s", "GitEntry", ["ensure_repo","git","fs"], _1r7lx5s);  
   $def("_yngfrp", "replay_pid_map", [], _yngfrp);  
   $def("_19c2k49", "replayGitEntries", ["modules","getVariableByPersistentId","runtime","replay_pid_map","GitEntry","realize","tag"], _19c2k49);  
-  $def("_oha4mi", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _oha4mi);  
+  $def("_7hpmkx", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _7hpmkx);  
   $def("_1ail6g2", "replay_git", ["isOnObservableCom","modules","replayGitCommits","relevant_git_commits"], _1ail6g2);  
   $def("_1rm7oy4", null, ["md"], _1rm7oy4);  
   $def("_m77twl", null, ["Inputs","exportToZip","fs","config","getCompactISODate"], _m77twl);  

--- a/notebooks/@tomlarkworthy_dataflow-templating.html
+++ b/notebooks/@tomlarkworthy_dataflow-templating.html
@@ -12473,7 +12473,7 @@ async function replayGitEntries(gitEntries, {
   return results;
 }
 )};
-const _oha4mi = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
+const _7hpmkx = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
 async function replayGitCommits(commits, {repo = config?.repo, branch = config?.branch, order = 'oldest-first'} = {}) {
   const list = Array.isArray(commits) ? commits : [];
   const ordered = order === 'newest-first' ? list.slice() : order === 'oldest-first' ? list.slice().reverse() : list.slice();
@@ -12502,10 +12502,10 @@ async function replayGitCommits(commits, {repo = config?.repo, branch = config?.
       const moduleName = p.module ?? 'main';
       if (baseHashes && baseHashes[moduleName]) {
         const currentHash = moduleBaseHash(moduleName);
-        if (currentHash && currentHash !== baseHashes[moduleName]) {
+        if (!currentHash || currentHash !== baseHashes[moduleName]) {
           if (!skippedModules.has(moduleName)) {
             skippedModules.add(moduleName);
-            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed`);
+            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed or module absent`);
           }
           continue;
         }
@@ -13700,7 +13700,7 @@ export default function define(runtime, observer) {
   $def("_1r7lx5s", "GitEntry", ["ensure_repo","git","fs"], _1r7lx5s);  
   $def("_yngfrp", "replay_pid_map", [], _yngfrp);  
   $def("_19c2k49", "replayGitEntries", ["modules","getVariableByPersistentId","runtime","replay_pid_map","GitEntry","realize","tag"], _19c2k49);  
-  $def("_oha4mi", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _oha4mi);  
+  $def("_7hpmkx", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _7hpmkx);  
   $def("_1ail6g2", "replay_git", ["isOnObservableCom","modules","replayGitCommits","relevant_git_commits"], _1ail6g2);  
   $def("_1rm7oy4", null, ["md"], _1rm7oy4);  
   $def("_m77twl", null, ["Inputs","exportToZip","fs","config","getCompactISODate"], _m77twl);  

--- a/notebooks/@tomlarkworthy_debugger-2.html
+++ b/notebooks/@tomlarkworthy_debugger-2.html
@@ -13635,7 +13635,7 @@ async function replayGitEntries(gitEntries, {
   return results;
 }
 )};
-const _oha4mi = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
+const _7hpmkx = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
 async function replayGitCommits(commits, {repo = config?.repo, branch = config?.branch, order = 'oldest-first'} = {}) {
   const list = Array.isArray(commits) ? commits : [];
   const ordered = order === 'newest-first' ? list.slice() : order === 'oldest-first' ? list.slice().reverse() : list.slice();
@@ -13664,10 +13664,10 @@ async function replayGitCommits(commits, {repo = config?.repo, branch = config?.
       const moduleName = p.module ?? 'main';
       if (baseHashes && baseHashes[moduleName]) {
         const currentHash = moduleBaseHash(moduleName);
-        if (currentHash && currentHash !== baseHashes[moduleName]) {
+        if (!currentHash || currentHash !== baseHashes[moduleName]) {
           if (!skippedModules.has(moduleName)) {
             skippedModules.add(moduleName);
-            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed`);
+            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed or module absent`);
           }
           continue;
         }
@@ -14862,7 +14862,7 @@ export default function define(runtime, observer) {
   $def("_1r7lx5s", "GitEntry", ["ensure_repo","git","fs"], _1r7lx5s);  
   $def("_yngfrp", "replay_pid_map", [], _yngfrp);  
   $def("_19c2k49", "replayGitEntries", ["modules","getVariableByPersistentId","runtime","replay_pid_map","GitEntry","realize","tag"], _19c2k49);  
-  $def("_oha4mi", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _oha4mi);  
+  $def("_7hpmkx", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _7hpmkx);  
   $def("_1ail6g2", "replay_git", ["isOnObservableCom","modules","replayGitCommits","relevant_git_commits"], _1ail6g2);  
   $def("_1rm7oy4", null, ["md"], _1rm7oy4);  
   $def("_m77twl", null, ["Inputs","exportToZip","fs","config","getCompactISODate"], _m77twl);  

--- a/notebooks/@tomlarkworthy_debugger.html
+++ b/notebooks/@tomlarkworthy_debugger.html
@@ -12894,7 +12894,7 @@ async function replayGitEntries(gitEntries, {
   return results;
 }
 )};
-const _oha4mi = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
+const _7hpmkx = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
 async function replayGitCommits(commits, {repo = config?.repo, branch = config?.branch, order = 'oldest-first'} = {}) {
   const list = Array.isArray(commits) ? commits : [];
   const ordered = order === 'newest-first' ? list.slice() : order === 'oldest-first' ? list.slice().reverse() : list.slice();
@@ -12923,10 +12923,10 @@ async function replayGitCommits(commits, {repo = config?.repo, branch = config?.
       const moduleName = p.module ?? 'main';
       if (baseHashes && baseHashes[moduleName]) {
         const currentHash = moduleBaseHash(moduleName);
-        if (currentHash && currentHash !== baseHashes[moduleName]) {
+        if (!currentHash || currentHash !== baseHashes[moduleName]) {
           if (!skippedModules.has(moduleName)) {
             skippedModules.add(moduleName);
-            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed`);
+            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed or module absent`);
           }
           continue;
         }
@@ -14121,7 +14121,7 @@ export default function define(runtime, observer) {
   $def("_1r7lx5s", "GitEntry", ["ensure_repo","git","fs"], _1r7lx5s);  
   $def("_yngfrp", "replay_pid_map", [], _yngfrp);  
   $def("_19c2k49", "replayGitEntries", ["modules","getVariableByPersistentId","runtime","replay_pid_map","GitEntry","realize","tag"], _19c2k49);  
-  $def("_oha4mi", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _oha4mi);  
+  $def("_7hpmkx", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _7hpmkx);  
   $def("_1ail6g2", "replay_git", ["isOnObservableCom","modules","replayGitCommits","relevant_git_commits"], _1ail6g2);  
   $def("_1rm7oy4", null, ["md"], _1rm7oy4);  
   $def("_m77twl", null, ["Inputs","exportToZip","fs","config","getCompactISODate"], _m77twl);  

--- a/notebooks/@tomlarkworthy_dom-view.html
+++ b/notebooks/@tomlarkworthy_dom-view.html
@@ -12473,7 +12473,7 @@ async function replayGitEntries(gitEntries, {
   return results;
 }
 )};
-const _oha4mi = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
+const _7hpmkx = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
 async function replayGitCommits(commits, {repo = config?.repo, branch = config?.branch, order = 'oldest-first'} = {}) {
   const list = Array.isArray(commits) ? commits : [];
   const ordered = order === 'newest-first' ? list.slice() : order === 'oldest-first' ? list.slice().reverse() : list.slice();
@@ -12502,10 +12502,10 @@ async function replayGitCommits(commits, {repo = config?.repo, branch = config?.
       const moduleName = p.module ?? 'main';
       if (baseHashes && baseHashes[moduleName]) {
         const currentHash = moduleBaseHash(moduleName);
-        if (currentHash && currentHash !== baseHashes[moduleName]) {
+        if (!currentHash || currentHash !== baseHashes[moduleName]) {
           if (!skippedModules.has(moduleName)) {
             skippedModules.add(moduleName);
-            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed`);
+            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed or module absent`);
           }
           continue;
         }
@@ -13700,7 +13700,7 @@ export default function define(runtime, observer) {
   $def("_1r7lx5s", "GitEntry", ["ensure_repo","git","fs"], _1r7lx5s);  
   $def("_yngfrp", "replay_pid_map", [], _yngfrp);  
   $def("_19c2k49", "replayGitEntries", ["modules","getVariableByPersistentId","runtime","replay_pid_map","GitEntry","realize","tag"], _19c2k49);  
-  $def("_oha4mi", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _oha4mi);  
+  $def("_7hpmkx", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _7hpmkx);  
   $def("_1ail6g2", "replay_git", ["isOnObservableCom","modules","replayGitCommits","relevant_git_commits"], _1ail6g2);  
   $def("_1rm7oy4", null, ["md"], _1rm7oy4);  
   $def("_m77twl", null, ["Inputs","exportToZip","fs","config","getCompactISODate"], _m77twl);  

--- a/notebooks/@tomlarkworthy_editor-5.html
+++ b/notebooks/@tomlarkworthy_editor-5.html
@@ -12471,7 +12471,7 @@ async function replayGitEntries(gitEntries, {
   return results;
 }
 )};
-const _oha4mi = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
+const _7hpmkx = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
 async function replayGitCommits(commits, {repo = config?.repo, branch = config?.branch, order = 'oldest-first'} = {}) {
   const list = Array.isArray(commits) ? commits : [];
   const ordered = order === 'newest-first' ? list.slice() : order === 'oldest-first' ? list.slice().reverse() : list.slice();
@@ -12500,10 +12500,10 @@ async function replayGitCommits(commits, {repo = config?.repo, branch = config?.
       const moduleName = p.module ?? 'main';
       if (baseHashes && baseHashes[moduleName]) {
         const currentHash = moduleBaseHash(moduleName);
-        if (currentHash && currentHash !== baseHashes[moduleName]) {
+        if (!currentHash || currentHash !== baseHashes[moduleName]) {
           if (!skippedModules.has(moduleName)) {
             skippedModules.add(moduleName);
-            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed`);
+            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed or module absent`);
           }
           continue;
         }
@@ -13698,7 +13698,7 @@ export default function define(runtime, observer) {
   $def("_1r7lx5s", "GitEntry", ["ensure_repo","git","fs"], _1r7lx5s);  
   $def("_yngfrp", "replay_pid_map", [], _yngfrp);  
   $def("_19c2k49", "replayGitEntries", ["modules","getVariableByPersistentId","runtime","replay_pid_map","GitEntry","realize","tag"], _19c2k49);  
-  $def("_oha4mi", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _oha4mi);  
+  $def("_7hpmkx", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _7hpmkx);  
   $def("_1ail6g2", "replay_git", ["isOnObservableCom","modules","replayGitCommits","relevant_git_commits"], _1ail6g2);  
   $def("_1rm7oy4", null, ["md"], _1rm7oy4);  
   $def("_m77twl", null, ["Inputs","exportToZip","fs","config","getCompactISODate"], _m77twl);  

--- a/notebooks/@tomlarkworthy_exporter-2.html
+++ b/notebooks/@tomlarkworthy_exporter-2.html
@@ -14519,7 +14519,7 @@ async function replayGitEntries(gitEntries, {
   return results;
 }
 )};
-const _oha4mi = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
+const _7hpmkx = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
 async function replayGitCommits(commits, {repo = config?.repo, branch = config?.branch, order = 'oldest-first'} = {}) {
   const list = Array.isArray(commits) ? commits : [];
   const ordered = order === 'newest-first' ? list.slice() : order === 'oldest-first' ? list.slice().reverse() : list.slice();
@@ -14548,10 +14548,10 @@ async function replayGitCommits(commits, {repo = config?.repo, branch = config?.
       const moduleName = p.module ?? 'main';
       if (baseHashes && baseHashes[moduleName]) {
         const currentHash = moduleBaseHash(moduleName);
-        if (currentHash && currentHash !== baseHashes[moduleName]) {
+        if (!currentHash || currentHash !== baseHashes[moduleName]) {
           if (!skippedModules.has(moduleName)) {
             skippedModules.add(moduleName);
-            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed`);
+            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed or module absent`);
           }
           continue;
         }
@@ -15746,7 +15746,7 @@ export default function define(runtime, observer) {
   $def("_1r7lx5s", "GitEntry", ["ensure_repo","git","fs"], _1r7lx5s);  
   $def("_yngfrp", "replay_pid_map", [], _yngfrp);  
   $def("_19c2k49", "replayGitEntries", ["modules","getVariableByPersistentId","runtime","replay_pid_map","GitEntry","realize","tag"], _19c2k49);  
-  $def("_oha4mi", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _oha4mi);  
+  $def("_7hpmkx", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _7hpmkx);  
   $def("_1ail6g2", "replay_git", ["isOnObservableCom","modules","replayGitCommits","relevant_git_commits"], _1ail6g2);  
   $def("_1rm7oy4", null, ["md"], _1rm7oy4);  
   $def("_m77twl", null, ["Inputs","exportToZip","fs","config","getCompactISODate"], _m77twl);  

--- a/notebooks/@tomlarkworthy_exporter-3.html
+++ b/notebooks/@tomlarkworthy_exporter-3.html
@@ -12473,7 +12473,7 @@ async function replayGitEntries(gitEntries, {
   return results;
 }
 )};
-const _oha4mi = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
+const _7hpmkx = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
 async function replayGitCommits(commits, {repo = config?.repo, branch = config?.branch, order = 'oldest-first'} = {}) {
   const list = Array.isArray(commits) ? commits : [];
   const ordered = order === 'newest-first' ? list.slice() : order === 'oldest-first' ? list.slice().reverse() : list.slice();
@@ -12502,10 +12502,10 @@ async function replayGitCommits(commits, {repo = config?.repo, branch = config?.
       const moduleName = p.module ?? 'main';
       if (baseHashes && baseHashes[moduleName]) {
         const currentHash = moduleBaseHash(moduleName);
-        if (currentHash && currentHash !== baseHashes[moduleName]) {
+        if (!currentHash || currentHash !== baseHashes[moduleName]) {
           if (!skippedModules.has(moduleName)) {
             skippedModules.add(moduleName);
-            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed`);
+            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed or module absent`);
           }
           continue;
         }
@@ -13700,7 +13700,7 @@ export default function define(runtime, observer) {
   $def("_1r7lx5s", "GitEntry", ["ensure_repo","git","fs"], _1r7lx5s);  
   $def("_yngfrp", "replay_pid_map", [], _yngfrp);  
   $def("_19c2k49", "replayGitEntries", ["modules","getVariableByPersistentId","runtime","replay_pid_map","GitEntry","realize","tag"], _19c2k49);  
-  $def("_oha4mi", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _oha4mi);  
+  $def("_7hpmkx", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _7hpmkx);  
   $def("_1ail6g2", "replay_git", ["isOnObservableCom","modules","replayGitCommits","relevant_git_commits"], _1ail6g2);  
   $def("_1rm7oy4", null, ["md"], _1rm7oy4);  
   $def("_m77twl", null, ["Inputs","exportToZip","fs","config","getCompactISODate"], _m77twl);  

--- a/notebooks/@tomlarkworthy_fileattachments.html
+++ b/notebooks/@tomlarkworthy_fileattachments.html
@@ -12473,7 +12473,7 @@ async function replayGitEntries(gitEntries, {
   return results;
 }
 )};
-const _oha4mi = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
+const _7hpmkx = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
 async function replayGitCommits(commits, {repo = config?.repo, branch = config?.branch, order = 'oldest-first'} = {}) {
   const list = Array.isArray(commits) ? commits : [];
   const ordered = order === 'newest-first' ? list.slice() : order === 'oldest-first' ? list.slice().reverse() : list.slice();
@@ -12502,10 +12502,10 @@ async function replayGitCommits(commits, {repo = config?.repo, branch = config?.
       const moduleName = p.module ?? 'main';
       if (baseHashes && baseHashes[moduleName]) {
         const currentHash = moduleBaseHash(moduleName);
-        if (currentHash && currentHash !== baseHashes[moduleName]) {
+        if (!currentHash || currentHash !== baseHashes[moduleName]) {
           if (!skippedModules.has(moduleName)) {
             skippedModules.add(moduleName);
-            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed`);
+            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed or module absent`);
           }
           continue;
         }
@@ -13700,7 +13700,7 @@ export default function define(runtime, observer) {
   $def("_1r7lx5s", "GitEntry", ["ensure_repo","git","fs"], _1r7lx5s);  
   $def("_yngfrp", "replay_pid_map", [], _yngfrp);  
   $def("_19c2k49", "replayGitEntries", ["modules","getVariableByPersistentId","runtime","replay_pid_map","GitEntry","realize","tag"], _19c2k49);  
-  $def("_oha4mi", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _oha4mi);  
+  $def("_7hpmkx", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _7hpmkx);  
   $def("_1ail6g2", "replay_git", ["isOnObservableCom","modules","replayGitCommits","relevant_git_commits"], _1ail6g2);  
   $def("_1rm7oy4", null, ["md"], _1rm7oy4);  
   $def("_m77twl", null, ["Inputs","exportToZip","fs","config","getCompactISODate"], _m77twl);  

--- a/notebooks/@tomlarkworthy_flow-queue.html
+++ b/notebooks/@tomlarkworthy_flow-queue.html
@@ -12473,7 +12473,7 @@ async function replayGitEntries(gitEntries, {
   return results;
 }
 )};
-const _oha4mi = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
+const _7hpmkx = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
 async function replayGitCommits(commits, {repo = config?.repo, branch = config?.branch, order = 'oldest-first'} = {}) {
   const list = Array.isArray(commits) ? commits : [];
   const ordered = order === 'newest-first' ? list.slice() : order === 'oldest-first' ? list.slice().reverse() : list.slice();
@@ -12502,10 +12502,10 @@ async function replayGitCommits(commits, {repo = config?.repo, branch = config?.
       const moduleName = p.module ?? 'main';
       if (baseHashes && baseHashes[moduleName]) {
         const currentHash = moduleBaseHash(moduleName);
-        if (currentHash && currentHash !== baseHashes[moduleName]) {
+        if (!currentHash || currentHash !== baseHashes[moduleName]) {
           if (!skippedModules.has(moduleName)) {
             skippedModules.add(moduleName);
-            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed`);
+            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed or module absent`);
           }
           continue;
         }
@@ -13700,7 +13700,7 @@ export default function define(runtime, observer) {
   $def("_1r7lx5s", "GitEntry", ["ensure_repo","git","fs"], _1r7lx5s);  
   $def("_yngfrp", "replay_pid_map", [], _yngfrp);  
   $def("_19c2k49", "replayGitEntries", ["modules","getVariableByPersistentId","runtime","replay_pid_map","GitEntry","realize","tag"], _19c2k49);  
-  $def("_oha4mi", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _oha4mi);  
+  $def("_7hpmkx", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _7hpmkx);  
   $def("_1ail6g2", "replay_git", ["isOnObservableCom","modules","replayGitCommits","relevant_git_commits"], _1ail6g2);  
   $def("_1rm7oy4", null, ["md"], _1rm7oy4);  
   $def("_m77twl", null, ["Inputs","exportToZip","fs","config","getCompactISODate"], _m77twl);  

--- a/notebooks/@tomlarkworthy_golden-layout-2-6-0.html
+++ b/notebooks/@tomlarkworthy_golden-layout-2-6-0.html
@@ -12473,7 +12473,7 @@ async function replayGitEntries(gitEntries, {
   return results;
 }
 )};
-const _oha4mi = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
+const _7hpmkx = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
 async function replayGitCommits(commits, {repo = config?.repo, branch = config?.branch, order = 'oldest-first'} = {}) {
   const list = Array.isArray(commits) ? commits : [];
   const ordered = order === 'newest-first' ? list.slice() : order === 'oldest-first' ? list.slice().reverse() : list.slice();
@@ -12502,10 +12502,10 @@ async function replayGitCommits(commits, {repo = config?.repo, branch = config?.
       const moduleName = p.module ?? 'main';
       if (baseHashes && baseHashes[moduleName]) {
         const currentHash = moduleBaseHash(moduleName);
-        if (currentHash && currentHash !== baseHashes[moduleName]) {
+        if (!currentHash || currentHash !== baseHashes[moduleName]) {
           if (!skippedModules.has(moduleName)) {
             skippedModules.add(moduleName);
-            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed`);
+            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed or module absent`);
           }
           continue;
         }
@@ -13700,7 +13700,7 @@ export default function define(runtime, observer) {
   $def("_1r7lx5s", "GitEntry", ["ensure_repo","git","fs"], _1r7lx5s);  
   $def("_yngfrp", "replay_pid_map", [], _yngfrp);  
   $def("_19c2k49", "replayGitEntries", ["modules","getVariableByPersistentId","runtime","replay_pid_map","GitEntry","realize","tag"], _19c2k49);  
-  $def("_oha4mi", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _oha4mi);  
+  $def("_7hpmkx", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _7hpmkx);  
   $def("_1ail6g2", "replay_git", ["isOnObservableCom","modules","replayGitCommits","relevant_git_commits"], _1ail6g2);  
   $def("_1rm7oy4", null, ["md"], _1rm7oy4);  
   $def("_m77twl", null, ["Inputs","exportToZip","fs","config","getCompactISODate"], _m77twl);  

--- a/notebooks/@tomlarkworthy_import-notebook.html
+++ b/notebooks/@tomlarkworthy_import-notebook.html
@@ -12471,7 +12471,7 @@ async function replayGitEntries(gitEntries, {
   return results;
 }
 )};
-const _oha4mi = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
+const _7hpmkx = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
 async function replayGitCommits(commits, {repo = config?.repo, branch = config?.branch, order = 'oldest-first'} = {}) {
   const list = Array.isArray(commits) ? commits : [];
   const ordered = order === 'newest-first' ? list.slice() : order === 'oldest-first' ? list.slice().reverse() : list.slice();
@@ -12500,10 +12500,10 @@ async function replayGitCommits(commits, {repo = config?.repo, branch = config?.
       const moduleName = p.module ?? 'main';
       if (baseHashes && baseHashes[moduleName]) {
         const currentHash = moduleBaseHash(moduleName);
-        if (currentHash && currentHash !== baseHashes[moduleName]) {
+        if (!currentHash || currentHash !== baseHashes[moduleName]) {
           if (!skippedModules.has(moduleName)) {
             skippedModules.add(moduleName);
-            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed`);
+            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed or module absent`);
           }
           continue;
         }
@@ -13698,7 +13698,7 @@ export default function define(runtime, observer) {
   $def("_1r7lx5s", "GitEntry", ["ensure_repo","git","fs"], _1r7lx5s);  
   $def("_yngfrp", "replay_pid_map", [], _yngfrp);  
   $def("_19c2k49", "replayGitEntries", ["modules","getVariableByPersistentId","runtime","replay_pid_map","GitEntry","realize","tag"], _19c2k49);  
-  $def("_oha4mi", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _oha4mi);  
+  $def("_7hpmkx", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _7hpmkx);  
   $def("_1ail6g2", "replay_git", ["isOnObservableCom","modules","replayGitCommits","relevant_git_commits"], _1ail6g2);  
   $def("_1rm7oy4", null, ["md"], _1rm7oy4);  
   $def("_m77twl", null, ["Inputs","exportToZip","fs","config","getCompactISODate"], _m77twl);  

--- a/notebooks/@tomlarkworthy_jest-expect-standalone.html
+++ b/notebooks/@tomlarkworthy_jest-expect-standalone.html
@@ -12473,7 +12473,7 @@ async function replayGitEntries(gitEntries, {
   return results;
 }
 )};
-const _oha4mi = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
+const _7hpmkx = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
 async function replayGitCommits(commits, {repo = config?.repo, branch = config?.branch, order = 'oldest-first'} = {}) {
   const list = Array.isArray(commits) ? commits : [];
   const ordered = order === 'newest-first' ? list.slice() : order === 'oldest-first' ? list.slice().reverse() : list.slice();
@@ -12502,10 +12502,10 @@ async function replayGitCommits(commits, {repo = config?.repo, branch = config?.
       const moduleName = p.module ?? 'main';
       if (baseHashes && baseHashes[moduleName]) {
         const currentHash = moduleBaseHash(moduleName);
-        if (currentHash && currentHash !== baseHashes[moduleName]) {
+        if (!currentHash || currentHash !== baseHashes[moduleName]) {
           if (!skippedModules.has(moduleName)) {
             skippedModules.add(moduleName);
-            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed`);
+            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed or module absent`);
           }
           continue;
         }
@@ -13700,7 +13700,7 @@ export default function define(runtime, observer) {
   $def("_1r7lx5s", "GitEntry", ["ensure_repo","git","fs"], _1r7lx5s);  
   $def("_yngfrp", "replay_pid_map", [], _yngfrp);  
   $def("_19c2k49", "replayGitEntries", ["modules","getVariableByPersistentId","runtime","replay_pid_map","GitEntry","realize","tag"], _19c2k49);  
-  $def("_oha4mi", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _oha4mi);  
+  $def("_7hpmkx", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _7hpmkx);  
   $def("_1ail6g2", "replay_git", ["isOnObservableCom","modules","replayGitCommits","relevant_git_commits"], _1ail6g2);  
   $def("_1rm7oy4", null, ["md"], _1rm7oy4);  
   $def("_m77twl", null, ["Inputs","exportToZip","fs","config","getCompactISODate"], _m77twl);  

--- a/notebooks/@tomlarkworthy_local-change-history.html
+++ b/notebooks/@tomlarkworthy_local-change-history.html
@@ -12502,10 +12502,10 @@ async function replayGitCommits(commits, {repo = config?.repo, branch = config?.
       const moduleName = p.module ?? 'main';
       if (baseHashes && baseHashes[moduleName]) {
         const currentHash = moduleBaseHash(moduleName);
-        if (currentHash && currentHash !== baseHashes[moduleName]) {
+        if (!currentHash || currentHash !== baseHashes[moduleName]) {
           if (!skippedModules.has(moduleName)) {
             skippedModules.add(moduleName);
-            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed`);
+            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed or module absent`);
           }
           continue;
         }

--- a/notebooks/@tomlarkworthy_local-change-history.html
+++ b/notebooks/@tomlarkworthy_local-change-history.html
@@ -1943,10 +1943,9 @@ const _1hybsm8 = function _coverage_failures(runtime_variables,liveCellMap,modul
   }
   return failures;
 };
-const _4tg5tm = function _test_cell_map_covers_all_runtime_variables(coverage_failures)
+const _1p0qclg = function _test_cell_map_covers_all_runtime_variables(coverage_failures)
 {
   if (coverage_failures.length) {
-    debugger;
     throw JSON.stringify(coverage_failures);
   }
   return "pass";
@@ -2188,7 +2187,7 @@ export default function define(runtime, observer) {
   $def("_1rtpyzk", "cellMapVizView", ["viewof cellMapViz"], _1rtpyzk);  
   $def("_1srzrzc", null, ["md"], _1srzrzc);  
   $def("_1hybsm8", "coverage_failures", ["runtime_variables","liveCellMap","modules"], _1hybsm8);  
-  $def("_4tg5tm", "test_cell_map_covers_all_runtime_variables", ["coverage_failures"], _4tg5tm);  
+  $def("_1p0qclg", "test_cell_map_covers_all_runtime_variables", ["coverage_failures"], _1p0qclg);  
   $def("_1a18z7a", "test_cell_map_no_variable_in_more_than_one_cell", ["runtime_variables","liveCellMap","modules"], _1a18z7a);  
   $def("_8nkqnx", null, ["md"], _8nkqnx);  
   $def("_2h3a9s", "importedModule", [], _2h3a9s);  
@@ -2246,17 +2245,29 @@ const _1i8jhrq = function _copyCellButton(Inputs,cellsToClipboard){return(
 (cells) =>
   Inputs.button("Copy cells", { reduce: () => cellsToClipboard(cells) })
 )};
-const _1imaqds = function _makeCell($0,defaultJS,defaultOther){return(
-(value) => {
+const _1ud4fa1 = function _makeCell($0,defaultJS,defaultOther){return(
+value => {
   const id = $0.value++;
-  debugger;
-  if (typeof value === "string") {
-    return { ...defaultJS, id, value };
-  } else if (typeof value === "object") {
-    if (value.type === "js") return { ...defaultJS, id, ...value };
-    return { ...defaultOther, id, ...value };
+  if (typeof value === 'string') {
+    return {
+      ...defaultJS,
+      id,
+      value
+    };
+  } else if (typeof value === 'object') {
+    if (value.type === 'js')
+      return {
+        ...defaultJS,
+        id,
+        ...value
+      };
+    return {
+      ...defaultOther,
+      id,
+      ...value
+    };
   } else {
-    throw new Error("Value must be string or object");
+    throw new Error('Value must be string or object');
   }
 }
 )};
@@ -2299,7 +2310,7 @@ export default function define(runtime, observer) {
   $def("_10uloef", null, ["md"], _10uloef);  
   $def("_1seifpc", "cellsToClipboard", ["makeCell"], _1seifpc);  
   $def("_1i8jhrq", "copyCellButton", ["Inputs","cellsToClipboard"], _1i8jhrq);  
-  $def("_1imaqds", "makeCell", ["mutable id","defaultJS","defaultOther"], _1imaqds);  
+  $def("_1ud4fa1", "makeCell", ["mutable id","defaultJS","defaultOther"], _1ud4fa1);  
   $def("_h1t91h", "defaultJS", [], _h1t91h);  
   $def("_but2s9", "defaultOther", [], _but2s9);  
   $def("_lj7470", "initial id", [], _lj7470);  
@@ -12473,7 +12484,7 @@ async function replayGitEntries(gitEntries, {
   return results;
 }
 )};
-const _oha4mi = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
+const _7hpmkx = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
 async function replayGitCommits(commits, {repo = config?.repo, branch = config?.branch, order = 'oldest-first'} = {}) {
   const list = Array.isArray(commits) ? commits : [];
   const ordered = order === 'newest-first' ? list.slice() : order === 'oldest-first' ? list.slice().reverse() : list.slice();
@@ -13700,7 +13711,7 @@ export default function define(runtime, observer) {
   $def("_1r7lx5s", "GitEntry", ["ensure_repo","git","fs"], _1r7lx5s);  
   $def("_yngfrp", "replay_pid_map", [], _yngfrp);  
   $def("_19c2k49", "replayGitEntries", ["modules","getVariableByPersistentId","runtime","replay_pid_map","GitEntry","realize","tag"], _19c2k49);  
-  $def("_oha4mi", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _oha4mi);  
+  $def("_7hpmkx", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _7hpmkx);  
   $def("_1ail6g2", "replay_git", ["isOnObservableCom","modules","replayGitCommits","relevant_git_commits"], _1ail6g2);  
   $def("_1rm7oy4", null, ["md"], _1rm7oy4);  
   $def("_m77twl", null, ["Inputs","exportToZip","fs","config","getCompactISODate"], _m77twl);  
@@ -23696,11 +23707,13 @@ md`### interval
 
 https://rxjs.dev/api/index/function/interval`
 )};
-const _bz8ib5 = function _interval(Inputs,Event){return(
+const _px7gfx = function _interval(Inputs,Event){return(
 function interval({period = 0, invalidation}) {
   const result = Inputs.input();
   let count = 0;
+  debugger;
   const onTick = () => {
+    debugger;
     result.value = count++;
     result.dispatchEvent(new Event('input'));
   };
@@ -23893,7 +23906,7 @@ export default function define(runtime, observer) {
   $def("_xvoqqz", null, ["md"], _xvoqqz);  
   $def("_1sychb7", null, ["md"], _1sychb7);  
   $def("_1a3sdj9", null, ["md"], _1a3sdj9);  
-  $def("_bz8ib5", "interval", ["Inputs","Event"], _bz8ib5);  
+  $def("_px7gfx", "interval", ["Inputs","Event"], _px7gfx);  
   $def("_11meps1", null, ["md"], _11meps1);  
   $def("_sdzl0o", "map", ["Inputs","Event"], _sdzl0o);  
   $def("_zawuyh", null, ["md"], _zawuyh);  
@@ -24391,138 +24404,138 @@ import {themes, theme_properties, css} from "@tomlarkworthy/themes"
 \`\`\`
 `
 )};
-const _1clcodb = function _theme_assets(Inputs,themes,current_theme){return(
+const _x91dc7 = function _theme_assets(Inputs,themes,current_theme){return(
 Inputs.select(themes, {
-    label: 'Theme',
-    value: current_theme || themes.get('near-midnight')
+  label: 'Theme',
+  value: current_theme || themes.get('near-midnight')
 })
 )};
 const _1sdw5pf = (G, _) => G.input(_);
 const _1wzah21 = function _theme_name(themes,theme_assets){return(
 [...themes.entries()].find(([, assets]) => assets === theme_assets)?.[0] ?? 'unknown'
 )};
-const _nz55m5 = function _4(css,themes,theme_assets,html)
+const _zy6iu8 = function _apply_theme(css,themes,theme_assets,html)
 {
-    const view = document.defaultView;
-    const sheets = [];
-    for (const [url, text] of css) {
-        if (typeof text !== 'string')
-            continue;
-        try {
-            const sheet = new view.CSSStyleSheet();
-            sheet.replaceSync(text);
-            sheets.push(sheet);
-        } catch (e) {
-            console.warn('Could not adopt stylesheet', url, e);
-        }
+  const view = document.defaultView;
+  const sheets = [];
+  for (const [url, text] of css) {
+    if (typeof text !== 'string')
+      continue;
+    try {
+      const sheet = new view.CSSStyleSheet();
+      sheet.replaceSync(text);
+      sheets.push(sheet);
+    } catch (e) {
+      console.warn('Could not adopt stylesheet', url, e);
     }
-    document.adoptedStyleSheets = sheets;
-    // Sync embedded <script id="<url>" data-mime="text/css"> cache blocks so
-    // current_theme (which sniffs by document.getElementById) and the next
-    // export reflect the live selection. Only touches blocks that belong to
-    // known theme URLs — leaves unrelated CSS asset blocks alone.
-    const knownThemeUrls = new Set();
-    for (const list of themes.values())
-        for (const u of list)
-            knownThemeUrls.add(u);
-    for (const u of knownThemeUrls) {
-        if (!theme_assets.includes(u))
-            document.getElementById(u)?.remove();
+  }
+  document.adoptedStyleSheets = sheets;
+  // Sync embedded <script id="<url>" data-mime="text/css"> cache blocks so
+  // current_theme (which sniffs by document.getElementById) and the next
+  // export reflect the live selection. Only touches blocks that belong to
+  // known theme URLs — leaves unrelated CSS asset blocks alone.
+  const knownThemeUrls = new Set();
+  for (const list of themes.values())
+    for (const u of list)
+      knownThemeUrls.add(u);
+  for (const u of knownThemeUrls) {
+    if (!theme_assets.includes(u))
+      document.getElementById(u)?.remove();
+  }
+  for (const [url, text] of css) {
+    if (!url || !url.startsWith('http'))
+      continue;
+    if (!theme_assets.includes(url))
+      continue;
+    let s = document.getElementById(url);
+    if (!s) {
+      s = document.createElement('script');
+      s.id = url;
+      s.type = 'text/plain';
+      s.setAttribute('data-mime', 'text/css');
+      document.head.appendChild(s);
     }
-    for (const [url, text] of css) {
-        if (!url || !url.startsWith('http'))
-            continue;
-        if (!theme_assets.includes(url))
-            continue;
-        let s = document.getElementById(url);
-        if (!s) {
-            s = document.createElement('script');
-            s.id = url;
-            s.type = 'text/plain';
-            s.setAttribute('data-mime', 'text/css');
-            document.head.appendChild(s);
-        }
-        // Always replace text so a freshly-fetched theme overwrites stale cache.
-        if (!s.hasAttribute('data-encoding'))
-            s.textContent = text;
-    }
-    return html`<div style="font:11px/1.4 var(--monospace, ui-monospace, monospace);color:var(--theme-foreground-muted);padding:6px 10px;border:1px solid var(--theme-foreground-faintest);border-radius:4px;display:inline-block">Applied ${ sheets.length } stylesheets to the page.</div>`;
+    // Always replace text so a freshly-fetched theme overwrites stale cache.
+    if (!s.hasAttribute('data-encoding'))
+      s.textContent = text;
+  }
+  return html`<div style="font:11px/1.4 var(--monospace, ui-monospace, monospace);color:var(--theme-foreground-muted);padding:6px 10px;border:1px solid var(--theme-foreground-faintest);border-radius:4px;display:inline-block">Applied ${ sheets.length } stylesheets to the page.</div>`;
 };
-const _11pe38r = function _5(theme_properties,html,htl,theme_name){return(
+const _10zmng3 = function _5(theme_properties,html,htl,theme_name){return(
 (() => {
-    const props = theme_properties;
-    const get = k => props[k] || '';
-    const groups = {
-        Background: [
-            '--theme-background',
-            '--theme-background-a',
-            '--theme-background-b',
-            '--theme-background-raised'
-        ],
-        Foreground: [
-            '--theme-foreground',
-            '--theme-foreground-muted',
-            '--theme-foreground-faint',
-            '--theme-foreground-fainter',
-            '--theme-foreground-faintest',
-            '--theme-foreground-focus',
-            '--theme-foreground-error'
-        ],
-        Syntax: [
-            '--syntax-keyword',
-            '--syntax-string',
-            '--syntax-comment',
-            '--syntax-literal',
-            '--syntax-atom',
-            '--syntax-variable',
-            '--syntax-definition'
-        ]
-    };
-    const fonts = [
-        [
-            '--serif',
-            'Serif'
-        ],
-        [
-            '--sans-serif',
-            'Sans-serif'
-        ],
-        [
-            '--monospace',
-            'Monospace'
-        ]
-    ].filter(([k]) => props[k]);
-    const swatch = key => {
-        const value = get(key);
-        if (!value)
-            return '';
-        return html`<div style="display:flex;align-items:center;gap:8px;padding:4px 6px;border-radius:4px;font:12px/1.4 var(--monospace, ui-monospace, monospace)">
+  const props = theme_properties;
+  const get = k => props[k] || '';
+  const groups = {
+    Background: [
+      '--theme-background',
+      '--theme-background-a',
+      '--theme-background-b',
+      '--theme-background-raised'
+    ],
+    Foreground: [
+      '--theme-foreground',
+      '--theme-foreground-muted',
+      '--theme-foreground-faint',
+      '--theme-foreground-fainter',
+      '--theme-foreground-faintest',
+      '--theme-foreground-focus',
+      '--theme-foreground-error'
+    ],
+    Syntax: [
+      '--syntax-keyword',
+      '--syntax-string',
+      '--syntax-comment',
+      '--syntax-literal',
+      '--syntax-atom',
+      '--syntax-variable',
+      '--syntax-definition'
+    ]
+  };
+  const fonts = [
+    [
+      '--serif',
+      'Serif'
+    ],
+    [
+      '--sans-serif',
+      'Sans-serif'
+    ],
+    [
+      '--monospace',
+      'Monospace'
+    ]
+  ].filter(([k]) => props[k]);
+  const swatch = key => {
+    const value = get(key);
+    if (!value)
+      return '';
+    return html`<div style="display:flex;align-items:center;gap:8px;padding:4px 6px;border-radius:4px;font:12px/1.4 var(--monospace, ui-monospace, monospace)">
             <span style="width:28px;height:28px;border-radius:4px;border:1px solid var(--theme-foreground-faintest);background:var(${ key });flex:none"></span>
             <div style="display:flex;flex-direction:column;min-width:0;flex:1">
                 <code style="color:var(--theme-foreground)">${ key }</code>
                 <span style="color:var(--theme-foreground-muted);overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${ value }</span>
             </div>
         </div>`;
-    };
-    const fontSample = ([key, label]) => {
-        const family = get(key);
-        const isMono = /mono/i.test(label) || /mono/i.test(key);
-        return html`<div style="padding:10px 12px;border:1px solid var(--theme-foreground-faintest);border-radius:6px;background:var(--theme-background-a, var(--theme-background))">
+  };
+  const fontSample = ([key, label]) => {
+    const family = get(key);
+    const isMono = /mono/i.test(label) || /mono/i.test(key);
+    return html`<div style="padding:10px 12px;border:1px solid var(--theme-foreground-faintest);border-radius:6px;background:var(--theme-background-a, var(--theme-background))">
             <div style="font:11px/1.2 var(--sans-serif, ui-sans-serif, system-ui);color:var(--theme-foreground-muted);margin-bottom:6px;letter-spacing:0.04em;text-transform:uppercase">${ label }</div>
             <div style="font-family:${ family };font-size:${ isMono ? '14px' : '22px' };line-height:1.3;color:var(--theme-foreground)">
                 ${ isMono ? html`<code>const greeting = "Hello, world";</code>` : 'The quick brown fox jumps over the lazy dog' }
             </div>
             <div style="font:11px/1.4 var(--monospace, ui-monospace, monospace);color:var(--theme-foreground-faint);margin-top:6px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${ family }</div>
         </div>`;
-    };
-    const codeSample = html`<pre style="margin:0;padding:12px;border-radius:6px;background:var(--theme-background-a, var(--theme-background));border:1px solid var(--theme-foreground-faintest);font:13px/1.5 var(--monospace, ui-monospace, monospace);color:var(--theme-foreground);overflow-x:auto"><span style="color:var(--syntax-comment)">// fibonacci</span>
+  };
+  const codeSample = html`<pre style="margin:0;padding:12px;border-radius:6px;background:var(--theme-background-a, var(--theme-background));border:1px solid var(--theme-foreground-faintest);font:13px/1.5 var(--monospace, ui-monospace, monospace);color:var(--theme-foreground);overflow-x:auto"><span style="color:var(--syntax-comment)">// fibonacci</span>
 <span style="color:var(--syntax-keyword)">function</span> <span style="color:var(--syntax-definition)">fib</span>(<span style="color:var(--syntax-variable)">n</span>) {
   <span style="color:var(--syntax-keyword)">if</span> (n &lt; <span style="color:var(--syntax-literal)">2</span>) <span style="color:var(--syntax-keyword)">return</span> n;
   <span style="color:var(--syntax-keyword)">return</span> <span style="color:var(--syntax-string)">\`fib(\${n})\`</span>;
 }
 <span style="color:var(--syntax-keyword)">const</span> result = fib(<span style="color:var(--syntax-literal)">10</span>);
 <span style="color:var(--syntax-keyword)">return</span> <span style="color:var(--syntax-atom)">null</span>;</pre>`;
-    return htl.html`<div style="background:var(--theme-background);color:var(--theme-foreground);padding:16px;border-radius:8px;font-family:var(--serif, var(--sans-serif, ui-sans-serif, system-ui))">
+  return htl.html`<div style="background:var(--theme-background);color:var(--theme-foreground);padding:16px;border-radius:8px;font-family:var(--serif, var(--sans-serif, ui-sans-serif, system-ui))">
         <div style="display:flex;align-items:baseline;gap:12px;margin-bottom:14px">
             <h3 style="margin:0;font-family:var(--serif, var(--sans-serif, ui-sans-serif));color:var(--theme-foreground)">${ theme_name }</h3>
             <span style="font:12px/1 var(--monospace, ui-monospace, monospace);color:var(--theme-foreground-muted)">theme preview</span>
@@ -24552,190 +24565,190 @@ md`## All CSS variables
 
 Every CSS custom property parsed from the active theme. \`theme_properties\` is exported as a plain JS object so other notebooks can consume theme values programmatically (canvas colors, chart palettes, inline styles) without parsing CSS.`
 )};
-const _1hu8vay = function _7(htl,theme_properties,html){return(
+const _18nx47m = function _7(htl,theme_properties,html){return(
 htl.html`<details style="background: var(--theme-background); color: var(--theme-foreground); padding: 12px; border-radius: 6px;">
 <summary style="cursor:pointer;font-weight:600">Show all ${ Object.keys(theme_properties).length } properties</summary>
 
 ${ Object.entries(theme_properties).map(([key, value]) => {
-    const isColor = /^(#|rgb|hsl|color-mix)/.test(value) || /^var\(--theme-(foreground|background|error)/.test(value);
-    return html`<p style="margin:4px 0"><span style="width: 16px; height: 16px; border-radius: 3px; border: 1px solid var(--theme-foreground-faintest); background: ${ isColor ? 'var(' + key + ')' : 'transparent' }; display: inline-block; vertical-align: middle;"></span> <code>${ key }</code> <span style="color: var(--theme-foreground-muted)">${ value }</span></p>`;
+  const isColor = /^(#|rgb|hsl|color-mix)/.test(value) || /^var\(--theme-(foreground|background|error)/.test(value);
+  return html`<p style="margin:4px 0"><span style="width: 16px; height: 16px; border-radius: 3px; border: 1px solid var(--theme-foreground-faintest); background: ${ isColor ? 'var(' + key + ')' : 'transparent' }; display: inline-block; vertical-align: middle;"></span> <code>${ key }</code> <span style="color: var(--theme-foreground-muted)">${ value }</span></p>`;
 }) }
 
 </details>
 `
 )};
-const _1k4keny = function _theme_properties(css){return(
+const _ebjyl2 = function _theme_properties(css){return(
 (() => {
-    const props = {};
-    for (const [url, text] of css) {
-        if (typeof text !== 'string')
-            continue;
-        for (const match of text.matchAll(/^\s+(--[a-z0-9-]+)\s*:\s*([^;]+);/gm)) {
-            props[match[1]] = match[2].trim();
-        }
+  const props = {};
+  for (const [url, text] of css) {
+    if (typeof text !== 'string')
+      continue;
+    for (const match of text.matchAll(/^\s+(--[a-z0-9-]+)\s*:\s*([^;]+);/gm)) {
+      props[match[1]] = match[2].trim();
     }
-    return props;
+  }
+  return props;
 })()
 )};
 const _iny180 = function _9(md){return(
 md`## Implementation`
 )};
-const _vhnhz5 = function _themes()
+const _p0at3d = function _themes()
 {
-    const baseURL = 'https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/';
-    return new Map(Object.entries({
-        air: [
-            baseURL + 'global.css',
-            baseURL + 'inspector.css',
-            baseURL + 'highlight.css',
-            baseURL + 'plot.css',
-            baseURL + 'index.css',
-            baseURL + 'theme-air.css',
-            baseURL + 'abstract-light.css',
-            baseURL + 'syntax-light.css'
-        ],
-        coffee: [
-            baseURL + 'global.css',
-            baseURL + 'inspector.css',
-            baseURL + 'highlight.css',
-            baseURL + 'plot.css',
-            baseURL + 'index.css',
-            baseURL + 'theme-coffee.css',
-            baseURL + 'abstract-dark.css',
-            baseURL + 'syntax-dark.css'
-        ],
-        cotton: [
-            baseURL + 'global.css',
-            baseURL + 'inspector.css',
-            baseURL + 'highlight.css',
-            baseURL + 'plot.css',
-            baseURL + 'index.css',
-            baseURL + 'theme-cotton.css',
-            baseURL + 'abstract-light.css',
-            baseURL + 'syntax-light.css'
-        ],
-        'deep-space': [
-            baseURL + 'global.css',
-            baseURL + 'inspector.css',
-            baseURL + 'highlight.css',
-            baseURL + 'plot.css',
-            baseURL + 'index.css',
-            baseURL + 'theme-deep-space.css',
-            baseURL + 'syntax-dark.css'
-        ],
-        glacier: [
-            baseURL + 'global.css',
-            baseURL + 'inspector.css',
-            baseURL + 'highlight.css',
-            baseURL + 'plot.css',
-            baseURL + 'index.css',
-            baseURL + 'theme-glacier.css',
-            baseURL + 'abstract-light.css',
-            baseURL + 'syntax-light.css'
-        ],
-        ink: [
-            baseURL + 'global.css',
-            baseURL + 'inspector.css',
-            baseURL + 'highlight.css',
-            baseURL + 'plot.css',
-            baseURL + 'index.css',
-            baseURL + 'theme-ink.css',
-            baseURL + 'abstract-dark.css',
-            baseURL + 'syntax-dark.css'
-        ],
-        midnight: [
-            baseURL + 'global.css',
-            baseURL + 'inspector.css',
-            baseURL + 'highlight.css',
-            baseURL + 'plot.css',
-            baseURL + 'index.css',
-            baseURL + 'theme-midnight.css',
-            baseURL + 'abstract-dark.css',
-            baseURL + 'syntax-dark.css'
-        ],
-        'near-midnight': [
-            baseURL + 'global.css',
-            baseURL + 'inspector.css',
-            baseURL + 'highlight.css',
-            baseURL + 'plot.css',
-            baseURL + 'index.css',
-            baseURL + 'theme-near-midnight.css',
-            baseURL + 'abstract-dark.css',
-            baseURL + 'syntax-dark.css'
-        ],
-        'ocean-floor': [
-            baseURL + 'global.css',
-            baseURL + 'inspector.css',
-            baseURL + 'highlight.css',
-            baseURL + 'plot.css',
-            baseURL + 'index.css',
-            baseURL + 'theme-ocean-floor.css',
-            baseURL + 'abstract-dark.css',
-            baseURL + 'syntax-dark.css'
-        ],
-        parchment: [
-            baseURL + 'global.css',
-            baseURL + 'inspector.css',
-            baseURL + 'highlight.css',
-            baseURL + 'plot.css',
-            baseURL + 'index.css',
-            baseURL + 'theme-parchment.css',
-            baseURL + 'abstract-light.css',
-            baseURL + 'syntax-light.css'
-        ],
-        slate: [
-            baseURL + 'global.css',
-            baseURL + 'inspector.css',
-            baseURL + 'highlight.css',
-            baseURL + 'plot.css',
-            baseURL + 'index.css',
-            baseURL + 'theme-slate.css',
-            baseURL + 'abstract-dark.css',
-            baseURL + 'syntax-dark.css'
-        ],
-        stark: [
-            baseURL + 'global.css',
-            baseURL + 'inspector.css',
-            baseURL + 'highlight.css',
-            baseURL + 'plot.css',
-            baseURL + 'index.css',
-            baseURL + 'theme-stark.css',
-            baseURL + 'syntax-dark.css'
-        ],
-        'sun-faded': [
-            baseURL + 'global.css',
-            baseURL + 'inspector.css',
-            baseURL + 'highlight.css',
-            baseURL + 'plot.css',
-            baseURL + 'index.css',
-            baseURL + 'theme-sun-faded.css',
-            baseURL + 'abstract-dark.css',
-            baseURL + 'syntax-dark.css'
-        ]
-    }));
+  const baseURL = 'https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/';
+  return new Map(Object.entries({
+    air: [
+      baseURL + 'global.css',
+      baseURL + 'inspector.css',
+      baseURL + 'highlight.css',
+      baseURL + 'plot.css',
+      baseURL + 'index.css',
+      baseURL + 'theme-air.css',
+      baseURL + 'abstract-light.css',
+      baseURL + 'syntax-light.css'
+    ],
+    coffee: [
+      baseURL + 'global.css',
+      baseURL + 'inspector.css',
+      baseURL + 'highlight.css',
+      baseURL + 'plot.css',
+      baseURL + 'index.css',
+      baseURL + 'theme-coffee.css',
+      baseURL + 'abstract-dark.css',
+      baseURL + 'syntax-dark.css'
+    ],
+    cotton: [
+      baseURL + 'global.css',
+      baseURL + 'inspector.css',
+      baseURL + 'highlight.css',
+      baseURL + 'plot.css',
+      baseURL + 'index.css',
+      baseURL + 'theme-cotton.css',
+      baseURL + 'abstract-light.css',
+      baseURL + 'syntax-light.css'
+    ],
+    'deep-space': [
+      baseURL + 'global.css',
+      baseURL + 'inspector.css',
+      baseURL + 'highlight.css',
+      baseURL + 'plot.css',
+      baseURL + 'index.css',
+      baseURL + 'theme-deep-space.css',
+      baseURL + 'syntax-dark.css'
+    ],
+    glacier: [
+      baseURL + 'global.css',
+      baseURL + 'inspector.css',
+      baseURL + 'highlight.css',
+      baseURL + 'plot.css',
+      baseURL + 'index.css',
+      baseURL + 'theme-glacier.css',
+      baseURL + 'abstract-light.css',
+      baseURL + 'syntax-light.css'
+    ],
+    ink: [
+      baseURL + 'global.css',
+      baseURL + 'inspector.css',
+      baseURL + 'highlight.css',
+      baseURL + 'plot.css',
+      baseURL + 'index.css',
+      baseURL + 'theme-ink.css',
+      baseURL + 'abstract-dark.css',
+      baseURL + 'syntax-dark.css'
+    ],
+    midnight: [
+      baseURL + 'global.css',
+      baseURL + 'inspector.css',
+      baseURL + 'highlight.css',
+      baseURL + 'plot.css',
+      baseURL + 'index.css',
+      baseURL + 'theme-midnight.css',
+      baseURL + 'abstract-dark.css',
+      baseURL + 'syntax-dark.css'
+    ],
+    'near-midnight': [
+      baseURL + 'global.css',
+      baseURL + 'inspector.css',
+      baseURL + 'highlight.css',
+      baseURL + 'plot.css',
+      baseURL + 'index.css',
+      baseURL + 'theme-near-midnight.css',
+      baseURL + 'abstract-dark.css',
+      baseURL + 'syntax-dark.css'
+    ],
+    'ocean-floor': [
+      baseURL + 'global.css',
+      baseURL + 'inspector.css',
+      baseURL + 'highlight.css',
+      baseURL + 'plot.css',
+      baseURL + 'index.css',
+      baseURL + 'theme-ocean-floor.css',
+      baseURL + 'abstract-dark.css',
+      baseURL + 'syntax-dark.css'
+    ],
+    parchment: [
+      baseURL + 'global.css',
+      baseURL + 'inspector.css',
+      baseURL + 'highlight.css',
+      baseURL + 'plot.css',
+      baseURL + 'index.css',
+      baseURL + 'theme-parchment.css',
+      baseURL + 'abstract-light.css',
+      baseURL + 'syntax-light.css'
+    ],
+    slate: [
+      baseURL + 'global.css',
+      baseURL + 'inspector.css',
+      baseURL + 'highlight.css',
+      baseURL + 'plot.css',
+      baseURL + 'index.css',
+      baseURL + 'theme-slate.css',
+      baseURL + 'abstract-dark.css',
+      baseURL + 'syntax-dark.css'
+    ],
+    stark: [
+      baseURL + 'global.css',
+      baseURL + 'inspector.css',
+      baseURL + 'highlight.css',
+      baseURL + 'plot.css',
+      baseURL + 'index.css',
+      baseURL + 'theme-stark.css',
+      baseURL + 'syntax-dark.css'
+    ],
+    'sun-faded': [
+      baseURL + 'global.css',
+      baseURL + 'inspector.css',
+      baseURL + 'highlight.css',
+      baseURL + 'plot.css',
+      baseURL + 'index.css',
+      baseURL + 'theme-sun-faded.css',
+      baseURL + 'abstract-dark.css',
+      baseURL + 'syntax-dark.css'
+    ]
+  }));
 };
-const _iq48k6 = function _cssForTheme(themes,extra_css){return(
+const _m8taeu = function _cssForTheme(themes,extra_css){return(
 async theme => [
-    ...await Promise.all(themes.get(theme).map(async url => [
-        url,
-        await (await fetch(url)).text()
-    ])),
-    extra_css
+  ...await Promise.all(themes.get(theme).map(async url => [
+    url,
+    await (await fetch(url)).text()
+  ])),
+  extra_css
 ]
 )};
-const _e3ckjw = async function _css(theme_assets,extra_css){return(
+const _yqy56c = async function _css(theme_assets,extra_css){return(
 [
-    ...await Promise.all(theme_assets.map(async url => [
-        url,
-        await (await fetch(url)).text()
-    ])),
-    extra_css
+  ...await Promise.all(theme_assets.map(async url => [
+    url,
+    await (await fetch(url)).text()
+  ])),
+  extra_css
 ]
 )};
-const _d7mxvx = function _extra_css(){return(
+const _16bhmn1 = function _extra_css(){return(
 [
-    'file://syntax.css',
-    `
+  'file://syntax.css',
+  `
 /* Center page */
 .lopecode-visualizer {
     max-width: 1200px;
@@ -24807,19 +24820,19 @@ export default function define(runtime, observer) {
   };
 
   $def("_1yy5rbo", null, ["md"], _1yy5rbo);  
-  $def("_1clcodb", "viewof theme_assets", ["Inputs","themes","current_theme"], _1clcodb);  
+  $def("_x91dc7", "viewof theme_assets", ["Inputs","themes","current_theme"], _x91dc7);  
   $def("_1sdw5pf", "theme_assets", ["Generators","viewof theme_assets"], _1sdw5pf);  
   $def("_1wzah21", "theme_name", ["themes","theme_assets"], _1wzah21);  
-  $def("_nz55m5", null, ["css","themes","theme_assets","html"], _nz55m5);  
-  $def("_11pe38r", null, ["theme_properties","html","htl","theme_name"], _11pe38r);  
+  $def("_zy6iu8", "apply_theme", ["css","themes","theme_assets","html"], _zy6iu8);  
+  $def("_10zmng3", null, ["theme_properties","html","htl","theme_name"], _10zmng3);  
   $def("_1txjoje", null, ["md"], _1txjoje);  
-  $def("_1hu8vay", null, ["htl","theme_properties","html"], _1hu8vay);  
-  $def("_1k4keny", "theme_properties", ["css"], _1k4keny);  
+  $def("_18nx47m", null, ["htl","theme_properties","html"], _18nx47m);  
+  $def("_ebjyl2", "theme_properties", ["css"], _ebjyl2);  
   $def("_iny180", null, ["md"], _iny180);  
-  $def("_vhnhz5", "themes", [], _vhnhz5);  
-  $def("_iq48k6", "cssForTheme", ["themes","extra_css"], _iq48k6);  
-  $def("_e3ckjw", "css", ["theme_assets","extra_css"], _e3ckjw);  
-  $def("_d7mxvx", "extra_css", [], _d7mxvx);  
+  $def("_p0at3d", "themes", [], _p0at3d);  
+  $def("_m8taeu", "cssForTheme", ["themes","extra_css"], _m8taeu);  
+  $def("_yqy56c", "css", ["theme_assets","extra_css"], _yqy56c);  
+  $def("_16bhmn1", "extra_css", [], _16bhmn1);  
   $def("_rijq1n", "current_theme", ["themes"], _rijq1n);
   return main;
 }</script>

--- a/notebooks/@tomlarkworthy_local-change-history.json
+++ b/notebooks/@tomlarkworthy_local-change-history.json
@@ -44,7 +44,7 @@
       ]
     },
     "@tomlarkworthy/cell-map": {
-      "hash": "c8281cd25de378ac872c7e289b0b715a",
+      "hash": "a58cde1f33bf1d60ba83caa866a03be1",
       "dependsOn": [
         "@tomlarkworthy/lopepage-urls",
         "@tomlarkworthy/module-map",
@@ -63,7 +63,7 @@
       ]
     },
     "@tomlarkworthy/cells-to-clipboard": {
-      "hash": "f245a2a1ad646c1f9430b0ecdf9b0cbc",
+      "hash": "7af7898b237728b52ea24b568ad2fd32",
       "dependedBy": [
         "@tomlarkworthy/editor-5"
       ]
@@ -124,7 +124,7 @@
       ]
     },
     "@tomlarkworthy/editor-5": {
-      "hash": "3a3d18678d8332cd040fbab943c01df0",
+      "hash": "4a9c313ccb5746d004530926cdca27ca",
       "files": [
         "cell_options.json"
       ],
@@ -230,7 +230,7 @@
       ]
     },
     "@tomlarkworthy/import-notebook": {
-      "hash": "b6c52cc7de8b52cdf491eb76049236cc",
+      "hash": "b6b75803b1a4b7006005a06e0495ee65",
       "dependsOn": [
         "@tomlarkworthy/runtime-sdk"
       ],
@@ -291,7 +291,7 @@
       ]
     },
     "@tomlarkworthy/local-change-history": {
-      "hash": "78e3a01016d8128ecc0537e7c756eaa3",
+      "hash": "ea8ffc1745c311432d4c097a64021ccd",
       "dependsOn": [
         "@tomlarkworthy/runtime-sdk",
         "@tomlarkworthy/lightning-fs-4-6-0",
@@ -317,7 +317,7 @@
       ]
     },
     "@tomlarkworthy/lopepage": {
-      "hash": "40d704b72338d342b63aca508662933f",
+      "hash": "633f78d13e1da2ee746dc2c8598b5a24",
       "dependsOn": [
         "@tomlarkworthy/golden-layout-2-6-0",
         "@tomlarkworthy/visualizer",
@@ -332,7 +332,7 @@
       ]
     },
     "@tomlarkworthy/lopepage-urls": {
-      "hash": "eee5c7951f9edd92f8fd1dba8442609b",
+      "hash": "28f1a31190b2a69e3c9d3ac522c41bd4",
       "dependsOn": [
         "@tomlarkworthy/runtime-sdk",
         "@tomlarkworthy/tests"
@@ -409,7 +409,7 @@
       ]
     },
     "@tomlarkworthy/observablejs-toolchain": {
-      "hash": "c966316acf0555f9b3780691ef4ce73c",
+      "hash": "d9a90e9fe4112061bbce4824bd88b307",
       "files": [
         "acorn-walk-8.3.2.js.gz",
         "parser-6.1.0.js.gz"
@@ -474,7 +474,7 @@
       ]
     },
     "@tomlarkworthy/stream-operators": {
-      "hash": "60e01583a36fc0e1abe3f5fa7b71efd7",
+      "hash": "e36abaedab4dca730a68bbd8fa2a72f5",
       "dependedBy": [
         "@tomlarkworthy/tests"
       ]
@@ -504,7 +504,7 @@
       ]
     },
     "@tomlarkworthy/themes": {
-      "hash": "2d0e95ad9db0f2e04ca5afa81cbdd089",
+      "hash": "0fe84814f727b3cc5f0f012ff9e556e9",
       "dependedBy": [
         "@tomlarkworthy/command-palette",
         "@tomlarkworthy/exporter-3"
@@ -542,6 +542,6 @@
       "@tomlarkworthy/local-change-history": "https://observablehq.com/@tomlarkworthy/local-change-history"
     }
   },
-  "observable_version": 2216,
-  "observable_update_time": "2026-05-17T10:04:59.131Z"
+  "observable_version": 2217,
+  "observable_update_time": "2026-05-24T18:23:19.884Z"
 }

--- a/notebooks/@tomlarkworthy_local-storage-view.html
+++ b/notebooks/@tomlarkworthy_local-storage-view.html
@@ -12473,7 +12473,7 @@ async function replayGitEntries(gitEntries, {
   return results;
 }
 )};
-const _oha4mi = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
+const _7hpmkx = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
 async function replayGitCommits(commits, {repo = config?.repo, branch = config?.branch, order = 'oldest-first'} = {}) {
   const list = Array.isArray(commits) ? commits : [];
   const ordered = order === 'newest-first' ? list.slice() : order === 'oldest-first' ? list.slice().reverse() : list.slice();
@@ -12502,10 +12502,10 @@ async function replayGitCommits(commits, {repo = config?.repo, branch = config?.
       const moduleName = p.module ?? 'main';
       if (baseHashes && baseHashes[moduleName]) {
         const currentHash = moduleBaseHash(moduleName);
-        if (currentHash && currentHash !== baseHashes[moduleName]) {
+        if (!currentHash || currentHash !== baseHashes[moduleName]) {
           if (!skippedModules.has(moduleName)) {
             skippedModules.add(moduleName);
-            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed`);
+            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed or module absent`);
           }
           continue;
         }
@@ -13700,7 +13700,7 @@ export default function define(runtime, observer) {
   $def("_1r7lx5s", "GitEntry", ["ensure_repo","git","fs"], _1r7lx5s);  
   $def("_yngfrp", "replay_pid_map", [], _yngfrp);  
   $def("_19c2k49", "replayGitEntries", ["modules","getVariableByPersistentId","runtime","replay_pid_map","GitEntry","realize","tag"], _19c2k49);  
-  $def("_oha4mi", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _oha4mi);  
+  $def("_7hpmkx", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _7hpmkx);  
   $def("_1ail6g2", "replay_git", ["isOnObservableCom","modules","replayGitCommits","relevant_git_commits"], _1ail6g2);  
   $def("_1rm7oy4", null, ["md"], _1rm7oy4);  
   $def("_m77twl", null, ["Inputs","exportToZip","fs","config","getCompactISODate"], _m77twl);  

--- a/notebooks/@tomlarkworthy_lopecode-tour.html
+++ b/notebooks/@tomlarkworthy_lopecode-tour.html
@@ -13575,7 +13575,7 @@ async function replayGitEntries(gitEntries, {
   return results;
 }
 )};
-const _oha4mi = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
+const _7hpmkx = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
 async function replayGitCommits(commits, {repo = config?.repo, branch = config?.branch, order = 'oldest-first'} = {}) {
   const list = Array.isArray(commits) ? commits : [];
   const ordered = order === 'newest-first' ? list.slice() : order === 'oldest-first' ? list.slice().reverse() : list.slice();
@@ -13604,10 +13604,10 @@ async function replayGitCommits(commits, {repo = config?.repo, branch = config?.
       const moduleName = p.module ?? 'main';
       if (baseHashes && baseHashes[moduleName]) {
         const currentHash = moduleBaseHash(moduleName);
-        if (currentHash && currentHash !== baseHashes[moduleName]) {
+        if (!currentHash || currentHash !== baseHashes[moduleName]) {
           if (!skippedModules.has(moduleName)) {
             skippedModules.add(moduleName);
-            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed`);
+            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed or module absent`);
           }
           continue;
         }
@@ -14802,7 +14802,7 @@ export default function define(runtime, observer) {
   $def("_1r7lx5s", "GitEntry", ["ensure_repo","git","fs"], _1r7lx5s);  
   $def("_yngfrp", "replay_pid_map", [], _yngfrp);  
   $def("_19c2k49", "replayGitEntries", ["modules","getVariableByPersistentId","runtime","replay_pid_map","GitEntry","realize","tag"], _19c2k49);  
-  $def("_oha4mi", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _oha4mi);  
+  $def("_7hpmkx", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _7hpmkx);  
   $def("_1ail6g2", "replay_git", ["isOnObservableCom","modules","replayGitCommits","relevant_git_commits"], _1ail6g2);  
   $def("_1rm7oy4", null, ["md"], _1rm7oy4);  
   $def("_m77twl", null, ["Inputs","exportToZip","fs","config","getCompactISODate"], _m77twl);  

--- a/notebooks/@tomlarkworthy_lopecode-vision.html
+++ b/notebooks/@tomlarkworthy_lopecode-vision.html
@@ -13395,7 +13395,7 @@ async function replayGitEntries(gitEntries, {
   return results;
 }
 )};
-const _oha4mi = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
+const _7hpmkx = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
 async function replayGitCommits(commits, {repo = config?.repo, branch = config?.branch, order = 'oldest-first'} = {}) {
   const list = Array.isArray(commits) ? commits : [];
   const ordered = order === 'newest-first' ? list.slice() : order === 'oldest-first' ? list.slice().reverse() : list.slice();
@@ -13424,10 +13424,10 @@ async function replayGitCommits(commits, {repo = config?.repo, branch = config?.
       const moduleName = p.module ?? 'main';
       if (baseHashes && baseHashes[moduleName]) {
         const currentHash = moduleBaseHash(moduleName);
-        if (currentHash && currentHash !== baseHashes[moduleName]) {
+        if (!currentHash || currentHash !== baseHashes[moduleName]) {
           if (!skippedModules.has(moduleName)) {
             skippedModules.add(moduleName);
-            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed`);
+            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed or module absent`);
           }
           continue;
         }
@@ -14622,7 +14622,7 @@ export default function define(runtime, observer) {
   $def("_1r7lx5s", "GitEntry", ["ensure_repo","git","fs"], _1r7lx5s);  
   $def("_yngfrp", "replay_pid_map", [], _yngfrp);  
   $def("_19c2k49", "replayGitEntries", ["modules","getVariableByPersistentId","runtime","replay_pid_map","GitEntry","realize","tag"], _19c2k49);  
-  $def("_oha4mi", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _oha4mi);  
+  $def("_7hpmkx", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _7hpmkx);  
   $def("_1ail6g2", "replay_git", ["isOnObservableCom","modules","replayGitCommits","relevant_git_commits"], _1ail6g2);  
   $def("_1rm7oy4", null, ["md"], _1rm7oy4);  
   $def("_m77twl", null, ["Inputs","exportToZip","fs","config","getCompactISODate"], _m77twl);  

--- a/notebooks/@tomlarkworthy_lopepage-urls.html
+++ b/notebooks/@tomlarkworthy_lopepage-urls.html
@@ -12473,7 +12473,7 @@ async function replayGitEntries(gitEntries, {
   return results;
 }
 )};
-const _oha4mi = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
+const _7hpmkx = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
 async function replayGitCommits(commits, {repo = config?.repo, branch = config?.branch, order = 'oldest-first'} = {}) {
   const list = Array.isArray(commits) ? commits : [];
   const ordered = order === 'newest-first' ? list.slice() : order === 'oldest-first' ? list.slice().reverse() : list.slice();
@@ -12502,10 +12502,10 @@ async function replayGitCommits(commits, {repo = config?.repo, branch = config?.
       const moduleName = p.module ?? 'main';
       if (baseHashes && baseHashes[moduleName]) {
         const currentHash = moduleBaseHash(moduleName);
-        if (currentHash && currentHash !== baseHashes[moduleName]) {
+        if (!currentHash || currentHash !== baseHashes[moduleName]) {
           if (!skippedModules.has(moduleName)) {
             skippedModules.add(moduleName);
-            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed`);
+            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed or module absent`);
           }
           continue;
         }
@@ -13700,7 +13700,7 @@ export default function define(runtime, observer) {
   $def("_1r7lx5s", "GitEntry", ["ensure_repo","git","fs"], _1r7lx5s);  
   $def("_yngfrp", "replay_pid_map", [], _yngfrp);  
   $def("_19c2k49", "replayGitEntries", ["modules","getVariableByPersistentId","runtime","replay_pid_map","GitEntry","realize","tag"], _19c2k49);  
-  $def("_oha4mi", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _oha4mi);  
+  $def("_7hpmkx", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _7hpmkx);  
   $def("_1ail6g2", "replay_git", ["isOnObservableCom","modules","replayGitCommits","relevant_git_commits"], _1ail6g2);  
   $def("_1rm7oy4", null, ["md"], _1rm7oy4);  
   $def("_m77twl", null, ["Inputs","exportToZip","fs","config","getCompactISODate"], _m77twl);  

--- a/notebooks/@tomlarkworthy_lopepage.html
+++ b/notebooks/@tomlarkworthy_lopepage.html
@@ -12484,7 +12484,7 @@ async function replayGitEntries(gitEntries, {
   return results;
 }
 )};
-const _oha4mi = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
+const _7hpmkx = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
 async function replayGitCommits(commits, {repo = config?.repo, branch = config?.branch, order = 'oldest-first'} = {}) {
   const list = Array.isArray(commits) ? commits : [];
   const ordered = order === 'newest-first' ? list.slice() : order === 'oldest-first' ? list.slice().reverse() : list.slice();
@@ -12513,10 +12513,10 @@ async function replayGitCommits(commits, {repo = config?.repo, branch = config?.
       const moduleName = p.module ?? 'main';
       if (baseHashes && baseHashes[moduleName]) {
         const currentHash = moduleBaseHash(moduleName);
-        if (currentHash && currentHash !== baseHashes[moduleName]) {
+        if (!currentHash || currentHash !== baseHashes[moduleName]) {
           if (!skippedModules.has(moduleName)) {
             skippedModules.add(moduleName);
-            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed`);
+            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed or module absent`);
           }
           continue;
         }
@@ -13711,7 +13711,7 @@ export default function define(runtime, observer) {
   $def("_1r7lx5s", "GitEntry", ["ensure_repo","git","fs"], _1r7lx5s);  
   $def("_yngfrp", "replay_pid_map", [], _yngfrp);  
   $def("_19c2k49", "replayGitEntries", ["modules","getVariableByPersistentId","runtime","replay_pid_map","GitEntry","realize","tag"], _19c2k49);  
-  $def("_oha4mi", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _oha4mi);  
+  $def("_7hpmkx", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _7hpmkx);  
   $def("_1ail6g2", "replay_git", ["isOnObservableCom","modules","replayGitCommits","relevant_git_commits"], _1ail6g2);  
   $def("_1rm7oy4", null, ["md"], _1rm7oy4);  
   $def("_m77twl", null, ["Inputs","exportToZip","fs","config","getCompactISODate"], _m77twl);  

--- a/notebooks/@tomlarkworthy_modern-screenshot.html
+++ b/notebooks/@tomlarkworthy_modern-screenshot.html
@@ -12473,7 +12473,7 @@ async function replayGitEntries(gitEntries, {
   return results;
 }
 )};
-const _oha4mi = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
+const _7hpmkx = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
 async function replayGitCommits(commits, {repo = config?.repo, branch = config?.branch, order = 'oldest-first'} = {}) {
   const list = Array.isArray(commits) ? commits : [];
   const ordered = order === 'newest-first' ? list.slice() : order === 'oldest-first' ? list.slice().reverse() : list.slice();
@@ -12502,10 +12502,10 @@ async function replayGitCommits(commits, {repo = config?.repo, branch = config?.
       const moduleName = p.module ?? 'main';
       if (baseHashes && baseHashes[moduleName]) {
         const currentHash = moduleBaseHash(moduleName);
-        if (currentHash && currentHash !== baseHashes[moduleName]) {
+        if (!currentHash || currentHash !== baseHashes[moduleName]) {
           if (!skippedModules.has(moduleName)) {
             skippedModules.add(moduleName);
-            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed`);
+            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed or module absent`);
           }
           continue;
         }
@@ -13700,7 +13700,7 @@ export default function define(runtime, observer) {
   $def("_1r7lx5s", "GitEntry", ["ensure_repo","git","fs"], _1r7lx5s);  
   $def("_yngfrp", "replay_pid_map", [], _yngfrp);  
   $def("_19c2k49", "replayGitEntries", ["modules","getVariableByPersistentId","runtime","replay_pid_map","GitEntry","realize","tag"], _19c2k49);  
-  $def("_oha4mi", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _oha4mi);  
+  $def("_7hpmkx", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _7hpmkx);  
   $def("_1ail6g2", "replay_git", ["isOnObservableCom","modules","replayGitCommits","relevant_git_commits"], _1ail6g2);  
   $def("_1rm7oy4", null, ["md"], _1rm7oy4);  
   $def("_m77twl", null, ["Inputs","exportToZip","fs","config","getCompactISODate"], _m77twl);  

--- a/notebooks/@tomlarkworthy_module-selection.html
+++ b/notebooks/@tomlarkworthy_module-selection.html
@@ -12473,7 +12473,7 @@ async function replayGitEntries(gitEntries, {
   return results;
 }
 )};
-const _oha4mi = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
+const _7hpmkx = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
 async function replayGitCommits(commits, {repo = config?.repo, branch = config?.branch, order = 'oldest-first'} = {}) {
   const list = Array.isArray(commits) ? commits : [];
   const ordered = order === 'newest-first' ? list.slice() : order === 'oldest-first' ? list.slice().reverse() : list.slice();
@@ -12502,10 +12502,10 @@ async function replayGitCommits(commits, {repo = config?.repo, branch = config?.
       const moduleName = p.module ?? 'main';
       if (baseHashes && baseHashes[moduleName]) {
         const currentHash = moduleBaseHash(moduleName);
-        if (currentHash && currentHash !== baseHashes[moduleName]) {
+        if (!currentHash || currentHash !== baseHashes[moduleName]) {
           if (!skippedModules.has(moduleName)) {
             skippedModules.add(moduleName);
-            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed`);
+            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed or module absent`);
           }
           continue;
         }
@@ -13700,7 +13700,7 @@ export default function define(runtime, observer) {
   $def("_1r7lx5s", "GitEntry", ["ensure_repo","git","fs"], _1r7lx5s);  
   $def("_yngfrp", "replay_pid_map", [], _yngfrp);  
   $def("_19c2k49", "replayGitEntries", ["modules","getVariableByPersistentId","runtime","replay_pid_map","GitEntry","realize","tag"], _19c2k49);  
-  $def("_oha4mi", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _oha4mi);  
+  $def("_7hpmkx", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _7hpmkx);  
   $def("_1ail6g2", "replay_git", ["isOnObservableCom","modules","replayGitCommits","relevant_git_commits"], _1ail6g2);  
   $def("_1rm7oy4", null, ["md"], _1rm7oy4);  
   $def("_m77twl", null, ["Inputs","exportToZip","fs","config","getCompactISODate"], _m77twl);  

--- a/notebooks/@tomlarkworthy_notes.html
+++ b/notebooks/@tomlarkworthy_notes.html
@@ -12519,7 +12519,7 @@ async function replayGitEntries(gitEntries, {
   return results;
 }
 )};
-const _oha4mi = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
+const _7hpmkx = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
 async function replayGitCommits(commits, {repo = config?.repo, branch = config?.branch, order = 'oldest-first'} = {}) {
   const list = Array.isArray(commits) ? commits : [];
   const ordered = order === 'newest-first' ? list.slice() : order === 'oldest-first' ? list.slice().reverse() : list.slice();
@@ -12548,10 +12548,10 @@ async function replayGitCommits(commits, {repo = config?.repo, branch = config?.
       const moduleName = p.module ?? 'main';
       if (baseHashes && baseHashes[moduleName]) {
         const currentHash = moduleBaseHash(moduleName);
-        if (currentHash && currentHash !== baseHashes[moduleName]) {
+        if (!currentHash || currentHash !== baseHashes[moduleName]) {
           if (!skippedModules.has(moduleName)) {
             skippedModules.add(moduleName);
-            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed`);
+            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed or module absent`);
           }
           continue;
         }
@@ -13746,7 +13746,7 @@ export default function define(runtime, observer) {
   $def("_1r7lx5s", "GitEntry", ["ensure_repo","git","fs"], _1r7lx5s);  
   $def("_yngfrp", "replay_pid_map", [], _yngfrp);  
   $def("_19c2k49", "replayGitEntries", ["modules","getVariableByPersistentId","runtime","replay_pid_map","GitEntry","realize","tag"], _19c2k49);  
-  $def("_oha4mi", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _oha4mi);  
+  $def("_7hpmkx", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _7hpmkx);  
   $def("_1ail6g2", "replay_git", ["isOnObservableCom","modules","replayGitCommits","relevant_git_commits"], _1ail6g2);  
   $def("_1rm7oy4", null, ["md"], _1rm7oy4);  
   $def("_m77twl", null, ["Inputs","exportToZip","fs","config","getCompactISODate"], _m77twl);  

--- a/notebooks/@tomlarkworthy_observablehq-lezer.html
+++ b/notebooks/@tomlarkworthy_observablehq-lezer.html
@@ -12473,7 +12473,7 @@ async function replayGitEntries(gitEntries, {
   return results;
 }
 )};
-const _oha4mi = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
+const _7hpmkx = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
 async function replayGitCommits(commits, {repo = config?.repo, branch = config?.branch, order = 'oldest-first'} = {}) {
   const list = Array.isArray(commits) ? commits : [];
   const ordered = order === 'newest-first' ? list.slice() : order === 'oldest-first' ? list.slice().reverse() : list.slice();
@@ -12502,10 +12502,10 @@ async function replayGitCommits(commits, {repo = config?.repo, branch = config?.
       const moduleName = p.module ?? 'main';
       if (baseHashes && baseHashes[moduleName]) {
         const currentHash = moduleBaseHash(moduleName);
-        if (currentHash && currentHash !== baseHashes[moduleName]) {
+        if (!currentHash || currentHash !== baseHashes[moduleName]) {
           if (!skippedModules.has(moduleName)) {
             skippedModules.add(moduleName);
-            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed`);
+            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed or module absent`);
           }
           continue;
         }
@@ -13700,7 +13700,7 @@ export default function define(runtime, observer) {
   $def("_1r7lx5s", "GitEntry", ["ensure_repo","git","fs"], _1r7lx5s);  
   $def("_yngfrp", "replay_pid_map", [], _yngfrp);  
   $def("_19c2k49", "replayGitEntries", ["modules","getVariableByPersistentId","runtime","replay_pid_map","GitEntry","realize","tag"], _19c2k49);  
-  $def("_oha4mi", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _oha4mi);  
+  $def("_7hpmkx", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _7hpmkx);  
   $def("_1ail6g2", "replay_git", ["isOnObservableCom","modules","replayGitCommits","relevant_git_commits"], _1ail6g2);  
   $def("_1rm7oy4", null, ["md"], _1rm7oy4);  
   $def("_m77twl", null, ["Inputs","exportToZip","fs","config","getCompactISODate"], _m77twl);  

--- a/notebooks/@tomlarkworthy_observablejs-toolchain.html
+++ b/notebooks/@tomlarkworthy_observablejs-toolchain.html
@@ -12471,7 +12471,7 @@ async function replayGitEntries(gitEntries, {
   return results;
 }
 )};
-const _oha4mi = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
+const _7hpmkx = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
 async function replayGitCommits(commits, {repo = config?.repo, branch = config?.branch, order = 'oldest-first'} = {}) {
   const list = Array.isArray(commits) ? commits : [];
   const ordered = order === 'newest-first' ? list.slice() : order === 'oldest-first' ? list.slice().reverse() : list.slice();
@@ -12500,10 +12500,10 @@ async function replayGitCommits(commits, {repo = config?.repo, branch = config?.
       const moduleName = p.module ?? 'main';
       if (baseHashes && baseHashes[moduleName]) {
         const currentHash = moduleBaseHash(moduleName);
-        if (currentHash && currentHash !== baseHashes[moduleName]) {
+        if (!currentHash || currentHash !== baseHashes[moduleName]) {
           if (!skippedModules.has(moduleName)) {
             skippedModules.add(moduleName);
-            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed`);
+            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed or module absent`);
           }
           continue;
         }
@@ -13698,7 +13698,7 @@ export default function define(runtime, observer) {
   $def("_1r7lx5s", "GitEntry", ["ensure_repo","git","fs"], _1r7lx5s);  
   $def("_yngfrp", "replay_pid_map", [], _yngfrp);  
   $def("_19c2k49", "replayGitEntries", ["modules","getVariableByPersistentId","runtime","replay_pid_map","GitEntry","realize","tag"], _19c2k49);  
-  $def("_oha4mi", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _oha4mi);  
+  $def("_7hpmkx", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _7hpmkx);  
   $def("_1ail6g2", "replay_git", ["isOnObservableCom","modules","replayGitCommits","relevant_git_commits"], _1ail6g2);  
   $def("_1rm7oy4", null, ["md"], _1rm7oy4);  
   $def("_m77twl", null, ["Inputs","exportToZip","fs","config","getCompactISODate"], _m77twl);  

--- a/notebooks/@tomlarkworthy_openai-responses-api.html
+++ b/notebooks/@tomlarkworthy_openai-responses-api.html
@@ -12473,7 +12473,7 @@ async function replayGitEntries(gitEntries, {
   return results;
 }
 )};
-const _oha4mi = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
+const _7hpmkx = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
 async function replayGitCommits(commits, {repo = config?.repo, branch = config?.branch, order = 'oldest-first'} = {}) {
   const list = Array.isArray(commits) ? commits : [];
   const ordered = order === 'newest-first' ? list.slice() : order === 'oldest-first' ? list.slice().reverse() : list.slice();
@@ -12502,10 +12502,10 @@ async function replayGitCommits(commits, {repo = config?.repo, branch = config?.
       const moduleName = p.module ?? 'main';
       if (baseHashes && baseHashes[moduleName]) {
         const currentHash = moduleBaseHash(moduleName);
-        if (currentHash && currentHash !== baseHashes[moduleName]) {
+        if (!currentHash || currentHash !== baseHashes[moduleName]) {
           if (!skippedModules.has(moduleName)) {
             skippedModules.add(moduleName);
-            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed`);
+            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed or module absent`);
           }
           continue;
         }
@@ -13700,7 +13700,7 @@ export default function define(runtime, observer) {
   $def("_1r7lx5s", "GitEntry", ["ensure_repo","git","fs"], _1r7lx5s);  
   $def("_yngfrp", "replay_pid_map", [], _yngfrp);  
   $def("_19c2k49", "replayGitEntries", ["modules","getVariableByPersistentId","runtime","replay_pid_map","GitEntry","realize","tag"], _19c2k49);  
-  $def("_oha4mi", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _oha4mi);  
+  $def("_7hpmkx", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _7hpmkx);  
   $def("_1ail6g2", "replay_git", ["isOnObservableCom","modules","replayGitCommits","relevant_git_commits"], _1ail6g2);  
   $def("_1rm7oy4", null, ["md"], _1rm7oy4);  
   $def("_m77twl", null, ["Inputs","exportToZip","fs","config","getCompactISODate"], _m77twl);  

--- a/notebooks/@tomlarkworthy_reversible-attachment.html
+++ b/notebooks/@tomlarkworthy_reversible-attachment.html
@@ -12473,7 +12473,7 @@ async function replayGitEntries(gitEntries, {
   return results;
 }
 )};
-const _oha4mi = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
+const _7hpmkx = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
 async function replayGitCommits(commits, {repo = config?.repo, branch = config?.branch, order = 'oldest-first'} = {}) {
   const list = Array.isArray(commits) ? commits : [];
   const ordered = order === 'newest-first' ? list.slice() : order === 'oldest-first' ? list.slice().reverse() : list.slice();
@@ -12502,10 +12502,10 @@ async function replayGitCommits(commits, {repo = config?.repo, branch = config?.
       const moduleName = p.module ?? 'main';
       if (baseHashes && baseHashes[moduleName]) {
         const currentHash = moduleBaseHash(moduleName);
-        if (currentHash && currentHash !== baseHashes[moduleName]) {
+        if (!currentHash || currentHash !== baseHashes[moduleName]) {
           if (!skippedModules.has(moduleName)) {
             skippedModules.add(moduleName);
-            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed`);
+            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed or module absent`);
           }
           continue;
         }
@@ -13700,7 +13700,7 @@ export default function define(runtime, observer) {
   $def("_1r7lx5s", "GitEntry", ["ensure_repo","git","fs"], _1r7lx5s);  
   $def("_yngfrp", "replay_pid_map", [], _yngfrp);  
   $def("_19c2k49", "replayGitEntries", ["modules","getVariableByPersistentId","runtime","replay_pid_map","GitEntry","realize","tag"], _19c2k49);  
-  $def("_oha4mi", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _oha4mi);  
+  $def("_7hpmkx", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _7hpmkx);  
   $def("_1ail6g2", "replay_git", ["isOnObservableCom","modules","replayGitCommits","relevant_git_commits"], _1ail6g2);  
   $def("_1rm7oy4", null, ["md"], _1rm7oy4);  
   $def("_m77twl", null, ["Inputs","exportToZip","fs","config","getCompactISODate"], _m77twl);  

--- a/notebooks/@tomlarkworthy_robocoop-2.html
+++ b/notebooks/@tomlarkworthy_robocoop-2.html
@@ -12473,7 +12473,7 @@ async function replayGitEntries(gitEntries, {
   return results;
 }
 )};
-const _oha4mi = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
+const _7hpmkx = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
 async function replayGitCommits(commits, {repo = config?.repo, branch = config?.branch, order = 'oldest-first'} = {}) {
   const list = Array.isArray(commits) ? commits : [];
   const ordered = order === 'newest-first' ? list.slice() : order === 'oldest-first' ? list.slice().reverse() : list.slice();
@@ -12502,10 +12502,10 @@ async function replayGitCommits(commits, {repo = config?.repo, branch = config?.
       const moduleName = p.module ?? 'main';
       if (baseHashes && baseHashes[moduleName]) {
         const currentHash = moduleBaseHash(moduleName);
-        if (currentHash && currentHash !== baseHashes[moduleName]) {
+        if (!currentHash || currentHash !== baseHashes[moduleName]) {
           if (!skippedModules.has(moduleName)) {
             skippedModules.add(moduleName);
-            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed`);
+            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed or module absent`);
           }
           continue;
         }
@@ -13700,7 +13700,7 @@ export default function define(runtime, observer) {
   $def("_1r7lx5s", "GitEntry", ["ensure_repo","git","fs"], _1r7lx5s);  
   $def("_yngfrp", "replay_pid_map", [], _yngfrp);  
   $def("_19c2k49", "replayGitEntries", ["modules","getVariableByPersistentId","runtime","replay_pid_map","GitEntry","realize","tag"], _19c2k49);  
-  $def("_oha4mi", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _oha4mi);  
+  $def("_7hpmkx", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _7hpmkx);  
   $def("_1ail6g2", "replay_git", ["isOnObservableCom","modules","replayGitCommits","relevant_git_commits"], _1ail6g2);  
   $def("_1rm7oy4", null, ["md"], _1rm7oy4);  
   $def("_m77twl", null, ["Inputs","exportToZip","fs","config","getCompactISODate"], _m77twl);  

--- a/notebooks/@tomlarkworthy_robocoop-3.html
+++ b/notebooks/@tomlarkworthy_robocoop-3.html
@@ -12473,7 +12473,7 @@ async function replayGitEntries(gitEntries, {
   return results;
 }
 )};
-const _oha4mi = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
+const _7hpmkx = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
 async function replayGitCommits(commits, {repo = config?.repo, branch = config?.branch, order = 'oldest-first'} = {}) {
   const list = Array.isArray(commits) ? commits : [];
   const ordered = order === 'newest-first' ? list.slice() : order === 'oldest-first' ? list.slice().reverse() : list.slice();
@@ -12502,10 +12502,10 @@ async function replayGitCommits(commits, {repo = config?.repo, branch = config?.
       const moduleName = p.module ?? 'main';
       if (baseHashes && baseHashes[moduleName]) {
         const currentHash = moduleBaseHash(moduleName);
-        if (currentHash && currentHash !== baseHashes[moduleName]) {
+        if (!currentHash || currentHash !== baseHashes[moduleName]) {
           if (!skippedModules.has(moduleName)) {
             skippedModules.add(moduleName);
-            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed`);
+            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed or module absent`);
           }
           continue;
         }
@@ -13700,7 +13700,7 @@ export default function define(runtime, observer) {
   $def("_1r7lx5s", "GitEntry", ["ensure_repo","git","fs"], _1r7lx5s);  
   $def("_yngfrp", "replay_pid_map", [], _yngfrp);  
   $def("_19c2k49", "replayGitEntries", ["modules","getVariableByPersistentId","runtime","replay_pid_map","GitEntry","realize","tag"], _19c2k49);  
-  $def("_oha4mi", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _oha4mi);  
+  $def("_7hpmkx", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _7hpmkx);  
   $def("_1ail6g2", "replay_git", ["isOnObservableCom","modules","replayGitCommits","relevant_git_commits"], _1ail6g2);  
   $def("_1rm7oy4", null, ["md"], _1rm7oy4);  
   $def("_m77twl", null, ["Inputs","exportToZip","fs","config","getCompactISODate"], _m77twl);  

--- a/notebooks/@tomlarkworthy_runtime-sdk.html
+++ b/notebooks/@tomlarkworthy_runtime-sdk.html
@@ -12473,7 +12473,7 @@ async function replayGitEntries(gitEntries, {
   return results;
 }
 )};
-const _oha4mi = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
+const _7hpmkx = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
 async function replayGitCommits(commits, {repo = config?.repo, branch = config?.branch, order = 'oldest-first'} = {}) {
   const list = Array.isArray(commits) ? commits : [];
   const ordered = order === 'newest-first' ? list.slice() : order === 'oldest-first' ? list.slice().reverse() : list.slice();
@@ -12502,10 +12502,10 @@ async function replayGitCommits(commits, {repo = config?.repo, branch = config?.
       const moduleName = p.module ?? 'main';
       if (baseHashes && baseHashes[moduleName]) {
         const currentHash = moduleBaseHash(moduleName);
-        if (currentHash && currentHash !== baseHashes[moduleName]) {
+        if (!currentHash || currentHash !== baseHashes[moduleName]) {
           if (!skippedModules.has(moduleName)) {
             skippedModules.add(moduleName);
-            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed`);
+            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed or module absent`);
           }
           continue;
         }
@@ -13700,7 +13700,7 @@ export default function define(runtime, observer) {
   $def("_1r7lx5s", "GitEntry", ["ensure_repo","git","fs"], _1r7lx5s);  
   $def("_yngfrp", "replay_pid_map", [], _yngfrp);  
   $def("_19c2k49", "replayGitEntries", ["modules","getVariableByPersistentId","runtime","replay_pid_map","GitEntry","realize","tag"], _19c2k49);  
-  $def("_oha4mi", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _oha4mi);  
+  $def("_7hpmkx", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _7hpmkx);  
   $def("_1ail6g2", "replay_git", ["isOnObservableCom","modules","replayGitCommits","relevant_git_commits"], _1ail6g2);  
   $def("_1rm7oy4", null, ["md"], _1rm7oy4);  
   $def("_m77twl", null, ["Inputs","exportToZip","fs","config","getCompactISODate"], _m77twl);  

--- a/notebooks/@tomlarkworthy_secrets.html
+++ b/notebooks/@tomlarkworthy_secrets.html
@@ -12473,7 +12473,7 @@ async function replayGitEntries(gitEntries, {
   return results;
 }
 )};
-const _oha4mi = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
+const _7hpmkx = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
 async function replayGitCommits(commits, {repo = config?.repo, branch = config?.branch, order = 'oldest-first'} = {}) {
   const list = Array.isArray(commits) ? commits : [];
   const ordered = order === 'newest-first' ? list.slice() : order === 'oldest-first' ? list.slice().reverse() : list.slice();
@@ -12502,10 +12502,10 @@ async function replayGitCommits(commits, {repo = config?.repo, branch = config?.
       const moduleName = p.module ?? 'main';
       if (baseHashes && baseHashes[moduleName]) {
         const currentHash = moduleBaseHash(moduleName);
-        if (currentHash && currentHash !== baseHashes[moduleName]) {
+        if (!currentHash || currentHash !== baseHashes[moduleName]) {
           if (!skippedModules.has(moduleName)) {
             skippedModules.add(moduleName);
-            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed`);
+            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed or module absent`);
           }
           continue;
         }
@@ -13700,7 +13700,7 @@ export default function define(runtime, observer) {
   $def("_1r7lx5s", "GitEntry", ["ensure_repo","git","fs"], _1r7lx5s);  
   $def("_yngfrp", "replay_pid_map", [], _yngfrp);  
   $def("_19c2k49", "replayGitEntries", ["modules","getVariableByPersistentId","runtime","replay_pid_map","GitEntry","realize","tag"], _19c2k49);  
-  $def("_oha4mi", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _oha4mi);  
+  $def("_7hpmkx", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _7hpmkx);  
   $def("_1ail6g2", "replay_git", ["isOnObservableCom","modules","replayGitCommits","relevant_git_commits"], _1ail6g2);  
   $def("_1rm7oy4", null, ["md"], _1rm7oy4);  
   $def("_m77twl", null, ["Inputs","exportToZip","fs","config","getCompactISODate"], _m77twl);  

--- a/notebooks/@tomlarkworthy_tests.html
+++ b/notebooks/@tomlarkworthy_tests.html
@@ -12473,7 +12473,7 @@ async function replayGitEntries(gitEntries, {
   return results;
 }
 )};
-const _oha4mi = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
+const _7hpmkx = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
 async function replayGitCommits(commits, {repo = config?.repo, branch = config?.branch, order = 'oldest-first'} = {}) {
   const list = Array.isArray(commits) ? commits : [];
   const ordered = order === 'newest-first' ? list.slice() : order === 'oldest-first' ? list.slice().reverse() : list.slice();
@@ -12502,10 +12502,10 @@ async function replayGitCommits(commits, {repo = config?.repo, branch = config?.
       const moduleName = p.module ?? 'main';
       if (baseHashes && baseHashes[moduleName]) {
         const currentHash = moduleBaseHash(moduleName);
-        if (currentHash && currentHash !== baseHashes[moduleName]) {
+        if (!currentHash || currentHash !== baseHashes[moduleName]) {
           if (!skippedModules.has(moduleName)) {
             skippedModules.add(moduleName);
-            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed`);
+            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed or module absent`);
           }
           continue;
         }
@@ -13700,7 +13700,7 @@ export default function define(runtime, observer) {
   $def("_1r7lx5s", "GitEntry", ["ensure_repo","git","fs"], _1r7lx5s);  
   $def("_yngfrp", "replay_pid_map", [], _yngfrp);  
   $def("_19c2k49", "replayGitEntries", ["modules","getVariableByPersistentId","runtime","replay_pid_map","GitEntry","realize","tag"], _19c2k49);  
-  $def("_oha4mi", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _oha4mi);  
+  $def("_7hpmkx", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _7hpmkx);  
   $def("_1ail6g2", "replay_git", ["isOnObservableCom","modules","replayGitCommits","relevant_git_commits"], _1ail6g2);  
   $def("_1rm7oy4", null, ["md"], _1rm7oy4);  
   $def("_m77twl", null, ["Inputs","exportToZip","fs","config","getCompactISODate"], _m77twl);  

--- a/notebooks/@tomlarkworthy_themes.html
+++ b/notebooks/@tomlarkworthy_themes.html
@@ -12484,7 +12484,7 @@ async function replayGitEntries(gitEntries, {
   return results;
 }
 )};
-const _oha4mi = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
+const _7hpmkx = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
 async function replayGitCommits(commits, {repo = config?.repo, branch = config?.branch, order = 'oldest-first'} = {}) {
   const list = Array.isArray(commits) ? commits : [];
   const ordered = order === 'newest-first' ? list.slice() : order === 'oldest-first' ? list.slice().reverse() : list.slice();
@@ -12513,10 +12513,10 @@ async function replayGitCommits(commits, {repo = config?.repo, branch = config?.
       const moduleName = p.module ?? 'main';
       if (baseHashes && baseHashes[moduleName]) {
         const currentHash = moduleBaseHash(moduleName);
-        if (currentHash && currentHash !== baseHashes[moduleName]) {
+        if (!currentHash || currentHash !== baseHashes[moduleName]) {
           if (!skippedModules.has(moduleName)) {
             skippedModules.add(moduleName);
-            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed`);
+            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed or module absent`);
           }
           continue;
         }
@@ -13711,7 +13711,7 @@ export default function define(runtime, observer) {
   $def("_1r7lx5s", "GitEntry", ["ensure_repo","git","fs"], _1r7lx5s);  
   $def("_yngfrp", "replay_pid_map", [], _yngfrp);  
   $def("_19c2k49", "replayGitEntries", ["modules","getVariableByPersistentId","runtime","replay_pid_map","GitEntry","realize","tag"], _19c2k49);  
-  $def("_oha4mi", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _oha4mi);  
+  $def("_7hpmkx", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _7hpmkx);  
   $def("_1ail6g2", "replay_git", ["isOnObservableCom","modules","replayGitCommits","relevant_git_commits"], _1ail6g2);  
   $def("_1rm7oy4", null, ["md"], _1rm7oy4);  
   $def("_m77twl", null, ["Inputs","exportToZip","fs","config","getCompactISODate"], _m77twl);  

--- a/notebooks/@tomlarkworthy_visualizer.html
+++ b/notebooks/@tomlarkworthy_visualizer.html
@@ -12473,7 +12473,7 @@ async function replayGitEntries(gitEntries, {
   return results;
 }
 )};
-const _oha4mi = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
+const _7hpmkx = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
 async function replayGitCommits(commits, {repo = config?.repo, branch = config?.branch, order = 'oldest-first'} = {}) {
   const list = Array.isArray(commits) ? commits : [];
   const ordered = order === 'newest-first' ? list.slice() : order === 'oldest-first' ? list.slice().reverse() : list.slice();
@@ -12502,10 +12502,10 @@ async function replayGitCommits(commits, {repo = config?.repo, branch = config?.
       const moduleName = p.module ?? 'main';
       if (baseHashes && baseHashes[moduleName]) {
         const currentHash = moduleBaseHash(moduleName);
-        if (currentHash && currentHash !== baseHashes[moduleName]) {
+        if (!currentHash || currentHash !== baseHashes[moduleName]) {
           if (!skippedModules.has(moduleName)) {
             skippedModules.add(moduleName);
-            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed`);
+            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed or module absent`);
           }
           continue;
         }
@@ -13700,7 +13700,7 @@ export default function define(runtime, observer) {
   $def("_1r7lx5s", "GitEntry", ["ensure_repo","git","fs"], _1r7lx5s);  
   $def("_yngfrp", "replay_pid_map", [], _yngfrp);  
   $def("_19c2k49", "replayGitEntries", ["modules","getVariableByPersistentId","runtime","replay_pid_map","GitEntry","realize","tag"], _19c2k49);  
-  $def("_oha4mi", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _oha4mi);  
+  $def("_7hpmkx", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _7hpmkx);  
   $def("_1ail6g2", "replay_git", ["isOnObservableCom","modules","replayGitCommits","relevant_git_commits"], _1ail6g2);  
   $def("_1rm7oy4", null, ["md"], _1rm7oy4);  
   $def("_m77twl", null, ["Inputs","exportToZip","fs","config","getCompactISODate"], _m77twl);  

--- a/notebooks/atproto.html
+++ b/notebooks/atproto.html
@@ -15153,7 +15153,7 @@ async function replayGitEntries(gitEntries, {
   return results;
 }
 )};
-const _oha4mi = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
+const _7hpmkx = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
 async function replayGitCommits(commits, {repo = config?.repo, branch = config?.branch, order = 'oldest-first'} = {}) {
   const list = Array.isArray(commits) ? commits : [];
   const ordered = order === 'newest-first' ? list.slice() : order === 'oldest-first' ? list.slice().reverse() : list.slice();
@@ -15182,10 +15182,10 @@ async function replayGitCommits(commits, {repo = config?.repo, branch = config?.
       const moduleName = p.module ?? 'main';
       if (baseHashes && baseHashes[moduleName]) {
         const currentHash = moduleBaseHash(moduleName);
-        if (currentHash && currentHash !== baseHashes[moduleName]) {
+        if (!currentHash || currentHash !== baseHashes[moduleName]) {
           if (!skippedModules.has(moduleName)) {
             skippedModules.add(moduleName);
-            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed`);
+            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed or module absent`);
           }
           continue;
         }
@@ -16380,7 +16380,7 @@ export default function define(runtime, observer) {
   $def("_1r7lx5s", "GitEntry", ["ensure_repo","git","fs"], _1r7lx5s);  
   $def("_yngfrp", "replay_pid_map", [], _yngfrp);  
   $def("_19c2k49", "replayGitEntries", ["modules","getVariableByPersistentId","runtime","replay_pid_map","GitEntry","realize","tag"], _19c2k49);  
-  $def("_oha4mi", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _oha4mi);  
+  $def("_7hpmkx", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _7hpmkx);  
   $def("_1ail6g2", "replay_git", ["isOnObservableCom","modules","replayGitCommits","relevant_git_commits"], _1ail6g2);  
   $def("_1rm7oy4", null, ["md"], _1rm7oy4);  
   $def("_m77twl", null, ["Inputs","exportToZip","fs","config","getCompactISODate"], _m77twl);  

--- a/notebooks/jumpgates.html
+++ b/notebooks/jumpgates.html
@@ -13863,7 +13863,7 @@ async function replayGitEntries(gitEntries, {
   return results;
 }
 )};
-const _oha4mi = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
+const _7hpmkx = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
 async function replayGitCommits(commits, {repo = config?.repo, branch = config?.branch, order = 'oldest-first'} = {}) {
   const list = Array.isArray(commits) ? commits : [];
   const ordered = order === 'newest-first' ? list.slice() : order === 'oldest-first' ? list.slice().reverse() : list.slice();
@@ -13892,10 +13892,10 @@ async function replayGitCommits(commits, {repo = config?.repo, branch = config?.
       const moduleName = p.module ?? 'main';
       if (baseHashes && baseHashes[moduleName]) {
         const currentHash = moduleBaseHash(moduleName);
-        if (currentHash && currentHash !== baseHashes[moduleName]) {
+        if (!currentHash || currentHash !== baseHashes[moduleName]) {
           if (!skippedModules.has(moduleName)) {
             skippedModules.add(moduleName);
-            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed`);
+            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed or module absent`);
           }
           continue;
         }
@@ -15090,7 +15090,7 @@ export default function define(runtime, observer) {
   $def("_1r7lx5s", "GitEntry", ["ensure_repo","git","fs"], _1r7lx5s);  
   $def("_yngfrp", "replay_pid_map", [], _yngfrp);  
   $def("_19c2k49", "replayGitEntries", ["modules","getVariableByPersistentId","runtime","replay_pid_map","GitEntry","realize","tag"], _19c2k49);  
-  $def("_oha4mi", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _oha4mi);  
+  $def("_7hpmkx", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _7hpmkx);  
   $def("_1ail6g2", "replay_git", ["isOnObservableCom","modules","replayGitCommits","relevant_git_commits"], _1ail6g2);  
   $def("_1rm7oy4", null, ["md"], _1rm7oy4);  
   $def("_m77twl", null, ["Inputs","exportToZip","fs","config","getCompactISODate"], _m77twl);  

--- a/notebooks/ledger.html
+++ b/notebooks/ledger.html
@@ -16236,7 +16236,7 @@ async function replayGitEntries(gitEntries, {
   return results;
 }
 )};
-const _oha4mi = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
+const _7hpmkx = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
 async function replayGitCommits(commits, {repo = config?.repo, branch = config?.branch, order = 'oldest-first'} = {}) {
   const list = Array.isArray(commits) ? commits : [];
   const ordered = order === 'newest-first' ? list.slice() : order === 'oldest-first' ? list.slice().reverse() : list.slice();
@@ -16265,10 +16265,10 @@ async function replayGitCommits(commits, {repo = config?.repo, branch = config?.
       const moduleName = p.module ?? 'main';
       if (baseHashes && baseHashes[moduleName]) {
         const currentHash = moduleBaseHash(moduleName);
-        if (currentHash && currentHash !== baseHashes[moduleName]) {
+        if (!currentHash || currentHash !== baseHashes[moduleName]) {
           if (!skippedModules.has(moduleName)) {
             skippedModules.add(moduleName);
-            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed`);
+            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed or module absent`);
           }
           continue;
         }
@@ -17463,7 +17463,7 @@ export default function define(runtime, observer) {
   $def("_1r7lx5s", "GitEntry", ["ensure_repo","git","fs"], _1r7lx5s);  
   $def("_yngfrp", "replay_pid_map", [], _yngfrp);  
   $def("_19c2k49", "replayGitEntries", ["modules","getVariableByPersistentId","runtime","replay_pid_map","GitEntry","realize","tag"], _19c2k49);  
-  $def("_oha4mi", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _oha4mi);  
+  $def("_7hpmkx", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _7hpmkx);  
   $def("_1ail6g2", "replay_git", ["isOnObservableCom","modules","replayGitCommits","relevant_git_commits"], _1ail6g2);  
   $def("_1rm7oy4", null, ["md"], _1rm7oy4);  
   $def("_m77twl", null, ["Inputs","exportToZip","fs","config","getCompactISODate"], _m77twl);  

--- a/notebooks/lopefeed.html
+++ b/notebooks/lopefeed.html
@@ -14952,7 +14952,7 @@ async function replayGitEntries(gitEntries, {
   return results;
 }
 )};
-const _oha4mi = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
+const _7hpmkx = function _replayGitCommits(config,parseGitMessage,moduleBaseHash,GitEntry,replayGitEntries){return(
 async function replayGitCommits(commits, {repo = config?.repo, branch = config?.branch, order = 'oldest-first'} = {}) {
   const list = Array.isArray(commits) ? commits : [];
   const ordered = order === 'newest-first' ? list.slice() : order === 'oldest-first' ? list.slice().reverse() : list.slice();
@@ -14981,10 +14981,10 @@ async function replayGitCommits(commits, {repo = config?.repo, branch = config?.
       const moduleName = p.module ?? 'main';
       if (baseHashes && baseHashes[moduleName]) {
         const currentHash = moduleBaseHash(moduleName);
-        if (currentHash && currentHash !== baseHashes[moduleName]) {
+        if (!currentHash || currentHash !== baseHashes[moduleName]) {
           if (!skippedModules.has(moduleName)) {
             skippedModules.add(moduleName);
-            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed`);
+            console.log(`[local-change-history] Skipping replay for module "${ moduleName }" — base changed or module absent`);
           }
           continue;
         }
@@ -16179,7 +16179,7 @@ export default function define(runtime, observer) {
   $def("_1r7lx5s", "GitEntry", ["ensure_repo","git","fs"], _1r7lx5s);  
   $def("_yngfrp", "replay_pid_map", [], _yngfrp);  
   $def("_19c2k49", "replayGitEntries", ["modules","getVariableByPersistentId","runtime","replay_pid_map","GitEntry","realize","tag"], _19c2k49);  
-  $def("_oha4mi", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _oha4mi);  
+  $def("_7hpmkx", "replayGitCommits", ["config","parseGitMessage","moduleBaseHash","GitEntry","replayGitEntries"], _7hpmkx);  
   $def("_1ail6g2", "replay_git", ["isOnObservableCom","modules","replayGitCommits","relevant_git_commits"], _1ail6g2);  
   $def("_1rm7oy4", null, ["md"], _1rm7oy4);  
   $def("_m77twl", null, ["Inputs","exportToZip","fs","config","getCompactISODate"], _m77twl);  


### PR DESCRIPTION
Fixes #185.

**This PR is a proposal** — the canonical HTML has been updated with the corrected cell, but ObservableHQ has not been pushed and consumer notebooks have not been re-synced yet. After approval, those steps will run and additional commits will be pushed to this branch.

## Root cause

In `@tomlarkworthy/local-change-history`, `replayGitCommits` guards each commit replay with:

```js
const currentHash = moduleBaseHash(moduleName);
if (currentHash && currentHash !== baseHashes[moduleName]) { continue; }  // skip — base changed
```

When the notebook/module was **renamed** between commit time and replay time, `moduleBaseHash(oldName)` returns `null`. The `currentHash &&` short-circuits the whole guard to falsy, so the entry is **not** skipped — it replays unconditionally. `replayGitEntries` then resolves each pid to wherever it now lives (the renamed module) and clobbers the post-rename cells with stale pre-rename definitions.

## Fix

Treat "module no longer present" as a *mismatch*, not as "no check applicable":

```js
if (!currentHash || currentHash !== baseHashes[moduleName]) { continue; }  // skip — base changed or module absent
```

A commit recorded against a module that's no longer in the DOM (renamed/removed) cannot safely apply via pid alone. Two-line diff (guard + the log message).

## Reproduction (live runtime, before fix)

Exercised the real `moduleBaseHash` against the in-the-wild rename `@tomlarkworthy/lopecode-newsletter-2026-05-16` -> `@tomlarkworthy/lopecode-newsletter-001`:

| value | result |
|---|---|
| `moduleBaseHash(currentName)` | `"_dzv27i"` (hashes fine) |
| `moduleBaseHash(oldRenamedName)` | `null` |
| buggy guard `currentHash && ...` | `false` -> **does not skip** -> stale entry replays (bug) |
| fixed guard `!currentHash \|\| ...` | `true` -> correctly skips |

## Targeted QA (live runtime)

- `replayGitCommits` redefined via `update_cell`; module recompiled cleanly. ✅
- Console after redefine: clean (no errors). ✅