### PR TITLE
Fix: editor-5 editable for runtime-created modules (reactive @tomlarkworthy/modules)

### DIFF
--- a/notebooks/@tomlarkworthy_atlas.html
+++ b/notebooks/@tomlarkworthy_atlas.html
@@ -7877,9 +7877,6 @@ async ({ cells, editedCell }) => {
 const _z9vacx = function _86(md){return(
 md`## Decompiler`
 )};
-const _kdc1xp = function _modules(moduleMap,runtime){return(
-moduleMap(runtime)
-)};
 const _gbuhyc = function _decompiled(editedCell,decompile)
 {
     if (!editedCell?.variables?.length)
@@ -8333,9 +8330,8 @@ export default function define(runtime, observer) {
   $def("_1mfm13h", "normalizeObservableClipboardCell", ["inferCellGroupNameFromOJS","escapeTemplateLiteral"], _1mfm13h);  
   $def("_1pa2xc8", "readObservableClipboardCells", ["globalThis"], _1pa2xc8);  
   $def("_1w99cbu", "pasteObservableCellsIntoModule", ["viewof liveCellMap","normalizeObservableClipboardCell","findCell","compile_and_update"], _1w99cbu);  
-  $def("_z9vacx", null, ["md"], _z9vacx);  
-  $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
-  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);  
+  $def("_z9vacx", null, ["md"], _z9vacx);
+  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
@@ -8393,7 +8389,9 @@ export default function define(runtime, observer) {
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
-  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
+  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));
+  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));
+  main.define("modules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", "modules", _));
   $def("_lbftlp", "literalCompletions", ["codemirror"], _lbftlp);  
   $def("_scoiwp", "completionFixture", ["EditorState","observableJS_language","literalCompletions"], _scoiwp);  
   $def("_160qhf1", "test_completion_string_literal", ["completionFixture"], _160qhf1);  

--- a/notebooks/@tomlarkworthy_atproto-comments.html
+++ b/notebooks/@tomlarkworthy_atproto-comments.html
@@ -7048,9 +7048,6 @@ async ({ cells, editedCell }) => {
 const _z9vacx = function _86(md){return(
 md`## Decompiler`
 )};
-const _kdc1xp = function _modules(moduleMap,runtime){return(
-moduleMap(runtime)
-)};
 const _gbuhyc = function _decompiled(editedCell,decompile)
 {
     if (!editedCell?.variables?.length)
@@ -7504,9 +7501,8 @@ export default function define(runtime, observer) {
   $def("_1mfm13h", "normalizeObservableClipboardCell", ["inferCellGroupNameFromOJS","escapeTemplateLiteral"], _1mfm13h);  
   $def("_1pa2xc8", "readObservableClipboardCells", ["globalThis"], _1pa2xc8);  
   $def("_1w99cbu", "pasteObservableCellsIntoModule", ["viewof liveCellMap","normalizeObservableClipboardCell","findCell","compile_and_update"], _1w99cbu);  
-  $def("_z9vacx", null, ["md"], _z9vacx);  
-  $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
-  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);  
+  $def("_z9vacx", null, ["md"], _z9vacx);
+  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
@@ -7564,7 +7560,9 @@ export default function define(runtime, observer) {
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
-  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
+  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));
+  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));
+  main.define("modules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", "modules", _));
   $def("_lbftlp", "literalCompletions", ["codemirror"], _lbftlp);  
   $def("_scoiwp", "completionFixture", ["EditorState","observableJS_language","literalCompletions"], _scoiwp);  
   $def("_160qhf1", "test_completion_string_literal", ["completionFixture"], _160qhf1);  

--- a/notebooks/@tomlarkworthy_blank-notebook.html
+++ b/notebooks/@tomlarkworthy_blank-notebook.html
@@ -6939,9 +6939,6 @@ async ({ cells, editedCell }) => {
 const _z9vacx = function _86(md){return(
 md`## Decompiler`
 )};
-const _kdc1xp = function _modules(moduleMap,runtime){return(
-moduleMap(runtime)
-)};
 const _gbuhyc = function _decompiled(editedCell,decompile)
 {
     if (!editedCell?.variables?.length)
@@ -7395,9 +7392,8 @@ export default function define(runtime, observer) {
   $def("_1mfm13h", "normalizeObservableClipboardCell", ["inferCellGroupNameFromOJS","escapeTemplateLiteral"], _1mfm13h);  
   $def("_1pa2xc8", "readObservableClipboardCells", ["globalThis"], _1pa2xc8);  
   $def("_1w99cbu", "pasteObservableCellsIntoModule", ["viewof liveCellMap","normalizeObservableClipboardCell","findCell","compile_and_update"], _1w99cbu);  
-  $def("_z9vacx", null, ["md"], _z9vacx);  
-  $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
-  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);  
+  $def("_z9vacx", null, ["md"], _z9vacx);
+  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
@@ -7455,7 +7451,9 @@ export default function define(runtime, observer) {
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
-  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
+  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));
+  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));
+  main.define("modules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", "modules", _));
   $def("_lbftlp", "literalCompletions", ["codemirror"], _lbftlp);  
   $def("_scoiwp", "completionFixture", ["EditorState","observableJS_language","literalCompletions"], _scoiwp);  
   $def("_160qhf1", "test_completion_string_literal", ["completionFixture"], _160qhf1);  

--- a/notebooks/@tomlarkworthy_bootloader.html
+++ b/notebooks/@tomlarkworthy_bootloader.html
@@ -7156,9 +7156,6 @@ async ({ cells, editedCell }) => {
 const _z9vacx = function _86(md){return(
 md`## Decompiler`
 )};
-const _kdc1xp = function _modules(moduleMap,runtime){return(
-moduleMap(runtime)
-)};
 const _gbuhyc = function _decompiled(editedCell,decompile)
 {
     if (!editedCell?.variables?.length)
@@ -7612,9 +7609,8 @@ export default function define(runtime, observer) {
   $def("_1mfm13h", "normalizeObservableClipboardCell", ["inferCellGroupNameFromOJS","escapeTemplateLiteral"], _1mfm13h);  
   $def("_1pa2xc8", "readObservableClipboardCells", ["globalThis"], _1pa2xc8);  
   $def("_1w99cbu", "pasteObservableCellsIntoModule", ["viewof liveCellMap","normalizeObservableClipboardCell","findCell","compile_and_update"], _1w99cbu);  
-  $def("_z9vacx", null, ["md"], _z9vacx);  
-  $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
-  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);  
+  $def("_z9vacx", null, ["md"], _z9vacx);
+  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
@@ -7672,7 +7668,9 @@ export default function define(runtime, observer) {
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
-  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
+  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));
+  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));
+  main.define("modules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", "modules", _));
   $def("_lbftlp", "literalCompletions", ["codemirror"], _lbftlp);  
   $def("_scoiwp", "completionFixture", ["EditorState","observableJS_language","literalCompletions"], _scoiwp);  
   $def("_160qhf1", "test_completion_string_literal", ["completionFixture"], _160qhf1);  

--- a/notebooks/@tomlarkworthy_cell-map.html
+++ b/notebooks/@tomlarkworthy_cell-map.html
@@ -6904,9 +6904,6 @@ async ({ cells, editedCell }) => {
 const _z9vacx = function _86(md){return(
 md`## Decompiler`
 )};
-const _kdc1xp = function _modules(moduleMap,runtime){return(
-moduleMap(runtime)
-)};
 const _gbuhyc = function _decompiled(editedCell,decompile)
 {
     if (!editedCell?.variables?.length)
@@ -7360,9 +7357,8 @@ export default function define(runtime, observer) {
   $def("_1mfm13h", "normalizeObservableClipboardCell", ["inferCellGroupNameFromOJS","escapeTemplateLiteral"], _1mfm13h);  
   $def("_1pa2xc8", "readObservableClipboardCells", ["globalThis"], _1pa2xc8);  
   $def("_1w99cbu", "pasteObservableCellsIntoModule", ["viewof liveCellMap","normalizeObservableClipboardCell","findCell","compile_and_update"], _1w99cbu);  
-  $def("_z9vacx", null, ["md"], _z9vacx);  
-  $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
-  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);  
+  $def("_z9vacx", null, ["md"], _z9vacx);
+  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
@@ -7420,7 +7416,9 @@ export default function define(runtime, observer) {
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
-  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
+  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));
+  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));
+  main.define("modules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", "modules", _));
   $def("_lbftlp", "literalCompletions", ["codemirror"], _lbftlp);  
   $def("_scoiwp", "completionFixture", ["EditorState","observableJS_language","literalCompletions"], _scoiwp);  
   $def("_160qhf1", "test_completion_string_literal", ["completionFixture"], _160qhf1);  

--- a/notebooks/@tomlarkworthy_cells-to-clipboard.html
+++ b/notebooks/@tomlarkworthy_cells-to-clipboard.html
@@ -6917,9 +6917,6 @@ async ({ cells, editedCell }) => {
 const _z9vacx = function _86(md){return(
 md`## Decompiler`
 )};
-const _kdc1xp = function _modules(moduleMap,runtime){return(
-moduleMap(runtime)
-)};
 const _gbuhyc = function _decompiled(editedCell,decompile)
 {
     if (!editedCell?.variables?.length)
@@ -7373,9 +7370,8 @@ export default function define(runtime, observer) {
   $def("_1mfm13h", "normalizeObservableClipboardCell", ["inferCellGroupNameFromOJS","escapeTemplateLiteral"], _1mfm13h);  
   $def("_1pa2xc8", "readObservableClipboardCells", ["globalThis"], _1pa2xc8);  
   $def("_1w99cbu", "pasteObservableCellsIntoModule", ["viewof liveCellMap","normalizeObservableClipboardCell","findCell","compile_and_update"], _1w99cbu);  
-  $def("_z9vacx", null, ["md"], _z9vacx);  
-  $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
-  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);  
+  $def("_z9vacx", null, ["md"], _z9vacx);
+  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
@@ -7433,7 +7429,9 @@ export default function define(runtime, observer) {
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
-  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
+  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));
+  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));
+  main.define("modules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", "modules", _));
   $def("_lbftlp", "literalCompletions", ["codemirror"], _lbftlp);  
   $def("_scoiwp", "completionFixture", ["EditorState","observableJS_language","literalCompletions"], _scoiwp);  
   $def("_160qhf1", "test_completion_string_literal", ["completionFixture"], _160qhf1);  

--- a/notebooks/@tomlarkworthy_claude-code-pairing.html
+++ b/notebooks/@tomlarkworthy_claude-code-pairing.html
@@ -6906,9 +6906,6 @@ async ({ cells, editedCell }) => {
 const _z9vacx = function _86(md){return(
 md`## Decompiler`
 )};
-const _kdc1xp = function _modules(moduleMap,runtime){return(
-moduleMap(runtime)
-)};
 const _gbuhyc = function _decompiled(editedCell,decompile)
 {
     if (!editedCell?.variables?.length)
@@ -7362,9 +7359,8 @@ export default function define(runtime, observer) {
   $def("_1mfm13h", "normalizeObservableClipboardCell", ["inferCellGroupNameFromOJS","escapeTemplateLiteral"], _1mfm13h);  
   $def("_1pa2xc8", "readObservableClipboardCells", ["globalThis"], _1pa2xc8);  
   $def("_1w99cbu", "pasteObservableCellsIntoModule", ["viewof liveCellMap","normalizeObservableClipboardCell","findCell","compile_and_update"], _1w99cbu);  
-  $def("_z9vacx", null, ["md"], _z9vacx);  
-  $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
-  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);  
+  $def("_z9vacx", null, ["md"], _z9vacx);
+  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
@@ -7422,7 +7418,9 @@ export default function define(runtime, observer) {
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
-  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
+  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));
+  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));
+  main.define("modules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", "modules", _));
   $def("_lbftlp", "literalCompletions", ["codemirror"], _lbftlp);  
   $def("_scoiwp", "completionFixture", ["EditorState","observableJS_language","literalCompletions"], _scoiwp);  
   $def("_160qhf1", "test_completion_string_literal", ["completionFixture"], _160qhf1);  

--- a/notebooks/@tomlarkworthy_codemirror-6-v2.html
+++ b/notebooks/@tomlarkworthy_codemirror-6-v2.html
@@ -6906,9 +6906,6 @@ async ({ cells, editedCell }) => {
 const _z9vacx = function _86(md){return(
 md`## Decompiler`
 )};
-const _kdc1xp = function _modules(moduleMap,runtime){return(
-moduleMap(runtime)
-)};
 const _gbuhyc = function _decompiled(editedCell,decompile)
 {
     if (!editedCell?.variables?.length)
@@ -7362,9 +7359,8 @@ export default function define(runtime, observer) {
   $def("_1mfm13h", "normalizeObservableClipboardCell", ["inferCellGroupNameFromOJS","escapeTemplateLiteral"], _1mfm13h);  
   $def("_1pa2xc8", "readObservableClipboardCells", ["globalThis"], _1pa2xc8);  
   $def("_1w99cbu", "pasteObservableCellsIntoModule", ["viewof liveCellMap","normalizeObservableClipboardCell","findCell","compile_and_update"], _1w99cbu);  
-  $def("_z9vacx", null, ["md"], _z9vacx);  
-  $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
-  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);  
+  $def("_z9vacx", null, ["md"], _z9vacx);
+  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
@@ -7422,7 +7418,9 @@ export default function define(runtime, observer) {
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
-  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
+  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));
+  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));
+  main.define("modules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", "modules", _));
   $def("_lbftlp", "literalCompletions", ["codemirror"], _lbftlp);  
   $def("_scoiwp", "completionFixture", ["EditorState","observableJS_language","literalCompletions"], _scoiwp);  
   $def("_160qhf1", "test_completion_string_literal", ["completionFixture"], _160qhf1);  

--- a/notebooks/@tomlarkworthy_command-palette.html
+++ b/notebooks/@tomlarkworthy_command-palette.html
@@ -7538,11 +7538,10 @@ lookupVariable(
   editorModule
 )
 )};
