### PR TITLE
lopepage-2: "+" Add-module button + plugin-registry menu (regenerate canonical HTML)

### DIFF
--- a/notebooks/@tomlarkworthy_lopepage-2.html
+++ b/notebooks/@tomlarkworthy_lopepage-2.html
@@ -16134,7 +16134,6 @@ export default function define(runtime, observer) {
   type="text/plain"
   data-mime="application/javascript"
 >
-
 const _1pg70e1 = function _lp2_doc_overview(md){return(
 md`# Lopepage-2: Multi-notebook layout
 
@@ -17513,34 +17512,31 @@ const _td27y7 = function _lp2_scrollToCell(lp2_anchor)
 const _1mnud0c = function _lp2_doc_menu(md){return(
 md`### Burger menu (plugin registry)
 
-A hamburger button docked at the left of the top-left tab bar opens a menu of pluggable items. \`viewof lp2MenuItems\` is the registry: a reactive array of \`{id, label, svg, action, children, order}\`. \`svg\` is an SVG string, an \`Element\`, or a function returning one; \`children\` nests a submenu; lower \`order\` sorts first.
+A hamburger button docked at the left of the top-left tab bar opens a menu of pluggable items. The registry is the [\`@tomlarkworthy/plugin-registry\`](https://observablehq.com/@tomlarkworthy/plugin-registry) set named \`"lp2-menu"\`; \`lp2MenuItems\` is \`plugins.get("lp2-menu")\`, a reactive array of \`{id, label, svg, action, children, order}\`. \`svg\` is an SVG string, an \`Element\`, or a function returning one; \`children\` nests a submenu; lower \`order\` sorts first.
 
-Plugins (this module's defaults, or any other notebook) register through \`lp2_registerMenuItem(item)\`, which upserts by \`id\` and returns a disposer — call it from \`invalidation\` so a re-run replaces rather than duplicates. Registration republishes only \`lp2MenuItems\`, and only \`lp2_menu_sync\` depends on it, so adding an item repopulates the popover in place — the layout, panes, and scroll state are untouched.
+Plugins (this module's defaults, or any other notebook) register through \`lp2_registerMenuItem(item)\` — an id-keyed wrapper over \`plugins.add("lp2-menu", item)\` that replaces by \`id\` and returns a disposer (call it from \`invalidation\` so a re-run replaces rather than duplicates). Any notebook can equally \`plugins.add("lp2-menu", item)\` directly without importing lopepage-2. Only \`lp2_menu_sync\` consumes \`lp2MenuItems\`, so adding an item repopulates the popover in place — the layout, panes, and scroll state are untouched.
 
 The button and popover are built once by \`lp2_burger\` (immortal, like panes) and reparented into the current top-left tab bar on each layout render. \`lp2_menu_defaults\` registers the built-ins: **Download** and **Fork** via [\`exporter-3\`](https://observablehq.com/@tomlarkworthy/exporter-3)'s \`downloadAnchor\`/\`forkAnchor\`, which serialise every booted main.`
 )};
-const _v3n2r8 = function _lp2MenuItems(Inputs){return(
-Inputs.input([])
+const _8wq5dn = function _lp2MenuItems(plugins){return(
+plugins.get("lp2-menu")
 )};
-const _8wq5dn = (G, _) => G.input(_);
-const _p9krt2 = function _lp2_registerMenuItem($0,Event){return(
-item => {
-  if (!item || !item.id)
-    throw new Error('menu item needs an id');
-  const el = $0;
-  const publish = items => {
-    el.value = items;
-    el.dispatchEvent(new Event('input', { bubbles: true }));
+const _p9krt2 = function _lp2_registerMenuItem(plugins){
+  // id-keyed adapter over the shared plugins bus (set name "lp2-menu"): re-registering an id replaces
+  // the prior value; the returned disposer removes only if this exact registration is still current.
+  const handles = new Map();   // id -> remove()
+  return item => {
+    if (!item || !item.id)
+      throw new Error('menu item needs an id');
+    const prev = handles.get(item.id);
+    if (prev) prev();                              // replace-by-id
+    const remove = plugins.add("lp2-menu", item);
+    handles.set(item.id, remove);
+    return () => {
+      if (handles.get(item.id) === remove) { remove(); handles.delete(item.id); }
+    };
   };
-  publish((el.value || []).filter(it => it.id !== item.id).concat([item]));
-  return () => {
-    const cur = el.value || [];
-    // only remove if this exact registration is still current (a re-register superseded us otherwise)
-    if (cur.includes(item))
-      publish(cur.filter(it => it !== item));
-  };
-}
-)};
+};
 const _6tghw4 = function _lp2_burger(invalidation)
 {
   const button = document.createElement('button');
@@ -17738,7 +17734,9 @@ export default function define(runtime, observer) {
 
   main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
-  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));  
+  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));
+  main.define("module @tomlarkworthy/plugin-registry", async () => runtime.module((await import("/@tomlarkworthy/plugin-registry.js?v=4")).default));
+  main.define("plugins", ["module @tomlarkworthy/plugin-registry", "@variable"], (_, v) => v.import("plugins", _));
   main.define("module @tomlarkworthy/claude-code-pairing", async () => runtime.module((await import("/@tomlarkworthy/claude-code-pairing.js?v=4")).default));  
   main.define("module @tomlarkworthy/command-palette", async () => runtime.module((await import("/@tomlarkworthy/command-palette.js?v=4")).default));  
   main.define("module @tomlarkworthy/themes", async () => runtime.module((await import("/@tomlarkworthy/themes.js?v=4")).default));  
@@ -17781,7 +17779,7 @@ export default function define(runtime, observer) {
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
   main.define("persistentId", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("persistentId", _));
   main.define("createModule", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("createModule", _));
-  main.define("realize", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("realize", _));
+  main.define("realize", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("realize", _));  
   main.define("visualizer", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("visualizer", _));  
   main.define("currentModules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", _));  
   main.define("cc_chat", ["module @tomlarkworthy/claude-code-pairing", "@variable"], (_, v) => v.import("cc_chat", _));  
@@ -17808,9 +17806,8 @@ export default function define(runtime, observer) {
   $def("_16ptruj", "lp2_watchModules", ["lp2Model","currentModules","viewof lp2_watchedModules","Event"], _16ptruj);  
   $def("_td27y7", "lp2_scrollToCell", ["lp2_anchor"], _td27y7);
   $def("_1mnud0c", "lp2_doc_menu", ["md"], _1mnud0c);
-  $def("_v3n2r8", "viewof lp2MenuItems", ["Inputs"], _v3n2r8);
-  $def("_8wq5dn", "lp2MenuItems", ["Generators","viewof lp2MenuItems"], _8wq5dn);
-  $def("_p9krt2", "lp2_registerMenuItem", ["viewof lp2MenuItems","Event"], _p9krt2);
+  $def("_8wq5dn", "lp2MenuItems", ["plugins"], _8wq5dn);
+  $def("_p9krt2", "lp2_registerMenuItem", ["plugins"], _p9krt2);
   $def("_6tghw4", "lp2_burger", ["invalidation"], _6tghw4);
   $def("_2xf9jm", "lp2_menu_sync", ["lp2_burger","lp2MenuItems"], _2xf9jm);
   $def("_hs74kp", "lp2_menu_defaults", ["lp2_registerMenuItem","disk_svg","downloadAnchor","forkAnchor","invalidation"], _hs74kp);
@@ -29850,6 +29847,247 @@ export default function define(runtime, observer) {
   return main;
 }
 </script>
+
+<script id="@tomlarkworthy/plugin-registry" 
+  type="text/plain"
+  data-mime="application/javascript"
+>
+const _1ej2r92 = function _intro(md){return(
+md`# Plugin Registry
+
+A foundational notebook for **decoupled reactive plugin wiring**.
+
+Consumers get a realtime stream of all registered providers under a name. Providers can register themselves under a name. Neither has direct references between each other. This allows you to add more consumers and providers without changing individual providers and consumers. Useful for reactive plugin systems like audio instruments, dyamic menus, LLM tools and entity component systems.
+`
+)};
+const _16jmxgh = function _diagram(htl){return(
+htl.html`<svg viewBox="0 0 720 300" width="100%" style="max-width:720px;font-family:system-ui,sans-serif">
+  <defs>
+    <marker id="pr-arr" markerWidth="9" markerHeight="9" refX="7" refY="4" orient="auto">
+      <path d="M0,0 L8,4 L0,8 Z" fill="var(--theme-foreground,#333)"></path>
+    </marker>
+    <style>
+      .pr-box{fill:var(--theme-background-alt,#f4f4f6);stroke:var(--theme-foreground-faint,#bbb);stroke-width:1.5}
+      .pr-hub{fill:var(--theme-foreground-faintest,#eef);stroke:var(--theme-foreground,#556);stroke-width:2}
+      .pr-t{fill:var(--theme-foreground,#222);font-size:13px}
+      .pr-s{fill:var(--theme-foreground-muted,#666);font-size:11px}
+      .pr-e{stroke:var(--theme-foreground,#333);stroke-width:1.5;fill:none;marker-end:url(#pr-arr)}
+    </style>
+  </defs>
+
+  <rect class="pr-box" x="10"  y="30"  width="170" height="48" rx="8"></rect>
+  <text class="pr-t" x="95" y="52" text-anchor="middle">Provider A</text>
+  <text class="pr-s" x="95" y="68" text-anchor="middle">plugins.add("x", v)</text>
+  <rect class="pr-box" x="10"  y="120" width="170" height="48" rx="8"></rect>
+  <text class="pr-t" x="95" y="142" text-anchor="middle">Provider B</text>
+  <text class="pr-s" x="95" y="158" text-anchor="middle">plugins.add("x", v, {invalidation})</text>
+  <text class="pr-s" x="95" y="215" text-anchor="middle">…N providers</text>
+
+  <rect class="pr-hub" x="270" y="78"  width="180" height="112" rx="10"></rect>
+  <text class="pr-t" x="360" y="104" text-anchor="middle" style="font-weight:600">plugins</text>
+  <text class="pr-s" x="360" y="128" text-anchor="middle">Map&lt;name, Set&lt;value&gt;&gt;</text>
+  <text class="pr-s" x="360" y="150" text-anchor="middle">add(name, value)</text>
+  <text class="pr-s" x="360" y="168" text-anchor="middle">get(name) → Generator</text>
+
+  <rect class="pr-box" x="540" y="30"  width="170" height="48" rx="8"></rect>
+  <text class="pr-t" x="625" y="52" text-anchor="middle">Consumer 1</text>
+  <text class="pr-s" x="625" y="68" text-anchor="middle">plugins.get("x")</text>
+  <rect class="pr-box" x="540" y="120" width="170" height="48" rx="8"></rect>
+  <text class="pr-t" x="625" y="142" text-anchor="middle">Consumer 2 (V2)</text>
+  <text class="pr-s" x="625" y="158" text-anchor="middle">plugins.get("x")</text>
+  <text class="pr-s" x="625" y="215" text-anchor="middle">…M consumers</text>
+
+  <path class="pr-e" d="M180,54 C225,54 235,116 268,126"></path>
+  <path class="pr-e" d="M180,144 C225,144 240,138 268,140"></path>
+  <path class="pr-e" d="M452,128 C500,116 510,54 538,54"></path>
+  <path class="pr-e" d="M452,142 C500,144 510,144 538,144"></path>
+</svg>`
+)};
+const _xnvzuh = function _contracts(md){return(
+md`## Contracts
+
+| Guarantee | How |
+|---|---|
+| **Named sets** | \`plugins\` maps a name → a set of values. Providers \`add\`, consumers \`get\`; they coordinate only by name. |
+| **Reactive** | \`get(name)\` is a Generator that yields the current set and re-yields on every add/remove for that name. |
+| **N↔M decoupling** | Providers and consumers share only \`plugins\`. Any number of each; a name is the whole contract. |
+| **Auto-cleanup** | \`add\` returns \`remove()\`. Pass \`{invalidation}\` (a cell's disposal promise) to remove automatically when the provider cell re-runs. |
+| **No leaks** | \`get\`'s Generator unsubscribes on disposal; per-name listeners are dropped when the last consumer leaves. |
+| **Eventual convergence** | Each consumer gets the current set immediately on \`get\`, then a full-set snapshot on every change — so any interleaving of add/remove/get converges. |`
+)};
+const _1ua5hud = function _apiReference(md){return(
+md`## API reference
+
+The whole API is two methods on \`plugins\`.
+
+**\`plugins.add(name, value, options?)\`** → \`remove()\`
+Add \`value\` to the set stored under \`name\` (creating the set on first use). Returns a \`remove()\` function
+that takes this value back out. \`options.invalidation\` (optional, may be null/omitted) is a promise — when
+it settles the value is removed automatically; pass a provider cell's built-in \`invalidation\` so re-running
+the cell replaces rather than duplicates. \`value\` is anything; for shared views it is commonly a factory
+\`() => element\` that each consumer calls to get its own instance.
+
+**\`plugins.get(name)\`** → Generator&lt;value[]&gt;
+Return a reactive Generator of the values currently in \`name\`'s set. It yields the current set immediately
+(so a late consumer still converges), then re-yields the full set on every add/remove. Use it from a cell
+and that cell recomputes on each change. Call it from as many consumers as you like (e.g. a module and its
+V2) — each call is an independent Generator that cleans up when its cell is torn down.`
+)};
+const _1pzt22q = function _createPlugins(Generators)
+{
+  return function createPlugins() {
+    const sets = new Map();
+    // name -> Set<value>
+    const listeners = new Map();
+    // name -> Set<() => void>
+    const notify = name => {
+      const ls = listeners.get(name);
+      if (ls)
+        for (const l of [...ls])
+          l();  // copy: a consumer may (un)subscribe while notifying
+    };
+    const add = (name, value, options) => {
+      let set = sets.get(name);
+      if (!set)
+        sets.set(name, set = new Set());
+      set.add(value);
+      notify(name);
+      const remove = () => {
+        const s = sets.get(name);
+        if (s && s.delete(value)) {
+          if (s.size === 0)
+            sets.delete(name);
+          notify(name);
+        }
+      };
+      const invalidation = options && options.invalidation;
+      if (invalidation)
+        Promise.resolve(invalidation).then(remove, remove);
+      return remove;
+    };
+    const get = name => Generators.observe(change => {
+      const push = () => change([...sets.get(name) ?? []]);
+      push();
+      // current set immediately → converges
+      let ls = listeners.get(name);
+      if (!ls)
+        listeners.set(name, ls = new Set());
+      ls.add(push);
+      return () => {
+        ls.delete(push);
+        if (ls.size === 0)
+          listeners.delete(name);
+      };  // leak-safe
+    });
+    return {
+      add,
+      get,
+      listenerCount: name => listeners.get(name)?.size ?? 0
+    };
+  };
+};
+const _1qu8dwj = function _plugins(createPlugins){return(
+createPlugins()
+)};
+const _a7p1z5 = function _testsHeader(md){return(
+md`## Tests`
+)};
+const _15xl311 = function _test_get_reflects_add(createPlugins){return(
+(async () => {
+  const p = createPlugins();
+  const gen = p.get('x');
+  if ((await (await gen.next()).value).length !== 0)
+    throw new Error('new set should start empty');
+  p.add('x', 1);
+  const after = await (await gen.next()).value;
+  if (after.length !== 1 || after[0] !== 1)
+    throw new Error('get did not reflect the add');
+  gen.return();
+  return '\u2705 get(name) yields the named set and updates on add';
+})()
+)};
+const _122zyhz = function _test_multi_provider_and_convergence(createPlugins)
+{
+  return (async () => {
+    const p = createPlugins();
+    const a = p.get('x'), b = p.get('x');
+    // two independent consumers
+    await (await a.next()).value;
+    await (await b.next()).value;
+    p.add('x', 'one');
+    // provider 1
+    p.add('x', 'two');
+    // provider 2
+    const va = (await (await a.next()).value).slice().sort().join(',');
+    const vb = (await (await b.next()).value).slice().sort().join(',');
+    if (va !== 'one,two' || vb !== 'one,two')
+      throw new Error('consumers did not converge to the full set');
+    a.return();
+    b.return();
+    return '\u2705 multiple providers accumulate; all consumers converge';
+  })();
+};
+const _1lojas7 = function _test_remove_and_names_isolated(createPlugins){return(
+(async () => {
+  const p = createPlugins();
+  const gx = p.get('x'), gy = p.get('y');
+  await (await gx.next()).value;
+  await (await gy.next()).value;
+  const remove = p.add('x', 1);
+  p.add('y', 2);
+  if ((await (await gx.next()).value).join() !== '1')
+    throw new Error('x set wrong');
+  if ((await (await gy.next()).value).join() !== '2')
+    throw new Error('names are not isolated');
+  remove();
+  if ((await (await gx.next()).value).length !== 0)
+    throw new Error('remove() did not take the value out');
+  gx.return();
+  gy.return();
+  return '\u2705 remove() works and names are isolated';
+})()
+)};
+const _8240yg = function _test_invalidation_and_no_leak(createPlugins){return(
+(async () => {
+  const p = createPlugins();
+  let settle;
+  p.add('x', 1, { invalidation: new Promise(r => settle = r) });
+  const gen = p.get('x');
+  if ((await (await gen.next()).value).length !== 1)
+    throw new Error('value should be present before invalidation');
+  if (p.listenerCount('x') !== 1)
+    throw new Error('get should have registered a listener');
+  settle();
+  await Promise.resolve();
+  await Promise.resolve();
+  if ((await (await gen.next()).value).length !== 0)
+    throw new Error('invalidation did not remove the value');
+  gen.return();
+  if (p.listenerCount('x') !== 0)
+    throw new Error('disposing the Generator leaked a listener');
+  return '\u2705 {invalidation} auto-removes and get() leaks no listeners';
+})()
+)};
+
+export default function define(runtime, observer) {
+  const main = runtime.module();
+  const $def = (pid, name, deps, fn) => {
+    main.variable(observer(name)).define(name, deps, fn).pid = pid;
+  };
+
+  $def("_1ej2r92", "intro", ["md"], _1ej2r92);  
+  $def("_16jmxgh", "diagram", ["htl"], _16jmxgh);  
+  $def("_xnvzuh", "contracts", ["md"], _xnvzuh);  
+  $def("_1ua5hud", "apiReference", ["md"], _1ua5hud);  
+  $def("_1pzt22q", "createPlugins", ["Generators"], _1pzt22q);  
+  $def("_1qu8dwj", "plugins", ["createPlugins"], _1qu8dwj);  
+  $def("_a7p1z5", "testsHeader", ["md"], _a7p1z5);  
+  $def("_15xl311", "test_get_reflects_add", ["createPlugins"], _15xl311);  
+  $def("_122zyhz", "test_multi_provider_and_convergence", ["createPlugins"], _122zyhz);  
+  $def("_1lojas7", "test_remove_and_names_isolated", ["createPlugins"], _1lojas7);  
+  $def("_8240yg", "test_invalidation_and_no_leak", ["createPlugins"], _8240yg);
+  return main;
+}</script>
 
 <!-- Bootloader -->
 <script id="bootconf.json"

--- a/notebooks/@tomlarkworthy_lopepage-2.html
+++ b/notebooks/@tomlarkworthy_lopepage-2.html
@@ -16134,6 +16134,7 @@ export default function define(runtime, observer) {
   type="text/plain"
   data-mime="application/javascript"
 >
+
 const _1pg70e1 = function _lp2_doc_overview(md){return(
 md`# Lopepage-2: Multi-notebook layout
 
@@ -16648,7 +16649,93 @@ const _sx484g = function _lp2_dragOut(){return(
   };
 }
 )};
-const _1l0f5al = function _lp2_view(lp2_host,lp2Model,lp2_installAnchor,lp2_anchor,$0,Event,lp2_getPane,lp2_dragOut,lp2_ops,linkTo,lp2_paneRegistry,lp2_renderNode,lp2_burger)
+const _1yan973 = function _lp2_add_module(createModule,runtime,realize,location,linkTo,invalidation)
+{
+  const button = document.createElement('button');
+  button.className = 'lp2-add-module';
+  button.title = 'Create module';
+  button.setAttribute('aria-haspopup', 'true');
+  button.setAttribute('aria-expanded', 'false');
+  button.textContent = '+';
+  Object.assign(button.style, {
+    border: 'none', background: 'transparent', padding: '4px 10px',
+    cursor: 'pointer', color: 'var(--theme-foreground)',
+    font: '15px var(--sans-serif, sans-serif)', lineHeight: '1'
+  });
+
+  const popover = document.createElement('div');
+  popover.className = 'lp2-menu';
+  Object.assign(popover.style, {
+    position: 'fixed', display: 'none', zIndex: 1000,
+    background: 'var(--theme-background-a, #fff)', color: 'var(--theme-foreground)',
+    border: '1px solid var(--theme-foreground-fainter)', borderRadius: '4px',
+    boxShadow: '0 4px 16px rgba(0,0,0,.18)', padding: '8px',
+    font: '12px var(--sans-serif, sans-serif)'
+  });
+  const input = document.createElement('input');
+  input.type = 'text';
+  input.placeholder = '@user/module-name';
+  input.title = 'Enter a module name and press ↵ to create';
+  input.spellcheck = false;
+  Object.assign(input.style, {
+    padding: '4px 8px', border: '1px solid var(--theme-foreground-fainter)',
+    borderRadius: '3px', font: '12px var(--monospace, monospace)',
+    width: '210px', outline: 'none', boxSizing: 'border-box',
+    background: 'var(--theme-background, #fff)', color: 'var(--theme-foreground)'
+  });
+  const hint = document.createElement('div');
+  hint.textContent = '↵ create · esc cancel';
+  Object.assign(hint.style, { marginTop: '5px', color: 'var(--theme-foreground-faint)', fontSize: '11px' });
+  popover.append(input, hint);
+  document.body.appendChild(popover);
+
+  const close = () => { popover.style.display = 'none'; button.setAttribute('aria-expanded', 'false'); };
+  const resetBorder = () => { input.style.borderColor = 'var(--theme-foreground-fainter)'; };
+  const open = () => {
+    const r = button.getBoundingClientRect();
+    popover.style.left = Math.round(Math.min(r.left, window.innerWidth - 240)) + 'px';
+    popover.style.top = Math.round(r.bottom + 2) + 'px';
+    popover.style.display = 'block';
+    button.setAttribute('aria-expanded', 'true');
+    input.value = '';
+    resetBorder();
+    input.focus();
+  };
+  const create = async () => {
+    let name = input.value.trim().split('#')[0].replace(/\/+$/, '');
+    if (!name) { input.style.borderColor = '#e5533d'; return; }
+    if (!name.includes('/')) name = '@user/' + name.replace(/^@+/, '');
+    const src = 'function intro(md){ return md`# ' + name.split('/').pop() + '`; }';
+    const mod = createModule(name, runtime);
+    const [fn] = await realize([src], runtime);
+    mod.variable({}).define('intro', ['md'], fn);
+    close();
+    location.hash = linkTo({ open: name }, { baseURI: location.href });
+  };
+
+  button.addEventListener('click', ev => {
+    ev.stopPropagation();
+    popover.style.display === 'none' ? open() : close();
+  });
+  input.addEventListener('input', resetBorder);
+  input.addEventListener('keydown', ev => {
+    if (ev.key === 'Enter') {
+      ev.preventDefault();
+      create().catch(e => { input.style.borderColor = '#e5533d'; console.error('lp2 create module failed', e); });
+    } else if (ev.key === 'Escape') { ev.preventDefault(); close(); }
+  });
+  const onDocDown = ev => {
+    if (popover.style.display !== 'none' && !popover.contains(ev.target) && !button.contains(ev.target)) close();
+  };
+  document.addEventListener('mousedown', onDocDown);
+  invalidation.then(() => {
+    document.removeEventListener('mousedown', onDocDown);
+    popover.remove();
+    button.remove();
+  });
+  return { button, close };
+};
+const _1l0f5al = function _lp2_view(lp2_host,lp2Model,lp2_installAnchor,lp2_anchor,$0,Event,lp2_getPane,lp2_dragOut,lp2_ops,linkTo,lp2_paneRegistry,lp2_renderNode,lp2_burger,lp2_add_module)
 {
   const host = lp2_host;
   lp2Model;
@@ -16675,12 +16762,15 @@ const _1l0f5al = function _lp2_view(lp2_host,lp2Model,lp2_installAnchor,lp2_anch
       saved.set(name, anc || { raw: entry.el.scrollTop });
     }
     host.replaceChildren(lp2_renderNode(ctx)(lp2Model));
-    // dock the immortal burger button into the top-left tab bar; a rerender moves
-    // the button so any open popover is anchored stale — close it
+    // dock immortal controls into the top-left tab bar; a rerender moves them so any
+    // open popover is anchored stale — close both before reparenting
     lp2_burger.close();
+    lp2_add_module.close();
     const firstTabs = host.querySelector('.lp2-tabs');
-    if (firstTabs)
+    if (firstTabs) {
       firstTabs.prepend(lp2_burger.button);
+      firstTabs.appendChild(lp2_add_module.button);
+    }
     for (const [name, anc] of saved) {
       const entry = lp2_paneRegistry.get(name);
       if (!entry || !entry.el.isConnected)
@@ -17674,7 +17764,8 @@ export default function define(runtime, observer) {
   $def("_6f57qb", "lp2_renderNode", ["lp2_renderStack","lp2_renderSplit"], _6f57qb);  
   $def("_1r0c4er", "lp2_ops", [], _1r0c4er);  
   $def("_sx484g", "lp2_dragOut", [], _sx484g);  
-  $def("_1l0f5al", "lp2_view", ["lp2_host","lp2Model","lp2_installAnchor","lp2_anchor","viewof lp2Model","Event","lp2_getPane","lp2_dragOut","lp2_ops","linkTo","lp2_paneRegistry","lp2_renderNode","lp2_burger"], _1l0f5al);
+  $def("_1yan973", "lp2_add_module", ["createModule","runtime","realize","location","linkTo","invalidation"], _1yan973);
+  $def("_1l0f5al", "lp2_view", ["lp2_host","lp2Model","lp2_installAnchor","lp2_anchor","viewof lp2Model","Event","lp2_getPane","lp2_dragOut","lp2_ops","linkTo","lp2_paneRegistry","lp2_renderNode","lp2_burger","lp2_add_module"], _1l0f5al);
   $def("_1bytrbx", "lp2_probe", ["lp2_view","lp2_paneRegistry"], _1bytrbx);  
   $def("_orvfgz", "lp2_doc_hash", ["md"], _orvfgz);  
   $def("_y2r8d1", "lp2_hash", ["Generators","location"], _y2r8d1);  
@@ -17688,7 +17779,9 @@ export default function define(runtime, observer) {
   $def("_z83rug", null, ["currentModules"], _z83rug);  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
-  main.define("persistentId", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("persistentId", _));  
+  main.define("persistentId", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("persistentId", _));
+  main.define("createModule", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("createModule", _));
+  main.define("realize", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("realize", _));
   main.define("visualizer", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("visualizer", _));  
   main.define("currentModules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", _));  
   main.define("cc_chat", ["module @tomlarkworthy/claude-code-pairing", "@variable"], (_, v) => v.import("cc_chat", _));  


### PR DESCRIPTION
Two changes, both verified booting together in a clean browser load of the captured HTML:

## 1. `lp2_add_module` — the "+" create-module button
New cell modelled on the immortal `lp2_burger`: builds the `+` button + a small popover once; `lp2_view` reparents it to the end of the top-left `.lp2-tabs` bar each render. Idiomatic and rerunnable:
- `invalidation.then(...)` removes the doc listener + both DOM nodes on recompute (verified: recompute keeps exactly 1 button/1 popover).
- Imports `createModule`/`realize` from `@tomlarkworthy/runtime-sdk` — no private internals, no `window.__ojs_observer`.
- Seeds the new module with a `# <name>` title via `mod.variable({}).define('intro', ['md'], fn)`; the seed is awaited **before** `location.hash` navigates (no navigate-before-seed race).
- `create()` rejections surface (red border + `console.error`), no silent catch.

## 2. Regenerate canonical HTML from the plugin-registry menu version
The lopepage-2 module store (`modules/@tomlarkworthy/lopepage-2.js`, commit `42c2635`) had migrated the burger menu to `@tomlarkworthy/plugin-registry` but the submodule HTML was never regenerated. This PR rebuilds the canonical HTML from that version and **bundles the `@tomlarkworthy/plugin-registry` `<script>` block** the menu now depends on (sourced from `command-palette.html`).

## Verification (clean reload, no live edits)
- Notebook boots; `lopepage-2` now `dependsOn @tomlarkworthy/plugin-registry` ✅
- Burger menu renders 3 bus-registered items (Save in place, Download, Fork) ✅
- `+` docks at tab-bar end; Enter creates `@user/<name>`, seeds title, opens the pane ✅
- Recompute leaves exactly one button + one popover ✅
- Console: clean

Diff: one file, +364/−33.

Note: ObservableHQ was not pushed and consumer notebooks (command-palette, lopecode-tour, save-in-place, robocoop-4, + lopebooks consumers) were not re-synced — they remain on the previous lopepage-2. Follow-up if a full propagation is wanted.