-const _hqns12 = function _cellEditor(cloneDataflow,editorTemplate,shellTemplate,createCell,findCell,pinOnCreate,getOption,Event,setOption)
-{
-  return (variable, {
+const _1q95xt6 = function _cellEditor(cloneDataflow,editorTemplate,shellTemplate,getOption,Event,setOption,createCell,findCell,pinOnCreate){return(
+(variable, {
     pinned = undefined
-  } = {}) => {
+} = {}) => {
     const host = document.createElement('div');
     let shellDispose = null;
     let heavyDispose = null;
@@ -7550,132 +7549,132 @@ const _hqns12 = function _cellEditor(cloneDataflow,editorTemplate,shellTemplate,
     let shellEl = null;
     let body = null;
     const clearBody = () => {
-      if (body)
-        body.replaceChildren();
+        if (body)
+            body.replaceChildren();
     };
     const closeHeavy = () => {
-      if (heavyDispose) {
-        heavyDispose();
-        heavyDispose = null;
-      }
-      clearBody();
+        if (heavyDispose) {
+            heavyDispose();
+            heavyDispose = null;
+        }
+        clearBody();
     };
     const openHeavy = () => {
-      if (heavyDispose)
-        return;
-      if (!body)
-        return;
-      heavyDispose = cloneDataflow(editorTemplate, name => {
-        if (name === 'editor_panel') {
-          return {
-            fulfilled: element => {
-              if (!element)
-                return;
-              if (!body)
-                return;
-              if (body.firstChild !== element || body.childNodes.length !== 1) {
-                body.replaceChildren(element);
-              }
+        if (heavyDispose)
+            return;
+        if (!body)
+            return;
+        heavyDispose = cloneDataflow(editorTemplate, name => {
+            if (name === 'editor_panel') {
+                return {
+                    fulfilled: element => {
+                        if (!element)
+                            return;
+                        if (!body)
+                            return;
+                        if (body.firstChild !== element || body.childNodes.length !== 1) {
+                            body.replaceChildren(element);
+                        }
+                    }
+                };
             }
-          };
-        }
-        if (name === 'selectVariable') {
-          return {
-            fulfilled: selectVariable => {
-              if (typeof selectVariable !== 'function')
-                return;
-              selectVariable(variable);
+            if (name === 'selectVariable') {
+                return {
+                    fulfilled: selectVariable => {
+                        if (typeof selectVariable !== 'function')
+                            return;
+                        selectVariable(variable);
+                    }
+                };
             }
-          };
-        }
-        return {};
-      });
+            return {};
+        });
     };
     const syncOpen = () => {
-      const open = !!(editView && editView.value);
-      if (open)
-        openHeavy();
-      else
-        closeHeavy();
-      if (shellEl) {
-        const bodyEl = shellEl.querySelector('.cell-editor-body');
-        if (bodyEl)
-          bodyEl.style.display = open ? 'block' : 'none';
-      }
+        const open = !!(editView && editView.value);
+        if (open)
+            openHeavy();
+        else
+            closeHeavy();
+        if (shellEl) {
+            const bodyEl = shellEl.querySelector('.cell-editor-body');
+            if (bodyEl)
+                bodyEl.style.display = open ? 'block' : 'none';
+        }
     };
     shellDispose = cloneDataflow(shellTemplate, name => {
-      if (name === 'hotbar_shell') {
-        return {
-          fulfilled: element => {
-            if (!element)
-              return;
-            shellEl = element;
-            host.replaceChildren(element);
-            body = element.querySelector('.cell-editor-body');
-            // Lightweight "add cell below" on the always-present shell,
-            // so a cell can be inserted without opening the heavy editor.
-            const hotbar = element.querySelector('.hotbar');
-            if (hotbar && !hotbar.querySelector('.add-cell-btn')) {
-              const add = document.createElement('span');
-              add.className = 'add-cell-btn';
-              add.textContent = '\u2795';
-              add.title = 'Add cell below';
-              add.style.cssText = 'cursor: pointer; margin-right: 6px;';
-              add.tabIndex = -1;
-              add.addEventListener('mousedown', e => e.preventDefault());
-              add.addEventListener('click', e => {
-                e.stopPropagation();
-                createCell({ cell: findCell(variable) });
-              });
-              hotbar.prepend(add);
-            }
-            if (body)
-              syncOpen();
-          }
-        };
-      }
-      if (name === 'selectVariable') {
-        return {
-          fulfilled: selectVariable => {
-            if (typeof selectVariable !== 'function')
-              return;
-            selectVariable(variable);
-          }
-        };
-      }
-      if (name === 'viewof edit') {
-        return {
-          fulfilled: view => {
-            if (!view)
-              return;
-            editView = view;
-            const forceOpen = !!(variable?.pid && pinOnCreate.has(variable.pid));
-            if (forceOpen)
-              pinOnCreate.delete(variable.pid);
-            const resolved_pinned = forceOpen || !!getOption(variable, 'pinned', pinned);
-            view.value = resolved_pinned;
-            view.dispatchEvent(new Event('input'));
-            syncOpen();
-            view.addEventListener('input', () => {
-              const next = !!view.value;
-              setOption(variable, 'pinned', next);
-              syncOpen();
-            });
-          }
-        };
-      }
-      return {};
+        if (name === 'hotbar_shell') {
+            return {
+                fulfilled: element => {
+                    if (!element)
+                        return;
+                    shellEl = element;
+                    host.replaceChildren(element);
+                    body = element.querySelector('.cell-editor-body');
+                    // Lightweight "add cell below" on the always-present shell,
+                    // so a cell can be inserted without opening the heavy editor.
+                    const hotbar = element.querySelector('.hotbar');
+                    if (hotbar && !hotbar.querySelector('.add-cell-btn')) {
+                        const add = document.createElement('span');
+                        add.className = 'add-cell-btn';
+                        add.textContent = '➕';
+                        add.title = 'Add cell below';
+                        add.style.cssText = 'cursor: pointer; margin-right: 6px;';
+                        add.tabIndex = -1;
+                        add.addEventListener('mousedown', e => e.preventDefault());
+                        add.addEventListener('click', e => {
+                            e.stopPropagation();
+                            createCell({ cell: findCell(variable) });
+                        });
+                        hotbar.prepend(add);
+                    }
+                    if (body)
+                        syncOpen();
+                }
+            };
+        }
+        if (name === 'selectVariable') {
+            return {
+                fulfilled: selectVariable => {
+                    if (typeof selectVariable !== 'function')
+                        return;
+                    selectVariable(variable);
+                }
+            };
+        }
+        if (name === 'viewof edit') {
+            return {
+                fulfilled: view => {
+                    if (!view)
+                        return;
+                    editView = view;
+                    const forceOpen = !!(variable?.pid && pinOnCreate.has(variable.pid));
+                    if (forceOpen)
+                        pinOnCreate.delete(variable.pid);
+                    const resolved_pinned = forceOpen || !!getOption(variable, 'pinned', pinned);
+                    view.value = resolved_pinned;
+                    view.dispatchEvent(new Event('input'));
+                    syncOpen();
+                    view.addEventListener('input', () => {
+                        const next = !!view.value;
+                        setOption(variable, 'pinned', next);
+                        syncOpen();
+                    });
+                }
+            };
+        }
+        return {};
     });
     host.dispose = () => {
-      closeHeavy();
-      if (shellDispose) {
-        shellDispose();
-        shellDispose = null;
-      }
+        closeHeavy();
+        if (shellDispose) {
+            shellDispose();
+            shellDispose = null;
+        }
     };
     return host;
-  };
-};
+}
+)};
 const _x5ixji = function _hotbar_shell($0,Event,htl,edit)
 {
   const toggle = () => {
@@ -8121,6 +8120,9 @@ async (cell, amount) =>
     }
   })
 )};
+const _pinoncr = function _pinOnCreate(){return(
+new Set()  // variable pids to open (pin) their editor as soon as the cell mounts
+)};
 const _19znal9 = function _createCell($0){return(
 async ({cell, source = "{}" } = {}) =>
   $0.send({
@@ -8182,71 +8184,69 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _1efmn99 = async function _command_processor(command,$0,compile_and_update,pinOnCreate,selectVariable,remove_variables,$1,findCellIndex,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,$2)
+const _2pkmxz = async function _command_processor(command,$0,compile_and_update,remove_variables,$1,findCellIndex,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2,pinOnCreate)
 {
-  if (command.processed)
-    return;
-  let result = undefined;
-  if (command.command == 'createCell') {
-    $0.value = true;
-    // Mark the new variable's pid (identity-stable, no cell-map lookup) so its
-    // cellEditor opens pinned as soon as auto_attach mounts the shell. Keyed by
-    // pid because findCell() lags one reactive tick behind creation here.
-    const newVars = [];
-    result = await compile_and_update('{}', newVars, command.args.cell);
-    const nv = newVars[0];
-    if (nv?.pid)
-      pinOnCreate.add(nv.pid);
-    if (nv)
-      await selectVariable(nv);
-  } else if (command.command == 'deleteCell') {
-    remove_variables(command.args.cell.variables);
-    result = true;
-  } else if (command.command == 'moveCell') {
-    const cellList = $1.value.get(command.args.cell.module.module);
-    const cellIndex = findCellIndex(command.args.cell.variables, cellList);
-    const targetCellIndex = cellIndex + command.args.amount;
-    const targetCell = lookupCellByIndex(targetCellIndex, cellList);
-    if (targetCell) {
-      const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
-      const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-      const change = targetFirstVariableIndex - currentFirstVariableIndex;
-      const dom = command.args.cell.dom;
-      const preY = dom?.getBoundingClientRect?.().top;
-      command.args.cell.variables.forEach(v => {
-        const currentIndex = findVariableIndex(v);
-        repositionSetElement(runtime._variables, v, currentIndex + change);
-      });
-      await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
-      // Keep moved cell at same screen position so neighbours shift around it.
-      // Cells here have wildly varying heights (some embed 500+ px iframes), so
-      // a one-position move can otherwise jump hundreds of pixels (#163). Poll
-      // for syncers' reactive DOM reorder before measuring postY — the chain
-      // runs on macrotasks, so requestAnimationFrame is not sufficient.
-      if (preY != null && dom?.isConnected) {
-        let postY = preY;
-        for (let i = 0; i < 30 && postY === preY; i++) {
-          await new Promise(r => setTimeout(r, 50));
-          if (!dom.isConnected)
-            break;
-          postY = dom.getBoundingClientRect().top;
+    if (command.processed)
+        return;
+    let result = undefined;
+    if (command.command == 'createCell') {
+        $0.value = true;
+        // Mark the new variable's pid (identity-stable, no cell-map lookup) so its
+        // cellEditor opens pinned as soon as auto_attach mounts the shell. Keyed by
+        // pid because findCell() lags one reactive tick behind creation here.
+        const newVars = [];
+        result = await compile_and_update('{}', newVars, command.args.cell);
+        const nv = newVars[0];
+        if (nv?.pid) pinOnCreate.add(nv.pid);
+        if (nv) await selectVariable(nv);
+    } else if (command.command == 'deleteCell') {
+        remove_variables(command.args.cell.variables);
+        result = true;
+    } else if (command.command == 'moveCell') {
+        const cellList = $1.value.get(command.args.cell.module.module);
+        const cellIndex = findCellIndex(command.args.cell.variables, cellList);
+        const targetCellIndex = cellIndex + command.args.amount;
+        const targetCell = lookupCellByIndex(targetCellIndex, cellList);
+        if (targetCell) {
+            const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+            const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+            const change = targetFirstVariableIndex - currentFirstVariableIndex;
+            const dom = command.args.cell.dom;
+            const preY = dom?.getBoundingClientRect?.().top;
+            command.args.cell.variables.forEach(v => {
+                const currentIndex = findVariableIndex(v);
+                repositionSetElement(runtime._variables, v, currentIndex + change);
+            });
+            await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+            // Keep moved cell at same screen position so neighbours shift around it.
+            // Cells here have wildly varying heights (some embed 500+ px iframes), so
+            // a one-position move can otherwise jump hundreds of pixels (#163). Poll
+            // for syncers' reactive DOM reorder before measuring postY — the chain
+            // runs on macrotasks, so requestAnimationFrame is not sufficient.
+            if (preY != null && dom?.isConnected) {
+                let postY = preY;
+                for (let i = 0; i < 30 && postY === preY; i++) {
+                    await new Promise(r => setTimeout(r, 50));
+                    if (!dom.isConnected)
+                        break;
+                    postY = dom.getBoundingClientRect().top;
+                }
+                const delta = postY - preY;
+                if (delta !== 0) {
+                    const scroller = dom.closest('.lm_content') || document.scrollingElement;
+                    scroller?.scrollBy?.({
+                        top: delta,
+                        behavior: 'instant'
+                    });
+                }
+            }
         }
-        const delta = postY - preY;
-        if (delta !== 0) {
-          const scroller = dom.closest('.lm_content') || document.scrollingElement;
-          scroller?.scrollBy?.({
-            top: delta,
-            behavior: 'instant'
-          });
-        }
-      }
+        result = true;
     }
-    result = true;
-  }
-  if (result) {
-    command.processed = true;
-    $2.resolve(result);
-  }
+    if (result) {
+        command.processed = true;
+        $2.resolve(result);
+    }
 };
 const _8iz5z2 = function _59(md){return(
 md`### UI Action`
@@ -8904,9 +8904,6 @@ async ({ cells, editedCell }) => {
 const _z9vacx = function _86(md){return(
 md`## Decompiler`
 )};
-const _kdc1xp = function _modules(moduleMap,runtime){return(
-moduleMap(runtime)
-)};
 const _gbuhyc = function _decompiled(editedCell,decompile)
 {
     if (!editedCell?.variables?.length)
@@ -9231,11 +9228,6 @@ const _bz6mai = function _test_completion_identifier_deferred(completionFixture)
     throw new Error('bare identifier (no dot) must defer');
   return 'identifier / no-dot bases deferred to the identifier-chain path';
 };
-const _y8yyf = function _pinOnCreate()
-{
-  return new Set()  // variable pids to open (pin) their editor as soon as the cell mounts
-;
-};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -9279,7 +9271,7 @@ export default function define(runtime, observer) {
   $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
   $def("_16ks4jz", null, ["md"], _16ks4jz);  
   $def("_199ztvl", "hotbarTemplate", ["lookupVariable","editorModule"], _199ztvl);  
-  $def("_hqns12", "cellEditor", ["cloneDataflow","editorTemplate","shellTemplate","createCell","findCell","pinOnCreate","getOption","Event","setOption"], _hqns12);  
+  $def("_1q95xt6", "cellEditor", ["cloneDataflow","editorTemplate","shellTemplate","getOption","Event","setOption","createCell","findCell","pinOnCreate"], _1q95xt6);
   $def("_x5ixji", "hotbar_shell", ["viewof edit","Event","htl","edit"], _x5ixji);  
   $def("_1ed5zb9", "editor_panel", ["viewof editedCell","htl","toolbar","nav","reversibleAttach","combine","code_editor"], _1ed5zb9);  
   $def("_yk7udl", "shellTemplate", ["viewof editedCell","editedCell","selectVariable","viewof edit","edit","hotbar_shell","lookupVariable","editorModule"], _yk7udl);  
@@ -9324,7 +9316,8 @@ export default function define(runtime, observer) {
   $def("_xvo1n6", "code_editor", ["code_editor_view"], _xvo1n6);  
   $def("_1imarq2", null, ["md"], _1imarq2);  
   $def("_470wv4", "moveCell", ["viewof command"], _470wv4);  
-  $def("_19znal9", "createCell", ["viewof command"], _19znal9);  
+  $def("_pinoncr", "pinOnCreate", [], _pinoncr);
+  $def("_19znal9", "createCell", ["viewof command"], _19znal9);
   $def("_d9nzys", "deleteCell", ["viewof command"], _d9nzys);  
   $def("_1toku21", null, ["md"], _1toku21);  
   $def("_d7ouqx", "viewof command", ["flowQueue"], _d7ouqx);  
@@ -9334,7 +9327,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_1efmn99", "command_processor", ["command","viewof edit","compile_and_update","pinOnCreate","selectVariable","remove_variables","viewof liveCellMap","findCellIndex","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","viewof command"], _1efmn99);  
+  $def("_2pkmxz", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","viewof liveCellMap","findCellIndex","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command","pinOnCreate"], _2pkmxz);  
   $def("_8iz5z2", null, ["md"], _8iz5z2);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -9364,9 +9357,8 @@ export default function define(runtime, observer) {
   $def("_1mfm13h", "normalizeObservableClipboardCell", ["inferCellGroupNameFromOJS","escapeTemplateLiteral"], _1mfm13h);  
   $def("_1pa2xc8", "readObservableClipboardCells", ["globalThis"], _1pa2xc8);  
   $def("_1w99cbu", "pasteObservableCellsIntoModule", ["viewof liveCellMap","normalizeObservableClipboardCell","findCell","compile_and_update"], _1w99cbu);  
-  $def("_z9vacx", null, ["md"], _z9vacx);  
-  $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
-  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);  
+  $def("_z9vacx", null, ["md"], _z9vacx);
+  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
@@ -9424,7 +9416,9 @@ export default function define(runtime, observer) {
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
-  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
+  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));
+  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));
+  main.define("modules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", "modules", _));
   $def("_lbftlp", "literalCompletions", ["codemirror"], _lbftlp);  
   $def("_scoiwp", "completionFixture", ["EditorState","observableJS_language","literalCompletions"], _scoiwp);  
   $def("_160qhf1", "test_completion_string_literal", ["completionFixture"], _160qhf1);  
@@ -9434,8 +9428,7 @@ export default function define(runtime, observer) {
   $def("_quyccp", "test_completion_bool_template_regexp", ["completionFixture"], _quyccp);  
   $def("_1cn3ucr", "test_completion_parenthesised_unwrap", ["completionFixture"], _1cn3ucr);  
   $def("_15vxhca", "test_completion_never_evaluates", ["completionFixture"], _15vxhca);  
-  $def("_bz6mai", "test_completion_identifier_deferred", ["completionFixture"], _bz6mai);  
-  $def("_y8yyf", "pinOnCreate", [], _y8yyf);
+  $def("_bz6mai", "test_completion_identifier_deferred", ["completionFixture"], _bz6mai);
   return main;
 }</script>
 <script id="@tomlarkworthy/escodegen/escodegen.browser.min.js.gz" 

--- a/notebooks/@tomlarkworthy_dataflow-templating.html
+++ b/notebooks/@tomlarkworthy_dataflow-templating.html
@@ -6906,9 +6906,6 @@ async ({ cells, editedCell }) => {
 const _z9vacx = function _86(md){return(
 md`## Decompiler`
 )};
-const _kdc1xp = function _modules(moduleMap,runtime){return(
-moduleMap(runtime)
-)};
 const _gbuhyc = function _decompiled(editedCell,decompile)
 {
     if (!editedCell?.variables?.length)
@@ -7362,9 +7359,8 @@ export default function define(runtime, observer) {
   $def("_1mfm13h", "normalizeObservableClipboardCell", ["inferCellGroupNameFromOJS","escapeTemplateLiteral"], _1mfm13h);  
   $def("_1pa2xc8", "readObservableClipboardCells", ["globalThis"], _1pa2xc8);  
   $def("_1w99cbu", "pasteObservableCellsIntoModule", ["viewof liveCellMap","normalizeObservableClipboardCell","findCell","compile_and_update"], _1w99cbu);  
-  $def("_z9vacx", null, ["md"], _z9vacx);  
-  $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
-  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);  
+  $def("_z9vacx", null, ["md"], _z9vacx);
+  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
@@ -7422,7 +7418,9 @@ export default function define(runtime, observer) {
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
-  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
+  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));
+  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));
+  main.define("modules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", "modules", _));
   $def("_lbftlp", "literalCompletions", ["codemirror"], _lbftlp);  
   $def("_scoiwp", "completionFixture", ["EditorState","observableJS_language","literalCompletions"], _scoiwp);  
   $def("_160qhf1", "test_completion_string_literal", ["completionFixture"], _160qhf1);  

--- a/notebooks/@tomlarkworthy_debugger-2.html
+++ b/notebooks/@tomlarkworthy_debugger-2.html
@@ -8068,9 +8068,6 @@ async ({ cells, editedCell }) => {
 const _z9vacx = function _86(md){return(
 md`## Decompiler`
 )};
-const _kdc1xp = function _modules(moduleMap,runtime){return(
-moduleMap(runtime)
-)};
 const _gbuhyc = function _decompiled(editedCell,decompile)
 {
     if (!editedCell?.variables?.length)
@@ -8524,9 +8521,8 @@ export default function define(runtime, observer) {
   $def("_1mfm13h", "normalizeObservableClipboardCell", ["inferCellGroupNameFromOJS","escapeTemplateLiteral"], _1mfm13h);  
   $def("_1pa2xc8", "readObservableClipboardCells", ["globalThis"], _1pa2xc8);  
   $def("_1w99cbu", "pasteObservableCellsIntoModule", ["viewof liveCellMap","normalizeObservableClipboardCell","findCell","compile_and_update"], _1w99cbu);  
-  $def("_z9vacx", null, ["md"], _z9vacx);  
-  $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
-  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);  
+  $def("_z9vacx", null, ["md"], _z9vacx);
+  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
@@ -8584,7 +8580,9 @@ export default function define(runtime, observer) {
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
-  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
+  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));
+  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));
+  main.define("modules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", "modules", _));
   $def("_lbftlp", "literalCompletions", ["codemirror"], _lbftlp);  
   $def("_scoiwp", "completionFixture", ["EditorState","observableJS_language","literalCompletions"], _scoiwp);  
   $def("_160qhf1", "test_completion_string_literal", ["completionFixture"], _160qhf1);  

--- a/notebooks/@tomlarkworthy_debugger.html
+++ b/notebooks/@tomlarkworthy_debugger.html
@@ -7327,9 +7327,6 @@ async ({ cells, editedCell }) => {
 const _z9vacx = function _86(md){return(
 md`## Decompiler`
 )};
-const _kdc1xp = function _modules(moduleMap,runtime){return(
-moduleMap(runtime)
-)};
 const _gbuhyc = function _decompiled(editedCell,decompile)
 {
     if (!editedCell?.variables?.length)
@@ -7783,9 +7780,8 @@ export default function define(runtime, observer) {
   $def("_1mfm13h", "normalizeObservableClipboardCell", ["inferCellGroupNameFromOJS","escapeTemplateLiteral"], _1mfm13h);  
   $def("_1pa2xc8", "readObservableClipboardCells", ["globalThis"], _1pa2xc8);  
   $def("_1w99cbu", "pasteObservableCellsIntoModule", ["viewof liveCellMap","normalizeObservableClipboardCell","findCell","compile_and_update"], _1w99cbu);  
-  $def("_z9vacx", null, ["md"], _z9vacx);  
-  $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
-  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);  
+  $def("_z9vacx", null, ["md"], _z9vacx);
+  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
@@ -7843,7 +7839,9 @@ export default function define(runtime, observer) {
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
-  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
+  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));
+  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));
+  main.define("modules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", "modules", _));
   $def("_lbftlp", "literalCompletions", ["codemirror"], _lbftlp);  
   $def("_scoiwp", "completionFixture", ["EditorState","observableJS_language","literalCompletions"], _scoiwp);  
   $def("_160qhf1", "test_completion_string_literal", ["completionFixture"], _160qhf1);  

--- a/notebooks/@tomlarkworthy_dom-view.html
+++ b/notebooks/@tomlarkworthy_dom-view.html
@@ -6906,9 +6906,6 @@ async ({ cells, editedCell }) => {
 const _z9vacx = function _86(md){return(
 md`## Decompiler`
 )};
-const _kdc1xp = function _modules(moduleMap,runtime){return(
-moduleMap(runtime)
-)};
 const _gbuhyc = function _decompiled(editedCell,decompile)
 {
     if (!editedCell?.variables?.length)
@@ -7362,9 +7359,8 @@ export default function define(runtime, observer) {
   $def("_1mfm13h", "normalizeObservableClipboardCell", ["inferCellGroupNameFromOJS","escapeTemplateLiteral"], _1mfm13h);  
   $def("_1pa2xc8", "readObservableClipboardCells", ["globalThis"], _1pa2xc8);  
   $def("_1w99cbu", "pasteObservableCellsIntoModule", ["viewof liveCellMap","normalizeObservableClipboardCell","findCell","compile_and_update"], _1w99cbu);  
-  $def("_z9vacx", null, ["md"], _z9vacx);  
-  $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
-  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);  
+  $def("_z9vacx", null, ["md"], _z9vacx);
+  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
@@ -7422,7 +7418,9 @@ export default function define(runtime, observer) {
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
-  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
+  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));
+  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));
+  main.define("modules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", "modules", _));
   $def("_lbftlp", "literalCompletions", ["codemirror"], _lbftlp);  
   $def("_scoiwp", "completionFixture", ["EditorState","observableJS_language","literalCompletions"], _scoiwp);  
   $def("_160qhf1", "test_completion_string_literal", ["completionFixture"], _160qhf1);  

--- a/notebooks/@tomlarkworthy_editor-5.html
+++ b/notebooks/@tomlarkworthy_editor-5.html
@@ -6938,9 +6938,6 @@ async ({ cells, editedCell }) => {
 const _z9vacx = function _86(md){return(
 md`## Decompiler`
 )};
-const _kdc1xp = function _modules(moduleMap,runtime){return(
-moduleMap(runtime)
-)};
 const _gbuhyc = function _decompiled(editedCell,decompile)
 {
     if (!editedCell?.variables?.length)
@@ -7394,9 +7391,8 @@ export default function define(runtime, observer) {
   $def("_1mfm13h", "normalizeObservableClipboardCell", ["inferCellGroupNameFromOJS","escapeTemplateLiteral"], _1mfm13h);  
   $def("_1pa2xc8", "readObservableClipboardCells", ["globalThis"], _1pa2xc8);  
   $def("_1w99cbu", "pasteObservableCellsIntoModule", ["viewof liveCellMap","normalizeObservableClipboardCell","findCell","compile_and_update"], _1w99cbu);  
-  $def("_z9vacx", null, ["md"], _z9vacx);  
-  $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
-  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);  
+  $def("_z9vacx", null, ["md"], _z9vacx);
+  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
@@ -7454,7 +7450,9 @@ export default function define(runtime, observer) {
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
-  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
+  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));
+  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));
+  main.define("modules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", "modules", _));
   $def("_lbftlp", "literalCompletions", ["codemirror"], _lbftlp);  
   $def("_scoiwp", "completionFixture", ["EditorState","observableJS_language","literalCompletions"], _scoiwp);  
   $def("_160qhf1", "test_completion_string_literal", ["completionFixture"], _160qhf1);  

--- a/notebooks/@tomlarkworthy_exporter-2.html
+++ b/notebooks/@tomlarkworthy_exporter-2.html
@@ -6940,9 +6940,6 @@ async ({ cells, editedCell }) => {
 const _z9vacx = function _86(md){return(
 md`## Decompiler`
 )};
-const _kdc1xp = function _modules(moduleMap,runtime){return(
-moduleMap(runtime)
-)};
 const _gbuhyc = function _decompiled(editedCell,decompile)
 {
     if (!editedCell?.variables?.length)
@@ -7396,9 +7393,8 @@ export default function define(runtime, observer) {
   $def("_1mfm13h", "normalizeObservableClipboardCell", ["inferCellGroupNameFromOJS","escapeTemplateLiteral"], _1mfm13h);  
   $def("_1pa2xc8", "readObservableClipboardCells", ["globalThis"], _1pa2xc8);  
   $def("_1w99cbu", "pasteObservableCellsIntoModule", ["viewof liveCellMap","normalizeObservableClipboardCell","findCell","compile_and_update"], _1w99cbu);  
-  $def("_z9vacx", null, ["md"], _z9vacx);  
-  $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
-  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);  
+  $def("_z9vacx", null, ["md"], _z9vacx);
+  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
@@ -7456,7 +7452,9 @@ export default function define(runtime, observer) {
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
-  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
+  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));
+  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));
+  main.define("modules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", "modules", _));
   $def("_lbftlp", "literalCompletions", ["codemirror"], _lbftlp);  
   $def("_scoiwp", "completionFixture", ["EditorState","observableJS_language","literalCompletions"], _scoiwp);  
   $def("_160qhf1", "test_completion_string_literal", ["completionFixture"], _160qhf1);  

--- a/notebooks/@tomlarkworthy_exporter-3.html
+++ b/notebooks/@tomlarkworthy_exporter-3.html
@@ -6938,9 +6938,6 @@ async ({ cells, editedCell }) => {
 const _z9vacx = function _86(md){return(
 md`## Decompiler`
 )};
-const _kdc1xp = function _modules(moduleMap,runtime){return(
-moduleMap(runtime)
-)};
 const _gbuhyc = function _decompiled(editedCell,decompile)
 {
     if (!editedCell?.variables?.length)
@@ -7394,9 +7391,8 @@ export default function define(runtime, observer) {
   $def("_1mfm13h", "normalizeObservableClipboardCell", ["inferCellGroupNameFromOJS","escapeTemplateLiteral"], _1mfm13h);  
   $def("_1pa2xc8", "readObservableClipboardCells", ["globalThis"], _1pa2xc8);  
   $def("_1w99cbu", "pasteObservableCellsIntoModule", ["viewof liveCellMap","normalizeObservableClipboardCell","findCell","compile_and_update"], _1w99cbu);  
-  $def("_z9vacx", null, ["md"], _z9vacx);  
-  $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
-  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);  
+  $def("_z9vacx", null, ["md"], _z9vacx);
+  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
@@ -7454,7 +7450,9 @@ export default function define(runtime, observer) {
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
-  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
+  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));
+  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));
+  main.define("modules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", "modules", _));
   $def("_lbftlp", "literalCompletions", ["codemirror"], _lbftlp);  
   $def("_scoiwp", "completionFixture", ["EditorState","observableJS_language","literalCompletions"], _scoiwp);  
   $def("_160qhf1", "test_completion_string_literal", ["completionFixture"], _160qhf1);  

--- a/notebooks/@tomlarkworthy_fileattachments.html
+++ b/notebooks/@tomlarkworthy_fileattachments.html
@@ -6906,9 +6906,6 @@ async ({ cells, editedCell }) => {
 const _z9vacx = function _86(md){return(
 md`## Decompiler`
 )};
-const _kdc1xp = function _modules(moduleMap,runtime){return(
-moduleMap(runtime)
-)};
 const _gbuhyc = function _decompiled(editedCell,decompile)
 {
     if (!editedCell?.variables?.length)
@@ -7362,9 +7359,8 @@ export default function define(runtime, observer) {
   $def("_1mfm13h", "normalizeObservableClipboardCell", ["inferCellGroupNameFromOJS","escapeTemplateLiteral"], _1mfm13h);  
   $def("_1pa2xc8", "readObservableClipboardCells", ["globalThis"], _1pa2xc8);  
   $def("_1w99cbu", "pasteObservableCellsIntoModule", ["viewof liveCellMap","normalizeObservableClipboardCell","findCell","compile_and_update"], _1w99cbu);  
-  $def("_z9vacx", null, ["md"], _z9vacx);  
-  $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
-  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);  
+  $def("_z9vacx", null, ["md"], _z9vacx);
+  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
@@ -7422,7 +7418,9 @@ export default function define(runtime, observer) {
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
-  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
+  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));
+  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));
+  main.define("modules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", "modules", _));
   $def("_lbftlp", "literalCompletions", ["codemirror"], _lbftlp);  
   $def("_scoiwp", "completionFixture", ["EditorState","observableJS_language","literalCompletions"], _scoiwp);  
   $def("_160qhf1", "test_completion_string_literal", ["completionFixture"], _160qhf1);  

--- a/notebooks/@tomlarkworthy_flow-queue.html
+++ b/notebooks/@tomlarkworthy_flow-queue.html
@@ -6906,9 +6906,6 @@ async ({ cells, editedCell }) => {
 const _z9vacx = function _86(md){return(
 md`## Decompiler`
 )};
-const _kdc1xp = function _modules(moduleMap,runtime){return(
-moduleMap(runtime)
-)};
 const _gbuhyc = function _decompiled(editedCell,decompile)
 {
     if (!editedCell?.variables?.length)
@@ -7362,9 +7359,8 @@ export default function define(runtime, observer) {
   $def("_1mfm13h", "normalizeObservableClipboardCell", ["inferCellGroupNameFromOJS","escapeTemplateLiteral"], _1mfm13h);  
   $def("_1pa2xc8", "readObservableClipboardCells", ["globalThis"], _1pa2xc8);  
   $def("_1w99cbu", "pasteObservableCellsIntoModule", ["viewof liveCellMap","normalizeObservableClipboardCell","findCell","compile_and_update"], _1w99cbu);  
-  $def("_z9vacx", null, ["md"], _z9vacx);  
-  $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
-  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);  
+  $def("_z9vacx", null, ["md"], _z9vacx);
+  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
@@ -7422,7 +7418,9 @@ export default function define(runtime, observer) {
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
-  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
+  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));
+  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));
+  main.define("modules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", "modules", _));
   $def("_lbftlp", "literalCompletions", ["codemirror"], _lbftlp);  
   $def("_scoiwp", "completionFixture", ["EditorState","observableJS_language","literalCompletions"], _scoiwp);  
   $def("_160qhf1", "test_completion_string_literal", ["completionFixture"], _160qhf1);  

--- a/notebooks/@tomlarkworthy_golden-layout-2-6-0.html
+++ b/notebooks/@tomlarkworthy_golden-layout-2-6-0.html
@@ -6906,9 +6906,6 @@ async ({ cells, editedCell }) => {
 const _z9vacx = function _86(md){return(
 md`## Decompiler`
 )};
-const _kdc1xp = function _modules(moduleMap,runtime){return(
-moduleMap(runtime)
-)};
 const _gbuhyc = function _decompiled(editedCell,decompile)
 {
     if (!editedCell?.variables?.length)
@@ -7362,9 +7359,8 @@ export default function define(runtime, observer) {
   $def("_1mfm13h", "normalizeObservableClipboardCell", ["inferCellGroupNameFromOJS","escapeTemplateLiteral"], _1mfm13h);  
   $def("_1pa2xc8", "readObservableClipboardCells", ["globalThis"], _1pa2xc8);  
   $def("_1w99cbu", "pasteObservableCellsIntoModule", ["viewof liveCellMap","normalizeObservableClipboardCell","findCell","compile_and_update"], _1w99cbu);  
-  $def("_z9vacx", null, ["md"], _z9vacx);  
-  $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
-  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);  
+  $def("_z9vacx", null, ["md"], _z9vacx);
+  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
@@ -7422,7 +7418,9 @@ export default function define(runtime, observer) {
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
-  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
+  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));
+  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));
+  main.define("modules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", "modules", _));
   $def("_lbftlp", "literalCompletions", ["codemirror"], _lbftlp);  
   $def("_scoiwp", "completionFixture", ["EditorState","observableJS_language","literalCompletions"], _scoiwp);  
   $def("_160qhf1", "test_completion_string_literal", ["completionFixture"], _160qhf1);  

--- a/notebooks/@tomlarkworthy_import-notebook.html
+++ b/notebooks/@tomlarkworthy_import-notebook.html
@@ -6904,9 +6904,6 @@ async ({ cells, editedCell }) => {
 const _z9vacx = function _86(md){return(
 md`## Decompiler`
 )};
-const _kdc1xp = function _modules(moduleMap,runtime){return(
-moduleMap(runtime)
-)};
 const _gbuhyc = function _decompiled(editedCell,decompile)
 {
     if (!editedCell?.variables?.length)
@@ -7360,9 +7357,8 @@ export default function define(runtime, observer) {
   $def("_1mfm13h", "normalizeObservableClipboardCell", ["inferCellGroupNameFromOJS","escapeTemplateLiteral"], _1mfm13h);  
   $def("_1pa2xc8", "readObservableClipboardCells", ["globalThis"], _1pa2xc8);  
   $def("_1w99cbu", "pasteObservableCellsIntoModule", ["viewof liveCellMap","normalizeObservableClipboardCell","findCell","compile_and_update"], _1w99cbu);  
-  $def("_z9vacx", null, ["md"], _z9vacx);  
-  $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
-  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);  
+  $def("_z9vacx", null, ["md"], _z9vacx);
+  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
@@ -7420,7 +7416,9 @@ export default function define(runtime, observer) {
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
-  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
+  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));
+  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));
+  main.define("modules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", "modules", _));
   $def("_lbftlp", "literalCompletions", ["codemirror"], _lbftlp);  
   $def("_scoiwp", "completionFixture", ["EditorState","observableJS_language","literalCompletions"], _scoiwp);  
   $def("_160qhf1", "test_completion_string_literal", ["completionFixture"], _160qhf1);  

--- a/notebooks/@tomlarkworthy_jest-expect-standalone.html
+++ b/notebooks/@tomlarkworthy_jest-expect-standalone.html
@@ -6906,9 +6906,6 @@ async ({ cells, editedCell }) => {
 const _z9vacx = function _86(md){return(
 md`## Decompiler`
 )};
-const _kdc1xp = function _modules(moduleMap,runtime){return(
-moduleMap(runtime)
-)};
 const _gbuhyc = function _decompiled(editedCell,decompile)
 {
     if (!editedCell?.variables?.length)
@@ -7362,9 +7359,8 @@ export default function define(runtime, observer) {
   $def("_1mfm13h", "normalizeObservableClipboardCell", ["inferCellGroupNameFromOJS","escapeTemplateLiteral"], _1mfm13h);  
   $def("_1pa2xc8", "readObservableClipboardCells", ["globalThis"], _1pa2xc8);  
   $def("_1w99cbu", "pasteObservableCellsIntoModule", ["viewof liveCellMap","normalizeObservableClipboardCell","findCell","compile_and_update"], _1w99cbu);  
-  $def("_z9vacx", null, ["md"], _z9vacx);  
-  $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
-  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);  
+  $def("_z9vacx", null, ["md"], _z9vacx);
+  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
@@ -7422,7 +7418,9 @@ export default function define(runtime, observer) {
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
-  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
+  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));
+  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));
+  main.define("modules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", "modules", _));
   $def("_lbftlp", "literalCompletions", ["codemirror"], _lbftlp);  
   $def("_scoiwp", "completionFixture", ["EditorState","observableJS_language","literalCompletions"], _scoiwp);  
   $def("_160qhf1", "test_completion_string_literal", ["completionFixture"], _160qhf1);  

--- a/notebooks/@tomlarkworthy_local-change-history.html
+++ b/notebooks/@tomlarkworthy_local-change-history.html
@@ -6917,9 +6917,6 @@ async ({ cells, editedCell }) => {
 const _z9vacx = function _86(md){return(
 md`## Decompiler`
 )};
-const _kdc1xp = function _modules(moduleMap,runtime){return(
-moduleMap(runtime)
-)};
 const _gbuhyc = function _decompiled(editedCell,decompile)
 {
     if (!editedCell?.variables?.length)
@@ -7373,9 +7370,8 @@ export default function define(runtime, observer) {
   $def("_1mfm13h", "normalizeObservableClipboardCell", ["inferCellGroupNameFromOJS","escapeTemplateLiteral"], _1mfm13h);  
   $def("_1pa2xc8", "readObservableClipboardCells", ["globalThis"], _1pa2xc8);  
   $def("_1w99cbu", "pasteObservableCellsIntoModule", ["viewof liveCellMap","normalizeObservableClipboardCell","findCell","compile_and_update"], _1w99cbu);  
-  $def("_z9vacx", null, ["md"], _z9vacx);  
-  $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
-  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);  
+  $def("_z9vacx", null, ["md"], _z9vacx);
+  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
@@ -7433,7 +7429,9 @@ export default function define(runtime, observer) {
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
-  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
+  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));
+  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));
+  main.define("modules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", "modules", _));
   $def("_lbftlp", "literalCompletions", ["codemirror"], _lbftlp);  
   $def("_scoiwp", "completionFixture", ["EditorState","observableJS_language","literalCompletions"], _scoiwp);  
   $def("_160qhf1", "test_completion_string_literal", ["completionFixture"], _160qhf1);  

--- a/notebooks/@tomlarkworthy_local-storage-view.html
+++ b/notebooks/@tomlarkworthy_local-storage-view.html
@@ -6906,9 +6906,6 @@ async ({ cells, editedCell }) => {
 const _z9vacx = function _86(md){return(
 md`## Decompiler`
 )};
-const _kdc1xp = function _modules(moduleMap,runtime){return(
-moduleMap(runtime)
-)};
 const _gbuhyc = function _decompiled(editedCell,decompile)
 {
     if (!editedCell?.variables?.length)
@@ -7362,9 +7359,8 @@ export default function define(runtime, observer) {
   $def("_1mfm13h", "normalizeObservableClipboardCell", ["inferCellGroupNameFromOJS","escapeTemplateLiteral"], _1mfm13h);  
   $def("_1pa2xc8", "readObservableClipboardCells", ["globalThis"], _1pa2xc8);  
   $def("_1w99cbu", "pasteObservableCellsIntoModule", ["viewof liveCellMap","normalizeObservableClipboardCell","findCell","compile_and_update"], _1w99cbu);  
-  $def("_z9vacx", null, ["md"], _z9vacx);  
-  $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
-  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);  
+  $def("_z9vacx", null, ["md"], _z9vacx);
+  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
@@ -7422,7 +7418,9 @@ export default function define(runtime, observer) {
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
-  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
+  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));
+  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));
+  main.define("modules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", "modules", _));
   $def("_lbftlp", "literalCompletions", ["codemirror"], _lbftlp);  
   $def("_scoiwp", "completionFixture", ["EditorState","observableJS_language","literalCompletions"], _scoiwp);  
   $def("_160qhf1", "test_completion_string_literal", ["completionFixture"], _160qhf1);  

--- a/notebooks/@tomlarkworthy_lopecode-tour.html
+++ b/notebooks/@tomlarkworthy_lopecode-tour.html
@@ -9545,11 +9545,10 @@ lookupVariable(
   editorModule
 )
 )};
-const _hqns12 = function _cellEditor(cloneDataflow,editorTemplate,shellTemplate,createCell,findCell,pinOnCreate,getOption,Event,setOption)
-{
-  return (variable, {
+const _1q95xt6 = function _cellEditor(cloneDataflow,editorTemplate,shellTemplate,getOption,Event,setOption,createCell,findCell,pinOnCreate){return(
+(variable, {
     pinned = undefined
-  } = {}) => {
+} = {}) => {
     const host = document.createElement('div');
     let shellDispose = null;
     let heavyDispose = null;
@@ -9557,132 +9556,132 @@ const _hqns12 = function _cellEditor(cloneDataflow,editorTemplate,shellTemplate,
     let shellEl = null;
     let body = null;
     const clearBody = () => {
-      if (body)
-        body.replaceChildren();
+        if (body)
+            body.replaceChildren();
     };
     const closeHeavy = () => {
-      if (heavyDispose) {
-        heavyDispose();
-        heavyDispose = null;
-      }
-      clearBody();
+        if (heavyDispose) {
+            heavyDispose();
+            heavyDispose = null;
+        }
+        clearBody();
     };
     const openHeavy = () => {
-      if (heavyDispose)
-        return;
-      if (!body)
-        return;
-      heavyDispose = cloneDataflow(editorTemplate, name => {
-        if (name === 'editor_panel') {
-          return {
-            fulfilled: element => {
-              if (!element)
-                return;
-              if (!body)
-                return;
-              if (body.firstChild !== element || body.childNodes.length !== 1) {
-                body.replaceChildren(element);
-              }
+        if (heavyDispose)
+            return;
+        if (!body)
+            return;
+        heavyDispose = cloneDataflow(editorTemplate, name => {
+            if (name === 'editor_panel') {
+                return {
+                    fulfilled: element => {
+                        if (!element)
+                            return;
+                        if (!body)
+                            return;
+                        if (body.firstChild !== element || body.childNodes.length !== 1) {
+                            body.replaceChildren(element);
+                        }
+                    }
+                };
             }
-          };
-        }
-        if (name === 'selectVariable') {
-          return {
-            fulfilled: selectVariable => {
-              if (typeof selectVariable !== 'function')
-                return;
-              selectVariable(variable);
+            if (name === 'selectVariable') {
+                return {
+                    fulfilled: selectVariable => {
+                        if (typeof selectVariable !== 'function')
+                            return;
+                        selectVariable(variable);
+                    }
+                };
             }
-          };
-        }
-        return {};
-      });
+            return {};
+        });
     };
     const syncOpen = () => {
-      const open = !!(editView && editView.value);
-      if (open)
-        openHeavy();
-      else
-        closeHeavy();
-      if (shellEl) {
-        const bodyEl = shellEl.querySelector('.cell-editor-body');
-        if (bodyEl)
-          bodyEl.style.display = open ? 'block' : 'none';
-      }
+        const open = !!(editView && editView.value);
+        if (open)
+            openHeavy();
+        else
+            closeHeavy();
+        if (shellEl) {
+            const bodyEl = shellEl.querySelector('.cell-editor-body');
+            if (bodyEl)
+                bodyEl.style.display = open ? 'block' : 'none';
+        }
     };
     shellDispose = cloneDataflow(shellTemplate, name => {
-      if (name === 'hotbar_shell') {
-        return {
-          fulfilled: element => {
-            if (!element)
-              return;
-            shellEl = element;
-            host.replaceChildren(element);
-            body = element.querySelector('.cell-editor-body');
-            // Lightweight "add cell below" on the always-present shell,
-            // so a cell can be inserted without opening the heavy editor.
-            const hotbar = element.querySelector('.hotbar');
-            if (hotbar && !hotbar.querySelector('.add-cell-btn')) {
-              const add = document.createElement('span');
-              add.className = 'add-cell-btn';
-              add.textContent = '\u2795';
-              add.title = 'Add cell below';
-              add.style.cssText = 'cursor: pointer; margin-right: 6px;';
-              add.tabIndex = -1;
-              add.addEventListener('mousedown', e => e.preventDefault());
-              add.addEventListener('click', e => {
-                e.stopPropagation();
-                createCell({ cell: findCell(variable) });
-              });
-              hotbar.prepend(add);
-            }
-            if (body)
-              syncOpen();
-          }
-        };
-      }
-      if (name === 'selectVariable') {
-        return {
-          fulfilled: selectVariable => {
-            if (typeof selectVariable !== 'function')
-              return;
-            selectVariable(variable);
-          }
-        };
-      }
-      if (name === 'viewof edit') {
-        return {
-          fulfilled: view => {
-            if (!view)
-              return;
-            editView = view;
-            const forceOpen = !!(variable?.pid && pinOnCreate.has(variable.pid));
-            if (forceOpen)
-              pinOnCreate.delete(variable.pid);
-            const resolved_pinned = forceOpen || !!getOption(variable, 'pinned', pinned);
-            view.value = resolved_pinned;
-            view.dispatchEvent(new Event('input'));
-            syncOpen();
-            view.addEventListener('input', () => {
-              const next = !!view.value;
-              setOption(variable, 'pinned', next);
-              syncOpen();
-            });
-          }
-        };
-      }
-      return {};
+        if (name === 'hotbar_shell') {
+            return {
+                fulfilled: element => {
+                    if (!element)
+                        return;
+                    shellEl = element;
+                    host.replaceChildren(element);
+                    body = element.querySelector('.cell-editor-body');
+                    // Lightweight "add cell below" on the always-present shell,
+                    // so a cell can be inserted without opening the heavy editor.
+                    const hotbar = element.querySelector('.hotbar');
+                    if (hotbar && !hotbar.querySelector('.add-cell-btn')) {
+                        const add = document.createElement('span');
+                        add.className = 'add-cell-btn';
+                        add.textContent = '➕';
+                        add.title = 'Add cell below';
+                        add.style.cssText = 'cursor: pointer; margin-right: 6px;';
+                        add.tabIndex = -1;
+                        add.addEventListener('mousedown', e => e.preventDefault());
+                        add.addEventListener('click', e => {
+                            e.stopPropagation();
+                            createCell({ cell: findCell(variable) });
+                        });
+                        hotbar.prepend(add);
+                    }
+                    if (body)
+                        syncOpen();
+                }
+            };
+        }
+        if (name === 'selectVariable') {
+            return {
+                fulfilled: selectVariable => {
+                    if (typeof selectVariable !== 'function')
+                        return;
+                    selectVariable(variable);
+                }
+            };
+        }
+        if (name === 'viewof edit') {
+            return {
+                fulfilled: view => {
+                    if (!view)
+                        return;
+                    editView = view;
+                    const forceOpen = !!(variable?.pid && pinOnCreate.has(variable.pid));
+                    if (forceOpen)
+                        pinOnCreate.delete(variable.pid);
+                    const resolved_pinned = forceOpen || !!getOption(variable, 'pinned', pinned);
+                    view.value = resolved_pinned;
+                    view.dispatchEvent(new Event('input'));
+                    syncOpen();
+                    view.addEventListener('input', () => {
+                        const next = !!view.value;
+                        setOption(variable, 'pinned', next);
+                        syncOpen();
+                    });
+                }
+            };
+        }
+        return {};
     });
     host.dispose = () => {
-      closeHeavy();
-      if (shellDispose) {
-        shellDispose();
-        shellDispose = null;
-      }
+        closeHeavy();
+        if (shellDispose) {
+            shellDispose();
+            shellDispose = null;
+        }
     };
     return host;
-  };
-};
+}
+)};
 const _x5ixji = function _hotbar_shell($0,Event,htl,edit)
 {
   const toggle = () => {
@@ -10128,6 +10127,9 @@ async (cell, amount) =>
     }
   })
 )};
+const _pinoncr = function _pinOnCreate(){return(
+new Set()  // variable pids to open (pin) their editor as soon as the cell mounts
+)};
 const _19znal9 = function _createCell($0){return(
 async ({cell, source = "{}" } = {}) =>
   $0.send({
@@ -10189,71 +10191,69 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _1efmn99 = async function _command_processor(command,$0,compile_and_update,pinOnCreate,selectVariable,remove_variables,$1,findCellIndex,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,$2)
+const _2pkmxz = async function _command_processor(command,$0,compile_and_update,remove_variables,$1,findCellIndex,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2,pinOnCreate)
 {
-  if (command.processed)
-    return;
-  let result = undefined;
-  if (command.command == 'createCell') {
-    $0.value = true;
-    // Mark the new variable's pid (identity-stable, no cell-map lookup) so its
-    // cellEditor opens pinned as soon as auto_attach mounts the shell. Keyed by
-    // pid because findCell() lags one reactive tick behind creation here.
-    const newVars = [];
-    result = await compile_and_update('{}', newVars, command.args.cell);
-    const nv = newVars[0];
-    if (nv?.pid)
-      pinOnCreate.add(nv.pid);
-    if (nv)
-      await selectVariable(nv);
-  } else if (command.command == 'deleteCell') {
-    remove_variables(command.args.cell.variables);
-    result = true;
-  } else if (command.command == 'moveCell') {
-    const cellList = $1.value.get(command.args.cell.module.module);
-    const cellIndex = findCellIndex(command.args.cell.variables, cellList);
-    const targetCellIndex = cellIndex + command.args.amount;
-    const targetCell = lookupCellByIndex(targetCellIndex, cellList);
-    if (targetCell) {
-      const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
-      const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-      const change = targetFirstVariableIndex - currentFirstVariableIndex;
-      const dom = command.args.cell.dom;
-      const preY = dom?.getBoundingClientRect?.().top;
-      command.args.cell.variables.forEach(v => {
-        const currentIndex = findVariableIndex(v);
-        repositionSetElement(runtime._variables, v, currentIndex + change);
-      });
-      await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
-      // Keep moved cell at same screen position so neighbours shift around it.
-      // Cells here have wildly varying heights (some embed 500+ px iframes), so
-      // a one-position move can otherwise jump hundreds of pixels (#163). Poll
-      // for syncers' reactive DOM reorder before measuring postY — the chain
-      // runs on macrotasks, so requestAnimationFrame is not sufficient.
-      if (preY != null && dom?.isConnected) {
-        let postY = preY;
-        for (let i = 0; i < 30 && postY === preY; i++) {
-          await new Promise(r => setTimeout(r, 50));
-          if (!dom.isConnected)
-            break;
-          postY = dom.getBoundingClientRect().top;
+    if (command.processed)
+        return;
+    let result = undefined;
+    if (command.command == 'createCell') {
+        $0.value = true;
+        // Mark the new variable's pid (identity-stable, no cell-map lookup) so its
+        // cellEditor opens pinned as soon as auto_attach mounts the shell. Keyed by
+        // pid because findCell() lags one reactive tick behind creation here.
+        const newVars = [];
+        result = await compile_and_update('{}', newVars, command.args.cell);
+        const nv = newVars[0];
+        if (nv?.pid) pinOnCreate.add(nv.pid);
+        if (nv) await selectVariable(nv);
+    } else if (command.command == 'deleteCell') {
+        remove_variables(command.args.cell.variables);
+        result = true;
+    } else if (command.command == 'moveCell') {
+        const cellList = $1.value.get(command.args.cell.module.module);
+        const cellIndex = findCellIndex(command.args.cell.variables, cellList);
+        const targetCellIndex = cellIndex + command.args.amount;
+        const targetCell = lookupCellByIndex(targetCellIndex, cellList);
+        if (targetCell) {
+            const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+            const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+            const change = targetFirstVariableIndex - currentFirstVariableIndex;
+            const dom = command.args.cell.dom;
+            const preY = dom?.getBoundingClientRect?.().top;
+            command.args.cell.variables.forEach(v => {
+                const currentIndex = findVariableIndex(v);
+                repositionSetElement(runtime._variables, v, currentIndex + change);
+            });
+            await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+            // Keep moved cell at same screen position so neighbours shift around it.
+            // Cells here have wildly varying heights (some embed 500+ px iframes), so
+            // a one-position move can otherwise jump hundreds of pixels (#163). Poll
+            // for syncers' reactive DOM reorder before measuring postY — the chain
+            // runs on macrotasks, so requestAnimationFrame is not sufficient.
+            if (preY != null && dom?.isConnected) {
+                let postY = preY;
+                for (let i = 0; i < 30 && postY === preY; i++) {
+                    await new Promise(r => setTimeout(r, 50));
+                    if (!dom.isConnected)
+                        break;
+                    postY = dom.getBoundingClientRect().top;
+                }
+                const delta = postY - preY;
+                if (delta !== 0) {
+                    const scroller = dom.closest('.lm_content') || document.scrollingElement;
+                    scroller?.scrollBy?.({
+                        top: delta,
+                        behavior: 'instant'
+                    });
+                }
+            }
         }
-        const delta = postY - preY;
-        if (delta !== 0) {
-          const scroller = dom.closest('.lm_content') || document.scrollingElement;
-          scroller?.scrollBy?.({
-            top: delta,
-            behavior: 'instant'
-          });
-        }
-      }
+        result = true;
     }
-    result = true;
-  }
-  if (result) {
-    command.processed = true;
-    $2.resolve(result);
-  }
+    if (result) {
+        command.processed = true;
+        $2.resolve(result);
+    }
 };
 const _8iz5z2 = function _59(md){return(
 md`### UI Action`
@@ -10911,9 +10911,6 @@ async ({ cells, editedCell }) => {
 const _z9vacx = function _86(md){return(
 md`## Decompiler`
 )};
-const _kdc1xp = function _modules(moduleMap,runtime){return(
-moduleMap(runtime)
-)};
 const _gbuhyc = function _decompiled(editedCell,decompile)
 {
     if (!editedCell?.variables?.length)
@@ -11238,11 +11235,6 @@ const _bz6mai = function _test_completion_identifier_deferred(completionFixture)
     throw new Error('bare identifier (no dot) must defer');
   return 'identifier / no-dot bases deferred to the identifier-chain path';
 };
-const _y8yyf = function _pinOnCreate()
-{
-  return new Set()  // variable pids to open (pin) their editor as soon as the cell mounts
-;
-};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -11286,7 +11278,7 @@ export default function define(runtime, observer) {
   $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
   $def("_16ks4jz", null, ["md"], _16ks4jz);  
   $def("_199ztvl", "hotbarTemplate", ["lookupVariable","editorModule"], _199ztvl);  
-  $def("_hqns12", "cellEditor", ["cloneDataflow","editorTemplate","shellTemplate","createCell","findCell","pinOnCreate","getOption","Event","setOption"], _hqns12);  
+  $def("_1q95xt6", "cellEditor", ["cloneDataflow","editorTemplate","shellTemplate","getOption","Event","setOption","createCell","findCell","pinOnCreate"], _1q95xt6);
   $def("_x5ixji", "hotbar_shell", ["viewof edit","Event","htl","edit"], _x5ixji);  
   $def("_1ed5zb9", "editor_panel", ["viewof editedCell","htl","toolbar","nav","reversibleAttach","combine","code_editor"], _1ed5zb9);  
   $def("_yk7udl", "shellTemplate", ["viewof editedCell","editedCell","selectVariable","viewof edit","edit","hotbar_shell","lookupVariable","editorModule"], _yk7udl);  
@@ -11331,7 +11323,8 @@ export default function define(runtime, observer) {
   $def("_xvo1n6", "code_editor", ["code_editor_view"], _xvo1n6);  
   $def("_1imarq2", null, ["md"], _1imarq2);  
   $def("_470wv4", "moveCell", ["viewof command"], _470wv4);  
-  $def("_19znal9", "createCell", ["viewof command"], _19znal9);  
+  $def("_pinoncr", "pinOnCreate", [], _pinoncr);
+  $def("_19znal9", "createCell", ["viewof command"], _19znal9);
   $def("_d9nzys", "deleteCell", ["viewof command"], _d9nzys);  
   $def("_1toku21", null, ["md"], _1toku21);  
   $def("_d7ouqx", "viewof command", ["flowQueue"], _d7ouqx);  
@@ -11341,7 +11334,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_1efmn99", "command_processor", ["command","viewof edit","compile_and_update","pinOnCreate","selectVariable","remove_variables","viewof liveCellMap","findCellIndex","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","viewof command"], _1efmn99);  
+  $def("_2pkmxz", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","viewof liveCellMap","findCellIndex","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command","pinOnCreate"], _2pkmxz);  
   $def("_8iz5z2", null, ["md"], _8iz5z2);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -11371,9 +11364,8 @@ export default function define(runtime, observer) {
   $def("_1mfm13h", "normalizeObservableClipboardCell", ["inferCellGroupNameFromOJS","escapeTemplateLiteral"], _1mfm13h);  
   $def("_1pa2xc8", "readObservableClipboardCells", ["globalThis"], _1pa2xc8);  
   $def("_1w99cbu", "pasteObservableCellsIntoModule", ["viewof liveCellMap","normalizeObservableClipboardCell","findCell","compile_and_update"], _1w99cbu);  
-  $def("_z9vacx", null, ["md"], _z9vacx);  
-  $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
-  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);  
+  $def("_z9vacx", null, ["md"], _z9vacx);
+  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
@@ -11431,7 +11423,9 @@ export default function define(runtime, observer) {
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
-  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
+  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));
+  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));
+  main.define("modules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", "modules", _));
   $def("_lbftlp", "literalCompletions", ["codemirror"], _lbftlp);  
   $def("_scoiwp", "completionFixture", ["EditorState","observableJS_language","literalCompletions"], _scoiwp);  
   $def("_160qhf1", "test_completion_string_literal", ["completionFixture"], _160qhf1);  
@@ -11441,8 +11435,7 @@ export default function define(runtime, observer) {
   $def("_quyccp", "test_completion_bool_template_regexp", ["completionFixture"], _quyccp);  
   $def("_1cn3ucr", "test_completion_parenthesised_unwrap", ["completionFixture"], _1cn3ucr);  
   $def("_15vxhca", "test_completion_never_evaluates", ["completionFixture"], _15vxhca);  
-  $def("_bz6mai", "test_completion_identifier_deferred", ["completionFixture"], _bz6mai);  
-  $def("_y8yyf", "pinOnCreate", [], _y8yyf);
+  $def("_bz6mai", "test_completion_identifier_deferred", ["completionFixture"], _bz6mai);
   return main;
 }</script>
 <script id="@tomlarkworthy/escodegen/escodegen.browser.min.js.gz" 

--- a/notebooks/@tomlarkworthy_lopecode-vision.html
+++ b/notebooks/@tomlarkworthy_lopecode-vision.html
@@ -7828,9 +7828,6 @@ async ({ cells, editedCell }) => {
 const _z9vacx = function _86(md){return(
 md`## Decompiler`
 )};
-const _kdc1xp = function _modules(moduleMap,runtime){return(
-moduleMap(runtime)
-)};
 const _gbuhyc = function _decompiled(editedCell,decompile)
 {
     if (!editedCell?.variables?.length)
@@ -8284,9 +8281,8 @@ export default function define(runtime, observer) {
   $def("_1mfm13h", "normalizeObservableClipboardCell", ["inferCellGroupNameFromOJS","escapeTemplateLiteral"], _1mfm13h);  
   $def("_1pa2xc8", "readObservableClipboardCells", ["globalThis"], _1pa2xc8);  
   $def("_1w99cbu", "pasteObservableCellsIntoModule", ["viewof liveCellMap","normalizeObservableClipboardCell","findCell","compile_and_update"], _1w99cbu);  
-  $def("_z9vacx", null, ["md"], _z9vacx);  
-  $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
-  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);  
+  $def("_z9vacx", null, ["md"], _z9vacx);
+  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
@@ -8344,7 +8340,9 @@ export default function define(runtime, observer) {
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
-  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
+  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));
+  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));
+  main.define("modules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", "modules", _));
   $def("_lbftlp", "literalCompletions", ["codemirror"], _lbftlp);  
   $def("_scoiwp", "completionFixture", ["EditorState","observableJS_language","literalCompletions"], _scoiwp);  
   $def("_160qhf1", "test_completion_string_literal", ["completionFixture"], _160qhf1);  

--- a/notebooks/@tomlarkworthy_lopepage-2.html
+++ b/notebooks/@tomlarkworthy_lopepage-2.html
@@ -6940,9 +6940,6 @@ async ({ cells, editedCell }) => {
 const _z9vacx = function _86(md){return(
 md`## Decompiler`
 )};
-const _kdc1xp = function _modules(moduleMap,runtime){return(
-moduleMap(runtime)
-)};
 const _gbuhyc = function _decompiled(editedCell,decompile)
 {
     if (!editedCell?.variables?.length)
@@ -7396,9 +7393,8 @@ export default function define(runtime, observer) {
   $def("_1mfm13h", "normalizeObservableClipboardCell", ["inferCellGroupNameFromOJS","escapeTemplateLiteral"], _1mfm13h);  
   $def("_1pa2xc8", "readObservableClipboardCells", ["globalThis"], _1pa2xc8);  
   $def("_1w99cbu", "pasteObservableCellsIntoModule", ["viewof liveCellMap","normalizeObservableClipboardCell","findCell","compile_and_update"], _1w99cbu);  
-  $def("_z9vacx", null, ["md"], _z9vacx);  
-  $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
-  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);  
+  $def("_z9vacx", null, ["md"], _z9vacx);
+  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
@@ -7456,7 +7452,9 @@ export default function define(runtime, observer) {
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
-  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
+  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));
+  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));
+  main.define("modules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", "modules", _));
   $def("_lbftlp", "literalCompletions", ["codemirror"], _lbftlp);  
   $def("_scoiwp", "completionFixture", ["EditorState","observableJS_language","literalCompletions"], _scoiwp);  
   $def("_160qhf1", "test_completion_string_literal", ["completionFixture"], _160qhf1);  

--- a/notebooks/@tomlarkworthy_lopepage-urls.html
+++ b/notebooks/@tomlarkworthy_lopepage-urls.html
@@ -6906,9 +6906,6 @@ async ({ cells, editedCell }) => {
 const _z9vacx = function _86(md){return(
 md`## Decompiler`
 )};
-const _kdc1xp = function _modules(moduleMap,runtime){return(
-moduleMap(runtime)
-)};
 const _gbuhyc = function _decompiled(editedCell,decompile)
 {
     if (!editedCell?.variables?.length)
@@ -7362,9 +7359,8 @@ export default function define(runtime, observer) {
   $def("_1mfm13h", "normalizeObservableClipboardCell", ["inferCellGroupNameFromOJS","escapeTemplateLiteral"], _1mfm13h);  
   $def("_1pa2xc8", "readObservableClipboardCells", ["globalThis"], _1pa2xc8);  
   $def("_1w99cbu", "pasteObservableCellsIntoModule", ["viewof liveCellMap","normalizeObservableClipboardCell","findCell","compile_and_update"], _1w99cbu);  
-  $def("_z9vacx", null, ["md"], _z9vacx);  
-  $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
-  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);  
+  $def("_z9vacx", null, ["md"], _z9vacx);
+  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
@@ -7422,7 +7418,9 @@ export default function define(runtime, observer) {
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
-  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
+  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));
+  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));
+  main.define("modules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", "modules", _));
   $def("_lbftlp", "literalCompletions", ["codemirror"], _lbftlp);  
   $def("_scoiwp", "completionFixture", ["EditorState","observableJS_language","literalCompletions"], _scoiwp);  
   $def("_160qhf1", "test_completion_string_literal", ["completionFixture"], _160qhf1);  

--- a/notebooks/@tomlarkworthy_lopepage.html
+++ b/notebooks/@tomlarkworthy_lopepage.html
@@ -6917,9 +6917,6 @@ async ({ cells, editedCell }) => {
 const _z9vacx = function _86(md){return(
 md`## Decompiler`
 )};
-const _kdc1xp = function _modules(moduleMap,runtime){return(
-moduleMap(runtime)
-)};
 const _gbuhyc = function _decompiled(editedCell,decompile)
 {
     if (!editedCell?.variables?.length)
@@ -7373,9 +7370,8 @@ export default function define(runtime, observer) {
   $def("_1mfm13h", "normalizeObservableClipboardCell", ["inferCellGroupNameFromOJS","escapeTemplateLiteral"], _1mfm13h);  
   $def("_1pa2xc8", "readObservableClipboardCells", ["globalThis"], _1pa2xc8);  
   $def("_1w99cbu", "pasteObservableCellsIntoModule", ["viewof liveCellMap","normalizeObservableClipboardCell","findCell","compile_and_update"], _1w99cbu);  
-  $def("_z9vacx", null, ["md"], _z9vacx);  
-  $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
-  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);  
+  $def("_z9vacx", null, ["md"], _z9vacx);
+  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
@@ -7433,7 +7429,9 @@ export default function define(runtime, observer) {
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
-  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
+  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));
+  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));
+  main.define("modules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", "modules", _));
   $def("_lbftlp", "literalCompletions", ["codemirror"], _lbftlp);  
   $def("_scoiwp", "completionFixture", ["EditorState","observableJS_language","literalCompletions"], _scoiwp);  
   $def("_160qhf1", "test_completion_string_literal", ["completionFixture"], _160qhf1);  

--- a/notebooks/@tomlarkworthy_modern-screenshot.html
+++ b/notebooks/@tomlarkworthy_modern-screenshot.html
@@ -6906,9 +6906,6 @@ async ({ cells, editedCell }) => {
 const _z9vacx = function _86(md){return(
 md`## Decompiler`
 )};
-const _kdc1xp = function _modules(moduleMap,runtime){return(
-moduleMap(runtime)
-)};
 const _gbuhyc = function _decompiled(editedCell,decompile)
 {
     if (!editedCell?.variables?.length)
@@ -7362,9 +7359,8 @@ export default function define(runtime, observer) {
   $def("_1mfm13h", "normalizeObservableClipboardCell", ["inferCellGroupNameFromOJS","escapeTemplateLiteral"], _1mfm13h);  
   $def("_1pa2xc8", "readObservableClipboardCells", ["globalThis"], _1pa2xc8);  
   $def("_1w99cbu", "pasteObservableCellsIntoModule", ["viewof liveCellMap","normalizeObservableClipboardCell","findCell","compile_and_update"], _1w99cbu);  
-  $def("_z9vacx", null, ["md"], _z9vacx);  
-  $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
-  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);  
+  $def("_z9vacx", null, ["md"], _z9vacx);
+  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
@@ -7422,7 +7418,9 @@ export default function define(runtime, observer) {
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
-  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
+  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));
+  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));
+  main.define("modules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", "modules", _));
   $def("_lbftlp", "literalCompletions", ["codemirror"], _lbftlp);  
   $def("_scoiwp", "completionFixture", ["EditorState","observableJS_language","literalCompletions"], _scoiwp);  
   $def("_160qhf1", "test_completion_string_literal", ["completionFixture"], _160qhf1);  

--- a/notebooks/@tomlarkworthy_module-selection.html
+++ b/notebooks/@tomlarkworthy_module-selection.html
@@ -6906,9 +6906,6 @@ async ({ cells, editedCell }) => {
 const _z9vacx = function _86(md){return(
 md`## Decompiler`
 )};
-const _kdc1xp = function _modules(moduleMap,runtime){return(
-moduleMap(runtime)
-)};
 const _gbuhyc = function _decompiled(editedCell,decompile)
 {
     if (!editedCell?.variables?.length)
@@ -7362,9 +7359,8 @@ export default function define(runtime, observer) {
   $def("_1mfm13h", "normalizeObservableClipboardCell", ["inferCellGroupNameFromOJS","escapeTemplateLiteral"], _1mfm13h);  
   $def("_1pa2xc8", "readObservableClipboardCells", ["globalThis"], _1pa2xc8);  
   $def("_1w99cbu", "pasteObservableCellsIntoModule", ["viewof liveCellMap","normalizeObservableClipboardCell","findCell","compile_and_update"], _1w99cbu);  
-  $def("_z9vacx", null, ["md"], _z9vacx);  
-  $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
-  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);  
+  $def("_z9vacx", null, ["md"], _z9vacx);
+  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
@@ -7422,7 +7418,9 @@ export default function define(runtime, observer) {
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
-  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
+  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));
+  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));
+  main.define("modules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", "modules", _));
   $def("_lbftlp", "literalCompletions", ["codemirror"], _lbftlp);  
   $def("_scoiwp", "completionFixture", ["EditorState","observableJS_language","literalCompletions"], _scoiwp);  
   $def("_160qhf1", "test_completion_string_literal", ["completionFixture"], _160qhf1);  

--- a/notebooks/@tomlarkworthy_notes.html
+++ b/notebooks/@tomlarkworthy_notes.html
@@ -6952,9 +6952,6 @@ async ({ cells, editedCell }) => {
 const _z9vacx = function _86(md){return(
 md`## Decompiler`
 )};
-const _kdc1xp = function _modules(moduleMap,runtime){return(
-moduleMap(runtime)
-)};
 const _gbuhyc = function _decompiled(editedCell,decompile)
 {
     if (!editedCell?.variables?.length)
@@ -7408,9 +7405,8 @@ export default function define(runtime, observer) {
   $def("_1mfm13h", "normalizeObservableClipboardCell", ["inferCellGroupNameFromOJS","escapeTemplateLiteral"], _1mfm13h);  
   $def("_1pa2xc8", "readObservableClipboardCells", ["globalThis"], _1pa2xc8);  
   $def("_1w99cbu", "pasteObservableCellsIntoModule", ["viewof liveCellMap","normalizeObservableClipboardCell","findCell","compile_and_update"], _1w99cbu);  
-  $def("_z9vacx", null, ["md"], _z9vacx);  
-  $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
-  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);  
+  $def("_z9vacx", null, ["md"], _z9vacx);
+  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
@@ -7468,7 +7464,9 @@ export default function define(runtime, observer) {
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
-  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
+  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));
+  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));
+  main.define("modules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", "modules", _));
   $def("_lbftlp", "literalCompletions", ["codemirror"], _lbftlp);  
   $def("_scoiwp", "completionFixture", ["EditorState","observableJS_language","literalCompletions"], _scoiwp);  
   $def("_160qhf1", "test_completion_string_literal", ["completionFixture"], _160qhf1);  

--- a/notebooks/@tomlarkworthy_observablehq-lezer.html
+++ b/notebooks/@tomlarkworthy_observablehq-lezer.html
@@ -6906,9 +6906,6 @@ async ({ cells, editedCell }) => {
 const _z9vacx = function _86(md){return(
 md`## Decompiler`
 )};
-const _kdc1xp = function _modules(moduleMap,runtime){return(
-moduleMap(runtime)
-)};
 const _gbuhyc = function _decompiled(editedCell,decompile)
 {
     if (!editedCell?.variables?.length)
@@ -7362,9 +7359,8 @@ export default function define(runtime, observer) {
   $def("_1mfm13h", "normalizeObservableClipboardCell", ["inferCellGroupNameFromOJS","escapeTemplateLiteral"], _1mfm13h);  
   $def("_1pa2xc8", "readObservableClipboardCells", ["globalThis"], _1pa2xc8);  
   $def("_1w99cbu", "pasteObservableCellsIntoModule", ["viewof liveCellMap","normalizeObservableClipboardCell","findCell","compile_and_update"], _1w99cbu);  
-  $def("_z9vacx", null, ["md"], _z9vacx);  
-  $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
-  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);  
+  $def("_z9vacx", null, ["md"], _z9vacx);
+  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
@@ -7422,7 +7418,9 @@ export default function define(runtime, observer) {
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
-  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
+  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));
+  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));
+  main.define("modules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", "modules", _));
   $def("_lbftlp", "literalCompletions", ["codemirror"], _lbftlp);  
   $def("_scoiwp", "completionFixture", ["EditorState","observableJS_language","literalCompletions"], _scoiwp);  
   $def("_160qhf1", "test_completion_string_literal", ["completionFixture"], _160qhf1);  

--- a/notebooks/@tomlarkworthy_observablejs-toolchain.html
+++ b/notebooks/@tomlarkworthy_observablejs-toolchain.html
@@ -6938,9 +6938,6 @@ async ({ cells, editedCell }) => {
 const _z9vacx = function _86(md){return(
 md`## Decompiler`
 )};
-const _kdc1xp = function _modules(moduleMap,runtime){return(
-moduleMap(runtime)
-)};
 const _gbuhyc = function _decompiled(editedCell,decompile)
 {
     if (!editedCell?.variables?.length)
@@ -7394,9 +7391,8 @@ export default function define(runtime, observer) {
   $def("_1mfm13h", "normalizeObservableClipboardCell", ["inferCellGroupNameFromOJS","escapeTemplateLiteral"], _1mfm13h);  
   $def("_1pa2xc8", "readObservableClipboardCells", ["globalThis"], _1pa2xc8);  
   $def("_1w99cbu", "pasteObservableCellsIntoModule", ["viewof liveCellMap","normalizeObservableClipboardCell","findCell","compile_and_update"], _1w99cbu);  
-  $def("_z9vacx", null, ["md"], _z9vacx);  
-  $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
-  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);  
+  $def("_z9vacx", null, ["md"], _z9vacx);
+  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
@@ -7454,7 +7450,9 @@ export default function define(runtime, observer) {
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
-  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
+  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));
+  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));
+  main.define("modules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", "modules", _));
   $def("_lbftlp", "literalCompletions", ["codemirror"], _lbftlp);  
   $def("_scoiwp", "completionFixture", ["EditorState","observableJS_language","literalCompletions"], _scoiwp);  
   $def("_160qhf1", "test_completion_string_literal", ["completionFixture"], _160qhf1);  

--- a/notebooks/@tomlarkworthy_openai-responses-api.html
+++ b/notebooks/@tomlarkworthy_openai-responses-api.html
@@ -6906,9 +6906,6 @@ async ({ cells, editedCell }) => {
 const _z9vacx = function _86(md){return(
 md`## Decompiler`
 )};
-const _kdc1xp = function _modules(moduleMap,runtime){return(
-moduleMap(runtime)
-)};
 const _gbuhyc = function _decompiled(editedCell,decompile)
 {
     if (!editedCell?.variables?.length)
@@ -7362,9 +7359,8 @@ export default function define(runtime, observer) {
   $def("_1mfm13h", "normalizeObservableClipboardCell", ["inferCellGroupNameFromOJS","escapeTemplateLiteral"], _1mfm13h);  
   $def("_1pa2xc8", "readObservableClipboardCells", ["globalThis"], _1pa2xc8);  
   $def("_1w99cbu", "pasteObservableCellsIntoModule", ["viewof liveCellMap","normalizeObservableClipboardCell","findCell","compile_and_update"], _1w99cbu);  
-  $def("_z9vacx", null, ["md"], _z9vacx);  
-  $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
-  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);  
+  $def("_z9vacx", null, ["md"], _z9vacx);
+  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
@@ -7422,7 +7418,9 @@ export default function define(runtime, observer) {
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
-  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
+  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));
+  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));
+  main.define("modules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", "modules", _));
   $def("_lbftlp", "literalCompletions", ["codemirror"], _lbftlp);  
   $def("_scoiwp", "completionFixture", ["EditorState","observableJS_language","literalCompletions"], _scoiwp);  
   $def("_160qhf1", "test_completion_string_literal", ["completionFixture"], _160qhf1);  

--- a/notebooks/@tomlarkworthy_reversible-attachment.html
+++ b/notebooks/@tomlarkworthy_reversible-attachment.html
@@ -6906,9 +6906,6 @@ async ({ cells, editedCell }) => {
 const _z9vacx = function _86(md){return(
 md`## Decompiler`
 )};
-const _kdc1xp = function _modules(moduleMap,runtime){return(
-moduleMap(runtime)
-)};
 const _gbuhyc = function _decompiled(editedCell,decompile)
 {
     if (!editedCell?.variables?.length)
@@ -7362,9 +7359,8 @@ export default function define(runtime, observer) {
   $def("_1mfm13h", "normalizeObservableClipboardCell", ["inferCellGroupNameFromOJS","escapeTemplateLiteral"], _1mfm13h);  
   $def("_1pa2xc8", "readObservableClipboardCells", ["globalThis"], _1pa2xc8);  
   $def("_1w99cbu", "pasteObservableCellsIntoModule", ["viewof liveCellMap","normalizeObservableClipboardCell","findCell","compile_and_update"], _1w99cbu);  
-  $def("_z9vacx", null, ["md"], _z9vacx);  
-  $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
-  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);  
+  $def("_z9vacx", null, ["md"], _z9vacx);
+  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
@@ -7422,7 +7418,9 @@ export default function define(runtime, observer) {
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
-  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
+  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));
+  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));
+  main.define("modules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", "modules", _));
   $def("_lbftlp", "literalCompletions", ["codemirror"], _lbftlp);  
   $def("_scoiwp", "completionFixture", ["EditorState","observableJS_language","literalCompletions"], _scoiwp);  
   $def("_160qhf1", "test_completion_string_literal", ["completionFixture"], _160qhf1);  

--- a/notebooks/@tomlarkworthy_robocoop-2.html
+++ b/notebooks/@tomlarkworthy_robocoop-2.html
@@ -6906,9 +6906,6 @@ async ({ cells, editedCell }) => {
 const _z9vacx = function _86(md){return(
 md`## Decompiler`
 )};
-const _kdc1xp = function _modules(moduleMap,runtime){return(
-moduleMap(runtime)
-)};
 const _gbuhyc = function _decompiled(editedCell,decompile)
 {
     if (!editedCell?.variables?.length)
@@ -7362,9 +7359,8 @@ export default function define(runtime, observer) {
   $def("_1mfm13h", "normalizeObservableClipboardCell", ["inferCellGroupNameFromOJS","escapeTemplateLiteral"], _1mfm13h);  
   $def("_1pa2xc8", "readObservableClipboardCells", ["globalThis"], _1pa2xc8);  
   $def("_1w99cbu", "pasteObservableCellsIntoModule", ["viewof liveCellMap","normalizeObservableClipboardCell","findCell","compile_and_update"], _1w99cbu);  
-  $def("_z9vacx", null, ["md"], _z9vacx);  
-  $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
-  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);  
+  $def("_z9vacx", null, ["md"], _z9vacx);
+  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
@@ -7422,7 +7418,9 @@ export default function define(runtime, observer) {
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
-  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
+  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));
+  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));
+  main.define("modules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", "modules", _));
   $def("_lbftlp", "literalCompletions", ["codemirror"], _lbftlp);  
   $def("_scoiwp", "completionFixture", ["EditorState","observableJS_language","literalCompletions"], _scoiwp);  
   $def("_160qhf1", "test_completion_string_literal", ["completionFixture"], _160qhf1);  

--- a/notebooks/@tomlarkworthy_robocoop-3.html
+++ b/notebooks/@tomlarkworthy_robocoop-3.html
@@ -6906,9 +6906,6 @@ async ({ cells, editedCell }) => {
 const _z9vacx = function _86(md){return(
 md`## Decompiler`
 )};
-const _kdc1xp = function _modules(moduleMap,runtime){return(
-moduleMap(runtime)
-)};
 const _gbuhyc = function _decompiled(editedCell,decompile)
 {
     if (!editedCell?.variables?.length)
@@ -7362,9 +7359,8 @@ export default function define(runtime, observer) {
   $def("_1mfm13h", "normalizeObservableClipboardCell", ["inferCellGroupNameFromOJS","escapeTemplateLiteral"], _1mfm13h);  
   $def("_1pa2xc8", "readObservableClipboardCells", ["globalThis"], _1pa2xc8);  
   $def("_1w99cbu", "pasteObservableCellsIntoModule", ["viewof liveCellMap","normalizeObservableClipboardCell","findCell","compile_and_update"], _1w99cbu);  
-  $def("_z9vacx", null, ["md"], _z9vacx);  
-  $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
-  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);  
+  $def("_z9vacx", null, ["md"], _z9vacx);
+  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
@@ -7422,7 +7418,9 @@ export default function define(runtime, observer) {
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
-  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
+  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));
+  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));
+  main.define("modules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", "modules", _));
   $def("_lbftlp", "literalCompletions", ["codemirror"], _lbftlp);  
   $def("_scoiwp", "completionFixture", ["EditorState","observableJS_language","literalCompletions"], _scoiwp);  
   $def("_160qhf1", "test_completion_string_literal", ["completionFixture"], _160qhf1);  

--- a/notebooks/@tomlarkworthy_robocoop-4.html
+++ b/notebooks/@tomlarkworthy_robocoop-4.html
@@ -6944,9 +6944,6 @@ async ({ cells, editedCell }) => {
 const _z9vacx = function _86(md){return(
 md`## Decompiler`
 )};
-const _kdc1xp = function _modules(moduleMap,runtime){return(
-moduleMap(runtime)
-)};
 const _gbuhyc = function _decompiled(editedCell,decompile)
 {
     if (!editedCell?.variables?.length)
@@ -7400,9 +7397,8 @@ export default function define(runtime, observer) {
   $def("_1mfm13h", "normalizeObservableClipboardCell", ["inferCellGroupNameFromOJS","escapeTemplateLiteral"], _1mfm13h);  
   $def("_1pa2xc8", "readObservableClipboardCells", ["globalThis"], _1pa2xc8);  
   $def("_1w99cbu", "pasteObservableCellsIntoModule", ["viewof liveCellMap","normalizeObservableClipboardCell","findCell","compile_and_update"], _1w99cbu);  
-  $def("_z9vacx", null, ["md"], _z9vacx);  
-  $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
-  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);  
+  $def("_z9vacx", null, ["md"], _z9vacx);
+  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
@@ -7460,7 +7456,9 @@ export default function define(runtime, observer) {
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
-  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
+  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));
+  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));
+  main.define("modules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", "modules", _));
   $def("_lbftlp", "literalCompletions", ["codemirror"], _lbftlp);  
   $def("_scoiwp", "completionFixture", ["EditorState","observableJS_language","literalCompletions"], _scoiwp);  
   $def("_160qhf1", "test_completion_string_literal", ["completionFixture"], _160qhf1);  

--- a/notebooks/@tomlarkworthy_runtime-sdk.html
+++ b/notebooks/@tomlarkworthy_runtime-sdk.html
@@ -9678,9 +9678,6 @@ async ({ cells, editedCell }) => {
 const _z9vacx = function _86(md){return(
 md`## Decompiler`
 )};
-const _kdc1xp = function _modules(moduleMap,runtime){return(
-moduleMap(runtime)
-)};
 const _gbuhyc = function _decompiled(editedCell,decompile)
 {
     if (!editedCell?.variables?.length)
@@ -10134,9 +10131,8 @@ export default function define(runtime, observer) {
   $def("_1mfm13h", "normalizeObservableClipboardCell", ["inferCellGroupNameFromOJS","escapeTemplateLiteral"], _1mfm13h);  
   $def("_1pa2xc8", "readObservableClipboardCells", ["globalThis"], _1pa2xc8);  
   $def("_1w99cbu", "pasteObservableCellsIntoModule", ["viewof liveCellMap","normalizeObservableClipboardCell","findCell","compile_and_update"], _1w99cbu);  
-  $def("_z9vacx", null, ["md"], _z9vacx);  
-  $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
-  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);  
+  $def("_z9vacx", null, ["md"], _z9vacx);
+  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
@@ -10194,7 +10190,9 @@ export default function define(runtime, observer) {
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
-  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
+  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));
+  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));
+  main.define("modules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", "modules", _));
   $def("_lbftlp", "literalCompletions", ["codemirror"], _lbftlp);  
   $def("_scoiwp", "completionFixture", ["EditorState","observableJS_language","literalCompletions"], _scoiwp);  
   $def("_160qhf1", "test_completion_string_literal", ["completionFixture"], _160qhf1);  

--- a/notebooks/@tomlarkworthy_save-in-place.html
+++ b/notebooks/@tomlarkworthy_save-in-place.html
@@ -6940,9 +6940,6 @@ async ({ cells, editedCell }) => {
 const _z9vacx = function _86(md){return(
 md`## Decompiler`
 )};
-const _kdc1xp = function _modules(moduleMap,runtime){return(
-moduleMap(runtime)
-)};
 const _gbuhyc = function _decompiled(editedCell,decompile)
 {
     if (!editedCell?.variables?.length)
@@ -7396,9 +7393,8 @@ export default function define(runtime, observer) {
   $def("_1mfm13h", "normalizeObservableClipboardCell", ["inferCellGroupNameFromOJS","escapeTemplateLiteral"], _1mfm13h);  
   $def("_1pa2xc8", "readObservableClipboardCells", ["globalThis"], _1pa2xc8);  
   $def("_1w99cbu", "pasteObservableCellsIntoModule", ["viewof liveCellMap","normalizeObservableClipboardCell","findCell","compile_and_update"], _1w99cbu);  
-  $def("_z9vacx", null, ["md"], _z9vacx);  
-  $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
-  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);  
+  $def("_z9vacx", null, ["md"], _z9vacx);
+  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
@@ -7456,7 +7452,9 @@ export default function define(runtime, observer) {
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
-  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
+  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));
+  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));
+  main.define("modules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", "modules", _));
   $def("_lbftlp", "literalCompletions", ["codemirror"], _lbftlp);  
   $def("_scoiwp", "completionFixture", ["EditorState","observableJS_language","literalCompletions"], _scoiwp);  
   $def("_160qhf1", "test_completion_string_literal", ["completionFixture"], _160qhf1);  

--- a/notebooks/@tomlarkworthy_secrets.html
+++ b/notebooks/@tomlarkworthy_secrets.html
@@ -6906,9 +6906,6 @@ async ({ cells, editedCell }) => {
 const _z9vacx = function _86(md){return(
 md`## Decompiler`
 )};
-const _kdc1xp = function _modules(moduleMap,runtime){return(
-moduleMap(runtime)
-)};
 const _gbuhyc = function _decompiled(editedCell,decompile)
 {
     if (!editedCell?.variables?.length)
@@ -7362,9 +7359,8 @@ export default function define(runtime, observer) {
   $def("_1mfm13h", "normalizeObservableClipboardCell", ["inferCellGroupNameFromOJS","escapeTemplateLiteral"], _1mfm13h);  
   $def("_1pa2xc8", "readObservableClipboardCells", ["globalThis"], _1pa2xc8);  
   $def("_1w99cbu", "pasteObservableCellsIntoModule", ["viewof liveCellMap","normalizeObservableClipboardCell","findCell","compile_and_update"], _1w99cbu);  
-  $def("_z9vacx", null, ["md"], _z9vacx);  
-  $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
-  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);  
+  $def("_z9vacx", null, ["md"], _z9vacx);
+  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
@@ -7422,7 +7418,9 @@ export default function define(runtime, observer) {
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
-  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
+  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));
+  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));
+  main.define("modules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", "modules", _));
   $def("_lbftlp", "literalCompletions", ["codemirror"], _lbftlp);  
   $def("_scoiwp", "completionFixture", ["EditorState","observableJS_language","literalCompletions"], _scoiwp);  
   $def("_160qhf1", "test_completion_string_literal", ["completionFixture"], _160qhf1);  

--- a/notebooks/@tomlarkworthy_tests.html
+++ b/notebooks/@tomlarkworthy_tests.html
@@ -6906,9 +6906,6 @@ async ({ cells, editedCell }) => {
 const _z9vacx = function _86(md){return(
 md`## Decompiler`
 )};
-const _kdc1xp = function _modules(moduleMap,runtime){return(
-moduleMap(runtime)
-)};
 const _gbuhyc = function _decompiled(editedCell,decompile)
 {
     if (!editedCell?.variables?.length)
@@ -7362,9 +7359,8 @@ export default function define(runtime, observer) {
   $def("_1mfm13h", "normalizeObservableClipboardCell", ["inferCellGroupNameFromOJS","escapeTemplateLiteral"], _1mfm13h);  
   $def("_1pa2xc8", "readObservableClipboardCells", ["globalThis"], _1pa2xc8);  
   $def("_1w99cbu", "pasteObservableCellsIntoModule", ["viewof liveCellMap","normalizeObservableClipboardCell","findCell","compile_and_update"], _1w99cbu);  
-  $def("_z9vacx", null, ["md"], _z9vacx);  
-  $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
-  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);  
+  $def("_z9vacx", null, ["md"], _z9vacx);
+  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
@@ -7422,7 +7418,9 @@ export default function define(runtime, observer) {
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
-  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
+  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));
+  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));
+  main.define("modules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", "modules", _));
   $def("_lbftlp", "literalCompletions", ["codemirror"], _lbftlp);  
   $def("_scoiwp", "completionFixture", ["EditorState","observableJS_language","literalCompletions"], _scoiwp);  
   $def("_160qhf1", "test_completion_string_literal", ["completionFixture"], _160qhf1);  

--- a/notebooks/@tomlarkworthy_themes.html
+++ b/notebooks/@tomlarkworthy_themes.html
@@ -6917,9 +6917,6 @@ async ({ cells, editedCell }) => {
 const _z9vacx = function _86(md){return(
 md`## Decompiler`
 )};
-const _kdc1xp = function _modules(moduleMap,runtime){return(
-moduleMap(runtime)
-)};
 const _gbuhyc = function _decompiled(editedCell,decompile)
 {
     if (!editedCell?.variables?.length)
@@ -7373,9 +7370,8 @@ export default function define(runtime, observer) {
   $def("_1mfm13h", "normalizeObservableClipboardCell", ["inferCellGroupNameFromOJS","escapeTemplateLiteral"], _1mfm13h);  
   $def("_1pa2xc8", "readObservableClipboardCells", ["globalThis"], _1pa2xc8);  
   $def("_1w99cbu", "pasteObservableCellsIntoModule", ["viewof liveCellMap","normalizeObservableClipboardCell","findCell","compile_and_update"], _1w99cbu);  
-  $def("_z9vacx", null, ["md"], _z9vacx);  
-  $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
-  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);  
+  $def("_z9vacx", null, ["md"], _z9vacx);
+  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
@@ -7433,7 +7429,9 @@ export default function define(runtime, observer) {
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
-  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
+  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));
+  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));
+  main.define("modules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", "modules", _));
   $def("_lbftlp", "literalCompletions", ["codemirror"], _lbftlp);  
   $def("_scoiwp", "completionFixture", ["EditorState","observableJS_language","literalCompletions"], _scoiwp);  
   $def("_160qhf1", "test_completion_string_literal", ["completionFixture"], _160qhf1);  

--- a/notebooks/@tomlarkworthy_visualizer.html
+++ b/notebooks/@tomlarkworthy_visualizer.html
@@ -9202,9 +9202,6 @@ async ({ cells, editedCell }) => {
 const _z9vacx = function _86(md){return(
 md`## Decompiler`
 )};
-const _kdc1xp = function _modules(moduleMap,runtime){return(
-moduleMap(runtime)
-)};
 const _gbuhyc = function _decompiled(editedCell,decompile)
 {
     if (!editedCell?.variables?.length)
@@ -9658,9 +9655,8 @@ export default function define(runtime, observer) {
   $def("_1mfm13h", "normalizeObservableClipboardCell", ["inferCellGroupNameFromOJS","escapeTemplateLiteral"], _1mfm13h);  
   $def("_1pa2xc8", "readObservableClipboardCells", ["globalThis"], _1pa2xc8);  
   $def("_1w99cbu", "pasteObservableCellsIntoModule", ["viewof liveCellMap","normalizeObservableClipboardCell","findCell","compile_and_update"], _1w99cbu);  
-  $def("_z9vacx", null, ["md"], _z9vacx);  
-  $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
-  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);  
+  $def("_z9vacx", null, ["md"], _z9vacx);
+  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
@@ -9718,7 +9714,9 @@ export default function define(runtime, observer) {
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
-  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
+  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));
+  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));
+  main.define("modules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", "modules", _));
   $def("_lbftlp", "literalCompletions", ["codemirror"], _lbftlp);  
   $def("_scoiwp", "completionFixture", ["EditorState","observableJS_language","literalCompletions"], _scoiwp);  
   $def("_160qhf1", "test_completion_string_literal", ["completionFixture"], _160qhf1);  

--- a/notebooks/atproto.html
+++ b/notebooks/atproto.html
@@ -9917,9 +9917,6 @@ async ({ cells, editedCell }) => {
 const _z9vacx = function _86(md){return(
 md`## Decompiler`
 )};
-const _kdc1xp = function _modules(moduleMap,runtime){return(
-moduleMap(runtime)
-)};
 const _gbuhyc = function _decompiled(editedCell,decompile)
 {
     if (!editedCell?.variables?.length)
@@ -10373,9 +10370,8 @@ export default function define(runtime, observer) {
   $def("_1mfm13h", "normalizeObservableClipboardCell", ["inferCellGroupNameFromOJS","escapeTemplateLiteral"], _1mfm13h);  
   $def("_1pa2xc8", "readObservableClipboardCells", ["globalThis"], _1pa2xc8);  
   $def("_1w99cbu", "pasteObservableCellsIntoModule", ["viewof liveCellMap","normalizeObservableClipboardCell","findCell","compile_and_update"], _1w99cbu);  
-  $def("_z9vacx", null, ["md"], _z9vacx);  
-  $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
-  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);  
+  $def("_z9vacx", null, ["md"], _z9vacx);
+  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
@@ -10433,7 +10429,9 @@ export default function define(runtime, observer) {
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
-  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
+  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));
+  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));
+  main.define("modules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", "modules", _));
   $def("_lbftlp", "literalCompletions", ["codemirror"], _lbftlp);  
   $def("_scoiwp", "completionFixture", ["EditorState","observableJS_language","literalCompletions"], _scoiwp);  
   $def("_160qhf1", "test_completion_string_literal", ["completionFixture"], _160qhf1);  

--- a/notebooks/jumpgates.html
+++ b/notebooks/jumpgates.html
@@ -10045,9 +10045,6 @@ async ({ cells, editedCell }) => {
 const _z9vacx = function _86(md){return(
 md`## Decompiler`
 )};
-const _kdc1xp = function _modules(moduleMap,runtime){return(
-moduleMap(runtime)
-)};
 const _gbuhyc = function _decompiled(editedCell,decompile)
 {
     if (!editedCell?.variables?.length)
@@ -10501,9 +10498,8 @@ export default function define(runtime, observer) {
   $def("_1mfm13h", "normalizeObservableClipboardCell", ["inferCellGroupNameFromOJS","escapeTemplateLiteral"], _1mfm13h);  
   $def("_1pa2xc8", "readObservableClipboardCells", ["globalThis"], _1pa2xc8);  
   $def("_1w99cbu", "pasteObservableCellsIntoModule", ["viewof liveCellMap","normalizeObservableClipboardCell","findCell","compile_and_update"], _1w99cbu);  
-  $def("_z9vacx", null, ["md"], _z9vacx);  
-  $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
-  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);  
+  $def("_z9vacx", null, ["md"], _z9vacx);
+  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
@@ -10561,7 +10557,9 @@ export default function define(runtime, observer) {
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
-  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
+  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));
+  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));
+  main.define("modules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", "modules", _));
   $def("_lbftlp", "literalCompletions", ["codemirror"], _lbftlp);  
   $def("_scoiwp", "completionFixture", ["EditorState","observableJS_language","literalCompletions"], _scoiwp);  
   $def("_160qhf1", "test_completion_string_literal", ["completionFixture"], _160qhf1);  

--- a/notebooks/ledger.html
+++ b/notebooks/ledger.html
@@ -9385,9 +9385,6 @@ async ({ cells, editedCell }) => {
 const _z9vacx = function _86(md){return(
 md`## Decompiler`
 )};
-const _kdc1xp = function _modules(moduleMap,runtime){return(
-moduleMap(runtime)
-)};
 const _gbuhyc = function _decompiled(editedCell,decompile)
 {
     if (!editedCell?.variables?.length)
@@ -9841,9 +9838,8 @@ export default function define(runtime, observer) {
   $def("_1mfm13h", "normalizeObservableClipboardCell", ["inferCellGroupNameFromOJS","escapeTemplateLiteral"], _1mfm13h);  
   $def("_1pa2xc8", "readObservableClipboardCells", ["globalThis"], _1pa2xc8);  
   $def("_1w99cbu", "pasteObservableCellsIntoModule", ["viewof liveCellMap","normalizeObservableClipboardCell","findCell","compile_and_update"], _1w99cbu);  
-  $def("_z9vacx", null, ["md"], _z9vacx);  
-  $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
-  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);  
+  $def("_z9vacx", null, ["md"], _z9vacx);
+  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
@@ -9901,7 +9897,9 @@ export default function define(runtime, observer) {
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
-  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
+  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));
+  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));
+  main.define("modules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", "modules", _));
   $def("_lbftlp", "literalCompletions", ["codemirror"], _lbftlp);  
   $def("_scoiwp", "completionFixture", ["EditorState","observableJS_language","literalCompletions"], _scoiwp);  
   $def("_160qhf1", "test_completion_string_literal", ["completionFixture"], _160qhf1);  

--- a/notebooks/lopefeed.html
+++ b/notebooks/lopefeed.html
@@ -9385,9 +9385,6 @@ async ({ cells, editedCell }) => {
 const _z9vacx = function _86(md){return(
 md`## Decompiler`
 )};
-const _kdc1xp = function _modules(moduleMap,runtime){return(
-moduleMap(runtime)
-)};
 const _gbuhyc = function _decompiled(editedCell,decompile)
 {
     if (!editedCell?.variables?.length)
@@ -9841,9 +9838,8 @@ export default function define(runtime, observer) {
   $def("_1mfm13h", "normalizeObservableClipboardCell", ["inferCellGroupNameFromOJS","escapeTemplateLiteral"], _1mfm13h);  
   $def("_1pa2xc8", "readObservableClipboardCells", ["globalThis"], _1pa2xc8);  
   $def("_1w99cbu", "pasteObservableCellsIntoModule", ["viewof liveCellMap","normalizeObservableClipboardCell","findCell","compile_and_update"], _1w99cbu);  
-  $def("_z9vacx", null, ["md"], _z9vacx);  
-  $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
-  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);  
+  $def("_z9vacx", null, ["md"], _z9vacx);
+  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
@@ -9901,7 +9897,9 @@ export default function define(runtime, observer) {
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
-  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
+  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));
+  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));
+  main.define("modules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", "modules", _));
   $def("_lbftlp", "literalCompletions", ["codemirror"], _lbftlp);  
   $def("_scoiwp", "completionFixture", ["EditorState","observableJS_language","literalCompletions"], _scoiwp);  
   $def("_160qhf1", "test_completion_string_literal", ["completionFixture"], _160qhf1);  


### PR DESCRIPTION
**This PR is a proposal** — the canonical `@tomlarkworthy_editor-5.html` has been updated with the fix, but ObservableHQ has not been pushed and the 200+ consumer notebooks have not been re-synced yet. After approval, those steps run and additional commits land on this branch.

## Reported symptom
Cells in modules created at runtime (e.g. every module robocoop-5's agent makes) render an edit hotbar, but the editor is dead — "the edit menu is there but you cannot use it". Edits silently never apply.

## Root cause
`editor-5.findCell` builds a cell's module handle by spreading `modules.get(variable._module)`. That `modules` dependency was `modules = moduleMap(runtime)` — a **one-shot, non-reactive** cell (inputs are only the stable `moduleMap` fn + `runtime`), so it computes once when editor-5 boots and never again. A module created afterward isn't in that stale snapshot → `modules.get(newModule)` is `undefined` → `cell.module.module` is `undefined` → the save path (`compile_and_update` reading `cell.module.module._scope`) throws, the throw is swallowed, and the edit is discarded.

## Fix (minimal)
Bind editor-5's `modules` cell to the **reactive, incremental** `currentModules` from `@tomlarkworthy/modules` (async-generator cumulative `Map`, keyed by `Module` → `{name,title,module,variable}` — a drop-in for the two call sites `findCell` and `variableLink`). No fallbacks, no test. Net diff: 5 insertions, 7 deletions.

```
- const _kdc1xp = function _modules(moduleMap,runtime){return( moduleMap(runtime) )};
- $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);
+ main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));
+ main.define("modules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", "modules", _));
```

## Manual QA (isolated Playwright, patched editor-5)
- Boot clean — no console errors from the new import (only the known-harmless `@import` warning).
- Created a module post-boot → clicked **edit** on a cell → editor populated with source (was dead before) → typed a change → **Shift+Enter applied it** → rendered `<h1>` updated live. ✅
- `findCell(newCell).module.module` set, `.name` correct. `compile_and_update` returns and the cell recompiles. ✅
- Regression: editing a pre-existing (booted) module cell still resolves `module.module` with the correct name. ✅

Canonical source edit lives in `modules/@tomlarkworthy/editor-5.js` (parent repo); this PR carries the regenerated content-repo bundle.