### PR TITLE
editor-5: reframe onto lopepage-2 + save-in-place (jumpgated from fixed Observable)

### DIFF
--- a/notebooks/@tomlarkworthy_editor-5.html
+++ b/notebooks/@tomlarkworthy_editor-5.html
@@ -4,12 +4,58 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
   <title>@tomlarkworthy/editor-5</title>
+  <meta property="og:title" content="@tomlarkworthy/editor-5">
+  <meta property="og:type" content="website">
   <link rel="icon" href="data:image/svg+xml;base64,PHN2ZyBmaWxsPSJ3aGl0ZSIgd2lkdGg9IjUwcHgiIGhlaWdodD0iNTBweCIgdmlld0JveD0iMCAwIDY0IDY0IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxyZWN0IGhlaWdodD0iNCIgd2lkdGg9IjQiIHg9IjIwIiB5PSI1MCI+PC9yZWN0PjxyZWN0IGhlaWdodD0iNCIgd2lkdGg9IjE2IiB4PSIyOCIgeT0iNTAiPjwvcmVjdD48cGF0aCBkPSJNMzIsMzhhOCw4LDAsMSwwLTgtOEE4LjAwOSw4LjAwOSwwLDAsMCwzMiwzOFptMC0xMmE0LDQsMCwxLDEtNCw0QTQsNCwwLDAsMSwzMiwyNloiPjwvcGF0aD48cGF0aCBkPSJNNiw2Mkg1OGEyLDIsMCwwLDAsMi0yVjE1YTIsMiwwLDAsMC0uNTg2LTEuNDE0bC0xMS0xMUEyLDIsMCwwLDAsNDcsMkg2QTIsMiwwLDAsMCw0LDRWNjBBMiwyLDAsMCwwLDYsNjJabTQyLTRIMTZWNDZINDhaTTE2LDZIMzF2NGg0VjZoNHY4SDE2Wk04LDZoNFYxNmEyLDIsMCwwLDAsMiwySDQxYTIsMiwwLDAsMCwyLTJWNmgzLjE3Mkw1NiwxNS44MjlWNThINTJWNDRhMiwyLDAsMCwwLTItMkgxNGEyLDIsMCwwLDAtMiwyVjU4SDhaIj48L3BhdGg+PC9zdmc+">
 </head>
 <body>
 <script id="networking_script">
   const normalize = url => url.replace(/^(?:https:\/\/api\.observablehq\.com)?\/(.*?)\.js(?:\?.*)?$/, '$1').replace(/^(d\/[a-f0-9]{16})@\d+$/, '$1');
   const isNotebook = id => /^(@[^/]+\/[^/]+|d\/[a-f0-9]{16})$/.test(id);
+
+  // --- streaming gate ---
+  // main runs from the TOP of the document, before the whole file has finished downloading, so a
+  // block a boot import needs may not have streamed in yet. __waitForId blocks until the block's
+  // <script> is fully parsed (el.nextSibling is non-null only after its </scr\ipt> is seen),
+  // bounded by window.__lopeStreaming, which flips to false once the document is fully parsed (so a
+  // genuinely-absent id resolves to a 404 rather than hanging).
+  //
+  // The wait is event-driven (MutationObserver + DOMContentLoaded/load), NOT a setTimeout poll:
+  // Safari throttles timers in background/unfocused tabs, and a fork opens via window.open into a
+  // tab that is often not foregrounded, so a poll loop stalls there (works in a foreground file://
+  // download but hangs in a backgrounded blob: fork). MutationObserver fires on the parser's node
+  // insertions regardless of timer throttling. The end-of-document sentinel stays as a redundant
+  // fast-path; DOMContentLoaded/load clear the flag even if that inline script never runs.
+  window.__lopeStreaming = true;
+  function __endStreaming() { window.__lopeStreaming = false; }
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", __endStreaming, { once: true });
+    window.addEventListener("load", __endStreaming, { once: true });
+  } else {
+    __endStreaming();
+  }
+  function __isComplete(el) { return !!el && (el.nextSibling != null || !window.__lopeStreaming); }
+  function __waitForId(id) {
+    if (__isComplete(document.getElementById(id)) || !window.__lopeStreaming) return Promise.resolve();
+    return new Promise((resolve) => {
+      let done = false;
+      const finish = () => {
+        if (done) return;
+        done = true;
+        mo.disconnect();
+        document.removeEventListener("DOMContentLoaded", onEnd);
+        window.removeEventListener("load", onEnd);
+        resolve();
+      };
+      const check = () => { if (__isComplete(document.getElementById(id)) || !window.__lopeStreaming) finish(); };
+      const onEnd = () => { __endStreaming(); finish(); };
+      const mo = new MutationObserver(check);
+      mo.observe(document.documentElement, { childList: true, subtree: true });
+      document.addEventListener("DOMContentLoaded", onEnd);
+      window.addEventListener("load", onEnd);
+      check();
+    });
+  }
 
   const b64ToBytes = (b64) => {
     const bin = atob(b64);
@@ -59,6 +105,7 @@
 
   // Async bytes for global fetch/XHR/blob URLs
   async function dvfBytes(id) {
+    await __waitForId(id);
     const el = document.getElementById(id);
     if (!el) return { status: 404 };
 
@@ -90,7 +137,11 @@
     return { status: 422 };
   }
 
-  // --- es-module-shims hooks (sync) ---
+  // --- es-module-shims hooks ---
+  // fetch and source are async and wait for not-yet-streamed blocks (es-module-shims awaits both:
+  // `c = await fetchHook(...)` and `await (sourceHook||default)(...)`). resolve is NOT awaited, so it
+  // stays synchronous — it just routes a not-yet-present notebook id to file:// (where fetch/source
+  // then wait) instead of rewriting it to the remote observablehq API.
   window.esmsInitOptions = {
     shimMode: true,
     resolve(id, parentUrl, defaultResolve) {
@@ -101,12 +152,14 @@
         if (el.href) return el.href;
         return `file://${id}`;
       }
+      if (window.__lopeStreaming && isNotebook(id)) return `file://${id}`;
       if (isNotebook(id)) id = `https://api.observablehq.com/${id}.js?v=4`;
       return defaultResolve(id, parentUrl);
     },
-    source(url, fetchOpts, parent, defaultSourceHook) {
+    async source(url, fetchOpts, parent, defaultSourceHook) {
       if (url.startsWith("file://")) {
         const id = url.slice(7);
+        await __waitForId(id);
         const el = document.getElementById(id);
         if (!el) return { type: "js", source: "throw new Error('DVF 404')" };
         const enc = (el.getAttribute("data-encoding") || "text").toLowerCase();
@@ -119,12 +172,13 @@
       }
       return defaultSourceHook(url, fetchOpts, parent);
     },
-    fetch(url, options, parent) {
+    async fetch(url, options, parent) {
       if (typeof url !== "string" || !url.startsWith("file://")) {
         return fetch(url, options);
       }
       const id = url.slice(7);
-      return dvfResponseSync(id); // must be synchronous
+      await __waitForId(id);
+      return dvfResponseSync(id);
     }
   };
 
@@ -234,6 +288,35 @@
       }
     }
   })();
+</script>
+
+<script id="main">
+(async () => {
+  await window.esmsInitOptions.fetch("file://es-module-shims@2.6.2").then(r => r.text()).then(src => {
+    const script = document.createElement('script');
+    script.textContent = src;
+    document.head.appendChild(script);
+  });
+
+  const style0 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/global.css", { with: { type: 'css' } });
+  const style1 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/inspector.css", { with: { type: 'css' } });
+  const style2 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/highlight.css", { with: { type: 'css' } });
+  const style3 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/plot.css", { with: { type: 'css' } });
+  const style4 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/index.css", { with: { type: 'css' } });
+  const style5 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/theme-parchment.css", { with: { type: 'css' } });
+  const style6 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/abstract-light.css", { with: { type: 'css' } });
+  const style7 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/syntax-light.css", { with: { type: 'css' } });
+  const style8 = await importShim("file://syntax.css", { with: { type: 'css' } });
+  document.adoptedStyleSheets = [style0.default,style1.default,style2.default,style3.default,style4.default,style5.default,style6.default,style7.default,style8.default];
+
+  const { Runtime } = await importShim("@observablehq/runtime@6.0.0");
+  const { Inspector } = await importShim("@observablehq/inspector@5.0.1");
+  const notebook = document.querySelector("notebook");
+  const runtime = new Runtime({__ojs_runtime: () => runtime, __ojs_observer: () => observer});
+  const observer = Inspector.into(document.body);
+  const {default: define} = await importShim("@tomlarkworthy/bootloader");
+  runtime.bootloader = runtime.module(define, () => ({}));
+})().catch((e) => console.error("boot error", e));
 </script>
 
 <!-- CSS -->
@@ -820,6 +903,3902 @@ H4sIAK6D82gAA7Uca2/cNvK7fwVjHAqpUTep+83bNC3uckCAJimatMDBMFx5V7bV7kp7ktaOz93/fiTn
   data-mime="application/javascript">
 H4sIAGWI82gAA+08/XfbOI6/969QdXlbuXHs2O112qRpm0ncndzko69J566X5BLFomNNZckryfnY1P/7AQRJkfqwZW96s7Pv+l5jiQRBEAABECTVblth5LGLUeRNApa0P0RXCYtv3KuADf/W9sNkzPppFLeTuN/2/GTspv1h6/fkyWAS9lM/Ci1Z6CCappXej+Gvx1LXDxrWwxNLPFtb8uH7d+thugkVN25seVF/MmJh2oV6RNCKbkMW74rSpsVu4AfbSriWxwbuJEh/89lta2eSpNGohzCI0B9YDvYfDWS7rS3LlpTaRI6lcIbslp4dIvpBUjhtILapxYKE5dpkdPRj5qaM9+3Y/MfmzQRsyw/9tKdhH7iATfwYgDn+8K7hP+eGZC4h4vDQdvrkSXsBsblx7N4bMvMTXubcuMGEEVtilk7i0NrmsH6yrdeDxPiTBXhTN+wjg/fC9DUHqqrtvJpZ/aJbXf3Fn4mcV+8E7mjMvNlQs2jA+llEfAwidz7Aq5ccAGWicdcPPXbnfGP3Bm/hnWskVljfrfWGtWrZ9sLiFG+H7oiZQs3KnRD+UN/9CCi2Qk11peYGbMR1FzQsJNUNW/3ATRLEAPC2TsPaWp8FAaK1CTJld+lOFKY0LS5XHrBuio+b2YjDhQc3iOKRmx7fj66iAEeHNiLhbyfRcRr74TV0IarHcZRGOLlaqajbzLihI3IIgyEME2mr7wYKbGGio6vf4UWS+2Bds/ToNvwUR2MWp/dEQ9K0FL0bADN0Ew0GjA3y7ogj2hRo5KhO3GteS4io9uPR55/3dnd7h1CO1jTjUwKquVVOwqauo2BoHSK8aeU11SSOmKPDGuqeutfRQFQbWKjoVBvGOU4kwS2umPEEmWj95S8lpS3UKGxgE1tso1c+HVW/2hDS+F7YbFJ9mrdbkhqAOyfri95CGDj+o/dNEGIcvJY8Qh+NseX412EUM+lPBJgSCVnwRWf1aDRJsUaq0fHXg5+P9o+B8lPA9yCku2HZHz5cXOwdHHw52f55v3exd7jb+6/e7sXFhw9200KWAcge2h/mQQF07Q98Fm8AX4AN0+YsXL/2vuYx/cruF8ezv3d8YqLZ95MU3rjX8ZNhLSwH259MJAfu2BZtON8r2h193u19luPggKL9UeyxGEfDC80RUdk4ZgP/jkpQiDPp+9zbga5MEj+zfhR7dag87p0UKTxmqSgwOUVlCUtVyVzqjk+2d341iTtO3f63Eik8OdcNg9RD7kdg0uRnVcBSaWnQJpGWtgZ+kLLYcSQ9EENZW+9w0p1SwTl3fdhhI5t+TwWiVsDC63TYEFNpU5u+ITkjCTgA1+o4CUf+NGlJITb0JiRFDPDQRRICDAS5/oCpKcOVoeIQLcJhoJVs06hJIuCRwiABjFYktMo2VN0w7A3xWSoFuFYxoPdiZDQkEKg9JbfLC6aXTdFO9CRfM3GrEcAQn1LPqg1/4y9Tw9TlrVw4CYKlDBy7gzjDY57hJj9Jl3g0aOZ81i5L+rE/huZJwTeSLVeNyd9puJwHDOHzkVFPUKB8xgVNDeGZaaCo3pqkZaQs3NumgACfB6G8zwIP/HoIoVDTCuUKhED1SBEUT3KxHKDo/BpKC6ArjKoAh7PyIAAT/+9s2rjcFCBECFILcxBCO4ClKmMJI1HhPHAadlVjyWfePlsGlRMOBusfHhngqD0ygJ01MkS11MjU1BUYBWmKrHxYMs0oJtOlaM53KpYHRm8YjRfsLKpXrvs9FRPAPKd+5QNZNOlu3oMtAINwWeDjVFClaXSo7FSO4KwC8Anq90a0/tmAWmHJtDpgN9So14y/2li1qSXHZQSM5Vzjc7mwCK/dXKNELYFwmVNrFYRPsxZC0pDZcsJniy3R2B2PWejtDP3AcwqrsoZJlouuId+oikjXpuZuyw9DFv9ycrCPevI2ubm2bn0vHW69tobMvx6m8MCHsPUst4pzwY4/e8dpfTt206HlbT07eGn9tL9udYav//4MeBkEW8/6kziGLneiIIqfWW1s8LYN3by7pP5nUHsC5vAQvIID0wdkBSqr6ZVtnaKm2taDPb2Ug3E9jyc4MEpkMC7HHkWThE3GEKxIIy6SH3o6ppWk0RjdhXvtchDlRseB22cOsrUpjT+MJHDHiWb90ZOZDoBEw/8qjaIHXd1gZWk56AR8qF7ftJ466AAUaAvfnEaj5UUhQ0/rW2+tLsCtrvqVWoJtWrQYkerB4yNejogaxprG7S6jNcDq7izF5vTbCjJJ7wPKQAVgAQD6KoggflT1tVTAss4m3fXuKwi3Y3ap0bG4zOdIXXAVxA3Rw88MpMQ0tjapFgafcooxwLvxocdj/yqAxalCsox0O28M6T4aLVPxy41Mpgm8dcxG0Q0j7tdEpzK1NDHsIHI9mbOcKr2bp1ZKtvqsPueTeioUTaZYAJO+Zn+uxSfOSMZEnOGk1rg4b9Jy+9yC4GGUxU33yH2R1IHmH/HVycAV9RzuuekHeF+lhGC8kMgQRiOEcgZAQZLFNzoF0I4oqNE5oijtnPvPx+u+pAdK4nI5aX0o5W7ytCBlhymK2eTqHBrajMrngxW1NDx5gogav6myMhwWbG+jmTcyPDWqtE4wThs75kbznXFTaGRVceLxDJboCAtnkZZpSkYctimQB4UziBNrW5SMzLUJ9paJibrO7EohHykXXznCcrU5CqnW5pXVoheBmy58LvcOt2rmqDItwKhxE4GkEnSqx+V3RCahBWsveANeqtV9KUk8pjPyhEWxVy4B8xHyHBHrWcFqGdeQ7txuFxCvJGph+WaJDeBgcbGrxSYq4sYZQg9Pt7by6+Wy0ahKEbFXilGYtdly1GuFCSkknGvP13rCrD1h/1+kRWMxW6h5v2xKd5b0Zs29aX6zJqNX25ckCoDQ0YzFm+ffEFZjqYeNagXItPYjbmObWjHyvGWi2u3hY1YtcvtmuAqTgLS2mke1ir9siLg0oksWnY6QwU3ke+ju87/cXusRGyLaLAqmKFU17j+bkNRztUBWHmCk0x8jizrcLgtvl+ByfSbVH6U1d5TcsC+IdOvd4zEvFxr/afhWPcCFkux9meUwTgYM3eSYBUysqWHEOl8ShmdPbiG4jm4xlMsgjbUcC1qUaud5Rze8ZnwvxcEKQJS6QAgfLOIXpgU3b/FVAXBoN+wPoxhhKwAGwEaOq2FuNFdmcpKhGwTR7b9uNr87K+ldJ50vETz558vnzxxbnYR++dh+cEa/m0tz/+lS+t3qnH63mNTXh7tULr6rpzXFfDVzmuiMu7US9OS4Z6YyRQ9Cc/JJeolgfp5e5uCK8FW2HjjSMKhcJtGJBBtGm6NqmPvjc/Oheh68W5kIVwM1N6F5I3Ot8mg7KMpL/QttofxkvdzvWK9/W/8jtlBo9AsrWqma5bRs8Z2WwjZ71UaLljD6sdstlMJ8hycua2e3gWm2PpEX3a5ZpCPaIrF1Wf7o/Hv3MRLw3boZ+O7MFHx3wSR4bnWrZR2rep+dg3+8/qsTsd1CJnYdVHit01w+Jcu1ugNqDahWLSjWRdQbjdN7rF7D6jWo3iwZQVX+1iLy/I6u3Qv1VbUbsTQf1AZFNSeKexRLsahUzNqeRo5TBq+yJOQSXf/oXZDuH7gN0nVK06lVWx8VGdR5Wenuj01Ld//QvPQ8FuZz0QvzUAX7j5QH7i6bCKbpYWRvHu/0DuKuSsfSGqyDHpXgcAXGn6yzu92frJUHNtXvN+Q9bPXoSxOmg9i9Hpn3isTA5AWojwLCKSZOZeNFk6cLp0RhGNw61eivJB9a2qzMg+qRi2w0IzvarUiPLsrTmfTxLjLqFmOBltf8h5lQSAKC3SJ+aLdmjJwfFTkekMQvnQVXbv8bMYo7El6jZ3Z24R2MDy/estrPrQ8XF5++fO5dXFjP2/yuHEI4qwigNqZ8UJxDjkotGyxxA0/2mbuEB3NL1lA7mGKyINPxYTSJcTmAEBiffDnZ+QWL9Hkw8sNJynJQB1RozBcGv14O7pgKTXxB4JcCH2g1RlYUlmfE56/MjR2txUdY8vAyMMMvG9O1lYex6+kABzC9hg7eAIPQp1sGwbnd4JUrD8SP79/VoOFRkspLNdLfW5cnhI234hg2qEC0FkhnIBDwokTA54FaEmlW3LReNKaXaDUv5c9/y9eSycxZdA9/jHtDWABB3jr2IfiyhmVN6xUh5wDvrDfwD2FWCcYAyQpemklkrBAzji/3jZ5BnrxuetkCuOPUjVOHQ4H7WrcXvxhGo0RJlsxNLmCaAhoJxry190Kgx/f41Fu6/14cR7E8ds/wRbtLR5U1rtJxwJIbo3R3KsG7JTydr+Onm2NyfbgU8Z/Zde9uLKmP+ZtGvqiuQT9BlgzAxPkIJAtEguTD3n/u7x3ipaiDvROguLtevKXIGzgJ/9G2M+RJY0qeZMZbAHDLSveJtYi2H03At0lc7VP7LDxvXzest+DpzarL72crD1CVRbxZgPGiZiZWT9/xdrWSqrInDDR+Q1a/ECm8F4tGMzwVrbDMTAnzYdsljcxw5z+Ojw5bBOwP7gW3tJyqCvxe6AliGk/gh9whUaNWMg58IPdMcQt5xWHEchaMmKkeeDFHSj0vFs+/qbN/acoEipeXSL7xHyIP+9IGL5lCFB64KUqEGJgEfp85602TgY3W75EfEstzI+PCgIXO8uMSHIph8gKUt4OzCbAZAl0z6ZFNZef50wbHQ5jGKw8mzmnWB0eerwet4UuUxKZLYJeFXuayXVxisAstl9mtmLsRkSWKgfMqT1y0d/yqo2Wq5TQ/9QBFceItsnlkGqx6u0C5ySGP38/cEipXowyHIaXLMinBclPYAp72r7iGYiiBhn7ONBKGDb9BcGk/2taPydwavM1xdpGtHI2vqn1Ni5PB1zD+mbHurPOgFEJnYeClEfr39caUsvi5urWXbygg1fxIVfKgRDhamCLQypnUPj07uzy7W19fgz9v4P8VPHTenJNPb2rIdoZu3KjoCOuc/lAG4Biv9CHYwawAFLbwzw68b6fOOiUPbn1+K7TPT2+QAei7CbNeb5iz1D47uxJaxevfFOtTvb7TKQLcGADdIsDAAHhRBIhtqcaijA/urdV5hRPqDLiGkwILVdzodF7hklQAvugKwCo4qONVwCiDxWaoJb8VgPwNZZr7FpSbWU7MWuyO9aXIYUKuhpqWLP4JDfH2UZAi49A0C5pVVVnYjLAnXz/1LraPvx7uAPSDuhZvu8l92LfOJuudN13bmuaBL/7aO+x93j45+lzd7LnZbmd/+/jYhOYz2IT6+OVw52Tv6NAELKOjggK97/x5IskNZ6DH2Zxl/MM9eJoJjzoYC4SBMR0G+a9ZDArnS4zZYm8jR2THtlRccZc5Y6h0fVdg+L5t5tv/FR20Cx3MR5TxpRJlPWyz8IgvM+Watf+HC/Tsqg22NkkdCBze67LfMEVcwCs3U9Tps6xt7mq6SL5KcZL0bPH9A2OjdsTpct5vcM08S5433jtnt6sNeNp616b5mGXiZ6J3cPqPTjvn6EgbNTs7c+AHe4RSeGrCf+wea+CpsRAFvO/3GiGZixCo0R3w7WwiEa2WU5dSFfNxQs+QUfQE5HJi//lGMltc5KW1RsXsvdnEja+TpiW/fpQZh0fbkVCpURk/mX3NORCjgNX4JXEnNP+WCadk81lkf2P3t3hSzYA3oynuWcgGK0bUO9lwnZSeZFjGD2bfmzC+vyTN+YZ66uY+wpT3EzJtmEvPVJw6FdZPJMPVJ4Skx9DvbJD9vYqigLnS6lLZBAL8AawAPXtDrbboXMLqFv90WMEGT7XW4WR0xeJC0y35C7Z0HZ1Vx2qLIkq62mvrOLVER/P7ufKv/TCt7AcwhPNQiL3JIgpjy1MIQM32GQjVpMpQynPVOa9fRGoQRmuGAhYjcTdLMQyc0kMaBxQyaeBBKX1ZLXSIzk9Jjtj4qvhpMMC8MVz4YN2uyjUb6G3MNdvNHMt5drqM4XN7xJGob2GV9QcdXPmex0KtU/tUlZ7PG5yaQ3Li6jlbvUMS4ak4xUwJ4HNNljpRMbsGsRXYoGeNC4zI0ZdRmO+a587PVUBlWWDHhmk6Tjba7Ws/HU6uIF4ctYPIc5Oh/LkKoqv2yE1SFrf9RCbx/22/+6qil92jg95dn41RrauGydPzhVFquf1FBpkL+PCfmB4OTQE8WGweCsSjxblzqI3C/NENal74ufn+f5eiCJf0peGsPM/KAwqGkjf5fXflM6ryBfrpy6PAo88KHLJbbaOAaogCTOllFy0K17L5yIFmiUVr5HpeJbx07NjN2MUDr+jCZeSWfZ8AMDYlIG9kfI2A16oPEizs6D12J938/tHONq4jLg62T3Z+wYD2LFmFKNVb3YD/Z42V9oiWi3sShzwCkR0ioGUb/6CtcfiKCtJhHN3yDXGaNrYvNumwWiYZ06GftC5CyqXgDxXzj7rOYGx2Lxl1DH2LeUj+wSKcGKdgF4T1IoeWvg2RFxlN/UZ5kxIRx5MwRN+nSBpMAjzZzDzDUtSgT5xcw5r8J2U1ncFQpFCGV10vdEFkoUEuLBPf16WBDfxYfA0DsebLsnHPrq2cLSr32siZy5ssB1lr5ki7Vk+CUiKFw1SGaJHbBS4gH7Wtzyo43XuK/BSBqK+LZBIxmlGJ/lGSXDvNo0hYzUIIGRbwKutv3g6SOHRTnJ1Cztgqoi5paS7oE9X2ZOyJ/XS5YkT/CXrN+VhfrxeTWv2ZZ4izXAz1Oc6/sl136xB3xmas+aTu5jdS6u4yztl4UwtAEgRfezRUEsC07JjZaTQMnhqY/RvVZ076MgR6oLMK6tM3080nyie0YEGD1/JV+kNYAhZnzlUs7VQNHXQSCwZNfWRtxv+/TVh8T7cuwH9kqDO26kjFsqDgdjKYMEohkIPFoq7StEyR9Oe/4gho1GCz3mrFNlxdRLph84mRUDVMvLZ3UVyLCGylH9ZGNWgob6DXlHynd/oEjHEUp7w7NSQk638B7sve5NpeAAA=
 </script>
+<script id="@tomlarkworthy/editor-5/cell_options.json" 
+  type="text/plain"
+  data-encoding="base64"
+  data-mime="application/json"
+>
+e30K
+</script>
+<script id="@tomlarkworthy/editor-5" 
+  type="text/plain"
+  data-mime="application/javascript"
+>
+const _1tdjp0a = function _title(md){return(
+md`# Editor: Reactive Userspace Cell Mutator (v5)
+
+[YouTube explainer](https://www.youtube.com/shorts/6FjeJRBC2iw)
+
+A cell that edits the source of other cells. It is implemented in userspace as a normal cell, so it follows exported notebooks, so exported notebooks become editable! It pairs particularly well with the [single file export](https://observablehq.com/@tomlarkworthy/exporter-3), because edits are also exported, so you can permanently save your works in a format that continues to be editable and exportable indefinitely. It works offline too!
+
+
+The editor is able to edit _any_ cell in the runtime, including those in dependancies. Import \`auto_attach\` and run that cell. You can also instanciate an editor component on any variable reference.
+
+\`\`\`js
+import {auto_attach, cellEditor} from '@tomlarkworthy/editor-5'
+\`\`\`
+
+
+#### Use cases
+- Edit notebooks offline
+- Try things out without committing to them
+- Improved debugging workflow, as you can insert \`debugger\` expressions to dependancies on-demand.
+`
+)};
+const _dm53bx = function _2(md){return(
+md`## Example`
+)};
+const _61oxjf = function _title_variable(lookupVariable,editorModule){return(
+lookupVariable("title", editorModule)
+)};
+const _15uilf0 = function _4(cellEditor,title_variable){return(
+cellEditor(title_variable, { pinned: true })
+)};
+const _wpcfq8 = function _5(md){return(
+md`## TODO
+- open new cell edtior
+- SyntaxErrors (see Runtime, they are cells)
+- Rename cell
+  - UI variable name does not update
+- Load cell from hash, will need the main module named properly in moduleMap
+- Import node support (maybe this is a different concern)`
+)};
+const _1ociws4 = function _6(md){return(
+md`## Sync editors`
+)};
+const _hdieof = function _editors(){return(
+new Map()
+)};
+const _ipx6cz = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,editors,cellEditor)
+{
+    keepalive(editorModule, 'editor_jobs');
+    syncers;
+    const placed = new Set();
+    if (attachContextManu) {
+        document.querySelectorAll('.observablehq').forEach(div => {
+            const variable = divToVar(runtime, div);
+            if (!variable)
+                return;
+            if (!editors.has(variable)) {
+                editors.set(variable, cellEditor(variable));
+            }
+            const editor = editors.get(variable);
+            const next = div.nextSibling;
+            if (next !== editor) {
+                const ae = document.activeElement;
+                const hadFocus = ae && editor.contains(ae);
+                let restore = null;
+                if (hadFocus) {
+                    const fe = ae;
+                    if (fe && (fe.tagName === 'INPUT' || fe.tagName === 'TEXTAREA') && 'selectionStart' in fe) {
+                        const start = fe.selectionStart, end = fe.selectionEnd;
+                        restore = () => {
+                            fe.focus({ preventScroll: true });
+                            fe.setSelectionRange(start, end);
+                        };
+                    } else {
+                        restore = () => fe?.focus?.({ preventScroll: true });
+                    }
+                }
+                div.after(editor);
+                restore?.();
+            }
+            placed.add(variable);
+        });
+    }
+    [...editors.entries()].forEach(([variable, editor]) => {
+        if (!placed.has(variable)) {
+            editor.dispose?.();
+            editor.remove();
+            editors.delete(variable);
+        }
+    });
+};
+const _1iwobxt = function _divToVar(){return(
+function divToVar(runtime, div) {
+  if (!div) return undefined;
+  if (div.variable) {
+    return div.variable;
+  } else {
+    return [...runtime._variables].find((v) => v._observer._node === div);
+  }
+}
+)};
+const _1usw8c2 = function _attachContextManu(Inputs,isOnObservableCom){return(
+Inputs.toggle({
+  label: "attach menu",
+  value: !isOnObservableCom()
+})
+)};
+const _1oaz8r1 = (G, _) => G.input(_);
+const _16ks4jz = function _12(md){return(
+md`## \`cellEditor\` component
+
+Using Dataflow templating to create reusable Hotbar Component builder`
+)};
+const _199ztvl = function _hotbarTemplate(lookupVariable,editorModule){return(
+lookupVariable(
+  [
+    ...[
+      "editedCell",
+      "edit",
+      "select",
+      "up",
+      "down",
+      "remove",
+      "apply",
+      "addCells",
+      "copy",
+      "paste"
+    ].flatMap((name) => ["viewof " + name, name]),
+    "code_editor",
+    "hotbar",
+    "code_editor_view",
+    "editor_manager",
+    "toolbar",
+    "selectVariable",
+    "compile_and_update",
+    "decompiled",
+    "editor_refresh_from_runtime"
+  ],
+  editorModule
+)
+)};
+const _hqns12 = function _cellEditor(cloneDataflow,editorTemplate,shellTemplate,createCell,findCell,pinOnCreate,getOption,Event,setOption)
+{
+  return (variable, {
+    pinned = undefined
+  } = {}) => {
+    const host = document.createElement('div');
+    let shellDispose = null;
+    let heavyDispose = null;
+    let editView = null;
+    let shellEl = null;
+    let body = null;
+    const clearBody = () => {
+      if (body)
+        body.replaceChildren();
+    };
+    const closeHeavy = () => {
+      if (heavyDispose) {
+        heavyDispose();
+        heavyDispose = null;
+      }
+      clearBody();
+    };
+    const openHeavy = () => {
+      if (heavyDispose)
+        return;
+      if (!body)
+        return;
+      heavyDispose = cloneDataflow(editorTemplate, name => {
+        if (name === 'editor_panel') {
+          return {
+            fulfilled: element => {
+              if (!element)
+                return;
+              if (!body)
+                return;
+              if (body.firstChild !== element || body.childNodes.length !== 1) {
+                body.replaceChildren(element);
+              }
+            }
+          };
+        }
+        if (name === 'selectVariable') {
+          return {
+            fulfilled: selectVariable => {
+              if (typeof selectVariable !== 'function')
+                return;
+              selectVariable(variable);
+            }
+          };
+        }
+        return {};
+      });
+    };
+    const syncOpen = () => {
+      const open = !!(editView && editView.value);
+      if (open)
+        openHeavy();
+      else
+        closeHeavy();
+      if (shellEl) {
+        const bodyEl = shellEl.querySelector('.cell-editor-body');
+        if (bodyEl)
+          bodyEl.style.display = open ? 'block' : 'none';
+      }
+    };
+    shellDispose = cloneDataflow(shellTemplate, name => {
+      if (name === 'hotbar_shell') {
+        return {
+          fulfilled: element => {
+            if (!element)
+              return;
+            shellEl = element;
+            host.replaceChildren(element);
+            body = element.querySelector('.cell-editor-body');
+            // Lightweight "add cell below" on the always-present shell,
+            // so a cell can be inserted without opening the heavy editor.
+            const hotbar = element.querySelector('.hotbar');
+            if (hotbar && !hotbar.querySelector('.add-cell-btn')) {
+              const add = document.createElement('span');
+              add.className = 'add-cell-btn';
+              add.textContent = '\u2795';
+              add.title = 'Add cell below';
+              add.style.cssText = 'cursor: pointer; margin-right: 6px;';
+              add.tabIndex = -1;
+              add.addEventListener('mousedown', e => e.preventDefault());
+              add.addEventListener('click', e => {
+                e.stopPropagation();
+                createCell({ cell: findCell(variable) });
+              });
+              hotbar.prepend(add);
+            }
+            if (body)
+              syncOpen();
+          }
+        };
+      }
+      if (name === 'selectVariable') {
+        return {
+          fulfilled: selectVariable => {
+            if (typeof selectVariable !== 'function')
+              return;
+            selectVariable(variable);
+          }
+        };
+      }
+      if (name === 'viewof edit') {
+        return {
+          fulfilled: view => {
+            if (!view)
+              return;
+            editView = view;
+            const forceOpen = !!(variable?.pid && pinOnCreate.has(variable.pid));
+            if (forceOpen)
+              pinOnCreate.delete(variable.pid);
+            const resolved_pinned = forceOpen || !!getOption(variable, 'pinned', pinned);
+            view.value = resolved_pinned;
+            view.dispatchEvent(new Event('input'));
+            syncOpen();
+            view.addEventListener('input', () => {
+              const next = !!view.value;
+              setOption(variable, 'pinned', next);
+              syncOpen();
+            });
+          }
+        };
+      }
+      return {};
+    });
+    host.dispose = () => {
+      closeHeavy();
+      if (shellDispose) {
+        shellDispose();
+        shellDispose = null;
+      }
+    };
+    return host;
+  };
+};
+const _x5ixji = function _hotbar_shell($0,Event,htl,edit)
+{
+  const toggle = () => {
+    $0.value = !$0.value;
+    $0.dispatchEvent(new Event("input"));
+  };
+
+  const el = htl.html`<div class="cell-editor"
+    style="display: flex;
+           flex-direction: column;
+           background: var(--theme-background-alt);">
+    <style>
+      .cell-editor .cm-editor {
+        height: fit-content;
+        background-color: var(--theme-background);
+      }
+      .cell-editor .hotbar {
+        margin-left: auto;
+        text-align: right;
+        font-family: var(--monospace);
+        font-size: 12px;
+        height: 17px;
+        outline: 1px solid var(--theme-background-alt);
+        user-select: none;
+      }
+    </style>
+
+    <div style="width:100%; cursor: pointer;" onclick=${toggle}>
+      <div class="hotbar">${edit ? "close" : "edit"}</div>
+    </div>
+
+    <div class="cell-editor-body" style="display: ${
+      edit ? "block" : "none"
+    };"></div>
+  </div>`;
+
+  el.addEventListener("click", (evt) => evt.stopPropagation());
+  return el;
+};
+const _1ed5zb9 = function _editor_panel($0,htl,toolbar,nav,reversibleAttach,combine,code_editor)
+{
+  const cell = $0.value;
+  return htl.html`<div style="display: flex; flex-direction: column;">
+    ${toolbar}
+    ${cell ? nav(cell) : null}
+    <div style="flex-grow: 1; padding-bottom: 1rem;">
+      ${reversibleAttach(combine, code_editor)}
+    </div>
+  </div>`;
+};
+const _yk7udl = function _shellTemplate($0,editedCell,selectVariable,$1,edit,hotbar_shell,lookupVariable,editorModule)
+{
+    // Force reactive deps on every looked-up variable so the cached lookup
+    // refreshes when any template cell is redefined. Without these, redefining
+    // e.g. `hotbar_shell` leaves clones holding stale variable handles.
+    [
+        $0,
+        editedCell,
+        selectVariable,
+        $1,
+        edit,
+        hotbar_shell
+    ];
+    return lookupVariable([
+        'editedCell',
+        'viewof editedCell',
+        'selectVariable',
+        'viewof edit',
+        'edit',
+        'hotbar_shell'
+    ], editorModule);
+};
+const _jot8he = function _editorTemplate($0,editedCell,selectVariable,$1,$2,$3,$4,$5,$6,$7,$8,toolbar,nav,cellLinks,variableLink,decompiled,code_editor_view,code_editor,editor_manager,editor_refresh_from_runtime,editor_panel,lookupVariable,editorModule)
+{
+    // Force reactive deps on every looked-up variable so the cached lookup
+    // refreshes when any template cell is redefined. Without these, redefining
+    // e.g. `viewof apply` leaves heavies cloning against stale variable handles.
+    [
+        $0,
+        editedCell,
+        selectVariable,
+        $1,
+        $2,
+        $3,
+        $4,
+        $5,
+        $6,
+        $7,
+        $8,
+        toolbar,
+        nav,
+        cellLinks,
+        variableLink,
+        decompiled,
+        code_editor_view,
+        code_editor,
+        editor_manager,
+        editor_refresh_from_runtime,
+        editor_panel
+    ];
+    return lookupVariable([
+        'editedCell',
+        'viewof editedCell',
+        'selectVariable',
+        'viewof select',
+        'viewof up',
+        'viewof down',
+        'viewof remove',
+        'viewof addCells',
+        'viewof apply',
+        'viewof copy',
+        'viewof paste',
+        'toolbar',
+        'nav',
+        'cellLinks',
+        'variableLink',
+        'decompiled',
+        'code_editor_view',
+        'code_editor',
+        'editor_manager',
+        'editor_refresh_from_runtime',
+        'editor_panel'
+    ], editorModule);
+};
+const _oshnzp = function _19(md){return(
+md`## Hotbar Prototype`
+)};
+const _1o2h65s = function _editedCell(Inputs){return(
+Inputs.input(null)
+)};
+const _7g3h7h = (G, _) => G.input(_);
+const _1urs1md = function _findCell($0,modules){return(
+(variable, dom = undefined) => {
+  if (variable) {
+    const cells = $0.value.get(variable._module) || [];
+    let cell = cells.find((cell) => cell.variables.includes(variable));
+    if (!cell) {
+      console.warn("Could not find cell for ", variable);
+      return;
+    }
+    cell = {
+      dom,
+      name: cell.name,
+      module: {
+        cells: cells,
+        ...modules.get(variable._module)
+      },
+      variables: cell.variables
+    };
+    return cell;
+  }
+}
+)};
+const _1uhm0y9 = function _selectVariable(findCell,_,$0,Event){return(
+async function selectVariable(variable, dom = undefined) {
+  console.log("selectVariable", variable);
+  let cell = findCell(variable, dom);
+  if (!_.isEqual($0.value, cell)) {
+    $0.value = cell;
+    $0.dispatchEvent(new Event("input"));
+  } else {
+    $0.value = cell;
+  }
+  return cell;
+}
+)};
+const _3jxaqk = function _23(selectVariable,hotbarTemplate)
+{
+return selectVariable(hotbarTemplate[5]);
+};
+const _49mpmh = function _hotbar($0,Event,setOption,$1,htl,edit,toolbar,nav,reversibleAttach,combine,code_editor)
+{
+  console.log("hotbar start");
+  const toggle = () => {
+    $0.value = !$0.value;
+    $0.dispatchEvent(new Event("input"));
+    setOption(
+      $1.value.variables[0],
+      "pinned",
+      $0.value
+    );
+  };
+
+  const combined = htl.html`<div class="cell-editor" 
+    style="display: flex;
+           flex-direction: column;
+           background: var(--theme-background-alt);">
+  <style>
+    .picked {
+      outline: 1px dashed #999;
+    }
+    .cm-editor {
+      height: fit-content;
+      background-color: var(--theme-background);
+    }
+    .hotbar {
+      margin-left: auto;
+      text-align: right;
+      font-family: var(--monospace);
+      font-size: 12px;
+      height: 17px;
+      outline: 1px solid var(--theme-background-alt);
+    }
+  </style>
+  <div style="width:100%; cursor: pointer;" onclick=${toggle}>
+    <div class="hotbar">
+      ${edit ? "close" : "edit"}
+    </div>
+  </div>
+  <div style="display: ${edit ? "block" : "none"};">
+    ${toolbar}
+    ${nav($1.value)}
+    <div style="flex-grow: 1; padding-bottom: 1rem;">
+      ${reversibleAttach(combine, code_editor)}
+    </div>
+  </div>
+    
+</div>`;
+
+  combined.addEventListener("mouseup", (event) => {});
+  combined.addEventListener("click", (evt) => {
+    evt.stopPropagation();
+  });
+  console.log("hotbar stop");
+  return combined;
+};
+const _n8s6yl = function _25($0){return(
+$0.value
+)};
+const _ytd2rq = function _26(nav,editedCell){return(
+nav(editedCell)
+)};
+const _1t4gep6 = function _nav(html,cellLinks){return(
+function nav(editedCell) {
+  const outputs = [...editedCell.variables[0]._outputs];
+  const inputs = editedCell.variables[0]._inputs;
+  return html`<div>
+<span>${cellLinks("inputs", inputs)}</span>
+<span>${cellLinks("outputs", outputs)}</span>
+</div>`;
+}
+)};
+const _1tv9qxo = function _cellLinks(html,variableLink){return(
+function cellLinks(label, variables) {
+  if (variables.length == 0) return [];
+  return html`${label}: ${variables.map(
+    (v, index) =>
+      html`${index > 0 ? ", " : ""}<a href="${variableLink(v)}">${
+        v._name || "anon"
+      }</a>`
+  )} `;
+}
+)};
+const _1opggh8 = async function _identity(lookupVariable,editorModule){return(
+(await lookupVariable("lookupVariable", editorModule))._definition
+)};
+const _1nfia2p = function _variableLink(identity,navHref,modules)
+{
+    return v => {
+        if (v._type === 2 && v._inputs.length == 1) {
+            // Implicit variable created on reference, go up one
+            v = v._inputs[0];
+        }
+        // Follow import chain to the defining module
+        const idStr = identity?.toString();
+        if (idStr) {
+            while (v._inputs?.length === 1 && v._definition?.toString() === idStr) {
+                v = v._inputs[0];
+            }
+        }
+        return navHref(`${ modules.get(v._module).name }${ typeof v._name == 'string' ? `#${ v._name }` : '' }`);
+    };
+};
+const _1tm2n0w = function _31(md){return(
+md`Save edits by exporting to a single file`
+)};
+const _16wblye = function _32(md){return(
+md`### Known Issues
+- If you create a new cell, it is invisible, it will appear after exporting.`
+)};
+const _1jdvxd9 = function _33(md){return(
+md`### Editor UI Components`
+)};
+const _1j1loxx = function _combine(Inputs){return(
+Inputs.toggle({
+  label: "untick to destructure",
+  value: true
+})
+)};
+const _1h8337z = (G, _) => G.input(_);
+const _tct2nf = function _edit(Inputs){return(
+Inputs.toggle({ label: "edit" })
+)};
+const _7izj7k = (G, _) => G.input(_);
+const _1fwb5jc = function _toolbar(htl,reversibleAttach,combine,$0,$1,$2,$3,$4,$5,$6,$7){return(
+htl.html`<div
+    class="toolbar"
+    style="display: flex; gap: 4px;"
+>
+    <style>
+      .toolbar form { width: auto; }
+      .toolbar label { user-select: none; }
+    </style>
+    ${reversibleAttach(combine, $0)}
+    ${reversibleAttach(combine, $1)}
+    ${reversibleAttach(combine, $2)}
+    ${reversibleAttach(combine, $3)}
+    ${reversibleAttach(combine, $4)}
+    ${reversibleAttach(combine, $5)}
+    ${reversibleAttach(combine, $6)}
+    ${reversibleAttach(combine, $7)}
+    <span style="flex-grow: 1;"></span>
+</div>`
+)};
+const _yej3hb = function _addCells(Inputs,createCell,$0){return(
+Inputs.button("➕", {
+  reduce: async () => {
+    await createCell({ cell: $0.value });
+  }
+})
+)};
+const _1aii9ps = (G, _) => G.input(_);
+const _1bn860e = function _remove(Inputs,deleteCell,$0){return(
+Inputs.button("🗑️", {
+  reduce: () => deleteCell({ cell: $0.value })
+})
+)};
+const _1ad0xr8 = (G, _) => G.input(_);
+const _lwb7d7 = function _apply(Inputs,compile_and_update,code_editor_view,editedCell,replaceCodeMirrorDoc)
+{
+    const button = Inputs.button('\u25B6️', {
+        reduce: async () => {
+            // #166: Read source directly from the live CodeMirror view rather than from
+            // `states.get(editedCell.variables[0])`. After a kind-changing recompile
+            // (regular -> import, etc.), `editedCell.variables[0]` is a freshly-defined
+            // variable that the `cellIdFacet` map was never keyed by, so a `states.get`
+            // lookup returns undefined and `.doc.toString()` throws.
+            // After compile, push the decompiled (canonical) source back into
+            // the editor so the user sees what the runtime actually has.
+            const canonical = await compile_and_update(code_editor_view.state.doc.toString(), editedCell.variables, editedCell);
+            if (typeof canonical === 'string') {
+                replaceCodeMirrorDoc(code_editor_view, canonical, { preserveCursor: true });
+            }
+        }
+    });
+    // supress gaining focus
+    // doesn't work on observable iframe
+    // https://issues.chromium.org/issues/40654608
+    button.tabIndex = '-1';
+    button.onmousedown = e => e.preventDefault();
+    return button;
+};
+const _1cjyuqm = (G, _) => G.input(_);
+const _14rfku9 = function _up(Inputs,moveCell,$0){return(
+Inputs.button("⬆", {
+  reduce: () => moveCell($0.value, -1)
+})
+)};
+const _frzs5d = (G, _) => G.input(_);
+const _9pymuj = function _paste(Inputs,readObservableClipboardCells,pasteObservableCellsIntoModule,editedCell){return(
+Inputs.button("📋", {
+  reduce: async () => {
+    const cells = await readObservableClipboardCells();
+    return pasteObservableCellsIntoModule({ cells, editedCell });
+  }
+})
+)};
+const _1whsszt = (G, _) => G.input(_);
+const _corxwl = function _down(Inputs,moveCell,$0){return(
+Inputs.button("⬇", {
+  reduce: () => moveCell($0.value, 1)
+})
+)};
+const _1to28po = (G, _) => G.input(_);
+const _gia2ci = function _copy(Inputs,html,$0,decompile,$1,getOption,cellsToClipboard){return(
+Inputs.button(
+  html`<span style="font-size: .875em; margin-right: .125em; position: relative; top: -.25em; left: -.125em">
+  📄<span style="position: absolute; top: .25em; left: .25em">📄</span>
+</span>`,
+  {
+    reduce: async () => {
+      const current = $0.value;
+      if (!current?.variables?.length) return;
+
+      const seen = new Set();
+      const cells = [];
+
+      const add = async (variables) => {
+        const key = variables?.[0];
+        if (!key || seen.has(key)) return;
+        seen.add(key);
+        cells.push(await decompile(variables));
+      };
+
+      await add(current.variables);
+
+      const live = $1.value;
+      if (live?.entries) {
+        for (const [, moduleCells] of live.entries()) {
+          for (const c of moduleCells || []) {
+            const v0 = c?.variables?.[0];
+            if (!v0) continue;
+            if (v0 === current.variables[0]) continue;
+            if (getOption(v0, "selected", false)) {
+              await add(c.variables);
+            }
+          }
+        }
+      }
+
+      await cellsToClipboard(cells);
+    }
+  }
+)
+)};
+const _fw41wt = (G, _) => G.input(_);
+const _srtw8o = function _module(editedCell){return(
+editedCell.module.module
+)};
+const _rv7t7x = function _code_editor_view(EditorView)
+{
+  console.log("code_editor_view");
+  return new EditorView();
+};
+const _xvo1n6 = function _code_editor(code_editor_view)
+{
+  console.log("code_editor");
+  code_editor_view.dom.addEventListener("click", (evt) => {
+    evt.stopPropagation();
+  });
+  return code_editor_view.dom;
+};
+const _1imarq2 = function _47(md){return(
+md`## API`
+)};
+const _470wv4 = function _moveCell($0){return(
+async (cell, amount) =>
+  $0.send({
+    command: "moveCell",
+    args: {
+      cell,
+      amount
+    }
+  })
+)};
+const _19znal9 = function _createCell($0){return(
+async ({cell, source = "{}" } = {}) =>
+  $0.send({
+    command: "createCell",
+    args: {
+      source,
+      cell
+    }
+  })
+)};
+const _d9nzys = function _deleteCell($0){return(
+async ({cell}) =>
+  $0.send({
+    command: "deleteCell",
+    args: {
+      cell
+    }
+  })
+)};
+const _1toku21 = function _51(md){return(
+md`## API handler`
+)};
+const _d7ouqx = function _command(flowQueue){return(
+flowQueue()
+)};
+const _118qt2v = (G, _) => G.input(_);
+const _c4420j = function _53(command){return(
+command
+)};
+const _1f6v167 = function _findCellByVariable(){return(
+(v, cells) =>
+  [...cells.entries()].find((vars) => vars.includes(v))
+)};
+const _dmk8lv = function _findCellIndex(){return(
+(variables, cells) => {
+  let index = 0;
+  for (let cellCandidate of cells.values()) {
+    if (cellCandidate.variables[0] === variables[0]) {
+      return index;
+    } else {
+      index++;
+    }
+  }
+}
+)};
+const _jy01vb = function _lookupCellByIndex(){return(
+(index, cells) => {
+  let current = 0;
+  for (let cellCandidate of cells.values()) {
+    if (current === index) {
+      return cellCandidate;
+    } else {
+      current++;
+    }
+  }
+}
+)};
+const _1rhoxk2 = function _findVariableIndex(runtime){return(
+(variable, variables = runtime._variables) =>
+  [...variables].findIndex((vi) => vi === variable)
+)};
+const _1efmn99 = async function _command_processor(command,$0,compile_and_update,pinOnCreate,selectVariable,remove_variables,$1,findCellIndex,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,$2)
+{
+  if (command.processed)
+    return;
+  let result = undefined;
+  if (command.command == 'createCell') {
+    $0.value = true;
+    // Mark the new variable's pid (identity-stable, no cell-map lookup) so its
+    // cellEditor opens pinned as soon as auto_attach mounts the shell. Keyed by
+    // pid because findCell() lags one reactive tick behind creation here.
+    const newVars = [];
+    result = await compile_and_update('{}', newVars, command.args.cell);
+    const nv = newVars[0];
+    if (nv?.pid)
+      pinOnCreate.add(nv.pid);
+    if (nv)
+      await selectVariable(nv);
+  } else if (command.command == 'deleteCell') {
+    remove_variables(command.args.cell.variables);
+    result = true;
+  } else if (command.command == 'moveCell') {
+    const cellList = $1.value.get(command.args.cell.module.module);
+    const cellIndex = findCellIndex(command.args.cell.variables, cellList);
+    const targetCellIndex = cellIndex + command.args.amount;
+    const targetCell = lookupCellByIndex(targetCellIndex, cellList);
+    if (targetCell) {
+      const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+      const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+      const change = targetFirstVariableIndex - currentFirstVariableIndex;
+      const dom = command.args.cell.dom;
+      const preY = dom?.getBoundingClientRect?.().top;
+      command.args.cell.variables.forEach(v => {
+        const currentIndex = findVariableIndex(v);
+        repositionSetElement(runtime._variables, v, currentIndex + change);
+      });
+      await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+      // Keep moved cell at same screen position so neighbours shift around it.
+      // Cells here have wildly varying heights (some embed 500+ px iframes), so
+      // a one-position move can otherwise jump hundreds of pixels (#163). Poll
+      // for syncers' reactive DOM reorder before measuring postY — the chain
+      // runs on macrotasks, so requestAnimationFrame is not sufficient.
+      if (preY != null && dom?.isConnected) {
+        let postY = preY;
+        for (let i = 0; i < 30 && postY === preY; i++) {
+          await new Promise(r => setTimeout(r, 50));
+          if (!dom.isConnected)
+            break;
+          postY = dom.getBoundingClientRect().top;
+        }
+        const delta = postY - preY;
+        if (delta !== 0) {
+          const scroller = dom.closest('.lm_content') || document.scrollingElement;
+          scroller?.scrollBy?.({
+            top: delta,
+            behavior: 'instant'
+          });
+        }
+      }
+    }
+    result = true;
+  }
+  if (result) {
+    command.processed = true;
+    $2.resolve(result);
+  }
+};
+const _8iz5z2 = function _59(md){return(
+md`### UI Action`
+)};
+const _m873d1 = function _states(){return(
+new Map()
+)};
+const _mxwoc4 = function _cellIdFacet(codemirror){return(
+codemirror.Facet.define({ combine: (v) => v[0] })
+)};
+const _y7997q = function _62(md){return(
+md`## LSP Integration
+
+Observable JS lezer parser, runtime-aware autocomplete, parse-error squiggles. Plumbed into the cell editor below.`
+)};
+const _7btuqg = function _observableJS_language(codemirror,observable_lezer_parser){return(
+codemirror.LRLanguage.define({
+    name: 'observable-javascript',
+    parser: observable_lezer_parser.configure({
+        props: [
+            codemirror.indentNodeProp.add({
+                Block: codemirror.delimitedIndent({ closing: '}' }),
+                ArrowFunction: codemirror.continuedIndent({ except: /^\s*({|case|default)/ })
+            }),
+            codemirror.foldNodeProp.add({ 'Block ObjectExpression ArrayExpression': codemirror.foldInside })
+        ]
+    }),
+    languageData: {
+        commentTokens: {
+            line: '//',
+            block: {
+                open: '/*',
+                close: '*/'
+            }
+        },
+        indentOnInput: /^\s*[)\]}]$/,
+        closeBrackets: {
+            brackets: [
+                '(',
+                '[',
+                '{',
+                '\'',
+                '"',
+                '`'
+            ]
+        },
+        wordChars: '$_'
+    }
+})
+)};
+const _1xf04v5 = function _observableJS_highlightStyle(codemirror,lezerhighlight){return(
+codemirror.HighlightStyle.define([
+    {
+        tag: lezerhighlight.tags.keyword,
+        color: 'var(--syntax-keyword)'
+    },
+    {
+        tag: [
+            lezerhighlight.tags.bool,
+            lezerhighlight.tags.null,
+            lezerhighlight.tags.atom
+        ],
+        color: 'var(--syntax-atom)'
+    },
+    {
+        tag: lezerhighlight.tags.string,
+        color: 'var(--syntax-string)'
+    },
+    {
+        tag: [
+            lezerhighlight.tags.number,
+            lezerhighlight.tags.regexp
+        ],
+        color: 'var(--syntax-literal)'
+    },
+    {
+        tag: lezerhighlight.tags.comment,
+        color: 'var(--syntax-comment)',
+        fontStyle: 'italic'
+    },
+    {
+        tag: lezerhighlight.tags.function(lezerhighlight.tags.variableName),
+        color: 'var(--syntax-definition)'
+    },
+    {
+        tag: lezerhighlight.tags.definition(lezerhighlight.tags.variableName),
+        color: 'var(--syntax-definition)'
+    },
+    {
+        tag: lezerhighlight.tags.variableName,
+        color: 'var(--syntax-variable)'
+    },
+    {
+        tag: lezerhighlight.tags.propertyName,
+        color: 'var(--syntax-variable)'
+    },
+    {
+        tag: lezerhighlight.tags.operator,
+        color: 'var(--syntax-keyword)'
+    }
+])
+)};
+const _19d9pua = function _observableJS_lint(codemirror){return(
+[
+    codemirror.lintGutter(),
+    codemirror.linter(view => {
+        const {state} = view;
+        const tree = codemirror.syntaxTree(state);
+        const seen = new Set();
+        const diagnostics = [];
+        tree.iterate({
+            enter: ({type, from, to}) => {
+                if (!type.isError)
+                    return;
+                const end = to > from ? to : Math.min(from + 1, state.doc.length);
+                const key = from + ':' + end;
+                if (seen.has(key))
+                    return;
+                seen.add(key);
+                diagnostics.push({
+                    from,
+                    to: end,
+                    severity: 'error',
+                    message: 'Syntax error'
+                });
+            }
+        });
+        return diagnostics;
+    }, { delay: 250 }),
+    codemirror.keymap.of(codemirror.lintKeymap ?? []),
+    codemirror.EditorView.baseTheme({
+        '.cm-lintRange': {
+            textDecorationThickness: '2px',
+            textUnderlineOffset: '3px'
+        },
+        '.cm-lintRange.cm-lintRange-error': { textDecoration: 'underline wavy #e11' },
+        '.cm-tooltip.cm-tooltip-lint': { fontSize: '12px' }
+    })
+]
+)};
+const _125gzhe = function _editor_manager(editedCell,globalThis,codemirror,literalCompletions,EditorState,decompiled,cellIdFacet,EditorView,states,compile_and_update,code_editor_view,replaceCodeMirrorDoc,observableJS_language,observableJS_highlightStyle,myDefaultTheme)
+{
+  if (!editedCell?.variables?.length)
+    return;
+  const variable = editedCell.variables[0];
+  const key = variable;
+  const mod = variable && variable._module;
+  const builtin = mod?._runtime?._builtin?._scope;
+  const isInternal = n => n.startsWith('module @') || n.startsWith('@variable') || n.startsWith('__ojs_');
+  const isPrivate = n => n.startsWith('_') || /^(webkit|moz|ms)[A-Z]/.test(n);
+  const valueOf = v => {
+    try {
+      return v?._value;
+    } catch {
+      return undefined;
+    }
+  };
+  const lookup = n => {
+    if (mod?._scope?.has(n))
+      return valueOf(mod._scope.get(n));
+    if (builtin?.has(n))
+      return valueOf(builtin.get(n));
+    try {
+      return globalThis[n];
+    } catch {
+      return undefined;
+    }
+  };
+  const allNames = () => {
+    const out = new Set();
+    for (const n of mod?._scope?.keys() ?? [])
+      if (!isInternal(n))
+        out.add(n);
+    for (const n of builtin?.keys() ?? [])
+      if (!isInternal(n))
+        out.add(n);
+    for (const n of Object.getOwnPropertyNames(globalThis))
+      if (!isPrivate(n))
+        out.add(n);
+    return out;
+  };
+  const isNoise = n => n.startsWith('_') || [
+    'prototype',
+    'constructor',
+    'caller',
+    'callee',
+    'arguments',
+    'name',
+    'length'
+  ].includes(n);
+  const stopAt = new Set([
+    Object.prototype,
+    Function.prototype
+  ]);
+  const propsOf = obj => {
+    const out = [];
+    const seen = new Set();
+    for (let o = Object(obj), d = 0; o && d < 4; o = Object.getPrototypeOf(o), d++) {
+      if (d > 0 && stopAt.has(o))
+        break;
+      for (const n of Object.getOwnPropertyNames(o)) {
+        if (seen.has(n) || isNoise(n))
+          continue;
+        seen.add(n);
+        const desc = Object.getOwnPropertyDescriptor(o, n);
+        out.push({
+          label: n,
+          type: typeof desc?.value === 'function' ? 'function' : 'property'
+        });
+      }
+    }
+    return out;
+  };
+  const classify = v => {
+    if (typeof v === 'function')
+      return /^\s*class\b/.test(Function.prototype.toString.call(v)) ? 'class' : 'function';
+    return v === null ? 'null' : typeof v === 'object' ? 'variable' : typeof v;
+  };
+  const completionSource = cx => {
+    for (let n = codemirror.syntaxTree(cx.state).resolve(cx.pos, -1); n; n = n.parent) {
+      if (/String|Template|Comment/.test(n.name))
+        return null;
+    }
+    // Member access on a non-identifier literal base ("".|, [].|, (5).|) — shared with the test_* cells.
+    const lit = literalCompletions(cx.state, cx.pos);
+    if (lit)
+      return lit;
+    const before = cx.state.sliceDoc(cx.state.doc.lineAt(cx.pos).from, cx.pos);
+    const m = before.match(/([A-Za-z_$][\w$]*(?:\.[A-Za-z_$\d]*)*)$/);
+    if (!m)
+      return null;
+    const chain = m[1].split('.');
+    const prefix = chain[chain.length - 1] ?? '';
+    const from = cx.pos - prefix.length;
+    if (!cx.explicit && prefix.length === 0 && chain.length === 1)
+      return null;
+    let options;
+    if (chain.length > 1) {
+      let base = lookup(chain[0]);
+      for (let i = 1; i < chain.length - 1; i++) {
+        try {
+          base = base?.[chain[i]];
+        } catch {
+          return null;
+        }
+        if (base == null)
+          return null;
+      }
+      if (base == null)
+        return null;
+      options = propsOf(base).filter(o => o.label.startsWith(prefix));
+    } else {
+      options = [];
+      for (const n of allNames()) {
+        if (!n.startsWith(prefix) || isNoise(n))
+          continue;
+        options.push({
+          label: n,
+          type: classify(lookup(n))
+        });
+      }
+    }
+    options.sort((a, b) => a.label.localeCompare(b.label));
+    return options.length ? {
+      from,
+      to: cx.pos,
+      options
+    } : null;
+  };
+  const lintSource = view => {
+    const seen = new Set();
+    const diags = [];
+    codemirror.syntaxTree(view.state).iterate({
+      enter: ({type, from, to}) => {
+        if (!type.isError)
+          return;
+        const end = to > from ? to : Math.min(from + 1, view.state.doc.length);
+        const k = from + ':' + end;
+        if (seen.has(k))
+          return;
+        seen.add(k);
+        diags.push({
+          from,
+          to: end,
+          severity: 'error',
+          message: 'Syntax error'
+        });
+      }
+    });
+    return diags;
+  };
+  const state = EditorState.create({
+    doc: decompiled,
+    extensions: [
+      cellIdFacet.of(key),
+      EditorView.updateListener.of(u => states.set(u.state.facet(cellIdFacet), u.state)),
+      codemirror.keymap.of([
+        codemirror.indentWithTab,
+        {
+          key: 'Shift-Enter',
+          run: () => {
+            // Mirror viewof apply: push the canonical decompiled
+            // source back into CodeMirror after compile.
+            (async () => {
+              const canonical = await compile_and_update(code_editor_view.state.doc.toString(), editedCell.variables, editedCell);
+              if (typeof canonical === 'string') {
+                replaceCodeMirrorDoc(code_editor_view, canonical, { preserveCursor: true });
+              }
+            })();
+            return true;
+          }
+        }
+      ]),
+      codemirror.EditorView.lineWrapping,
+      observableJS_language,
+      codemirror.syntaxHighlighting(observableJS_highlightStyle),
+      codemirror.autocompletion({
+        override: [
+          codemirror.localCompletionSource,
+          completionSource
+        ]
+      }),
+      codemirror.lintGutter(),
+      codemirror.linter(lintSource, { delay: 250 }),
+      codemirror.EditorView.baseTheme({
+        '.cm-lintRange.cm-lintRange-error': {
+          textDecoration: 'underline wavy #e11',
+          textUnderlineOffset: '3px'
+        }
+      }),
+      codemirror.basicSetup,
+      myDefaultTheme
+    ]
+  });
+  code_editor_view.setState(state);
+  states.set(key, state);
+};
+const _65mlp5 = function _divToCell(){return(
+(entries, div) => {
+  if (!div) return undefined;
+  if (div.variable) {
+    return (
+      entries.find(
+        ([name, cell]) => cell[0] && cell.find((v) => v == div.variable)
+      ) || div.variable
+    );
+  } else {
+    return entries.find(
+      ([name, cell]) => cell[0] && cell[0]._observer._node === div
+    );
+  }
+}
+)};
+const _bt6o0p = function _68(md){return(
+md`## Reacting to runtime changes
+
+Other editors might change the definition underfoot, so we need to reload the code mirror state`
+)};
+const _jh2ad1 = function _editor_refresh_from_runtime(editedCell,decompile,code_editor_view,replaceCodeMirrorDoc,queueMicrotask,onCodeChange,invalidation)
+{
+  const lastSyncedByKey = this?.lastSyncedByKey ?? new WeakMap();
+  const staleByKey = this?.staleByKey ?? new WeakMap();
+  let scheduled = false;
+
+  const getKey = () => editedCell?.variables?.[0] ?? null;
+
+  const syncNow = async ({ force = false } = {}) => {
+    const cell = editedCell;
+    if (!cell?.variables?.length) return false;
+
+    const key = getKey();
+    if (!key) return false;
+
+    const runtimeSource = await decompile(cell.variables);
+    const editorSource = code_editor_view?.state?.doc?.toString?.() ?? "";
+
+    if (runtimeSource === editorSource) {
+      lastSyncedByKey.set(key, runtimeSource);
+      staleByKey.set(key, false);
+      return false;
+    }
+
+    const last = lastSyncedByKey.get(key);
+    const isDirty = typeof last === "string" && editorSource !== last;
+
+    if (!force && isDirty) {
+      staleByKey.set(key, true);
+      return false;
+    }
+
+    const changed = replaceCodeMirrorDoc(code_editor_view, runtimeSource, {
+      preserveCursor: true
+    });
+    if (changed) {
+      lastSyncedByKey.set(key, runtimeSource);
+      staleByKey.set(key, false);
+    }
+    return changed;
+  };
+
+  const scheduleSync = ({ force = false } = {}) => {
+    if (scheduled) return;
+    scheduled = true;
+    queueMicrotask(async () => {
+      scheduled = false;
+      try {
+        await syncNow({ force });
+      } catch {}
+    });
+  };
+
+  const unsubscribe = onCodeChange(({ variable }) => {
+    const cell = editedCell;
+    if (!cell?.variables?.length) return;
+    if (!variable) return;
+    if (!cell.variables.includes(variable)) return;
+    scheduleSync({ force: false });
+  });
+
+  scheduleSync({ force: true });
+  invalidation.then(() => unsubscribe());
+
+  return {
+    lastSyncedByKey,
+    staleByKey,
+    syncNow,
+    scheduleSync,
+    get stale() {
+      const k = getKey();
+      return k ? !!staleByKey.get(k) : false;
+    }
+  };
+};
+const _dvne2z = function _replaceCodeMirrorDoc(){return(
+(view, nextText, {preserveCursor = true} = {}) => {
+  if (!view?.state) return false;
+  const prev = view.state.doc.toString();
+  const next = String(nextText ?? "");
+  if (prev === next) return false;
+
+  const head = view.state.selection?.main?.head ?? 0;
+  const anchor = view.state.selection?.main?.anchor ?? head;
+  const nextPos = (p) => Math.max(0, Math.min(p, next.length));
+
+  view.dispatch({
+    changes: {from: 0, to: view.state.doc.length, insert: next},
+    ...(preserveCursor
+      ? {selection: {anchor: nextPos(anchor), head: nextPos(head)}}
+      : null)
+  });
+
+  return true;
+}
+)};
+const _cbcryi = function _71(md){return(
+md`### Selection`
+)};
+const _rtf009 = function _select(editedCell,Inputs,getOption,setOption){return(
+(() => {
+  const v0 = editedCell?.variables?.[0] ?? null;
+  const el = Inputs.toggle({
+    value: v0 ? getOption(v0, "selected", false) : false
+  });
+
+  el.style.margin = "0";
+
+  el.addEventListener("input", () => {
+    const v = editedCell?.variables?.[0] ?? null;
+    if (!v) return;
+    setOption(v, "selected", el.value);
+  });
+
+  return el;
+})()
+)};
+const _14mwbuc = (G, _) => G.input(_);
+const _d2lrrw = function _73(md){return(
+md`## Pinning`
+)};
+const _ucf24e = function _74(FileAttachment){return(
+FileAttachment("cell_options.json")
+)};
+const _kygz54 = function _optionsFile(getFileAttachment,editorModule){return(
+getFileAttachment("cell_options.json", editorModule)
+)};
+const _760ozq = async function _options(Inputs,optionsFile){return(
+Inputs.input(await optionsFile.json())
+)};
+const _4rh26k = (G, _) => G.input(_);
+const _1lqy7cs = function _setOption(findCell,_,$0,Event){return(
+(variable, option, value) => {
+  const cell = findCell(variable);
+  _.set(
+    $0.value,
+    `${cell.module.name}.${cell.name}.${option}`,
+    value
+  );
+  $0.dispatchEvent(new Event("input"));
+}
+)};
+const _1oxe5ee = function _getOption(findCell,_,$0){return(
+(variable, option, defaultValue) => {
+  const cell = findCell(variable);
+  return (
+    _.get($0.value, `${cell.module.name}.${cell.name}.${option}`) ||
+    defaultValue
+  );
+}
+)};
+const _kwq69p = function _save_options(setFileAttachment,jsonFileAttachment,options,editorModule){return(
+setFileAttachment(
+  jsonFileAttachment("cell_options.json", options),
+  editorModule
+)
+)};
+const _1ag9ajn = function _80(md){return(
+md`## Pasting`
+)};
+const _dbvt0t = function _escapeTemplateLiteral(){return(
+(s = "") =>
+  String(s)
+    .replace(/\\/g, "\\\\")
+    .replace(/`/g, "\\`")
+)};
+const _1q2xn50 = function _inferCellGroupNameFromOJS(parser){return(
+(source) => {
+  let cell;
+  try {
+    cell = parser.parseCell(String(source ?? ""));
+  } catch {
+    return null;
+  }
+  if (!cell) return null;
+
+  if (cell.id) {
+    if (cell.id.type === "Identifier") return cell.id.name;
+    if (cell.id.type === "ViewExpression") return `viewof ${cell.id.id.name}`;
+    if (cell.id.type === "MutableExpression") return `mutable ${cell.id.id.name}`;
+  }
+
+  if (cell.body?.type === "ImportDeclaration") {
+    const mod = cell.body.source?.value;
+    if (typeof mod === "string" && mod.length) return `module ${mod}`;
+  }
+
+  return null;
+}
+)};
+const _1mfm13h = function _normalizeObservableClipboardCell(inferCellGroupNameFromOJS,escapeTemplateLiteral){return(
+(cell) => {
+  const mode = cell?.mode ?? "js";
+  const value = String(cell?.value ?? "");
+  const explicitName = typeof cell?.name === "string" && cell.name.length ? cell.name : null;
+
+  if (mode === "js") {
+    const name = inferCellGroupNameFromOJS(value) ?? explicitName;
+    return { mode, name, source: value };
+  }
+
+  if (mode === "md") {
+    const expr = `md\`${escapeTemplateLiteral(value)}\``;
+    const source = explicitName ? `${explicitName} = ${expr}` : expr;
+    const name = explicitName ?? null;
+    return { mode, name, source };
+  }
+
+  if (mode === "html") {
+    const expr = `htl.html\`${escapeTemplateLiteral(value)}\``;
+    const source = explicitName ? `${explicitName} = ${expr}` : expr;
+    const name = explicitName ?? null;
+    return { mode, name, source };
+  }
+
+  const name = inferCellGroupNameFromOJS(value) ?? explicitName;
+  return { mode, name, source: value };
+}
+)};
+const _1pa2xc8 = function _readObservableClipboardCells(globalThis){return(
+async () => {
+  const mime = "application/vnd.observablehq+json";
+
+  if (globalThis.navigator?.clipboard?.read) {
+    const items = await navigator.clipboard.read();
+    for (const item of items) {
+      if (item.types?.includes?.(mime)) {
+        const blob = await item.getType(mime);
+        const text = await blob.text();
+        const json = JSON.parse(text);
+        if (Array.isArray(json)) return json;
+      }
+    }
+  }
+
+  if (globalThis.navigator?.clipboard?.readText) {
+    const text = await navigator.clipboard.readText();
+    if (text == null) throw new Error("Clipboard readText returned null/undefined.");
+    return [{ mode: "js", value: String(text), name: null }];
+  }
+
+  throw new Error("Clipboard API unavailable (need navigator.clipboard.read or readText).");
+}
+)};
+const _1w99cbu = function _pasteObservableCellsIntoModule($0,normalizeObservableClipboardCell,findCell,compile_and_update){return(
+async ({ cells, editedCell }) => {
+  if (!editedCell?.module?.module) throw new Error("No selected cell/module to paste into.");
+  if (!Array.isArray(cells) || cells.length === 0) return { total: 0, matched: 0, replacedCurrent: false, inserted: 0 };
+
+  const moduleRuntime = editedCell.module.module;
+  const moduleCells = $0.value.get(moduleRuntime) || [];
+  const byName = new Map(
+    moduleCells
+      .filter((c) => typeof c?.name === "string" && c.name.length)
+      .map((c) => [c.name, c])
+  );
+
+  const normalized = cells.map((c) => normalizeObservableClipboardCell(c)).filter((c) => typeof c?.source === "string" && c.source.length);
+
+  const matched = [];
+  const unmatched = [];
+
+  for (const entry of normalized) {
+    if (entry.name && byName.has(entry.name)) {
+      const target = byName.get(entry.name);
+      const ctx = findCell(target.variables[0]);
+      if (ctx) matched.push({ entry, ctx });
+      else unmatched.push(entry);
+    } else {
+      unmatched.push(entry);
+    }
+  }
+
+  for (const { entry, ctx } of matched) {
+    compile_and_update(entry.source, ctx.variables, ctx);
+  }
+
+  let replacedCurrent = false;
+  let inserted = 0;
+
+  if (unmatched.length > 0) {
+    replacedCurrent = true;
+    compile_and_update(unmatched[0].source, editedCell.variables, editedCell);
+
+    let anchor = editedCell;
+    for (let i = 1; i < unmatched.length; i++) {
+      const vars = [];
+      compile_and_update(unmatched[i].source, vars, anchor);
+      anchor = { ...anchor, variables: vars, name: unmatched[i].name ?? anchor.name, dom: undefined };
+      inserted++;
+    }
+  }
+
+  return { total: normalized.length, matched: matched.length, replacedCurrent, inserted };
+}
+)};
+const _z9vacx = function _86(md){return(
+md`## Decompiler`
+)};
+const _gbuhyc = function _decompiled(editedCell,decompile)
+{
+    if (!editedCell?.variables?.length)
+        return '';
+    return decompile(editedCell.variables);
+};
+const _w5q3yf = function _editorModule(thisModule){return(
+thisModule()
+)};
+const _18kaj2p = (G, _) => G.input(_);
+const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_options)
+{
+  //editedCell;
+  command_processor;
+  submit_summary;
+  save_options;
+  return "editor_jobs";
+};
+const _1whoy5n = function _91(md){return(
+md`### Apply Update`
+)};
+const _gk83fp = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
+{
+  return async (source, variables = [], cell) => {
+    try {
+      const newVariables = compile(source);
+      // Skip emitting `module @X` if one already exists in the target
+      // module's scope and isn't one of OUR old variables. Without this,
+      // the second define() collides on the shared name and Observable
+      // rewrites BOTH the new and pre-existing module variables to a
+      // "defined more than once" thrower, breaking every pre-existing
+      // consumer of `@X` in the module. The new import-name bindings
+      // reference `module @X` by name and resolve to whatever module
+      // variable is currently in scope.
+      const targetScope = cell.module.module._scope;
+      const ourOldNames = new Set(variables.map(v => v._name));
+      const isModuleImport = nv => nv._name?.startsWith('module @') && nv._inputs.length === 0;
+      const shouldSkip = nv => isModuleImport(nv) && targetScope.has(nv._name) && !ourOldNames.has(nv._name);
+      const allocation = newVariables.map(nv => shouldSkip(nv) ? { reuse: targetScope.get(nv._name) } : { fresh: nv });
+      const freshNewVariables = allocation.filter(a => a.fresh).map(a => a.fresh);
+      let reposition = false, insertionIndex = -1;
+      if (!variables || variables.length !== freshNewVariables.length) {
+        reposition = true;
+        // Reuse existing variable slots where we can. Preserves the first slot's
+        // observer/inspector/editor-row binding so a 1→N compile (viewof = 2,
+        // mutable = 3, import = 1+N bindings) keeps the user's cell visible
+        // and re-editable. Only the surplus old vars are deleted; only the
+        // surplus new vars are freshly created.
+        const overlap = Math.min(variables.length, freshNewVariables.length);
+        for (let i = overlap; i < variables.length; i++)
+          variables[i].delete();
+        variables.length = overlap;
+        for (let i = overlap; i < freshNewVariables.length; i++) {
+          const newVariable = cell.module.module.variable({});
+          // Assign a random pid up-front so blank/identical new cells don't
+          // collide via persistentId's contentHash. See lopecode#144.
+          newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
+          variables.push(newVariable);
+        }
+      }
+      if (reposition) {
+        insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
+      }
+      const fns = await realize(freshNewVariables.map(v => v._definition), runtime);
+      freshNewVariables.forEach((v, i) => {
+        const variable = variables[i];
+        const _fn = fns[i];
+        if (v._name) {
+          variable.define(v._name, v._inputs, _fn);
+        } else {
+          variable.define(v._inputs, _fn);
+        }
+        if (reposition)
+          repositionSetElement(runtime._variables, variable, insertionIndex + i);
+      });
+      // Build the full variable set for decompile, mixing reused module-import
+      // variables with the freshly-defined runtime variables, in the same order
+      // as `allocation`.
+      let freshIdx = 0;
+      const decompileVars = allocation.map(a => a.reuse ? a.reuse : variables[freshIdx++]);
+      return await decompile(decompileVars);
+    } catch (e) {
+      console.error(e);
+    }
+  };
+};
+const _1g3bdxp = function _93(md){return(
+md`### Remove Cells`
+)};
+const _mhcibs = function _remove_variables(){return(
+(variables) => {
+  variables.forEach((v) => v.delete());
+}
+)};
+const _1qb4uz = function _95(md){return(
+md`### Runtime Representation`
+)};
+const _rwez9 = function _variable(Inputs,editedCell){return(
+Inputs.radio(editedCell.variables, {
+  label: "variable in cell group",
+  format: (v) => v._name,
+  value: editedCell.variables[0]
+})
+)};
+const _11gvkq4 = (G, _) => G.input(_);
+const _r5nvms = function _name(variable){return(
+variable._name
+)};
+const _9vxebx = function _inputs(variable){return(
+variable._inputs.map((v) => v._name)
+)};
+const _1348jvx = function _definition(Inputs,variable){return(
+Inputs.textarea({
+  label: "variable._definition",
+  value: variable._definition.toString(),
+  rows: 10
+})
+)};
+const _b4rsn5 = (G, _) => G.input(_);
+const _1pimibm = function _100(Inputs,definition,variable,realize,runtime,inputs){return(
+Inputs.button("update variable", {
+  disabled: definition === variable._definition.toString(),
+  reduce: async () => {
+    const [_fn] = await realize([definition], runtime);
+    variable.define(variable._name, inputs, _fn);
+  }
+})
+)};
+const _1d94dks = function _javascriptPlugin(codemirror){return(
+codemirror
+)};
+const _1j5gu2y = function _102(md){return(
+md`### Libraries`
+)};
+const _lbftlp = function _literalCompletions(codemirror)
+{
+  // Pure extract of editor_manager's literal-base completion, for the test_* cells.
+  const isNoise = n => n.startsWith('_') || [
+    'prototype',
+    'constructor',
+    'caller',
+    'callee',
+    'arguments',
+    'name',
+    'length'
+  ].includes(n);
+  const stopAt = new Set([
+    Object.prototype,
+    Function.prototype
+  ]);
+  const propsOf = obj => {
+    const out = [], seen = new Set();
+    for (let o = Object(obj), d = 0; o && d < 4; o = Object.getPrototypeOf(o), d++) {
+      if (d > 0 && stopAt.has(o))
+        break;
+      for (const n of Object.getOwnPropertyNames(o)) {
+        if (seen.has(n) || isNoise(n))
+          continue;
+        seen.add(n);
+        const desc = Object.getOwnPropertyDescriptor(o, n);
+        out.push({
+          label: n,
+          type: typeof desc?.value === 'function' ? 'function' : 'property'
+        });
+      }
+    }
+    return out;
+  };
+  const literalProto = name => {
+    switch (name) {
+    case 'String':
+    case 'TemplateString':
+      return '';
+    case 'Number':
+      return 0;
+    case 'BooleanLiteral':
+      return false;
+    case 'ArrayExpression':
+      return [];
+    case 'ObjectExpression':
+      return {};
+    case 'RegExp':
+      return /(?:)/;
+    default:
+      return undefined;
+    }
+  };
+  return (state, pos) => {
+    const before = state.sliceDoc(state.doc.lineAt(pos).from, pos);
+    const dm = before.match(/\.([A-Za-z_$][\w$]*)?$/);
+    if (!dm)
+      return null;
+    const prefix = dm[1] ?? '';
+    const dotPos = pos - prefix.length - 1;
+    let mem = null;
+    for (let n = codemirror.syntaxTree(state).resolveInner(dotPos, -1); n; n = n.parent) {
+      if (n.name === 'MemberExpression') {
+        mem = n;
+        break;
+      }
+    }
+    if (!mem)
+      return null;
+    let obj = mem.firstChild;
+    while (obj && obj.name === 'ParenthesizedExpression')
+      obj = obj.firstChild?.nextSibling ?? null;
+    const base = obj && literalProto(obj.name);
+    if (base === undefined)
+      return null;
+    const options = propsOf(base).filter(o => o.label.startsWith(prefix));
+    options.sort((a, b) => a.label.localeCompare(b.label));
+    return options.length ? {
+      from: pos - prefix.length,
+      to: pos,
+      options
+    } : null;
+  };
+};
+const _scoiwp = function _completionFixture(EditorState,observableJS_language,literalCompletions)
+{
+  return doc => {
+    // Headless EditorState so the syntax tree parses; return labels at end of `doc`.
+    const state = EditorState.create({
+      doc,
+      extensions: [observableJS_language]
+    });
+    const r = literalCompletions(state, doc.length);
+    return r ? r.options.map(o => o.label) : [];
+  };
+};
+const _160qhf1 = function _test_completion_string_literal(completionFixture)
+{
+  const labels = completionFixture('"".');
+  for (const method of [
+      'charAt',
+      'slice',
+      'split',
+      'toUpperCase'
+    ]) {
+    if (!labels.includes(method))
+      throw new Error(`"". missing String method '${ method }'; got ${ labels.slice(0, 8) }`);
+  }
+  return `"". → ${ labels.length } String.prototype methods`;
+};
+const _xrmooc = function _test_completion_string_prefix(completionFixture)
+{
+  const labels = completionFixture('"".sl');
+  if (labels.join() !== 'slice')
+    throw new Error(`"".sl expected ['slice'], got ${ labels }`);
+  return `"".sl → slice (prefix filtered)`;
+};
+const _m0ar50 = function _test_completion_array_literal(completionFixture)
+{
+  const labels = completionFixture('[].');
+  for (const method of [
+      'map',
+      'filter',
+      'forEach',
+      'find',
+      'reduce'
+    ]) {
+    if (!labels.includes(method))
+      throw new Error(`[]. missing Array method '${ method }'; got ${ labels.slice(0, 8) }`);
+  }
+  return `[]. → ${ labels.length } Array.prototype methods`;
+};
+const _13247rm = function _test_completion_number_literal(completionFixture)
+{
+  const labels = completionFixture('(5).');
+  for (const method of [
+      'toFixed',
+      'toExponential',
+      'toPrecision'
+    ]) {
+    if (!labels.includes(method))
+      throw new Error(`(5). missing Number method '${ method }'; got ${ labels }`);
+  }
+  return `(5). → ${ labels.length } Number.prototype methods`;
+};
+const _quyccp = function _test_completion_bool_template_regexp(completionFixture)
+{
+  if (!completionFixture('true.').includes('valueOf'))
+    throw new Error('true. should expose Boolean.prototype (valueOf)');
+  if (!completionFixture('`x`.').includes('charAt'))
+    throw new Error('`x`. should expose String.prototype (charAt)');
+  if (!completionFixture('/a/.').includes('test'))
+    throw new Error('/a/. should expose RegExp.prototype (test)');
+  return 'true. / `x`. / /a/. expose Boolean / String / RegExp methods';
+};
+const _1cn3ucr = function _test_completion_parenthesised_unwrap(completionFixture)
+{
+  if (!completionFixture('("hi").').includes('slice'))
+    throw new Error('("hi"). should unwrap to a String');
+  if (!completionFixture('(([])).').includes('map'))
+    throw new Error('(([])). should unwrap nested parens to an Array');
+  return 'parenthesised (and nested) literals unwrap to their inner type';
+};
+const _15vxhca = function _test_completion_never_evaluates(completionFixture)
+{
+  // Undefined ref inside the array still yields Array methods — type-based, never executed.
+  if (!completionFixture('[neverDefinedRef].').includes('map')) {
+    throw new Error('array literal should offer Array methods by type, without evaluation');
+  }
+  // Non-literal bases (calls, arithmetic, scope refs) offer nothing.
+  for (const doc of [
+      'foo().',
+      '(1 + 2).',
+      '(x + y).'
+    ]) {
+    const labels = completionFixture(doc);
+    if (labels.length)
+      throw new Error(`${ doc } should yield no literal completions, got ${ labels.slice(0, 5) }`);
+  }
+  return 'completions are type-based \u2014 literals are never evaluated';
+};
+const _bz6mai = function _test_completion_identifier_deferred(completionFixture)
+{
+  // Identifier (foo.) and bare-word (ht) bases defer to the identifier-chain path.
+  if (completionFixture('foo.').length)
+    throw new Error('identifier base must defer to the identifier-chain path');
+  if (completionFixture('ht').length)
+    throw new Error('bare identifier (no dot) must defer');
+  return 'identifier / no-dot bases deferred to the identifier-chain path';
+};
+const _y8yyf = function _pinOnCreate()
+{
+  return new Set()  // variable pids to open (pin) their editor as soon as the cell mounts
+;
+};
+
+export default function define(runtime, observer) {
+  const main = runtime.module();
+  const $def = (pid, name, deps, fn) => {
+    main.variable(observer(name)).define(name, deps, fn).pid = pid;
+  };
+  const fileAttachments = new Map(["cell_options.json"].map((name) => {
+    const module_name = "@tomlarkworthy/editor-5";
+    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
+    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
+    return [name, {url: blob_url, mimeType: mime}]
+  }));
+  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
+  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));  
+  main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
+  main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
+  main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
+  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
+  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
+  main.define("module @tomlarkworthy/cells-to-clipboard", async () => runtime.module((await import("/@tomlarkworthy/cells-to-clipboard.js?v=4")).default));  
+  main.define("module @tomlarkworthy/observablehq-lezer", async () => runtime.module((await import("/@tomlarkworthy/observablehq-lezer.js?v=4")).default));  
+  main.define("module @tomlarkworthy/dataflow-templating", async () => runtime.module((await import("/@tomlarkworthy/dataflow-templating.js?v=4")).default));  
+  main.define("module @tomlarkworthy/fileattachments", async () => runtime.module((await import("/@tomlarkworthy/fileattachments.js?v=4")).default));  
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/codemirror-6-v2", async () => runtime.module((await import("/@tomlarkworthy/codemirror-6-v2.js?v=4")).default));  
+  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
+  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
+  $def("_1tdjp0a", "title", ["md"], _1tdjp0a);  
+  $def("_dm53bx", null, ["md"], _dm53bx);  
+  $def("_61oxjf", "title_variable", ["lookupVariable","editorModule"], _61oxjf);  
+  $def("_15uilf0", null, ["cellEditor","title_variable"], _15uilf0);  
+  $def("_wpcfq8", null, ["md"], _wpcfq8);  
+  $def("_1ociws4", null, ["md"], _1ociws4);  
+  main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
+  main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
+  $def("_hdieof", "editors", [], _hdieof);  
+  $def("_ipx6cz", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","editors","cellEditor"], _ipx6cz);  
+  $def("_1iwobxt", "divToVar", [], _1iwobxt);  
+  $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
+  $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
+  $def("_16ks4jz", null, ["md"], _16ks4jz);  
+  $def("_199ztvl", "hotbarTemplate", ["lookupVariable","editorModule"], _199ztvl);  
+  $def("_hqns12", "cellEditor", ["cloneDataflow","editorTemplate","shellTemplate","createCell","findCell","pinOnCreate","getOption","Event","setOption"], _hqns12);  
+  $def("_x5ixji", "hotbar_shell", ["viewof edit","Event","htl","edit"], _x5ixji);  
+  $def("_1ed5zb9", "editor_panel", ["viewof editedCell","htl","toolbar","nav","reversibleAttach","combine","code_editor"], _1ed5zb9);  
+  $def("_yk7udl", "shellTemplate", ["viewof editedCell","editedCell","selectVariable","viewof edit","edit","hotbar_shell","lookupVariable","editorModule"], _yk7udl);  
+  $def("_jot8he", "editorTemplate", ["viewof editedCell","editedCell","selectVariable","viewof select","viewof up","viewof down","viewof remove","viewof addCells","viewof apply","viewof copy","viewof paste","toolbar","nav","cellLinks","variableLink","decompiled","code_editor_view","code_editor","editor_manager","editor_refresh_from_runtime","editor_panel","lookupVariable","editorModule"], _jot8he);  
+  $def("_oshnzp", null, ["md"], _oshnzp);  
+  $def("_1o2h65s", "viewof editedCell", ["Inputs"], _1o2h65s);  
+  $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
+  $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
+  $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
+  $def("_3jxaqk", null, ["selectVariable","hotbarTemplate"], _3jxaqk);  
+  $def("_49mpmh", "hotbar", ["viewof edit","Event","setOption","viewof editedCell","htl","edit","toolbar","nav","reversibleAttach","combine","code_editor"], _49mpmh);  
+  $def("_n8s6yl", null, ["viewof editedCell"], _n8s6yl);  
+  $def("_ytd2rq", null, ["nav","editedCell"], _ytd2rq);  
+  $def("_1t4gep6", "nav", ["html","cellLinks"], _1t4gep6);  
+  $def("_1tv9qxo", "cellLinks", ["html","variableLink"], _1tv9qxo);  
+  $def("_1opggh8", "identity", ["lookupVariable","editorModule"], _1opggh8);  
+  $def("_1nfia2p", "variableLink", ["identity","navHref","modules"], _1nfia2p);  
+  $def("_1tm2n0w", null, ["md"], _1tm2n0w);  
+  $def("_16wblye", null, ["md"], _16wblye);  
+  $def("_1jdvxd9", null, ["md"], _1jdvxd9);  
+  $def("_1j1loxx", "viewof combine", ["Inputs"], _1j1loxx);  
+  $def("_1h8337z", "combine", ["Generators","viewof combine"], _1h8337z);  
+  $def("_tct2nf", "viewof edit", ["Inputs"], _tct2nf);  
+  $def("_7izj7k", "edit", ["Generators","viewof edit"], _7izj7k);  
+  $def("_1fwb5jc", "toolbar", ["htl","reversibleAttach","combine","viewof select","viewof up","viewof down","viewof remove","viewof addCells","viewof apply","viewof copy","viewof paste"], _1fwb5jc);  
+  $def("_yej3hb", "viewof addCells", ["Inputs","createCell","viewof editedCell"], _yej3hb);  
+  $def("_1aii9ps", "addCells", ["Generators","viewof addCells"], _1aii9ps);  
+  $def("_1bn860e", "viewof remove", ["Inputs","deleteCell","viewof editedCell"], _1bn860e);  
+  $def("_1ad0xr8", "remove", ["Generators","viewof remove"], _1ad0xr8);  
+  $def("_lwb7d7", "viewof apply", ["Inputs","compile_and_update","code_editor_view","editedCell","replaceCodeMirrorDoc"], _lwb7d7);  
+  $def("_1cjyuqm", "apply", ["Generators","viewof apply"], _1cjyuqm);  
+  $def("_14rfku9", "viewof up", ["Inputs","moveCell","viewof editedCell"], _14rfku9);  
+  $def("_frzs5d", "up", ["Generators","viewof up"], _frzs5d);  
+  $def("_9pymuj", "viewof paste", ["Inputs","readObservableClipboardCells","pasteObservableCellsIntoModule","editedCell"], _9pymuj);  
+  $def("_1whsszt", "paste", ["Generators","viewof paste"], _1whsszt);  
+  $def("_corxwl", "viewof down", ["Inputs","moveCell","viewof editedCell"], _corxwl);  
+  $def("_1to28po", "down", ["Generators","viewof down"], _1to28po);  
+  $def("_gia2ci", "viewof copy", ["Inputs","html","viewof editedCell","decompile","viewof liveCellMap","getOption","cellsToClipboard"], _gia2ci);  
+  $def("_fw41wt", "copy", ["Generators","viewof copy"], _fw41wt);  
+  $def("_srtw8o", "module", ["editedCell"], _srtw8o);  
+  $def("_rv7t7x", "code_editor_view", ["EditorView"], _rv7t7x);  
+  $def("_xvo1n6", "code_editor", ["code_editor_view"], _xvo1n6);  
+  $def("_1imarq2", null, ["md"], _1imarq2);  
+  $def("_470wv4", "moveCell", ["viewof command"], _470wv4);  
+  $def("_19znal9", "createCell", ["viewof command"], _19znal9);  
+  $def("_d9nzys", "deleteCell", ["viewof command"], _d9nzys);  
+  $def("_1toku21", null, ["md"], _1toku21);  
+  $def("_d7ouqx", "viewof command", ["flowQueue"], _d7ouqx);  
+  $def("_118qt2v", "command", ["Generators","viewof command"], _118qt2v);  
+  $def("_c4420j", null, ["command"], _c4420j);  
+  $def("_1f6v167", "findCellByVariable", [], _1f6v167);  
+  $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
+  $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
+  $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
+  $def("_1efmn99", "command_processor", ["command","viewof edit","compile_and_update","pinOnCreate","selectVariable","remove_variables","viewof liveCellMap","findCellIndex","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","viewof command"], _1efmn99);  
+  $def("_8iz5z2", null, ["md"], _8iz5z2);  
+  $def("_m873d1", "states", [], _m873d1);  
+  $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
+  $def("_y7997q", null, ["md"], _y7997q);  
+  $def("_7btuqg", "observableJS_language", ["codemirror","observable_lezer_parser"], _7btuqg);  
+  $def("_1xf04v5", "observableJS_highlightStyle", ["codemirror","lezerhighlight"], _1xf04v5);  
+  $def("_19d9pua", "observableJS_lint", ["codemirror"], _19d9pua);  
+  $def("_125gzhe", "editor_manager", ["editedCell","globalThis","codemirror","literalCompletions","EditorState","decompiled","cellIdFacet","EditorView","states","compile_and_update","code_editor_view","replaceCodeMirrorDoc","observableJS_language","observableJS_highlightStyle","myDefaultTheme"], _125gzhe);  
+  $def("_65mlp5", "divToCell", [], _65mlp5);  
+  $def("_bt6o0p", null, ["md"], _bt6o0p);  
+  $def("_jh2ad1", "editor_refresh_from_runtime", ["editedCell","decompile","code_editor_view","replaceCodeMirrorDoc","queueMicrotask","onCodeChange","invalidation"], _jh2ad1);  
+  $def("_dvne2z", "replaceCodeMirrorDoc", [], _dvne2z);  
+  $def("_cbcryi", null, ["md"], _cbcryi);  
+  $def("_rtf009", "viewof select", ["editedCell","Inputs","getOption","setOption"], _rtf009);  
+  $def("_14mwbuc", "select", ["Generators","viewof select"], _14mwbuc);  
+  $def("_d2lrrw", null, ["md"], _d2lrrw);  
+  $def("_ucf24e", null, ["FileAttachment"], _ucf24e);  
+  $def("_kygz54", "optionsFile", ["getFileAttachment","editorModule"], _kygz54);  
+  $def("_760ozq", "viewof options", ["Inputs","optionsFile"], _760ozq);  
+  $def("_4rh26k", "options", ["Generators","viewof options"], _4rh26k);  
+  $def("_1lqy7cs", "setOption", ["findCell","_","viewof options","Event"], _1lqy7cs);  
+  $def("_1oxe5ee", "getOption", ["findCell","_","viewof options"], _1oxe5ee);  
+  $def("_kwq69p", "save_options", ["setFileAttachment","jsonFileAttachment","options","editorModule"], _kwq69p);  
+  $def("_1ag9ajn", null, ["md"], _1ag9ajn);  
+  $def("_dbvt0t", "escapeTemplateLiteral", [], _dbvt0t);  
+  $def("_1q2xn50", "inferCellGroupNameFromOJS", ["parser"], _1q2xn50);  
+  $def("_1mfm13h", "normalizeObservableClipboardCell", ["inferCellGroupNameFromOJS","escapeTemplateLiteral"], _1mfm13h);  
+  $def("_1pa2xc8", "readObservableClipboardCells", ["globalThis"], _1pa2xc8);  
+  $def("_1w99cbu", "pasteObservableCellsIntoModule", ["viewof liveCellMap","normalizeObservableClipboardCell","findCell","compile_and_update"], _1w99cbu);  
+  $def("_z9vacx", null, ["md"], _z9vacx);  
+  main.define("modules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", "modules", _));  
+  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);  
+  $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
+  $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
+  $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
+  $def("_1whoy5n", null, ["md"], _1whoy5n);  
+  $def("_gk83fp", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _gk83fp);  
+  $def("_1g3bdxp", null, ["md"], _1g3bdxp);  
+  $def("_mhcibs", "remove_variables", [], _mhcibs);  
+  $def("_1qb4uz", null, ["md"], _1qb4uz);  
+  $def("_rwez9", "viewof variable", ["Inputs","editedCell"], _rwez9);  
+  $def("_11gvkq4", "variable", ["Generators","viewof variable"], _11gvkq4);  
+  $def("_r5nvms", "name", ["variable"], _r5nvms);  
+  $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
+  $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
+  $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
+  $def("_1pimibm", null, ["Inputs","definition","variable","realize","runtime","inputs"], _1pimibm);  
+  $def("_1d94dks", "javascriptPlugin", ["codemirror"], _1d94dks);  
+  $def("_1j5gu2y", null, ["md"], _1j5gu2y);  
+  main.define("reversibleAttach", ["module @tomlarkworthy/reversible-attachment", "@variable"], (_, v) => v.import("reversibleAttach", _));  
+  main.define("flowQueue", ["module @tomlarkworthy/flow-queue", "@variable"], (_, v) => v.import("flowQueue", _));  
+  main.define("viewof liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("viewof liveCellMap", _));  
+  main.define("liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("liveCellMap", _));  
+  main.define("hash", ["module d/57d79353bac56631@44", "@variable"], (_, v) => v.import("hash", _));  
+  main.define("extractNotebookAndCell", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("extractNotebookAndCell", _));  
+  main.define("navHref", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("navHref", _));  
+  main.define("cellsToClipboard", ["module @tomlarkworthy/cells-to-clipboard", "@variable"], (_, v) => v.import("cellsToClipboard", _));  
+  main.define("observable_lezer_parser", ["module @tomlarkworthy/observablehq-lezer", "@variable"], (_, v) => v.import("observable_lezer_parser", _));  
+  main.define("lezerhighlight", ["module @tomlarkworthy/observablehq-lezer", "@variable"], (_, v) => v.import("lezerhighlight", _));  
+  main.define("cloneDataflow", ["module @tomlarkworthy/dataflow-templating", "@variable"], (_, v) => v.import("cloneDataflow", _));  
+  main.define("lookupVariable", ["module @tomlarkworthy/dataflow-templating", "@variable"], (_, v) => v.import("lookupVariable", _));  
+  main.define("getFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachment", _));  
+  main.define("setFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("setFileAttachment", _));  
+  main.define("removeFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("removeFileAttachment", _));  
+  main.define("jsonFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("jsonFileAttachment", _));  
+  main.define("createFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("createFileAttachment", _));  
+  main.define("realize", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("realize", _));  
+  main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
+  main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
+  main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
+  main.define("isOnObservableCom", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("isOnObservableCom", _));  
+  main.define("thisModule", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("thisModule", _));  
+  main.define("keepalive", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("keepalive", _));  
+  main.define("toObject", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("toObject", _));  
+  main.define("isnode", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("isnode", _));  
+  main.define("repositionSetElement", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("repositionSetElement", _));  
+  main.define("onCodeChange", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("onCodeChange", _));  
+  main.define("EditorState", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("EditorState", _));  
+  main.define("EditorView", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("EditorView", _));  
+  main.define("codemirror", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("codemirror", _));  
+  main.define("myDefaultTheme", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("myDefaultTheme", _));  
+  main.define("decompile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("decompile", _));  
+  main.define("compile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("compile", _));  
+  main.define("cellMap", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("cellMap", _));  
+  main.define("findModuleName", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("findModuleName", _));  
+  main.define("parser", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("parser", _));  
+  main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
+  main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
+  main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
+  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
+  $def("_lbftlp", "literalCompletions", ["codemirror"], _lbftlp);  
+  $def("_scoiwp", "completionFixture", ["EditorState","observableJS_language","literalCompletions"], _scoiwp);  
+  $def("_160qhf1", "test_completion_string_literal", ["completionFixture"], _160qhf1);  
+  $def("_xrmooc", "test_completion_string_prefix", ["completionFixture"], _xrmooc);  
+  $def("_m0ar50", "test_completion_array_literal", ["completionFixture"], _m0ar50);  
+  $def("_13247rm", "test_completion_number_literal", ["completionFixture"], _13247rm);  
+  $def("_quyccp", "test_completion_bool_template_regexp", ["completionFixture"], _quyccp);  
+  $def("_1cn3ucr", "test_completion_parenthesised_unwrap", ["completionFixture"], _1cn3ucr);  
+  $def("_15vxhca", "test_completion_never_evaluates", ["completionFixture"], _15vxhca);  
+  $def("_bz6mai", "test_completion_identifier_deferred", ["completionFixture"], _bz6mai);  
+  $def("_y8yyf", "pinOnCreate", [], _y8yyf);
+  return main;
+}</script>
+
+<script id="@tomlarkworthy/lopepage-2" 
+  type="text/plain"
+  data-mime="application/javascript"
+>
+const _1pg70e1 = function _lp2_doc_overview(md){return(
+md`# Lopepage-2: Multi-notebook layout
+
+A layout engine for lopecode notebooks. It tiles modules into resizable splits and tabbed stacks, serialises the layout to the URL hash, and preserves scroll position across layout changes. It owns its DOM directly.
+
+It rests on three mechanisms, each described in its own section:
+
+1. **Immortal panes** — one scroll container per module, created once and reparented on layout change, so \`scrollTop\` is retained.
+2. **Persistent-id scroll anchoring** — when a pane's content resizes after load, the cell at the viewport top is held in place by its \`pid\`.
+3. **A layout tree** reconciled to DOM and round-tripped through the \`#view=\` DSL under loop-protected hash ownership.
+
+Dependencies: [\`runtime-sdk\`](https://observablehq.com/@tomlarkworthy/runtime-sdk) (\`persistentId\`, \`runtime\`), [\`visualizer\`](https://observablehq.com/@tomlarkworthy/visualizer) (cell rendering), [\`modules\`](https://observablehq.com/@tomlarkworthy/modules) (\`currentModules\` — incremental module discovery), [\`themes\`](https://observablehq.com/@tomlarkworthy/themes) (\`apply_theme\`). Four orthogonal feature modules are composed by import and kept reachable from \`lp2_background_jobs\`: [\`command-palette\`](https://observablehq.com/@tomlarkworthy/command-palette) (⌘K), [\`claude-code-pairing\`](https://observablehq.com/@tomlarkworthy/claude-code-pairing) (\`cc_chat\`), [\`local-change-history\`](https://observablehq.com/@tomlarkworthy/local-change-history) (edit recording/replay), and [\`editor-5\`](https://observablehq.com/@tomlarkworthy/editor-5) (\`auto_attach\` — inline cell editing).`
+)};
+const _1ov8ye5 = function _lp2_doc_model(md){return(
+md`### Layout model and DSL
+
+The layout is a single tree. \`viewof lp2Model\` holds it as reactive state. A node is one of:
+
+- \`{t:'row'|'col', sizes:[..%], children:[node]}\` — a split; \`sizes\` are percentages summing to 100, one per child.
+- \`{t:'stack', active:int, tabs:[{module}]}\` — a tabbed pane; \`active\` indexes \`tabs\`.
+
+There is always exactly one root node. \`lp2_parseDSL\` and \`lp2_serializeDSL\` convert the tree to and from the \`#view=\` \`R\`/\`C\`/\`S\` weighted DSL, the same grammar the rest of lopecode uses, so a layout is fully described by its URL.`
+)};
+const _1rihrff = function _lp2Model(Inputs){return(
+Inputs.input({
+  t: 'row',
+  sizes: [
+    50,
+    50
+  ],
+  children: [
+    {
+      t: 'stack',
+      active: 0,
+      tabs: [{ module: '@tomlarkworthy/runtime-sdk' }]
+    },
+    {
+      t: 'stack',
+      active: 0,
+      tabs: [{ module: '@tomlarkworthy/visualizer' }]
+    }
+  ]
+})
+)};
+const _1ow4sob = (G, _) => G.input(_);
+const _l8xp7u = function _lp2_parseDSL(){return(
+input => {
+  if (!input)
+    return null;
+  input = String(input);
+  if (input.startsWith('#'))
+    input = input.slice(1);
+  const mView = input.match(/(?:^|&)view=([^&]*)/);
+  if (mView)
+    input = mView[1];
+  let i = 0;
+  const num = () => {
+    const s = i;
+    while (i < input.length && input[i] >= '0' && input[i] <= '9')
+      i++;
+    return s < i ? parseInt(input.slice(s, i), 10) : null;
+  };
+  const moduleName = () => {
+    const s = i;
+    while (i < input.length && !',)#'.includes(input[i]))
+      i++;
+    return input.slice(s, i);
+  };
+  const parseLeaf = () => {
+    const weight = num();
+    const module = moduleName();
+    let cell;
+    if (input[i] === '#') {
+      i++;
+      const s = i;
+      while (i < input.length && !',)'.includes(input[i]))
+        i++;
+      cell = input.slice(s, i);
+    }
+    return {
+      node: {
+        module,
+        ...cell ? { cell } : {}
+      },
+      weight
+    };
+  };
+  const parseItem = () => {
+    const c = input[i];
+    return c === 'R' || c === 'C' || c === 'S' ? parseGroup() : parseLeaf();
+  };
+  const parseList = isStack => {
+    const items = [];
+    while (i < input.length && input[i] !== ')') {
+      items.push(isStack ? parseLeaf() : parseItem());
+      if (input[i] === ',')
+        i++;
+    }
+    return items;
+  };
+  const parseGroup = () => {
+    const type = input[i++];
+    const weight = num();
+    let items = [];
+    if (input[i] === '(') {
+      i++;
+      items = parseList(type === 'S');
+      if (input[i] === ')')
+        i++;
+    }
+    if (type === 'S')
+      return {
+        node: {
+          t: 'stack',
+          active: 0,
+          tabs: items.map(it => it.node)
+        },
+        weight
+      };
+    const children = items.map(it => it.node);
+    const sizes = items.map(it => it.weight != null ? it.weight : Math.round(100 / items.length));
+    return {
+      node: {
+        t: type === 'R' ? 'row' : 'col',
+        children,
+        sizes
+      },
+      weight
+    };
+  };
+  const r = parseItem();
+  return r ? r.node : null;
+}
+)};
+const _15gufbj = function _lp2_serializeDSL(){return(
+root => {
+  const s = (node, weight) => {
+    const w = weight != null ? weight : 100;
+    if (!node)
+      return '';
+    if (node.t === 'stack') {
+      const tabs = (node.tabs || []).map(l => l.module + (l.cell ? '#' + l.cell : '')).join(',');
+      return `S${ w }(${ tabs })`;
+    }
+    if (node.t === 'row' || node.t === 'col') {
+      const n = node.children || [];
+      const kids = n.map((c, idx) => s(c, node.sizes && node.sizes[idx] != null ? node.sizes[idx] : Math.round(100 / n.length))).join(',');
+      return `${ node.t === 'row' ? 'R' : 'C' }${ w }(${ kids })`;
+    }
+    return (node.module || '') + (node.cell ? '#' + node.cell : '');
+  };
+  return s(root, 100);
+}
+)};
+const _14hgn59 = function _lp2_doc_panes(md){return(
+md`### Immortal panes
+
+\`lp2_paneRegistry\` is a \`Map\` from module name to a single scroll \`<div>\` that hosts that module's [\`visualizer\`](https://observablehq.com/@tomlarkworthy/visualizer) render. \`lp2_getPane\` builds the pane on first request and returns the cached element thereafter. \`lp2_moduleByName\` resolves a module name to its runtime module via \`currentModules\` from [\`modules\`](https://observablehq.com/@tomlarkworthy/modules), an async generator that yields a cumulative module map as modules resolve.
+
+Invariants:
+
+- One pane element per module name, for the lifetime of the page.
+- A layout change reparents the cached element; it is never recreated, so its rendered content and DOM state are preserved.
+- A layout-only change does not alter a pane's content height, so capturing \`scrollTop\` before the reparent and restoring it after is exact.`
+)};
+const _r14r4j = function _lp2_moduleByName(lp2_watchedModules){return(
+name => lp2_watchedModules && lp2_watchedModules.get ? lp2_watchedModules.get(name) : undefined
+)};
+const _j3eb9x = function _lp2_paneRegistry(){return(
+new Map()
+)};
+const _z08s5w = function _lp2_getPane(lp2_scrollToCell,lp2_paneRegistry,lp2_moduleByName,visualizer,runtime,lp2_installAnchor)
+{
+  return (moduleName, deepLinkCell) => {
+    const applyDeepLink = entry => {
+      if (deepLinkCell && !entry.transient && entry.deepLink !== deepLinkCell) {
+        entry.deepLink = deepLinkCell;
+        lp2_scrollToCell(entry, deepLinkCell);
+      }
+      return entry;
+    };
+    let entry = lp2_paneRegistry.get(moduleName);
+    if (entry)
+      return applyDeepLink(entry);
+    const el = document.createElement('div');
+    el.className = 'lp2-pane';
+    el.dataset.module = moduleName;
+    Object.assign(el.style, {
+      overflow: 'auto',
+      height: '100%',
+      width: '100%',
+      position: 'relative',
+      overflowAnchor: 'auto'
+    });
+    const mod = lp2_moduleByName(moduleName);
+    if (!mod) {
+      // Module not in the (incrementally-populated) map yet. Return a transient placeholder
+      // WITHOUT caching, so a later render retries once the module resolves. Caching here would
+      // freeze the pane on "not found" forever (panes are immortal).
+      el.textContent = 'loading ' + moduleName + '\u2026';
+      el.style.cssText += ';display:flex;align-items:center;justify-content:center;color:var(--theme-foreground-faint);font:12px var(--monospace,monospace)';
+      return {
+        el,
+        viz: null,
+        moduleName,
+        anchor: null,
+        transient: true
+      };
+    }
+    const viz = visualizer(runtime, {
+      invalidation: new Promise(() => {
+      }),
+      module: mod,
+      filter: (cell_name, variables) => {
+        if (variables?.[0]?._type !== 1)
+          return false;
+        if (typeof cell_name === 'string' && cell_name.startsWith('dynamic '))
+          return false;
+        return true;
+      }
+    });
+    el.appendChild(viz);
+    entry = {
+      el,
+      viz,
+      moduleName,
+      anchor: null
+    };
+    lp2_paneRegistry.set(moduleName, entry);
+    lp2_installAnchor(entry);
+    return applyDeepLink(entry);
+  };
+};
+const _88b5go = function _lp2_doc_scroll(md){return(
+md`### Scroll anchoring
+
+When a pane's content changes height after mount (async cells, images), the anchor keeps the viewport stable. \`lp2_anchor\` records the cell at the viewport top as \`{pid, offset}\`, where \`pid\` is \`persistentId(node.variable)\` from [\`runtime-sdk\`](https://observablehq.com/@tomlarkworthy/runtime-sdk). Every visualizer cell node carries a \`.variable\` backref, so the pid is read without modifying the visualizer.
+
+\`lp2_installAnchor\` attaches a \`ResizeObserver\` to the pane content and re-applies the anchor (\`scrollTop = node.offsetTop + offset\`) on each callback. The observer fires after layout and before paint, so the correction lands in the same frame. A programmatic \`scrollTop\` write disables the browser's native \`overflow-anchor\`, so the anchor is maintained in JS.`
+)};
+const _78h40x = function _lp2_anchor(persistentId)
+{
+  const cellNodes = paneEl => [...paneEl.querySelectorAll('.observablehq[cell]')];
+  const pidOf = node => {
+    try {
+      return node.variable ? persistentId(node.variable) : null;
+    } catch (e) {
+      return null;
+    }
+  };
+  const capture = paneEl => {
+    const top = paneEl.scrollTop;
+    if (top <= 0)
+      return null;
+    for (const node of cellNodes(paneEl)) {
+      const nTop = node.offsetTop, nBot = nTop + node.offsetHeight;
+      if (nBot > top + 1) {
+        const pid = pidOf(node);
+        if (pid)
+          return {
+            pid,
+            offset: top - nTop
+          };
+      }
+    }
+    return null;
+  };
+  const restore = (paneEl, anchor) => {
+    if (!anchor || !anchor.pid)
+      return false;
+    const node = cellNodes(paneEl).find(n => pidOf(n) === anchor.pid);
+    if (!node)
+      return false;
+    paneEl.scrollTop = node.offsetTop + anchor.offset;
+    return true;
+  };
+  return {
+    cellNodes,
+    pidOf,
+    capture,
+    restore
+  };
+};
+const _d4xe91 = function _lp2_installAnchor(lp2_anchor,ResizeObserver){return(
+entry => {
+  const el = entry.el;
+  if (el.__lp2_anchor_bound)
+    return;
+  el.__lp2_anchor_bound = true;
+  const A = lp2_anchor;
+  let raf = 0;
+  el.addEventListener('scroll', () => {
+    if (el.__lp2_pinning)
+      return;
+    if (raf)
+      return;
+    raf = requestAnimationFrame(() => {
+      raf = 0;
+      entry.anchor = A.capture(el);
+    });
+  }, { passive: true });
+  const content = el.querySelector('.lope-viz') || el.firstElementChild;
+  if (content && window.ResizeObserver) {
+    const ro = new ResizeObserver(() => {
+      if (!entry.anchor)
+        return;
+      el.__lp2_pinning = true;
+      A.restore(el, entry.anchor);
+      requestAnimationFrame(() => {
+        el.__lp2_pinning = false;
+      });
+    });
+    ro.observe(content);
+    entry.ro = ro;
+  }
+}
+)};
+const _xwsg4w = function _lp2_doc_layout(md){return(
+md`### Layout rendering and docking
+
+\`lp2_renderNode\` reconciles the model tree to DOM: rows and cols are flexbox with draggable splitters that write percentages back to \`node.sizes\`; a stack is a tab header plus the active pane. \`lp2_view\` runs the render together with the scroll capture/restore, and exposes \`commit(newRoot)\`, which republishes the model through the \`lp2Model\` viewof. Every structural change therefore re-renders and round-trips to the URL through one path.
+
+\`lp2_ops\` holds the tree operations: \`findHost\`, \`removeLeaf\`, \`dropBeside\`, \`normalize\`, and \`move\`. \`normalize\` collapses emptied stacks and single-child splits, so the tree stays minimal. Dragging a tab onto a pane's edge splits it (left/right/top/bottom); onto its centre merges into that stack. \`lp2_dragOut\` writes the module's \`.js\` source to the drag \`DataTransfer\`, so the same drag can drop the module out to the filesystem.`
+)};
+const _1fxe40f = function _lp2_host()
+{
+  const host = document.createElement('div');
+  host.className = 'lp2-host';
+  Object.assign(host.style, {
+    position: 'absolute',
+    inset: '0',
+    display: 'flex',
+    overflow: 'hidden'
+  });
+  return host;
+};
+const _6f57qb = function _lp2_renderNode(lp2_renderStack,lp2_renderSplit)
+{
+  return ctx => {
+    // dispatch a layout node to its renderer; `make` recurses for nested splits
+    const make = node => {
+      if (!node)
+        return document.createTextNode('');
+      if (node.t === 'stack')
+        return lp2_renderStack(node, ctx);
+      if (node.t === 'row' || node.t === 'col')
+        return lp2_renderSplit(node, ctx, make);
+      return document.createTextNode('unknown node ' + node.t);
+    };
+    return make;
+  };
+};
+const _1r0c4er = function _lp2_ops()
+{
+  // pure-ish surgery on the live layout tree; mutate then commit() to republish
+  const replaceNode = (root, oldRef, newNode) => {
+    if (root === oldRef)
+      return newNode;
+    const rec = n => {
+      if (!n || !n.children)
+        return;
+      for (let i = 0; i < n.children.length; i++) {
+        if (n.children[i] === oldRef) {
+          n.children[i] = newNode;
+          return true;
+        }
+        if (rec(n.children[i]))
+          return true;
+      }
+      return false;
+    };
+    rec(root);
+    return root;
+  };
+  // collapse empty stacks and single-child splits; returns cleaned node or null
+  const normalize = node => {
+    if (!node)
+      return null;
+    if (node.t === 'stack')
+      return node.tabs && node.tabs.length ? node : null;
+    const kids = (node.children || []).map(normalize).filter(Boolean);
+    if (kids.length === 0)
+      return null;
+    if (kids.length === 1)
+      return kids[0];
+    node.children = kids;
+    node.sizes = kids.map(() => Math.round(100 / kids.length));
+    return node;
+  };
+  // find the stack holding `module`; returns {stack, tabIndex} or null
+  const findHost = (root, module) => {
+    let res = null;
+    const rec = n => {
+      if (!n || res)
+        return;
+      if (n.t === 'stack') {
+        const ti = (n.tabs || []).findIndex(l => l.module === module);
+        if (ti >= 0)
+          res = {
+            stack: n,
+            tabIndex: ti
+          };
+      } else
+        (n.children || []).forEach(rec);
+    };
+    rec(root);
+    return res;
+  };
+  // is `target` reachable from root?
+  const contains = (root, target) => {
+    if (root === target)
+      return true;
+    return (root.children || []).some(c => contains(c, target));
+  };
+  // remove first leaf with `module`; returns {root, leaf}
+  const removeLeaf = (root, module) => {
+    const host = findHost(root, module);
+    if (!host)
+      return {
+        root,
+        leaf: null
+      };
+    const [leaf] = host.stack.tabs.splice(host.tabIndex, 1);
+    if (host.stack.active >= host.stack.tabs.length)
+      host.stack.active = Math.max(0, host.stack.tabs.length - 1);
+    return {
+      root: normalize(root) || {
+        t: 'stack',
+        active: 0,
+        tabs: []
+      },
+      leaf
+    };
+  };
+  // drop `leaf` relative to `targetStack`: side = left|right|top|bottom|center
+  const dropBeside = (root, targetStack, leaf, side) => {
+    if (side === 'center') {
+      targetStack.tabs.push(leaf);
+      targetStack.active = targetStack.tabs.length - 1;
+      return root;
+    }
+    const orient = side === 'left' || side === 'right' ? 'row' : 'col';
+    const newStack = {
+      t: 'stack',
+      active: 0,
+      tabs: [leaf]
+    };
+    const order = side === 'left' || side === 'top' ? [
+      newStack,
+      targetStack
+    ] : [
+      targetStack,
+      newStack
+    ];
+    const repl = {
+      t: orient,
+      sizes: [
+        50,
+        50
+      ],
+      children: order
+    };
+    return replaceNode(root, targetStack, repl);
+  };
+  // perform a full move: remove dragged module, then drop beside target
+  const move = (root, module, targetStack, side) => {
+    const host = findHost(root, module);
+    if (!host)
+      return root;
+    // dragging a tab within its own stack: a lone tab has nowhere to go;
+    // a centre-drop onto its own stack is a no-op
+    if (host.stack === targetStack && (host.stack.tabs.length === 1 || side === 'center'))
+      return root;
+    const {
+      root: r2,
+      leaf
+    } = removeLeaf(root, module);
+    if (!leaf)
+      return root;
+    // the target stack object is mutated in place, so it survives removal unless it
+    // was the host and got emptied (guarded above); confirm it is still in the tree
+    if (!contains(r2, targetStack)) {
+      // target collapsed away: drop the leaf back into whatever remains as the root
+      return dropBeside(r2, r2, leaf, side);
+    }
+    return dropBeside(r2, targetStack, leaf, side);
+  };
+  return {
+    replaceNode,
+    normalize,
+    findHost,
+    contains,
+    removeLeaf,
+    dropBeside,
+    move
+  };
+};
+const _sx484g = function _lp2_dragOut(){return(
+(moduleName, dataTransfer) => {
+  const res = window.lopecode.contentSync(moduleName);
+  const text = res && res.bytes ? new TextDecoder().decode(res.bytes) : '';
+  const mime = res && res.mime || 'application/javascript';
+  const fname = moduleName.replace(/^@/, '').replace(/\//g, '_') + '.js';
+  dataTransfer.setData('text/plain', text);
+  dataTransfer.setData('application/javascript', text);
+  dataTransfer.setData('DownloadURL', mime + ':' + fname + ':data:' + mime + ';base64,' + btoa(unescape(encodeURIComponent(text))));
+  dataTransfer.effectAllowed = 'copy';
+  return {
+    fname,
+    len: text.length,
+    mime
+  };
+}
+)};
+const _fnh26m = function _lp2_view(lp2_host,lp2Model,lp2_installAnchor,lp2_anchor,$0,Event,lp2_getPane,lp2_dragOut,lp2_ops,linkTo,lp2_paneRegistry,lp2_renderNode,lp2_burger)
+{
+  const host = lp2_host;
+  lp2Model;
+  lp2_installAnchor;
+  lp2_anchor;
+  const vmEl = $0;
+  const commit = newRoot => {
+    vmEl.value = newRoot;
+    vmEl.dispatchEvent(new Event('input', { bubbles: true }));
+  };
+  const ctx = {
+    getPane: lp2_getPane,
+    dragOut: lp2_dragOut,
+    ops: lp2_ops,
+    commit,
+    getRoot: () => lp2Model,
+    linkTo
+  };
+  const rerender = () => {
+    const saved = new Map();
+    for (const [name, entry] of lp2_paneRegistry) {
+      lp2_installAnchor(entry);
+      const anc = lp2_anchor.capture(entry.el);
+      saved.set(name, anc || { raw: entry.el.scrollTop });
+    }
+    host.replaceChildren(lp2_renderNode(ctx)(lp2Model));
+    // dock the immortal burger button into the top-left tab bar; a rerender moves
+    // the button so any open popover is anchored stale — close it
+    lp2_burger.close();
+    const firstTabs = host.querySelector('.lp2-tabs');
+    if (firstTabs)
+      firstTabs.prepend(lp2_burger.button);
+    for (const [name, anc] of saved) {
+      const entry = lp2_paneRegistry.get(name);
+      if (!entry || !entry.el.isConnected)
+        continue;
+      if (entry.pendingDeepLink)
+        continue;
+      if (anc.pid) {
+        if (!lp2_anchor.restore(entry.el, anc) && anc.raw)
+          entry.el.scrollTop = anc.raw;
+      } else if (anc.raw)
+        entry.el.scrollTop = anc.raw;
+      entry.anchor = anc.pid ? anc : entry.anchor;
+    }
+  };
+  rerender();
+  return host;
+};
+const _1bytrbx = function _lp2_probe(lp2_view,lp2_paneRegistry)
+{
+  lp2_view;
+  return 'lp2 mounted, panes=' + lp2_paneRegistry.size;
+};
+const _orvfgz = function _lp2_doc_hash(md){return(
+md`### Hash ownership
+
+\`lp2_hash\` observes \`location.hash\`. \`lp2_syncFromUrl\` parses it into the model when it changes externally; \`lp2_syncToUrl\` serialises the model back. \`lp2_setHash\` writes via \`history.replaceState\`, which updates the URL without firing \`hashchange\`.
+
+\`view=\` is the layout (the \`R\`/\`S\`/\`C\` DSL) and is lopepage-2's to own. \`open=@mod[#cell]\` and \`close=@mod\` are one-shot intents: \`lp2_syncFromUrl\` overlays a module into the layout (setting a leaf's deep-link \`cell\` when \`#cell\` is given) or removes one — merging into the live layout when there is no \`view=\` — and \`lp2_syncToUrl\` drops the intent once the layout reflects it. The tab close \`×\` writes \`close=\` via \`linkTo\`, so closing exercises the same path.
+
+Invariants:
+
+- \`lp2_syncToUrl\` writes only when the model round-trips: \`serialize(parse(serialize(model))) === serialize(model)\`. A layout that does not round-trip never reaches the URL.
+- Writing is gated on \`window.__lp2_owns_hash\`, set only while lopepage-2 is the mounted page, so the URL is left untouched when the module is imported as a dependency.
+- Only \`view=\` and the intents it consumes (\`open\`) are managed; every other hash param (e.g. \`cc=\`) is preserved verbatim, because a decoupled module cannot assume it owns them.
+- Because \`replaceState\` is silent and the read path is driven by \`hashchange\`, a write does not re-trigger a read.`
+)};
+const _y2r8d1 = function _lp2_hash(Generators,location){return(
+Generators.observe(notify => {
+  const update = () => notify(location.hash);
+  update();
+  window.addEventListener('hashchange', update);
+  return () => window.removeEventListener('hashchange', update);
+})
+)};
+const _1nwbntj = function _lp2_setHash(location,history){return(
+newHash => {
+  const h = newHash.startsWith('#') ? newHash : '#' + newHash;
+  const href = location.pathname + location.search + h;
+  try {
+    history.replaceState(null, '', href);
+    return true;
+  } catch (e) {
+    try {
+      location.hash = h;
+      return true;
+    } catch (e2) {
+      return false;
+    }
+  }
+}
+)};
+const _1vcr15c = function _lp2_syncFromUrl($0,lp2_hash,lp2_parseDSL,lp2_ops,lp2_serializeDSL,Event)
+{
+  const el = $0;
+  // element ref (NOT value) -> only re-runs on hash change, no loop
+  const hash = lp2_hash;
+  // re-run on external hashchange / initial load
+  let view = null, open = null, close = null;
+  for (const part of String(hash).replace(/^#/, '').split('&').filter(Boolean)) {
+    const eq = part.indexOf('=');
+    const key = eq >= 0 ? part.slice(0, eq) : part;
+    const val = eq >= 0 ? part.slice(eq + 1) : '';
+    if (key === 'view')
+      view = decodeURIComponent(val);
+    else if (key === 'open')
+      open = decodeURIComponent(val);
+    else if (key === 'close')
+      close = decodeURIComponent(val);  // every other param (cc=, and anything other modules own) is ignored here
+  }
+  if (!view && !open && !close)
+    return { status: 'skipped' };
+  // base model: parse view= when present, else clone the live layout so
+  // `open` / `close` apply to it rather than replacing it
+  let model;
+  try {
+    model = view ? lp2_parseDSL(view) : JSON.parse(JSON.stringify(el.value));
+  } catch (e) {
+    return {
+      status: 'error',
+      error: String(e)
+    };
+  }
+  // apply the one-shot open=@mod[#cell] intent
+  let openApplied = false;
+  if (open) {
+    const [modRaw, cellRaw] = open.split('#');
+    const module = (modRaw || '').trim();
+    const cell = (cellRaw || '').trim() || null;
+    if (module) {
+      const findLeaf = n => {
+        if (!n)
+          return null;
+        if (n.t === 'stack') {
+          for (const leaf of n.tabs || [])
+            if (leaf.module === module)
+              return {
+                stack: n,
+                leaf
+              };
+          return null;
+        }
+        for (const c of n.children || []) {
+          const f = findLeaf(c);
+          if (f)
+            return f;
+        }
+        return null;
+      };
+      const firstStack = n => {
+        if (!n)
+          return null;
+        if (n.t === 'stack')
+          return n;
+        for (const c of n.children || []) {
+          const f = firstStack(c);
+          if (f)
+            return f;
+        }
+        return null;
+      };
+      const found = findLeaf(model);
+      if (found) {
+        if (cell)
+          found.leaf.cell = cell;
+        found.stack.active = found.stack.tabs.indexOf(found.leaf);
+      } else {
+        let st = firstStack(model);
+        if (!st)
+          model = st = {
+            t: 'stack',
+            active: 0,
+            tabs: []
+          };
+        st.tabs = st.tabs || [];
+        st.tabs.push(cell ? {
+          module,
+          cell
+        } : { module });
+        st.active = st.tabs.length - 1;
+      }
+      openApplied = true;
+    }
+  }
+  // apply the one-shot close=@mod intent (remove the leaf, collapse via normalize)
+  let closeApplied = false;
+  if (close) {
+    const r = lp2_ops.removeLeaf(model, close);
+    if (r.leaf) {
+      model = r.root;
+      closeApplied = true;
+    }
+  }
+  const reser = lp2_serializeDSL(model);
+  // republish when the layout changed, or when open set active/cell on an
+  // already-present module (active is not serialized, so compare by intent)
+  const applied = openApplied || closeApplied || reser !== lp2_serializeDSL(el.value);
+  if (applied) {
+    el.value = model;
+    el.dispatchEvent(new Event('input'));
+  }
+  return {
+    status: 'ok',
+    view,
+    open,
+    close,
+    openApplied,
+    closeApplied,
+    reser,
+    applied
+  };
+};
+const _1rf2mk0 = function _lp2_syncToUrl(lp2Model,lp2_serializeDSL,lp2_parseDSL,location,lp2_setHash)
+{
+  const model = lp2Model;
+  // re-run on model change
+  if (!window.__lp2_owns_hash)
+    return { status: 'dormant' };
+  // armed only when lopepage-2 is the page
+  let dsl;
+  try {
+    dsl = lp2_serializeDSL(model);
+  } catch (e) {
+    return {
+      status: 'serialize-failed',
+      error: String(e)
+    };
+  }
+  // loop protection: only write if the DSL round-trips stably
+  let ok = false;
+  try {
+    ok = lp2_serializeDSL(lp2_parseDSL(dsl)) === dsl;
+  } catch (e) {
+    ok = false;
+  }
+  if (!ok)
+    return {
+      status: 'blocked-roundtrip',
+      dsl
+    };
+  // preserve unknown params (cc=...), strip one-shot intents
+  const raw = String(location.hash || '').replace(/^#/, '');
+  const intents = new Set([
+    'open',
+    'close',
+    'focus',
+    'from'
+  ]);
+  const extra = [];
+  let currentView = null;
+  for (const part of raw.split('&').filter(Boolean)) {
+    const eq = part.indexOf('=');
+    const key = eq >= 0 ? part.slice(0, eq) : part;
+    if (key === 'view')
+      currentView = decodeURIComponent(part.slice(eq + 1));
+    else if (!intents.has(key))
+      extra.push(part);
+  }
+  const newHash = '#view=' + dsl + (extra.length ? '&' + extra.join('&') : '');
+  if (newHash !== location.hash) {
+    lp2_setHash(newHash);
+    return {
+      status: 'written',
+      dsl
+    };
+  }
+  return {
+    status: 'no-change',
+    dsl
+  };
+};
+const _6e8yep = function _lp2_doc_mount(md){return(
+md`### Page mount, theme, and orthogonal features
+
+\`lp2_page\` builds the fullscreen \`#lopepage-2\` container, adopts the [\`themes\`](https://observablehq.com/@tomlarkworthy/themes) stylesheets via \`apply_theme\`, and appends the [\`command-palette\`](https://observablehq.com/@tomlarkworthy/command-palette) chrome (\`commandPaletteStyles\` + the hidden \`commandPaletteOverlay\`) so ⌘K has a node to reveal.
+
+\`lp2_background_jobs\` holds references to the main-loop cells of orthogonal feature modules so the runtime instantiates them while lopepage-2 is the page: \`commandPaletteKeybinding\` (installs the ⌘K listener), \`cc_chat\` (opens the [\`claude-code-pairing\`](https://observablehq.com/@tomlarkworthy/claude-code-pairing) connection), \`change_listener\`/\`commit_history\`/\`replay_git\` (the [\`local-change-history\`](https://observablehq.com/@tomlarkworthy/local-change-history) edit recorder/replayer), and \`auto_attach\` (the [\`editor-5\`](https://observablehq.com/@tomlarkworthy/editor-5) editor that attaches CodeMirror to rendered cells for inline editing). These modules are composed by import, not added to \`mains\`.
+
+\`lp2_append_to_body\` is the keystone cell: reachable only when lopepage-2 is booted as a main, it appends the page to \`document.body\`, references \`lp2_background_jobs\`, and sets \`window.__lp2_owns_hash\`. With \`bootconf.headless\` set, the runtime observes this cell as the page's single output.`
+)};
+const _1y1ubko = function _lp2_page(apply_theme,lp2_host,commandPaletteStyles,commandPaletteOverlay)
+{
+  apply_theme;
+  // adopt theme stylesheets into the document
+  const root = document.createElement('div');
+  root.id = 'lopepage-2';
+  Object.assign(root.style, {
+    position: 'fixed',
+    inset: '0',
+    height: '100vh',
+    width: '100vw',
+    overflow: 'hidden',
+    background: 'var(--theme-background-a, #fff)'
+  });
+  const style = document.createElement('style');
+  style.textContent = [
+    'html,body{margin:0;padding:0;max-width:100vw;}',
+    '#lopepage-2 .lope-viz .observablehq{position:relative;min-height:17px;}',
+    '#lopepage-2 .lope-viz .observablehq:not(.observablehq--running):empty::after{content:\'<detached>\';font-style:oblique;opacity:.5;}',
+    '#lopepage-2 .lp2-tabs button:hover{background:rgba(0,0,0,.06);}',
+    '#lopepage-2 .lp2-splitter:hover{background:#bbb;}'
+  ].join('\n');
+  root.appendChild(style);
+  root.appendChild(lp2_host);
+  // command-palette chrome: a <style> and a fixed overlay, hidden until ⌘K
+  root.appendChild(commandPaletteStyles);
+  root.appendChild(commandPaletteOverlay);
+  return root;
+};
+const _1q105of = function _lp2_background_jobs(commandPaletteKeybinding,cc_chat,change_listener,commit_history,replay_git,auto_attach,lp2_watchModules,lp2_menu_sync,lp2_menu_defaults)
+{
+  // hold references so these orthogonal features' main-loop cells instantiate
+  commandPaletteKeybinding;
+  // installs the ⌘K keydown listener
+  cc_chat;
+  // instantiates the pairing connection
+  change_listener;
+  // records cell edits into local-change-history
+  commit_history;
+  // commits runtime edit history
+  replay_git;
+  // replays git commits on load
+  auto_attach;
+  // attaches editor-5 CodeMirror editors to rendered cells
+  lp2_watchModules;
+  // keeps the layout-relevant module watcher running
+  lp2_menu_sync;
+  // keeps the burger menu populated from the plugin registry
+  lp2_menu_defaults;
+  // registers the built-in menu items (download, fork)
+  return 'background jobs: command-palette, claude-code-pairing, local-change-history, editor-5, module-watcher, burger-menu';
+};
+const _1yumqn = function _lp2_append_to_body(lp2_view,lp2_syncFromUrl,lp2_syncToUrl,lp2_page)
+{
+  lp2_view;
+  // ensure the layout renders into the host
+  lp2_syncFromUrl;
+  // keep hash -> model live
+  lp2_syncToUrl;
+  // keep model -> hash live (dormant until armed below)
+  // background jobs (⌘K palette, pairing, history) run under their own observer;
+  // not a dep so their failure (e.g. no IndexedDB in a blob: fork tab) cannot block mount
+  window.__lp2_owns_hash = true;
+  // arm hash ownership; only reachable when lopepage-2 is the page
+  const page = lp2_page;
+  if (!page.isConnected)
+    document.body.appendChild(page);
+  return 'lopepage-2 mounted';
+};
+const _z83rug = function _29(currentModules){return(
+currentModules
+)};
+const _12ez53h = function _lp2_renderTab(location)
+{
+  return (node, i, ctx) => {
+    const leaf = node.tabs[i];
+    const active = node.active || 0;
+    const tab = document.createElement('button');
+    tab.textContent = leaf.module.split('/').pop();
+    tab.title = leaf.module + '  (drag to a pane edge to dock, or out to save as .js)';
+    Object.assign(tab.style, {
+      border: 'none',
+      padding: '4px 8px',
+      cursor: 'grab',
+      fontSize: '11px',
+      background: i === active ? 'var(--theme-background-a)' : 'transparent',
+      color: i === active ? 'var(--theme-foreground)' : 'var(--theme-foreground-faint)'
+    });
+    tab.onclick = () => {
+      node.active = i;
+      ctx.commit(ctx.getRoot());
+    };
+    tab.draggable = true;
+    tab.addEventListener('dragstart', ev => {
+      window.__lp2_drag = { module: leaf.module };
+      try {
+        ev.dataTransfer.setData('application/x-lp2-leaf', leaf.module);
+      } catch (_) {
+      }
+      try {
+        ctx.dragOut(leaf.module, ev.dataTransfer);
+      } catch (_) {
+      }
+    });
+    tab.addEventListener('dragend', () => {
+      window.__lp2_drag = null;
+      if (window.__lp2_dropZone) {
+        window.__lp2_dropZone.style.display = 'none';
+        window.__lp2_dropZone = null;
+      }
+    });
+    const close = document.createElement('span');
+    close.textContent = '\xD7';
+    close.title = 'Close';
+    Object.assign(close.style, {
+      marginLeft: '6px',
+      opacity: '.45',
+      fontWeight: '700',
+      cursor: 'pointer'
+    });
+    close.onmouseenter = () => close.style.opacity = '1';
+    close.onmouseleave = () => close.style.opacity = '.45';
+    // don't let a grab on × start a tab drag or activate the tab
+    close.addEventListener('mousedown', ev => ev.stopPropagation());
+    close.addEventListener('click', ev => {
+      ev.stopPropagation();
+      // route through the URL intent system: close=<module>
+      location.hash = ctx.linkTo({ close: leaf.module }, { baseURI: location.href });
+    });
+    tab.appendChild(close);
+    return tab;
+  };
+};
+const _m7n4c3 = function _lp2_dropZone()
+{
+  return (body, tabsEl, node, ctx) => {
+    // which edge/centre of `el` the pointer is over: centre = merge, edge = split that side
+    const sideOf = (ev, el) => {
+      const r = el.getBoundingClientRect();
+      const x = (ev.clientX - r.left) / r.width, y = (ev.clientY - r.top) / r.height;
+      if (x > 0.3 && x < 0.7 && y > 0.3 && y < 0.7)
+        return 'center';
+      const d = {
+        left: x,
+        right: 1 - x,
+        top: y,
+        bottom: 1 - y
+      };
+      return Object.keys(d).reduce((a, b) => d[b] < d[a] ? b : a);
+    };
+    const zone = document.createElement('div');
+    Object.assign(zone.style, {
+      position: 'absolute',
+      pointerEvents: 'none',
+      display: 'none',
+      background: 'rgba(40,120,255,.18)',
+      outline: '2px solid rgba(40,120,255,.6)',
+      outlineOffset: '-2px',
+      zIndex: 5,
+      boxSizing: 'border-box'
+    });
+    body.appendChild(zone);
+    const showZone = side => {
+      const f = {
+        left: [
+          '0',
+          '0',
+          '50%',
+          '100%'
+        ],
+        right: [
+          '50%',
+          '0',
+          '50%',
+          '100%'
+        ],
+        top: [
+          '0',
+          '0',
+          '100%',
+          '50%'
+        ],
+        bottom: [
+          '0',
+          '50%',
+          '100%',
+          '50%'
+        ],
+        center: [
+          '15%',
+          '15%',
+          '70%',
+          '70%'
+        ]
+      }[side];
+      Object.assign(zone.style, {
+        display: 'block',
+        left: f[0],
+        top: f[1],
+        width: f[2],
+        height: f[3]
+      });
+    };
+    body.addEventListener('dragover', ev => {
+      if (!window.__lp2_drag)
+        return;
+      ev.preventDefault();
+      try {
+        ev.dataTransfer.dropEffect = 'copy';
+      } catch (_) {
+      }
+      // only one zone visible: hide whichever was last shown elsewhere
+      if (window.__lp2_dropZone && window.__lp2_dropZone !== zone)
+        window.__lp2_dropZone.style.display = 'none';
+      window.__lp2_dropZone = zone;
+      showZone(sideOf(ev, body));
+    });
+    body.addEventListener('dragleave', ev => {
+      // ignore moves between this body's own descendants
+      if (ev.relatedTarget && body.contains(ev.relatedTarget))
+        return;
+      zone.style.display = 'none';
+      if (window.__lp2_dropZone === zone)
+        window.__lp2_dropZone = null;
+    });
+    body.addEventListener('drop', ev => {
+      if (!window.__lp2_drag)
+        return;
+      ev.preventDefault();
+      const side = sideOf(ev, body);
+      zone.style.display = 'none';
+      window.__lp2_dropZone = null;
+      const m = window.__lp2_drag.module;
+      window.__lp2_drag = null;
+      ctx.commit(ctx.ops.move(ctx.getRoot(), m, node, side));
+    });
+    // the tab header is also a drop target: dropping a tab onto it merges into this
+    // stack (the natural "combine into tabs" gesture); always a centre merge.
+    if (tabsEl) {
+      tabsEl.addEventListener('dragover', ev => {
+        if (!window.__lp2_drag)
+          return;
+        ev.preventDefault();
+        try {
+          ev.dataTransfer.dropEffect = 'copy';
+        } catch (_) {
+        }
+        if (window.__lp2_dropZone && window.__lp2_dropZone !== zone)
+          window.__lp2_dropZone.style.display = 'none';
+        window.__lp2_dropZone = zone;
+        showZone('center');
+      });
+      tabsEl.addEventListener('dragleave', ev => {
+        if (ev.relatedTarget && (tabsEl.contains(ev.relatedTarget) || body.contains(ev.relatedTarget)))
+          return;
+        zone.style.display = 'none';
+        if (window.__lp2_dropZone === zone)
+          window.__lp2_dropZone = null;
+      });
+      tabsEl.addEventListener('drop', ev => {
+        if (!window.__lp2_drag)
+          return;
+        ev.preventDefault();
+        zone.style.display = 'none';
+        window.__lp2_dropZone = null;
+        const m = window.__lp2_drag.module;
+        window.__lp2_drag = null;
+        ctx.commit(ctx.ops.move(ctx.getRoot(), m, node, 'center'));
+      });
+    }
+    return zone;
+  };
+};
+const _1hs48bp = function _lp2_splitter()
+{
+  return (node, i, row, wrap, slots, ctx) => {
+    const sp = document.createElement('div');
+    sp.className = 'lp2-splitter';
+    Object.assign(sp.style, {
+      flex: '0 0 6px',
+      cursor: row ? 'col-resize' : 'row-resize',
+      background: '#ddd',
+      flexShrink: 0
+    });
+    sp.addEventListener('pointerdown', e => {
+      e.preventDefault();
+      try {
+        sp.setPointerCapture(e.pointerId);
+      } catch (_) {
+      }
+      const startPos = row ? e.clientX : e.clientY;
+      const wrapSize = row ? wrap.clientWidth : wrap.clientHeight;
+      const s0 = node.sizes[i], s1 = node.sizes[i + 1], total = s0 + s1;
+      const onMove = ev => {
+        const delta = ((row ? ev.clientX : ev.clientY) - startPos) / wrapSize * 100;
+        // integer percentages so the layout round-trips through the integer-only #view= DSL
+        const n0 = Math.round(Math.max(5, Math.min(total - 5, s0 + delta)));
+        node.sizes[i] = n0;
+        node.sizes[i + 1] = total - n0;
+        slots[i].style.flex = node.sizes[i] + ' 1 0';
+        slots[i + 1].style.flex = node.sizes[i + 1] + ' 1 0';
+      };
+      const onUp = () => {
+        document.removeEventListener('pointermove', onMove);
+        document.removeEventListener('pointerup', onUp);
+        ctx.commit(ctx.getRoot());
+      };
+      document.addEventListener('pointermove', onMove);
+      document.addEventListener('pointerup', onUp);
+    });
+    return sp;
+  };
+};
+const _nj1uts = function _lp2_renderStack(lp2_renderTab,lp2_dropZone){return(
+(node, ctx) => {
+  const wrap = document.createElement('div');
+  wrap.className = 'lp2-stack';
+  Object.assign(wrap.style, {
+    display: 'flex',
+    flexDirection: 'column',
+    minWidth: 0,
+    minHeight: 0,
+    height: '100%',
+    width: '100%'
+  });
+  const tabsEl = document.createElement('div');
+  tabsEl.className = 'lp2-tabs';
+  Object.assign(tabsEl.style, {
+    display: 'flex',
+    gap: '2px',
+    flex: '0 0 auto',
+    background: 'var(--theme-background-b)',
+    borderBottom: '1px solid var(--theme-foreground-fainter)',
+    overflow: 'hidden'
+  });
+  const body = document.createElement('div');
+  Object.assign(body.style, {
+    flex: '1 1 auto',
+    minHeight: 0,
+    position: 'relative',
+    display: 'flex'
+  });
+  const active = node.active || 0;
+  (node.tabs || []).forEach((leaf, i) => {
+    const pane = ctx.getPane(leaf.module, leaf.cell).el;
+    pane.style.display = i === active ? 'block' : 'none';
+    pane.style.flex = '1 1 auto';
+    body.appendChild(pane);
+    tabsEl.appendChild(lp2_renderTab(node, i, ctx));
+  });
+  lp2_dropZone(body, tabsEl, node, ctx);
+  wrap.append(tabsEl, body);
+  return wrap;
+}
+)};
+const _a9rn1a = function _lp2_renderSplit(lp2_splitter){return(
+(node, ctx, make) => {
+  const row = node.t === 'row';
+  const wrap = document.createElement('div');
+  Object.assign(wrap.style, {
+    display: 'flex',
+    flexDirection: row ? 'row' : 'column',
+    minWidth: 0,
+    minHeight: 0,
+    height: '100%',
+    width: '100%'
+  });
+  const kids = node.children || [];
+  if (!node.sizes || node.sizes.length !== kids.length)
+    node.sizes = kids.map(() => Math.round(100 / kids.length));
+  const slots = [];
+  kids.forEach((child, i) => {
+    const slot = document.createElement('div');
+    Object.assign(slot.style, {
+      flex: node.sizes[i] + ' 1 0',
+      minWidth: 0,
+      minHeight: 0,
+      display: 'flex',
+      overflow: 'hidden'
+    });
+    slot.appendChild(make(child));
+    wrap.appendChild(slot);
+    slots.push(slot);
+    if (i < kids.length - 1)
+      wrap.appendChild(lp2_splitter(node, i, row, wrap, slots, ctx));
+  });
+  return wrap;
+}
+)};
+const _6vp46e = function _lp2_watchedModules(Inputs){return(
+Inputs.input(new Map())
+)};
+const _1hxhexc = (G, _) => G.input(_);
+const _16ptruj = function _lp2_watchModules(lp2Model,currentModules,$0,Event)
+{
+  // Collect the module names the current layout actually references.
+  const names = new Set();
+  const walk = n => {
+    if (!n)
+      return;
+    if (n.t === 'stack')
+      (n.tabs || []).forEach(leaf => leaf?.module && names.add(leaf.module));
+    else
+      (n.children || []).forEach(walk);
+  };
+  walk(lp2Model);
+  // Resolve those names against the (churning) currentModules map.
+  const byName = new Map();
+  for (const [mod, info] of currentModules)
+    if (info?.name)
+      byName.set(info.name, info.module ?? mod);
+  const next = new Map();
+  for (const name of names) {
+    const m = byName.get(name);
+    if (m)
+      next.set(name, m);
+  }
+  // Only republish when the relevant resolved set actually changed — this is what
+  // decouples the repaint from raw currentModules churn.
+  const prev = $0.value;
+  let changed = !(prev instanceof Map) || prev.size !== next.size;
+  if (!changed)
+    for (const [k, v] of next)
+      if (prev.get(k) !== v) {
+        changed = true;
+        break;
+      }
+  if (changed) {
+    $0.value = next;
+    $0.dispatchEvent(new Event('input', { bubbles: true }));
+  }
+  return `watch ${ names.size } / resolved ${ next.size }${ changed ? ' (updated)' : '' }`;
+};
+const _td27y7 = function _lp2_scrollToCell(lp2_anchor)
+{
+  return (entry, cellName) => {
+    // One-shot deep-link: scroll the pane so `cellName` (a variable name, e.g. from @mod#cell) sits at
+    // the top, then seed the pane's pid anchor so the ResizeObserver re-pins it through later reflow.
+    // Right after a reparent the immortal pane's content is momentarily short, which clamps scrollTop
+    // back to 0, so retry until the scroll lands — or until content height settles (target is genuinely
+    // past the last full page, so we can only scroll as far as it goes).
+    if (!cellName || !entry || entry.transient)
+      return;
+    // Own the pane scroll until the deep-link lands, so a concurrent rerender's scroll-restore
+    // (which captured the pre-deep-link scrollTop) does not clobber it. Cleared on land or give-up.
+    entry.pendingDeepLink = true;
+    const done = () => entry.pendingDeepLink = false;
+    let tries = 0, lastSH = -1, stable = 0;
+    const attempt = () => {
+      const el = entry.el;
+      const again = () => {
+        if (tries++ < 60)
+          window.setTimeout(attempt, 80);
+        else
+          done();
+      };
+      if (!el || !el.isConnected || !el.clientHeight)
+        return again();
+      const node = lp2_anchor.cellNodes(el).find(n => n.getAttribute('cell') === cellName);
+      if (!node)
+        return again();
+      const targetTop = node.offsetTop;
+      el.__lp2_pinning = true;
+      el.scrollTop = targetTop;
+      const pid = lp2_anchor.pidOf(node);
+      if (pid)
+        entry.anchor = {
+          pid,
+          offset: 0
+        };
+      window.requestAnimationFrame(() => {
+        el.__lp2_pinning = false;
+      });
+      if (Math.abs(el.scrollTop - targetTop) <= 2)
+        return done();
+      if (el.scrollHeight === lastSH) {
+        if (++stable >= 3)
+          return done();
+      } else {
+        stable = 0;
+        lastSH = el.scrollHeight;
+      }
+      return again();
+    };
+    // Defer so the first attempt runs AFTER this rerender's synchronous scroll-restore and after
+    // getPane reparents the (immortal) pane; pendingDeepLink stays true across that window so the
+    // restore skips this pane, then the deferred attempt scrolls the now-settled pane to the cell.
+    window.setTimeout(attempt, 0);
+  };
+};
+const _8vk6lr = function _lp2_doc_menu(md){return(
+md`### Burger menu (plugin registry)
+
+A hamburger button docked at the left of the top-left tab bar opens a menu of pluggable items. The registry is the [\`@tomlarkworthy/plugin-registry\`](https://observablehq.com/@tomlarkworthy/plugin-registry) set named \`"lp2-menu"\`; \`lp2MenuItems\` is \`plugins.get("lp2-menu")\`, a reactive array of \`{id, label, svg, action, children, order}\`. \`svg\` is an SVG string, an \`Element\`, or a function returning one; \`children\` nests a submenu; lower \`order\` sorts first.
+
+Plugins (this module's defaults, or any other notebook) register through \`lp2_registerMenuItem(item)\` — an id-keyed wrapper over \`plugins.add("lp2-menu", item)\` that replaces by \`id\` and returns a disposer (call it from \`invalidation\` so a re-run replaces rather than duplicates). Any notebook can equally \`plugins.add("lp2-menu", item)\` directly without importing lopepage-2. Only \`lp2_menu_sync\` consumes \`lp2MenuItems\`, so adding an item repopulates the popover in place — the layout, panes, and scroll state are untouched.
+
+The button and popover are built once by \`lp2_burger\` (immortal, like panes) and reparented into the current top-left tab bar on each layout render. \`lp2_menu_defaults\` registers the built-ins: **Download** and **Fork** via [\`exporter-3\`](https://observablehq.com/@tomlarkworthy/exporter-3)'s \`downloadAnchor\`/\`forkAnchor\`, which serialise every booted main.`
+)};
+const _1uvdt3f = function _lp2MenuItems(plugins){return(
+plugins.get('lp2-menu')
+)};
+const _qcv0dp = function _lp2_registerMenuItem(plugins)
+{
+  // id-keyed adapter over the shared plugins bus (set name "lp2-menu"): re-registering an id replaces
+  // the prior value; the returned disposer removes only if this exact registration is still current.
+  const handles = new Map();
+  // id -> remove()
+  return item => {
+    if (!item || !item.id)
+      throw new Error('menu item needs an id');
+    const prev = handles.get(item.id);
+    if (prev)
+      prev();
+    // replace-by-id
+    const remove = plugins.add('lp2-menu', item);
+    handles.set(item.id, remove);
+    return () => {
+      if (handles.get(item.id) === remove) {
+        remove();
+        handles.delete(item.id);
+      }
+    };
+  };
+};
+const _bt1fe2 = function _lp2_burger(invalidation)
+{
+  const button = document.createElement('button');
+  button.className = 'lp2-burger';
+  button.title = 'Menu';
+  button.setAttribute('aria-haspopup', 'true');
+  button.setAttribute('aria-expanded', 'false');
+  button.innerHTML = '<svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M2 4h12M2 8h12M2 12h12"/></svg>';
+  Object.assign(button.style, {
+    border: 'none',
+    background: 'transparent',
+    padding: '4px 8px',
+    cursor: 'pointer',
+    color: 'var(--theme-foreground)',
+    display: 'inline-flex',
+    alignItems: 'center'
+  });
+  const popover = document.createElement('div');
+  popover.className = 'lp2-menu';
+  Object.assign(popover.style, {
+    position: 'fixed',
+    display: 'none',
+    zIndex: 1000,
+    minWidth: '190px',
+    background: 'var(--theme-background-a, #fff)',
+    color: 'var(--theme-foreground)',
+    border: '1px solid var(--theme-foreground-fainter)',
+    borderRadius: '4px',
+    boxShadow: '0 4px 16px rgba(0,0,0,.18)',
+    padding: '4px',
+    font: '12px var(--sans-serif, sans-serif)'
+  });
+  const style = document.createElement('style');
+  style.textContent = [
+    '.lp2-menu button.lp2-menu-item{display:flex;align-items:center;gap:8px;width:100%;text-align:left;background:transparent;border:none;cursor:pointer;padding:6px 10px;font:inherit;color:inherit;border-radius:3px;}',
+    '.lp2-menu button.lp2-menu-item:hover{background:rgba(128,128,128,.15);}'
+  ].join('\n');
+  popover.appendChild(style);
+  const list = document.createElement('div');
+  popover.appendChild(list);
+  document.body.appendChild(popover);
+  const close = () => {
+    popover.style.display = 'none';
+    button.setAttribute('aria-expanded', 'false');
+  };
+  const open = () => {
+    const r = button.getBoundingClientRect();
+    popover.style.left = Math.round(r.left) + 'px';
+    popover.style.top = Math.round(r.bottom + 2) + 'px';
+    popover.style.display = 'block';
+    button.setAttribute('aria-expanded', 'true');
+  };
+  button.addEventListener('click', ev => {
+    ev.stopPropagation();
+    popover.style.display === 'none' ? open() : close();
+  });
+  // a click that lands outside the popover/button dismisses; so does Escape
+  const onDocDown = ev => {
+    if (popover.style.display === 'none')
+      return;
+    if (popover.contains(ev.target) || button.contains(ev.target))
+      return;
+    close();
+  };
+  const onKey = ev => {
+    if (ev.key === 'Escape')
+      close();
+  };
+  document.addEventListener('mousedown', onDocDown);
+  document.addEventListener('keydown', onKey);
+  invalidation.then(() => {
+    document.removeEventListener('mousedown', onDocDown);
+    document.removeEventListener('keydown', onKey);
+    popover.remove();
+    button.remove();
+  });
+  return {
+    button,
+    popover,
+    list,
+    open,
+    close
+  };
+};
+const _wypj4o = function _lp2_menu_sync(lp2_burger,Element,lp2MenuItems)
+{
+  const {list, close} = lp2_burger;
+  const bySort = arr => [...arr || []].sort((a, b) => (a.order ?? 100) - (b.order ?? 100) || String(a.label ?? a.id).localeCompare(String(b.label ?? b.id)));
+  const icon = svg => {
+    const span = document.createElement('span');
+    Object.assign(span.style, {
+      width: '16px',
+      height: '16px',
+      flex: '0 0 16px',
+      display: 'inline-flex',
+      alignItems: 'center',
+      justifyContent: 'center'
+    });
+    let node = typeof svg === 'function' ? svg() : svg;
+    if (typeof node === 'string') {
+      const t = document.createElement('template');
+      t.innerHTML = node.trim();
+      node = t.content.firstElementChild;
+    }
+    if (node instanceof Element) {
+      node = node.cloneNode(true);
+      node.setAttribute('width', '16');
+      node.setAttribute('height', '16');
+      span.appendChild(node);
+    }
+    return span;
+  };
+  let count = 0;
+  const addItems = (arr, depth, container) => {
+    for (const item of bySort(arr)) {
+      count++;
+      const btn = document.createElement('button');
+      btn.className = 'lp2-menu-item';
+      btn.style.paddingLeft = 10 + depth * 16 + 'px';
+      btn.appendChild(icon(item.svg));
+      const lbl = document.createElement('span');
+      lbl.textContent = item.label ?? item.id;
+      lbl.style.flex = '1 1 auto';
+      btn.appendChild(lbl);
+      container.appendChild(btn);
+      if (item.children && item.children.length) {
+        const caret = document.createElement('span');
+        caret.textContent = '\u25B8';
+        caret.style.opacity = '.6';
+        btn.appendChild(caret);
+        const sub = document.createElement('div');
+        sub.style.display = 'none';
+        container.appendChild(sub);
+        addItems(item.children, depth + 1, sub);
+        btn.addEventListener('click', ev => {
+          ev.stopPropagation();
+          const opening = sub.style.display === 'none';
+          sub.style.display = opening ? 'block' : 'none';
+          caret.textContent = opening ? '\u25BE' : '\u25B8';
+        });
+      } else
+        btn.addEventListener('click', ev => {
+          ev.stopPropagation();
+          close();
+          try {
+            item.action && item.action();
+          } catch (err) {
+            console.error('lp2 menu item', item.id, err);
+          }
+        });
+    }
+  };
+  list.replaceChildren();
+  addItems(lp2MenuItems, 0, list);
+  if (!count) {
+    const empty = document.createElement('div');
+    empty.textContent = 'no menu items';
+    Object.assign(empty.style, {
+      padding: '6px 10px',
+      color: 'var(--theme-foreground-faint)'
+    });
+    list.appendChild(empty);
+  }
+  return `menu: ${ count } item${ count === 1 ? '' : 's' }`;
+};
+const _1kos97o = function _lp2_menu_defaults(lp2_registerMenuItem,disk_svg,downloadAnchor,forkAnchor,invalidation)
+{
+  // built-in items, registered through the same plugin path any other notebook uses;
+  // the anchors carry exporter-3's export behaviour, so acting = clicking a fresh one
+  const disposers = [
+    lp2_registerMenuItem({
+      id: 'download',
+      order: 10,
+      label: 'Download',
+      svg: () => disk_svg('currentColor'),
+      action: () => downloadAnchor({}, 'download').click()
+    }),
+    lp2_registerMenuItem({
+      id: 'fork',
+      order: 20,
+      label: 'Fork (new tab)',
+      svg: '<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="4" cy="3.5" r="1.8"/><circle cx="12" cy="3.5" r="1.8"/><circle cx="8" cy="12.5" r="1.8"/><path d="M4 5.3v1.2a2 2 0 0 0 2 2h4a2 2 0 0 0 2-2V5.3M8 8.5v2.2"/></svg>',
+      action: () => forkAnchor({}, 'fork').click()
+    })
+  ];
+  invalidation.then(() => disposers.forEach(d => d()));
+  return 'menu defaults: download, fork';
+};
+
+export default function define(runtime, observer) {
+  const main = runtime.module();
+  const $def = (pid, name, deps, fn) => {
+    main.variable(observer(name)).define(name, deps, fn).pid = pid;
+  };
+
+  main.define("module @tomlarkworthy/plugin-registry", async () => runtime.module((await import("/@tomlarkworthy/plugin-registry.js?v=4")).default));  
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
+  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));  
+  main.define("module @tomlarkworthy/claude-code-pairing", async () => runtime.module((await import("/@tomlarkworthy/claude-code-pairing.js?v=4")).default));  
+  main.define("module @tomlarkworthy/command-palette", async () => runtime.module((await import("/@tomlarkworthy/command-palette.js?v=4")).default));  
+  main.define("module @tomlarkworthy/themes", async () => runtime.module((await import("/@tomlarkworthy/themes.js?v=4")).default));  
+  main.define("module @tomlarkworthy/local-change-history", async () => runtime.module((await import("/@tomlarkworthy/local-change-history.js?v=4")).default));  
+  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
+  main.define("module @tomlarkworthy/editor-5", async () => runtime.module((await import("/@tomlarkworthy/editor-5.js?v=4")).default));  
+  main.define("module @tomlarkworthy/exporter-3", async () => runtime.module((await import("/@tomlarkworthy/exporter-3.js?v=4")).default));  
+  $def("_1pg70e1", "lp2_doc_overview", ["md"], _1pg70e1);  
+  $def("_1ov8ye5", "lp2_doc_model", ["md"], _1ov8ye5);  
+  $def("_1rihrff", "viewof lp2Model", ["Inputs"], _1rihrff);  
+  $def("_1ow4sob", "lp2Model", ["Generators","viewof lp2Model"], _1ow4sob);  
+  $def("_l8xp7u", "lp2_parseDSL", [], _l8xp7u);  
+  $def("_15gufbj", "lp2_serializeDSL", [], _15gufbj);  
+  $def("_14hgn59", "lp2_doc_panes", ["md"], _14hgn59);  
+  $def("_r14r4j", "lp2_moduleByName", ["lp2_watchedModules"], _r14r4j);  
+  $def("_j3eb9x", "lp2_paneRegistry", [], _j3eb9x);  
+  $def("_z08s5w", "lp2_getPane", ["lp2_scrollToCell","lp2_paneRegistry","lp2_moduleByName","visualizer","runtime","lp2_installAnchor"], _z08s5w);  
+  $def("_88b5go", "lp2_doc_scroll", ["md"], _88b5go);  
+  $def("_78h40x", "lp2_anchor", ["persistentId"], _78h40x);  
+  $def("_d4xe91", "lp2_installAnchor", ["lp2_anchor","ResizeObserver"], _d4xe91);  
+  $def("_xwsg4w", "lp2_doc_layout", ["md"], _xwsg4w);  
+  $def("_1fxe40f", "lp2_host", [], _1fxe40f);  
+  $def("_6f57qb", "lp2_renderNode", ["lp2_renderStack","lp2_renderSplit"], _6f57qb);  
+  $def("_1r0c4er", "lp2_ops", [], _1r0c4er);  
+  $def("_sx484g", "lp2_dragOut", [], _sx484g);  
+  $def("_fnh26m", "lp2_view", ["lp2_host","lp2Model","lp2_installAnchor","lp2_anchor","viewof lp2Model","Event","lp2_getPane","lp2_dragOut","lp2_ops","linkTo","lp2_paneRegistry","lp2_renderNode","lp2_burger"], _fnh26m);  
+  $def("_1bytrbx", "lp2_probe", ["lp2_view","lp2_paneRegistry"], _1bytrbx);  
+  $def("_orvfgz", "lp2_doc_hash", ["md"], _orvfgz);  
+  $def("_y2r8d1", "lp2_hash", ["Generators","location"], _y2r8d1);  
+  $def("_1nwbntj", "lp2_setHash", ["location","history"], _1nwbntj);  
+  $def("_1vcr15c", "lp2_syncFromUrl", ["viewof lp2Model","lp2_hash","lp2_parseDSL","lp2_ops","lp2_serializeDSL","Event"], _1vcr15c);  
+  $def("_1rf2mk0", "lp2_syncToUrl", ["lp2Model","lp2_serializeDSL","lp2_parseDSL","location","lp2_setHash"], _1rf2mk0);  
+  $def("_6e8yep", "lp2_doc_mount", ["md"], _6e8yep);  
+  $def("_1y1ubko", "lp2_page", ["apply_theme","lp2_host","commandPaletteStyles","commandPaletteOverlay"], _1y1ubko);  
+  $def("_1q105of", "lp2_background_jobs", ["commandPaletteKeybinding","cc_chat","change_listener","commit_history","replay_git","auto_attach","lp2_watchModules","lp2_menu_sync","lp2_menu_defaults"], _1q105of);  
+  $def("_1yumqn", "lp2_append_to_body", ["lp2_view","lp2_syncFromUrl","lp2_syncToUrl","lp2_page"], _1yumqn);  
+  $def("_z83rug", null, ["currentModules"], _z83rug);  
+  $def("_12ez53h", "lp2_renderTab", ["location"], _12ez53h);  
+  $def("_m7n4c3", "lp2_dropZone", [], _m7n4c3);  
+  $def("_1hs48bp", "lp2_splitter", [], _1hs48bp);  
+  $def("_nj1uts", "lp2_renderStack", ["lp2_renderTab","lp2_dropZone"], _nj1uts);  
+  $def("_a9rn1a", "lp2_renderSplit", ["lp2_splitter"], _a9rn1a);  
+  $def("_6vp46e", "viewof lp2_watchedModules", ["Inputs"], _6vp46e);  
+  $def("_1hxhexc", "lp2_watchedModules", ["Generators","viewof lp2_watchedModules"], _1hxhexc);  
+  $def("_16ptruj", "lp2_watchModules", ["lp2Model","currentModules","viewof lp2_watchedModules","Event"], _16ptruj);  
+  $def("_td27y7", "lp2_scrollToCell", ["lp2_anchor"], _td27y7);  
+  $def("_8vk6lr", "lp2_doc_menu", ["md"], _8vk6lr);  
+  $def("_1uvdt3f", "lp2MenuItems", ["plugins"], _1uvdt3f);  
+  $def("_qcv0dp", "lp2_registerMenuItem", ["plugins"], _qcv0dp);  
+  $def("_bt1fe2", "lp2_burger", ["invalidation"], _bt1fe2);  
+  $def("_wypj4o", "lp2_menu_sync", ["lp2_burger","Element","lp2MenuItems"], _wypj4o);  
+  $def("_1kos97o", "lp2_menu_defaults", ["lp2_registerMenuItem","disk_svg","downloadAnchor","forkAnchor","invalidation"], _1kos97o);  
+  main.define("plugins", ["module @tomlarkworthy/plugin-registry", "@variable"], (_, v) => v.import("plugins", _));  
+  main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
+  main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
+  main.define("persistentId", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("persistentId", _));  
+  main.define("visualizer", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("visualizer", _));  
+  main.define("currentModules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", _));  
+  main.define("cc_chat", ["module @tomlarkworthy/claude-code-pairing", "@variable"], (_, v) => v.import("cc_chat", _));  
+  main.define("commandPaletteKeybinding", ["module @tomlarkworthy/command-palette", "@variable"], (_, v) => v.import("commandPaletteKeybinding", _));  
+  main.define("commandPaletteOverlay", ["module @tomlarkworthy/command-palette", "@variable"], (_, v) => v.import("commandPaletteOverlay", _));  
+  main.define("commandPaletteStyles", ["module @tomlarkworthy/command-palette", "@variable"], (_, v) => v.import("commandPaletteStyles", _));  
+  main.define("apply_theme", ["module @tomlarkworthy/themes", "@variable"], (_, v) => v.import("apply_theme", _));  
+  main.define("current_theme", ["module @tomlarkworthy/themes", "@variable"], (_, v) => v.import("current_theme", _));  
+  main.define("change_listener", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("change_listener", _));  
+  main.define("commit_history", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("commit_history", _));  
+  main.define("replay_git", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("replay_git", _));  
+  main.define("linkTo", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("linkTo", _));  
+  main.define("auto_attach", ["module @tomlarkworthy/editor-5", "@variable"], (_, v) => v.import("auto_attach", _));  
+  main.define("disk_svg", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("disk_svg", _));  
+  main.define("downloadAnchor", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("downloadAnchor", _));  
+  main.define("forkAnchor", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("forkAnchor", _));
+  return main;
+}</script>
+
+<script id="@tomlarkworthy/save-in-place" 
+  type="text/plain"
+  data-mime="application/javascript"
+>
+const _3p04iq = function _sip_doc(md){return(
+md`# Save in place
+
+A lopepage-2 menu plugin that writes the current notebook back to its own file on
+disk via the File System Access API, instead of downloading a fresh copy.
+
+It carries its own dependencies — [\`exporter-3\`](https://observablehq.com/@tomlarkworthy/exporter-3) (\`exportToHTML\`) for the bytes and the FSA/IndexedDB handle machinery here — and composes into lopepage-2 purely by \`plugins.add("lp2-menu", …)\` on the shared [\`@tomlarkworthy/plugin-registry\`](https://observablehq.com/@tomlarkworthy/plugin-registry) bus. It imports NEITHER lopepage-2 (they meet only at the \`"lp2-menu"\` name) nor anything lopepage-specific; a notebook opts in by adding \`@tomlarkworthy/save-in-place\` to its bootconf \`mains\`.
+
+Mechanics:
+
+- **Handle persistence** — the picked \`FileSystemFileHandle\` is stored in IndexedDB keyed by the notebook's path (\`sip_notebookId\`), so subsequent saves skip the picker while read-write permission holds; permission is re-requested on demand.
+- **Export** — \`exportToHTML\` re-serialises the live runtime. The saved boot hash keeps the current \`view=\` layout but strips volatile params (\`cc\`, \`open\`, \`close\`, \`filesync\`) so a pairing token is never baked into the file.
+- **Feedback** — \`sip_toast\` surfaces Saving / Saved / failure in place, since the menu closes on click.
+
+Constraints (shared with [\`file-sync\`](https://observablehq.com/@tomlarkworthy/file-sync)): Chromium only, secure context (\`file://\` or \`https://\`), and the write happens in the user's own browser — not the headless QA browser, whose picker is not driven.`
+)};
+const _fx6mmk = function _sip_notebookId(location){return(
+(location.pathname || '') + (location.search || '')
+)};
+const _ez9ia7 = function _sip_handleStore(sip_notebookId)
+{
+  const IDB_NAME = 'lopecode-save-in-place';
+  const STORE = 'handles';
+  const key = sip_notebookId || 'default';
+  const openDB = () => new Promise((resolve, reject) => {
+    const req = window.indexedDB.open(IDB_NAME, 1);
+    req.onupgradeneeded = () => req.result.createObjectStore(STORE);
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+  const get = async () => {
+    const db = await openDB();
+    return new Promise((resolve, reject) => {
+      const r = db.transaction(STORE, 'readonly').objectStore(STORE).get(key);
+      r.onsuccess = () => resolve(r.result);
+      r.onerror = () => reject(r.error);
+    });
+  };
+  const put = async handle => {
+    const db = await openDB();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(STORE, 'readwrite');
+      tx.objectStore(STORE).put(handle, key);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+  };
+  const del = async () => {
+    const db = await openDB();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(STORE, 'readwrite');
+      tx.objectStore(STORE).delete(key);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+  };
+  return {
+    get,
+    put,
+    del,
+    key
+  };
+};
+const _8yf35i = function _sip_toast()
+{
+  // a single fixed toast, bottom-left; returns a handle to update + auto-dismiss
+  return (msg, kind) => {
+    let el = document.querySelector('.sip-toast');
+    if (!el) {
+      el = document.createElement('div');
+      el.className = 'sip-toast';
+      Object.assign(el.style, {
+        position: 'fixed',
+        left: '12px',
+        bottom: '12px',
+        zIndex: 2000,
+        padding: '8px 12px',
+        borderRadius: '5px',
+        font: '12px var(--sans-serif, sans-serif)',
+        boxShadow: '0 3px 12px rgba(0,0,0,.22)',
+        border: '1px solid var(--theme-foreground-faint, rgba(128,128,128,.3))',
+        borderLeft: '3px solid transparent',
+        maxWidth: '60vw',
+        pointerEvents: 'none'
+      });
+      document.body.appendChild(el);
+    }
+    if (el.__sipTimer) {
+      window.clearTimeout(el.__sipTimer);
+      el.__sipTimer = 0;
+    }
+    const paint = (text, k) => {
+      el.textContent = text;
+      // solid themed surface + themed foreground = guaranteed contrast in any theme;
+      // status is carried by the left-border accent, not the background tint
+      const accent = {
+        ok: 'var(--theme-green, #3fb950)',
+        err: 'var(--theme-error, var(--theme-red, #e5534b))',
+        busy: 'var(--theme-foreground-focus, #6cb0ff)',
+        muted: 'var(--theme-foreground-muted, #888)'
+      };
+      el.style.background = 'var(--theme-background-raised, var(--theme-background-b, #fff))';
+      el.style.color = 'var(--theme-foreground, #000)';
+      el.style.borderLeftColor = accent[k] || accent.busy;
+      el.style.opacity = '1';
+    };
+    const hide = ms => {
+      el.__sipTimer = window.setTimeout(() => {
+        el.style.opacity = '0';
+        el.style.transition = 'opacity .4s';
+      }, ms);
+    };
+    paint(msg, kind);
+    if (kind && kind !== 'busy')
+      hide(kind === 'err' ? 5000 : 2200);
+    return {
+      done: (text, k) => {
+        paint(text, k);
+        hide(k === 'err' ? 5000 : 2200);
+      }
+    };
+  };
+};
+const _1a1j664 = function _sip_svg(){return(
+'<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.3"><path d="M2.5 2.5h8.3L13.5 5.2v8.3a.7.7 0 0 1-.7.7H3.2a.7.7 0 0 1-.7-.7V3.2a.7.7 0 0 1 .7-.7Z"/><path d="M5 2.5h5v3H5z" fill="currentColor" stroke="none"/><rect x="4.5" y="8.5" width="7" height="4" rx=".4"/></svg>'
+)};
+const _1c9i265 = function _sip_save(sip_handleStore,location,sip_toast,exportToHTML,runtime)
+{
+  const store = sip_handleStore;
+  // current layout, minus volatile params, becomes the saved file's boot hash
+  const cleanHash = () => {
+    const raw = String(location.hash || '').replace(/^#/, '');
+    const drop = new Set([
+      'cc',
+      'open',
+      'close',
+      'filesync',
+      'from',
+      'focus'
+    ]);
+    const kept = raw.split('&').filter(Boolean).filter(p => !drop.has(p.split('=')[0]));
+    return kept.length ? '#' + kept.join('&') : '';
+  };
+  const acquire = async () => {
+    const saved = await store.get().catch(() => null);
+    if (saved) {
+      let perm = 'granted';
+      if (saved.queryPermission)
+        perm = await saved.queryPermission({ mode: 'readwrite' }).catch(() => 'denied');
+      if (perm !== 'granted' && saved.requestPermission)
+        perm = await saved.requestPermission({ mode: 'readwrite' }).catch(() => 'denied');
+      if (perm === 'granted')
+        return saved;
+    }
+    if (!window.showSaveFilePicker)
+      throw new Error('File System Access API unavailable (needs Chromium + a secure context)');
+    const suggested = (document.title || 'notebook').replace(/[^\w.-]+/g, '_').replace(/^_+|_+$/g, '') || 'notebook';
+    const handle = await window.showSaveFilePicker({
+      suggestedName: suggested + '.html',
+      types: [{
+          description: 'HTML',
+          accept: { 'text/html': ['.html'] }
+        }]
+    });
+    await store.put(handle).catch(() => {
+    });
+    return handle;
+  };
+  const save = async () => {
+    const toast = sip_toast('Saving\u2026', 'busy');
+    try {
+      const handle = await acquire();
+      // pass mains explicitly (like exporter-3's exportAnchor) — a bare call leaves
+      // bootconf mains empty and the saved file boots blank. runtime.mains re-includes
+      // every booted main, so the saved copy keeps save-in-place too.
+      const resp = await exportToHTML({
+        mains: new Map(runtime.mains),
+        runtime,
+        options: { hash: cleanHash() }
+      });
+      const html = resp?.source ?? resp;
+      if (typeof html !== 'string' || html.length < 1000)
+        throw new Error('export produced no source');
+      const writable = await handle.createWritable();
+      await writable.write(html);
+      await writable.close();
+      toast.done('Saved \u2713 ' + handle.name, 'ok');
+      return {
+        ok: true,
+        name: handle.name,
+        bytes: html.length
+      };
+    } catch (e) {
+      if (e && e.name === 'AbortError') {
+        toast.done('Save cancelled', 'muted');
+        return {
+          ok: false,
+          cancelled: true
+        };
+      }
+      toast.done('Save failed: ' + (e && e.message || e), 'err');
+      throw e;
+    }
+  };
+  return save;
+};
+const _1uj52bj = function _sip_register(plugins,sip_svg,sip_save,invalidation)
+{
+  // Register straight onto the shared plugin-registry "lp2-menu" set — no import of lopepage-2.
+  // {invalidation} auto-removes the item if this cell re-runs.
+  plugins.add('lp2-menu', {
+    id: 'save-in-place',
+    order: 5,
+    label: 'Save in place',
+    svg: sip_svg,
+    action: () => {
+      sip_save();
+    }
+  }, { invalidation });
+  return 'registered: save-in-place';
+};
+
+export default function define(runtime, observer) {
+  const main = runtime.module();
+  const $def = (pid, name, deps, fn) => {
+    main.variable(observer(name)).define(name, deps, fn).pid = pid;
+  };
+
+  main.define("module @tomlarkworthy/exporter-3", async () => runtime.module((await import("/@tomlarkworthy/exporter-3.js?v=4")).default));  
+  main.define("module @tomlarkworthy/plugin-registry", async () => runtime.module((await import("/@tomlarkworthy/plugin-registry.js?v=4")).default));  
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  $def("_3p04iq", "sip_doc", ["md"], _3p04iq);  
+  $def("_fx6mmk", "sip_notebookId", ["location"], _fx6mmk);  
+  $def("_ez9ia7", "sip_handleStore", ["sip_notebookId"], _ez9ia7);  
+  $def("_8yf35i", "sip_toast", [], _8yf35i);  
+  $def("_1a1j664", "sip_svg", [], _1a1j664);  
+  $def("_1c9i265", "sip_save", ["sip_handleStore","location","sip_toast","exportToHTML","runtime"], _1c9i265);  
+  $def("_1uj52bj", "sip_register", ["plugins","sip_svg","sip_save","invalidation"], _1uj52bj);  
+  main.define("exportToHTML", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("exportToHTML", _));  
+  main.define("plugins", ["module @tomlarkworthy/plugin-registry", "@variable"], (_, v) => v.import("plugins", _));  
+  main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));
+  return main;
+}</script>
 
 <script id="@mbostock/safe-local-storage" 
   type="text/plain"
@@ -3536,212 +7515,227 @@ function handleCommand(cmd) {
     return handler(cmd, rt);
 }
 )};
-const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation)
+const _11jras6 = function _cc_ws(cc_config,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,sessionStorage,invalidation)
 {
-    return function () {
-        var port = cc_config.port, host = cc_config.host;
-        var ws = null;
-        var paired = false;
-        function connect(token) {
-            if (ws) {
-                ws.close();
-                ws = null;
-            }
-            if (token) {
-                try {
-                    sessionStorage.setItem('lopecode_cc_token', token);
-                } catch (e) {
-                }
-                var hash = location.hash || '#';
-                if (/[&?]cc=/.test(hash)) {
-                    hash = hash.replace(/([&?])cc=[^&]*/, '$1cc=' + token);
-                } else {
-                    hash += (hash.length > 1 ? '&' : '') + 'cc=' + token;
-                }
-                try {
-                    window.history.replaceState(null, '', hash);
-                } catch (e) {
-                }
-            }
-            var connectPort = port;
-            if (token) {
-                var parts = token.match(/^LOPE-(\d+)-[A-Z0-9]+$/);
-                if (parts)
-                    connectPort = parseInt(parts[1], 10);
-            }
-            cc_status.value = 'connecting';
-            cc_status.dispatchEvent(new Event('input'));
-            ws = new WebSocket('ws://' + host + ':' + connectPort + '/ws');
-            ws.onopen = function () {
-                if (token) {
-                    cc_status.value = 'pairing';
-                    cc_status.dispatchEvent(new Event('input'));
-                    var toolDescriptors = [];
-                    var _mcpToolsVal = $0 && $0.value;
-                    if (_mcpToolsVal && _mcpToolsVal.size > 0) {
-                        _mcpToolsVal.forEach(function (t, name) {
-                            toolDescriptors.push({
-                                name: name,
-                                description: t.description,
-                                inputSchema: t.inputSchema
-                            });
-                        });
-                    }
-                    ws.send(JSON.stringify({
-                        type: 'pair',
-                        token: token,
-                        url: cc_notebook_id,
-                        title: document.title || 'Untitled',
-                        tools: toolDescriptors
-                    }));
-                }
-            };
-            ws.onmessage = function (event) {
-                var msg;
-                try {
-                    msg = JSON.parse(event.data);
-                } catch (e) {
-                    return;
-                }
-                switch (msg.type) {
-                case 'paired':
-                    paired = true;
-                    cc_status.value = 'connected';
-                    cc_status.dispatchEvent(new Event('input'));
-                    // Provide send callback to watchers
-                    cc_watchers.setSend(function (m) {
-                        if (paired && ws)
-                            ws.send(JSON.stringify(m));
-                    });
-                    var modules = [];
-                    var rt = window.__ojs_runtime;
-                    if (rt) {
-                        var seen = new Set();
-                        for (var v of rt._variables) {
-                            var name = v._module && v._module._name;
-                            if (name && !seen.has(name)) {
-                                seen.add(name);
-                                modules.push(name);
-                            }
-                        }
-                    }
-                    ws.send(JSON.stringify({
-                        type: 'notebook-info',
-                        url: cc_notebook_id,
-                        title: document.title,
-                        modules: modules,
-                        hash: location.hash
-                    }));
-                    // Set up watches from cc_watches
-                    var rt2 = window.__ojs_runtime;
-                    if (rt2) {
-                        var initialWatches = $1.value || [];
-                        for (var i = 0; i < initialWatches.length; i++) {
-                            cc_watchers.watchVariable(rt2, initialWatches[i].name, initialWatches[i].module);
-                        }
-                    }
-                    break;
-                case 'pair-failed':
-                    paired = false;
-                    cc_status.value = 'disconnected';
-                    cc_status.dispatchEvent(new Event('input'));
-                    break;
-                case 'reply':
-                    var msgs = cc_messages.value.concat([{
-                            role: 'assistant',
-                            content: msg.markdown,
-                            timestamp: Date.now()
-                        }]);
-                    cc_messages.value = msgs;
-                    cc_messages.dispatchEvent(new Event('input'));
-                    break;
-                case 'tool-activity':
-                    // Update the activity status bar (not the chat messages)
-                    var activityEntry = {
-                        tool_name: msg.tool_name,
-                        content: msg.summary,
-                        timestamp: msg.timestamp || Date.now()
-                    };
-                    cc_activity.value = cc_activity.value.concat([activityEntry]).slice(-20);
-                    cc_activity.dispatchEvent(new Event('input'));
-                    break;
-                case 'command':
-                    Promise.resolve(cc_command_handlers(msg)).then(function (result) {
-                        ws.send(JSON.stringify({
-                            type: 'command-result',
-                            id: msg.id,
-                            ok: result.ok,
-                            result: result.result,
-                            error: result.error
-                        }));
-                    }).catch(function (e) {
-                        ws.send(JSON.stringify({
-                            type: 'command-result',
-                            id: msg.id,
-                            ok: false,
-                            error: e.message
-                        }));
-                    });
-                    break;
-                case 'assistant-text':
-                    // Side-comment: Claude's CLI text output from session log
-                    var sideMsg = cc_messages.value.concat([{
-                            role: 'side',
-                            content: msg.text,
-                            timestamp: msg.timestamp || Date.now()
-                        }]);
-                    cc_messages.value = sideMsg;
-                    cc_messages.dispatchEvent(new Event('input'));
-                    break;
-                }
-            };
-            ws.onclose = function () {
-                paired = false;
-                cc_watchers.setSend(null);
-                cc_status.value = 'disconnected';
-                cc_status.dispatchEvent(new Event('input'));
-                ws = null;
-            };
-            ws.onerror = function () {
-            };
+  return (function () {
+    var port = cc_config.port,
+      host = cc_config.host;
+    var ws = null;
+    var paired = false;
+    function connect(token) {
+      if (ws) {
+        ws.close();
+        ws = null;
+      }
+      if (token) {
+        try {
+          window.sessionStorage.setItem("lopecode_cc_token", token);
+        } catch (e) {}
+        var hash = location.hash || "#";
+        if (/[&?]cc=/.test(hash)) {
+          hash = hash.replace(/([&?])cc=[^&]*/, "$1cc=" + token);
+        } else {
+          hash += (hash.length > 1 ? "&" : "") + "cc=" + token;
         }
-        // Auto-connect: check hash param first, then sessionStorage fallback
-        (function autoConnect() {
-            var token = null;
-            var hash = location.hash || '';
-            var match = hash.match(/[&?]cc=(LOPE-[A-Z0-9-]+)/);
-            if (match) {
-                token = match[1];
-            }
-            if (!token) {
-                try {
-                    token = sessionStorage.getItem('lopecode_cc_token');
-                } catch (e) {
+        try {
+          window.history.replaceState(null, "", hash);
+        } catch (e) {}
+      }
+      var connectPort = port;
+      if (token) {
+        var parts = token.match(/^LOPE-(\d+)-[A-Z0-9]+$/);
+        if (parts) connectPort = parseInt(parts[1], 10);
+      }
+      cc_status.value = "connecting";
+      cc_status.dispatchEvent(new Event("input"));
+      ws = new WebSocket("ws://" + host + ":" + connectPort + "/ws");
+      ws.onopen = function () {
+        if (token) {
+          cc_status.value = "pairing";
+          cc_status.dispatchEvent(new Event("input"));
+          var toolDescriptors = [];
+          var _mcpToolsVal = $0 && $0.value;
+          if (_mcpToolsVal && _mcpToolsVal.size > 0) {
+            _mcpToolsVal.forEach(function (t, name) {
+              toolDescriptors.push({
+                name: name,
+                description: t.description,
+                inputSchema: t.inputSchema
+              });
+            });
+          }
+          ws.send(
+            JSON.stringify({
+              type: "pair",
+              token: token,
+              url: cc_notebook_id,
+              title: document.title || "Untitled",
+              tools: toolDescriptors
+            })
+          );
+        }
+      };
+      ws.onmessage = function (event) {
+        var msg;
+        try {
+          msg = JSON.parse(event.data);
+        } catch (e) {
+          return;
+        }
+        switch (msg.type) {
+          case "paired":
+            paired = true;
+            cc_status.value = "connected";
+            cc_status.dispatchEvent(new Event("input"));
+            // Provide send callback to watchers
+            cc_watchers.setSend(function (m) {
+              if (paired && ws) ws.send(JSON.stringify(m));
+            });
+            var modules = [];
+            var rt = window.__ojs_runtime;
+            if (rt) {
+              var seen = new Set();
+              for (var v of rt._variables) {
+                var name = v._module && v._module._name;
+                if (name && !seen.has(name)) {
+                  seen.add(name);
+                  modules.push(name);
                 }
+              }
             }
-            if (token) {
-                setTimeout(function () {
-                    connect(token);
-                }, 500);
+            ws.send(
+              JSON.stringify({
+                type: "notebook-info",
+                url: cc_notebook_id,
+                title: document.title,
+                modules: modules,
+                hash: location.hash
+              })
+            );
+            // Set up watches from cc_watches
+            var rt2 = window.__ojs_runtime;
+            if (rt2) {
+              var initialWatches = $1.value || [];
+              for (var i = 0; i < initialWatches.length; i++) {
+                cc_watchers.watchVariable(
+                  rt2,
+                  initialWatches[i].name,
+                  initialWatches[i].module
+                );
+              }
             }
-        }());
-        invalidation.then(function () {
-            cc_watchers.setSend(null);
-            if (ws) {
-                ws.close();
-                ws = null;
-            }
-        });
-        return {
-            connect: connect,
-            get paired() {
-                return paired;
-            },
-            get ws() {
-                return ws;
-            }
-        };
-    }();
+            break;
+          case "pair-failed":
+            paired = false;
+            cc_status.value = "disconnected";
+            cc_status.dispatchEvent(new Event("input"));
+            break;
+          case "reply":
+            var msgs = cc_messages.value.concat([
+              {
+                role: "assistant",
+                content: msg.markdown,
+                timestamp: Date.now()
+              }
+            ]);
+            cc_messages.value = msgs;
+            cc_messages.dispatchEvent(new Event("input"));
+            break;
+          case "tool-activity":
+            // Update the activity status bar (not the chat messages)
+            var activityEntry = {
+              tool_name: msg.tool_name,
+              content: msg.summary,
+              timestamp: msg.timestamp || Date.now()
+            };
+            cc_activity.value = cc_activity.value
+              .concat([activityEntry])
+              .slice(-20);
+            cc_activity.dispatchEvent(new Event("input"));
+            break;
+          case "command":
+            Promise.resolve(cc_command_handlers(msg))
+              .then(function (result) {
+                ws.send(
+                  JSON.stringify({
+                    type: "command-result",
+                    id: msg.id,
+                    ok: result.ok,
+                    result: result.result,
+                    error: result.error
+                  })
+                );
+              })
+              .catch(function (e) {
+                ws.send(
+                  JSON.stringify({
+                    type: "command-result",
+                    id: msg.id,
+                    ok: false,
+                    error: e.message
+                  })
+                );
+              });
+            break;
+          case "assistant-text":
+            // Side-comment: Claude's CLI text output from session log
+            var sideMsg = cc_messages.value.concat([
+              {
+                role: "side",
+                content: msg.text,
+                timestamp: msg.timestamp || Date.now()
+              }
+            ]);
+            cc_messages.value = sideMsg;
+            cc_messages.dispatchEvent(new Event("input"));
+            break;
+        }
+      };
+      ws.onclose = function () {
+        paired = false;
+        cc_watchers.setSend(null);
+        cc_status.value = "disconnected";
+        cc_status.dispatchEvent(new Event("input"));
+        ws = null;
+      };
+      ws.onerror = function () {};
+    }
+    // Auto-connect: check hash param first, then sessionStorage fallback
+    (function autoConnect() {
+      var token = null;
+      var hash = location.hash || "";
+      var match = hash.match(/[&?]cc=(LOPE-[A-Z0-9-]+)/);
+      if (match) {
+        token = match[1];
+      }
+      if (!token) {
+        try {
+          token = sessionStorage.getItem("lopecode_cc_token");
+        } catch (e) {}
+      }
+      if (token) {
+        setTimeout(function () {
+          connect(token);
+        }, 500);
+      }
+    })();
+    invalidation.then(function () {
+      cc_watchers.setSend(null);
+      if (ws) {
+        ws.close();
+        ws = null;
+      }
+    });
+    return {
+      connect: connect,
+      get paired() {
+        return paired;
+      },
+      get ws() {
+        return ws;
+      }
+    };
+  })();
 };
 const _agu8h7 = function _cc_doc_side_effects(md){return(
 md`---
@@ -4211,7 +8205,7 @@ export default function define(runtime, observer) {
   $def("_bzq7u5", null, ["viewof mcpTools","fileSyncTools","Event"], _bzq7u5);  
   $def("_npplqm", "cc_handle_call_tool", ["viewof mcpTools","cc_watchers","runtime"], _npplqm);  
   $def("_ptgn2x", "cc_command_handlers", ["runtime","cc_handle_get_variable","cc_handle_define_variable","cc_handle_define_cell","cc_handle_delete_variable","cc_handle_delete_cell","cc_handle_update_cell","cc_handle_list_variables","cc_handle_list_cells","cc_handle_run_tests","cc_handle_create_module","cc_handle_delete_module","cc_handle_eval","cc_handle_fork","cc_handle_export_module","cc_handle_watch","cc_handle_unwatch","cc_handle_call_tool"], _ptgn2x);  
-  $def("_1s8ywlt", "cc_ws", ["cc_config","sessionStorage","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1s8ywlt);  
+  $def("_11jras6", "cc_ws", ["cc_config","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","sessionStorage","invalidation"], _11jras6);  
   $def("_agu8h7", "cc_doc_side_effects", ["md"], _agu8h7);  
   $def("_d9cyj2", "cc_change_forwarder", ["cc_ws","history","invalidation"], _d9cyj2);  
   $def("_56tjlo", "cc_voice", ["voiceEnabled","KeyboardEvent","SpeechSynthesisUtterance","invalidation"], _56tjlo);  
@@ -4427,80 +8421,64 @@ export default function define(runtime, observer) {
   type="text/plain"
   data-mime="application/javascript"
 >
-const _13upker = function _1(md){return(
+const _tku1if = function _1(md){return(
 md`# Command Palette
 
-Plugin-driven command palette. Press **Cmd+K** (Mac) or **Ctrl+K** to open.
+Plugin-driven command palette. Press **Cmd+K** (Mac) or **Ctrl+K** to open, or pick **Command palette** from the lopepage-2 burger menu (registered on the shared \`"lp2-menu"\` plugin bus).
 
 \`\`\`js
 import {commandPaletteOverlay, commandPaletteStyles, commandPaletteKeybinding} from "@tomlarkworthy/command-palette"
 \`\`\`
 
-## Registering a plugin
+## Registering a command provider
 
-A plugin is a function \`(query: string) => Command[]\` where \`Command = {label, href, hint?, module?, badge?, snippet?, score?}\`. Plugins run on every keystroke; results are merged and sorted by \`score\` (descending).
+A provider is a function \`(query: string) => Command[]\` where \`Command = {label, href, hint?, module?, badge?, snippet?, score?}\`. Providers run on every keystroke; results are merged and sorted by \`score\` (descending).
+
+Providers register on the shared [\`@tomlarkworthy/plugin-registry\`](https://observablehq.com/@tomlarkworthy/plugin-registry) set named \`"lopecode_commands"\` — no import of this notebook needed, so any notebook can extend the palette:
 
 \`\`\`js
-import {viewof commands as commandsView} from "@tomlarkworthy/command-palette"
+import {plugins} from "@tomlarkworthy/plugin-registry"
 {
-  const myPlugin = (q) => [{label: "Hello " + q, href: "#" + q, score: 100}];
-  const unregister = commandsView.addCommand(myPlugin);
-  invalidation.then(unregister);
+  const provider = (q) => [{label: "Hello " + q, href: "#" + q, score: 100}];
+  plugins.add("lopecode_commands", provider, {invalidation});
 }
 \`\`\`
 
-## Built-in plugins
+## Built-in providers
 
 - **Module finder** — type a module name to open it.
 - **Cell search** — type to find cells across all loaded modules.`
 )};
-const _1eng7wy = function _commands(Inputs,Event)
-{
-    const input = Inputs.input([]);
-    input.addCommand = function (plugin) {
-        input.value.push(plugin);
-        input.dispatchEvent(new Event('input'));
-        return () => {
-            const i = input.value.indexOf(plugin);
-            if (i >= 0) {
-                input.value.splice(i, 1);
-                input.dispatchEvent(new Event('input'));
-            }
-        };
-    };
-    return input;
-};
-const _7bve6u = (G, _) => G.input(_);
-const _bpk8h7 = function _searchIndex(liveCellMap,modules){return(
+const _yavx6b = function _searchIndex(liveCellMap,modules){return(
 (() => {
-    const index = [];
-    for (const [mod, cells] of liveCellMap.entries()) {
-        const moduleName = modules?.get(mod)?.name ?? '<unknown>';
-        for (const cell of cells) {
-            if (!cell.name && cell.type !== 'import')
-                continue;
-            let source = null;
-            try {
-                const v = cell.variables?.[0];
-                if (v?._definition)
-                    source = v._definition.toString();
-            } catch (e) {
-            }
-            index.push({
-                module: moduleName,
-                name: cell.name ?? null,
-                type: cell.type ?? 'simple',
-                source
-            });
-        }
+  const index = [];
+  for (const [mod, cells] of liveCellMap.entries()) {
+    const moduleName = modules?.get(mod)?.name ?? '<unknown>';
+    for (const cell of cells) {
+      if (!cell.name && cell.type !== 'import')
+        continue;
+      let source = null;
+      try {
+        const v = cell.variables?.[0];
+        if (v?._definition)
+          source = v._definition.toString();
+      } catch (e) {
+      }
+      index.push({
+        module: moduleName,
+        name: cell.name ?? null,
+        type: cell.type ?? 'simple',
+        source
+      });
     }
-    return index;
+  }
+  return index;
 })()
 )};
-const _1ptnr90 = function _commandPaletteStyles(theme_assets,htl)
+const _rmjyys = function _commandPaletteStyles(theme_assets,htl)
 {
-    theme_assets;
-    return htl.html`<style>
+  theme_assets;
+  return htl.html`<style>
 .command-palette-overlay {
   position: fixed;
   inset: 0;
@@ -4622,15 +8600,15 @@ const _1ptnr90 = function _commandPaletteStyles(theme_assets,htl)
 }
 </style>`;
 };
-const _fomuvm = function _commandPaletteOverlay($0,Node,invalidation)
+const _1q8grv4 = function _commandPaletteOverlay(Node,invalidation)
 {
-    const $commands = $0;
-    let selectedIdx = 0;
-    let results = [];
-    const overlay = document.createElement('div');
-    overlay.className = 'command-palette-overlay';
-    overlay.hidden = true;
-    overlay.innerHTML = `<div class="command-palette-box">
+  let selectedIdx = 0;
+  let results = [];
+  let providers = [];
+  const overlay = document.createElement('div');
+  overlay.className = 'command-palette-overlay';
+  overlay.hidden = true;
+  overlay.innerHTML = `<div class="command-palette-box">
       <input class="command-palette-input" placeholder="Type a command..." autocomplete="off" />
       <div class="command-palette-results"></div>
       <div class="command-palette-hint">
@@ -4639,147 +8617,156 @@ const _fomuvm = function _commandPaletteOverlay($0,Node,invalidation)
         <span><kbd>Esc</kbd> close</span>
       </div>
     </div>`;
-    const input = overlay.querySelector('.command-palette-input');
-    const resultsContainer = overlay.querySelector('.command-palette-results');
-    function search(query) {
-        if (!query || query.length < 1)
-            return [];
-        const plugins = $commands.value || [];
-        let all = [];
-        for (const plugin of plugins) {
-            try {
-                const out = plugin(query);
-                if (Array.isArray(out))
-                    all = all.concat(out);
-            } catch (e) {
-                console.error('[command-palette] plugin error:', e);
-            }
-        }
-        all.sort((a, b) => (b.score ?? 0) - (a.score ?? 0));
-        return all.slice(0, 50);
+  const input = overlay.querySelector('.command-palette-input');
+  const resultsContainer = overlay.querySelector('.command-palette-results');
+  function search(query) {
+    if (!query || query.length < 1)
+      return [];
+    let all = [];
+    for (const provider of providers) {
+      try {
+        const out = provider(query);
+        if (Array.isArray(out))
+          all = all.concat(out);
+      } catch (e) {
+        console.error('[command-palette] provider error:', e);
+      }
     }
-    function render() {
-        resultsContainer.innerHTML = '';
-        if (results.length === 0 && input.value.length > 0) {
-            resultsContainer.innerHTML = '<div class="command-palette-empty">No results found</div>';
-            return;
+    all.sort((a, b) => (b.score ?? 0) - (a.score ?? 0));
+    return all.slice(0, 50);
+  }
+  function render() {
+    resultsContainer.innerHTML = '';
+    if (results.length === 0 && input.value.length > 0) {
+      resultsContainer.innerHTML = '<div class="command-palette-empty">No results found</div>';
+      return;
+    }
+    results.forEach((r, i) => {
+      const row = document.createElement('a');
+      row.className = 'command-palette-result' + (i === selectedIdx ? ' selected' : '');
+      row.href = r.href || '#';
+      row.style.textDecoration = 'none';
+      row.style.color = 'inherit';
+      if (r.module) {
+        const modSpan = document.createElement('span');
+        modSpan.className = 'command-palette-module';
+        modSpan.textContent = r.module;
+        row.appendChild(modSpan);
+      }
+      const labelSpan = document.createElement('span');
+      labelSpan.className = 'command-palette-label';
+      labelSpan.textContent = r.label ?? '';
+      row.appendChild(labelSpan);
+      if (r.badge) {
+        const badgeSpan = document.createElement('span');
+        badgeSpan.className = 'command-palette-badge';
+        badgeSpan.textContent = r.badge;
+        row.appendChild(badgeSpan);
+      }
+      if (r.hint) {
+        const hintSpan = document.createElement('span');
+        hintSpan.className = 'command-palette-hint-right';
+        hintSpan.textContent = r.hint;
+        row.appendChild(hintSpan);
+      }
+      row.addEventListener('click', e => {
+        e.preventDefault();
+        close();
+        window.location.href = row.href;
+      });
+      resultsContainer.appendChild(row);
+      if (r.snippet) {
+        const snippet = document.createElement('div');
+        snippet.className = 'command-palette-snippet';
+        if (i === selectedIdx)
+          snippet.style.background = '#eef4ff';
+        if (typeof r.snippet === 'string') {
+          snippet.textContent = r.snippet;
+        } else if (r.snippet instanceof Node) {
+          snippet.appendChild(r.snippet);
         }
-        results.forEach((r, i) => {
-            const row = document.createElement('a');
-            row.className = 'command-palette-result' + (i === selectedIdx ? ' selected' : '');
-            row.href = r.href || '#';
-            row.style.textDecoration = 'none';
-            row.style.color = 'inherit';
-            if (r.module) {
-                const modSpan = document.createElement('span');
-                modSpan.className = 'command-palette-module';
-                modSpan.textContent = r.module;
-                row.appendChild(modSpan);
-            }
-            const labelSpan = document.createElement('span');
-            labelSpan.className = 'command-palette-label';
-            labelSpan.textContent = r.label ?? '';
-            row.appendChild(labelSpan);
-            if (r.badge) {
-                const badgeSpan = document.createElement('span');
-                badgeSpan.className = 'command-palette-badge';
-                badgeSpan.textContent = r.badge;
-                row.appendChild(badgeSpan);
-            }
-            if (r.hint) {
-                const hintSpan = document.createElement('span');
-                hintSpan.className = 'command-palette-hint-right';
-                hintSpan.textContent = r.hint;
-                row.appendChild(hintSpan);
-            }
-            row.addEventListener('click', e => {
-                e.preventDefault();
-                close();
-                window.location.href = row.href;
-            });
-            resultsContainer.appendChild(row);
-            if (r.snippet) {
-                const snippet = document.createElement('div');
-                snippet.className = 'command-palette-snippet';
-                if (i === selectedIdx)
-                    snippet.style.background = '#eef4ff';
-                if (typeof r.snippet === 'string') {
-                    snippet.textContent = r.snippet;
-                } else if (r.snippet instanceof Node) {
-                    snippet.appendChild(r.snippet);
-                }
-                snippet.addEventListener('click', e => {
-                    e.preventDefault();
-                    close();
-                    window.location.href = row.href;
-                });
-                resultsContainer.appendChild(snippet);
-            }
+        snippet.addEventListener('click', e => {
+          e.preventDefault();
+          close();
+          window.location.href = row.href;
         });
-    }
-    function open() {
-        overlay.hidden = false;
-        input.value = '';
-        results = [];
-        selectedIdx = 0;
-        render();
-        requestAnimationFrame(() => input.focus());
-    }
-    function close() {
-        overlay.hidden = true;
-        input.blur();
-    }
-    function navigateToSelected() {
-        if (results[selectedIdx]) {
-            const r = results[selectedIdx];
-            close();
-            window.location.href = r.href || '#';
-        }
-    }
-    input.addEventListener('input', () => {
-        results = search(input.value);
-        selectedIdx = 0;
-        render();
+        resultsContainer.appendChild(snippet);
+      }
     });
-    input.addEventListener('keydown', e => {
-        if (e.key === 'ArrowDown') {
-            e.preventDefault();
-            selectedIdx = Math.min(selectedIdx + 1, results.length - 1);
-            render();
-            const sel = resultsContainer.querySelector('.selected');
-            if (sel)
-                sel.scrollIntoView({ block: 'nearest' });
-        } else if (e.key === 'ArrowUp') {
-            e.preventDefault();
-            selectedIdx = Math.max(selectedIdx - 1, 0);
-            render();
-            const sel = resultsContainer.querySelector('.selected');
-            if (sel)
-                sel.scrollIntoView({ block: 'nearest' });
-        } else if (e.key === 'Enter') {
-            e.preventDefault();
-            navigateToSelected();
-        } else if (e.key === 'Escape') {
-            e.preventDefault();
-            close();
-        }
-    });
-    overlay.addEventListener('click', e => {
-        if (e.target === overlay)
-            close();
-    });
-    invalidation.then(() => overlay.remove());
-    overlay._openPalette = open;
-    overlay._closePalette = close;
-    overlay._isOpen = () => !overlay.hidden;
-    return overlay;
+  }
+  function open() {
+    overlay.hidden = false;
+    input.value = '';
+    results = [];
+    selectedIdx = 0;
+    render();
+    requestAnimationFrame(() => input.focus());
+  }
+  function close() {
+    overlay.hidden = true;
+    input.blur();
+  }
+  function navigateToSelected() {
+    if (results[selectedIdx]) {
+      const r = results[selectedIdx];
+      close();
+      window.location.href = r.href || '#';
+    }
+  }
+  input.addEventListener('input', () => {
+    results = search(input.value);
+    selectedIdx = 0;
+    render();
+  });
+  input.addEventListener('keydown', e => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      selectedIdx = Math.min(selectedIdx + 1, results.length - 1);
+      render();
+      const sel = resultsContainer.querySelector('.selected');
+      if (sel)
+        sel.scrollIntoView({ block: 'nearest' });
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      selectedIdx = Math.max(selectedIdx - 1, 0);
+      render();
+      const sel = resultsContainer.querySelector('.selected');
+      if (sel)
+        sel.scrollIntoView({ block: 'nearest' });
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      navigateToSelected();
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      close();
+    }
+  });
+  overlay.addEventListener('click', e => {
+    if (e.target === overlay)
+      close();
+  });
+  invalidation.then(() => overlay.remove());
+  overlay._openPalette = open;
+  overlay._closePalette = close;
+  overlay._isOpen = () => !overlay.hidden;
+  // Stable setter fed by command_provider_sync; re-searches live if the palette is open.
+  overlay._setProviders = arr => {
+    providers = arr || [];
+    if (!overlay.hidden) {
+      results = search(input.value);
+      selectedIdx = 0;
+      render();
+    }
+  };
+  return overlay;
 };
-const _mqy6k9 = function _commandPaletteKeybinding(cellSearchPlugin,moduleFinderPlugin,commandPaletteOverlay,invalidation)
+const _1vuj6tn = function _commandPaletteKeybinding(cellSearchPlugin,moduleFinderPlugin,command_provider_sync,commandPaletteOverlay,invalidation)
 {
   cellSearchPlugin;
   moduleFinderPlugin;
-  const handler = (e) => {
-    if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+  command_provider_sync;
+  const handler = e => {
+    if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
       e.preventDefault();
       e.stopPropagation();
       if (commandPaletteOverlay._isOpen()) {
@@ -4789,24 +8776,23 @@ const _mqy6k9 = function _commandPaletteKeybinding(cellSearchPlugin,moduleFinder
       }
     }
   };
-  document.addEventListener("keydown", handler, true);
-  invalidation.then(() =>
-    document.removeEventListener("keydown", handler, true)
-  );
+  document.addEventListener('keydown', handler, true);
+  invalidation.then(() => document.removeEventListener('keydown', handler, true));
   return null;
 };
-const _k261kj = function _cellSearchPlugin(searchIndex,linkTo,$0,invalidation)
+const _104tbig = function _cellSearchPlugin(searchIndex,linkTo,plugins,invalidation)
 {
-  const plugin = (query) => {
-    if (!query || query.length < 1) return [];
+  const plugin = query => {
+    if (!query || query.length < 1)
+      return [];
     const q = query.toLowerCase();
     const out = [];
     for (const entry of searchIndex) {
       let score = 0;
       let nameMatch = false;
       let sourceMatch = false;
-      const name = String(entry.name ?? "").toLowerCase();
-      const mod = String(entry.module ?? "").toLowerCase();
+      const name = String(entry.name ?? '').toLowerCase();
+      const mod = String(entry.module ?? '').toLowerCase();
       if (name.length && name.startsWith(q)) {
         score += 150;
         nameMatch = true;
@@ -4821,50 +8807,42 @@ const _k261kj = function _cellSearchPlugin(searchIndex,linkTo,$0,invalidation)
         score += 10;
         sourceMatch = true;
       }
-      if (score === 0) continue;
-      const nameStr = String(entry.name ?? "");
-      const modStr = String(entry.module ?? "");
-      const href = linkTo(nameStr ? modStr + "#" + nameStr : modStr);
+      if (score === 0)
+        continue;
+      const nameStr = String(entry.name ?? '');
+      const modStr = String(entry.module ?? '');
+      const href = linkTo(nameStr ? modStr + '#' + nameStr : modStr);
       let snippet = null;
       if (entry.source) {
         const src = String(entry.source);
         const idx = src.toLowerCase().indexOf(q);
         const frag = document.createDocumentFragment();
         if (idx >= 0) {
-          const start = Math.max(
-            0,
-            src.lastIndexOf("\n", Math.max(0, idx - 40)) + 1
-          );
-          const endNL = src.indexOf("\n", idx + query.length + 40);
-          const lineEnd =
-            endNL < 0 ? Math.min(src.length, idx + query.length + 80) : endNL;
+          const start = Math.max(0, src.lastIndexOf('\n', Math.max(0, idx - 40)) + 1);
+          const endNL = src.indexOf('\n', idx + query.length + 40);
+          const lineEnd = endNL < 0 ? Math.min(src.length, idx + query.length + 80) : endNL;
           const before = src.slice(start, idx);
           const match = src.slice(idx, idx + query.length);
           const after = src.slice(idx + query.length, lineEnd);
           if (start > 0)
-            frag.appendChild(document.createTextNode("\u2026" + before));
-          else frag.appendChild(document.createTextNode(before));
-          const mark = document.createElement("mark");
+            frag.appendChild(document.createTextNode('\u2026' + before));
+          else
+            frag.appendChild(document.createTextNode(before));
+          const mark = document.createElement('mark');
           mark.textContent = match;
           frag.appendChild(mark);
-          frag.appendChild(
-            document.createTextNode(
-              after + (lineEnd < src.length ? "\u2026" : "")
-            )
-          );
+          frag.appendChild(document.createTextNode(after + (lineEnd < src.length ? '\u2026' : '')));
         } else {
-          const firstLine = src.slice(0, src.indexOf("\n", 0));
-          frag.appendChild(
-            document.createTextNode((firstLine || src).slice(0, 120))
-          );
+          const firstLine = src.slice(0, src.indexOf('\n', 0));
+          frag.appendChild(document.createTextNode((firstLine || src).slice(0, 120)));
         }
         snippet = frag;
       }
       out.push({
-        label: nameStr || "(anonymous)",
+        label: nameStr || '(anonymous)',
         module: modStr,
-        badge: entry.type && entry.type !== "simple" ? entry.type : null,
-        hint: sourceMatch && !nameMatch ? "source" : null,
+        badge: entry.type && entry.type !== 'simple' ? entry.type : null,
+        hint: sourceMatch && !nameMatch ? 'source' : null,
         snippet,
         href,
         score
@@ -4872,37 +8850,69 @@ const _k261kj = function _cellSearchPlugin(searchIndex,linkTo,$0,invalidation)
     }
     return out;
   };
-  const unregister = $0.addCommand(plugin);
-  invalidation.then(unregister);
-  return "cell-search plugin registered";
+  plugins.add('lopecode_commands', plugin, { invalidation });
+  return 'cell-search plugin registered';
 };
-const _lq3msy = function _moduleFinderPlugin(modules,linkTo,$0,invalidation)
+const _1opf5e1 = function _moduleFinderPlugin(currentModules,linkTo,plugins,invalidation)
 {
-  const plugin = (query) => {
-    if (!query || query.length < 1) return [];
+  // Use the REACTIVE module set (module-map currentModules), not cell-map's one-shot `modules` snapshot,
+  // so modules created live (e.g. by robocoop-4) are immediately findable. This cell recomputes whenever
+  // currentModules changes; the old plugin is unregistered via invalidation before the new one registers.
+  const plugin = query => {
+    if (!query || query.length < 1)
+      return [];
     const q = query.toLowerCase();
     const out = [];
-    for (const [, info] of modules.entries()) {
-      const name = info?.name ?? "";
-      if (!name) continue;
+    for (const [, info] of currentModules.entries()) {
+      const name = info?.name ?? '';
+      if (!name)
+        continue;
       const lower = name.toLowerCase();
       let score = 0;
-      if (lower === q) score = 1000;
-      else if (lower.startsWith(q)) score = 800;
-      else if (lower.includes(q)) score = 600;
-      if (score === 0) continue;
+      if (lower === q)
+        score = 1000;
+      else if (lower.startsWith(q))
+        score = 800;
+      else if (lower.includes(q))
+        score = 600;
+      if (score === 0)
+        continue;
       out.push({
         label: name,
         href: linkTo(name),
-        hint: "open module",
+        hint: 'open module',
         score
       });
     }
     return out;
   };
-  const unregister = $0.addCommand(plugin);
-  invalidation.then(unregister);
-  return "module-finder plugin registered";
+  plugins.add('lopecode_commands', plugin, { invalidation });
+  return 'module-finder plugin registered';
+};
+const _1seh1ei = function _cp_menu_register(plugins,commandPaletteOverlay,invalidation)
+{
+  // Surface the palette in the lopepage-2 burger menu so it's discoverable without knowing the
+  // Cmd/Ctrl+K shortcut. Registers straight onto the shared plugin-registry "lp2-menu" set — no
+  // import of lopepage-2; a notebook opts in by adding both modules to its bootconf mains.
+  const isMac = /Mac|iP(hone|ad|od)/.test(navigator.platform || navigator.userAgent || '');
+  plugins.add('lp2-menu', {
+    id: 'command-palette',
+    order: 3,
+    label: 'Command palette  ' + (isMac ? '\u2318K' : 'Ctrl+K'),
+    svg: '<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.3"><circle cx="7" cy="7" r="4.2"/><path d="M10.2 10.2 14 14"/></svg>',
+    action: () => commandPaletteOverlay._openPalette()
+  }, { invalidation });
+  return 'registered: command-palette menu item';
+};
+const _7c6wp9 = function _commandProviders(plugins){return(
+plugins.get('lopecode_commands')
+)};
+const _13y9cxb = function _command_provider_sync(commandPaletteOverlay,commandProviders)
+{
+  // Push the current provider set (from the "lopecode_commands" bus) into the stable overlay,
+  // so the overlay is built once yet always searches the live set. Recomputes on every add/remove.
+  commandPaletteOverlay._setProviders(commandProviders);
+  return `command providers: ${ commandProviders.length }`;
 };
 
 export default function define(runtime, observer) {
@@ -4914,20 +8924,25 @@ export default function define(runtime, observer) {
   main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
   main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
   main.define("module @tomlarkworthy/themes", async () => runtime.module((await import("/@tomlarkworthy/themes.js?v=4")).default));  
-  $def("_13upker", null, ["md"], _13upker);  
-  $def("_1eng7wy", "viewof commands", ["Inputs","Event"], _1eng7wy);  
-  $def("_7bve6u", "commands", ["Generators","viewof commands"], _7bve6u);  
-  $def("_bpk8h7", "searchIndex", ["liveCellMap","modules"], _bpk8h7);  
-  $def("_1ptnr90", "commandPaletteStyles", ["theme_assets","htl"], _1ptnr90);  
-  $def("_fomuvm", "commandPaletteOverlay", ["viewof commands","Node","invalidation"], _fomuvm);  
-  $def("_mqy6k9", "commandPaletteKeybinding", ["cellSearchPlugin","moduleFinderPlugin","commandPaletteOverlay","invalidation"], _mqy6k9);  
-  $def("_k261kj", "cellSearchPlugin", ["searchIndex","linkTo","viewof commands","invalidation"], _k261kj);  
-  $def("_lq3msy", "moduleFinderPlugin", ["modules","linkTo","viewof commands","invalidation"], _lq3msy);  
+  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
+  main.define("module @tomlarkworthy/plugin-registry", async () => runtime.module((await import("/@tomlarkworthy/plugin-registry.js?v=4")).default));  
+  $def("_tku1if", null, ["md"], _tku1if);  
+  $def("_yavx6b", "searchIndex", ["liveCellMap","modules"], _yavx6b);  
+  $def("_rmjyys", "commandPaletteStyles", ["theme_assets","htl"], _rmjyys);  
+  $def("_1q8grv4", "commandPaletteOverlay", ["Node","invalidation"], _1q8grv4);  
+  $def("_1vuj6tn", "commandPaletteKeybinding", ["cellSearchPlugin","moduleFinderPlugin","command_provider_sync","commandPaletteOverlay","invalidation"], _1vuj6tn);  
+  $def("_104tbig", "cellSearchPlugin", ["searchIndex","linkTo","plugins","invalidation"], _104tbig);  
+  $def("_1opf5e1", "moduleFinderPlugin", ["currentModules","linkTo","plugins","invalidation"], _1opf5e1);  
   main.define("viewof liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("viewof liveCellMap", _));  
   main.define("liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("liveCellMap", _));  
   main.define("modules", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("modules", _));  
   main.define("linkTo", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("linkTo", _));  
-  main.define("theme_assets", ["module @tomlarkworthy/themes", "@variable"], (_, v) => v.import("theme_assets", _));
+  main.define("theme_assets", ["module @tomlarkworthy/themes", "@variable"], (_, v) => v.import("theme_assets", _));  
+  main.define("currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("currentModules", _));  
+  main.define("plugins", ["module @tomlarkworthy/plugin-registry", "@variable"], (_, v) => v.import("plugins", _));  
+  $def("_1seh1ei", "cp_menu_register", ["plugins","commandPaletteOverlay","invalidation"], _1seh1ei);  
+  $def("_7c6wp9", "commandProviders", ["plugins"], _7c6wp9);  
+  $def("_13y9cxb", "command_provider_sync", ["commandPaletteOverlay","commandProviders"], _13y9cxb);
   return main;
 }</script>
 <script id="@tomlarkworthy/dataflow-templating/dataflow_templating%401.svg" 
@@ -5421,2050 +9436,6 @@ export default function define(runtime, observer) {
   $def("_ngavq7", null, ["viewof example","html"], _ngavq7);
   return main;
 }</script>
-<script id="@tomlarkworthy/editor-5/cell_options.json" 
-  type="text/plain"
-  data-encoding="base64"
-  data-mime="application/json"
->
-e30K
-</script>
-<script id="@tomlarkworthy/editor-5" 
-  type="text/plain"
-  data-mime="application/javascript"
->
-const _1tdjp0a = function _title(md){return(
-md`# Editor: Reactive Userspace Cell Mutator (v5)
-
-[YouTube explainer](https://www.youtube.com/shorts/6FjeJRBC2iw)
-
-A cell that edits the source of other cells. It is implemented in userspace as a normal cell, so it follows exported notebooks, so exported notebooks become editable! It pairs particularly well with the [single file export](https://observablehq.com/@tomlarkworthy/exporter-3), because edits are also exported, so you can permanently save your works in a format that continues to be editable and exportable indefinitely. It works offline too!
-
-
-The editor is able to edit _any_ cell in the runtime, including those in dependancies. Import \`auto_attach\` and run that cell. You can also instanciate an editor component on any variable reference.
-
-\`\`\`js
-import {auto_attach, cellEditor} from '@tomlarkworthy/editor-5'
-\`\`\`
-
-
-#### Use cases
-- Edit notebooks offline
-- Try things out without committing to them
-- Improved debugging workflow, as you can insert \`debugger\` expressions to dependancies on-demand.
-`
-)};
-const _dm53bx = function _2(md){return(
-md`## Example`
-)};
-const _61oxjf = function _title_variable(lookupVariable,editorModule){return(
-lookupVariable("title", editorModule)
-)};
-const _15uilf0 = function _4(cellEditor,title_variable){return(
-cellEditor(title_variable, { pinned: true })
-)};
-const _wpcfq8 = function _5(md){return(
-md`## TODO
-- open new cell edtior
-- SyntaxErrors (see Runtime, they are cells)
-- Rename cell
-  - UI variable name does not update
-- Load cell from hash, will need the main module named properly in moduleMap
-- Import node support (maybe this is a different concern)`
-)};
-const _1ociws4 = function _6(md){return(
-md`## Sync editors`
-)};
-const _hdieof = function _editors(){return(
-new Map()
-)};
-const _ipx6cz = function _auto_attach(keepalive,editorModule,syncers,attachContextManu,divToVar,runtime,editors,cellEditor)
-{
-    keepalive(editorModule, 'editor_jobs');
-    syncers;
-    const placed = new Set();
-    if (attachContextManu) {
-        document.querySelectorAll('.observablehq').forEach(div => {
-            const variable = divToVar(runtime, div);
-            if (!variable)
-                return;
-            if (!editors.has(variable)) {
-                editors.set(variable, cellEditor(variable));
-            }
-            const editor = editors.get(variable);
-            const next = div.nextSibling;
-            if (next !== editor) {
-                const ae = document.activeElement;
-                const hadFocus = ae && editor.contains(ae);
-                let restore = null;
-                if (hadFocus) {
-                    const fe = ae;
-                    if (fe && (fe.tagName === 'INPUT' || fe.tagName === 'TEXTAREA') && 'selectionStart' in fe) {
-                        const start = fe.selectionStart, end = fe.selectionEnd;
-                        restore = () => {
-                            fe.focus({ preventScroll: true });
-                            fe.setSelectionRange(start, end);
-                        };
-                    } else {
-                        restore = () => fe?.focus?.({ preventScroll: true });
-                    }
-                }
-                div.after(editor);
-                restore?.();
-            }
-            placed.add(variable);
-        });
-    }
-    [...editors.entries()].forEach(([variable, editor]) => {
-        if (!placed.has(variable)) {
-            editor.dispose?.();
-            editor.remove();
-            editors.delete(variable);
-        }
-    });
-};
-const _1iwobxt = function _divToVar(){return(
-function divToVar(runtime, div) {
-  if (!div) return undefined;
-  if (div.variable) {
-    return div.variable;
-  } else {
-    return [...runtime._variables].find((v) => v._observer._node === div);
-  }
-}
-)};
-const _1usw8c2 = function _attachContextManu(Inputs,isOnObservableCom){return(
-Inputs.toggle({
-  label: "attach menu",
-  value: !isOnObservableCom()
-})
-)};
-const _1oaz8r1 = (G, _) => G.input(_);
-const _16ks4jz = function _12(md){return(
-md`## \`cellEditor\` component
-
-Using Dataflow templating to create reusable Hotbar Component builder`
-)};
-const _199ztvl = function _hotbarTemplate(lookupVariable,editorModule){return(
-lookupVariable(
-  [
-    ...[
-      "editedCell",
-      "edit",
-      "select",
-      "up",
-      "down",
-      "remove",
-      "apply",
-      "addCells",
-      "copy",
-      "paste"
-    ].flatMap((name) => ["viewof " + name, name]),
-    "code_editor",
-    "hotbar",
-    "code_editor_view",
-    "editor_manager",
-    "toolbar",
-    "selectVariable",
-    "compile_and_update",
-    "decompiled",
-    "editor_refresh_from_runtime"
-  ],
-  editorModule
-)
-)};
-const _1q95xt6 = function _cellEditor(cloneDataflow,editorTemplate,shellTemplate,getOption,Event,setOption,createCell,findCell,pinOnCreate){return(
-(variable, {
-    pinned = undefined
-} = {}) => {
-    const host = document.createElement('div');
-    let shellDispose = null;
-    let heavyDispose = null;
-    let editView = null;
-    let shellEl = null;
-    let body = null;
-    const clearBody = () => {
-        if (body)
-            body.replaceChildren();
-    };
-    const closeHeavy = () => {
-        if (heavyDispose) {
-            heavyDispose();
-            heavyDispose = null;
-        }
-        clearBody();
-    };
-    const openHeavy = () => {
-        if (heavyDispose)
-            return;
-        if (!body)
-            return;
-        heavyDispose = cloneDataflow(editorTemplate, name => {
-            if (name === 'editor_panel') {
-                return {
-                    fulfilled: element => {
-                        if (!element)
-                            return;
-                        if (!body)
-                            return;
-                        if (body.firstChild !== element || body.childNodes.length !== 1) {
-                            body.replaceChildren(element);
-                        }
-                    }
-                };
-            }
-            if (name === 'selectVariable') {
-                return {
-                    fulfilled: selectVariable => {
-                        if (typeof selectVariable !== 'function')
-                            return;
-                        selectVariable(variable);
-                    }
-                };
-            }
-            return {};
-        });
-    };
-    const syncOpen = () => {
-        const open = !!(editView && editView.value);
-        if (open)
-            openHeavy();
-        else
-            closeHeavy();
-        if (shellEl) {
-            const bodyEl = shellEl.querySelector('.cell-editor-body');
-            if (bodyEl)
-                bodyEl.style.display = open ? 'block' : 'none';
-        }
-    };
-    shellDispose = cloneDataflow(shellTemplate, name => {
-        if (name === 'hotbar_shell') {
-            return {
-                fulfilled: element => {
-                    if (!element)
-                        return;
-                    shellEl = element;
-                    host.replaceChildren(element);
-                    body = element.querySelector('.cell-editor-body');
-                    // Lightweight "add cell below" on the always-present shell,
-                    // so a cell can be inserted without opening the heavy editor.
-                    const hotbar = element.querySelector('.hotbar');
-                    if (hotbar && !hotbar.querySelector('.add-cell-btn')) {
-                        const add = document.createElement('span');
-                        add.className = 'add-cell-btn';
-                        add.textContent = '➕';
-                        add.title = 'Add cell below';
-                        add.style.cssText = 'cursor: pointer; margin-right: 6px;';
-                        add.tabIndex = -1;
-                        add.addEventListener('mousedown', e => e.preventDefault());
-                        add.addEventListener('click', e => {
-                            e.stopPropagation();
-                            createCell({ cell: findCell(variable) });
-                        });
-                        hotbar.prepend(add);
-                    }
-                    if (body)
-                        syncOpen();
-                }
-            };
-        }
-        if (name === 'selectVariable') {
-            return {
-                fulfilled: selectVariable => {
-                    if (typeof selectVariable !== 'function')
-                        return;
-                    selectVariable(variable);
-                }
-            };
-        }
-        if (name === 'viewof edit') {
-            return {
-                fulfilled: view => {
-                    if (!view)
-                        return;
-                    editView = view;
-                    const forceOpen = !!(variable?.pid && pinOnCreate.has(variable.pid));
-                    if (forceOpen)
-                        pinOnCreate.delete(variable.pid);
-                    const resolved_pinned = forceOpen || !!getOption(variable, 'pinned', pinned);
-                    view.value = resolved_pinned;
-                    view.dispatchEvent(new Event('input'));
-                    syncOpen();
-                    view.addEventListener('input', () => {
-                        const next = !!view.value;
-                        setOption(variable, 'pinned', next);
-                        syncOpen();
-                    });
-                }
-            };
-        }
-        return {};
-    });
-    host.dispose = () => {
-        closeHeavy();
-        if (shellDispose) {
-            shellDispose();
-            shellDispose = null;
-        }
-    };
-    return host;
-}
-)};
-const _x5ixji = function _hotbar_shell($0,Event,htl,edit)
-{
-  const toggle = () => {
-    $0.value = !$0.value;
-    $0.dispatchEvent(new Event("input"));
-  };
-
-  const el = htl.html`<div class="cell-editor"
-    style="display: flex;
-           flex-direction: column;
-           background: var(--theme-background-alt);">
-    <style>
-      .cell-editor .cm-editor {
-        height: fit-content;
-        background-color: var(--theme-background);
-      }
-      .cell-editor .hotbar {
-        margin-left: auto;
-        text-align: right;
-        font-family: var(--monospace);
-        font-size: 12px;
-        height: 17px;
-        outline: 1px solid var(--theme-background-alt);
-        user-select: none;
-      }
-    </style>
-
-    <div style="width:100%; cursor: pointer;" onclick=${toggle}>
-      <div class="hotbar">${edit ? "close" : "edit"}</div>
-    </div>
-
-    <div class="cell-editor-body" style="display: ${
-      edit ? "block" : "none"
-    };"></div>
-  </div>`;
-
-  el.addEventListener("click", (evt) => evt.stopPropagation());
-  return el;
-};
-const _1ed5zb9 = function _editor_panel($0,htl,toolbar,nav,reversibleAttach,combine,code_editor)
-{
-  const cell = $0.value;
-  return htl.html`<div style="display: flex; flex-direction: column;">
-    ${toolbar}
-    ${cell ? nav(cell) : null}
-    <div style="flex-grow: 1; padding-bottom: 1rem;">
-      ${reversibleAttach(combine, code_editor)}
-    </div>
-  </div>`;
-};
-const _yk7udl = function _shellTemplate($0,editedCell,selectVariable,$1,edit,hotbar_shell,lookupVariable,editorModule)
-{
-    // Force reactive deps on every looked-up variable so the cached lookup
-    // refreshes when any template cell is redefined. Without these, redefining
-    // e.g. `hotbar_shell` leaves clones holding stale variable handles.
-    [
-        $0,
-        editedCell,
-        selectVariable,
-        $1,
-        edit,
-        hotbar_shell
-    ];
-    return lookupVariable([
-        'editedCell',
-        'viewof editedCell',
-        'selectVariable',
-        'viewof edit',
-        'edit',
-        'hotbar_shell'
-    ], editorModule);
-};
-const _jot8he = function _editorTemplate($0,editedCell,selectVariable,$1,$2,$3,$4,$5,$6,$7,$8,toolbar,nav,cellLinks,variableLink,decompiled,code_editor_view,code_editor,editor_manager,editor_refresh_from_runtime,editor_panel,lookupVariable,editorModule)
-{
-    // Force reactive deps on every looked-up variable so the cached lookup
-    // refreshes when any template cell is redefined. Without these, redefining
-    // e.g. `viewof apply` leaves heavies cloning against stale variable handles.
-    [
-        $0,
-        editedCell,
-        selectVariable,
-        $1,
-        $2,
-        $3,
-        $4,
-        $5,
-        $6,
-        $7,
-        $8,
-        toolbar,
-        nav,
-        cellLinks,
-        variableLink,
-        decompiled,
-        code_editor_view,
-        code_editor,
-        editor_manager,
-        editor_refresh_from_runtime,
-        editor_panel
-    ];
-    return lookupVariable([
-        'editedCell',
-        'viewof editedCell',
-        'selectVariable',
-        'viewof select',
-        'viewof up',
-        'viewof down',
-        'viewof remove',
-        'viewof addCells',
-        'viewof apply',
-        'viewof copy',
-        'viewof paste',
-        'toolbar',
-        'nav',
-        'cellLinks',
-        'variableLink',
-        'decompiled',
-        'code_editor_view',
-        'code_editor',
-        'editor_manager',
-        'editor_refresh_from_runtime',
-        'editor_panel'
-    ], editorModule);
-};
-const _oshnzp = function _19(md){return(
-md`## Hotbar Prototype`
-)};
-const _1o2h65s = function _editedCell(Inputs){return(
-Inputs.input(null)
-)};
-const _7g3h7h = (G, _) => G.input(_);
-const _1urs1md = function _findCell($0,modules){return(
-(variable, dom = undefined) => {
-  if (variable) {
-    const cells = $0.value.get(variable._module) || [];
-    let cell = cells.find((cell) => cell.variables.includes(variable));
-    if (!cell) {
-      console.warn("Could not find cell for ", variable);
-      return;
-    }
-    cell = {
-      dom,
-      name: cell.name,
-      module: {
-        cells: cells,
-        ...modules.get(variable._module)
-      },
-      variables: cell.variables
-    };
-    return cell;
-  }
-}
-)};
-const _1uhm0y9 = function _selectVariable(findCell,_,$0,Event){return(
-async function selectVariable(variable, dom = undefined) {
-  console.log("selectVariable", variable);
-  let cell = findCell(variable, dom);
-  if (!_.isEqual($0.value, cell)) {
-    $0.value = cell;
-    $0.dispatchEvent(new Event("input"));
-  } else {
-    $0.value = cell;
-  }
-  return cell;
-}
-)};
-const _3jxaqk = function _23(selectVariable,hotbarTemplate)
-{
-return selectVariable(hotbarTemplate[5]);
-};
-const _49mpmh = function _hotbar($0,Event,setOption,$1,htl,edit,toolbar,nav,reversibleAttach,combine,code_editor)
-{
-  console.log("hotbar start");
-  const toggle = () => {
-    $0.value = !$0.value;
-    $0.dispatchEvent(new Event("input"));
-    setOption(
-      $1.value.variables[0],
-      "pinned",
-      $0.value
-    );
-  };
-
-  const combined = htl.html`<div class="cell-editor" 
-    style="display: flex;
-           flex-direction: column;
-           background: var(--theme-background-alt);">
-  <style>
-    .picked {
-      outline: 1px dashed #999;
-    }
-    .cm-editor {
-      height: fit-content;
-      background-color: var(--theme-background);
-    }
-    .hotbar {
-      margin-left: auto;
-      text-align: right;
-      font-family: var(--monospace);
-      font-size: 12px;
-      height: 17px;
-      outline: 1px solid var(--theme-background-alt);
-    }
-  </style>
-  <div style="width:100%; cursor: pointer;" onclick=${toggle}>
-    <div class="hotbar">
-      ${edit ? "close" : "edit"}
-    </div>
-  </div>
-  <div style="display: ${edit ? "block" : "none"};">
-    ${toolbar}
-    ${nav($1.value)}
-    <div style="flex-grow: 1; padding-bottom: 1rem;">
-      ${reversibleAttach(combine, code_editor)}
-    </div>
-  </div>
-    
-</div>`;
-
-  combined.addEventListener("mouseup", (event) => {});
-  combined.addEventListener("click", (evt) => {
-    evt.stopPropagation();
-  });
-  console.log("hotbar stop");
-  return combined;
-};
-const _n8s6yl = function _25($0){return(
-$0.value
-)};
-const _ytd2rq = function _26(nav,editedCell){return(
-nav(editedCell)
-)};
-const _1t4gep6 = function _nav(html,cellLinks){return(
-function nav(editedCell) {
-  const outputs = [...editedCell.variables[0]._outputs];
-  const inputs = editedCell.variables[0]._inputs;
-  return html`<div>
-<span>${cellLinks("inputs", inputs)}</span>
-<span>${cellLinks("outputs", outputs)}</span>
-</div>`;
-}
-)};
-const _1tv9qxo = function _cellLinks(html,variableLink){return(
-function cellLinks(label, variables) {
-  if (variables.length == 0) return [];
-  return html`${label}: ${variables.map(
-    (v, index) =>
-      html`${index > 0 ? ", " : ""}<a href="${variableLink(v)}">${
-        v._name || "anon"
-      }</a>`
-  )} `;
-}
-)};
-const _1opggh8 = async function _identity(lookupVariable,editorModule){return(
-(await lookupVariable("lookupVariable", editorModule))._definition
-)};
-const _1nfia2p = function _variableLink(identity,navHref,modules)
-{
-    return v => {
-        if (v._type === 2 && v._inputs.length == 1) {
-            // Implicit variable created on reference, go up one
-            v = v._inputs[0];
-        }
-        // Follow import chain to the defining module
-        const idStr = identity?.toString();
-        if (idStr) {
-            while (v._inputs?.length === 1 && v._definition?.toString() === idStr) {
-                v = v._inputs[0];
-            }
-        }
-        return navHref(`${ modules.get(v._module).name }${ typeof v._name == 'string' ? `#${ v._name }` : '' }`);
-    };
-};
-const _1tm2n0w = function _31(md){return(
-md`Save edits by exporting to a single file`
-)};
-const _16wblye = function _32(md){return(
-md`### Known Issues
-- If you create a new cell, it is invisible, it will appear after exporting.`
-)};
-const _1jdvxd9 = function _33(md){return(
-md`### Editor UI Components`
-)};
-const _1j1loxx = function _combine(Inputs){return(
-Inputs.toggle({
-  label: "untick to destructure",
-  value: true
-})
-)};
-const _1h8337z = (G, _) => G.input(_);
-const _tct2nf = function _edit(Inputs){return(
-Inputs.toggle({ label: "edit" })
-)};
-const _7izj7k = (G, _) => G.input(_);
-const _1fwb5jc = function _toolbar(htl,reversibleAttach,combine,$0,$1,$2,$3,$4,$5,$6,$7){return(
-htl.html`<div
-    class="toolbar"
-    style="display: flex; gap: 4px;"
->
-    <style>
-      .toolbar form { width: auto; }
-      .toolbar label { user-select: none; }
-    </style>
-    ${reversibleAttach(combine, $0)}
-    ${reversibleAttach(combine, $1)}
-    ${reversibleAttach(combine, $2)}
-    ${reversibleAttach(combine, $3)}
-    ${reversibleAttach(combine, $4)}
-    ${reversibleAttach(combine, $5)}
-    ${reversibleAttach(combine, $6)}
-    ${reversibleAttach(combine, $7)}
-    <span style="flex-grow: 1;"></span>
-</div>`
-)};
-const _yej3hb = function _addCells(Inputs,createCell,$0){return(
-Inputs.button("➕", {
-  reduce: async () => {
-    await createCell({ cell: $0.value });
-  }
-})
-)};
-const _1aii9ps = (G, _) => G.input(_);
-const _1bn860e = function _remove(Inputs,deleteCell,$0){return(
-Inputs.button("🗑️", {
-  reduce: () => deleteCell({ cell: $0.value })
-})
-)};
-const _1ad0xr8 = (G, _) => G.input(_);
-const _lwb7d7 = function _apply(Inputs,compile_and_update,code_editor_view,editedCell,replaceCodeMirrorDoc)
-{
-    const button = Inputs.button('\u25B6️', {
-        reduce: async () => {
-            // #166: Read source directly from the live CodeMirror view rather than from
-            // `states.get(editedCell.variables[0])`. After a kind-changing recompile
-            // (regular -> import, etc.), `editedCell.variables[0]` is a freshly-defined
-            // variable that the `cellIdFacet` map was never keyed by, so a `states.get`
-            // lookup returns undefined and `.doc.toString()` throws.
-            // After compile, push the decompiled (canonical) source back into
-            // the editor so the user sees what the runtime actually has.
-            const canonical = await compile_and_update(code_editor_view.state.doc.toString(), editedCell.variables, editedCell);
-            if (typeof canonical === 'string') {
-                replaceCodeMirrorDoc(code_editor_view, canonical, { preserveCursor: true });
-            }
-        }
-    });
-    // supress gaining focus
-    // doesn't work on observable iframe
-    // https://issues.chromium.org/issues/40654608
-    button.tabIndex = '-1';
-    button.onmousedown = e => e.preventDefault();
-    return button;
-};
-const _1cjyuqm = (G, _) => G.input(_);
-const _14rfku9 = function _up(Inputs,moveCell,$0){return(
-Inputs.button("⬆", {
-  reduce: () => moveCell($0.value, -1)
-})
-)};
-const _frzs5d = (G, _) => G.input(_);
-const _9pymuj = function _paste(Inputs,readObservableClipboardCells,pasteObservableCellsIntoModule,editedCell){return(
-Inputs.button("📋", {
-  reduce: async () => {
-    const cells = await readObservableClipboardCells();
-    return pasteObservableCellsIntoModule({ cells, editedCell });
-  }
-})
-)};
-const _1whsszt = (G, _) => G.input(_);
-const _corxwl = function _down(Inputs,moveCell,$0){return(
-Inputs.button("⬇", {
-  reduce: () => moveCell($0.value, 1)
-})
-)};
-const _1to28po = (G, _) => G.input(_);
-const _gia2ci = function _copy(Inputs,html,$0,decompile,$1,getOption,cellsToClipboard){return(
-Inputs.button(
-  html`<span style="font-size: .875em; margin-right: .125em; position: relative; top: -.25em; left: -.125em">
-  📄<span style="position: absolute; top: .25em; left: .25em">📄</span>
-</span>`,
-  {
-    reduce: async () => {
-      const current = $0.value;
-      if (!current?.variables?.length) return;
-
-      const seen = new Set();
-      const cells = [];
-
-      const add = async (variables) => {
-        const key = variables?.[0];
-        if (!key || seen.has(key)) return;
-        seen.add(key);
-        cells.push(await decompile(variables));
-      };
-
-      await add(current.variables);
-
-      const live = $1.value;
-      if (live?.entries) {
-        for (const [, moduleCells] of live.entries()) {
-          for (const c of moduleCells || []) {
-            const v0 = c?.variables?.[0];
-            if (!v0) continue;
-            if (v0 === current.variables[0]) continue;
-            if (getOption(v0, "selected", false)) {
-              await add(c.variables);
-            }
-          }
-        }
-      }
-
-      await cellsToClipboard(cells);
-    }
-  }
-)
-)};
-const _fw41wt = (G, _) => G.input(_);
-const _srtw8o = function _module(editedCell){return(
-editedCell.module.module
-)};
-const _rv7t7x = function _code_editor_view(EditorView)
-{
-  console.log("code_editor_view");
-  return new EditorView();
-};
-const _xvo1n6 = function _code_editor(code_editor_view)
-{
-  console.log("code_editor");
-  code_editor_view.dom.addEventListener("click", (evt) => {
-    evt.stopPropagation();
-  });
-  return code_editor_view.dom;
-};
-const _1imarq2 = function _47(md){return(
-md`## API`
-)};
-const _470wv4 = function _moveCell($0){return(
-async (cell, amount) =>
-  $0.send({
-    command: "moveCell",
-    args: {
-      cell,
-      amount
-    }
-  })
-)};
-const _pinoncr = function _pinOnCreate(){return(
-new Set()  // variable pids to open (pin) their editor as soon as the cell mounts
-)};
-const _19znal9 = function _createCell($0){return(
-async ({cell, source = "{}" } = {}) =>
-  $0.send({
-    command: "createCell",
-    args: {
-      source,
-      cell
-    }
-  })
-)};
-const _d9nzys = function _deleteCell($0){return(
-async ({cell}) =>
-  $0.send({
-    command: "deleteCell",
-    args: {
-      cell
-    }
-  })
-)};
-const _1toku21 = function _51(md){return(
-md`## API handler`
-)};
-const _d7ouqx = function _command(flowQueue){return(
-flowQueue()
-)};
-const _118qt2v = (G, _) => G.input(_);
-const _c4420j = function _53(command){return(
-command
-)};
-const _1f6v167 = function _findCellByVariable(){return(
-(v, cells) =>
-  [...cells.entries()].find((vars) => vars.includes(v))
-)};
-const _dmk8lv = function _findCellIndex(){return(
-(variables, cells) => {
-  let index = 0;
-  for (let cellCandidate of cells.values()) {
-    if (cellCandidate.variables[0] === variables[0]) {
-      return index;
-    } else {
-      index++;
-    }
-  }
-}
-)};
-const _jy01vb = function _lookupCellByIndex(){return(
-(index, cells) => {
-  let current = 0;
-  for (let cellCandidate of cells.values()) {
-    if (current === index) {
-      return cellCandidate;
-    } else {
-      current++;
-    }
-  }
-}
-)};
-const _1rhoxk2 = function _findVariableIndex(runtime){return(
-(variable, variables = runtime._variables) =>
-  [...variables].findIndex((vi) => vi === variable)
-)};
-const _2pkmxz = async function _command_processor(command,$0,compile_and_update,remove_variables,$1,findCellIndex,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2,pinOnCreate)
-{
-    if (command.processed)
-        return;
-    let result = undefined;
-    if (command.command == 'createCell') {
-        $0.value = true;
-        // Mark the new variable's pid (identity-stable, no cell-map lookup) so its
-        // cellEditor opens pinned as soon as auto_attach mounts the shell. Keyed by
-        // pid because findCell() lags one reactive tick behind creation here.
-        const newVars = [];
-        result = await compile_and_update('{}', newVars, command.args.cell);
-        const nv = newVars[0];
-        if (nv?.pid) pinOnCreate.add(nv.pid);
-        if (nv) await selectVariable(nv);
-    } else if (command.command == 'deleteCell') {
-        remove_variables(command.args.cell.variables);
-        result = true;
-    } else if (command.command == 'moveCell') {
-        const cellList = $1.value.get(command.args.cell.module.module);
-        const cellIndex = findCellIndex(command.args.cell.variables, cellList);
-        const targetCellIndex = cellIndex + command.args.amount;
-        const targetCell = lookupCellByIndex(targetCellIndex, cellList);
-        if (targetCell) {
-            const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
-            const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-            const change = targetFirstVariableIndex - currentFirstVariableIndex;
-            const dom = command.args.cell.dom;
-            const preY = dom?.getBoundingClientRect?.().top;
-            command.args.cell.variables.forEach(v => {
-                const currentIndex = findVariableIndex(v);
-                repositionSetElement(runtime._variables, v, currentIndex + change);
-            });
-            await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
-            // Keep moved cell at same screen position so neighbours shift around it.
-            // Cells here have wildly varying heights (some embed 500+ px iframes), so
-            // a one-position move can otherwise jump hundreds of pixels (#163). Poll
-            // for syncers' reactive DOM reorder before measuring postY — the chain
-            // runs on macrotasks, so requestAnimationFrame is not sufficient.
-            if (preY != null && dom?.isConnected) {
-                let postY = preY;
-                for (let i = 0; i < 30 && postY === preY; i++) {
-                    await new Promise(r => setTimeout(r, 50));
-                    if (!dom.isConnected)
-                        break;
-                    postY = dom.getBoundingClientRect().top;
-                }
-                const delta = postY - preY;
-                if (delta !== 0) {
-                    const scroller = dom.closest('.lm_content') || document.scrollingElement;
-                    scroller?.scrollBy?.({
-                        top: delta,
-                        behavior: 'instant'
-                    });
-                }
-            }
-        }
-        result = true;
-    }
-    if (result) {
-        command.processed = true;
-        $2.resolve(result);
-    }
-};
-const _8iz5z2 = function _59(md){return(
-md`### UI Action`
-)};
-const _m873d1 = function _states(){return(
-new Map()
-)};
-const _mxwoc4 = function _cellIdFacet(codemirror){return(
-codemirror.Facet.define({ combine: (v) => v[0] })
-)};
-const _y7997q = function _62(md){return(
-md`## LSP Integration
-
-Observable JS lezer parser, runtime-aware autocomplete, parse-error squiggles. Plumbed into the cell editor below.`
-)};
-const _7btuqg = function _observableJS_language(codemirror,observable_lezer_parser){return(
-codemirror.LRLanguage.define({
-    name: 'observable-javascript',
-    parser: observable_lezer_parser.configure({
-        props: [
-            codemirror.indentNodeProp.add({
-                Block: codemirror.delimitedIndent({ closing: '}' }),
-                ArrowFunction: codemirror.continuedIndent({ except: /^\s*({|case|default)/ })
-            }),
-            codemirror.foldNodeProp.add({ 'Block ObjectExpression ArrayExpression': codemirror.foldInside })
-        ]
-    }),
-    languageData: {
-        commentTokens: {
-            line: '//',
-            block: {
-                open: '/*',
-                close: '*/'
-            }
-        },
-        indentOnInput: /^\s*[)\]}]$/,
-        closeBrackets: {
-            brackets: [
-                '(',
-                '[',
-                '{',
-                '\'',
-                '"',
-                '`'
-            ]
-        },
-        wordChars: '$_'
-    }
-})
-)};
-const _1xf04v5 = function _observableJS_highlightStyle(codemirror,lezerhighlight){return(
-codemirror.HighlightStyle.define([
-    {
-        tag: lezerhighlight.tags.keyword,
-        color: 'var(--syntax-keyword)'
-    },
-    {
-        tag: [
-            lezerhighlight.tags.bool,
-            lezerhighlight.tags.null,
-            lezerhighlight.tags.atom
-        ],
-        color: 'var(--syntax-atom)'
-    },
-    {
-        tag: lezerhighlight.tags.string,
-        color: 'var(--syntax-string)'
-    },
-    {
-        tag: [
-            lezerhighlight.tags.number,
-            lezerhighlight.tags.regexp
-        ],
-        color: 'var(--syntax-literal)'
-    },
-    {
-        tag: lezerhighlight.tags.comment,
-        color: 'var(--syntax-comment)',
-        fontStyle: 'italic'
-    },
-    {
-        tag: lezerhighlight.tags.function(lezerhighlight.tags.variableName),
-        color: 'var(--syntax-definition)'
-    },
-    {
-        tag: lezerhighlight.tags.definition(lezerhighlight.tags.variableName),
-        color: 'var(--syntax-definition)'
-    },
-    {
-        tag: lezerhighlight.tags.variableName,
-        color: 'var(--syntax-variable)'
-    },
-    {
-        tag: lezerhighlight.tags.propertyName,
-        color: 'var(--syntax-variable)'
-    },
-    {
-        tag: lezerhighlight.tags.operator,
-        color: 'var(--syntax-keyword)'
-    }
-])
-)};
-const _19d9pua = function _observableJS_lint(codemirror){return(
-[
-    codemirror.lintGutter(),
-    codemirror.linter(view => {
-        const {state} = view;
-        const tree = codemirror.syntaxTree(state);
-        const seen = new Set();
-        const diagnostics = [];
-        tree.iterate({
-            enter: ({type, from, to}) => {
-                if (!type.isError)
-                    return;
-                const end = to > from ? to : Math.min(from + 1, state.doc.length);
-                const key = from + ':' + end;
-                if (seen.has(key))
-                    return;
-                seen.add(key);
-                diagnostics.push({
-                    from,
-                    to: end,
-                    severity: 'error',
-                    message: 'Syntax error'
-                });
-            }
-        });
-        return diagnostics;
-    }, { delay: 250 }),
-    codemirror.keymap.of(codemirror.lintKeymap ?? []),
-    codemirror.EditorView.baseTheme({
-        '.cm-lintRange': {
-            textDecorationThickness: '2px',
-            textUnderlineOffset: '3px'
-        },
-        '.cm-lintRange.cm-lintRange-error': { textDecoration: 'underline wavy #e11' },
-        '.cm-tooltip.cm-tooltip-lint': { fontSize: '12px' }
-    })
-]
-)};
-const _125gzhe = function _editor_manager(editedCell,globalThis,codemirror,literalCompletions,EditorState,decompiled,cellIdFacet,EditorView,states,compile_and_update,code_editor_view,replaceCodeMirrorDoc,observableJS_language,observableJS_highlightStyle,myDefaultTheme)
-{
-  if (!editedCell?.variables?.length)
-    return;
-  const variable = editedCell.variables[0];
-  const key = variable;
-  const mod = variable && variable._module;
-  const builtin = mod?._runtime?._builtin?._scope;
-  const isInternal = n => n.startsWith('module @') || n.startsWith('@variable') || n.startsWith('__ojs_');
-  const isPrivate = n => n.startsWith('_') || /^(webkit|moz|ms)[A-Z]/.test(n);
-  const valueOf = v => {
-    try {
-      return v?._value;
-    } catch {
-      return undefined;
-    }
-  };
-  const lookup = n => {
-    if (mod?._scope?.has(n))
-      return valueOf(mod._scope.get(n));
-    if (builtin?.has(n))
-      return valueOf(builtin.get(n));
-    try {
-      return globalThis[n];
-    } catch {
-      return undefined;
-    }
-  };
-  const allNames = () => {
-    const out = new Set();
-    for (const n of mod?._scope?.keys() ?? [])
-      if (!isInternal(n))
-        out.add(n);
-    for (const n of builtin?.keys() ?? [])
-      if (!isInternal(n))
-        out.add(n);
-    for (const n of Object.getOwnPropertyNames(globalThis))
-      if (!isPrivate(n))
-        out.add(n);
-    return out;
-  };
-  const isNoise = n => n.startsWith('_') || [
-    'prototype',
-    'constructor',
-    'caller',
-    'callee',
-    'arguments',
-    'name',
-    'length'
-  ].includes(n);
-  const stopAt = new Set([
-    Object.prototype,
-    Function.prototype
-  ]);
-  const propsOf = obj => {
-    const out = [];
-    const seen = new Set();
-    for (let o = Object(obj), d = 0; o && d < 4; o = Object.getPrototypeOf(o), d++) {
-      if (d > 0 && stopAt.has(o))
-        break;
-      for (const n of Object.getOwnPropertyNames(o)) {
-        if (seen.has(n) || isNoise(n))
-          continue;
-        seen.add(n);
-        const desc = Object.getOwnPropertyDescriptor(o, n);
-        out.push({
-          label: n,
-          type: typeof desc?.value === 'function' ? 'function' : 'property'
-        });
-      }
-    }
-    return out;
-  };
-  const classify = v => {
-    if (typeof v === 'function')
-      return /^\s*class\b/.test(Function.prototype.toString.call(v)) ? 'class' : 'function';
-    return v === null ? 'null' : typeof v === 'object' ? 'variable' : typeof v;
-  };
-  const completionSource = cx => {
-    for (let n = codemirror.syntaxTree(cx.state).resolve(cx.pos, -1); n; n = n.parent) {
-      if (/String|Template|Comment/.test(n.name))
-        return null;
-    }
-    // Member access on a non-identifier literal base ("".|, [].|, (5).|) — shared with the test_* cells.
-    const lit = literalCompletions(cx.state, cx.pos);
-    if (lit)
-      return lit;
-    const before = cx.state.sliceDoc(cx.state.doc.lineAt(cx.pos).from, cx.pos);
-    const m = before.match(/([A-Za-z_$][\w$]*(?:\.[A-Za-z_$\d]*)*)$/);
-    if (!m)
-      return null;
-    const chain = m[1].split('.');
-    const prefix = chain[chain.length - 1] ?? '';
-    const from = cx.pos - prefix.length;
-    if (!cx.explicit && prefix.length === 0 && chain.length === 1)
-      return null;
-    let options;
-    if (chain.length > 1) {
-      let base = lookup(chain[0]);
-      for (let i = 1; i < chain.length - 1; i++) {
-        try {
-          base = base?.[chain[i]];
-        } catch {
-          return null;
-        }
-        if (base == null)
-          return null;
-      }
-      if (base == null)
-        return null;
-      options = propsOf(base).filter(o => o.label.startsWith(prefix));
-    } else {
-      options = [];
-      for (const n of allNames()) {
-        if (!n.startsWith(prefix) || isNoise(n))
-          continue;
-        options.push({
-          label: n,
-          type: classify(lookup(n))
-        });
-      }
-    }
-    options.sort((a, b) => a.label.localeCompare(b.label));
-    return options.length ? {
-      from,
-      to: cx.pos,
-      options
-    } : null;
-  };
-  const lintSource = view => {
-    const seen = new Set();
-    const diags = [];
-    codemirror.syntaxTree(view.state).iterate({
-      enter: ({type, from, to}) => {
-        if (!type.isError)
-          return;
-        const end = to > from ? to : Math.min(from + 1, view.state.doc.length);
-        const k = from + ':' + end;
-        if (seen.has(k))
-          return;
-        seen.add(k);
-        diags.push({
-          from,
-          to: end,
-          severity: 'error',
-          message: 'Syntax error'
-        });
-      }
-    });
-    return diags;
-  };
-  const state = EditorState.create({
-    doc: decompiled,
-    extensions: [
-      cellIdFacet.of(key),
-      EditorView.updateListener.of(u => states.set(u.state.facet(cellIdFacet), u.state)),
-      codemirror.keymap.of([
-        codemirror.indentWithTab,
-        {
-          key: 'Shift-Enter',
-          run: () => {
-            // Mirror viewof apply: push the canonical decompiled
-            // source back into CodeMirror after compile.
-            (async () => {
-              const canonical = await compile_and_update(code_editor_view.state.doc.toString(), editedCell.variables, editedCell);
-              if (typeof canonical === 'string') {
-                replaceCodeMirrorDoc(code_editor_view, canonical, { preserveCursor: true });
-              }
-            })();
-            return true;
-          }
-        }
-      ]),
-      codemirror.EditorView.lineWrapping,
-      observableJS_language,
-      codemirror.syntaxHighlighting(observableJS_highlightStyle),
-      codemirror.autocompletion({
-        override: [
-          codemirror.localCompletionSource,
-          completionSource
-        ]
-      }),
-      codemirror.lintGutter(),
-      codemirror.linter(lintSource, { delay: 250 }),
-      codemirror.EditorView.baseTheme({
-        '.cm-lintRange.cm-lintRange-error': {
-          textDecoration: 'underline wavy #e11',
-          textUnderlineOffset: '3px'
-        }
-      }),
-      codemirror.basicSetup,
-      myDefaultTheme
-    ]
-  });
-  code_editor_view.setState(state);
-  states.set(key, state);
-};
-const _65mlp5 = function _divToCell(){return(
-(entries, div) => {
-  if (!div) return undefined;
-  if (div.variable) {
-    return (
-      entries.find(
-        ([name, cell]) => cell[0] && cell.find((v) => v == div.variable)
-      ) || div.variable
-    );
-  } else {
-    return entries.find(
-      ([name, cell]) => cell[0] && cell[0]._observer._node === div
-    );
-  }
-}
-)};
-const _bt6o0p = function _68(md){return(
-md`## Reacting to runtime changes
-
-Other editors might change the definition underfoot, so we need to reload the code mirror state`
-)};
-const _jh2ad1 = function _editor_refresh_from_runtime(editedCell,decompile,code_editor_view,replaceCodeMirrorDoc,queueMicrotask,onCodeChange,invalidation)
-{
-  const lastSyncedByKey = this?.lastSyncedByKey ?? new WeakMap();
-  const staleByKey = this?.staleByKey ?? new WeakMap();
-  let scheduled = false;
-
-  const getKey = () => editedCell?.variables?.[0] ?? null;
-
-  const syncNow = async ({ force = false } = {}) => {
-    const cell = editedCell;
-    if (!cell?.variables?.length) return false;
-
-    const key = getKey();
-    if (!key) return false;
-
-    const runtimeSource = await decompile(cell.variables);
-    const editorSource = code_editor_view?.state?.doc?.toString?.() ?? "";
-
-    if (runtimeSource === editorSource) {
-      lastSyncedByKey.set(key, runtimeSource);
-      staleByKey.set(key, false);
-      return false;
-    }
-
-    const last = lastSyncedByKey.get(key);
-    const isDirty = typeof last === "string" && editorSource !== last;
-
-    if (!force && isDirty) {
-      staleByKey.set(key, true);
-      return false;
-    }
-
-    const changed = replaceCodeMirrorDoc(code_editor_view, runtimeSource, {
-      preserveCursor: true
-    });
-    if (changed) {
-      lastSyncedByKey.set(key, runtimeSource);
-      staleByKey.set(key, false);
-    }
-    return changed;
-  };
-
-  const scheduleSync = ({ force = false } = {}) => {
-    if (scheduled) return;
-    scheduled = true;
-    queueMicrotask(async () => {
-      scheduled = false;
-      try {
-        await syncNow({ force });
-      } catch {}
-    });
-  };
-
-  const unsubscribe = onCodeChange(({ variable }) => {
-    const cell = editedCell;
-    if (!cell?.variables?.length) return;
-    if (!variable) return;
-    if (!cell.variables.includes(variable)) return;
-    scheduleSync({ force: false });
-  });
-
-  scheduleSync({ force: true });
-  invalidation.then(() => unsubscribe());
-
-  return {
-    lastSyncedByKey,
-    staleByKey,
-    syncNow,
-    scheduleSync,
-    get stale() {
-      const k = getKey();
-      return k ? !!staleByKey.get(k) : false;
-    }
-  };
-};
-const _dvne2z = function _replaceCodeMirrorDoc(){return(
-(view, nextText, {preserveCursor = true} = {}) => {
-  if (!view?.state) return false;
-  const prev = view.state.doc.toString();
-  const next = String(nextText ?? "");
-  if (prev === next) return false;
-
-  const head = view.state.selection?.main?.head ?? 0;
-  const anchor = view.state.selection?.main?.anchor ?? head;
-  const nextPos = (p) => Math.max(0, Math.min(p, next.length));
-
-  view.dispatch({
-    changes: {from: 0, to: view.state.doc.length, insert: next},
-    ...(preserveCursor
-      ? {selection: {anchor: nextPos(anchor), head: nextPos(head)}}
-      : null)
-  });
-
-  return true;
-}
-)};
-const _cbcryi = function _71(md){return(
-md`### Selection`
-)};
-const _rtf009 = function _select(editedCell,Inputs,getOption,setOption){return(
-(() => {
-  const v0 = editedCell?.variables?.[0] ?? null;
-  const el = Inputs.toggle({
-    value: v0 ? getOption(v0, "selected", false) : false
-  });
-
-  el.style.margin = "0";
-
-  el.addEventListener("input", () => {
-    const v = editedCell?.variables?.[0] ?? null;
-    if (!v) return;
-    setOption(v, "selected", el.value);
-  });
-
-  return el;
-})()
-)};
-const _14mwbuc = (G, _) => G.input(_);
-const _d2lrrw = function _73(md){return(
-md`## Pinning`
-)};
-const _ucf24e = function _74(FileAttachment){return(
-FileAttachment("cell_options.json")
-)};
-const _kygz54 = function _optionsFile(getFileAttachment,editorModule){return(
-getFileAttachment("cell_options.json", editorModule)
-)};
-const _760ozq = async function _options(Inputs,optionsFile){return(
-Inputs.input(await optionsFile.json())
-)};
-const _4rh26k = (G, _) => G.input(_);
-const _1lqy7cs = function _setOption(findCell,_,$0,Event){return(
-(variable, option, value) => {
-  const cell = findCell(variable);
-  _.set(
-    $0.value,
-    `${cell.module.name}.${cell.name}.${option}`,
-    value
-  );
-  $0.dispatchEvent(new Event("input"));
-}
-)};
-const _1oxe5ee = function _getOption(findCell,_,$0){return(
-(variable, option, defaultValue) => {
-  const cell = findCell(variable);
-  return (
-    _.get($0.value, `${cell.module.name}.${cell.name}.${option}`) ||
-    defaultValue
-  );
-}
-)};
-const _kwq69p = function _save_options(setFileAttachment,jsonFileAttachment,options,editorModule){return(
-setFileAttachment(
-  jsonFileAttachment("cell_options.json", options),
-  editorModule
-)
-)};
-const _1ag9ajn = function _80(md){return(
-md`## Pasting`
-)};
-const _dbvt0t = function _escapeTemplateLiteral(){return(
-(s = "") =>
-  String(s)
-    .replace(/\\/g, "\\\\")
-    .replace(/`/g, "\\`")
-)};
-const _1q2xn50 = function _inferCellGroupNameFromOJS(parser){return(
-(source) => {
-  let cell;
-  try {
-    cell = parser.parseCell(String(source ?? ""));
-  } catch {
-    return null;
-  }
-  if (!cell) return null;
-
-  if (cell.id) {
-    if (cell.id.type === "Identifier") return cell.id.name;
-    if (cell.id.type === "ViewExpression") return `viewof ${cell.id.id.name}`;
-    if (cell.id.type === "MutableExpression") return `mutable ${cell.id.id.name}`;
-  }
-
-  if (cell.body?.type === "ImportDeclaration") {
-    const mod = cell.body.source?.value;
-    if (typeof mod === "string" && mod.length) return `module ${mod}`;
-  }
-
-  return null;
-}
-)};
-const _1mfm13h = function _normalizeObservableClipboardCell(inferCellGroupNameFromOJS,escapeTemplateLiteral){return(
-(cell) => {
-  const mode = cell?.mode ?? "js";
-  const value = String(cell?.value ?? "");
-  const explicitName = typeof cell?.name === "string" && cell.name.length ? cell.name : null;
-
-  if (mode === "js") {
-    const name = inferCellGroupNameFromOJS(value) ?? explicitName;
-    return { mode, name, source: value };
-  }
-
-  if (mode === "md") {
-    const expr = `md\`${escapeTemplateLiteral(value)}\``;
-    const source = explicitName ? `${explicitName} = ${expr}` : expr;
-    const name = explicitName ?? null;
-    return { mode, name, source };
-  }
-
-  if (mode === "html") {
-    const expr = `htl.html\`${escapeTemplateLiteral(value)}\``;
-    const source = explicitName ? `${explicitName} = ${expr}` : expr;
-    const name = explicitName ?? null;
-    return { mode, name, source };
-  }
-
-  const name = inferCellGroupNameFromOJS(value) ?? explicitName;
-  return { mode, name, source: value };
-}
-)};
-const _1pa2xc8 = function _readObservableClipboardCells(globalThis){return(
-async () => {
-  const mime = "application/vnd.observablehq+json";
-
-  if (globalThis.navigator?.clipboard?.read) {
-    const items = await navigator.clipboard.read();
-    for (const item of items) {
-      if (item.types?.includes?.(mime)) {
-        const blob = await item.getType(mime);
-        const text = await blob.text();
-        const json = JSON.parse(text);
-        if (Array.isArray(json)) return json;
-      }
-    }
-  }
-
-  if (globalThis.navigator?.clipboard?.readText) {
-    const text = await navigator.clipboard.readText();
-    if (text == null) throw new Error("Clipboard readText returned null/undefined.");
-    return [{ mode: "js", value: String(text), name: null }];
-  }
-
-  throw new Error("Clipboard API unavailable (need navigator.clipboard.read or readText).");
-}
-)};
-const _1w99cbu = function _pasteObservableCellsIntoModule($0,normalizeObservableClipboardCell,findCell,compile_and_update){return(
-async ({ cells, editedCell }) => {
-  if (!editedCell?.module?.module) throw new Error("No selected cell/module to paste into.");
-  if (!Array.isArray(cells) || cells.length === 0) return { total: 0, matched: 0, replacedCurrent: false, inserted: 0 };
-
-  const moduleRuntime = editedCell.module.module;
-  const moduleCells = $0.value.get(moduleRuntime) || [];
-  const byName = new Map(
-    moduleCells
-      .filter((c) => typeof c?.name === "string" && c.name.length)
-      .map((c) => [c.name, c])
-  );
-
-  const normalized = cells.map((c) => normalizeObservableClipboardCell(c)).filter((c) => typeof c?.source === "string" && c.source.length);
-
-  const matched = [];
-  const unmatched = [];
-
-  for (const entry of normalized) {
-    if (entry.name && byName.has(entry.name)) {
-      const target = byName.get(entry.name);
-      const ctx = findCell(target.variables[0]);
-      if (ctx) matched.push({ entry, ctx });
-      else unmatched.push(entry);
-    } else {
-      unmatched.push(entry);
-    }
-  }
-
-  for (const { entry, ctx } of matched) {
-    compile_and_update(entry.source, ctx.variables, ctx);
-  }
-
-  let replacedCurrent = false;
-  let inserted = 0;
-
-  if (unmatched.length > 0) {
-    replacedCurrent = true;
-    compile_and_update(unmatched[0].source, editedCell.variables, editedCell);
-
-    let anchor = editedCell;
-    for (let i = 1; i < unmatched.length; i++) {
-      const vars = [];
-      compile_and_update(unmatched[i].source, vars, anchor);
-      anchor = { ...anchor, variables: vars, name: unmatched[i].name ?? anchor.name, dom: undefined };
-      inserted++;
-    }
-  }
-
-  return { total: normalized.length, matched: matched.length, replacedCurrent, inserted };
-}
-)};
-const _z9vacx = function _86(md){return(
-md`## Decompiler`
-)};
-const _gbuhyc = function _decompiled(editedCell,decompile)
-{
-    if (!editedCell?.variables?.length)
-        return '';
-    return decompile(editedCell.variables);
-};
-const _w5q3yf = function _editorModule(thisModule){return(
-thisModule()
-)};
-const _18kaj2p = (G, _) => G.input(_);
-const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_options)
-{
-  //editedCell;
-  command_processor;
-  submit_summary;
-  save_options;
-  return "editor_jobs";
-};
-const _1whoy5n = function _91(md){return(
-md`### Apply Update`
-)};
-const _gk83fp = function _compile_and_update(compile,runtime,realize,repositionSetElement,decompile)
-{
-  return async (source, variables = [], cell) => {
-    try {
-      const newVariables = compile(source);
-      // Skip emitting `module @X` if one already exists in the target
-      // module's scope and isn't one of OUR old variables. Without this,
-      // the second define() collides on the shared name and Observable
-      // rewrites BOTH the new and pre-existing module variables to a
-      // "defined more than once" thrower, breaking every pre-existing
-      // consumer of `@X` in the module. The new import-name bindings
-      // reference `module @X` by name and resolve to whatever module
-      // variable is currently in scope.
-      const targetScope = cell.module.module._scope;
-      const ourOldNames = new Set(variables.map(v => v._name));
-      const isModuleImport = nv => nv._name?.startsWith('module @') && nv._inputs.length === 0;
-      const shouldSkip = nv => isModuleImport(nv) && targetScope.has(nv._name) && !ourOldNames.has(nv._name);
-      const allocation = newVariables.map(nv => shouldSkip(nv) ? { reuse: targetScope.get(nv._name) } : { fresh: nv });
-      const freshNewVariables = allocation.filter(a => a.fresh).map(a => a.fresh);
-      let reposition = false, insertionIndex = -1;
-      if (!variables || variables.length !== freshNewVariables.length) {
-        reposition = true;
-        // Reuse existing variable slots where we can. Preserves the first slot's
-        // observer/inspector/editor-row binding so a 1→N compile (viewof = 2,
-        // mutable = 3, import = 1+N bindings) keeps the user's cell visible
-        // and re-editable. Only the surplus old vars are deleted; only the
-        // surplus new vars are freshly created.
-        const overlap = Math.min(variables.length, freshNewVariables.length);
-        for (let i = overlap; i < variables.length; i++)
-          variables[i].delete();
-        variables.length = overlap;
-        for (let i = overlap; i < freshNewVariables.length; i++) {
-          const newVariable = cell.module.module.variable({});
-          // Assign a random pid up-front so blank/identical new cells don't
-          // collide via persistentId's contentHash. See lopecode#144.
-          newVariable.pid = '_' + Math.random().toString(36).slice(2, 9);
-          variables.push(newVariable);
-        }
-      }
-      if (reposition) {
-        insertionIndex = [...runtime._variables].findIndex(v => v == cell.variables.at(-1)) + 1;
-      }
-      const fns = await realize(freshNewVariables.map(v => v._definition), runtime);
-      freshNewVariables.forEach((v, i) => {
-        const variable = variables[i];
-        const _fn = fns[i];
-        if (v._name) {
-          variable.define(v._name, v._inputs, _fn);
-        } else {
-          variable.define(v._inputs, _fn);
-        }
-        if (reposition)
-          repositionSetElement(runtime._variables, variable, insertionIndex + i);
-      });
-      // Build the full variable set for decompile, mixing reused module-import
-      // variables with the freshly-defined runtime variables, in the same order
-      // as `allocation`.
-      let freshIdx = 0;
-      const decompileVars = allocation.map(a => a.reuse ? a.reuse : variables[freshIdx++]);
-      return await decompile(decompileVars);
-    } catch (e) {
-      console.error(e);
-    }
-  };
-};
-const _1g3bdxp = function _93(md){return(
-md`### Remove Cells`
-)};
-const _mhcibs = function _remove_variables(){return(
-(variables) => {
-  variables.forEach((v) => v.delete());
-}
-)};
-const _1qb4uz = function _95(md){return(
-md`### Runtime Representation`
-)};
-const _rwez9 = function _variable(Inputs,editedCell){return(
-Inputs.radio(editedCell.variables, {
-  label: "variable in cell group",
-  format: (v) => v._name,
-  value: editedCell.variables[0]
-})
-)};
-const _11gvkq4 = (G, _) => G.input(_);
-const _r5nvms = function _name(variable){return(
-variable._name
-)};
-const _9vxebx = function _inputs(variable){return(
-variable._inputs.map((v) => v._name)
-)};
-const _1348jvx = function _definition(Inputs,variable){return(
-Inputs.textarea({
-  label: "variable._definition",
-  value: variable._definition.toString(),
-  rows: 10
-})
-)};
-const _b4rsn5 = (G, _) => G.input(_);
-const _1pimibm = function _100(Inputs,definition,variable,realize,runtime,inputs){return(
-Inputs.button("update variable", {
-  disabled: definition === variable._definition.toString(),
-  reduce: async () => {
-    const [_fn] = await realize([definition], runtime);
-    variable.define(variable._name, inputs, _fn);
-  }
-})
-)};
-const _1d94dks = function _javascriptPlugin(codemirror){return(
-codemirror
-)};
-const _1j5gu2y = function _102(md){return(
-md`### Libraries`
-)};
-const _lbftlp = function _literalCompletions(codemirror)
-{
-  // Pure extract of editor_manager's literal-base completion, for the test_* cells.
-  const isNoise = n => n.startsWith('_') || [
-    'prototype',
-    'constructor',
-    'caller',
-    'callee',
-    'arguments',
-    'name',
-    'length'
-  ].includes(n);
-  const stopAt = new Set([
-    Object.prototype,
-    Function.prototype
-  ]);
-  const propsOf = obj => {
-    const out = [], seen = new Set();
-    for (let o = Object(obj), d = 0; o && d < 4; o = Object.getPrototypeOf(o), d++) {
-      if (d > 0 && stopAt.has(o))
-        break;
-      for (const n of Object.getOwnPropertyNames(o)) {
-        if (seen.has(n) || isNoise(n))
-          continue;
-        seen.add(n);
-        const desc = Object.getOwnPropertyDescriptor(o, n);
-        out.push({
-          label: n,
-          type: typeof desc?.value === 'function' ? 'function' : 'property'
-        });
-      }
-    }
-    return out;
-  };
-  const literalProto = name => {
-    switch (name) {
-    case 'String':
-    case 'TemplateString':
-      return '';
-    case 'Number':
-      return 0;
-    case 'BooleanLiteral':
-      return false;
-    case 'ArrayExpression':
-      return [];
-    case 'ObjectExpression':
-      return {};
-    case 'RegExp':
-      return /(?:)/;
-    default:
-      return undefined;
-    }
-  };
-  return (state, pos) => {
-    const before = state.sliceDoc(state.doc.lineAt(pos).from, pos);
-    const dm = before.match(/\.([A-Za-z_$][\w$]*)?$/);
-    if (!dm)
-      return null;
-    const prefix = dm[1] ?? '';
-    const dotPos = pos - prefix.length - 1;
-    let mem = null;
-    for (let n = codemirror.syntaxTree(state).resolveInner(dotPos, -1); n; n = n.parent) {
-      if (n.name === 'MemberExpression') {
-        mem = n;
-        break;
-      }
-    }
-    if (!mem)
-      return null;
-    let obj = mem.firstChild;
-    while (obj && obj.name === 'ParenthesizedExpression')
-      obj = obj.firstChild?.nextSibling ?? null;
-    const base = obj && literalProto(obj.name);
-    if (base === undefined)
-      return null;
-    const options = propsOf(base).filter(o => o.label.startsWith(prefix));
-    options.sort((a, b) => a.label.localeCompare(b.label));
-    return options.length ? {
-      from: pos - prefix.length,
-      to: pos,
-      options
-    } : null;
-  };
-};
-const _scoiwp = function _completionFixture(EditorState,observableJS_language,literalCompletions)
-{
-  return doc => {
-    // Headless EditorState so the syntax tree parses; return labels at end of `doc`.
-    const state = EditorState.create({
-      doc,
-      extensions: [observableJS_language]
-    });
-    const r = literalCompletions(state, doc.length);
-    return r ? r.options.map(o => o.label) : [];
-  };
-};
-const _160qhf1 = function _test_completion_string_literal(completionFixture)
-{
-  const labels = completionFixture('"".');
-  for (const method of [
-      'charAt',
-      'slice',
-      'split',
-      'toUpperCase'
-    ]) {
-    if (!labels.includes(method))
-      throw new Error(`"". missing String method '${ method }'; got ${ labels.slice(0, 8) }`);
-  }
-  return `"". → ${ labels.length } String.prototype methods`;
-};
-const _xrmooc = function _test_completion_string_prefix(completionFixture)
-{
-  const labels = completionFixture('"".sl');
-  if (labels.join() !== 'slice')
-    throw new Error(`"".sl expected ['slice'], got ${ labels }`);
-  return `"".sl → slice (prefix filtered)`;
-};
-const _m0ar50 = function _test_completion_array_literal(completionFixture)
-{
-  const labels = completionFixture('[].');
-  for (const method of [
-      'map',
-      'filter',
-      'forEach',
-      'find',
-      'reduce'
-    ]) {
-    if (!labels.includes(method))
-      throw new Error(`[]. missing Array method '${ method }'; got ${ labels.slice(0, 8) }`);
-  }
-  return `[]. → ${ labels.length } Array.prototype methods`;
-};
-const _13247rm = function _test_completion_number_literal(completionFixture)
-{
-  const labels = completionFixture('(5).');
-  for (const method of [
-      'toFixed',
-      'toExponential',
-      'toPrecision'
-    ]) {
-    if (!labels.includes(method))
-      throw new Error(`(5). missing Number method '${ method }'; got ${ labels }`);
-  }
-  return `(5). → ${ labels.length } Number.prototype methods`;
-};
-const _quyccp = function _test_completion_bool_template_regexp(completionFixture)
-{
-  if (!completionFixture('true.').includes('valueOf'))
-    throw new Error('true. should expose Boolean.prototype (valueOf)');
-  if (!completionFixture('`x`.').includes('charAt'))
-    throw new Error('`x`. should expose String.prototype (charAt)');
-  if (!completionFixture('/a/.').includes('test'))
-    throw new Error('/a/. should expose RegExp.prototype (test)');
-  return 'true. / `x`. / /a/. expose Boolean / String / RegExp methods';
-};
-const _1cn3ucr = function _test_completion_parenthesised_unwrap(completionFixture)
-{
-  if (!completionFixture('("hi").').includes('slice'))
-    throw new Error('("hi"). should unwrap to a String');
-  if (!completionFixture('(([])).').includes('map'))
-    throw new Error('(([])). should unwrap nested parens to an Array');
-  return 'parenthesised (and nested) literals unwrap to their inner type';
-};
-const _15vxhca = function _test_completion_never_evaluates(completionFixture)
-{
-  // Undefined ref inside the array still yields Array methods — type-based, never executed.
-  if (!completionFixture('[neverDefinedRef].').includes('map')) {
-    throw new Error('array literal should offer Array methods by type, without evaluation');
-  }
-  // Non-literal bases (calls, arithmetic, scope refs) offer nothing.
-  for (const doc of [
-      'foo().',
-      '(1 + 2).',
-      '(x + y).'
-    ]) {
-    const labels = completionFixture(doc);
-    if (labels.length)
-      throw new Error(`${ doc } should yield no literal completions, got ${ labels.slice(0, 5) }`);
-  }
-  return 'completions are type-based \u2014 literals are never evaluated';
-};
-const _bz6mai = function _test_completion_identifier_deferred(completionFixture)
-{
-  // Identifier (foo.) and bare-word (ht) bases defer to the identifier-chain path.
-  if (completionFixture('foo.').length)
-    throw new Error('identifier base must defer to the identifier-chain path');
-  if (completionFixture('ht').length)
-    throw new Error('bare identifier (no dot) must defer');
-  return 'identifier / no-dot bases deferred to the identifier-chain path';
-};
-
-export default function define(runtime, observer) {
-  const main = runtime.module();
-  const $def = (pid, name, deps, fn) => {
-    main.variable(observer(name)).define(name, deps, fn).pid = pid;
-  };
-  const fileAttachments = new Map(["cell_options.json"].map((name) => {
-    const module_name = "@tomlarkworthy/editor-5";
-    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
-    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
-    return [name, {url: blob_url, mimeType: mime}]
-  }));
-  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
-
-  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
-  main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
-  main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
-  main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
-  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
-  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
-  main.define("module @tomlarkworthy/cells-to-clipboard", async () => runtime.module((await import("/@tomlarkworthy/cells-to-clipboard.js?v=4")).default));  
-  main.define("module @tomlarkworthy/observablehq-lezer", async () => runtime.module((await import("/@tomlarkworthy/observablehq-lezer.js?v=4")).default));  
-  main.define("module @tomlarkworthy/dataflow-templating", async () => runtime.module((await import("/@tomlarkworthy/dataflow-templating.js?v=4")).default));  
-  main.define("module @tomlarkworthy/fileattachments", async () => runtime.module((await import("/@tomlarkworthy/fileattachments.js?v=4")).default));  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
-  main.define("module @tomlarkworthy/codemirror-6-v2", async () => runtime.module((await import("/@tomlarkworthy/codemirror-6-v2.js?v=4")).default));  
-  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
-  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
-  $def("_1tdjp0a", "title", ["md"], _1tdjp0a);  
-  $def("_dm53bx", null, ["md"], _dm53bx);  
-  $def("_61oxjf", "title_variable", ["lookupVariable","editorModule"], _61oxjf);  
-  $def("_15uilf0", null, ["cellEditor","title_variable"], _15uilf0);  
-  $def("_wpcfq8", null, ["md"], _wpcfq8);  
-  $def("_1ociws4", null, ["md"], _1ociws4);  
-  main.define("syncers", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("syncers", _));  
-  main.define("TRACE_CELL", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("TRACE_CELL", _));  
-  $def("_hdieof", "editors", [], _hdieof);  
-  $def("_ipx6cz", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","editors","cellEditor"], _ipx6cz);  
-  $def("_1iwobxt", "divToVar", [], _1iwobxt);  
-  $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
-  $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
-  $def("_16ks4jz", null, ["md"], _16ks4jz);  
-  $def("_199ztvl", "hotbarTemplate", ["lookupVariable","editorModule"], _199ztvl);  
-  $def("_1q95xt6", "cellEditor", ["cloneDataflow","editorTemplate","shellTemplate","getOption","Event","setOption","createCell","findCell","pinOnCreate"], _1q95xt6);
-  $def("_x5ixji", "hotbar_shell", ["viewof edit","Event","htl","edit"], _x5ixji);  
-  $def("_1ed5zb9", "editor_panel", ["viewof editedCell","htl","toolbar","nav","reversibleAttach","combine","code_editor"], _1ed5zb9);  
-  $def("_yk7udl", "shellTemplate", ["viewof editedCell","editedCell","selectVariable","viewof edit","edit","hotbar_shell","lookupVariable","editorModule"], _yk7udl);  
-  $def("_jot8he", "editorTemplate", ["viewof editedCell","editedCell","selectVariable","viewof select","viewof up","viewof down","viewof remove","viewof addCells","viewof apply","viewof copy","viewof paste","toolbar","nav","cellLinks","variableLink","decompiled","code_editor_view","code_editor","editor_manager","editor_refresh_from_runtime","editor_panel","lookupVariable","editorModule"], _jot8he);  
-  $def("_oshnzp", null, ["md"], _oshnzp);  
-  $def("_1o2h65s", "viewof editedCell", ["Inputs"], _1o2h65s);  
-  $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
-  $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
-  $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
-  $def("_3jxaqk", null, ["selectVariable","hotbarTemplate"], _3jxaqk);  
-  $def("_49mpmh", "hotbar", ["viewof edit","Event","setOption","viewof editedCell","htl","edit","toolbar","nav","reversibleAttach","combine","code_editor"], _49mpmh);  
-  $def("_n8s6yl", null, ["viewof editedCell"], _n8s6yl);  
-  $def("_ytd2rq", null, ["nav","editedCell"], _ytd2rq);  
-  $def("_1t4gep6", "nav", ["html","cellLinks"], _1t4gep6);  
-  $def("_1tv9qxo", "cellLinks", ["html","variableLink"], _1tv9qxo);  
-  $def("_1opggh8", "identity", ["lookupVariable","editorModule"], _1opggh8);  
-  $def("_1nfia2p", "variableLink", ["identity","navHref","modules"], _1nfia2p);  
-  $def("_1tm2n0w", null, ["md"], _1tm2n0w);  
-  $def("_16wblye", null, ["md"], _16wblye);  
-  $def("_1jdvxd9", null, ["md"], _1jdvxd9);  
-  $def("_1j1loxx", "viewof combine", ["Inputs"], _1j1loxx);  
-  $def("_1h8337z", "combine", ["Generators","viewof combine"], _1h8337z);  
-  $def("_tct2nf", "viewof edit", ["Inputs"], _tct2nf);  
-  $def("_7izj7k", "edit", ["Generators","viewof edit"], _7izj7k);  
-  $def("_1fwb5jc", "toolbar", ["htl","reversibleAttach","combine","viewof select","viewof up","viewof down","viewof remove","viewof addCells","viewof apply","viewof copy","viewof paste"], _1fwb5jc);  
-  $def("_yej3hb", "viewof addCells", ["Inputs","createCell","viewof editedCell"], _yej3hb);  
-  $def("_1aii9ps", "addCells", ["Generators","viewof addCells"], _1aii9ps);  
-  $def("_1bn860e", "viewof remove", ["Inputs","deleteCell","viewof editedCell"], _1bn860e);  
-  $def("_1ad0xr8", "remove", ["Generators","viewof remove"], _1ad0xr8);  
-  $def("_lwb7d7", "viewof apply", ["Inputs","compile_and_update","code_editor_view","editedCell","replaceCodeMirrorDoc"], _lwb7d7);  
-  $def("_1cjyuqm", "apply", ["Generators","viewof apply"], _1cjyuqm);  
-  $def("_14rfku9", "viewof up", ["Inputs","moveCell","viewof editedCell"], _14rfku9);  
-  $def("_frzs5d", "up", ["Generators","viewof up"], _frzs5d);  
-  $def("_9pymuj", "viewof paste", ["Inputs","readObservableClipboardCells","pasteObservableCellsIntoModule","editedCell"], _9pymuj);  
-  $def("_1whsszt", "paste", ["Generators","viewof paste"], _1whsszt);  
-  $def("_corxwl", "viewof down", ["Inputs","moveCell","viewof editedCell"], _corxwl);  
-  $def("_1to28po", "down", ["Generators","viewof down"], _1to28po);  
-  $def("_gia2ci", "viewof copy", ["Inputs","html","viewof editedCell","decompile","viewof liveCellMap","getOption","cellsToClipboard"], _gia2ci);  
-  $def("_fw41wt", "copy", ["Generators","viewof copy"], _fw41wt);  
-  $def("_srtw8o", "module", ["editedCell"], _srtw8o);  
-  $def("_rv7t7x", "code_editor_view", ["EditorView"], _rv7t7x);  
-  $def("_xvo1n6", "code_editor", ["code_editor_view"], _xvo1n6);  
-  $def("_1imarq2", null, ["md"], _1imarq2);  
-  $def("_470wv4", "moveCell", ["viewof command"], _470wv4);  
-  $def("_pinoncr", "pinOnCreate", [], _pinoncr);
-  $def("_19znal9", "createCell", ["viewof command"], _19znal9);
-  $def("_d9nzys", "deleteCell", ["viewof command"], _d9nzys);  
-  $def("_1toku21", null, ["md"], _1toku21);  
-  $def("_d7ouqx", "viewof command", ["flowQueue"], _d7ouqx);  
-  $def("_118qt2v", "command", ["Generators","viewof command"], _118qt2v);  
-  $def("_c4420j", null, ["command"], _c4420j);  
-  $def("_1f6v167", "findCellByVariable", [], _1f6v167);  
-  $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
-  $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
-  $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_2pkmxz", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","viewof liveCellMap","findCellIndex","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command","pinOnCreate"], _2pkmxz);  
-  $def("_8iz5z2", null, ["md"], _8iz5z2);  
-  $def("_m873d1", "states", [], _m873d1);  
-  $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
-  $def("_y7997q", null, ["md"], _y7997q);  
-  $def("_7btuqg", "observableJS_language", ["codemirror","observable_lezer_parser"], _7btuqg);  
-  $def("_1xf04v5", "observableJS_highlightStyle", ["codemirror","lezerhighlight"], _1xf04v5);  
-  $def("_19d9pua", "observableJS_lint", ["codemirror"], _19d9pua);  
-  $def("_125gzhe", "editor_manager", ["editedCell","globalThis","codemirror","literalCompletions","EditorState","decompiled","cellIdFacet","EditorView","states","compile_and_update","code_editor_view","replaceCodeMirrorDoc","observableJS_language","observableJS_highlightStyle","myDefaultTheme"], _125gzhe);  
-  $def("_65mlp5", "divToCell", [], _65mlp5);  
-  $def("_bt6o0p", null, ["md"], _bt6o0p);  
-  $def("_jh2ad1", "editor_refresh_from_runtime", ["editedCell","decompile","code_editor_view","replaceCodeMirrorDoc","queueMicrotask","onCodeChange","invalidation"], _jh2ad1);  
-  $def("_dvne2z", "replaceCodeMirrorDoc", [], _dvne2z);  
-  $def("_cbcryi", null, ["md"], _cbcryi);  
-  $def("_rtf009", "viewof select", ["editedCell","Inputs","getOption","setOption"], _rtf009);  
-  $def("_14mwbuc", "select", ["Generators","viewof select"], _14mwbuc);  
-  $def("_d2lrrw", null, ["md"], _d2lrrw);  
-  $def("_ucf24e", null, ["FileAttachment"], _ucf24e);  
-  $def("_kygz54", "optionsFile", ["getFileAttachment","editorModule"], _kygz54);  
-  $def("_760ozq", "viewof options", ["Inputs","optionsFile"], _760ozq);  
-  $def("_4rh26k", "options", ["Generators","viewof options"], _4rh26k);  
-  $def("_1lqy7cs", "setOption", ["findCell","_","viewof options","Event"], _1lqy7cs);  
-  $def("_1oxe5ee", "getOption", ["findCell","_","viewof options"], _1oxe5ee);  
-  $def("_kwq69p", "save_options", ["setFileAttachment","jsonFileAttachment","options","editorModule"], _kwq69p);  
-  $def("_1ag9ajn", null, ["md"], _1ag9ajn);  
-  $def("_dbvt0t", "escapeTemplateLiteral", [], _dbvt0t);  
-  $def("_1q2xn50", "inferCellGroupNameFromOJS", ["parser"], _1q2xn50);  
-  $def("_1mfm13h", "normalizeObservableClipboardCell", ["inferCellGroupNameFromOJS","escapeTemplateLiteral"], _1mfm13h);  
-  $def("_1pa2xc8", "readObservableClipboardCells", ["globalThis"], _1pa2xc8);  
-  $def("_1w99cbu", "pasteObservableCellsIntoModule", ["viewof liveCellMap","normalizeObservableClipboardCell","findCell","compile_and_update"], _1w99cbu);  
-  $def("_z9vacx", null, ["md"], _z9vacx);
-  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);
-  $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
-  $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
-  $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
-  $def("_1whoy5n", null, ["md"], _1whoy5n);  
-  $def("_gk83fp", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _gk83fp);  
-  $def("_1g3bdxp", null, ["md"], _1g3bdxp);  
-  $def("_mhcibs", "remove_variables", [], _mhcibs);  
-  $def("_1qb4uz", null, ["md"], _1qb4uz);  
-  $def("_rwez9", "viewof variable", ["Inputs","editedCell"], _rwez9);  
-  $def("_11gvkq4", "variable", ["Generators","viewof variable"], _11gvkq4);  
-  $def("_r5nvms", "name", ["variable"], _r5nvms);  
-  $def("_9vxebx", "inputs", ["variable"], _9vxebx);  
-  $def("_1348jvx", "viewof definition", ["Inputs","variable"], _1348jvx);  
-  $def("_b4rsn5", "definition", ["Generators","viewof definition"], _b4rsn5);  
-  $def("_1pimibm", null, ["Inputs","definition","variable","realize","runtime","inputs"], _1pimibm);  
-  $def("_1d94dks", "javascriptPlugin", ["codemirror"], _1d94dks);  
-  $def("_1j5gu2y", null, ["md"], _1j5gu2y);  
-  main.define("reversibleAttach", ["module @tomlarkworthy/reversible-attachment", "@variable"], (_, v) => v.import("reversibleAttach", _));  
-  main.define("flowQueue", ["module @tomlarkworthy/flow-queue", "@variable"], (_, v) => v.import("flowQueue", _));  
-  main.define("viewof liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("viewof liveCellMap", _));  
-  main.define("liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("liveCellMap", _));  
-  main.define("hash", ["module d/57d79353bac56631@44", "@variable"], (_, v) => v.import("hash", _));  
-  main.define("extractNotebookAndCell", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("extractNotebookAndCell", _));  
-  main.define("navHref", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("navHref", _));  
-  main.define("cellsToClipboard", ["module @tomlarkworthy/cells-to-clipboard", "@variable"], (_, v) => v.import("cellsToClipboard", _));  
-  main.define("observable_lezer_parser", ["module @tomlarkworthy/observablehq-lezer", "@variable"], (_, v) => v.import("observable_lezer_parser", _));  
-  main.define("lezerhighlight", ["module @tomlarkworthy/observablehq-lezer", "@variable"], (_, v) => v.import("lezerhighlight", _));  
-  main.define("cloneDataflow", ["module @tomlarkworthy/dataflow-templating", "@variable"], (_, v) => v.import("cloneDataflow", _));  
-  main.define("lookupVariable", ["module @tomlarkworthy/dataflow-templating", "@variable"], (_, v) => v.import("lookupVariable", _));  
-  main.define("getFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachment", _));  
-  main.define("setFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("setFileAttachment", _));  
-  main.define("removeFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("removeFileAttachment", _));  
-  main.define("jsonFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("jsonFileAttachment", _));  
-  main.define("createFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("createFileAttachment", _));  
-  main.define("realize", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("realize", _));  
-  main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
-  main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
-  main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
-  main.define("isOnObservableCom", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("isOnObservableCom", _));  
-  main.define("thisModule", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("thisModule", _));  
-  main.define("keepalive", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("keepalive", _));  
-  main.define("toObject", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("toObject", _));  
-  main.define("isnode", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("isnode", _));  
-  main.define("repositionSetElement", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("repositionSetElement", _));  
-  main.define("onCodeChange", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("onCodeChange", _));  
-  main.define("EditorState", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("EditorState", _));  
-  main.define("EditorView", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("EditorView", _));  
-  main.define("codemirror", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("codemirror", _));  
-  main.define("myDefaultTheme", ["module @tomlarkworthy/codemirror-6-v2", "@variable"], (_, v) => v.import("myDefaultTheme", _));  
-  main.define("decompile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("decompile", _));  
-  main.define("compile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("compile", _));  
-  main.define("cellMap", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("cellMap", _));  
-  main.define("findModuleName", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("findModuleName", _));  
-  main.define("parser", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("parser", _));  
-  main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
-  main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
-  main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
-  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));
-  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));
-  main.define("modules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", "modules", _));
-  $def("_lbftlp", "literalCompletions", ["codemirror"], _lbftlp);  
-  $def("_scoiwp", "completionFixture", ["EditorState","observableJS_language","literalCompletions"], _scoiwp);  
-  $def("_160qhf1", "test_completion_string_literal", ["completionFixture"], _160qhf1);  
-  $def("_xrmooc", "test_completion_string_prefix", ["completionFixture"], _xrmooc);  
-  $def("_m0ar50", "test_completion_array_literal", ["completionFixture"], _m0ar50);  
-  $def("_13247rm", "test_completion_number_literal", ["completionFixture"], _13247rm);  
-  $def("_quyccp", "test_completion_bool_template_regexp", ["completionFixture"], _quyccp);  
-  $def("_1cn3ucr", "test_completion_parenthesised_unwrap", ["completionFixture"], _1cn3ucr);  
-  $def("_15vxhca", "test_completion_never_evaluates", ["completionFixture"], _15vxhca);  
-  $def("_bz6mai", "test_completion_identifier_deferred", ["completionFixture"], _bz6mai);
-  return main;
-}</script>
 <script id="@tomlarkworthy/escodegen/escodegen.browser.min.js.gz" 
   type="text/plain"
   data-encoding="base64"
@@ -7525,12 +9496,12 @@ md`# Exporter 3
 ## [video explainer for exporter 2](https://www.youtube.com/watch?v=wx93r1pY_6Y)
 `
 )};
-const _1xs1o58 = function _2(exporter,$0,Event){return(
+const _vpmotg = function _2(exporter,$0,Event){return(
 exporter({
-    output: out => {
-        $0.value = out;
-        $0.dispatchEvent(new Event('input'));
-    }
+  output: out => {
+    $0.value = out;
+    $0.dispatchEvent(new Event('input'));
+  }
 })
 )};
 const _16yvadj = function _3(md,downloadAnchor,forkAnchor){return(
@@ -7630,28 +9601,28 @@ fill => html`<svg ${ fill ? `fill="${ fill }" ` : '' }width="50px" height="50px"
 const _ibwdcx = function _11(md){return(
 md`## Implementation`
 )};
-const _4vze8h = function _exporter(actionHandler,css,keepalive,exporter_module,variable,domView,view,disk_svg,Inputs,createShowable,top120List,themes,$0,bindOneWay){return(
+const _10a18gh = function _exporter(actionHandler,css,keepalive,exporter_module,variable,domView,view,disk_svg,Inputs,createShowable,top120List,themes,$0,bindOneWay){return(
 ({handler = actionHandler, style = css, output = out => {
-    }, notebook_url = '', debug = false} = {}) => {
-    keepalive(exporter_module, 'futureExportedState');
-    const handlerVar = variable(handler);
-    const feedback = domView();
-    const options = {
-        style,
-        output,
-        debug
-    };
-    const spinner = async (...args) => {
-        try {
-            ui.querySelector('.disk-image').classList.add('spinning');
-            await handler(...args, cb => feedback.value = cb);
-            ui.querySelector('.disk-image').classList.remove('spinning');
-        } catch (e) {
-            ui.querySelector('.disk-image').classList.remove('spinning');
-            throw e;
-        }
-    };
-    const ui = view`<div class="moldbook-exporter" style="max-width: 520px;">
+  }, notebook_url = '', debug = false} = {}) => {
+  keepalive(exporter_module, 'futureExportedState');
+  const handlerVar = variable(handler);
+  const feedback = domView();
+  const options = {
+    style,
+    output,
+    debug
+  };
+  const spinner = async (...args) => {
+    try {
+      ui.querySelector('.disk-image').classList.add('spinning');
+      await handler(...args, cb => feedback.value = cb);
+      ui.querySelector('.disk-image').classList.remove('spinning');
+    } catch (e) {
+      ui.querySelector('.disk-image').classList.remove('spinning');
+      throw e;
+    }
+  };
+  const ui = view`<div class="moldbook-exporter" style="max-width: 520px;">
     <style>
       .moldbook-exporter {
         margin: 10px;
@@ -7690,9 +9661,9 @@ const _4vze8h = function _exporter(actionHandler,css,keepalive,exporter_module,v
       }
     </style>
     ${ [
-        'handler',
-        handlerVar
-    ] }
+    'handler',
+    handlerVar
+  ] }
     <div style="display: flex;">
       <div class="disk-image">${ disk_svg() }</div>
       <div style="width: 100%">
@@ -7701,56 +9672,56 @@ const _4vze8h = function _exporter(actionHandler,css,keepalive,exporter_module,v
             fork
             <div style="flex-grow:1"></div>
             ${ [
-        'source',
-        Inputs.select([
-            'this notebook',
-            'a notebook url',
-            'the top 100'
-        ])
-    ] }
+    'source',
+    Inputs.select([
+      'this notebook',
+      'a notebook url',
+      'the top 100'
+    ])
+  ] }
           </span>
           ${ [
-        'notebook_url',
-        createShowable(Inputs.text({
-            value: notebook_url,
-            placeholder: '@tomlarkworthy/exporter'
-        }))
-    ] }
+    'notebook_url',
+    createShowable(Inputs.text({
+      value: notebook_url,
+      placeholder: '@tomlarkworthy/exporter'
+    }))
+  ] }
           ${ [
-        'top_100',
-        createShowable(Inputs.select(top120List))
-    ] }
+    'top_100',
+    createShowable(Inputs.select(top120List))
+  ] }
         </div>
         <div class="moldbook-dark">
           <div>
             <div style="display: flex; gap: 5px; justify-content: flex-end; align-items: center; flex-wrap: wrap;">
               <div style="flex-grow:1; flex-basis: 58%; flex-shrink: 2; min-width: 240px;">
                 ${ [
-        'bootloader',
-        Inputs.text({
-            value: '@tomlarkworthy/bootloader',
-            placeholder: '@tomlarkworthy/bootloader'
-        })
-    ] }
+    'bootloader',
+    Inputs.text({
+      value: '@tomlarkworthy/bootloader',
+      placeholder: '@tomlarkworthy/bootloader'
+    })
+  ] }
               </div>
               <div style="flex-grow:1; flex-basis: 28%; min-width: 150px;">
                 ${ [
-        'theme',
-        Inputs.bind(Inputs.select(themes), $0)
-    ] }
+    'theme',
+    Inputs.bind(Inputs.select(themes), $0)
+  ] }
               </div>
               ${ [
-        'copyjs',
-        Inputs.button('Copy as JS', { reduce: () => spinner('copyjs', ui.value, options) })
-    ] }
+    'copyjs',
+    Inputs.button('Copy as JS', { reduce: () => spinner('copyjs', ui.value, options) })
+  ] }
               ${ [
-        'blob',
-        Inputs.button('Fork', { reduce: () => spinner('tab', ui.value, options) })
-    ] }
+    'blob',
+    Inputs.button('Fork', { reduce: () => spinner('tab', ui.value, options) })
+  ] }
               ${ [
-        'html',
-        Inputs.button('Download', { reduce: () => spinner('file', ui.value, options) })
-    ] }
+    'html',
+    Inputs.button('Download', { reduce: () => spinner('file', ui.value, options) })
+  ] }
             </div>
           </div>
         </div>
@@ -7758,38 +9729,38 @@ const _4vze8h = function _exporter(actionHandler,css,keepalive,exporter_module,v
     </div>
     <div>${ feedback }</div>
   </div>`;
-    bindOneWay(ui.notebook_url.show, ui.source, { transform: src => src === 'a notebook url' });
-    bindOneWay(ui.top_100.show, ui.source, { transform: src => src === 'the top 100' });
-    return ui;
+  bindOneWay(ui.notebook_url.show, ui.source, { transform: src => src === 'a notebook url' });
+  bindOneWay(ui.top_100.show, ui.source, { transform: src => src === 'the top 100' });
+  return ui;
 }
 )};
-const _5xp8ad = function _copyTextToClipboard(globalThis){return(
+const _14mjs7h = function _copyTextToClipboard(globalThis){return(
 async text => {
-    text = String(text ?? '');
-    if (globalThis.navigator?.clipboard?.writeText) {
-        await navigator.clipboard.writeText(text);
-        return true;
-    }
-    const ta = document.createElement('textarea');
-    ta.value = text;
-    ta.setAttribute('readonly', '');
-    ta.style.position = 'fixed';
-    ta.style.left = '-9999px';
-    ta.style.top = '0';
-    document.body.appendChild(ta);
-    ta.select();
-    const ok = document.execCommand('copy');
-    ta.remove();
-    if (!ok)
-        throw new Error('Clipboard copy failed (no navigator.clipboard and execCommand failed)');
+  text = String(text ?? '');
+  if (globalThis.navigator?.clipboard?.writeText) {
+    await navigator.clipboard.writeText(text);
     return true;
+  }
+  const ta = document.createElement('textarea');
+  ta.value = text;
+  ta.setAttribute('readonly', '');
+  ta.style.position = 'fixed';
+  ta.style.left = '-9999px';
+  ta.style.top = '0';
+  document.body.appendChild(ta);
+  ta.select();
+  const ok = document.execCommand('copy');
+  ta.remove();
+  if (!ok)
+    throw new Error('Clipboard copy failed (no navigator.clipboard and execCommand failed)');
+  return true;
 }
 )};
-const _ywlem4 = function _htmlToConsoleSnippet(utf8ToBase64){return(
+const _1sbph8c = function _htmlToConsoleSnippet(utf8ToBase64){return(
 (html, {title = 'Observable notebook', zIndex = 2147483647} = {}) => {
-    const b64 = utf8ToBase64(html);
-    const safeTitle = String(title).replace(/`/g, '\\`');
-    return `(async () => {
+  const b64 = utf8ToBase64(html);
+  const safeTitle = String(title).replace(/`/g, '\\`');
+  return `(async () => {
   const b64 = "${ b64 }";
   const bytes = Uint8Array.from(atob(b64), c => c.charCodeAt(0));
   const html = new TextDecoder().decode(bytes);
@@ -7874,103 +9845,103 @@ const _ywlem4 = function _htmlToConsoleSnippet(utf8ToBase64){return(
 })();`;
 }
 )};
-const _1gdtxyo = function _exportAnchor(Node,notebook_name,main,_runtime,exportToHTML,location,getCompactISODate){return(
+const _1w6fc3k = function _exportAnchor(Node,notebook_name,main,_runtime,exportToHTML,location,getCompactISODate){return(
 (action, attrs = {}, label = action, exportOpts = {}) => {
-    const a = document.createElement('a');
-    const {href = '#', title, className, style, target, rel, ...rest} = attrs ?? {};
-    a.href = href;
-    if (title != null)
-        a.title = title;
-    if (className != null)
-        a.className = className;
-    if (style != null)
-        a.setAttribute('style', style);
-    if (target != null)
-        a.target = target;
-    if (rel != null)
-        a.rel = rel;
-    for (const [k, v] of Object.entries(rest)) {
-        if (v == null)
-            continue;
-        if (k.startsWith('on') && typeof v === 'function')
-            continue;
-        try {
-            a.setAttribute(k, String(v));
-        } catch {
-        }
+  const a = document.createElement('a');
+  const {href = '#', title, className, style, target, rel, ...rest} = attrs ?? {};
+  a.href = href;
+  if (title != null)
+    a.title = title;
+  if (className != null)
+    a.className = className;
+  if (style != null)
+    a.setAttribute('style', style);
+  if (target != null)
+    a.target = target;
+  if (rel != null)
+    a.rel = rel;
+  for (const [k, v] of Object.entries(rest)) {
+    if (v == null)
+      continue;
+    if (k.startsWith('on') && typeof v === 'function')
+      continue;
+    try {
+      a.setAttribute(k, String(v));
+    } catch {
     }
-    if (label instanceof Node)
-        a.appendChild(label);
-    else
-        a.textContent = label == null ? '' : String(label);
-    const clickHandler = async event => {
-        event.preventDefault();
-        event.stopPropagation();
-        if (a.dataset.busy === '1')
-            return;
-        a.dataset.busy = '1';
-        const prevAriaBusy = a.getAttribute('aria-busy');
-        a.setAttribute('aria-busy', 'true');
-        const prevPointerEvents = a.style.pointerEvents;
-        const prevOpacity = a.style.opacity;
-        a.style.pointerEvents = 'none';
-        a.style.opacity = '0.6';
-        let blobUrl = null;
-        try {
-            const mains = exportOpts.mains ?? (notebook_name ? new Map([[
-                    notebook_name,
-                    main
-                ]]) : _runtime.mains);
-            const runtime = exportOpts.runtime ?? _runtime;
-            const title = exportOpts.title ?? [...mains.keys()][0] ?? 'notebook';
-            const bootloader = exportOpts.bootloader ?? '@tomlarkworthy/bootloader';
-            const appendHash = exportOpts.appendHash ?? true;
-            const resp = await exportToHTML({
-                mains,
-                runtime,
-                options: {
-                    title,
-                    bootloader,
-                    ...exportOpts.options ?? {},
-                    ...exportOpts.theme != null ? { theme: exportOpts.theme } : null,
-                    ...exportOpts.style != null ? { style: exportOpts.style } : null,
-                    ...exportOpts.head != null ? { head: exportOpts.head } : null,
-                    ...exportOpts.headless != null ? { headless: exportOpts.headless } : null,
-                    ...exportOpts.hash != null ? { hash: exportOpts.hash } : null
-                }
-            });
-            const html = resp?.source ?? resp;
-            blobUrl = URL.createObjectURL(new Blob([html], { type: 'text/html' }));
-            if (action === 'tab' || action === 'fork') {
-                const hash = exportOpts.hash ?? location.hash ?? '';
-                window.open(blobUrl + (appendHash ? hash : ''), '_blank');
-                setTimeout(() => URL.revokeObjectURL(blobUrl), 60000);
-            } else if (action === 'download' || action === 'file') {
-                const filename = exportOpts.filename ?? `${ title }_${ getCompactISODate() }.html`;
-                const dl = document.createElement('a');
-                dl.href = blobUrl;
-                dl.download = filename;
-                dl.click();
-                setTimeout(() => URL.revokeObjectURL(blobUrl), 5000);
-            } else {
-                throw new Error(`Unknown export action: ${ action }`);
-            }
-        } finally {
-            a.dataset.busy = '0';
-            if (prevAriaBusy == null)
-                a.removeAttribute('aria-busy');
-            else
-                a.setAttribute('aria-busy', prevAriaBusy);
-            a.style.pointerEvents = prevPointerEvents;
-            a.style.opacity = prevOpacity;
+  }
+  if (label instanceof Node)
+    a.appendChild(label);
+  else
+    a.textContent = label == null ? '' : String(label);
+  const clickHandler = async event => {
+    event.preventDefault();
+    event.stopPropagation();
+    if (a.dataset.busy === '1')
+      return;
+    a.dataset.busy = '1';
+    const prevAriaBusy = a.getAttribute('aria-busy');
+    a.setAttribute('aria-busy', 'true');
+    const prevPointerEvents = a.style.pointerEvents;
+    const prevOpacity = a.style.opacity;
+    a.style.pointerEvents = 'none';
+    a.style.opacity = '0.6';
+    let blobUrl = null;
+    try {
+      const mains = exportOpts.mains ?? (notebook_name ? new Map([[
+          notebook_name,
+          main
+        ]]) : _runtime.mains);
+      const runtime = exportOpts.runtime ?? _runtime;
+      const title = exportOpts.title ?? [...mains.keys()][0] ?? 'notebook';
+      const bootloader = exportOpts.bootloader ?? '@tomlarkworthy/bootloader';
+      const appendHash = exportOpts.appendHash ?? true;
+      const resp = await exportToHTML({
+        mains,
+        runtime,
+        options: {
+          title,
+          bootloader,
+          ...exportOpts.options ?? {},
+          ...exportOpts.theme != null ? { theme: exportOpts.theme } : null,
+          ...exportOpts.style != null ? { style: exportOpts.style } : null,
+          ...exportOpts.head != null ? { head: exportOpts.head } : null,
+          ...exportOpts.headless != null ? { headless: exportOpts.headless } : null,
+          ...exportOpts.hash != null ? { hash: exportOpts.hash } : null
         }
-    };
-    a.addEventListener('click', clickHandler);
-    if (typeof attrs?.onclick === 'function') {
-        const userHandler = attrs.onclick;
-        a.addEventListener('click', e => userHandler(e));
+      });
+      const html = resp?.source ?? resp;
+      blobUrl = URL.createObjectURL(new Blob([html], { type: 'text/html' }));
+      if (action === 'tab' || action === 'fork') {
+        const hash = exportOpts.hash ?? location.hash ?? '';
+        window.open(blobUrl + (appendHash ? hash : ''), '_blank');
+        setTimeout(() => URL.revokeObjectURL(blobUrl), 60000);
+      } else if (action === 'download' || action === 'file') {
+        const filename = exportOpts.filename ?? `${ title }_${ getCompactISODate() }.html`;
+        const dl = document.createElement('a');
+        dl.href = blobUrl;
+        dl.download = filename;
+        dl.click();
+        setTimeout(() => URL.revokeObjectURL(blobUrl), 5000);
+      } else {
+        throw new Error(`Unknown export action: ${ action }`);
+      }
+    } finally {
+      a.dataset.busy = '0';
+      if (prevAriaBusy == null)
+        a.removeAttribute('aria-busy');
+      else
+        a.setAttribute('aria-busy', prevAriaBusy);
+      a.style.pointerEvents = prevPointerEvents;
+      a.style.opacity = prevOpacity;
     }
-    return a;
+  };
+  a.addEventListener('click', clickHandler);
+  if (typeof attrs?.onclick === 'function') {
+    const userHandler = attrs.onclick;
+    a.addEventListener('click', e => userHandler(e));
+  }
+  return a;
 }
 )};
 const _1u2ju69 = function _forkAnchor(exportAnchor){return(
@@ -7979,64 +9950,64 @@ const _1u2ju69 = function _forkAnchor(exportAnchor){return(
 const _1a8n42w = function _downloadAnchor(exportAnchor){return(
 (attrs = {}, label = 'download', exportOpts = {}) => exportAnchor('download', attrs, label, exportOpts)
 )};
-const _r3bep4 = function _actionHandler(Inputs,getSourceModule,notebook_name,_runtime,exportToHTML,htmlToConsoleSnippet,copyTextToClipboard,view,location,getCompactISODate){return(
+const _1w6a2m0 = function _actionHandler(Inputs,getSourceModule,notebook_name,_runtime,exportToHTML,htmlToConsoleSnippet,copyTextToClipboard,view,location,getCompactISODate){return(
 async (action, state, options, feedback_callback) => {
-    feedback_callback(Inputs.textarea({ value: `Generating source...\n` }));
-    const {notebook, module, runtime} = await getSourceModule(state);
-    const mains = notebook_name ? new Map([[
-            notebook,
-            module
-        ]]) : _runtime.mains;
-    const title = [...mains.keys()][0];
-    const response = await exportToHTML({
-        mains,
-        runtime,
-        options: {
-            bootloader: state.bootloader,
-            title,
-            ...options
-        }
-    });
-    if (options.output)
-        options.output(response);
-    const {source, report} = response;
-    if (action === 'copyjs') {
-        const snippet = htmlToConsoleSnippet(source, { title });
-        await copyTextToClipboard(snippet);
-        feedback_callback(view`<div style="padding: 8px;">
+  feedback_callback(Inputs.textarea({ value: `Generating source...\n` }));
+  const {notebook, module, runtime} = await getSourceModule(state);
+  const mains = notebook_name ? new Map([[
+      notebook,
+      module
+    ]]) : _runtime.mains;
+  const title = [...mains.keys()][0];
+  const response = await exportToHTML({
+    mains,
+    runtime,
+    options: {
+      bootloader: state.bootloader,
+      title,
+      ...options
+    }
+  });
+  if (options.output)
+    options.output(response);
+  const {source, report} = response;
+  if (action === 'copyjs') {
+    const snippet = htmlToConsoleSnippet(source, { title });
+    await copyTextToClipboard(snippet);
+    feedback_callback(view`<div style="padding: 8px;">
       <div><b>Copied</b> JS snippet to clipboard.</div>
       <div style="opacity: 0.75; font-size: 12px;">Paste into a JS console to inject the notebook as a full-screen overlay.</div>
     </div>`);
-        return;
-    }
-    const url = URL.createObjectURL(new Blob([source], { type: 'text/html' }));
-    feedback_callback(view`
+    return;
+  }
+  const url = URL.createObjectURL(new Blob([source], { type: 'text/html' }));
+  feedback_callback(view`
     <center><a href="${ url }" target="_blank">export</a></center>
     ${ Inputs.table(report.filter(f => !f.file), {
-        columns: [
-            'id',
-            'size'
-        ],
-        width: {
-            id: '80%',
-            size: '20%'
-        },
-        sort: 'size',
-        reverse: true
-    }) }
+    columns: [
+      'id',
+      'size'
+    ],
+    width: {
+      id: '80%',
+      size: '20%'
+    },
+    sort: 'size',
+    reverse: true
+  }) }
   `);
-    if (action === 'tab') {
-        window.open(url + location.hash, '_blank');
-    } else if (action === 'file') {
-        const a = document.createElement('a');
-        a.href = url;
-        a.download = `${ title }_${ getCompactISODate() }.html`;
-        a.click();
-        URL.revokeObjectURL(url);
-    }
+  if (action === 'tab') {
+    window.open(url + location.hash, '_blank');
+  } else if (action === 'file') {
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${ title }_${ getCompactISODate() }.html`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
 }
 )};
-const _1i2b0pi = function _exportToHTML(_runtime, importShim, cssForTheme, css, location, keepalive, exporter_module, $0) {
+const _10fpobz = function _exportToHTML(_runtime, cssForTheme, css, location, keepalive, exporter_module, $0) {
     return async function exportToHTML({mains = new Map(), runtime = _runtime, options = {}} = {}) {
         let conf = { headless: false };
         try {
@@ -8052,6 +10023,12 @@ const _1i2b0pi = function _exportToHTML(_runtime, importShim, cssForTheme, css, 
         if (!options.headless) {
             options.headless = conf.headless;
         }
+        if (options.tick == null) {
+            options.tick = conf.tick;
+        }
+        if (options.tickDelayMs == null) {
+            options.tickDelayMs = conf.tickDelayMs;
+        }
         if (options.theme) {
             options.style = await cssForTheme(options.theme);
         }
@@ -8060,6 +10037,16 @@ const _1i2b0pi = function _exportToHTML(_runtime, importShim, cssForTheme, css, 
         }
         if (!options.hash) {
             options.hash = location.hash;
+        }
+        if (runtime === _runtime && (options.description == null || options.image == null)) {
+            try {
+                const ogContent = sel => document.querySelector(sel)?.getAttribute('content')?.trim() || undefined;
+                if (options.description == null)
+                    options.description = ogContent('meta[property="og:description"]') || ogContent('meta[name="description"]');
+                if (options.image == null)
+                    options.image = ogContent('meta[property="og:image"]');
+            } catch (_) {
+            }
         }
         keepalive(exporter_module, 'tomlarkworthy_exporter_task');
         const response = await $0.send({
@@ -8070,7 +10057,7 @@ const _1i2b0pi = function _exportToHTML(_runtime, importShim, cssForTheme, css, 
         return response;
     };
 };
-const _17k9v19 = function _getSourceModule(notebook_name, main, _runtime, importShim) {
+const _bga69d = function _getSourceModule(notebook_name, main, _runtime) {
     return async state => {
         if (state.source == 'this notebook')
             return {
@@ -8092,188 +10079,188 @@ const _17k9v19 = function _getSourceModule(notebook_name, main, _runtime, import
         };
     };
 };
-const _6vlf2p = function _createShowable(variable,view)
+const _tpv4tl = function _createShowable(variable,view)
 {
-    return function createShowable(child, {
-        show = true
-    } = {}) {
-        const showVariable = variable(show, { name: 'show' });
-        const showable = view`<div>${ [
-            'show',
-            showVariable
-        ] }${ [
-            'child',
-            child
-        ] }`;
-        // The showable logic is to toggle the visibility of the enclosing div based
-        // on the show variable state
-        const updateDisplay = () => {
-            if (showVariable.value) {
-                showable.style.display = 'inline';
-            } else {
-                showable.style.display = 'none';
-            }
-        };
-        // Variables have additional assign event so presentation can be
-        // updated as soon as variables change but before dataflow
-        // because this is a pure presentation state it makes sense not to trigger
-        // dataflow so we do not use 'input' event
-        showVariable.addEventListener('assign', updateDisplay);
-        updateDisplay();
-        return showable;
+  return function createShowable(child, {
+    show = true
+  } = {}) {
+    const showVariable = variable(show, { name: 'show' });
+    const showable = view`<div>${ [
+      'show',
+      showVariable
+    ] }${ [
+      'child',
+      child
+    ] }`;
+    // The showable logic is to toggle the visibility of the enclosing div based
+    // on the show variable state
+    const updateDisplay = () => {
+      if (showVariable.value) {
+        showable.style.display = 'inline';
+      } else {
+        showable.style.display = 'none';
+      }
     };
+    // Variables have additional assign event so presentation can be
+    // updated as soon as variables change but before dataflow
+    // because this is a pure presentation state it makes sense not to trigger
+    // dataflow so we do not use 'input' event
+    showVariable.addEventListener('assign', updateDisplay);
+    updateDisplay();
+    return showable;
+  };
 };
-const _zclcql = function _reportValidity(){return(
+const _rnq9mt = function _reportValidity(){return(
 (view, invalidation) => {
-    const input = view.querySelector('input');
-    const report = () => view.reportValidity();
-    input.addEventListener('input', report);
-    invalidation.then(() => input.removeEventListener('input', report));
-    return view;
+  const input = view.querySelector('input');
+  const report = () => view.reportValidity();
+  input.addEventListener('input', report);
+  invalidation.then(() => input.removeEventListener('input', report));
+  return view;
 }
 )};
-const _10rnvxz = function _top120List(){return(
+const _3vwqe7 = function _top120List(){return(
 [
-    '@jashkenas/inputs',
-    '@d3/gallery',
-    '@d3/learn-d3',
-    '@makio135/creative-coding',
-    '@observablehq/module-require-debugger',
-    '@d3/zoomable-sunburst',
-    '@observablehq/plot',
-    '@tmcw/enigma-machine',
-    '@d3/force-directed-graph-component',
-    '@d3/bar-chart-race-explained',
-    '@observablehq/data-wrangler',
-    '@d3/collapsible-tree',
-    '@sxywu/introduction-to-svg-and-d3-js',
-    '@d3/sankey-component',
-    '@d3/zoomable-circle-packing',
-    '@d3/selection-join',
-    '@bstaats/graph-visualization-introduction',
-    '@d3/color-legend',
-    '@uwdata/introducing-arquero',
-    '@mbostock/10-years-of-open-source-visualization',
-    '@nitaku/tangled-tree-visualization-ii',
-    '@makio135/give-me-colors',
-    '@johnburnmurdoch/bar-chart-race-the-most-populous-cities-in-the-world',
-    '@d3/color-schemes',
-    '@tezzutezzu/world-history-timeline',
-    '@d3/calendar',
-    '@observablehq/a-taste-of-observable',
-    '@d3/bar-chart-race',
-    '@mourner/martin-real-time-rtin-terrain-mesh',
-    '@uwdata/introduction-to-vega-lite',
-    '@mbostock/voronoi-stippling',
-    '@ben-tanen/a-tutorial-to-using-d3-force-from-someone-who-just-learned-ho',
-    '@d3/hierarchical-edge-bundling',
-    '@observablehq/introduction-to-data',
-    '@harrystevens/directly-labelling-lines',
-    '@observablehq/summary-table',
-    '@observablehq/plot-cheatsheets',
-    '@tomshanley/cheysson-color-palettes',
-    '@tophtucker/inferring-chart-type-from-autocorrelation-and-other-evils',
-    '@mitvis/introduction-to-d3',
-    '@veltman/watercolor',
-    '@veltman/centerline-labeling',
-    '@mbostock/scrubber',
-    '@observablehq/electoral-college-decision-tree',
-    '@d3/tree-component',
-    '@d3/radial-tree-component',
-    '@d3/world-tour',
-    '@observablehq/introduction-to-generators',
-    '@yurivish/peak-detection',
-    '@mkfreeman/plot-tooltip',
-    '@aboutaaron/racial-demographic-dot-density-map',
-    '@mbostock/methods-of-comparison-compared',
-    '@rreusser/gpgpu-boids',
-    '@rreusser/2d-n-body-gravity-with-poissons-equation',
-    '@bumbeishvili/data-driven-range-sliders',
-    '@observablehq/introducing-visual-dataflow',
-    '@observablehq/vega-lite',
-    '@observablehq/observable-for-jupyter-users',
-    '@observablehq/how-observable-runs',
-    '@unkleho/introducing-d3-render-truly-declarative-and-reusable-d3',
-    '@vega/a-guide-to-guides-axes-legends-in-vega',
-    '@bartok32/diy-inputs',
-    '@mbostock/polar-clock',
-    '@dakoop/learn-js-data',
-    '@mbostock/manipulating-flat-arrays',
-    '@uwdata/an-illustrated-guide-to-arquero-verbs',
-    '@daformat/rounding-polygon-corners',
-    '@yurivish/seasonal-spirals',
-    '@emamd/animating-lots-and-lots-of-circles-with-regl-js',
-    '@uwdata/data-visualization-curriculum',
-    '@d3/d3-group',
-    '@d3/tree-of-life',
-    '@d3/arc-diagram',
-    '@d3/choropleth',
-    '@mattdzugan/generative-art-using-wind-turbine-data',
-    '@jashkenas/handy-embed-code-generator',
-    '@analyzer2004/plot-gallery',
-    '@nsthorat/how-to-build-a-teachable-machine-with-tensorflow-js',
-    '@d3/sunburst-component',
-    '@tomlarkworthy/saas-tutorial',
-    '@mbostock/the-wealth-health-of-nations',
-    '@yy/covid-19-fatality-rate',
-    '@bryangingechen/importing-data-from-google-spreadsheets-into-a-notebook-we',
-    '@mbostock/slide',
-    '@kerryrodden/sequences-sunburst',
-    '@d3/zoom-to-bounding-box',
-    '@ambassadors/interactive-plot-dashboard',
-    '@sethpipho/fractal-tree',
-    '@mbostock/saving-svg',
-    '@analyzer2004/west-coast-weather-from-seattle-to-san-diego',
-    '@tmcw/tables',
-    '@observablehq/introduction-to-serverless-notebooks',
-    '@mootari/range-slider',
-    '@d3/animated-treemap',
-    '@d3/treemap-component',
-    '@uwdata/interaction',
-    '@hydrosquall/d3-annotation-with-d3-line-chart',
-    '@jiazhewang/introduction-to-antv',
-    '@d3/hierarchical-bar-chart',
-    '@uwdata/data-types-graphical-marks-and-visual-encoding-channels',
-    '@observablehq/why-use-a-radial-data-visualization',
-    '@kerryrodden/introduction-to-text-analysis-with-tf-idf',
-    '@uw-info474/javascript-data-wrangling',
-    '@karimdouieb/try-to-impeach-this-challenge-accepted',
-    '@observablehq/plot-gallery',
-    '@carmen-tm/women-architects-i-didnt-hear-about',
-    '@d3/versor-dragging',
-    '@analyzer2004/timespiral',
-    '@d3/brushable-scatterplot-matrix',
-    '@observablehq/require',
-    '@anjana/functional-javascript-first-steps',
-    '@hamzaamjad/tiny-charts',
-    '@observablehq/views',
-    '@yurivish/quarantine-now',
-    '@analyzer2004/performance-chart',
-    '@freedmand/sounds',
-    '@d3/bubble-chart-component',
-    '@d3/mobile-patent-suits',
-    '@observablehq/notebook-visualizer',
-    '@d3/force-directed-tree'
+  '@jashkenas/inputs',
+  '@d3/gallery',
+  '@d3/learn-d3',
+  '@makio135/creative-coding',
+  '@observablehq/module-require-debugger',
+  '@d3/zoomable-sunburst',
+  '@observablehq/plot',
+  '@tmcw/enigma-machine',
+  '@d3/force-directed-graph-component',
+  '@d3/bar-chart-race-explained',
+  '@observablehq/data-wrangler',
+  '@d3/collapsible-tree',
+  '@sxywu/introduction-to-svg-and-d3-js',
+  '@d3/sankey-component',
+  '@d3/zoomable-circle-packing',
+  '@d3/selection-join',
+  '@bstaats/graph-visualization-introduction',
+  '@d3/color-legend',
+  '@uwdata/introducing-arquero',
+  '@mbostock/10-years-of-open-source-visualization',
+  '@nitaku/tangled-tree-visualization-ii',
+  '@makio135/give-me-colors',
+  '@johnburnmurdoch/bar-chart-race-the-most-populous-cities-in-the-world',
+  '@d3/color-schemes',
+  '@tezzutezzu/world-history-timeline',
+  '@d3/calendar',
+  '@observablehq/a-taste-of-observable',
+  '@d3/bar-chart-race',
+  '@mourner/martin-real-time-rtin-terrain-mesh',
+  '@uwdata/introduction-to-vega-lite',
+  '@mbostock/voronoi-stippling',
+  '@ben-tanen/a-tutorial-to-using-d3-force-from-someone-who-just-learned-ho',
+  '@d3/hierarchical-edge-bundling',
+  '@observablehq/introduction-to-data',
+  '@harrystevens/directly-labelling-lines',
+  '@observablehq/summary-table',
+  '@observablehq/plot-cheatsheets',
+  '@tomshanley/cheysson-color-palettes',
+  '@tophtucker/inferring-chart-type-from-autocorrelation-and-other-evils',
+  '@mitvis/introduction-to-d3',
+  '@veltman/watercolor',
+  '@veltman/centerline-labeling',
+  '@mbostock/scrubber',
+  '@observablehq/electoral-college-decision-tree',
+  '@d3/tree-component',
+  '@d3/radial-tree-component',
+  '@d3/world-tour',
+  '@observablehq/introduction-to-generators',
+  '@yurivish/peak-detection',
+  '@mkfreeman/plot-tooltip',
+  '@aboutaaron/racial-demographic-dot-density-map',
+  '@mbostock/methods-of-comparison-compared',
+  '@rreusser/gpgpu-boids',
+  '@rreusser/2d-n-body-gravity-with-poissons-equation',
+  '@bumbeishvili/data-driven-range-sliders',
+  '@observablehq/introducing-visual-dataflow',
+  '@observablehq/vega-lite',
+  '@observablehq/observable-for-jupyter-users',
+  '@observablehq/how-observable-runs',
+  '@unkleho/introducing-d3-render-truly-declarative-and-reusable-d3',
+  '@vega/a-guide-to-guides-axes-legends-in-vega',
+  '@bartok32/diy-inputs',
+  '@mbostock/polar-clock',
+  '@dakoop/learn-js-data',
+  '@mbostock/manipulating-flat-arrays',
+  '@uwdata/an-illustrated-guide-to-arquero-verbs',
+  '@daformat/rounding-polygon-corners',
+  '@yurivish/seasonal-spirals',
+  '@emamd/animating-lots-and-lots-of-circles-with-regl-js',
+  '@uwdata/data-visualization-curriculum',
+  '@d3/d3-group',
+  '@d3/tree-of-life',
+  '@d3/arc-diagram',
+  '@d3/choropleth',
+  '@mattdzugan/generative-art-using-wind-turbine-data',
+  '@jashkenas/handy-embed-code-generator',
+  '@analyzer2004/plot-gallery',
+  '@nsthorat/how-to-build-a-teachable-machine-with-tensorflow-js',
+  '@d3/sunburst-component',
+  '@tomlarkworthy/saas-tutorial',
+  '@mbostock/the-wealth-health-of-nations',
+  '@yy/covid-19-fatality-rate',
+  '@bryangingechen/importing-data-from-google-spreadsheets-into-a-notebook-we',
+  '@mbostock/slide',
+  '@kerryrodden/sequences-sunburst',
+  '@d3/zoom-to-bounding-box',
+  '@ambassadors/interactive-plot-dashboard',
+  '@sethpipho/fractal-tree',
+  '@mbostock/saving-svg',
+  '@analyzer2004/west-coast-weather-from-seattle-to-san-diego',
+  '@tmcw/tables',
+  '@observablehq/introduction-to-serverless-notebooks',
+  '@mootari/range-slider',
+  '@d3/animated-treemap',
+  '@d3/treemap-component',
+  '@uwdata/interaction',
+  '@hydrosquall/d3-annotation-with-d3-line-chart',
+  '@jiazhewang/introduction-to-antv',
+  '@d3/hierarchical-bar-chart',
+  '@uwdata/data-types-graphical-marks-and-visual-encoding-channels',
+  '@observablehq/why-use-a-radial-data-visualization',
+  '@kerryrodden/introduction-to-text-analysis-with-tf-idf',
+  '@uw-info474/javascript-data-wrangling',
+  '@karimdouieb/try-to-impeach-this-challenge-accepted',
+  '@observablehq/plot-gallery',
+  '@carmen-tm/women-architects-i-didnt-hear-about',
+  '@d3/versor-dragging',
+  '@analyzer2004/timespiral',
+  '@d3/brushable-scatterplot-matrix',
+  '@observablehq/require',
+  '@anjana/functional-javascript-first-steps',
+  '@hamzaamjad/tiny-charts',
+  '@observablehq/views',
+  '@yurivish/quarantine-now',
+  '@analyzer2004/performance-chart',
+  '@freedmand/sounds',
+  '@d3/bubble-chart-component',
+  '@d3/mobile-patent-suits',
+  '@observablehq/notebook-visualizer',
+  '@d3/force-directed-tree'
 ]
 )};
-const _1iotzy = function _notebook_name()
+const _yq61j2 = function _notebook_name()
 {
-    if (document.baseURI.startsWith('https://observablehq.com')) {
-        return new URL(document.baseURI).pathname.replace('/', '');
-    }
+  if (document.baseURI.startsWith('https://observablehq.com')) {
+    return new URL(document.baseURI).pathname.replace('/', '');
+  }
 };
 const _1pwnq79 = function _notebook_title(notebook_name,_runtime){return(
 notebook_name || [..._runtime.mains.keys()][0]
 )};
-const _1xzlmfy = function _utf8ToBase64(){return(
+const _433z46 = function _utf8ToBase64(){return(
 str => {
-    const bytes = new TextEncoder().encode(String(str));
-    const chunk = 32768;
-    let bin = '';
-    for (let i = 0; i < bytes.length; i += chunk) {
-        bin += String.fromCharCode(...bytes.subarray(i, i + chunk));
-    }
-    return btoa(bin);
+  const bytes = new TextEncoder().encode(String(str));
+  const chunk = 32768;
+  let bin = '';
+  for (let i = 0; i < bytes.length; i += chunk) {
+    bin += String.fromCharCode(...bytes.subarray(i, i + chunk));
+  }
+  return btoa(bin);
 }
 )};
 const _14gyvdn = function _27(md){return(
@@ -8291,77 +10278,77 @@ task.runtime
 const _tdkfs5 = function _runtime_variables(task_runtime,variableToObject){return(
 [...task_runtime._variables].map(variableToObject)
 )};
-const _1thre44 = function _buildModuleNames()
+const _qc5kek = function _buildModuleNames()
 {
-    return function buildModuleNames(runtime, {
-        cache = []
-    } = {}) {
-        const names = new Map();
-        for (const [module, info] of cache)
-            names.set(module, info);
-        if (runtime.mains) {
-            for (const [name, module] of runtime.mains) {
-                if (!names.has(module))
-                    names.set(module, {
-                        name,
-                        module
-                    });
+  return function buildModuleNames(runtime, {
+    cache = []
+  } = {}) {
+    const names = new Map();
+    for (const [module, info] of cache)
+      names.set(module, info);
+    if (runtime.mains) {
+      for (const [name, module] of runtime.mains) {
+        if (!names.has(module))
+          names.set(module, {
+            name,
+            module
+          });
+      }
+    }
+    // Pass 1: "module X" variables with resolved _value
+    for (const v of runtime._variables) {
+      if (typeof v._name === 'string' && v._name.startsWith('module ') && v._value && !names.has(v._value)) {
+        const name = v._name.slice(7);
+        names.set(v._value, {
+          name,
+          module: v._value
+        });
+      }
+    }
+    // Pass 2: for import-bridged variables whose source module is still unnamed,
+    // find the "module X" variable in the same module and use its name.
+    // This handles lazy/unresolved modules on Observable.
+    for (const v of runtime._variables) {
+      if (v._inputs?.length === 1 && v._inputs[0]?._module && v._inputs[0]._module !== v._module && !names.has(v._inputs[0]._module)) {
+        // Find a "module X" variable in v._module that could reference this source
+        for (const mv of runtime._variables) {
+          if (mv._module === v._module && typeof mv._name === 'string' && mv._name.startsWith('module ')) {
+            // Try to match: if mv._value is the source module, or if mv._value is unresolved
+            // but mv is the only module var, use its name
+            const targetModule = v._inputs[0]._module;
+            if (mv._value === targetModule) {
+              names.set(targetModule, {
+                name: mv._name.slice(7),
+                module: targetModule
+              });
+              break;
             }
+          }
         }
-        // Pass 1: "module X" variables with resolved _value
-        for (const v of runtime._variables) {
-            if (typeof v._name === 'string' && v._name.startsWith('module ') && v._value && !names.has(v._value)) {
-                const name = v._name.slice(7);
-                names.set(v._value, {
-                    name,
-                    module: v._value
-                });
-            }
-        }
-        // Pass 2: for import-bridged variables whose source module is still unnamed,
-        // find the "module X" variable in the same module and use its name.
-        // This handles lazy/unresolved modules on Observable.
-        for (const v of runtime._variables) {
-            if (v._inputs?.length === 1 && v._inputs[0]?._module && v._inputs[0]._module !== v._module && !names.has(v._inputs[0]._module)) {
-                // Find a "module X" variable in v._module that could reference this source
-                for (const mv of runtime._variables) {
-                    if (mv._module === v._module && typeof mv._name === 'string' && mv._name.startsWith('module ')) {
-                        // Try to match: if mv._value is the source module, or if mv._value is unresolved
-                        // but mv is the only module var, use its name
-                        const targetModule = v._inputs[0]._module;
-                        if (mv._value === targetModule) {
-                            names.set(targetModule, {
-                                name: mv._name.slice(7),
-                                module: targetModule
-                            });
-                            break;
-                        }
-                    }
-                }
-            }
-            // Also for @variable pattern imports
-            if (v._inputs?.length === 2 && v._inputs[1]?._name === '@variable' && v._inputs[0]?._value && !names.has(v._inputs[0]._value)) {
-                names.set(v._inputs[0]._value, {
-                    name: v._inputs[0]._name?.slice(7) || 'unknown',
-                    module: v._inputs[0]._value
-                });
-            }
-        }
-        const builtinModule = runtime._builtin;
-        if (builtinModule && !names.has(builtinModule))
-            names.set(builtinModule, {
-                name: 'builtin',
-                module: builtinModule
-            });
-        for (const v of runtime._variables) {
-            if (!names.has(v._module))
-                names.set(v._module, {
-                    name: 'main',
-                    module: v._module
-                });
-        }
-        return names;
-    };
+      }
+      // Also for @variable pattern imports
+      if (v._inputs?.length === 2 && v._inputs[1]?._name === '@variable' && v._inputs[0]?._value && !names.has(v._inputs[0]._value)) {
+        names.set(v._inputs[0]._value, {
+          name: v._inputs[0]._name?.slice(7) || 'unknown',
+          module: v._inputs[0]._value
+        });
+      }
+    }
+    const builtinModule = runtime._builtin;
+    if (builtinModule && !names.has(builtinModule))
+      names.set(builtinModule, {
+        name: 'builtin',
+        module: builtinModule
+      });
+    for (const v of runtime._variables) {
+      if (!names.has(v._module))
+        names.set(v._module, {
+          name: 'main',
+          module: v._module
+        });
+    }
+    return names;
+  };
 };
 const _1pfdk6e = function _isModuleVar(){return(
 v => typeof v._name === 'string' && v._name.startsWith('module ')
@@ -8369,48 +10356,48 @@ v => typeof v._name === 'string' && v._name.startsWith('module ')
 const _1vua7u7 = function _isDynamicVar(){return(
 v => typeof v._name === 'string' && v._name.startsWith('dynamic ')
 )};
-const _13nx5f5 = function _isImportBridged()
+const _9cxfm9 = function _isImportBridged()
 {
-    return function isImportBridged(v) {
-        if (v._inputs.length === 1 && v._inputs[0]._module !== v._module && !v._inputs[0]._name?.startsWith?.('@'))
-            return true;
-        if (v._inputs.length === 2 && v._inputs[1]?._name === '@variable')
-            return true;
-        // Observable closure-based imports: single @variable input + definition contains .import(
-        if (v._inputs.length === 1 && v._inputs[0]?._name === '@variable' && v._definition?.toString().includes('.import('))
-            return true;
-        return false;
-    };
+  return function isImportBridged(v) {
+    if (v._inputs.length === 1 && v._inputs[0]._module !== v._module && !v._inputs[0]._name?.startsWith?.('@'))
+      return true;
+    if (v._inputs.length === 2 && v._inputs[1]?._name === '@variable')
+      return true;
+    // Observable closure-based imports: single @variable input + definition contains .import(
+    if (v._inputs.length === 1 && v._inputs[0]?._name === '@variable' && v._definition?.toString().includes('.import('))
+      return true;
+    return false;
+  };
 };
-const _4l3h5t = function _findImportedName3(){return(
+const _1omyant = function _findImportedName3(){return(
 async function findImportedName(v) {
-    if (v._inputs.length === 1 && v._inputs[0]._name === '@variable') {
-        let capture;
-        await v._definition({ import: (...args) => capture = args });
-        return capture[0];
-    }
-    if (v._inputs.length === 1)
-        return v._inputs[0]._name;
-    const regex = /v\.import\("([^"]+)",\s*"([^"]+)"/;
-    const match = v._definition.toString().match(regex);
-    if (match)
-        return match[1];
-    return v._name;
+  if (v._inputs.length === 1 && v._inputs[0]._name === '@variable') {
+    let capture;
+    await v._definition({ import: (...args) => capture = args });
+    return capture[0];
+  }
+  if (v._inputs.length === 1)
+    return v._inputs[0]._name;
+  const regex = /v\.import\("([^"]+)",\s*"([^"]+)"/;
+  const match = v._definition.toString().match(regex);
+  if (match)
+    return match[1];
+  return v._name;
 }
 )};
-const _1r5dbt4 = function _moduleNames(task,moduleMap,task_runtime)
+const _x9dxs8 = function _moduleNames(task,moduleMap,task_runtime)
 {
-    if (task.options?.debug)
-        debugger;
-    return moduleMap(task_runtime, {
-        cache: [...task.mains.entries()].map(([name, module]) => [
-            module,
-            {
-                name,
-                module
-            }
-        ])
-    });
+  if (task.options?.debug)
+    debugger;
+  return moduleMap(task_runtime, {
+    cache: [...task.mains.entries()].map(([name, module]) => [
+      module,
+      {
+        name,
+        module
+      }
+    ])
+  });
 };
 const _2o6tia = function _38(resolve_modules){return(
 resolve_modules
@@ -8418,12 +10405,13 @@ resolve_modules
 const _dx8tp1 = function _39(summary){return(
 summary
 )};
-const _abbxde = function _excluded_module_names(){return(
+const _ti9fu1 = function _excluded_module_names(){return(
 [
-    'TBD',
-    'error',
-    'builtin',
-    'main'
+  'TBD',
+  'error',
+  'builtin',
+  'main',
+  'bootloader'
 ]
 )};
 const _po3sop = function _excluded_modules(moduleNames,excluded_module_names){return(
@@ -8432,154 +10420,176 @@ new Map([...moduleNames.entries()].filter(([m, info]) => excluded_module_names.i
 const _16u7vne = function _included_modules(moduleNames,excluded_module_names){return(
 new Map([...moduleNames.entries()].filter(([m, info]) => !excluded_module_names.includes(info.name)))
 )};
-const _1y5e5x8 = async function _module_specs(task,included_modules,TRACE_MODULE,task_runtime,isModuleVar,isDynamicVar,getFileAttachments,main,generate_module_source,moduleNames)
+const _kxkh98 = async function _module_specs(task,included_modules,TRACE_MODULE,task_runtime,isModuleVar,isDynamicVar,getFileAttachments,main,generate_module_source,moduleNames)
 {
-    if (task.options?.debug)
-        debugger;
-    return new Map(await Promise.all([...included_modules.entries()].map(async ([module, spec]) => {
-        if (spec.name === TRACE_MODULE)
-            debugger;
-        // Raw variables for this module (user-defined, non-dynamic)
-        const variables = [...task_runtime._variables].filter(v => v._module === module && (v._type === 1 || isModuleVar(v)) && !isDynamicVar(v));
-        const imports = variables.filter(v => isModuleVar(v)).map(v => v._name.slice(7)).filter(m => !['builtin'].includes(m));
-        const fileAttachments = getFileAttachments(module) || new Map();
-        if (spec.name === task.notebook && task?.options?.main_files !== false) {
-            getFileAttachments(main).forEach((value, key) => fileAttachments.set(key, value));
-        }
-        const source = await generate_module_source(spec, variables, fileAttachments, { moduleNames });
-        return [
-            spec.name,
-            {
-                url: spec.name,
-                imports,
-                fileAttachments,
-                source,
-                variables,
-                module,
-                define: spec.define
-            }
-        ];
-    })));
+  if (task.options?.debug)
+    debugger;
+  return new Map(await Promise.all([...included_modules.entries()].map(async ([module, spec]) => {
+    if (spec.name === TRACE_MODULE)
+      debugger;
+    // Raw variables for this module (user-defined, non-dynamic)
+    const variables = [...task_runtime._variables].filter(v => v._module === module && (v._type === 1 || isModuleVar(v)) && !isDynamicVar(v));
+    const imports = variables.filter(v => isModuleVar(v)).map(v => v._name.slice(7)).filter(m => !['builtin'].includes(m));
+    const fileAttachments = getFileAttachments(module) || new Map();
+    if (spec.name === task.notebook && task?.options?.main_files !== false) {
+      getFileAttachments(main).forEach((value, key) => fileAttachments.set(key, value));
+    }
+    const source = await generate_module_source(spec, variables, fileAttachments, { moduleNames });
+    return [
+      spec.name,
+      {
+        url: spec.name,
+        imports,
+        fileAttachments,
+        source,
+        variables,
+        module,
+        define: spec.define
+      }
+    ];
+  })));
 };
 const _1r3eg9r = function _findImports(){return(
 cells => [...cells.keys()].filter(name => typeof name === 'string' && name.startsWith('module ')).map(name => name.replace('module ', ''))
 )};
-const _ipv4ft = function _getFileAttachments(){return(
+const _15bukmh = function _getFileAttachments(){return(
 module => {
-    let fileMap;
-    const FileAttachment = module._builtins.get('FileAttachment');
-    const backup_get = Map.prototype.get;
-    const backup_has = Map.prototype.has;
-    Map.prototype.has = Map.prototype.get = function (...args) {
-        fileMap = this;
-    };
-    try {
-        FileAttachment('');
-    } catch (e) {
-    }
-    Map.prototype.has = backup_has;
-    Map.prototype.get = backup_get;
-    return fileMap;
+  let fileMap;
+  const FileAttachment = module._builtins.get('FileAttachment');
+  const backup_get = Map.prototype.get;
+  const backup_has = Map.prototype.has;
+  Map.prototype.has = Map.prototype.get = function (...args) {
+    fileMap = this;
+  };
+  try {
+    FileAttachment('');
+  } catch (e) {
+  }
+  Map.prototype.has = backup_has;
+  Map.prototype.get = backup_get;
+  return fileMap;
 }
 )};
-const _1x463u7 = function _book(task,inlineModule,inlineGzipModule,es_module_shims,runtime_gz,inspector_gz,module_specs,lopemodule,lopebook){return(
+const _g0wr2v = function _streamingModuleOrder()
+{
+  return (mainNames, specByName) => {
+    // Deterministic, churn-free order: bootconf-declared mains first so a notebook's own page/entry
+    // modules stream before anything else, then every other module — each group sorted alphabetically.
+    // Order depends only on the set of module names (not on the import graph), so re-exporting an
+    // unchanged notebook produces byte-identical block order. Each module's FileAttachment blocks
+    // already precede its source (see lopemodule), so define-time contentSync never misses.
+    const mains = new Set(mainNames.filter(n => specByName.has(n)));
+    const lead = [...mains].sort();
+    const rest = [...specByName.keys()].filter(n => !mains.has(n)).sort();
+    return [
+      ...lead,
+      ...rest
+    ];
+  };
+};
+const _15y6f5s = function _book(task,inlineModule,inlineGzipModule,es_module_shims,runtime_gz,inspector_gz,streamingModuleOrder,module_specs,lopemodule,lopebook){return(
 (async () => {
-    const cssBlocks = task.options.style.map(([url, content]) => inlineModule(url, content, { mime: 'text/css' })).join('\n');
-    const cssUrls = task.options.style.map(([url]) => url);
-    const systemBlocks = [
-        inlineGzipModule('es-module-shims@2.6.2', es_module_shims),
-        inlineGzipModule('@observablehq/runtime@6.0.0', runtime_gz),
-        inlineGzipModule('@observablehq/inspector@5.0.1', inspector_gz)
-    ].join('\n');
-    const userBlocks = (await Promise.all([...module_specs.values()].sort((a, b) => a.url.localeCompare(b.url)).map(m => lopemodule(m)))).join('');
-    const bootloader = task.options.bootloader || '@tomlarkworthy/bootloader';
-    const bootconfBlock = `<script id="bootconf.json"
+  const cssBlocks = task.options.style.map(([url, content]) => inlineModule(url, content, { mime: 'text/css' })).join('\n');
+  const cssUrls = task.options.style.map(([url]) => url);
+  const systemBlocks = [
+    inlineGzipModule('es-module-shims@2.6.2', es_module_shims),
+    inlineGzipModule('@observablehq/runtime@6.0.0', runtime_gz),
+    inlineGzipModule('@observablehq/inspector@5.0.1', inspector_gz)
+  ].join('\n');
+  const orderedNames = streamingModuleOrder([...task.mains.keys()], module_specs);
+  const userBlocks = (await Promise.all(orderedNames.map(name => lopemodule(module_specs.get(name))))).join('');
+  const bootloader = task.options.bootloader || '@tomlarkworthy/bootloader';
+  const tickLine = task.options.tick != null ? `,\n  "tick": ${ JSON.stringify(task.options.tick) }` : '';
+  const tickDelayLine = task.options.tickDelayMs != null ? `,\n  "tickDelayMs": ${ JSON.stringify(task.options.tickDelayMs) }` : '';
+  const bootconfBlock = `<script id="bootconf.json"
         type="text/plain"
         data-mime="application/json"
 >
 {
   "mains": ${ JSON.stringify([...task.mains.keys()]) },
   "hash": "${ task.options.hash || '' }",
-  "headless": ${ !!task.options.headless }
+  "headless": ${ !!task.options.headless }${ tickLine }${ tickDelayLine }
 }
 </scr` + `ipt>`;
-    const bootloaderBlock = inlineModule(bootloader, await (await fetch(`https://api.observablehq.com/${ bootloader }.js?v=4`)).text());
-    const blocks = [
-        '<!-- CSS -->',
-        cssBlocks,
-        `<style>
+  const bootloaderBlock = inlineModule(bootloader, await (await fetch(`https://api.observablehq.com/${ bootloader }.js?v=4`)).text());
+  const blocks = [
+    '<!-- CSS -->',
+    cssBlocks,
+    `<style>
 body .inputs-3a86ea-table thead th {
   background: var(--theme-foreground-faintest);
 }
 </style>`,
-        '<!-- System Modules -->',
-        systemBlocks,
-        userBlocks,
-        '<!-- Bootloader -->',
-        bootconfBlock,
-        bootloaderBlock
-    ].join('\n');
-    return lopebook({
-        blocks,
-        cssUrls,
-        bootloader,
-        title: task.options.title || 'Lopecode notebook',
-        head: task.options.head
-    });
+    '<!-- System Modules -->',
+    systemBlocks,
+    userBlocks,
+    '<!-- Bootloader -->',
+    bootconfBlock,
+    bootloaderBlock
+  ].join('\n');
+  return lopebook({
+    blocks,
+    cssUrls,
+    bootloader,
+    title: task.options.title || 'Lopecode notebook',
+    description: task.options.description,
+    image: task.options.image,
+    head: task.options.head
+  });
 })()
 )};
-const _18javdl = function _47(Inputs,module_specs){return(
+const _tztkf6 = function _48(Inputs,module_specs){return(
 Inputs.table([...module_specs.entries().map(([name, spec]) => ({
+    name,
+    source: spec.source.length,
+    imports: spec.imports,
+    fileAttachments: spec.fileAttachments
+  }))], {
+  layout: 'auto',
+  format: {
+    fileAttachments: f => !f ? 'none' : Inputs.table([...f.entries().map(([name, f]) => ({
         name,
-        source: spec.source.length,
-        imports: spec.imports,
-        fileAttachments: spec.fileAttachments
-    }))], {
-    layout: 'auto',
-    format: {
-        fileAttachments: f => !f ? 'none' : Inputs.table([...f.entries().map(([name, f]) => ({
-                name,
-                url: f.url || f
-            }))]),
-        imports: f => Inputs.table(f.map(i => ({ name: i })))
-    }
+        url: f.url || f
+      }))]),
+    imports: f => Inputs.table(f.map(i => ({ name: i })))
+  }
 })
 )};
-const _1gb47v = function _48(md){return(
+const _1razd4c = function _49(md){return(
 md`##### Generate a report on the sizes of components`
 )};
-const _5m8hbe = function _report(DOMParser,book)
+const _avn3ei = function _report(DOMParser,book)
 {
-    let report;
-    try {
-        report = [...new DOMParser().parseFromString(book, 'text/html').querySelectorAll('script')].map(script => ({
-            ...script.getAttribute('file') && {
-                file: script.getAttribute('file'),
-                module: script.getAttribute('module')
-            },
-            type: script.getAttribute('data-mime') || 'application/javascript',
-            size: script.text.length,
-            id: script.id
-        }));
-    } catch (err) {
-        report = err;
-    }
-    console.log('report', report);
-    return report;
+  let report;
+  try {
+    report = [...new DOMParser().parseFromString(book, 'text/html').querySelectorAll('script')].map(script => ({
+      ...script.getAttribute('file') && {
+        file: script.getAttribute('file'),
+        module: script.getAttribute('module')
+      },
+      type: script.getAttribute('data-mime') || 'application/javascript',
+      size: script.text.length,
+      id: script.id
+    }));
+  } catch (err) {
+    report = err;
+  }
+  console.log('report', report);
+  return report;
 };
-const _4x0qc2 = function _tomlarkworthy_exporter_task(book,report,exporter_module,$0)
+const _186iat6 = function _tomlarkworthy_exporter_task(book,report,exporter_module,$0)
 {
-    const result = {
-        source: book,
-        report: report
-    };
-    exporter_module;
-    return $0.resolve(result);
+  const result = {
+    source: book,
+    report: report
+  };
+  exporter_module;
+  return $0.resolve(result);
 };
-const _1exq2jt = function _51(md){return(
+const _9aqzbs = function _52(md){return(
 md`## Module Source Generator`
 )};
-const _fctoc0 = function _52(md){return(
+const _1h8zj4h = function _53(md){return(
 md`### exportModuleJS
 
 Serialize a single module from the live runtime to a \`.js\` module source string. Unlike \`module_specs\` (which serializes all modules as part of the full HTML export pipeline), \`exportModuleJS\` works on-demand against the live runtime with no \`task\` dependency.
@@ -8602,12 +10612,9 @@ const {source, fileAttachments} = await exportModuleJS(moduleId, {runtime, modul
 - \`fileAttachments\` — \`Map<name, {url, mimeType}>\` of the module's file attachments
 `
 )};
-const _85q15a = function _exportModuleJS(_runtime,buildModuleNames,isModuleVar,isDynamicVar,getFileAttachments,generate_module_source)
+const _1xx9ynh = function _exportModuleJS(_runtime,buildModuleNames,isModuleVar,isDynamicVar,getFileAttachments,generate_module_source)
 {
-  const fn = async (
-    moduleId,
-    { runtime = _runtime, moduleNamesFn = buildModuleNames } = {}
-  ) => {
+  const fn = async (moduleId, {runtime = _runtime, moduleNamesFn = buildModuleNames} = {}) => {
     const names = moduleNamesFn(runtime);
     let targetModule = null;
     for (const [module, info] of names) {
@@ -8616,21 +10623,12 @@ const _85q15a = function _exportModuleJS(_runtime,buildModuleNames,isModuleVar,i
         break;
       }
     }
-    if (!targetModule) throw new Error(`Module not found: ${moduleId}`);
-    const variables = [...runtime._variables].filter(
-      (v) =>
-        v._module === targetModule &&
-        (v._type === 1 || isModuleVar(v)) &&
-        !isDynamicVar(v)
-    );
+    if (!targetModule)
+      throw new Error(`Module not found: ${ moduleId }`);
+    const variables = [...runtime._variables].filter(v => v._module === targetModule && (v._type === 1 || isModuleVar(v)) && !isDynamicVar(v));
     const fileAttachments = getFileAttachments(targetModule) || new Map();
     const spec = { name: moduleId };
-    const source = await generate_module_source(
-      spec,
-      variables,
-      fileAttachments,
-      { moduleNames: names }
-    );
+    const source = await generate_module_source(spec, variables, fileAttachments, { moduleNames: names });
     return {
       source,
       fileAttachments
@@ -8646,7 +10644,7 @@ ${ await generate_define(spec, variables, fileAttachments, { moduleNames }) }`
 const _19ft5zb = function _generate_definitions(variableToDefinition){return(
 variables => variables.map(v => variableToDefinition(v)).join('')
 )};
-const _7nr512 = function _generate_define(variableToDefine) {
+const _u3aown = function _generate_define(variableToDefine) {
     return async (spec, variables, fileAttachments, {moduleNames} = {}) => {
         const fileAttachmentExpression = fileAttachments?.size ? `  const fileAttachments = new Map(${ JSON.stringify([...fileAttachments.keys()]) }.map((name) => {
     const module_name = "${ spec.name }";
@@ -8680,123 +10678,123 @@ ${ varLines.join('  \n') }
 const _1hslsmt = function _isLiveImport(){return(
 v => !v._name && v._definition?.toString().includes('observablehq' + '--inspect ' + 'observablehq--import')
 )};
-const _g39v22 = function _variableToDefinition(isModuleVar,isImportBridged,isLiveImport,isDynamicVar,pid,restoreCanonicalImports){return(
+const _4i5mmq = function _variableToDefinition(isModuleVar,isImportBridged,isLiveImport,isDynamicVar,pid,restoreCanonicalImports){return(
 function variableToDefinition(v) {
-    if (isModuleVar(v))
-        return '';
-    if (isImportBridged(v))
-        return '';
-    if (isLiveImport(v))
-        return '';
-    if (isDynamicVar(v))
-        return '';
-    return `const ${ pid(v) } = ${ restoreCanonicalImports(v._definition.toString()) };\n`;
+  if (isModuleVar(v))
+    return '';
+  if (isImportBridged(v))
+    return '';
+  if (isLiveImport(v))
+    return '';
+  if (isDynamicVar(v))
+    return '';
+  return `const ${ pid(v) } = ${ restoreCanonicalImports(v._definition.toString()) };\n`;
 }
 )};
-const _5zomoj = function _restoreCanonicalImports(acorn,escodegen){return(
+const _1ohymeb = function _restoreCanonicalImports(acorn,escodegen){return(
 source => {
-    if (!/\bimportShim\s*\(/.test(source))
-        return source;
-    let ast;
-    try {
-        ast = acorn.Parser.parse(source, {
-            ecmaVersion: 'latest',
-            sourceType: 'script',
-            allowAwaitOutsideFunction: true,
-            allowReturnOutsideFunction: true,
-            allowImportExportEverywhere: true
-        });
-    } catch (e) {
-        console.warn('[exporter-3] importShim AST parse failed; leaving cell unchanged:', e.message);
-        return source;
+  if (!/\bimportShim\s*\(/.test(source))
+    return source;
+  let ast;
+  try {
+    ast = acorn.Parser.parse(source, {
+      ecmaVersion: 'latest',
+      sourceType: 'script',
+      allowAwaitOutsideFunction: true,
+      allowReturnOutsideFunction: true,
+      allowImportExportEverywhere: true
+    });
+  } catch (e) {
+    console.warn('[exporter-3] importShim AST parse failed; leaving cell unchanged:', e.message);
+    return source;
+  }
+  const visit = node => {
+    if (!node || typeof node !== 'object')
+      return;
+    if (node.type === 'CallExpression' && node.callee && node.callee.type === 'Identifier' && node.callee.name === 'importShim' && node.arguments.length >= 1) {
+      const spec = node.arguments[0];
+      for (const k of Object.keys(node))
+        delete node[k];
+      node.type = 'ImportExpression';
+      node.source = spec;
     }
-    const visit = node => {
-        if (!node || typeof node !== 'object')
-            return;
-        if (node.type === 'CallExpression' && node.callee && node.callee.type === 'Identifier' && node.callee.name === 'importShim' && node.arguments.length >= 1) {
-            const spec = node.arguments[0];
-            for (const k of Object.keys(node))
-                delete node[k];
-            node.type = 'ImportExpression';
-            node.source = spec;
-        }
-        for (const k of Object.keys(node)) {
-            const v = node[k];
-            if (Array.isArray(v))
-                v.forEach(visit);
-            else if (v && typeof v === 'object' && v.type)
-                visit(v);
-        }
-    };
-    visit(ast);
-    return escodegen.generate(ast);
+    for (const k of Object.keys(node)) {
+      const v = node[k];
+      if (Array.isArray(v))
+        v.forEach(visit);
+      else if (v && typeof v === 'object' && v.type)
+        visit(v);
+    }
+  };
+  visit(ast);
+  return escodegen.generate(ast);
 }
 )};
-const _1g36je3 = function _variableToDefine(isLiveImport,isDynamicVar,isModuleVar,isImportBridged,findImportedName3,pid)
+const _1g13ozv = function _variableToDefine(isLiveImport,isDynamicVar,isModuleVar,isImportBridged,findImportedName3,pid)
 {
-    const EXCLUDED = [
-        'main',
-        'builtin',
-        'TBD',
-        'error'
-    ];
-    return async function variableToDefine(v, {moduleNames} = {}) {
-        if (isLiveImport(v))
-            return [];
-        if (isDynamicVar(v))
-            return [];
-        if (isModuleVar(v)) {
-            // On Observable, module vars may be named "module 1" instead of "module @author/name"
-            // Look up the proper name via moduleNames map (keyed by module object)
-            let moduleName = v._name.slice(7);
-            if (v._value && moduleNames?.has(v._value)) {
-                moduleName = moduleNames.get(v._value).name;
-            }
-            if (EXCLUDED.includes(moduleName))
-                return [];
-            return [`  main.define("module ${ moduleName }", async () => runtime.module((await import("/${ moduleName }.js?v=4")).default));`];
+  const EXCLUDED = [
+    'main',
+    'builtin',
+    'TBD',
+    'error'
+  ];
+  return async function variableToDefine(v, {moduleNames} = {}) {
+    if (isLiveImport(v))
+      return [];
+    if (isDynamicVar(v))
+      return [];
+    if (isModuleVar(v)) {
+      // On Observable, module vars may be named "module 1" instead of "module @author/name"
+      // Look up the proper name via moduleNames map (keyed by module object)
+      let moduleName = v._name.slice(7);
+      if (v._value && moduleNames?.has(v._value)) {
+        moduleName = moduleNames.get(v._value).name;
+      }
+      if (EXCLUDED.includes(moduleName))
+        return [];
+      return [`  main.define("module ${ moduleName }", async () => runtime.module((await import("/${ moduleName }.js?v=4")).default));`];
+    }
+    if (isImportBridged(v)) {
+      const importedName = await findImportedName3(v);
+      let moduleVarName = null;
+      if (v._inputs.length === 2 && v._inputs[1]?._name === '@variable') {
+        // Also resolve the module var name for imports
+        const moduleVar = v._inputs[0];
+        let resolvedModuleName = moduleVar._name?.slice(7);
+        if (moduleVar._value && moduleNames?.has(moduleVar._value)) {
+          resolvedModuleName = moduleNames.get(moduleVar._value).name;
         }
-        if (isImportBridged(v)) {
-            const importedName = await findImportedName3(v);
-            let moduleVarName = null;
-            if (v._inputs.length === 2 && v._inputs[1]?._name === '@variable') {
-                // Also resolve the module var name for imports
-                const moduleVar = v._inputs[0];
-                let resolvedModuleName = moduleVar._name?.slice(7);
-                if (moduleVar._value && moduleNames?.has(moduleVar._value)) {
-                    resolvedModuleName = moduleNames.get(moduleVar._value).name;
-                }
-                moduleVarName = `module ${ resolvedModuleName }`;
-            } else if (v._inputs.length === 1 && v._inputs[0]?._name === '@variable') {
-                // Observable closure-based import: single @variable input, module captured in closure.
-                // Find source module by searching which module's _scope contains this variable name.
-                for (const [mod, info] of moduleNames) {
-                    if (info.name === 'main' || info.name === 'builtin')
-                        continue;
-                    if (mod._scope?.has(v._name)) {
-                        moduleVarName = `module ${ info.name }`;
-                        break;
-                    }
-                }
-            } else if (v._inputs.length === 1 && v._inputs[0]._module !== v._module) {
-                const sourceModule = v._inputs[0]._module;
-                const sourceInfo = moduleNames?.get(sourceModule);
-                if (sourceInfo)
-                    moduleVarName = `module ${ sourceInfo.name }`;
-            }
-            if (!moduleVarName)
-                return [];
-            const resolvedName = moduleVarName.slice(7);
-            if (EXCLUDED.includes(resolvedName))
-                return [];
-            return [`  main.define("${ v._name }", ["${ moduleVarName }", "@variable"], (_, v) => v.import(${ importedName && importedName !== v._name ? `"${ importedName }", ` : '' }"${ v._name }", _));`];
+        moduleVarName = `module ${ resolvedModuleName }`;
+      } else if (v._inputs.length === 1 && v._inputs[0]?._name === '@variable') {
+        // Observable closure-based import: single @variable input, module captured in closure.
+        // Find source module by searching which module's _scope contains this variable name.
+        for (const [mod, info] of moduleNames) {
+          if (info.name === 'main' || info.name === 'builtin')
+            continue;
+          if (mod._scope?.has(v._name)) {
+            moduleVarName = `module ${ info.name }`;
+            break;
+          }
         }
-        const deps = JSON.stringify(v._inputs.map(i => i._name));
-        const name_literal = v._name ? `"${ v._name }"` : 'null';
-        return [`  $def("${ pid(v) }", ${ name_literal }, ${ deps }, ${ pid(v) });`];
-    };
+      } else if (v._inputs.length === 1 && v._inputs[0]._module !== v._module) {
+        const sourceModule = v._inputs[0]._module;
+        const sourceInfo = moduleNames?.get(sourceModule);
+        if (sourceInfo)
+          moduleVarName = `module ${ sourceInfo.name }`;
+      }
+      if (!moduleVarName)
+        return [];
+      const resolvedName = moduleVarName.slice(7);
+      if (EXCLUDED.includes(resolvedName))
+        return [];
+      return [`  main.define("${ v._name }", ["${ moduleVarName }", "@variable"], (_, v) => v.import(${ importedName && importedName !== v._name ? `"${ importedName }", ` : '' }"${ v._name }", _));`];
+    }
+    const deps = JSON.stringify(v._inputs.map(i => i._name));
+    const name_literal = v._name ? `"${ v._name }"` : 'null';
+    return [`  $def("${ pid(v) }", ${ name_literal }, ${ deps }, ${ pid(v) });`];
+  };
 };
-const _dxkjia = function _61(md){return(
+const _8rymrb = function _62(md){return(
 md`## Assemble `
 )};
 const _g33g3u = function _es_module_shims(){return(
@@ -8823,24 +10821,192 @@ ${ source }
 const _bwex58 = function _normalize(){return(
 url => url.replace(/^(?:https:\/\/api\.observablehq\.com)?\/(.*?)\.js(?:\?.*)?$/, '$1').replace(/^(d\/[a-f0-9]{16})@\d+$/, '$1')
 )};
-const _eoywzy = function _test_normalize(expect,normalize)
+const _1vymoni = function _test_normalize(expect,normalize)
 {
-    expect(normalize('d/57d79353bac56631@4')).toBe('d/57d79353bac56631');
-    expect(normalize('https://api.observablehq.com/@tomlarkworthy/runtime-sdk.js?v=4')).toBe('@tomlarkworthy/runtime-sdk');
-    expect(normalize('https://api.observablehq.com/@tomlarkworthy/bootloader.js?v=4')).toBe('@tomlarkworthy/bootloader');
-    expect(normalize('https://api.observablehq.com/d/57d79353bac56631.js?v=4')).toBe('d/57d79353bac56631');
-    expect(normalize('/@tomlarkworthy/runtime-sdk.js?v=4')).toBe('@tomlarkworthy/runtime-sdk');
-    expect(normalize('/d/57d79353bac56631.js?v=4')).toBe('d/57d79353bac56631');
-    expect(normalize('/@tomlarkworthy/fileattachments.js?v=4&resolutions=4b0160c7af70b609@8453')).toBe('@tomlarkworthy/fileattachments');
-    expect(normalize('https://api.observablehq.com/@tomlarkworthy/jest-expect-standalone.js?v=4&resolutions=03dda470c56b93ff@8390')).toBe('@tomlarkworthy/jest-expect-standalone');
+  expect(normalize('d/57d79353bac56631@4')).toBe('d/57d79353bac56631');
+  expect(normalize('https://api.observablehq.com/@tomlarkworthy/runtime-sdk.js?v=4')).toBe('@tomlarkworthy/runtime-sdk');
+  expect(normalize('https://api.observablehq.com/@tomlarkworthy/bootloader.js?v=4')).toBe('@tomlarkworthy/bootloader');
+  expect(normalize('https://api.observablehq.com/d/57d79353bac56631.js?v=4')).toBe('d/57d79353bac56631');
+  expect(normalize('/@tomlarkworthy/runtime-sdk.js?v=4')).toBe('@tomlarkworthy/runtime-sdk');
+  expect(normalize('/d/57d79353bac56631.js?v=4')).toBe('d/57d79353bac56631');
+  expect(normalize('/@tomlarkworthy/fileattachments.js?v=4&resolutions=4b0160c7af70b609@8453')).toBe('@tomlarkworthy/fileattachments');
+  expect(normalize('https://api.observablehq.com/@tomlarkworthy/jest-expect-standalone.js?v=4&resolutions=03dda470c56b93ff@8390')).toBe('@tomlarkworthy/jest-expect-standalone');
+};
+const _158qnvp = function _test_networking_script_is_streaming(networking_script,expect)
+{
+  const src = networking_script;
+  // the streaming gate + waiting helper
+  expect(src.includes('window.__lopeStreaming = true')).toBe(true);
+  expect(src.includes('function __waitForId')).toBe(true);
+  // event-driven (MutationObserver), not a setTimeout poll: robust to Safari background-tab
+  // timer throttling when a fork opens via window.open into an unfocused blob: tab
+  expect(src.includes('new MutationObserver')).toBe(true);
+  expect(src.includes('await new Promise((r) => setTimeout')).toBe(false);
+  // DOMContentLoaded/load clear the streaming flag even if the inline sentinel never runs.
+  // String checks, not regex literals: the push decompiler can't round-trip regex literals.
+  expect(src.includes('addEventListener("DOMContentLoaded", __endStreaming')).toBe(true);
+  expect(src.includes('window.addEventListener("load", __endStreaming')).toBe(true);
+  // dvfBytes (global fetch / XHR / blob path) waits for the block to stream in.
+  // Keep braces balanced everywhere in this cell (even in strings and comments): the
+  // module source extractor counts braces literally, so a stray open brace makes this
+  // cell's _definition run past its end and decompile/push silently drops it.
+  expect(src.includes('async function dvfBytes(id)')).toBe(true);
+  expect(src.includes('await __waitForId(id);')).toBe(true);
+  // es-module-shims fetch + source hooks are async and wait (es-module-shims awaits both)
+  expect(src.includes('async fetch(url, options, parent)')).toBe(true);
+  expect(src.includes('async source(url, fetchOpts, parent, defaultSourceHook)')).toBe(true);
+  const fetchIdx = src.indexOf('async fetch(url, options, parent)');
+  expect(fetchIdx).toBeGreaterThan(-1);
+  expect(src.indexOf('await __waitForId(id);', fetchIdx)).toBeGreaterThan(fetchIdx);
+  // resolve stays synchronous (es-module-shims does not await it) but keeps streaming notebook
+  // ids local instead of rewriting them to the remote observablehq API
+  expect(src.includes('\n    resolve(id, parentUrl, defaultResolve)')).toBe(true);
+  expect(src.includes('if (window.__lopeStreaming && isNotebook(id)) return')).toBe(true);
+  return 'ok';
+};
+const _1d9ux6v = function _test_lopebook_main_at_top_with_sentinel(lopebook,expect)
+{
+  const MARK = '<!--USER_BLOCKS_MARK-->';
+  const html = lopebook({
+    blocks: MARK,
+    cssUrls: [],
+    bootloader: '@tomlarkworthy/bootloader',
+    title: 't'
+  });
+  const mainIdx = html.indexOf('<script id="main">');
+  const blocksIdx = html.indexOf(MARK);
+  const sentinelIdx = html.indexOf('streaming_sentinel');
+  // main is a classic (non-deferred) script so it runs from the top during streaming
+  expect(mainIdx).toBeGreaterThan(-1);
+  expect(html.includes('<script type="module" id="main">')).toBe(false);
+  // main runs before the module blocks, the end sentinel after them
+  expect(mainIdx).toBeLessThan(blocksIdx);
+  expect(sentinelIdx).toBeGreaterThan(blocksIdx);
+  // bootstrap awaits the now-async fetch hook before reading .text()
+  expect(html.includes('.fetch("file://es-module-shims@2.6.2").then(r => r.text())')).toBe(true);
+  return 'ok';
+};
+const _13d3rb0 = function _test_streaming_order_prioritizes_mains(expect,streamingModuleOrder)
+{
+  const mk = names => new Map(names.map(n => [
+    n,
+    {
+      url: n,
+      imports: []
+    }
+  ]));
+  const specByName = mk([
+    '@u/app',
+    '@u/lib',
+    '@u/junk'
+  ]);
+  // single main leads, then everything else alphabetically (imports are ignored)
+  expect(streamingModuleOrder(['@u/app'], specByName).join(',')).toBe('@u/app,@u/junk,@u/lib');
+  // multiple mains are themselves alphabetical and still lead
+  expect(streamingModuleOrder([
+    '@u/lib',
+    '@u/app'
+  ], specByName).join(',')).toBe('@u/app,@u/lib,@u/junk');
+  // deterministic: independent of specByName insertion order
+  expect(streamingModuleOrder(['@u/app'], mk([
+    '@u/junk',
+    '@u/lib',
+    '@u/app'
+  ])).join(',')).toBe('@u/app,@u/junk,@u/lib');
+  // unknown main is ignored; every module still present exactly once
+  expect(streamingModuleOrder(['@u/missing'], specByName).join(',')).toBe('@u/app,@u/junk,@u/lib');
+  return 'ok';
+};
+const _18z61zg = function _test_streaming_order_runtime(Runtime,streamingModuleOrder,expect)
+{
+  // Build a real Runtime with the module-import wiring the exporter introspects, then order it.
+  const rt = new Runtime();
+  const libMod = rt.module();
+  libMod.variable().define('x', [], () => 1);
+  const appMod = rt.module();
+  appMod.variable().define('module @u/lib', [], () => libMod);
+  // app imports lib
+  const junkMod = rt.module();
+  junkMod.variable().define('y', [], () => 2);
+  // derive specs exactly as `module_specs` does: a module's `module ` vars are its imports
+  const names = new Map([
+    [
+      appMod,
+      '@u/app'
+    ],
+    [
+      libMod,
+      '@u/lib'
+    ],
+    [
+      junkMod,
+      '@u/junk'
+    ]
+  ]);
+  const specByName = new Map();
+  for (const [mod, name] of names) {
+    const imports = [...rt._variables].filter(v => v._module === mod && typeof v._name === 'string' && v._name.startsWith('module ')).map(v => v._name.slice(7));
+    specByName.set(name, {
+      url: name,
+      imports
+    });
+  }
+  const order = streamingModuleOrder(['@u/app'], specByName);
+  expect(order.join(',')).toBe('@u/app,@u/junk,@u/lib');
+  // main first, then the rest alphabetically
+  return 'ok';
 };
 const _1vgrzwk = function _isNotebook(){return(
 id => /^(@[^/]+\/[^/]+|d\/[a-f0-9]{16})$/.test(id)
 )};
-const _1pcnq22 = function _networking_script(normalize,isNotebook){return(
+const _1s9g3fb = function _networking_script(normalize,isNotebook){return(
 `
   const normalize = ${ normalize.toString() };
   const isNotebook = ${ isNotebook.toString() };
+
+  // --- streaming gate ---
+  // main runs from the TOP of the document, before the whole file has finished downloading, so a
+  // block a boot import needs may not have streamed in yet. __waitForId blocks until the block's
+  // <script> is fully parsed (el.nextSibling is non-null only after its </scr\\ipt> is seen),
+  // bounded by window.__lopeStreaming, which flips to false once the document is fully parsed (so a
+  // genuinely-absent id resolves to a 404 rather than hanging).
+  //
+  // The wait is event-driven (MutationObserver + DOMContentLoaded/load), NOT a setTimeout poll:
+  // Safari throttles timers in background/unfocused tabs, and a fork opens via window.open into a
+  // tab that is often not foregrounded, so a poll loop stalls there (works in a foreground file://
+  // download but hangs in a backgrounded blob: fork). MutationObserver fires on the parser's node
+  // insertions regardless of timer throttling. The end-of-document sentinel stays as a redundant
+  // fast-path; DOMContentLoaded/load clear the flag even if that inline script never runs.
+  window.__lopeStreaming = true;
+  function __endStreaming() { window.__lopeStreaming = false; }
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", __endStreaming, { once: true });
+    window.addEventListener("load", __endStreaming, { once: true });
+  } else {
+    __endStreaming();
+  }
+  function __isComplete(el) { return !!el && (el.nextSibling != null || !window.__lopeStreaming); }
+  function __waitForId(id) {
+    if (__isComplete(document.getElementById(id)) || !window.__lopeStreaming) return Promise.resolve();
+    return new Promise((resolve) => {
+      let done = false;
+      const finish = () => {
+        if (done) return;
+        done = true;
+        mo.disconnect();
+        document.removeEventListener("DOMContentLoaded", onEnd);
+        window.removeEventListener("load", onEnd);
+        resolve();
+      };
+      const check = () => { if (__isComplete(document.getElementById(id)) || !window.__lopeStreaming) finish(); };
+      const onEnd = () => { __endStreaming(); finish(); };
+      const mo = new MutationObserver(check);
+      mo.observe(document.documentElement, { childList: true, subtree: true });
+      document.addEventListener("DOMContentLoaded", onEnd);
+      window.addEventListener("load", onEnd);
+      check();
+    });
+  }
 
   const b64ToBytes = (b64) => {
     const bin = atob(b64);
@@ -8890,6 +11056,7 @@ const _1pcnq22 = function _networking_script(normalize,isNotebook){return(
 
   // Async bytes for global fetch/XHR/blob URLs
   async function dvfBytes(id) {
+    await __waitForId(id);
     const el = document.getElementById(id);
     if (!el) return { status: 404 };
 
@@ -8921,7 +11088,11 @@ const _1pcnq22 = function _networking_script(normalize,isNotebook){return(
     return { status: 422 };
   }
 
-  // --- es-module-shims hooks (sync) ---
+  // --- es-module-shims hooks ---
+  // fetch and source are async and wait for not-yet-streamed blocks (es-module-shims awaits both:
+  // \`c = await fetchHook(...)\` and \`await (sourceHook||default)(...)\`). resolve is NOT awaited, so it
+  // stays synchronous — it just routes a not-yet-present notebook id to file:// (where fetch/source
+  // then wait) instead of rewriting it to the remote observablehq API.
   window.esmsInitOptions = {
     shimMode: true,
     resolve(id, parentUrl, defaultResolve) {
@@ -8932,12 +11103,14 @@ const _1pcnq22 = function _networking_script(normalize,isNotebook){return(
         if (el.href) return el.href;
         return \`file://\${id}\`;
       }
+      if (window.__lopeStreaming && isNotebook(id)) return \`file://\${id}\`;
       if (isNotebook(id)) id = \`https://api.observablehq.com/\${id}.js?v=4\`;
       return defaultResolve(id, parentUrl);
     },
-    source(url, fetchOpts, parent, defaultSourceHook) {
+    async source(url, fetchOpts, parent, defaultSourceHook) {
       if (url.startsWith("file://")) {
         const id = url.slice(7);
+        await __waitForId(id);
         const el = document.getElementById(id);
         if (!el) return { type: "js", source: "throw new Error('DVF 404')" };
         const enc = (el.getAttribute("data-encoding") || "text").toLowerCase();
@@ -8950,12 +11123,13 @@ const _1pcnq22 = function _networking_script(normalize,isNotebook){return(
       }
       return defaultSourceHook(url, fetchOpts, parent);
     },
-    fetch(url, options, parent) {
+    async fetch(url, options, parent) {
       if (typeof url !== "string" || !url.startsWith("file://")) {
         return fetch(url, options);
       }
       const id = url.slice(7);
-      return dvfResponseSync(id); // must be synchronous
+      await __waitForId(id);
+      return dvfResponseSync(id);
     }
   };
 
@@ -9066,26 +11240,34 @@ const _1pcnq22 = function _networking_script(normalize,isNotebook){return(
     }
   })();`
 )};
-const _1crzwh0 = function _lopebook(diskDataUrl, networking_script) {
-    return ({blocks = '', cssUrls = [], bootloader = '@tomlarkworthy/bootloader', title = 'Lopecode notebook', head} = {}) => {
+const _q60b6z = function _lopebook(diskDataUrl, networking_script) {
+    return ({blocks = '', cssUrls = [], bootloader = '@tomlarkworthy/bootloader', title = 'Lopecode notebook', description, image, head} = {}) => {
         const styleImports = cssUrls.map((url, i) => `  const style${ i } = await importShim(${ JSON.stringify(url) }, { with: { type: 'css' } });`).join('\n');
         const styleAdopt = cssUrls.map((_, i) => `style${ i }.default`).join(',');
+        const attr = s => String(s).replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+        const ogTags = [
+            `<meta property="og:title" content="${ attr(title) }">`,
+            `<meta property="og:type" content="website">`,
+            description ? `<meta name="description" content="${ attr(description) }">` : '',
+            description ? `<meta property="og:description" content="${ attr(description) }">` : '',
+            image ? `<meta property="og:image" content="${ attr(image) }">` : ''
+        ].filter(Boolean).join('\n  ');
         return `<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
   <title>${ title }</title>
+  ${ ogTags }
   ${ head ? head : `<link rel="icon" href="${ diskDataUrl }">` }
 </head>
 <body>
 <script id="networking_script">${ networking_script }
 </scr\ipt>
 
-${ blocks }
-
-<script type="module" id="main">
-  await window.esmsInitOptions.fetch("file://es-module-shims@2.6.2").text().then(src => {
+<script id="main">
+(async () => {
+  await window.esmsInitOptions.fetch("file://es-module-shims@2.6.2").then(r => r.text()).then(src => {
     const script = document.createElement('script');
     script.textContent = src;
     document.head.appendChild(script);
@@ -9101,76 +11283,81 @@ ${ styleImports }
   const observer = Inspector.into(document.body);
   const {default: define} = await importShim(${ JSON.stringify(bootloader) });
   runtime.bootloader = runtime.module(define, () => ({}));
+})().catch((e) => console.error("boot error", e));
 </scr\ipt>
+
+${ blocks }
+
+<script id="streaming_sentinel">window.__lopeStreaming = false;</scr\ipt>
 </body>
 </html>`;
     };
 };
-const _lzzjtg = function _lopemodule(TRACE_MODULE,CSS,arrayBufferToBase64,inlineModule,escapeScriptTags)
+const _li7wcc = function _lopemodule(TRACE_MODULE,CSS,arrayBufferToBase64,inlineModule,escapeScriptTags)
 {
-    return async module => {
-        if (module.url === TRACE_MODULE) {
-            debugger;
-        }
-        const moduleId = module.url.replace(/^(d\/[a-f0-9]{16})@\d+$/, '$1');
-        const files = module.fileAttachments ? await Promise.all([...module.fileAttachments.entries()].map(async ([name, attachment]) => {
-            const url = attachment.url || attachment;
-            const file_url = `${ moduleId }/${ encodeURIComponent(name) }`;
-            // Get from local when possible
-            const lopefile = !url.startsWith('blob:') && document.querySelector(`script[type=lope-file][module='${ CSS.escape(module.url) }'][file='${ CSS.escape(encodeURIComponent(name)) }']`);
-            let data64, mime = undefined;
-            if (!lopefile) {
-                const response = await fetch(url);
-                data64 = await response.arrayBuffer().then(arrayBufferToBase64);
-                mime = response.headers.get('content-type');
-            } else {
-                data64 = lopefile.textContent;
-                mime = lopefile.getAttribute('mime');
-            }
-            return `<script id="${ file_url }" 
+  return async module => {
+    if (module.url === TRACE_MODULE) {
+      debugger;
+    }
+    const moduleId = module.url.replace(/^(d\/[a-f0-9]{16})@\d+$/, '$1');
+    const files = module.fileAttachments ? await Promise.all([...module.fileAttachments.entries()].map(async ([name, attachment]) => {
+      const url = attachment.url || attachment;
+      const file_url = `${ moduleId }/${ encodeURIComponent(name) }`;
+      // Get from local when possible
+      const lopefile = !url.startsWith('blob:') && document.querySelector(`script[type=lope-file][module='${ CSS.escape(module.url) }'][file='${ CSS.escape(encodeURIComponent(name)) }']`);
+      let data64, mime = undefined;
+      if (!lopefile) {
+        const response = await fetch(url);
+        data64 = await response.arrayBuffer().then(arrayBufferToBase64);
+        mime = response.headers.get('content-type');
+      } else {
+        data64 = lopefile.textContent;
+        mime = lopefile.getAttribute('mime');
+      }
+      return `<script id="${ file_url }" 
   type="text/plain"
   data-encoding="base64"
   data-mime="${ mime }"
 >
 ${ data64 }
-</scr\ipt>`;    // return `<script type="lope-file" module="${
-                //   module.url
-                // }" file="${encodeURIComponent(
-                //   name
-                // )}" mime="${mime}">${data64}</scr\ipt>\n`;
-        })) : [];
-        return `${ files.join('\n') }\n${ inlineModule(moduleId, escapeScriptTags(module.source)) }\n`;
-    };
+</scr\ipt>`;  // return `<script type="lope-file" module="${
+              //   module.url
+              // }" file="${encodeURIComponent(
+              //   name
+              // )}" mime="${mime}">${data64}</scr\ipt>\n`;
+    })) : [];
+    return `${ files.join('\n') }\n${ inlineModule(moduleId, escapeScriptTags(module.source)) }\n`;
+  };
 };
 const _19l1umr = function _escapeScriptTags(){return(
 str => str.replaceAll('</scr\ipt', '</scr\\ipt')
 )};
-const _1hwkszj = function _arrayBufferToBase64(){return(
+const _xpg7uv = function _arrayBufferToBase64(){return(
 async function arrayBufferToBase64(buffer) {
-    const bytes = new Uint8Array(buffer);
-    const binary = bytes.reduce((data, byte) => data + String.fromCharCode(byte), '');
-    return btoa(binary);
+  const bytes = new Uint8Array(buffer);
+  const binary = bytes.reduce((data, byte) => data + String.fromCharCode(byte), '');
+  return btoa(binary);
 }
 )};
-const _am38ex = function _74(md){return(
+const _1miwrx0 = function _79(md){return(
 md`### Global Output`
 )};
-const _kx1h0y = function _75(md){return(
+const _g3fd9a = function _80(md){return(
 md`## Utils`
 )};
-const _t237wb = function _getCompactISODate(){return(
+const _fw7q7v = function _getCompactISODate(){return(
 function getCompactISODate() {
-    const date = new Date();
-    const year = date.getUTCFullYear();
-    const month = String(date.getUTCMonth() + 1).padStart(2, '0');
-    const day = String(date.getUTCDate()).padStart(2, '0');
-    const hours = String(date.getUTCHours()).padStart(2, '0');
-    const minutes = String(date.getUTCMinutes()).padStart(2, '0');
-    const seconds = String(date.getUTCSeconds()).padStart(2, '0');
-    return `${ year }${ month }${ day }T${ hours }${ minutes }${ seconds }Z`;
+  const date = new Date();
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(date.getUTCDate()).padStart(2, '0');
+  const hours = String(date.getUTCHours()).padStart(2, '0');
+  const minutes = String(date.getUTCMinutes()).padStart(2, '0');
+  const seconds = String(date.getUTCSeconds()).padStart(2, '0');
+  return `${ year }${ month }${ day }T${ hours }${ minutes }${ seconds }Z`;
 }
 )};
-const _1nku2br = function _77(md){return(
+const _os8ogr = function _82(md){return(
 md`## Additional Tests`
 )};
 const _8765p8 = function _diskDataUrl(disk_svg){return(
@@ -9208,7 +11395,7 @@ export default function define(runtime, observer) {
   main.define("module @tomlarkworthy/jest-expect-standalone", async () => runtime.module((await import("/@tomlarkworthy/jest-expect-standalone.js?v=4")).default));  
   main.define("module @tomlarkworthy/themes", async () => runtime.module((await import("/@tomlarkworthy/themes.js?v=4")).default));  
   $def("_1noor04", null, ["md"], _1noor04);  
-  $def("_1xs1o58", null, ["exporter","viewof output","Event"], _1xs1o58);  
+  $def("_vpmotg", null, ["exporter","viewof output","Event"], _vpmotg);  
   $def("_16yvadj", null, ["md","downloadAnchor","forkAnchor"], _16yvadj);  
   $def("_xnho81", null, ["md","forkAnchor","downloadAnchor"], _xnho81);  
   $def("_lv8hyy", null, ["md"], _lv8hyy);  
@@ -9218,72 +11405,77 @@ export default function define(runtime, observer) {
   $def("_17bj13d", null, ["disk_svg"], _17bj13d);  
   $def("_fl78rz", "disk_svg", ["html"], _fl78rz);  
   $def("_ibwdcx", null, ["md"], _ibwdcx);  
-  $def("_4vze8h", "exporter", ["actionHandler","css","keepalive","exporter_module","variable","domView","view","disk_svg","Inputs","createShowable","top120List","themes","viewof theme_assets","bindOneWay"], _4vze8h);  
-  $def("_5xp8ad", "copyTextToClipboard", ["globalThis"], _5xp8ad);  
-  $def("_ywlem4", "htmlToConsoleSnippet", ["utf8ToBase64"], _ywlem4);  
-  $def("_1gdtxyo", "exportAnchor", ["Node","notebook_name","main","_runtime","exportToHTML","location","getCompactISODate"], _1gdtxyo);  
+  $def("_10a18gh", "exporter", ["actionHandler","css","keepalive","exporter_module","variable","domView","view","disk_svg","Inputs","createShowable","top120List","themes","viewof theme_assets","bindOneWay"], _10a18gh);  
+  $def("_14mjs7h", "copyTextToClipboard", ["globalThis"], _14mjs7h);  
+  $def("_1sbph8c", "htmlToConsoleSnippet", ["utf8ToBase64"], _1sbph8c);  
+  $def("_1w6fc3k", "exportAnchor", ["Node","notebook_name","main","_runtime","exportToHTML","location","getCompactISODate"], _1w6fc3k);  
   $def("_1u2ju69", "forkAnchor", ["exportAnchor"], _1u2ju69);  
   $def("_1a8n42w", "downloadAnchor", ["exportAnchor"], _1a8n42w);  
-  $def("_r3bep4", "actionHandler", ["Inputs","getSourceModule","notebook_name","_runtime","exportToHTML","htmlToConsoleSnippet","copyTextToClipboard","view","location","getCompactISODate"], _r3bep4);  
-  $def("_1i2b0pi", "exportToHTML", ["_runtime","importShim","cssForTheme","css","location","keepalive","exporter_module","viewof task"], _1i2b0pi);  
-  $def("_17k9v19", "getSourceModule", ["notebook_name","main","_runtime","importShim"], _17k9v19);  
-  $def("_6vlf2p", "createShowable", ["variable","view"], _6vlf2p);  
-  $def("_zclcql", "reportValidity", [], _zclcql);  
-  $def("_10rnvxz", "top120List", [], _10rnvxz);  
-  $def("_1iotzy", "notebook_name", [], _1iotzy);  
+  $def("_1w6a2m0", "actionHandler", ["Inputs","getSourceModule","notebook_name","_runtime","exportToHTML","htmlToConsoleSnippet","copyTextToClipboard","view","location","getCompactISODate"], _1w6a2m0);  
+  $def("_10fpobz", "exportToHTML", ["_runtime","cssForTheme","css","location","keepalive","exporter_module","viewof task"], _10fpobz);  
+  $def("_bga69d", "getSourceModule", ["notebook_name","main","_runtime"], _bga69d);  
+  $def("_tpv4tl", "createShowable", ["variable","view"], _tpv4tl);  
+  $def("_rnq9mt", "reportValidity", [], _rnq9mt);  
+  $def("_3vwqe7", "top120List", [], _3vwqe7);  
+  $def("_yq61j2", "notebook_name", [], _yq61j2);  
   $def("_1pwnq79", "notebook_title", ["notebook_name","_runtime"], _1pwnq79);  
-  $def("_1xzlmfy", "utf8ToBase64", [], _1xzlmfy);  
+  $def("_433z46", "utf8ToBase64", [], _433z46);  
   $def("_14gyvdn", null, ["md"], _14gyvdn);  
   $def("_3dtu61", "TRACE_MODULE", [], _3dtu61);  
   $def("_g3fan0", null, ["task"], _g3fan0);  
   $def("_1km8e4e", "task_runtime", ["task"], _1km8e4e);  
   $def("_tdkfs5", "runtime_variables", ["task_runtime","variableToObject"], _tdkfs5);  
-  $def("_1thre44", "buildModuleNames", [], _1thre44);  
+  $def("_qc5kek", "buildModuleNames", [], _qc5kek);  
   $def("_1pfdk6e", "isModuleVar", [], _1pfdk6e);  
   $def("_1vua7u7", "isDynamicVar", [], _1vua7u7);  
-  $def("_13nx5f5", "isImportBridged", [], _13nx5f5);  
-  $def("_4l3h5t", "findImportedName3", [], _4l3h5t);  
-  $def("_1r5dbt4", "moduleNames", ["task","moduleMap","task_runtime"], _1r5dbt4);  
+  $def("_9cxfm9", "isImportBridged", [], _9cxfm9);  
+  $def("_1omyant", "findImportedName3", [], _1omyant);  
+  $def("_x9dxs8", "moduleNames", ["task","moduleMap","task_runtime"], _x9dxs8);  
   $def("_2o6tia", null, ["resolve_modules"], _2o6tia);  
   $def("_dx8tp1", null, ["summary"], _dx8tp1);  
-  $def("_abbxde", "excluded_module_names", [], _abbxde);  
+  $def("_ti9fu1", "excluded_module_names", [], _ti9fu1);  
   $def("_po3sop", "excluded_modules", ["moduleNames","excluded_module_names"], _po3sop);  
   $def("_16u7vne", "included_modules", ["moduleNames","excluded_module_names"], _16u7vne);  
-  $def("_1y5e5x8", "module_specs", ["task","included_modules","TRACE_MODULE","task_runtime","isModuleVar","isDynamicVar","getFileAttachments","main","generate_module_source","moduleNames"], _1y5e5x8);  
+  $def("_kxkh98", "module_specs", ["task","included_modules","TRACE_MODULE","task_runtime","isModuleVar","isDynamicVar","getFileAttachments","main","generate_module_source","moduleNames"], _kxkh98);  
   $def("_1r3eg9r", "findImports", [], _1r3eg9r);  
-  $def("_ipv4ft", "getFileAttachments", [], _ipv4ft);  
-  $def("_1x463u7", "book", ["task","inlineModule","inlineGzipModule","es_module_shims","runtime_gz","inspector_gz","module_specs","lopemodule","lopebook"], _1x463u7);  
-  $def("_18javdl", null, ["Inputs","module_specs"], _18javdl);  
-  $def("_1gb47v", null, ["md"], _1gb47v);  
-  $def("_5m8hbe", "report", ["DOMParser","book"], _5m8hbe);  
-  $def("_4x0qc2", "tomlarkworthy_exporter_task", ["book","report","exporter_module","viewof task"], _4x0qc2);  
-  $def("_1exq2jt", null, ["md"], _1exq2jt);  
-  $def("_fctoc0", null, ["md"], _fctoc0);  
-  $def("_85q15a", "exportModuleJS", ["_runtime","buildModuleNames","isModuleVar","isDynamicVar","getFileAttachments","generate_module_source"], _85q15a);  
+  $def("_15bukmh", "getFileAttachments", [], _15bukmh);  
+  $def("_g0wr2v", "streamingModuleOrder", [], _g0wr2v);  
+  $def("_15y6f5s", "book", ["task","inlineModule","inlineGzipModule","es_module_shims","runtime_gz","inspector_gz","streamingModuleOrder","module_specs","lopemodule","lopebook"], _15y6f5s);  
+  $def("_tztkf6", null, ["Inputs","module_specs"], _tztkf6);  
+  $def("_1razd4c", null, ["md"], _1razd4c);  
+  $def("_avn3ei", "report", ["DOMParser","book"], _avn3ei);  
+  $def("_186iat6", "tomlarkworthy_exporter_task", ["book","report","exporter_module","viewof task"], _186iat6);  
+  $def("_9aqzbs", null, ["md"], _9aqzbs);  
+  $def("_1h8zj4h", null, ["md"], _1h8zj4h);  
+  $def("_1xx9ynh", "exportModuleJS", ["_runtime","buildModuleNames","isModuleVar","isDynamicVar","getFileAttachments","generate_module_source"], _1xx9ynh);  
   $def("_udwrns", "generate_module_source", ["generate_definitions","generate_define"], _udwrns);  
   $def("_19ft5zb", "generate_definitions", ["variableToDefinition"], _19ft5zb);  
-  $def("_7nr512", "generate_define", ["variableToDefine"], _7nr512);  
+  $def("_u3aown", "generate_define", ["variableToDefine"], _u3aown);  
   $def("_1hslsmt", "isLiveImport", [], _1hslsmt);  
-  $def("_g39v22", "variableToDefinition", ["isModuleVar","isImportBridged","isLiveImport","isDynamicVar","pid","restoreCanonicalImports"], _g39v22);  
-  $def("_5zomoj", "restoreCanonicalImports", ["acorn","escodegen"], _5zomoj);  
-  $def("_1g36je3", "variableToDefine", ["isLiveImport","isDynamicVar","isModuleVar","isImportBridged","findImportedName3","pid"], _1g36je3);  
-  $def("_dxkjia", null, ["md"], _dxkjia);  
+  $def("_4i5mmq", "variableToDefinition", ["isModuleVar","isImportBridged","isLiveImport","isDynamicVar","pid","restoreCanonicalImports"], _4i5mmq);  
+  $def("_1ohymeb", "restoreCanonicalImports", ["acorn","escodegen"], _1ohymeb);  
+  $def("_1g13ozv", "variableToDefine", ["isLiveImport","isDynamicVar","isModuleVar","isImportBridged","findImportedName3","pid"], _1g13ozv);  
+  $def("_8rymrb", null, ["md"], _8rymrb);  
   $def("_g33g3u", "es_module_shims", [], _g33g3u);  
   $def("_1na8qih", "inspector_gz", [], _1na8qih);  
   $def("_3naqgd", "inlineModule", [], _3naqgd);  
   $def("_19eucuj", "inlineGzipModule", [], _19eucuj);  
   $def("_bwex58", "normalize", [], _bwex58);  
-  $def("_eoywzy", "test_normalize", ["expect","normalize"], _eoywzy);  
+  $def("_1vymoni", "test_normalize", ["expect","normalize"], _1vymoni);  
+  $def("_158qnvp", "test_networking_script_is_streaming", ["networking_script","expect"], _158qnvp);  
+  $def("_1d9ux6v", "test_lopebook_main_at_top_with_sentinel", ["lopebook","expect"], _1d9ux6v);  
+  $def("_13d3rb0", "test_streaming_order_prioritizes_mains", ["expect","streamingModuleOrder"], _13d3rb0);  
+  $def("_18z61zg", "test_streaming_order_runtime", ["Runtime","streamingModuleOrder","expect"], _18z61zg);  
   $def("_1vgrzwk", "isNotebook", [], _1vgrzwk);  
-  $def("_1pcnq22", "networking_script", ["normalize","isNotebook"], _1pcnq22);  
-  $def("_1crzwh0", "lopebook", ["diskDataUrl","networking_script"], _1crzwh0);  
-  $def("_lzzjtg", "lopemodule", ["TRACE_MODULE","CSS","arrayBufferToBase64","inlineModule","escapeScriptTags"], _lzzjtg);  
+  $def("_1s9g3fb", "networking_script", ["normalize","isNotebook"], _1s9g3fb);  
+  $def("_q60b6z", "lopebook", ["diskDataUrl","networking_script"], _q60b6z);  
+  $def("_li7wcc", "lopemodule", ["TRACE_MODULE","CSS","arrayBufferToBase64","inlineModule","escapeScriptTags"], _li7wcc);  
   $def("_19l1umr", "escapeScriptTags", [], _19l1umr);  
-  $def("_1hwkszj", "arrayBufferToBase64", [], _1hwkszj);  
-  $def("_am38ex", null, ["md"], _am38ex);  
-  $def("_kx1h0y", null, ["md"], _kx1h0y);  
-  $def("_t237wb", "getCompactISODate", [], _t237wb);  
-  $def("_1nku2br", null, ["md"], _1nku2br);  
+  $def("_xpg7uv", "arrayBufferToBase64", [], _xpg7uv);  
+  $def("_1miwrx0", null, ["md"], _1miwrx0);  
+  $def("_g3fd9a", null, ["md"], _g3fd9a);  
+  $def("_fw7q7v", "getCompactISODate", [], _fw7q7v);  
+  $def("_os8ogr", null, ["md"], _os8ogr);  
   $def("_8765p8", "diskDataUrl", ["disk_svg"], _8765p8);  
   $def("_z4k2or", "viewof task", ["flowQueue"], _z4k2or);  
   $def("_ngmf1x", "task", ["Generators","viewof task"], _ngmf1x);  
@@ -9292,6 +11484,7 @@ export default function define(runtime, observer) {
   $def("_blfbdd", "viewof exporter_module", ["thisModule"], _blfbdd);  
   $def("_1iao5e4", "exporter_module", ["Generators","viewof exporter_module"], _1iao5e4);  
   main.define("runtime_gz", ["module @tomlarkworthy/observable-runtime-v6", "@variable"], (_, v) => v.import("source_gz", "runtime_gz", _));  
+  main.define("Runtime", ["module @tomlarkworthy/observable-runtime-v6", "@variable"], (_, v) => v.import("Runtime", _));  
   main.define("flowQueue", ["module @tomlarkworthy/flow-queue", "@variable"], (_, v) => v.import("flowQueue", _));  
   main.define("cellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("cellMap", _));  
   main.define("findModuleName", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("findModuleName", _));  
@@ -9470,7 +11663,7 @@ const _yqx7l8 = function _syncEnabled(notebookId,htl)
     return container;
 };
 const _xltqf6 = (G, _) => G.input(_);
-const _1mb10vh = function _disassemble(htl, directory, notebookId, manifestWriter, readFile, writeFile, syncableModules, exportModuleJS, hashSource, currentModules, runtime, probeDefine, tag, importShim, $0) {
+const _1nuhj4u = function _disassemble(htl, directory, notebookId, manifestWriter, readFile, writeFile, syncableModules, exportModuleJS, hashSource, currentModules, runtime, probeDefine, tag, $0) {
     const container = htl.html`<div>
     <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
       <button class="disassemble" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Disassemble to disk</button>
@@ -10060,7 +12253,7 @@ const _1bf1rb4 = function _fileSyncLastSeen(directory)
     void directory;
     return new window.Map();
 };
-const _43mwl9 = function _filesToNotebook(directory, syncArmed, currentModules, fileSyncLastSeen, notebookId, runtime, probeDefine, tag, readFile, exportModuleJS, manifestWriter, hashSource, writeFile, getFileAttachmentsMap, invalidation) {
+const _19e6n4y = function _filesToNotebook(directory, syncArmed, currentModules, fileSyncLastSeen, notebookId, runtime, probeDefine, tag, readFile, exportModuleJS, importShim, manifestWriter, hashSource, writeFile, getFileAttachmentsMap, invalidation) {
     if (!directory)
         return 'Waiting for directory...';
     if (!syncArmed || !syncArmed.armed)
@@ -10224,7 +12417,7 @@ const _43mwl9 = function _filesToNotebook(directory, syncArmed, currentModules, 
                         const blob = new window.Blob([diskText], { type: 'text/javascript' });
                         const url = window.URL.createObjectURL(blob);
                         try {
-                            const mod = await window.importShim(url, 'file://@tomlarkworthy/file-sync');
+                            const mod = await import(url);
                             if (typeof mod.default === 'function') {
                                 applyModule(moduleId, mod.default);
                                 console.log('[file-sync] applied ' + moduleId + ' from disk');
@@ -10331,7 +12524,7 @@ const _43mwl9 = function _filesToNotebook(directory, syncArmed, currentModules, 
                 const blob = new window.Blob([diskText], { type: 'text/javascript' });
                 const url = window.URL.createObjectURL(blob);
                 try {
-                    const imported = await window.importShim(url, 'file://@tomlarkworthy/file-sync');
+                    const imported = await import(url);
                     if (typeof imported.default === 'function') {
                         const newMod = runtime.module(imported.default, () => null);
                         runtime.mains.set(moduleId, newMod);
@@ -10443,6 +12636,196 @@ md`## TODO
 - **Import cell validation**: verify import bridges survive round-trip correctly
 - **Conflict resolution**: when both disk and runtime edit the same cell simultaneously, detect and surface the conflict instead of last-write-wins`
 )};
+const _qq3v7b = function _jbApply(importShim) {
+    let pidSeq = 0;
+    const genPid = () => '_jb' + (pidSeq++).toString(36) + Math.floor(Math.random() * 1000000).toString(36);
+    const hasVarInput = inputs => (inputs || []).some(iv => (typeof iv === 'string' ? iv : iv && iv._name) === '@variable');
+    const importPath = defn => {
+        const m = (defn ? defn.toString() : '').match(/import\(\s*["'`]([^"'`]+)["'`]/);
+        return m ? m[1] : null;
+    };
+    return function makeApply({currentModules, runtime, probeDefine, createModule, obj_observer} = {}) {
+        const resolveModule = moduleId => {
+            if (currentModules)
+                for (const [, info] of currentModules)
+                    if (info.name === moduleId)
+                        return info.module;
+            const r = runtime;
+            if (r.mains && r.mains.has(moduleId))
+                return r.mains.get(moduleId);
+            if (typeof createModule === 'function') {
+                try {
+                    return createModule(moduleId, r);
+                } catch (e) {
+                    return null;
+                }
+            }
+            return null;
+        };
+        const obsFactory = (() => {
+            if (typeof obj_observer === 'function')
+                return obj_observer;
+            try {
+                const f = runtime && runtime._builtin && runtime._builtin._scope.get('__ojs_observer');
+                return f && typeof f._value === 'function' ? f._value : null;
+            } catch (e) {
+                return null;
+            }
+        })();
+        return function applyModule(moduleId, defineFn) {
+            const mod = resolveModule(moduleId);
+            if (!mod)
+                return {
+                    applied: false,
+                    reason: 'module not loaded and cannot create: ' + moduleId
+                };
+            const existingByName = new Map();
+            const existingByPid = new Map();
+            for (const v of runtime._variables) {
+                if (v._module !== mod)
+                    continue;
+                if (v._name)
+                    existingByName.set(v._name, v);
+                if (v.pid)
+                    existingByPid.set(v.pid, v);
+            }
+            const cells = probeDefine(defineFn);
+            const seenPids = new Set();
+            const seenNames = new Set();
+            let changes = 0;
+            for (const cell of cells) {
+                if (cell.name === '@variable')
+                    continue;
+                const upsertLoader = (loaderName, defn) => {
+                    seenNames.add(loaderName);
+                    const spec = loaderName.slice('module '.length);
+                    const child = resolveModule(spec);
+                    const path = importPath(defn);
+                    const key = child ? 'live:' + spec : path ? 'path:' + path : null;
+                    if (key == null)
+                        return;
+                    const make = child ? () => child : async () => runtime.module((await import(path)).default);
+                    const existing = existingByName.get(loaderName);
+                    if (existing) {
+                        if (existing._jbKey !== undefined && existing._jbKey !== key) {
+                            existing.define(loaderName, [], make);
+                            existing._jbKey = key;
+                            changes++;
+                        }
+                        return;
+                    }
+                    const v = mod.variable(null);
+                    v.define(loaderName, [], make);
+                    v._jbKey = key;
+                    existingByName.set(loaderName, v);
+                    changes++;
+                };
+                const upsertBinding = (name, inputs, defn) => {
+                    seenNames.add(name);
+                    const existing = existingByName.get(name);
+                    if (!existing) {
+                        const v = mod.variable(null);
+                        v.define(name, inputs, defn);
+                        existingByName.set(name, v);
+                        changes++;
+                        return;
+                    }
+                    const existingInputNames = (existing._inputs || []).map(iv => typeof iv === 'string' ? iv : iv._name);
+                    const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(inputs);
+                    const defnMatch = existing._definition && existing._definition.toString() === (defn ? defn.toString() : '');
+                    if (!(inputsMatch && defnMatch)) {
+                        existing.define(name, inputs, defn);
+                        changes++;
+                    }
+                };
+                if (cell.type === 'import') {
+                    const spec = cell.from;
+                    const child = spec && resolveModule(spec);
+                    if (!child)
+                        continue;
+                    const loaderName = 'module ' + spec;
+                    seenNames.add(loaderName);
+                    if (!existingByName.has(loaderName)) {
+                        const lv = mod.variable(null);
+                        lv.define(loaderName, [], () => child);
+                        lv._jbKey = 'live:' + spec;
+                        existingByName.set(loaderName, lv);
+                        changes++;
+                    }
+                    const alias = cell.alias || cell.remote;
+                    upsertBinding(alias, [
+                        loaderName,
+                        '@variable'
+                    ], (_, vv) => vv.import(cell.remote, _));
+                    continue;
+                }
+                if (cell.name && cell.name.startsWith('module ')) {
+                    upsertLoader(cell.name, cell.definition);
+                    continue;
+                }
+                if (hasVarInput(cell.inputs)) {
+                    if (cell.name)
+                        upsertBinding(cell.name, cell.inputs, cell.definition);
+                    continue;
+                }
+                let pid = cell.pid;
+                if (!pid) {
+                    const byName = cell.name && existingByName.get(cell.name);
+                    pid = byName && byName.pid || genPid();
+                }
+                seenPids.add(pid);
+                if (cell.name)
+                    seenNames.add(cell.name);
+                const existing = existingByPid.get(pid) || cell.name && existingByName.get(cell.name);
+                if (!existing) {
+                    const v = mod.variable({});
+                    v.define(cell.name, cell.inputs, cell.definition);
+                    v.pid = pid;
+                    existingByPid.set(pid, v);
+                    if (cell.name)
+                        existingByName.set(cell.name, v);
+                    changes++;
+                    continue;
+                }
+                const existingInputNames = (existing._inputs || []).map(iv => typeof iv === 'string' ? iv : iv._name);
+                const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+                const defnMatch = existing._definition && existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+                if (inputsMatch && defnMatch) {
+                    if (!existing.pid)
+                        existing.pid = pid;
+                    continue;
+                }
+                existing.define(cell.name, cell.inputs, cell.definition).pid = pid;
+                changes++;
+            }
+            for (const v of [...runtime._variables]) {
+                if (v._module !== mod)
+                    continue;
+                const name = v._name;
+                if (name === '@variable')
+                    continue;
+                if (name && seenNames.has(name))
+                    continue;
+                if (name && name.startsWith('module ') || hasVarInput(v._inputs)) {
+                    if (name) {
+                        v.delete();
+                        changes++;
+                    }
+                    continue;
+                }
+                if (!v.pid || seenPids.has(v.pid))
+                    continue;
+                v.delete();
+                changes++;
+            }
+            return {
+                applied: true,
+                moduleId,
+                changes
+            };
+        };
+    };
+};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -10460,7 +12843,7 @@ export default function define(runtime, observer) {
   $def("_jnt0bt", "directory", ["Generators","viewof directory"], _jnt0bt);  
   $def("_yqx7l8", "viewof syncEnabled", ["notebookId","htl"], _yqx7l8);  
   $def("_xltqf6", "syncEnabled", ["Generators","viewof syncEnabled"], _xltqf6);  
-  $def("_1mb10vh", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","importShim","viewof syncEnabled"], _1mb10vh);  
+  $def("_1nuhj4u", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","viewof syncEnabled"], _1nuhj4u);  
   $def("_eoa5ga", "disassemble", ["Generators","viewof disassemble"], _eoa5ga);  
   $def("_1jyon1g", "syncStatus", ["htl","directory","syncableModules","notebookToFiles","filesToNotebook"], _1jyon1g);  
   $def("_1dl3i63", null, ["md"], _1dl3i63);  
@@ -10477,7 +12860,7 @@ export default function define(runtime, observer) {
   $def("_1cy7bqk", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1cy7bqk);  
   $def("_3zm0bx", "notebookToFiles", ["directory","syncArmed","currentModules","notebookId","exportModuleJS","writeFile","manifestWriter","hashSource","readFile","onCodeChange","invalidation"], _3zm0bx);  
   $def("_1bf1rb4", "fileSyncLastSeen", ["directory"], _1bf1rb4);  
-  $def("_43mwl9", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _43mwl9);  
+  $def("_19e6n4y", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","importShim","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _19e6n4y);  
   $def("_1b4kluo", null, ["md"], _1b4kluo);  
   $def("_1h2nj16", null, ["md"], _1h2nj16);  
   main.define("viewof currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("viewof currentModules", _));  
@@ -10487,7 +12870,8 @@ export default function define(runtime, observer) {
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("importShim", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("importShim", _));  
   main.define("tag", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("tag", _));  
-  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));
+  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));  
+  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);
   return main;
 }</script>
 
@@ -11107,681 +13491,6 @@ export default function define(runtime, observer) {
   $def("_1fs0h4q", null, ["suite","flowQueue","testing"], _1fs0h4q);
   return main;
 }</script>
-<script id="@tomlarkworthy/golden-layout-2-6-0/golden-layout-2.6.0.js.gz" 
-  type="text/plain"
-  data-encoding="base64"
-  data-mime="application/gzip"
->
-H4sICCjkcmcCA2dvbGRlbi1sYXlvdXRAMi42LjAuanMA7L1rexs3kij8Pb+iw2ffGTKhaEnOzdI4M4rsxNoTXx5JnsysXz/aFtmSOqbYXDZpW5vRfz8oFC5VQKG7Sckzs2dnzslaRAMFoFAoFAp1efAgm1WT4uy6mqymRf3gsppOitnWNL+pVssHk7JePijq6wfL+kGxWFQL9c/HZbGY5dMt/Xv0a/3Z+3yRPTWlT6Ewe5yNp3ldZ1B3NqkzLP3tsyx78MUX2Z/KGVbOvnigisbVrF4uVuNltegvb+bFMLsu6jq/LAa6RZbVq3mx6NvCfV22vCrrEdRWfcE/UHr72e2+HsxhNbsoL1eLfFlWs8SI2Hg7jMx0P9TY4iPrsf56fvxkqNBKDQL+YUN9Vc0Vnn+YVuN3xeR+hxoMkvUUDNIN52BeftJBHLw6SnX9Qzn7tAiADqTOP3uw7hawPfMtcDTrtgVieh+r3hNU/5//9hvUud3L/u03qHb7b7+Zetnjx4+z91U5ybazP2a9XraX9dT/z760gG7/M1jbui4WS3l0fOzhKBvG10OovXASrOfXs0WRj6/y82lxmNfF5kNQwEqA8ud8ukqOKOjNDU2hkrW/Aypfz4qP82K8LCYvVtPpfaOUQ29Dra37ejYpLspZiovcx3BcF+kxrbGZVstyqvbSznezLTWOcnZZu52kyk6waP+z/sVqNgbG2ifFuzjGabHMylm5LPNpWRcTNemLfFprDqtnpz5eVPXL81/V8NVHnBYywsN8NquWPxSHiljU1H4pl1c/LarVbHK0LK6Roe+ZBllWTvay7aH5oXCQr6ZLRSAIKRtrUNl5kY0RWPZBQcsuNbjMw+tpALcI59W0UMR5XFwqjBSLg0O/GD+a+fLud4TuNYhsYWBkOV3SzKKN9XpYXc+rWTFbniqm8qJa2v6LycFsAgzSVXj6Xv2fZ/lsMi0WqqLa5uWlWnk+qN14UA6APpYzQMzCdZIpeFncTXaF/ejauelJHvdRfTBVSJ7c+JHzIT1sGlJZZzk2J4NKdaRm/edysVwBw+B9fNXSB0zjvW06yo6L/1qVi6LOFlW1fLa8nj6dFtdQ9aIsppMHl8VSjYONAvudOqBPqgKG8yx/XxxzGHxgX0cD+70BpUjDDnCigOkhXilwGfae9YKx9X5Px+NpWKMFiMeNjY/gmxg1vrHFTXWBxOHGxCZ/NHuvtrPifdfnxeJVvlgezU7K/y5w5/PevhV6w9bZTDfP5qq94gJZrSBkyGZYZ69n72bVh9lrxUTS3XwXd2PaZSvVsBm+4qLzaqG5Z1Mfj6Q+XNuGfoDzAsOj3HFUqh22mgHPQ+Y3elfc1H3CDQejaTG7XF4FrNI3eA9HJG8CdS1XycZXxfjdkeO9fXtolBdZ/3PCkwdulheKKfU1x1a9bO+rf/4gDlp9+fJL34yOTzXUA3pTvt13n6FHKFXts8/VQV7StiB+L6oP2az4QAWgfu/oxcnR9vbOznZPSwallrAMGHPc4/9us0IdKQxk6UetRmIGNTILR1p+Rv/F/8tPK8WrzXUgWL8Au3Ca85L9z24H9EDM/va3jP1Wp93tYIBCQsnKNSoWi/yG1rfIH2xwhNfLm2mxpVcpny3dKX4CxYe2lB7k/Is5y4NCi07HZ35QZ91/HCkJ5KOaQy9fLavefodmTxb5pW/2cLdTo5NlPn73PP9YXsNC+eZf7fQ04nl7jfugyKJ/bWQCY3Qo/KWcLK9eLp4V5eXV8tWiUvLY8uZFfl1QbCYrGcSmv48+wCeYmP5Do6ah9pUug+r4F+Ii2UCjJf2VEuhJOWFTgt+WLODP0bKaQ7/qH1w/XTgtLvRo4F9SvLCjXJhB2g/n1XJZXcMX/MuspfqGK1hO+Kh+ri7LcT7F5afDYx/MOHnZ6DzXu7YH/+ohBN8niizhO/wrfa8ZBUJNXoJjZ430JHhJcjan1RMk+ef53AjGMNK9YGc0bEI4rmDwrU38BoQmfBatjaWNaK8+/15XM32Ro0vjCs2yuPOqrOFTXx9r9oBYFMvVwn7CQ85UsEzZgxthLWD2+o/9GDiDwLv4XDNcBQMZr6nyu99l+i99bM3UXQ9KgAEoAQk/wMW0V2m4veSY3P2G/tT04apq2vC/KF2AeHaqNWjkpmXKDBLdz5G506hB4V96UP4znLSw8aoPwYdxNV1dA/J6+FfwWVOFI/KorZVcdXMrMuIJaGrh8Wd/0OkdF7VqUJfvi+cVZzL8i5lqUDiaqc6gX/hXjyuskE8/5De1PpL0X2Klajatco02/AsHz2vpKQRFnEf+dwEi5FMl2XJe6csdzyRFb3qvyo/FtAdySm/+0fBDXqFYjAGlusr/J9X4cZHr3nID52Ih1Xp6jV8Lx1r9Z8NiSYGdXONU3BZbLm7UXUAJmmx71eqmPb7KeKGSGIH7MmgjjYQ9J5uZfSnU2W+AgXhqg4K1GuB4bLaA8hUboD29boHy9Ho/uFuE9VH3te8vFOHajiz6tdCKfzIOqIT763z5r8W5z8XxNxdJgdrvnbx++uNXXz169F1vmPljK7WCuEKgItN/rLFB15Zh9f8FGdaRB97GTyu9iDWlCEuBUKLEPLyO9He2B9mXhl3dejBz3fy0Qt0ABYN3ROxGwVBjR4iLYj7Nx0UfQA2zXk+jyPQ5Byr+UfHjZd81HLD+6vm0XOKQDpY/lot6+aKaqc6LRTk+vMrZCMyBbWeyKK+V8LJY9gf+io1XblfH38DhCms/qhN/O5AefoOJQZ+gDdlTsxhmF/Fg7EdUB7BrK9y6bYsn5WW5RLUKioh+GFjxslo+KcbldT59VZX61HVKVfkSbwDwazvOWNGsWwtyaUclQa2H0oc6A3pnh6+6IYhFvVGP3+eT8yj3Sa1ztWHeNV/iVS/BVHlHXbuKOhO7ywS82ut/qDCQVQeI0QmMpYbBODqqV+eoEepvDxNjNpwBQURVBEgJMJqu+waaTJ1+gA1UGg/h1jwhfEaEakIflFdo2vhekcZ2DwRm/fMP6ucjziwui6VRZupLaL/AHwyUKRtVFxd1gfU4A5BhDDN9YaasRxcc1MjgQMvCOR7WhznaLrXWxN3AWfPENPAS3WEeWDExEQ5lmOFdnk4FS9JzMS3iyTgFAYfQtCoHs0nDtHADadzsSWuFOlPsbU9EAmpHRUQ8KRV7z2/+XNblean4/I3HyXsomxrGDoyCFYTTniAgkHx7EetNVnU3Ckb0xaxeLQozwldVXULpwXmtbk3LguMIFys332xdfRMxZT17tvBBzG1V4K9he3mKcw89bBBNYVIU86f61bGvDkC13sNM3WA9LtUP3TMKnbY/fbDglN4VN6Dqdo0st1YFo6u8fvlhZhVJfVV1EKuK7VGsGrxRNYiuGL8XH5XIorjcqR4eMGL9R1CXFKoqflb6Ct3nMLgARvn2radmBLgv46oJqkMd0w18TnQDgcDwHtUiASkCBEkPER7aSTHFV8GpaCBMo4x1HRo6SwtuZczLWCwyZLRP1LqHyPvtdmgBBAsRLIGGYWRlflLrve40L6CSoWM0QKDYwQ9PekKBLxWhP/Zr4XsI6S/aDKw7sp9ghhb0oFW6MdQS9CaRzdo9JkScmMJ454Oww7W6THSaxGm4fBt1mexUZia45rxsv8MIIihNA/os9atJgGQ8elFcV++LHxfVNS5TuSyuh1kOf9PDpTTybo5rCr9eXujKA3u0mCoK3Vs7Ftn+4mpuqof57PdL02kGzbML1bUBq1V99mlY8f3lVYFfek4NixXhNqaucrrHYbYzCOUKdXH9r1VxNOkzGaL/PF9ejRb5bFIpyTX7Itspdr4e+Kvmw28G/pY4spfEQGKBaTxHW5c+4cdqMlpzPYZ9pisFjLgYGQsZkRnbDYpqXvOq6ynWwhA5lfnoHqJ17719ttxrX9zH+pl+67qclRdl4Szb8PX+uSmlGjv+ZZfSDrw4K9J5o0fUU2IXkHfdQ5Gtp87xZ0U+KRauBG1X8nIGDwanlYK8VD+Khf1eK9auO306Az3IxJZPSsXwa1XuIJ1XCwVYC4i2SM0IqAxlwqCQVbzSg+L14JlDSRwfb1hNV8orT/NztU5uUtMKLNBMf+Ydg/TPfs+1ORHBxxKUsu4nsdyJCk+W+dKVlg43H+iAl6ThFRtzWR+qcQJWXd1yOQ3G9ctVNS30e4wtVzLYDE2g3Hzn+QJsZ9wAQEP2vgAs6/ujLV4UeomClcR1+2mRnyOidemDB/r5Z3WdPfxGScdqjxT1MJtUmluMF1VdawPbbKpo5XPV4q1Xt6AJg6NBuG1jT1qfYYdSffDY1E8Tlt7oVP2zwyYLC4gCzgYc8YNiX6pLO9JO9hSwlYwYln2v8OBZRMRpT6squ85nN7j9VJ+4pTO7pdXHeS/QEwabuIvxAVPM57N6qsjPPH8BZx9ifzd2oEZorLRKcT8h70NDLvBDSZvED9KlG8Lk/xQ3XNTi4zBIo9XVkLCO+lsDbxSrwqarWbJxIBHCXOzjG/wdXjaqNwz2W60eMgUo3joIDrv7gpbICrrVfmJ1g/Wi/diXQ2l1UU5IL667NOhFo3cGsviJi8KaSsUIlf6WoNBYroG6BMri2Xsw4ezJOa5lmseieG2peeNrRSxZ6+0iXhia1qyRusP20o5OmjfFF6l475kO8IPH6SA5bdPAbjOpCWNlbuX8tmSvT9Elmkpe7j1+RHTxO5E81js7OwPbcHKxowpaKzMbadkPYf8zb60Wy8zx3T0l8unWTH7dl3EQMid+ojRPEo6PN/qB5Gi2hOpDOHfe0ulaOKg0Bt3zwwHiExAkQXzz8K2w794hzxaWD5f7H7yAdBD/sCX8RJhACcmv83vkkdJKd+iqIyGgZkckBa+3YtY1ficRMpYODSIoBSeHFaP08aCGRgDRdWk4Ubd2UgMTFkcaHCI7PTyzGGaAwaP5WkO8HQQXM/22GxRt8LqLsuSDRVFX0/fFZAt/21visSn29t6BtU3w1VvchB+sGVjtfDaA+vacTZAxQxraTbvUZuhv3mIBmEg7f4naPGjvsddw8naP1dQuO9HNUA/HCoXm+l0DK4Htds8I+v4etadvG9Y02wv52j/ksJrf9KtFeVlC/3YCodWEraC9HAPriQARe+I3dTOQP+A9J7JLsAtxXH14uTjUdfyajBqHvi/2o29QyW70VfJuHbhbWbIT787R2NFgYxuMw6PDw0c7D7/+qjfM2IoNvSuCcX7Qai7t91DPizFswkl4E5P2gh8uXMTcD4GujElnnxKMpabuRJS0mIepPjl+tPP1N7s9hzDFPH5SbM7gTXu4oBz8s2YfOIm/G3kyDNwfUVqwn4AMI9AbUeCTJ7AsDxUNfgLSM0N01PfE+zmQt3o2Ra0iRiihra1HAHpvq6MuRuR+w6CCrrTZKysJBuaWdMNBaYJpHpDrQg/G/QoG4t0LNxwJ7tPmofhO9Fj8T2txGrSxVqdhcWBCqz+jwrbtgI9rBQe9UMEe+NTg3RkdgRiFbXbhp+8RCx86mavxlK2vqg/Bc7L5lnh/E0wj0xdUeouGnvb0/2V23a7AORrrkj1/bMDvIQGEeldSAQtoFa2GJDX0b1rBqiZJHVvEqhmNJa1mimi1ZX7+ZFHNJ9WHGalJSr1yQBJTzYI1HWmKSM1aq09NFINljHwbqllyJnsgrt0CTNwTwYEhbYigSrAbwq92Kxxwzbm+RqwrSuJ9VonryL6d0lgL01xa8Qo2FKbNH5xgx6q3Q/zQd13tsWJPiea7hYxSuad19ZN+QiGbfYYiW8XJ55Q8TwgMJquHlSgkkNfd93Li2nuXlGijuEpUvvcwXKGtFjx6kLrBF9sAH532Gujd0LEku46w9eAzsu0MV8KVDw+MiOI6SZjCGnMyGxuHUzeuWAfsKNHrgcfG6TB1aR4LHqEIBhW98dEl4UjVlTS+XfHj5w4I8r8aZPBOW5DLGNEetBdau3mEudqLcmI/tbUQt1hTo6Zd16FduBGbmoh7s2GHhCKEtGkb+2vfx2vy7HB7Ix+96z5NiuPkbAuasoMt/CadasJ9RTrZhGrB6SbVsNg6Zo/AxByaWKloKDxoRX5dCPKz5UGkJgjAhCvQT/uhWjNo2GSOIQCSlbySU00jXlLTVRNJfWoTCe5BEgi50P+KI5wbKJCq/IOtrs0lKCLh972e7n5ZCAVQwZ+WR5W1echeZDBplJ0CFN2gu0ghkvP6iqtw+/Z0nCE6pCGiWn9b74h1cP51zP6THbPhXlv/7GDbUD51xf0j75P7oPouOjMUJMlwOP0HmiHJ2JnX7za8sFMn0bJTjcgSAhgmT0jfJZlC1NtKUoVYMXbnP7wqp4TCBJnA6r4DpVpKDd5RId2gTu6qFqZ+X82qeNOAOOBtoiE+fnn48uTV4ZH6fzsPv/nuW8VWQ5zIYoq8FKMI+aiE5WX/0lZ8OlGnRYrpzMES6/svhUAnLG2gFqD8p4He/yWjJGSU9aWM+9kLXS7dIgB2VMo15MOyWradktUyfTwSkh9L70zNu8Q0iTFUrS3glzVv9a9j+pMc03xhQqTr4zkkKUa51TJJslWbYBeGTZWoNawj02t/wXoLjxPLahfBmOih/+atOuLf8Bpvubu6fD+kJkWO8XKmu7O9HfNVbheE0UUiProtcsmUSRE3KuJMj7guOLWDrxlepXRtzwEpzUQrYraz28qMQsLajEaijxKVUHsQiULodxLd98T4DfGXX1u6a0nEFcSmYzbQcexZtEdcQmLc0W+hB0ywDucYVN34wpzCPtd7mgPRb7OmzsvZax0IKhwCjf60F4SR0rGo3NLn5y/fF4tpPj+YTqsP4IJGyMzM5eXsND9/XsxWh9MSBk37UgAAEYtq+lK7ywN5k+kezV7ODvFxOSAi8ZTZjWRA4Wk8vQ5UDherDAmrXUszJ61d8J7uP/lG6RV1jVNVPBB5wflbffCZzpPTApkn/TAk7tECRdA3+vBrhNOQXELU8u+s54CUaLfsE1sWQmN0SVzxZ8yU4DbY6AnpY9dYEdiK5ErAWMzIVaCsLFHFMjTkSU+cxyHnSr58t8EmpdNWIS6MlOR86TCo6rzmourui29idXjUKZK0kz43Nw4usqkqKSDhwIWvjU0bu3c1PAjq5Ena0WLSH/P+pN2wD0KDGLH8i0TfhIYaKZzXFA49RkEuLnhELGHE8IAmtps+t0kx4iLvbDd8boPIF27XgwrW6OF2/Mm3Ik+wilF4PCZZBamSZhYMDmUXG9qudeITaGuWsCBrtR+bVIzNw8/g9EqblnUyLOtkVtbVqIztkxZTMrNHbC1hfyDmIOYvBBfmgt6e6LLrKEpjrQf/9MK3k73IGZgiIXQMdkhm7sQBRnr5ZFKirwJ8qHuMemNjOU6VgpmcWMGTLLm6o3AiaxC8q7f3Mg7vGLwnC0/fRvHPzQ1o4IYXvu0Qf3SqMfMBAvZa97ejFHfRMyLAXosUETUMX30lrEeNrGeNcx/pprrisNd4gUppibSHW7D8EReyvWM1OoaELikylEisrV1d416kfQrYJd/8sZdQgMTdaxgDz3IYpSSwqFq/9NUsINKSwOtMJfHIbFMCbS2CjSH65oNQ5GkhxxhWYH1AKdRi1hR8Ftj9RgQbq60ksm1/dKCL8s/48NC8HTZ6gGikTPP2QEr2Y09ao3ydEkABP+fegWGUANZyqLnToHmUtF8XY0F4GbQermaEJk7FZJMx8rZDVFy0DJN3TyI6CGpS2jJ5oorKr5gmJBVYXIsown7RQggXIrHszpfND8HF5gO/z1zF9yR+Q4L8C3t0t12Qj0q4olJdNZekOTORFmnO1hKkOTMF8LXwBzAOm5bhSGmJHh4UMKkKe2rc1LsjU4kSQkM1QcBa314Pz0Wvl7nLycigDEQZSqLvUYoHi0dj88Eonov+MhOejG3nYuJY9Peb+GBsOhbXsMqzsjC9a5kip8QHi+Cj2StdTF/tafnQkTPQzF4H8hNHh80HsVRJlYj+1O4iYkojSJ7YhGfG7Vo2zB380rk7uvwglX6CMighz5BDtd8+HECyOnhY1OYtPxeX+fgGFBRGnt7wETPtchvnru3TDGom1yC6cd6gT6dJxTHM/v3k5YsR2i2rj/SpNeG5urYPruh7uyHm1vHPDf1y77XL9Auw5Ld7x67XfhZ+ffj66PD466+/evSo9UFYsCb3xuOyaX1gH+Xvf+69VfCONOh587bhWmelcANHDCPbIoZ3F8S5KC6gwU5HVaCCoRAiVrqxiFb67jmaFUhYPpr0ywm7W0+a0NpsCpOMW8vDQ6kOw5j65WQkJRlYu+/m6FHl5M32WyFKVMJz1gO9bUP50cRj+2giIRo2XF/bP6FEaKObr8PJAVM6y+Ln6RXSAXNIZ29EK4BUyJG3g+QaYjh4YsaoDksTVf1z0UtZaiQu7G/GiMHgpdmAwV/jk8GFG0cl9GsXonvHici7lF/KuY/BlObk4cOHj7Z7g5b0ClKYte6kIk706+07YjeA12rqt6aRH+u969aDafjNB7+k7fccrVv61jQQbv34OAZ/PSOJBlyAuJPOO80BfRO/D71t0i/aQTxBEkFlxC/BntkPm+BoWZtnIcnv82B3rBe1cUMo4b4NmjRSlcdk3WA/tB5lufGtAbQtDkIHonULWa9rLypFFUgQrCFFT7OmgF/A8+l4BQok+KLRi/g4wSApYy2DG8+MUD1u1bct9LuTZPUGgMTxnfK1gcUa+LttkSm221HWGQ0gzXWtKwY/kZ+Sxt0CnkiBTkiQk8js9MOavS1QvRZ3dazVN/rfKOgNHBJr9oN3K7mrQ5sn0f4pBbNZsz8WwEYIXOOD1qRC+qw9wSCMTyJ8Dw/d4/I5EjVBwqawORBNMgCNDVQLp7nzX9NCZe/s7HJKc6tu8HJvLxqoGlKSp4tw7rctDP4sp8fGlXl+9fv/d78jTe8Umyb5vGZfv/tnuU7W44agY9VokTMcFVEt4scRBtShEW4UNOaAo37vyXNh4HyFPzbq4bwkg3FzmAkmfbzfcEJxdB3/qr8hSCnUjnny3xBiHODHWRdsOsa2OD8bwm2MCiTetuVgQaIeg1k+tIQH6hAWSLqyqzuA4wgBA9QKiYnPmIcsRXMSwxTjr2JoK5v5zzYXNjuoCu5HI2C7ERImlRNMBIgVRkocnegIFv1+OVHM8/H3qsauHl7EPQf7gY7hY/Z9eBmMMRBmviMYdKOw6T4mJtlHfI2jyPPx8YPOSwqUqyaEm21XbDffImmXEm0DWTh36/1QpnRfRNHvmqAxbCBSAm0QrITwAv2bGv2QtHGOA9I2EjcLVdLQcn3AJ6JutUTbaoiyJUfXuietPp7Xw+zsnBoPRCgSeZCMHKqU5zD5XV4DjYHpmzDRAWMjUmDUO6RkDQ1YPKC9TLitsRuZOEyrCCDDcHB42S/ReL2mYP/OEZQCLTcLBxM7/IbOPYHTjuDD4/11oiAKkvMOyltkFP5jB0nqjsGL+mfnvPOgRjCC82AE51ky/lHH8EfpuCfxJh1ZKZoWeYG69dkyip3U/BoCEWvt5PoLF9ggdkLbjAwpeEuLvJeEAzqmatZbKaiPG18oBLIcRA5oCMioSYFMJJhui8rlDDJ4qAXVxEgiIaim7RHCa6fpoMV9htcLQHcNshcRHl17k6/E/vx/+0HOJoAOA0X4h7gwLWdJqwkvrgGs8B3PpJUW2GRDdOIgM5Ac+fr14euTo8Pjw0c7OztfdXtnT+hf/RtlyQJlSOr4xhdJkXUJvCUOsGHJIKj06YwkHTDanVvnoJyQBcWW9BCfYtoefJuFJbiJCZHymiLktUTGS0fEu3eJVP039pfM9SPfxSHvQqbSBaYNQkdThbRDjhNESgHSGZiyzlb2la/X9Nxzv9K5STAGjtZUbUfNMDAgGVPgi597LN2qjWOWiNJEpn5anULdfhztSWQzFnA4htDc4Z/u3vFPd/No0KCi2BcY4wzpeRbGbeFXjPiSEV0zxIsGvWoIl41/3HUjdsyO7hu8whrXDYk5NMaBCyLBfZIrCF1sIaRcHHyxfzZO8FAMtsjxMQ7wMVb4+O12DSeLpgijn/oWFMVa/NdtpkPcw6BBY6TRoO7d443K151E1NHo7nqH2KMpWB0jkIpk3vXO1eGYTYcXNkKRFEB4n5kER60Co2AbaTiyPhVg2iaz1fV5sWhp4hPMccPX3nlVTYt8tn7zyHjVOoP2OjAfCdv6PhgX72MKMznwZGvAydZAk/8KMHm/katerx+56r4CS97Hbepfevg76+ETkrCTgxPr/ffTz+9l0t2P9lhOBv8onX27F04j+j6ROBfKGNK6/m/TbHcS8DZdzv9ZquJAG1s3KI1BhaIZ4ssFsxYsJgfLn4u8Xr6cjQtuF4GNYNm71P00WmlUJ3c8qULtdFKz3OLgVdYZOHipboeZsQaszAM4RMMPOmk10/88hcLQXB8RU7dbgFINXXf72eS4qRzV1ns4ZiPcbO8FpVl2rsSUd/tS5d24chfSDA1W2rrZibtpIOY1oEfCWVchTclo8Ibx3bdff/1Nb9i60sES3X4m/x1yAVTXj2OJTX7h8PZRRP6hitYu5BsBCNmD6ObRuuqSDRPvhC+bsANbRxZj5O/3Dhev3H5sOoonXNS4y+vcNKnnDV7qZK/SmMMmhtPxDQ/vKEeHjx59vbMbP+IlgXd+0UtA2Oh5r5O83Ox7+P/uwyC2Q7tzubkWVqkgMaZf7Qc5N3LDrb3NSzrj/YApYbuk1/h0KR4EjQ7T8RhCa5377FxQQcQDuNPjrTgI4RDsdPz9eHz41VffPvrWJEoWXID9dhZIpukhuSH6e3vU93S098Yo7/8Krr6Giuro8Oh4t6NyaoNw6o06Keb7LUUuHzQmj2uMmtYSmoDbyATnLosNE1ETdsGO13u6xnQwoEn5s6UcBqSF664feblwLsSOGx2Jy7cQcmXfYRmDU+yIE+YnPKkaI3qI3Fm8vrWcRYnwHZvCF4+bhlgd3fvZ5ESB8+Tl6+8ePdrdkQ+UFF0mKC/Q+ZAvGFJHyNKQzs6QCjZ2tzj7IY/b7bsoTYGTmzVRUv9N1H+F+u9C/ac40tmV+u9X9d+7VjOLdMR4VMvWLkA3cU5ihbF7Uu1iTiWAr6HWlYNZOQ3v+tHs0WjiTtPa2MyiZTLd4+ujpcOdJhEC7WAd0XEam8T8759N7jqhFPBgYpNgYpPuE9s0H0H/rLjzThIABxMrgokVa+yitfIk9M8u7r6DKMhgIhfBRC7W2UFrZG7on13edR4C3GAyl8FkLrtPZpOEEv2zq3vibhxyMKurYFZXazO57pku+me/3sMyMaDBbH4NZvPrWmvUKftG/+zdPTBsBzCYwLtgAu/WYtaJbCBJ7RlNERLJ/0JykIakIJ8sGYgTnkhEyhbxSTaRFTN1EAuBVNYGbS5AE0iYET0R6tNBdhlFFKYmkeeh2xh09fQQBJmRJb5AMXFCUjMQ2g6KY+r2FWjqlU3lQyHKfMeMLigV3tssHORNhcP0TDomm2nPJtOY76U1GUwq1QtKpveASAp2U9lUwmK3FDQoj97DNDjgTWVRaSKdk+Og+HmfcxFXpbP82TgZKW9Pw0kkcLfgLEqoo3adsuKJcEJ0Y30xhI7cJtmwcyYpwbgnRmtwaHWsyEx1EimG1unenFbd6gWdc94igOi2m6W+u+6eprZ3INYGS6SQbDtKDgHxmtBm97Pxha55iCXsqymSUhi3rp0ltEhedwIUxLpLaMJ9aERrWtoQGZHHH+ko+nlm9SSJ42ZCiMS3gA4w+t0nIAPd8X4UWfVTEkEk+N4FzrokYOyN748CfjErk/4o5U9rzJv2KfKluauU9dayN9JhNs3PFdY20Uur/6bqv2tminiF0f8sPfXvHDYtpkMd2OwxrdloweTu5p+z6HHuTk4iq6XC9JoepSYbBGNrNJUxXXUG2tlEiuMvTn+Ht6c7xbpDUB0ufkhzDD4piuHjRxm+dB3r30lJA/hBReqRwuFAV9cLp2rjv3vd1kdOJIjXErxjbY7octbhQrU5niPwna85IRJ4ukQfKxA10HivuWPcwA6XmA0xkehB0m7fneasf/0dqS6Opji2+ssrjfHLzTE+FhSXknZ8Q3RL4CU19d1xrXWld0R0mOrThZhERTHqvO8YbrKDlntT0pZ76KyGjsiuOWNp/+xa42S6OU4IvGDQ02DQ083Rku7kOujkuitmkjlaG66ZybCeu1Fcz2Qm00+XwRTA91hKpvCjSQYbJz1dL9mpNdWSMvKx7JusQmRfJCQbFCGLFkgg1kLyLyrWThkoyC+WCD+uU49lUfVGgXXK84ihETMXXqUqydCe0iCsI09LoE/TlEdQTomaY2deI+TBBEPGYZC5NLCss0vSlIWUk49pQfOssVnKaUhpgrRkwlCJPuScoT55WyKbqQhKSGhqIxKISUdFIPY2J0IOis09L8GBxoH9brxV1/CiHHfxnhRJIGVsKOWnZXQh7HAKy1rfJ6ligwx8qcy0nchLwNc9JN4brxeFj4+uq19lWQcDf7k4bnCbHRPfQaHyvhAr33KNgOmFX+Ect/bR0tFCJuN/SMcL5R94ZzPOPvSoYR/u7DLKoP09k341HIVsTD7zbidPnDa+7NkGy8CrBJko6WEyTWxzeth7SwvrdGUow+wOs+72B1RNRtVi3BwbF5jkZ21IimzyV9rKXFerx5fMfCIkNPhA3/tNewzC0EFr4wTaIPOtTyKLOiQL90p6YZTUNeRdl78B2VS0qCyxcKGsg/LDQeWZdk0yW9TCWJCqqIO+w0v0Lj9v1qh9blqBe3rPlRZPUoB0WbyL+3r1F9ZdUpl0WPfL+xmSQDKS2qKNZO7pDSamNknJ0UJtbTdImwZ6wxd1bN7hNf0Df541/Mq/I+k5EjxIFeMs2kEt8jjZAk/Ouh1UgsIuwIQc3UENVdYFUJTQu8PCtb0u0wTcLYm310u4LckDqVD//HIcyknpq7G5WEaVk0k6WE35UixVSVyKpe7jK3HM0aXrMH0vTFyEu193k5fdUYusKt5qUlcR6aLLgAlXEfmaG99yGZzociTdccMrLoNgr7gi2KDYXHHjdOMo77C69mMHuQc+JvKTo8DDALMaHYQfCt0mNG9IZC4iCdsF2BDWkKtjhPsh19VJw/hUwZTWUgeEMSCTOyjWAQRNN901DRNt3jyd1QthaKfUTuqoGmiOXOm3SlDPfkjQfxjciX5dg6ibsInN25UZEviuKo00mehfEekiQTrSOQxCQmBCqU4BIRLAGkJEJFo0Bo3wdcNRJgLJtyFTGHdbFPn2FdIDCpZJl2k9Qdw6Ido4kcYtL89DjdE6h1muHXJMKDQwBqpp/sPfFGO+LhblWBEzWOeXl6oC/D3MLspFvXxRzV5ghcOrfIGV7IcnUBmKtPE+JOhaYqcHyx/jtmRQGoc+xJRq/EJHMB3pGRzNwFbQj2NnW9fHd5AX+QsNyD1+NPqg/+e//VbufDfDXus3hgK+Nf8++CI7mr3Pp+UEu4fujnQIOGyQffFA13x7u5f9229++Lf/qQfExCY/G22r9Zhnzl0ubl7B1PoR6gb7LM04Nm6Mkd95mln2nftLTfX17N2s+jCDHqRJJqcpiqmfx1SluOJ4upoUtZtI91gBqQlk2SPyt55EvZrPq4XO8p2aSMNU2nIV01Cfkvf2rd9txK6Yt8RZG7BQ6EPnKlLOvuSkgWA8zvbjPsJwhlJ3Lk99TDxR8AGGgs3Hifj47MGDbFZNirPrarKaFvWDy2o6KWZb+CjzYFLWywdFff1gWT9YLctp/aB4rw7NreK6XC7Vjv+11jrPp1D4FMtAhz7N6zo7Y6WOZy1W46WiGc8Aynp0puhR1z5ZndfjRTlfGlNCq6XGWjX9+jxXd1ogqj+dnb16ffz07EyRkKZQ9cVGOdbtVrPzUmcX1r8WxXX1vtC9/axmV8yKBamrEHh5qSehf8I87cGgMFXU01LNXmEFVnNrVnxcbqmSIvsTBAzAsW1hpQezams1W9XFZEthqFbtFRf5YXWu2um++7P8WpFBvrD6e93FF1/AUL7IAGtZPss0ttUfEwjAUV7cZFMz5FrXw8p/Unw3v8a6kMIj28pOr4oMOsiqCzWRAr+x2tCxqngwmZSAznwKJYrdz5a1apGDNa+6DpwX6liqIfPGstKAbP8aFuxYwFDfdT3MRqORn5Oxtlyd0zWV13J0WRA4lK/S1tIlPQBPf45qnXWy8TGC1TfSkBx2jQ456IjFW6P1+hYf0j3ckdiBIX+KSNLKUCYjH6mmIaHsT4r+igWsqVsic3y0r9RmK5RcGbMiXVciuQLwTSH5H4BOik2Hzh/yutDNFbsNAHAxHDcwytKMIY4SzYd6eHSkieXTf3Zc9n+2oSInOtacuM5yx1U0WVi2N7oDdxurA+Uc0qFj5fmieF9Wq3p6ow7MS+hsoViaq3RdLK+qSdav5sgKB467CYcFnZiFwBG5QgwcWvCPXT2CKoRskJXsIADlcFhdXDSNI3XQiW2idcHaei10/U3OGjgvcFXVX01L436qBsXHYrxaFtmHK2jmQFXj8coceLAm+WTyKRZEgd14NWati9Fp0A2bucPown6BNft1AsGS7+qDn38+e/rnpy9O6TUlKYyN5qv6qs+GKtqg1YEEt8ZZ4k+T5gOfn7DyyISbQjiyN7YJOboTo60LxvbY90SYKGENu235+1pG7I2uYci5EysdEGTCROSe11n25YpSy72obMfn2E5xjdXMFhWeZ2U9dQOKO44TrLWjqm5ETud1Xxc842CY052TvVZjvrwIKd8mbv9DY46+F5Waubp1a/zp6xGgTkJagDI+Bimt+22zSJIUztiERcq0GswmNkX1mYCKBkDf8/yI5KQ4WOjQIDCsUHAlNdTFsr4qLyQCjyYRbxV5+B3E5PSMIqlZGoCRosk8REq+pVZLlOEYUyRW5JmQGmbvDOamkwjxSqjN11F4nnqGBimTFPU+8x+TTU+r1fjqZJkvlqn2voYGgooIJr4a7AjEyfUTZ3g/P1OwLotleETOsGv97z77gvXhG/7Fv5b1q0U1zy+18uxkWc3nqPL3Dne4BgACYPcjuz3ff1gf+0u1oKO59SiYFEo2HudLNYzXsMv/pBD1LmMLvged1fN8XAxGfYbLPY3fwQhh32alQp9aBotOGFS1KC/LWfdBQRsJSSkIUl0Kr1ZFpEY/XMjEgviAtpabcXrkJPWYk5inPE3OvG6h06ZtSJRIk4g18GlVVxoU8Omde17wigNOgr4REKn/Fa6C/5LCvdQ2RpWAg8cCYjzS/B7+dJhbQh/rYs430tvb/Yo2ovuSpHuhbYy5FCIep1CkX6CY1hXengLlLL46raH3HdtIlw9cxNYtV2Y1wC5gq4uL6fTAdt0idbCwaIwDj03U4zN83gVHbj265/ksvwRri7NiWlzjl9V8opiYf5TXnaly8KKzf1+Vk8L+fVGNV7X9cT5dLRgxIClQzcaZs5Y5o04I+A3HB9/wL/qNDRmqsAJa00wG6pg/6VdxglBX/MC05hYFUNv9oDUcYqCG+0FreHRBFf+L1nFYhCruBxsJHNQuPzM/97CGDSGxzYZn41ew0vdlXZ5PecIVy9NP1Cxnv5TLq/8oFhWLTRDWDdNim9WV8mxb4DYzFKntC1nVWbks86lOfimB1h8C/OiacXOGZ4io7vabrc7IagQSvavShwpD2z97GdG08xSp7VVV66cAOBCLxfLmx0V1/QPrq+80FJc2CVQ/eKYiy0jr4hLKla9cABJbG3eRXNvvsPiOQaWZFZFmYuZkJRe2zLfIgy5pBvYXVAhjA4ko5DZsq5Mlrdf2fblYrvKp3Iov/MjUFbvuBMDVpiCW+bncWH1g9XR+1YYl8onKbRNGonLTiDnatmX9rJyoAyps9jljBhyVukjuR6ivN59cu7Zb0JLcsf1aZGaXetQjIE9KdBvL4MONbns51eDhKH3y8nlmj4cPV8Wi0F27Q/j3tU1wAaH6YTvMJvhkNy3fAww/GgNFHgg5dhIX+Emhjufqph8omqdFXhcBmzAfNTaOi/9aqZb2dKCWqe7doN8zwHtcD7r2nraI8tv56XqTRnW1oreiFvBslxnyHGR9eJq9KiBeLq86AOUDJE3Ipwt1JbrJrjT5jvzzbg1FVsU9X5Tqpq8WTJVptQyFNXKqb2gRvJy747ofK/LhGLyHKZjNwsauA8CsNXZoEYzdCSPC2H8EGUPXowOeGVNHD1bLIn0wK1kUtRNRMFEG68wLLbx26l0KIWszrw7DAHmnyyicXNQ2iBPgsQqT2ipED+JDCSq7AL3Z6SJ/XyxqRaqrObbUXAlWdrkoimw1W5ZT9Tu7KEEIzyFlLWTvwCQSlh9gS6AENSTVo+Iiy1pDUU3G42oBKzu9GZGXoKMLixYr8Jf17PeK4IFJjBUHyuHp5iLsERuXS7MJa0QSeyFCIdA8LBUfzG819TmEwGJVjWjo65oCVtm0sB3iDE9W43FRX6xYFcvsPNEWSxqRy/oM+RdzCJVdq9sKyN9OcqO3AK2DJJVAVkTUq7tZ8OEYHSFYqb1bGANtSaXLUqMdHZ6cvDo+7A2znnAnG+cz2NFXimYgW4gZiQmOkH7UsSNy2dBc6p6KahvDWqBCJXPZj2oKlUYUeTCYDwpawXHIzNU/l7ErfFETZi8QfBQRguVkRdELgnGTLNUhZQxD5AH9Mesh+fSyPYg8oQiqF+boG68WMPkTtKoEYnrjAAe5TFlVYew85Unxca6gFJMXqhYhlMOTnZ2dR1/1mvPi4dgUIDMuMlfVsZvVH+3m28s+0IB9JD9OtcynOo4dKAfIBL7I+jvZA78ijoJ0rmD1ZWd7ezCIAap7iuI0SyUsot3CCdYm/XwBTeOGk2K6BGeLVI9bBPSAjkxXMcIW/G0fHFSLHTZAUXPfAiTS35OnBNL00LcMqY0CZTZJEs0zOI8fx/s3TtGaaD4ydsAeaUHC0ZioWqF9+RhXqVvqUoYFvNZqxs0zZiVSloWhQm7Dw1jHYQokKUBnqQXusbn7j7LDfAYmc/Aip8TV8xtsfV4p+sC2VoIwZ3muFrbOPhSKk+UevF0T05U6ee2hOTLSV47BsowAdl4oYivC0S3rYnphh1dMvKiif/fp83Ko2QiU5Cid62a9QCVqrnoGZPz+d1zMp7lamWDqYOKfX1wAF1ECI1767FupbuDvEnHetcY7h7Zu5olHJVANL6PHwQi0CGyMIHMyD99Jb9AYSqEhcWJ7jjdRk9SgSOqqSkrpv9Lqr0ZFZH/Mc3DdTVMlAdtIVcUJXNafDIK4Rrqu+fZnuPmU03J5c3iVzy71PVYdfmjKk4zD2RmCmS5TSQxiphSP6xh3zhrD4ZqV0YVq9oNmG39mEHFY/CRbLm4Czt02FDYvIzpTXR8Dfws3E8UwxU6EYR9cKBldGjWHKmAR9RGFNt78ubosFZv+jyMwouhHMUQI39M7CRdv0otZnL0y4t2iSSMEl2SwoFZ/146jqEMA7hioHAouKrqZKUu806a1IHTL3zref+n66qLnwr6fF4tLc/jNF9X7ElRLOCN1XUKrcCPLZWoom4430hP5QeMDEo5bVwvsVj+ivstyx0lRzJ/qsj6Z1hDHzFRTFhkMgngVr4Pz+05L0zBVNyQ2T87S6/BBwBzCsl2yQL/h5H4fzK5G5S4d1KnW9upiPijTd1ClQYMINfPz/jI/54BUARwQ+XmkFlRlkJFRNWgG61lt/30+XRWxhNN2ANwH+1+X+eNQJXN2GA2biJFu+HERdi2+i3E0kDAVOiIBe3qDQun86PaolhD220EEIafJDlVS/Gn1opqgPJ88U4Z6FIMIBNDQiVY9CtK+FNewbawKYRyPn2s8/u1vDI+6cDD4H4GFlJdgZ0ILhr32PN0Qn2n9tmxYKR/clIeoGvwr+zU6z2vPmaK6U/qLsg72Qa+rkUykBpn0EaJa0t9MrkW/LiPP4HfOLPopmcNqiKluH30Lz1f63lErbIKfgxLV59UiV2JcH7QSkFPkEtx4EUxdZZMKFLcF+pzdGKP/UUonWkABJEGFxIeyZpQ/5hNtUPCgf0VyT9TunQbzTLDXmSECGYRVTW6SoC6TMruQBqCEVoff/Ubfmo/l0qEgJMKEfJkCBb9OmGVEPzr4udlEYMTQMjnevG1WTSNpkp3bLDxSD4oa03c+qde4EN3tOhRehu7xKiRfhO5yDWrRahG5lnMQUGQZDVbL66FhEqeVs/2s6buVui9cLvLr63wJBKNmFj9keWigrxoiPHjo1feNlZJkx/YVxvhpiW9F8ODzUX4aij+phR6DjhfGCswOHzqzsea7LU9B5BRmrG+IUCkpe0mA8kMdRtwJDowhqk8MSAMjbWSlazHTNdnpegoV6/tkCBXQNnH3odPqZ24R0uylgbcBfL2jLxb64/iqGL/TAgfogrjA0e/uqsFO42A/x2xqXeZzb8yiAR+dsdEVC7JMkkCFVDmND7y/h7KSIEGJIUldA3YenVY2u1E+f8OAvN0XliE5YLMWDMKQd92OyLWVlmsfhGyrqqP+ZlqM5qYj4xuheG9PVFC3te21zq/zzmbyTKAALpQwKkKB2ASzSydgkJNXgpMaS584KcdHrASpmE06jKcBLc3bT3h4ud+75pr3L/GC2OLEdRIZ8xhlKXTZG+xL5b02Z/VnkXUTNgYTp8bG8WNQhONACA4euAS5d18KLNDv4Vub6+kYe+4NWywsKUY4saH3XfgC0rT5O/WlHbjWNPJfVNP6wfmi+lAXiy0M0mfN+3/AUhedq92ynwlc1np+K/tJjwC5A1op4Sde3SivMe7aCT7IH2TX+VzLjlkgeEF0UzBdgjioKelNdiyI+gl9DDZ0CIjH/1jobDM3gbI+QkApG3pcORc4FQxDyGcMtodf/b10WeFjXj8VQZVyK9b/48DMTXhRPcxBvYAdZxb35tEXHldvvJUswOyxvYdH/uX0SP0Dj/xWQLgslj+5QrsyYWUXas0Xjer8fYH0Z1uBlQbQjv+lKCqcNsdqZHCDsXoJsnUgXlYS2VXpFhj0M+5jVCuEFbO/dIj8mWz8s5uUHQ1GAk02+GuHSKDJxqcWaXThbPR3H0LTRGKWFpGHWbZBlsWaPIAyjYBsgxjf7rfHug0pRcfoFEN0RjXJ1zh8ZlTbhYIVgndGlf3HMIpmVNXEnQ1iWNqUAFHYTMq52oJmsrpiyMw147QGSxgd0S07rMWc7YdXP/10tPvVN48e9qQYjwLVnp15dAo2wMtFWbw3754zJUS/L+wpaIYIPvdo71zWJqatUYc817IaDjifSeNVR+e4wEBSLtgJrhpY7ABTtAxRCaDAIF0wHK0Roe+5lpXfPz5/2f7u292drzvi06IwYV4UrH4ggYXbWwOhh1R8eWGKOAvENuEWSdB4nC/HV1mfnFO37U/5c/QHdrLKstJ20ejUrKRPe1saoTV04b4gKGO7a+yi3+flVPuN5bObazDYAqNsdRmpMxv/Bs0D4GiCJ9lqfl3VS2ahDUuuxnTk3WCmzl3KW9hqq0N2mZZ2MbGXEtlC6LradCgHgU3FJY3PXcua52Ux+SkFi7zm/3Y7TPQpADzGIOhN0Ec8JDxt1xjC0+8XF+vZbZpXR8c7jx49+k4UYhYgsTNLcX4X8BX8qGijO4zqp4dfPfp2l4/K0w1ISK4fWDltQPrDzSugtVeGIPoymbhI9JqUPEyurCfgJevZIPB9amTMvLUhAn6ifWjlYzfJdrxWCqPczFZaLxRpDxRwxaxJdUJKQzIWg3xfADoLbWzb590NcWSDUAblvYvp1EaaPbycHWKOUq4SqLA4xVH19SBhyWnsYPWEkTe+Pv5Z37rMsaVvbsXSRIbUX0BEAltV9OGAWsnbGbuU8Nhdi6nFPtZ6vZhyBuIibjzPl1eji2mlaF7/uVCDqK4VvC+yneKbgY+P+vAbBuBCgV0pYcb2o454PHlxQD+az31Jgo1vdQ1CrFCZy7Ha2++XNcDrBs/W6kMdJqvzXAmTvVnV80JzNY0Kp9VYh8XgpeoiXEOQvKi61kTDAaeKb4ralavbQQURihY1rw+qyZUpQ3IbNFxjL6fVeT49hU9AV31FFz6eg13BQXSoUSjC82GnLXWuEPHOpr2qT4HjohBnU7vFoUIL/K5JH9v9gEAMSzaKFAOZv2YAQ9ftW2IeJ0NgcjE3ijzXm1b5pDfM1MZ4/D22sHKM3YHD7DdtoKiEXhTuG9ZG6ACVZKsZ62gz3MvsLLPD1qJQ87NRyPUcwtomqbW4x+C8eQT86n0OjEgNzP7qEwT6uoA8E/K8STts6t670H54vL3z3Vdf9dKxv1tuQt4gLFllxFRA0apUM/KVPkf73gXUpqyXx9MiXziUp5rHFk/y8jWniBVeyBc4DzjGQP1YXWTvips9bZang8/l9vyrTHivWh8xccRMrPbS1NqSHBNr29skAJp+kpYPKtYXP07ZJxN53YfZ1k5LWFFNE17ORVCZBAbDMEKzL7PeY4gkxyq9UV/e+iN4IF0qJai/VuWs3xsKlquhMHJhDKy9uAFyFAS1N17J2Myogn56ehrILMFqKJDN4ooWRHj+gGW1ULzs/xSQH6J3Od3CYWxhl1uAE3VcvZ6V/7UqjibhNchceMRMKZC2/OLG6GipHC48jsGxPT3BoQAj1RKpH9ow+/eTly9GSKcKqHXdcBwjvilHGl08/tAz88OiXJpIgrTnzMxWV31e1LUqUzCFaxFKeJqnHf/ct0LH6GpRXJjaqoaaSL4YX72CFdOGSH2P396QYH7ANFDQ0tNcbNoOft6GZqY3Zl3d7lP3hssrVWwD2NLIC9ZsZWVio58XSXu58HDdnOdbLk8fY4KzGzM1ZRRkr0Hc50we3N5Pq35KjtRa1qSUCekC99Ow0U8/ebGwoXmdNszvYtCIgcgH/lfqVgEf+SuSOZbMIqFxUWlCYbiDKLU6wWnFHqrDp5bA7i7UcFSKUWmRJBSutJQSP4pGbx4MJUez95WSDbOvt8EHH6y9qJYQhSsW+Tqampd87CsWWOlfF6CCIeMj7n1qHEPV4UYviDpYwANzQ9/SxmEuNhi9SN8tKFgQASwOEWbUZemHu/ClLfnQ1hTVqzlW15yqTeI0FkvmarcMA0xN/Ldyss7LX1n/pFUd4qdjfYuKy413uvRJP4knGnmfvvCrcQW2ecf5OyfJsEMqQAmppA67EwbEFMRVOChSmIzY1RiwSzGZibWjJGEhax01j62gYsnL5dSYCukV5n42b4OXYqe14roMsjPq/pgleGShtpbJSFLLIIBUOUnEGJoQy3eoxTxLCOXp8obbi47Pxeg7EQSK1dksuheGtCIoSgTT8jV4yCi7xgmUMBq43SBAEvYinR9BR6SKWwZtmJWZXaY9gIPGJYaP0N+jVsybuKH1YRjjK4aAiwR4aIGF/OBvf7O/kds0pHUYg25Tnx8YZQjeTnSZ6nBgI+sUOk4NTxFADgyTJUBDsm8wGFCbNXlXFHOtSlUNfrkqFFgdksiElNLdYCuEEiR4QCXsmGpgPcDAwMEE5A7fV7xK28Xl9oU0NDc2VFLe1k6rzQSOjsx+ZPOA+YBfqpSr9bX2yw0/1AHzCBHaLnLkonpFRk98ZjbaN9pC7kT66VbNPvHkjqIzSGnK+LHmNBOUowsqOCJZp4LndNClHB69Ptze/u7btugozA+SkhOxO+xqjL+auw2Rocij7vP0YqtuI/kEHHA1SRjje03b9RwcftDb0LXIx2AwpsPHXeezcr6amgNtWha1l5etkb86lJaF3x/pPcm+IEVvwRNopQU5s1FtAql8PtfetaxRvaqh9Lgw4VZe1+huYGJHacq+niO7zb0S5ME95OFyjy7j6MVlyMflrmrO9ctaxvgSZxyDRXtNnIHGpm/dXtvDLOYgYxolpTCsm1Jak52W1nGqwVMg7eZctDbcWPqS5qa0VtrBSWCif6hLA/JSTW3w2OXJ1xCEq8KJy9Z1xdEtx0YM0UtqoQxdw6E9A17aDjbl5xY2U9vgvgeXENXY1vBG1f5z9xOAhfM6PDo+PNp9qP6fjuhlTgU9Y+QBI485YzmCp0WF4dnio4GOeF39MozmFY5G5toe+Iiti10N4lUSIYs5mESLJvB5D8Fd1aj9HakQHHBBnAfpTESNlG5t27g5iBuPfsfLi+vd34GCSub6wir62wup7G9Eri67E8VVQ9DR3QjR7Nel4ajsQBQvDr/6+ptHj3rptxiptyYm5eu2cig2f8qihPAfydBQqchP1Uxd8UoIj2ncz0YutuZieZWbxCmo6IllADQOC/OJSTrA9jB/KeTvqP9tNyv5GoWT25QAzzWdTlw3lrsw9bFRwes3fhPsCpWTVk9FxAsLKLwJgAKvnBTUwEkbCTH+bM1N4CU4pUI/D4zUBWt7HDDWAN8MarRh4jHo89yZbUxsSai+6xRpw52PbGhNb4P5dAxCmrHvNMMLcCHpE6JbsK+MOXOSgkgy6fe4JcX3OJnQuzSaPjkYHc3gre803vi8NTm3gLKr8vJqCgYOTxbV/D8UifWV8HQDOYWKnONtoiqcaouBo9mkHOfLaiFTiVDRH98ilHW37cHh0bMn//H118RalW9coZeRm+mBmlof5tcp6dJd5eVqBpjl0jJFrvXxjITqxngtkQOR4BUGbNqk+DbZW+LXLu+8+qRUAnR+Q8LABH6sLDSGRNFpkT0MzCjJDW9HNYuwcdvkchZ5nKXmGnHnJyjLmNjIeqvloEmnLDUlK4fhu++CBBkFHVUJoU48wVHRkARamFl7xsqdF+252g6yjIElzX+ByoPDy0S6UssJWSnn7hod49rHHdfbNXiX8A8I9i96vaRl7oJpC/diZaTn4mMCEh6otIOpmv2huvGDu9o4sL5FtxBoBw942ZfZpBrrLNCj82pyM0LbLefZYRx20XNFN9J/y62894k1PUAvdt2OuLLjV+fIrj9Tb3ab4d3Q3cedPebvcaN+q6Hbnx938bO2PyCWcje7upoq5uZw9Wpxoa4pJmatWkn+mRAt4t27OTCyObVqG3Xvoqq5WkfgNO/KEPTgQ5XVy2Je72U/lgvMERc0yME0XL8qKqFXNRu6sN4z/aCpIWJ8BoWr1QIMmGxoBZghvEZXS60sPNUsAon5PK9B7wsAbF63oQvGPcbApcD2hy6gGkSsU7tqAS/8kMiVRINwo6UBwRUDOi+ucsi0u1CsZq4f+KpZ1Ci1Y1B0X+cFtmGPo3XIpJdIT8xbYEZoeJb7Ul2yact0uDFzBUQ5UQqKBvFwG5KVWAdqbmNdTujd4HP/gOyeUkZo01LUUDdgx0FNbZFTTtpFhJLbL9ef8IAIVUhJqS70Bf708gHXRt/bsS0HBaDoxusojfxx/3inF1/dU0K8cFe6iC/Zey4+6OTEZ1PPPFuW1+ZN5tXPTw9OnmYvXp4+VRcp7SGt1qFwmldM86296fllRgFdQMKC66LZ9Cp8N12SLShee+7rxsOAcbTTa03y5smdBPTfqgVLpN58+/HmMsXEZrtd3NhE2TOe/GGkhMWxTmPywT6JuaTaJdzazw0XRKj4Aa7nc/P4rfNAWK8nZGbxy8Csa1J2hJ9U5LpOkSfPosywOn455F01T0tw69oJ7542iz1UJC4iLouyMxdSw0wnuddCmE5CLyeItEoo+iYlabLEZylvpxGD4ceJoMQhZ5hBUfGeKk/Tb1T1+KoAI57QvCEM1pGAKurJFKfVePvXmv3PWTPHRQ4Ui1/kJo1Pjcyg0G+Q6IpoZmxvE9lJdV3Yysur3CaNWRR+62pbyC3NQwrzFqikxi2iN7SGV+qqDKwLmiOcaqYOW7RK3YJQjUoQPQdLVGP2V+ewVP+NPVzn77Qh5nWmHSlXWq2xEWeKbao3wHikzQ3sg9wTEjQaCE8/sWTRSDFpq/6EAdMbgPEWA44FFN6pYRjilTjjLDCO8cGsvNZNfgSTampeyNl6ExpbdfHWSNRlea/dcmk6O+u4ePdDKd0nxi8HbagODeq6U8amJps2qys32iQGRpHZJjXpvLPVJvUWRXvN9vpDr3JAycrmeOtNyve9wSA25DTzOAu9pUl2sIRVJctgEOQPXRTVYlIsns6AAxHLTV5OWuTz+fTmNQjj8MUovuPMnM7AOp8tbVQiYulo4xQFHgQYp+qp0y014shbFNBWI73Q4MsFOt2+2ZG96bW9UfRM0YMvLBXYfMvsqm2gofGHVw3TrsJwOi5vMEjkcfj0viUDE5ktohEGfJix1CGWG8GL3bR4LeawIPWZATeqdVkRXk9VEc/i5r4LWekaasfJ4waDDTOcakXVfSQ3tQnm7pbmtBUK3ycymHgvNdimCvumMesmrbhGKlVhaqHVKhJtc+vYLlZfDRtsYy3j8pl1IQJMEL0pyK/ra3TM4Bqlbu2aFdawUbmu+bhuelGC6+B1QR8WvBAAN7HYIJwxJi2wlvgud0EmoM5zXyxNhs6yvmBx3tNwOlGd/RCATffAAdFXARFmthc343p/p/1wQqjamHs6qRFsUU/VgSJ8L3vz1qnOlTi+5+36aTHYmexxk3/nf456uz1myB98JM1JiXN6t5GMShe7yB2Ie3h+u6rOUnTPneamwLutU+6yJ/Ic5yYPFLJHN0kYocl67z3Tv4sJSfaERU4RNL/px0Q28OgmDNODlZJIjRWoQ8aM0cOAFsVwdZqRPZ/IJAjdxBVPiZg+mxutHH7z3XffPWwyWknYrARaWstKHjgDUojKnim5+uNNQ7j15uj1YvDkNQLRN8ShJxu1aSAbRZ6nsFmlOwWfDwYshcncMJp8MN4k5O5ry4LJR2dHW0z/SENOAeFHF/rbq9AbXlT6jRAIGeM5Rl9GIgRpHz3wgmQPWvG7TSKPME1f/Hua3ycOK2avxLqO0da2ZQHCuo8zJzfwBD5Qau2ihll0zKbybN3eQ7qgGJUE4n7H9ydcnyuSnEQASt6V/Np2sX5B6NR2pBm6M2OJ82Uboz39AODSU9Is5EYEWzt7NolZpAZzMIZweNwFycStVWMDI/pEamvhGfVHIzEGV6PfxLt5cPtWazgiIGj0FxFc86ux7iaZ4e0HdUerwS4ZR1MPBEyH2G1PCu5Vd6Zto1bQz5Xj3tosxnhvfIiEdB5TsGfpiP1QM2LQb2HcEf2ArF6nQbe+vBtVD3XbNZssbNzEAbppCpgRnHTxIHVbD5/gfAmJhIdqn+B7ttbq9maKGnrhu8pvPFKykrMeE7MkLdwczCaC6DLYj96SHSfqkgSDruLdVJJz55woaye582KrnpIqJbnKcTQa5YtLrS2rBy2awXu67frt/GdwupVccn3nxC93PYyuluW0fgDSz9bURGiyWAR5ykZtavfMZyG0C6dmU/UX+cF0Wn3QRA+SOhqu1g3Bs4unxIH+qeRBr1F1ujAxVsUw17rKk+rDjIWfgijHxXuvXKtmr3xN+CIAgTgg3YBAzQSQ1/NuIF7PQwBLDMoQxCfCb7nFrEEqWE4S7CuyTS8A80KvnhhlMNELsyX5oZrcUJ0xmPLRCrMnBbCbx9nOd9vb/EPpYnPv8C9/8dEVTclfo5KXJmbqX5JfojY2hZlEFxY3Qlwys1ATyFEwbCGjVHSw25SaysSbguvqK069DG4tbwRz0b3DgN3oxrAU0yfRXWi+qMbqSIYP8CbeJ34Nt9rMm+6T6qn8shmSo7dGwxYjDMk3gNdxUwKv8eV1vrgZRKmxq8VEre/Sh15UTc0oDv1HOxh2KJnZ0DETeIEc0VKZsVxGj6TW6GOSNmmtG3HPpYkRVj1c24gdDdYEupqHIAPm1B7gL+S/4cOX51lRVJmGEM2KTyyWT9xNnAecWizCQIqVEnN0KET9UQiSGIX0o6wqJm3NvVOkHcw5NK30u4dCsQMwtK6EXvjXpCDqy2ToYAAbEyRuzTXdN3X3uiz+om0oOHlGbJU3+Wvc5K+hj7Dno7FXHdTSYVTz87pvBzbIvo+Y/t/+loX1/irUG3ShhcBXlY9SuEf0e/DREfvsL+6vvw49PoJloCdxFeM/5JMVv8aGn6NFxNQZIartfhHzYEGMQ7uHWPVAEJcFhdvND6EEKXAjESIfkNdh43Lh1hSeiC2Qnit98IWWMjVk80zsHoqjM/B+gdPMGp5n/teqWNycqHuOlmN75QXYq/QGA6fFBnqGlvSRxfyxpz6YyxfcJE0eL8d1t9AmBRy1g3xsCYElImQgqF6acLuv7prMjeCnSQ5Z56xaD3LrgRWFlmu4H9z6UDeWwfwTbE1KA+FhGu6twPIipHyB7mWh8h4g/iN3ESo1Ig0v7hS1tp7vu0MxKvkrDaQlyJbMQivxNvpxzxiW6qPYeRTR0r+2vKFtmI0LQoJoS1dzYz8xv91tPbqYl/WfFTohZ+EwO8N00JeL/PyEhDOxxq+2ok5O5X6xdL4mdVUQxe3MQtTR9c2ff6Bt/kh/7LlKcgi9DlZK3NsvSdYWXYSsHcY4WVuP4PzymdbzrWUzFTVr3mhnqEoM9hoCEIeF9Z9+BDnDoDnA+xbBb6rlqwquVRGsB9luHCrGLv6AOCCHc8Qta7NaXZ9DmsdX5cdiWve3gn4db0xBcd5+ASBCNV9GQw/FhibcI/bfm2kxkcGRfVIeWXOoKQ9ueeouU9jdMGi9KT8tAq+qRfnfoP3lKHzmijsisXW0gr+wZEIYYWMQqoWI+g3sD6iKM/T3ehNBezvYNBSgbLkkuSfjDQTPnRfagHds7Jp5WzqZUaLB5ka/6v68VS22xjr6pz1djqsPLxcuICgeMGe0cEPzXxtlVDLaRMPehe/kFXvWabYHjpoN2XgDFm45+zCzA+J2whE0OPqiQnY++uOYubPbcKuf247kkKvC1zPtwm9GfEhsYunzjDQEc0405FTwaeVG59q46Rfvg81h/eSP93XgQbMIZst0HRDyXUkPPeS6PSU79DTv6EnjfOWTFQdZLl2V5+WsS638o1ir/lBq1RQJ1UuuBuDW6AzmFJ3siR9wi+3FoSMUxNNEJGD437mi3XfuFECF0p4Qk4mFCzt+eXh4eLq9/Wj36/AtVacYsjatzDhsGFiFGRMNm4WIx0lzr5mR7WDPQemJVmyyCRozrROEaI0uNXYXm/TQbH6fIunWBPX7nzo7NfaW2aXnzyIUPu4Cz2nf0c2dprcS4qB5UfGQxgE0UWsJDK3xJ1aJxG2CPoGHWeXoMOT0XoFYFTfjZJ6efNqZXOtVFKfQpmfOBA2nGFrNajPMI0onZNLmO+ucGnpF8ZuafIWFvGJx/8x1OCCqdJTLyEDJOAROJiZdFx2i8QaEE62Cl3dgZ5vEBz3VCRUNlzUOVtCXCRaqw/ZHHZloa8H/ji6UtGMAQ/LNRfW+hIAVziTHxR7VwVLNDJTo0hiDFHI4wlOIhVJnHyqIt3heYG6rYmIiamjo0yJ/XxAjoJk4Uvu/HGJ3wPJric5ad+tQaDW6PoL4NJvYbBKYWELtu2vF9su5sdZLQXeh1GaFA4BTVzhVezC7rHRfOA0SQETnFfiQLya1kALF2TFtEDGVxbkMlWqMWyUDkwXPAK3BhY3ZvDnS/YWexFu3ygB82LjOP/a3h44+dwYDLmDRaQQJChPsEqC8dWY65QxO5oPJr/kYTCmsIkHjXGEM0pbwwZIXruBLB1g0TmtoxiNnxgrYbdu4MRiTDrxxH0Pn4BpHn45sKErLkdOZDPiWGIY1UDhj3eYgNsLxTvYgScOQdNCaSQAZcWaTeGRZI7BgHHrXzigZO6Q9dAiJhQs2htExlYjo57ZJ0OgxiwEYPO76OMaITILaJNl6Kc2sQNwrgvvicdZX6Ff7kYAdqOVya+L4kND6sesimWMvEUd0w/CQqfDJPJC+CenLMgJ3PINpeHx6zI1NVGY8LU2E/GF2vlpqs+GJDZTm++oWNL8huHLHWPmcmx8ZCI5vO3Y7dKE57xRdf8R0GlIkZS6XxHGV+Y3yDRv52/C9LVEtDlTMq9sQ4awVDwJpOVqHNdpvP2B1uA4X6aIx7r6RbQFykmX42B7pHn16voRWhkeWRrtz1y2L8igdGckAwOtu3dtktPO8iXAwIm6uyAvi8RAMdA1oHrgZJmNNWzJoBoZ1w9DVwXvPvTA7KYARZPvSUUCAF3l9ksOclqwhCt1Mh2TwUYgg1CXAdkhrdN4RQof9uVxAagRoMHGCw4EOSSVFEZM8eDjlNEb1Wi+mWIex3aayhdGIgCZen4nXfG06yA6DgP4mQUPtwgxSqvx9rbNHmCOntlcpZxE+ZEpjBDeZ1I5xG6glhBdcfigwuVu3CIAk9o4YpkfITt+wTHeQirqKmpKI1CBzUn+vdUYHp540wkTPHa4O0g2pHIhDb3E7SzhDJ7yNXdjFyMkYR5QIhv1P6H/c4Gfc6ly7tpOL9E5xN1+XcMuEO7BbYh+3XscF5Jl5r4HVAZ8E97HzWg1+yT/fbiQ/E6sQ1G0IZ82pi+e7MOPSJFL7YOvauVQePahlTPrP3Aw7m8PjZWZyAINaBfx+SvS9c+oyq5IJGCgR2g/qurxUI4NAiKATU4uhIWsmq0MRFot8vCRp7dN5gEOcst2X029OLrPTFVfjDtxSR3yjMEd+gvrZV/GvMtSn8Ab29gVs7Msvw5wd1G7BPOMRSKLzdoI1DoN+x4uqrg8+lvyxPOXm3REonUxaIXOXYYs93HHUMirSgbmQlkzYbLtRcJspwQ2CiRqNr1NVWhlPyyFB7mVwWkY5mYPSmy3cLsnEuykSZ5tjWS2VqMUfUftNR+9AC0nh0yu9tBq3uz276X+hLnKu9NlmPnmwKXHMrlcoYusV2/eE+8RB8NHCzXi2YozY1Wd9+IbkyTe8cMW96MobdPKMBAS/5YhAPqqd5Lb3P4vVRHWY4PwuurFxZ6WY7iVQI8GShKovzNSjhForZjydra5Hr4rFOAgqSdRe/kjoexx/EcNGhdegSQ+cfEY+OPnmm0e7vThlEsP5l7GuzOHdxJ+22rc483d4MCQmtsX7HIhh4V2vViQLgA9DmhxKBJeI7h4wuECOMAxO5mz62WtaXdroChB3FzzFwY+q3iPiwJZ+frMZAGGUeLk30PFBCsJuZlfw8JQbq4HVQq1CbYbuQB1dEDCgw9neVtQBz5x6CygM5zppu7a5zbSLTT1gT0xgNabu6HAy/FqdZxN1BU/3oCb1/38PnQwZjFrHnijcPMyjmmLscCGFr+TOr4SenQcPLYtHDBpZSnfSBJmiqK4QS2x0V6vZZKGvx2blEHK5yCpjJ9yCQ5jhH2CGbBhYZVFgzP6G2Q0zMMFalOdwlplkpDkoK3WWUlgdMO+CO3t0S5a6gsfPxt5KyOUIZigEL5pWCQIYeAEZFJM67aQJDWuR0HrsBtcAs1Ud35b4df2LmtCPIPbqnWvYneXermlUY/vvzt69+s0noY74uq1s7YhsOXsKgWWSeP8eDwesUfZl3M8+qcRshmjus7gTj0LeT2IVkJfHanoyuGBRNh1qZOrUeEodn3z1CNKfDbN/P3n5YoTxg8uLGzbUpH+ZPm50lGM8btB/AY5MfrOF9KrFePm8nNm3pH7wDJcMzBt3odmITiKaQLV0wbYEd+Gqgse3DgRpHyP1c5fuw6NV2hDN3UapjuStkQBCNkjimS81AVl6EQhr0NSB2YvSdkqmBGxaXL68ibSG8RJ/v9kS39N63WXFxDX7envD5dlwgegSEc739ba0hnfg+Zvw/QSKUsihZgBr0l4qavvk11W9tNkZzZOSulTVmBldwwvfU64RPl6+FMkqcWGUzqcbD4ndmK/9l0iZRLTCz1FxGiYnpq3/oBYMHMWS1+0/sGQBDZzWSQYv32ubX/qM6L69Bnkr+GgSEMzUuVHUvvGb4JxXYtRTrCN9XF+/JpNtQq2TIt7IGiKtFvIECF3CdG/2GQ9zUP5A13cQiyAOiWpD0rXciu6BOs0Z9ET0/lRxT1rTnd+cFIGuMbl7qu4JuK4jKBu7zwKyQBFIwxPzy3oakWoy7SWnxsd2G7Di79lk6Uq0HEn2yWWyGheGtQJRMuAPGHBOHXg1UWKU3eG0ZbNoESCshenapeGtYl7rZjOh6g88cBHLozqiAVDTMRywg4nPcesx7SCiHgM9UemW7SMOGDyKgxPeU8kbQjBevfiW9EZA/fOefGRC5Vt79nFORHVU4ml4m3rUdlnwTI5h5845zM5L8ESy6UjgQmx1B7VLa2f0BzlkdwIFhHuVzoyCwNkjw5lXXpRgEmtiKGpLIhsSjFx4f4ErsYI9qYoarIgm0Ee1urzSqh39HIyqCesbZAbx5OXz2GKryTbaAkhZ5iazY/k33NjDgXgsUXQGiuKhoOEeJpyEbAxTa6JUzVxQjn51caFEjb8MM/zjrzQalu1aO+jXblmjJin4JlZCPwVTB+ewrRqgoB95AxhVIYIjm2UZi+htbx3LdZW2NNIv/qwvQpbwTFwVRQbOedmYxltCxlaL4hKsybUC0BO2NvPGZ5Q8u87n1lYD1H2BcYfJ2K0NcXHzXCyNMY4DOIRkklcwmA9X5fhKq5/yiwsd0hk4nqqMYBxlqW2gzQgFus0O9Ih8jswjr9VkewZ7aMqtqlGD1gcO2WmjQ79U1uJQXiHLHxEne0m3GKdkBoQlq2VfKn7OVcpNkrJgK+sk7pP4mmFKmWjtTp3I5D54eSBmDcLjAyjMY4kjYz2u9Zrw0/Mnj7777uHOenoaDt+47Ptbjeg7k3BRDIymA9/EPxKwI6OAMhcg8yy2l65B37/Cjf1TYW5q1+BdtLqmw8d8ikV2Wb6HzK5wAFuVPiZU1Lu9VctKDXFO4aAVyKmOlK/PHUlR1WksEgRbNXhBtFC+7HAPjHWHLNMhhbefsm4De0HF1eze/X2dMZfvi1JdXjPH1kfhu01glAZcSvuI6DzPFfDcvtV5kwNe+9TYmQEXVUuDWRevq1WNNsQYRSS1Vo0nSuSASIPhSVyO6syRT/1ivOvxPfy0eqG97PWdrh5hFR479k3gfPuWAdVMzVCHCFJXWAcijsHTXJJYOAWzCTAyjIa7IWyciQA66Wi83e5lvLUD6jK6NFscA4N2H2S/BltsgmtsjSfy1hhlGNOYbwljpmRlUPOOZ/0A7FNb7RKjOXtQemrbsDXa62xhHrc054OJGOczlNhjUdhB4Z4LRh5UaLDPSdz+ykjXZB7uEctOBviATm89Ky41BKGDv36KDloYQZPUS/g1FjlJhhxaduh7tv1+whuB0SeJ0NRAgevm9FCH/MuTJ18/2t39hvtGuOE73w0sGab3kGkftCxnqZZ+3G27FwFQ7oElGI8kDlCCXwftBjVOviyEaDm0D1F9mWhtQsUIze/MBeB2NIK0MkWwiUU+EBg5aipAfmBday0/aLxM6GJ8abbGEjb3pwH7ES7xJpNkpoOKdT1T6WUvin4XU8Jm5A0mMQ93E2lr1j3B6RvyD4i2ezjCKdSDC7zp3/UQD5UHFo1Hs2OwxnUWczGevySzA/e7Ppnsl36MQT9aFqTWA/b5ymLCxDeiE6kDCyRe93Fy7F/EvXEwHjzMc0edEwlQgyZYjfwhYDrbg/1OfCHZbJ30rJFvTxi8v3+xmun3vT7x9NjFjWM/EQvGJ5Z4NEhnXepoim5OEvwFchhgoJcoQkRgHdkP3BLE8BCXoe1r7MsA/9EZjRJzYPaZ7Ms+xUDdGQPDjAX6746IWkaEhdeEjzqBj6CthJY6iZa6A1rkCEy7JAQTu//EQQF3G+LwtcYDhB1Mwu7pGy0PuKffvqLTvENkNHx6ZVHRjFwWRkQLVqQDbHUSMcDgQBhBpZfnIBgZWz+GPlAh0d/7n90O6L4GobDPw4D9dgssYe0AY5f6fYYl7cB84ixPxxkp88HF5NwevzUnFV5U1ZLGRYmyzTZFFLP59fxwbHI9ja0+Bz4YauFhSIefiDXGFMY+iXwUAXbdsF9Cst+wyNvMnVvpwke2+qD6K7K+5MILMcxVXdPoj+YPHdq8rFb1SamdcrK9xEhGamGX2iGOWj1roFa1rS6Rdti/+53uj+wGA68OtxtLPiylH1Zbg+os3aQBflJlyczQIi//eHLoTIcSTJDtDzt0/kf/a30Zu2am+7nKJ/ZZD3On27uMcU2DsDijLDutsqmqamoab1btHXLw6mjI0iCzFOw2DTI0xg+37vYAZcdqT4cbmyX0gNDPuhI5K3h9OWQ0vlirioebB3oKmBkxosmC+E5BRz4egosa7ufBzlr2BCM8/UYh8ELSCkLhbe+lbRRovZ29yFih+Kh2vmIqxxHSEuEDslQTFmqzaSjWzLT9+eKno5+Pt7/9dnen126apQmazgAjAYBllhonc71uI3YwuF6Dyk3cs9vgwW1rB8gWY0HlNY5Chx74AAnlTQStWTS639cW8zQI1D9vYLWpy5+9v6bnqs1h2xCtIjg0WIswCohJW0ui3zWHIdHJGdVK6+efvPb0wjL8NWoc7jecHHEWpqG6zLza4yQ5mZQkB9a+HH8EWtwLwxXdGmbspntQa1ZVduTJ90M+aLkTwhi5rNINa3iMO8eMHpIvwZKeFz4ldePixccEwI5Ta45Cabc5EmAWAmYn9NpHSMjhjjszMxN/JGpx1wO8iRA38F4PFtWI6XDhgRXFAH3G7apWh87U+LE2JbC+U2wyv/G6xie77/A2qfhiiQgCqVgNG0gctu5qFrjV8PCAQWQJfWzDg3lft2yQlPV3OfCZIHOEHj8sRKy+3fqYF/TCY2+Ux0yS05GhaYEcGzUz81K9m16wytqWF4eHh998893D3Z7oArNGOIo41yfdZia8u0/28be/2ZyjUvzHJkoNX0Y652JfLxv7Ouyhi3f+9tvUqDo54tPmwThvu0QZogj8p+DZOFCAAAO8/d8ep8kYZpaT4gD8MsMAHarsxLrasMfJuX6I0w2BY1J9EwAasQotfPHl+a/FeDl6V9zUfdZuYO9zXpYuJx9F0yDVWD/us+ZhBFZVqBqrqoGbBFjZ+IcxsyVgGpxzYr3oga79ie7w5ODbb7/++mEv7e8OsEdmgPAPd4Jg03oD39++2XmLOnnFQqkVt4KDFcBWA34Ibd+C7YZZWnJxVSNaH9KXAiSczGpxkevUqxpxo4+7ptfRRx2qAktvXOnNDrsa4ykz+fjll7b/zgfFlWJTU2BVTxbV/D+UuNr/OMxuhhpIw7Ze5ufQ4BWwmCtQIi+COztKPI3QfR4N+MqFItp9aPUoXsuEc90e3vqmGmmDg+yOXmKxlwAmQtDXRAPmqsgnWrtr+3mmC9jdA4tMj4fV/MZHtTftSVJxsvlgxGteA8vUHUIDE2VP2iu5u+gGnaM3P+beEcmw5YOkcy1d26XOpfD4MUvJAIJIc6VxFEHo7vTQeTE6rUKndWhYCaJ+w9d1TDrhWKESPiBERO9jT93RGfL2QjQFojDRhTOAOwhwtxduEPOk1BQYFJb18/7YxhN0DwbkUWqAq6rDw+vJgBaW5+ZoXMXkAmoY4SIu2GvYXZfSeH2SoJxj43FB+qEcmmSzSV0CySr8UefXQ3mbhUJtgIXdB2Bcrr4YjMF8zQWWpOtw+nMnX2A66OTlNuEDV5unqsd2zIGJfoQ4oRp1zYpwcNcVMQN0Mau3R183YpPWvyNex20o5ZeJB9mLiiu28xm80b/DS8Gll0uz7Fn1QQd11dxSVzSqE/LYa7SDYBCG1cBQRVungfk19ujDvWbl9dw8GEKfSny2Bgaqu4PxWKdzvJzeoKbRGR9ABFnbEIL8rZYoQ4KXTFZ8HBdztLOHQLNZfVWtphPsGYPSnhcmTQLk98JurVSTeCh48t233z7cITEI/2nQ9j6flrDSTyqdMPUfgMF4BC3I/LPG5m6P5mQ7mE75q6IcZlQbstGEXJOimP8UN48OoqGBMWiI16mGgczdPWg0jyUcx4/lVOcg7TKOIXpms7TqqWQ8pc3CU1p9b5lPf8lnSztOwaPHmyEkYlscytKzO+Y6dyh2Kfp4m3osT3LkKtqyQBqJP9y8quZHJkbq0aQ/p78+9WppnLAe4VF8PF2pS10wkqa5RAF1U49Il2DgCzllCLdAdyLGjopaHSDLrUmpY9NugcXtliopsj+B8FOPF+V8uYWVHsyqrdUM8tBsvc+1zwzEGR2DZWNMB8PsohqvakgHM5+rKdQ/wk+SF/02HWaWRU20+q8OgREj6wx7geysM1xHY9hdX3gXbeFddIW3LhelyOwMEMfizHhlFbmu2j1SlvlFtOXYSTpsVBNbpgJNA3em8xW2aTDfIaZPV2edOrR+XM4+8fz19ZR1yF0dI11/GlW3IcrSk02iLJp90srX8w9j5Au4OTCKIV8NSnbtLPSPUaittDO82d3Lejc7Lm/eR/j90f++2YHvu/47/P642yOeswPdn4JJRqc1oNpgMSq0Vovthqif1PwUbSTxtkjMUH/Sxag2D8xR78GitRUEvPYSEFrLz0HIVqUUy+1GpeQY4ku0iUmpy4eOmq8tJYcuK5e2FlVlP+iydGJ0bAopaM+LqdoOdX0IFYfZGWy8p++jMOtOS2f+ouaXrgl8dj+Ygea0HL/TpSQjcb94T+MMHEIdKKMNl9VqfKV9RFtan7qKIYh7S61ukSRW1TktdYpYhdD9CHEYYgHz2fAACy7JjQhW9csm3u9pVNo0BQJih0p2mKtRKsFkD1Mb3XaErHFdmxAQjehv68PM2RLqYWg3GtlWntEH//vIOA074SzfT2afXhOpg86QuiPRwOyfuXcgBxkvrCAaDpiH4llOn5WJXuosZymOZJySLca2ttuxdudgZb6j2lrcbsbClvm5ZVyn+TnjVy1ptM8CG6CzMRXD4fe0qnF11I8LJ4CrH84nnvG5mGRYD8DbWAE3QCd9Q01WwDmhHZWu5n7ROn6wUMf/CrO7+zlAPV7Cs07jRQUCTvp7pCHO/FxTRQNnNTWeVB9mEXvOzz2ZNIJI82eNg2gM/GSwNfpxS7n/qDnpfyDikbaGxzUKwQcq0F9C1wOzzE+QByWHEdXsR7iEQ8SYHlEw+nDxsNS1SNc05Z/ksCMikhoYkZBgm3IByQwfxvK0tft6ns96yYYNg4BadBj6vJUGgntqfTzQdulx6FoBSpDAEngpkmcenXjHJnSM5CbO2Q1JtxO5OtA5ovukYstzxdcUpnq9Jvu9xpYz1XkvSl3j6DQYX0y2/DvISkuyFfxJKm+RwPpVB1t4OoP5g3MRHrBBF7zWQD+a6VP2d7+DU/Zzesqq33vSicCj66jJggV+HYCmJrW8S57rVJceYxUhC1BngTDk5/crDkrsPt2DdznfiD7bZd/w4EgPpWMHwpwTh0y6q/btE3pliHwLyW9fcMKiqIQtlp/TsLISoWJOKCANTBTfIy+xVtq2QoIsbtuvRHkKjVDQ7w/2zLVTIYU1M3dF1wkbvNxTJDk5M8xJMV8UOkY2s7hT87d2dqztrYuORtVTa3S67h0E6lOeLjeiNWhLuvyJQZIatCVnLHJbFhnKczcLpo7BRG7ZugCtC/DZXmZnrmqUIVzkcal03EYnH9eWzTpPbOQOReS/r3EZbDiO+aJ6X4LLD8ZZ0++FEOnDBsa01fOly0lRZXk2Xy3UXxCEYwGEV4P3rVae9U2eCWx/tbyeql4v64ELVZlfF6avEc1KRmU2dp1iElA5U0t0Ct0+xnE1aRtcBQkZkDJEYyNH6V8bto/AplVh5HKRX0MQBHiRNGHVjHObalOjTat+SRsl3jnQPnygrVLULmczNZzEMg1KRf4u8vhxwFsSsa3liwxlSBxyeKZ0cDFHBDF3WtNRi/t6qgfD4TftJFxQc19wFJ4KAyNrQdSN9zx5BaXHjHD7jD9HF8+4yhqqllBcuZuiRRJPBDULk6LXVLCsKZG43s+79H6e6v28Mw4S4kqTtH1xsZG47aS7RsFW5uO3yVXuD5pdL36YrhYLcsp124Gw/zRdq9n5e9uPWNJ6nb0HsOkJmdqtEwruofcym41gRqmrz3OTSEsHdiaCBossZwM7w/HiMxl+dMG1WOUbsfJNWFmIgxWoaqLgV0wQkt1xYrt6iPd+Uc6KibEyOH355OTJz693trcfPeylDXJlhin02b3X3YcPtx/1WmSnoEtjKx7P3+Y6puwgLWiFtCtrtJoR/nnK/4lV828i+8k6wg1JJkwdBM6cm2DBpTm2iccsUlCg7yQaYmMxnC8udSA+/W2EPwlLNJ8fB0p9HWEw/MZUQIx2EPi5ecYLI+fr1rNqWV7c6C0aSdMiiB3QbnS9kLNOtIarvw5thCpfMkE/thSuAuIQJtptvcFxH0aeGSR0WX6qbKYsOUJEeluE+uYuYIJZQNLjfL7UVxBFt2wWOtDuRFGnyVFf6aAuQGJQ9WJRXaPEr+PzJjPbqBv8fAGVCjvk5xYu3Of15voN6+nD4IGh93pZzV8tqnl+qW9DOAn1NYEONt+IOVBRdFNe/OJw5+vt7W977eoXzQwF+h+0OvQyCoxmQSXmjWdx0D4L389mswgu4EzgCHgrjJYe5fxJcZi9ifnX2+hdxfHzML9A4umlRSXsn8/bnl6a9mcokH4iCeHJ8XfffvvV181UGcvha84xhW8NqjPCO5+vmz/y1lvOPJG899Y0uFfCUiX5zHvsb0S0+Ef60utKnzCJSL8BV3PgdUa1gTccwe5lgzdgMjD28EDKxXY/smdfoVhs9SR6CE584rszNXt8SU59Dd4r69BG+AzCnf25BM8MeBA7MmEbtnbSnUuP0u2vmHWhDdnWf8ms+VNmLV6X7AifbjaOoHnjeGzds6n6zsf2xHyCll2G2fAs59TTasYJtbT6EtQ8hNAQ6dok/oRtJKy+3F6oeBete4CIlAqcVZLaN72A8Dopu6NkMDqGMikKHXyHsHLB3ScWdDUB2lBxIPHp8NJ1XY0xNVRp4sHlcXKbDnmWrHbRJ1CC96XAtoZFltlkyv60tdMOLGgeP+ZvRYOWaGq37IJ2biQY+zQ2Ck+RYD7eUUHXVgxvognz0IuNuka6pmfSribeuvl9O9H6iXRfF1rSMK3IWqXkNizVT7BTuepNf4zSNanSqKM/hCwWjBLAQC0Of8cr8hCR+bm31k8BNEmFuijcmYGEhx1sHdTZRWT8D6NfSqUMCHGMVZOJlCDiqg2znZbofreypww12Vf3YvCaMQIbmE2cG983fMD1TjPzRTUu6jp4EDIiQl+BF56KaPoGfAQJ5YJNlsC4NPsXobb1kAe3LzJh4Q2LujLET01ZMLMylWSbVvuDfKtgnn/PTg4Oj77+5ptkoH1PimsYp7wE/czzYrbSio5B4OaWFuVAf7el1Uh0Ht+nT3UpySI2PQ3pn0BkWRYdcfwKbvW+0r4q+B6o5detrTDlMwH761veza+B83KQXtlX3H7r+lNj7Zym8dWqvircS53LCQHb3YoQJlNclr/PyylcRrN6DlFLzDasVxcX5bik4SbRV+wUcwzWfdfwF3QSy5s3HfT7JCFwG9/w1Ri2tcXUcnHzmvfIQQyzLiPwZ8jnBr5fpmhI1BHy3sfgt1/Qr7NmCMS7WDsdXFk4nP2GyvT6FAp18hwna84x0mAQpsl98TwDOozYY9ObhOFF6jqxVVzPlzdI2dcrRTnolY1o8TFfShKm0+8YoEV1jVphQgg1Z5uqi2enzs8h+e00nx9Mp9UHiHjx9OO4KCbamo85wrqTNGzgtnwXnii0D2I1MdZOcGzTJwo4HXkpagO+1+UyvdmxSZDmb7f88GMB1v2zhq1vvBNs68/TyvtWge1pEOaR8mI3zOf54rKcHYNrp0tMpL3Or+erJUShUZfevsOtkwFH177dfiPUOCeM1OtAAGLplyAH0xPhhy+DjgiEeBd8+dhB5Bmo3zsKiLaLIFIo0YMvQNw87rzRAz0g3ntdjibo8bKkx8DSWXeZMYQQC8cYrJ3UWyrRddjl9wHj5kuij8QGNhdKMzrvGdbdZx/C1VfMPpTNYoLQycQQGlhHh0Pfiob+QAm8IDQNeOcCqWwAugyARvOz8P4g8fl4ZkxaBOFQY0D9Gyb8puSHtPkzJhL6VbM0ikOFUiwEo5zeVk8RR5gZDcc1yPacFX1SHA3SF/235esBSED5r4P1YLF5+B8hkNvPJJDyaVOGje9yGGx0JEhjTtBes+jAY22EQMnDeakFIkIB0fXCzz9YxF6+WlYBBUS12TKF9HJX/G6A3dvEZcgMJYlSCHYSbpZwQFbolmTrzdC5LkI7ozRQEKdJN9S73ycJy/Fe0qskgOm8ndfB+zo4vxsJr03Atw1X8yjQDjeUvoLgTbCcmb6Xw+GRTyZaIZ5P8ZZj7UkgjyNYY1SV4qyzG7jXm5cWYvqs4B249vC8ZN9wotf2lpebXjTWZzqOxP2N9QrC797LWNkrk6Q7FzWh6UfTfmzWwCATXXsXyMnqEeAOavguHa4N5k4e1MbXnkV/cK/pNouYHsnTa8w7uolzNe7hYWYvzfptXce2N4ZjquBSdBQwD+7MG3tezRV0+8vmhjitLi+n/kHfOeGrH4EL/T2ZAfAkaIPNXL9dApQzmnLFWW8QFOHbPC2hdRuwBw0bPrPReMzqIfmftJaAcagtFMtBPNB13f5qiNcBFYOi/6kmE+NmL/mW6CWbBC5ZVB8w1CchoChTHmwrF+zFZ7Sj1JD8vAwscMyTqS+TH09Tb6CYy21Z+PQ1lKm3PKDGje/2pOrgdX1bZUFZzDMXMcJgytwgWAsc+5gBFBWK8FvYlM4j2VVkH+IWP0Msmbj+z2GIGbtvhR6CT1KrqBf2gbUwuaukfvgnqVXcD/0QOyjFndDyqH4E3pcGNG+XVOgh/ppoG/UWfttnbvAQBKzv6UP94raO+Qy3yiGJmi4dIX8PIynz5OtNkYxMIcZaSET4WXdQyUhB6TgMpgUNw2CK1g3DQDleYELQGo8hMe6Nug7vnxvHg/rEoaC6grcUoO3KX8/luCgBDppuJQibpPN2JBZPQNvIr+be9FUeS9sUtBWcXuKXWje87rsSa7wfP9MFzEawCbM1/CGuDmka400DGyY41DA0M+SxxwLkN11fB2IiA360hcMPxY+mkZOjDQeNBXy8eLpj61detE2OLjj9wvHZz91GyI5FHKMtglFSqY6O83ksVEPdxIg5uxfDY3QbrT/9hj5ujcMm8YcYxC6ZrdIPiQIhXCSJZ8mZ8DK6xxP6ZX9D/1cjnkJrnWBO+x0uq0wxhBk4X9hHZjRQBKtNIFfZVtMKYNa+Ew7cRE2T9sZZsBYXS/3SAyd2IpYCr8PtXwlXSFm+BvdI2xZvj3Ijf7PsZsjrt3Ro1tvZQpeDuWd7XQa8OVqGdDizsBmJEzgV50Ouvd/ocQ8EuCiMLVxX33uXYtA7dQzSN/XYiV6+o8f12K08/hxfyAUQ8jW8oeKPzTEC0jdtYYBcBuJGj9JhL3rCdzzvG8ILSN54fx9Ta4GYulleSwhsaRnN8cdyphPiwezOc+C5FbpPMvvQZe2nbRIxAyoQc4CHkfVf1OHXsRw9bi8AS1c57iTDw9kBkMJBi9muNPlUkwZ3sLsYtEpD2AhelOPe2YMN2hJRqoONRdvxxxrsNvjC1Jrs6ALvHfhjtICiYab/hipvfXB+Dy+mnVdBGBkdRmisZZdyWi5vRmwrYPygreyXqwKeKOBsR4fEB8YlT2pqM3e7RoaIFJF+UDRl7AovVtMUFakhHYd6NAljkrItRJ/JluhHKfAMtOdDascDwzgh24llRxeQNxdC6xjdPdh9Qo/OnVdLZ0OdXwQ2jmI/ELLbjstb2WEic5CRtDl9YVJsaTNSBDatZqC/dm1X6iSbZmqtPJRaPxXZGkl3YWHuxMLUO5ATo89midY34VZ9gnnz54klYnbLCXBSJo9aVKh6c5Bp4ZJbRe4TKbs7VSeytEuZ+nPxjBn+B8l3wQ9gLJmrO9SUaf/9ZrTg/87VcfGu+2Nq4LltriKfR+kpfeKGJ/hOqIVHpJuovXcJIfNoum7eoVsKoLXfBuUcwSvEdZCXVjvQZd9nOw1MPJ/PpzcmzMqfgd8kAq9tENUqCOciBXS5j7hWa3XTehC7NEKCZ3Z4X9/QN/vZq+cHf9n55tGjZm973pu3tCqWBzZQnImb5KROptHuPmXT6tNO+ejFp5ky1YqkfBbv3ScieUB5wUm0ihe353boVITH8jOTsps+8vyxXf03KRXOaiWg1CMGZ8+b7RIfGyaPRcFXzrh5n00izsxtpIomA3loUkjH0xZCSAbY1rEbYaeeidE/NwxdB1G8ZRRKH216zRpstT03iLVlPa6UT7nLUKwpbKeR8MrJgUQ+bJ7OWzyHWm0PmH4wwcc6vgCPm71W4nNW8reUdRUbx9R69uz08Onu7u6jr1qDanU0VeoUH6nbs3cbwiRtzKYHxLPTA46H5ogljUZVa059U7MreslooB0WGWUMBqxT6LHf5k6ZVGLdhdienKxLbRtZk3UiwlY1v3SEBu9RUkC3dik8ghN6hcsPo8wTt5XEhGeiaEJdnvHwyvDLVTUtdEBciSsxZe4d6OOHVy+f7nz73cN2+pjTeQVLzltQD5vA7a8L+99v9h2MXaC5GxyOc43QcXdNy9jh7S0pZTNd+8ac9Ifnp093viGL2Chr07Gl5Oej2fvqHShebWw7p1mCYHGYN5cEt8v6IDKXy9/XKG5XC/dMMmgKfIcWbHeP1Ech3XFG+vli0xndcwDCCFzHsHFh1iWqRPFvN5uS24tnh1+1EpvvyBsZto5bTABFDoPwZWnzGZyetE8h6C6cx3rW06A1qx9odam1nMYM0tZw+gx/Wvtpx9MwTS2wJc1BO5hSR5Fn4HQZmufeOFA3WCtDeDL1H9hUX4BdtfpPiepnv6r/3qn/pv+3vS/tbuPI2f3uX9HWmTuhxhQtybsUz4xMx7He6+1YdpbJ8VG4tKSOKbaGTVrm+NV/vwXUBlShupuy7EnuSeZMInbXgkJXoVAo4AH4TKv/l+BJrf7/b/V/8NEGp2zwdl7sEq/m2u67Zpw9OR/kupDUDc5fRkGQkLtmOeRcl119tGR+jSW4t7WVheO6isQyJLkX1tf1JpZ4SHrD13lLYeenCQ6NQRiZ+JSXrtEd4haMFVzfqfmuzCXbrjOkO1WOduZt6qwZG+IPOtgWtWEITYRwfpKKcFTMqjm6p8HcDrhi+vxl891uQz9SM4wjDNE/zpPtueOmxW5cQyss0IONWdII76bqgL9ukeBnk+FhaI/ezqFOIDTCf3sjPp037SHcodGAkFFAyEiVTPCVdJIuEfcrlpVIGQekjFXleN4T32bNKa3fIX+O8d9H+O+8Da/yFK9yozYGJB4FJB59JW6JxBwHxBzL/NJ1KcdO/TzvHL7Hf/+G/z5pw7OTFM9O3HIJCP0tIPS3r8S1BDnvA3Ley3yztZkQRRRkYFWJ/z7Ff0/asG2SYttE+4kHRJ4GRJ5+JZ5JtJQBLaXMMKzK5pnZ85BJuCse/hv/fdaGYWcphp05v/2Azn8HdP77a80zmZxZQM4sMc9M7V0OIGjNE8iwBf5bC7mqDfOqFPNYnEBA8DwgeP6V+JemaBFQtJBZSBoQlTofZ+FEH7QbgVAZBdPYXUjKdNhzdvSe7Cra9OjgmWLePbTvFK3oyjIvzzL9zpZm7so7dvOKGiXOyK4QbX1tLbPPbZXA1XgnwYSwuOnD7wlhL/aNrUhjYHaMRIzo986/tkjUrvYxsdTw6B3tCh++tKSan/Z17MW+wxZQRFzoo86LR4SSl1p73JWykntf6PDEo52i+dyy5yDiOAETPuQmPUfINrIODxuznoSC0zqzQ7L3czQAWe0XX8a+5GbBsWN8TcE38WE5EXpnV/KKEXtBtc+I1QtaQqLB5t0OChUbKip7eI/CI+EYYo61NNJxteAkqZF0ZBLaFkhYEswTMSYJMO31edndpvPjc5RGM5QmgZkKGnRFohv6sYz6jpXs8TjyZAgrkbNbOqzJhKQLoVQ1kVQSk9d5FN3iTE+WV8aRVjrM1znpob+41E/CWVwqStuy2S+lyv7Ay0sfJIMWDP1h7II3u9RXCwIZ9ONnLcIZTANyVINg3CIJNffU6nns/B3SLvdR0YbmBatAIi1pXJDnNI3diUh9b/flthy3YlCssEASePCKR2r4a0hu0xMAFLWYUl94MRlng8n5YFkZAEVjkFtjy4wOlYeACHzT8x5u+TtH5WzE3Vv5+Ib5cTH9oZjNF4MJVBi72Q3RX1N3NTqfLbmA0X0ASvMBseFx71jvNl4RYqzZ6aiYoqcwazZIVjsdt6CtxnoNkyK+6ysqfeE8gQ+rv7zaLNaFjJM1Q00iLhJv+VqUd3kvicQhbY5AMrLZgfbdnh5sYGp0de1hhT5LlNXeUA8zaSTU/sjLR/CitUa6b9U5wrlLJsr8/WFEVR0o6a9hfdDVy6NsBibqnewvn+o6u8iKsStTjC9+Td+6Sl8+pDPpAExjKTiHA+dflCUdFnqh6oPPghoSv3eNYZMCxmhhY03OFOcb4k+WZ0EYBvChSDMkCVnFNhEafeLGoDS2AAuLvMSI307Ne583BrI/DtQ5pDyGcIN/meC1eudlrzxI2jv7EnUT5V1XHwkiLHamdPCojRiBvVlLsQqtIoIK0iAMhCTCfksSYeMHt6mw5RFfBCl6SSdGzSd7GnkJByXGuYJPQXmn60n97GjfdjMVB3wS1t0AJr5hgTOMfp0Ln9Ra/ugsLgrdl7sgTSHJc8Ui23Sr0c2n5EtxPY347yoy0Wqxg4NKDxFhvRaGmUPbO0bi1qJjy9Qz1FSavEgEtQAm8P70g9omxwOqY4f6QDuOxH4wfiVI3iKxMIjB2WVPlmSUBFt29dFZsh8Vu+tCKnXgMQXNDdWatGpTx99AaOng0UG4gHyW3hS9Us+f1RbUPoDs4RKYeSJCxIQFwH6Pf67X6Xw+D27tWo0XqaQNthGPx3Xi8VgSj/yqfpcq6CS3dMpM1OIC0qIzXXAKWDPSGWggJ7VIKMf4LdqNjqbMFj2/2mbOPvKZOxvzIAsxMGwFp+JliM9DT26tvvtWQYL2rJ0ubjtR4toxy8/iN0rrIksNl1Q3w4CKILTXR4G5e3W3fFQjO5nfBda64YU8dhM+1J3ZNqBLak6lM0rR7nbWvvEX4dHDg/H4Dzs6RXvD6NLjt5oAzQRQ3x7vm2v+DvHfsLS+U0Fqjk7y0Xvr2vKcGS34kVDJzHLyIed+HcQ7w7xnnVONSjrFSPSg9r83He9z/bUT96/tjOvi59HnYH6AiKZfoozR5yTdrXAZbIxsAvhimr9GOPmGWbU2HmZbu/UJew72+g8e3Nu+vxaFMK58sEv30L9//046I5CZnloYNjF0FdsEPZflARJvq3Ng3Gvzycx8Urmj1MGL2HC0FYqd3i5zvmx3fGunMJkJX1gclTBXmfDB3uf5GT7mMnQUqcGuDl26TGK1OIYwXyiQJz8Wk8mj/LH66HONpZ5YMDrP+G6LA9PD+gMT17iNMsnTmNACw8li1okiy3TuoYj+OBuKgMswRrhsl2UPdJotpc5YQI+t3VYWhljsi11F9oWk4aAO4sLqP3wSMQ3aTyOanamGQ+2m/cW1NlOfeYDb/UqHheKUKGfudhmxVTR2CKAjTJQ8GS/dZfjYOXmHl6ex1dfti8GYbE+dGpPDqWuXr9JTqb/rDR1GJ55gxyYb4mqm3MsYcy9p0FzJnBkYjNM7Xmgx9XsMaOnIncj5N4l9L2+Zz/d+2r9/7969W2vrqUxubUS3mwBu8rSfcE3f39hK/pwBbAZ8xK9xBRNg/8VVTgApsXwAAEaP0sCIqz1OxzJasqfRbZHeGgUwW9oRAJLGX60/ArS4ukMC1rqMR4LdptjoMM9eqU8dHSEVqTXxt9BZ/PAGkfd5WrNKNxeH1rGrslojsJhyDy3BRzp2ahqZgCUrnaTC8SxSfoy18T2GLBvkk/lcgRqUaF6am+5pfbZAMTJBTcPFZE6sBM5OoMfYvRbIDuN+p9T4EST+yvs0hqGz7svD9DaF4U/+4q06xpKX8NMXONW28h2nTRyw+uYBaYI88cUK6ylYjLsCQJF96R6QDuwqcmWciPSF9IKw3MBDGXXdpJwIPredNMGRRX+JRFDfy/d6sWbqs4LadlwW02P48sNc433MitH7JbzdQUA8JcVmiHAFAb5natIMnLGWXhhpk+2Fqoe4IfZyQ0NVmXDCOcKB2XbKaZYXDi8MS9tUxqBkIi3lWTczuGfDcj4vUf0EJ5hsWMwtRJ+ZTgCRNdA9dc5PitEJjhDLgMcgUlTOclx1PmnKQX6sU99lL8rzrgU4iQZd0gBI3as6hereVMuzXGeumyyz0SQfqI/5Yw4WECyJi96gqaitsgLvRsOdXi/7rRxmY6C0c4qAFuozHJfl2K5Fgzc2GGYmKzBUHqgDX3kKYIUFxIcBBpkSlgaE5VxNIFDJkW/q0fk6/QZHnqTzeHyWlWeD2RyYBC6+gDw2QH6fljMtESYFWu4RJq2o+aoWLO0MPpv5gLP8GIHhciWRNDCanvIGwHGEBlsELjybALaMJVcRMhopDiiaJhZ57u10kldVFz7yqFzMdGYwhrFmDyWAhqi++8C0D4xXP/U0gS8J9JwPLHCNIsp+PEUTfFQkcSx/StekrmyGfzbLwSYDI9fWGQSAG+NDqIU8wJIA3Mh4RBfNweA0118CVcEZ5EIC5uAiuGk+MiYcqvRMrmBsVYmzvJxD0iGXauiB/aTzEzVFRkrKn5XwuQu8FjtBMs0Cgua7wvpb1/OdXGPmhgaTYqUzg2WkWbKe3bArBigko4oDgT83orycggMyN8eAQIgvhsmqx+1yzaZP53qREqK5caGHlv+lliiPs/etpbfedsG1By8fP96/e//Bg82mu2DZThhQ0irVfA0/huV4GXJD7nizq/2zdgUHrQtq2ap+UFo+GOyyh1miVzXX1rzfkUAUTL81Zi+rnpaz4j9gGqxpF2ZyXcM4e3m7UziTPMqPQNxdll7slgVODKp+OZupCfDKJiMibFGqnFZhvO8iunOgMFS9sLHKhV/bmL/gQEfdQkIQLXa789pcAOBRjlw8aOH3OD8aKK2CrIEwcNQp2IIKw4/AlfUEX+F6opCvJTKzk0oTVDIlg8ndOozStUAZhn5X8BXhF9xk9WANYxxPXSEr9P4YLP6KvA2nfsQiejyjkzp5VAuuJ0iV1E0KWdL/MB1aO/GNbCuQY+40kf3tYbbZuyNdSeDrh75oqgwcJWg5+J2kPnEZIp639ASkQuQf4VxUQ6RTeLd5YibnJPQWTDHV4suZEVGfO9EiTijtCdQ/727bpf35Hcc/a/fpwTyjd+lw75Ja0h0HTTgzz2Zy2jzM7mzWTJr0SzNb7Bn0u+nitPcqn41IqndKaGq+REgu9FgDeZABzBjRv/2hBnX+kujPeBWImr5WMC00eoWaKILu6tZLUDHPITLOVdCatVFJbaugWOAfECp0bNXpc3S0H+bkCEE1RY1LDbc5e0M1Rxeq8QM1sfJp9hMrsRRK/JzSNk/Upj+Bjd+pdhDDZOUS2lz1HH+fL/15UYySCIWZHfNDqMsXDOijNGdU3Ngvpva7Hn4leMnsT+p37+NW9m2G+a71z+3s7+TnEt4u/U94u2QYzKqdqlb95VlFnVbjSkaOe46bgbpcE7qiltFSraCPTXbiJkU8puGRmmSunBmo6L6X0o3TIS/wOeLLhFxOufrQJl31jDXmGZ/h7yIKrN3TU0QbgI8dRhv2XBO3xQz+zW3UxXHhhk1oYWHMpP0I11k66bxQJewh5/u9p/2tW5v373KnC0a6xeQkPcEE3+APtoRBOyBYWnIZVl1uhQnNoiVIDJjWMOenpFuVO2yeftzaId9PEdglL5f85ZK9/LjNa26zmvzlctvPYmI9tBP/90AWX0y7zWZsvLWP4m+k79LD3eNhu4/Bp0s4bD4jwnHzuRcOnE+vS3yQr09awkqclg9BIJOMMSp9oolONP51P9GWUuCZ+PibUtm37/x+P5xI8J3Lfs267wFWxUt9jhYsvYIx36sfNKljpDsy6ve75hoJXuXbzcx+dkVf796d37EUbF4QX0k01u8/eH/x1daTPJmufJV9aVF4iWF8tZ2tMVdSqRrC4ywk07LnZHMM7sWnVJc8bIO+s+mRzmb5h6JcVGFDqUOqfW8gU+zP+EaDoAug63RYMo6MQKQCV0zynuUQkjQBTxPQw0VT+LuP1253lLouHKWY7q8I9B8bJ/7edKxnm/TZJdYh1F7oQOWyRARwUvFZFjt9aXInqFmkps18+WJwapMy7NSU0OkYdkPviF9c7+/Ao10wr7XJaCFnH5CdyGvTUhiq9OtWPun1ySZseyc83cRnxO5nWV1U/mVG16rFFQcYebE5d64VnNPrYNUTtpggrOeDyxNaPTMnsWCKx8lEwVAeILBJOcVZM1KZpjbQ9ApCotLJtYSE467ErjgmU64ymFN7s9lg2YmGvO4RXed2iA8txKh5aj00zdNz1XGuZId98W3MyFBGRVQlBuVH/Yul5saNd1RixS1dl6FRDBrXKzCgnwC88oyukphNv9jxqA4BgzYsIN0fGwmpunmD8Nz72vJbzuSrAKGgtw6IraxsX3r69PG/Hr/Zf3Bva2uTm5jQkdCZUjkr3fTnhghqk3utugrntZUBiuZH4MpXTI/7kwKxuUbz8C7uxMB9wWHMN4mnsxse5QrsG71qNCsnE1VUauGZPl6TJvDALbcBhW0jxvDs54C3DEExr255u88z3fLW5qZ/601Gb5B0QsiJzcazTctvN5SX1W/iUpGAQqZLdtuXsmkO94Y6+iLMpmeqEe6aJ5RX5hFLcWSeBcthXNK9h65veYlpct+FiQzVGzvDXPmmeRXU1VPL/Gg3r4IWzNSyTbScV4Imlc4BlVlO+34YPZn5Nv417ypzn4UQGipP0iVC2KvQLOs2pirs9ZxODnqnAOxAdBzb6V//moGbsP15w7XGOcPmLM92KY9Iz6UbNwQ3ebJJmQUi7FJA2HXfK9OMKTEO6JEPhFIv3aN4p5fJ0U/ZQ2H82c1sm3YKjWPpOL8alQduULvCyuvpi9q98W8DuDB1gIFDvLlF5Azrqd64YTZkdqE0PR/MT8BxmHAcXQpSCkc7ogdHSq3Lp+PVKb4WrO+gIN3Omhptt7/Jfbg1JbxbZe+TW/BLWmq+pfyq64CseamHczkFXqMUNIDs0NpTbK2OTUwSRZu43sa19ArtKUam3aATbYQfUJ8LQ5sNJyi0vwTk3qhjmRdIySUU8aD2Y3JxneBC0FjIjrCv2hGEvIk5vGzBYYEPRCUVVN4eM7rhXX/XhZp5IZs494m35GlUAmGpW1zcegiO2OpjOmlOKMZV526MqCmBkKbS2gKIK/pYdskD7ctJnxi3UQ/0+khbcTnSa+v1myANwGWhtzWYDqFJLg6BEr12ms7zol+DkG5QvNK+ZNafg6ePHv+rf397++6d2tAfNnNbe7jQSlwif/6xcpWDZYujpWLD4wd3ycFSkGrNS5r96mZbEVAd97cxnFoxX6VN3SNh4khADLWNxcisElJXEPZZ32KUR1lskacCqm1RSh6o0VhJVrvaFiTcbmYtw0xiYKxVXwVLfHdazFU7xtTqa0IZapIaLobDidKdLFYdBuHRBrDqI1qq4zqzsOguiZa3GZIyrIu2YxWgx1cZcFB95VH7+l9/6GkUdTp3KDpDCF64Sich5jrtoxYr0TmWrtJbC1z2+nS1JD7Ro+/y3S8Ec4h2tyCEHkjq0zypzWQR3+DE6CX/9zjhbHSTFbniWbdn3RJzf35KQXL65RnXYkxGkZo90WSnipQcl56c3trtxIYqF077mTR2M6JaafbYpsWAJSGMN2PpOXzuDedJTd7YiFfpHaZuECsZcS+9I6kl7OuUat0UABvOosQdC12jUATwhricgohmV2vNTFRFTOdoMcXcBBrHcFs3ZR9mcgK/7UD0OiuiKxAmQBgXH6weIuuiQaKDIM9BoPw2NqHDt30bGrOYN2IYn3sLKfBcc4GTDy6a9PfutYt1zS5wMe3YJBGfLiB7xArZIm2q0ZsgWDaUHvFxabNGgtR5BQ9c5kibMpLuSjZPZOR3DlHQBnFY/Q5u7b3zOS22bLzcp9kntUA85BLxMEiRchiIyMNSnXYA0ZTH1OiEkiznAm1XcYD9puVYh1CQPeCOsxzQ6lAAdtUlOZFQlD+hZc3R3rtHW7Kq+Q8Axbonv2epwyFRBjxY62ad8uhIbbE/QXgw/PFzNzMJZm1uE4gZVftRqtx6Yy8HEATI8sSYMFRW1wTS2ElorwR0yMFuKl+8Tsxs2LbqZdjjV/2tzc0H99YE/A3Wg4HgJGc2AdGrlsYnMtDJqAHiJD1apnsJxVjQjVWkaIIL/Ybb/uJcJkLik3GuFqnai+CQohScn37m6ygIbrKwFUATTM2qE9IEBhZrJnEf22apMP3LcLGBHIW9q6+j5FE+bkyK9xCkA/JjMcsxiF5fJ7PwGg/eQZSmeB4aofVT14qvn/nRLN6RajYkViW9p4wtFWRf8WKa7y30CvS7VWhhVdK0mLAWT4hWq0Qq4OZ+JRpIhTQFUIj0DzcGqd5X7bxN37xruWdAa23uuzob+LxMpEpN91CKEgC/w0RMfhhsHZMOBG6zoq4FcWoERavvYtlwiBqF4O7Sek2IDaQZY6xnhDU2S4SQpepQytnExthYuobIaJMKdnWCGKbVNxugHhTs+exK4XZRoSPdw7pqz6LcR03yhptkZVq8gVYP8BdMSmgwL/BvbUJ+F0BFpVuD69/N+BZT/vzNl3/SV5SgJ7lXmonECHzSrKQXJ4OuqEMG5Ho/x+sRbBjz+awYLuZ5Z00v5q64ueM7STRwFrxRqrkZP7uwrWuthr9CDjPWDtUCLhAfLlIB2OnseAa3oRRdOVALfAG/aGilS1riH796/Pz5Tz/fu7W1+aDWFK/78uLJ993LufuKRe0a+WItvU8c1htc7c9WuG91FX+2FVvdAztEup8c07HzG7oNdhXryv5My/5sy1J/kcj9uz+YTIYgvwDE6EM+W2anpdJtn0OgNB4JsvFC4y+hitXLHtvZUlngIXieFZVur5oXk4mFHoK3mFFCl8HDDgD5gKO5hlfl5y/Af7L3BR5LabSYocjFgGwHeMXOouY4Y06k4+LoCETJKM+OZuUpdmRlFznNQpDz2UehnZ/btLOsa0dzbiN1EG44hLHVB94W+FgdFY7zn6iCsmSvfm6jicuHEPg6AhLuAeBrISYZXvG4AXf9V0IcNVVCyRzV36xAUCvxE1mrQi3/rU1BZG6Km+Jgo1vCGj/yymRf7WkDhRKm8HnelD5MmCFAf8y+pUuSbnvONWaUF5MOKRPcoHmfKbfMxWaOJqWShKSQBCS9ZPT8TBtayvT8LNGzZPTIzQT0/PyZe/PHVTdlPokZtkCwJZnIddHegPWuC/YFyfTiq3Bxi1ADPF+YhK/QJcXXm2Tw+UnuT7OIxaf2w6I6Adg5Ind1CSoMUaoq9U+/00hlSpgW8zoJBDYbJmpqrqAPv7Zr8+NXLx/f2tzc2krs/PLN8zhvtrgAci+s7+elLw2XDwaKox+b9RpnjlRVNi81zCHzWaT2pInkF680d6+CTodCr3X+fpxpg3fai3D+M7F2m5GyhlNDli3Cl/8kwRnHoeJI7dUHi7MNlsMaS3KSuiLJ1jcdOQOXG481MfI5Yb2N6RKOqyKLpORoUkGaO0kQaW/R60KLI1hsGRq5vql8fFlVt53HqXuD6LQqIZgS8WFEOLX1ELJyyBrouMV1h5KysAeXOATDxl6RUDVnBiTu9hNMjGyCqqSyNLINhmHa9Ujc//u/roHPGpZuWG0nN5XUNi0mxkdtlA6KpPGj0Gth72qtQapqA/okJSER2kZD2qRqqfg1Frem27ZhiMZa8w8+3h0bhmFjQR5m19sUrzu+rziyukZajVPcI2FRuk0SO+1mjbV8+kG8Gb70RWZVLmajnN5kHuATd5V5SJ59SnhLkLvG6FrRuWMe5h+Vvr83mZTngL+Kol5rFRW9fQQwuZezJ/MpfWjSiB2aPGKHxZhfIbS/WvSXDYfMXmHeJknECsm34ndyI2E3mO6pWAcHysrjE1oWeQBF8A/6pgALp/p3zeVsdLm5OD1dfo/GGTev2xmdzSYB9V+X5XxfQvt77aHkksB/a0packN2QJNXKECmfu/sTdJZsysR1K0Zq3yPahkmnNPB+biE1DQlMchMTPkKgJHdU720bG7WBaIOK2m/RJzrXmpLDjNIEHexBtLgaIPw44VBXMaDClg6jbUJqEr6CwiDb0NBap6pT8UKs9XXbVxube7GB7M5XI5rEwS/c8eX+s1lb9n1c3PTLh8hjwyMPB0oqF2WAG0wamWeMbMJ7YFgHnRtiCabFSom7GGEQUKmEgYAStIw0gOc3RT8OiO6sKppchDL8hAQF6zbUoS6cDSfPhaaj08UrkEOnE12rF5R+R9MpzZefYm+WGL1sUwMi5gj6SjjlJQ7qSH1KpqxMkpwma4X9odbwY5J1pqshHcazTloyTbTItgmwZ0EEYENK7QzNDCaDztksrSVCqU1Z1NTyVcwPCXcEDJ2qN2WBxlfNGXcFGahS70pMUBOwslP2iBthZRz4d6YysCZ2nJb7MocN+NsUZ106g/IfJ9Y2VJ18PLxweO7d+/dvlt7SzUmHnl2K8LfzE7IHeJElo0kY0ktt5z0nA2mWkY3GfiEkizwT2po9SATZN0bxjop+jTujNDnXHqC3dyxO0LCaQwqoVst1TdaKWNG4wl1HFR8uH3X62LDHO5RxlqNgxwTSU1MUnmEbA9kPqfs3EztCOxTjYr6Rez96yVr6ALctN+N9PbGfcKud9aYIFyDi6CR90AHCkiXTZsqgobXlkCfXHKuBMdcdvT8HO/c8mxD36FtFG4Ku+OtZHTX59xPwUH2a/ioRdQwb7WYVslzqpiu6i5Ea9Q4dkMp6tkNv1v7BtE+LuEweZE6CIkm3ItrAaKcCW49VewrpnL9uquygQO7My2seHM2cMh0jfUTpqeBAya2tGw0t5WyQA0cVLElrEVjDmc6WxtOytH7Nc/ocb5CUK7bI2h80yUNVn4jipf2G3G7/W8tbU/pYSGsbYlYvrIu4V18OC+9GAjtPOBTwTCowwKYy2lvWgA2odqTFzP8ryq4vcnsqANbBE+QbwoM4bONrb5sPzctk6CbwFC/c3YGyxO+5dnuoTM36CfqiG2nNuZ3zQfVYpZ3ct4C82tqhdNktlmPLnQ03/F+TfZUoUTJjnNasg9RPuy4brTzCkMR0Ks+LEIwAi4us+YW80ItOLRfbJwshnaVYTzL08XQW4fdk+aQF+1hXplEbK6i9e5klo7AortBHJiU7HIeTNVyOlJq7xTSXgzz+XludL5zterK86pNcAzvqSbMZYXwFcQrhPERha7jn1JDEz54oqasSS3iC+kWjyflcDB5Y3JksUY7jvm9vqvmo1slOrrZp+xMfbfiA5xsZ4s8u4i1avh4kKJTO1aBLj0t58XR0ps5Y5OWD+jVFqop/GlsU94KZkurzaeCdBrjMS5ddRZQTxYaUg9zx52DY9swR1p1Ej/8/qZ/29ZiOClG7qOG0bu9Xg/6oSo7CTsGCxSkK3k0Kwfj0aCahxnJoLm3tEDHNiieOzUmbIqGxM2taxsWxWleVWomYXJANXpMemL98TRU7FSxwszsXpoHMtFUGuvYXlbOxB1yjnQzRzy3gWsRr2+c7Rxsa88mE3rmI6Q/Y07H9O3bE6aJ9i9RVpgfmdJm1Cv8SFXy7JdkEfm44eySzvZFdbAY/ojfLJhf4MM3OAa4hFL7P0RNpz0eSF1g5N50rHqZz/I81UatCVu7MGmGZLMBBmeXVI6mTcmB9BJcKsf5fFBMnPOk/rnbYi7qkj0yIPNEnpOvLEsqL3Os3DBRbsMlrg9wPzSJVed2nLrEN1X2+OXzhkE3fzd5/G73p/NjR7Q6mZK+XQezeFzRzBcES2Ff53WynSByQV5pGW+rj2CXnZiMwuS5JjHRsLUuLqq5Uqvwy6SXqCOFnVBRcsEWSJa+fuaNg7bMqgbB756+evNq6869e/e5v4RuD08xg/nohKzdmqlj14CZNucn5SRXgh1XFjpmzHTmYc0YUItaTJKGBRoGg7+dvp+W59P0JpJEMA4kD3BAQ5ck8IyNKRk+4feThGmSNALIxErL/X6yb/Q1fuli2mFQZPqRXsIwXVYVW9x8yCxgdgoa+5f7GUxJOL4eT/SmcYidrKHtySmfYHkiSu3Kdif9aMOopFZNfhaoikZX5o8bFGanLI3cvbzSmLLH5Wn29M3zZ07fz8xFOk5bOC1eC6dkpPJiu+DiWqXVXQ0a/WMxP3F35XsLJQIcdD3DPiVVHudDdRAa5bgJf8DMqVvsCMmLfYdcyMc/nsBMqxDRkGFUmmuWal9fa2vokKjvQxY4o++zWJy4n8jq/S/v+KWwZBWMDsiigSEsVdhg3agXC1xBINHgEPFMyGj4nBYN4Rz4kT+CWUu1+SYqWduwv4mKR4IoT3DQRceO6nVenanJpY4U0nc5KmbV/Jna2YWPmvuFR0+ENAOnLuitZJzbxOLFX3woZvPFYAIwVN7XIx6JWAxOJdPjRxAcFqBzW2+z/6jJjaE2aDZIl9Qz/eVQKTcfnFfEa/awQ7wOtCrk6LBAWwEnQDfRqSLfTieKr/SISQ+WtEynVRtwLyJ8QTtxdVJZXc2cAHLWO4A82f4hS/10caZLP2ctuLodjr5EVGXVmpdR9EWQXc1KtJczV+IZ8X/kzTSX163vb92fHsxnOkjlJB+995LH8lEXBxCxowJWmFwKtkXeP4/tvS46j1pkuyAMuKYhruND8JArIUf/Sw3YqkzQytVZkd3ajIYkPFBui4czxg39c5yfzXJI+TmG7KLZp39Oiun7rMNE3A7ur+skNvICrUq5kjqOkllZztvSAOXJjiFXIwUamCBsMHKTiVCPera8KcFSos/SZLzCfiV3mrh+tnxA2SvXdIGRtqyWx3JhHxnJlO/XuVpqaiPQxzb7ee1WYL7shTMSZupnOSpw4Jg0BxVybhg0WjmomHDmAe4sjBXpLFT100bDwLKCkBp2g5IxNcxbypCZcUQULo5bB+2ak05/MAU3wsEIjRi24UxjT6PTX4u4XeKu4L36SQgv9eag2n1cO5Fg0fGEqmCCn0FiAfJcKJvvZDcC4KyBjuFeL+J3kUo2LNhYrUosnagc/fh845Rb4GUYWWSJ27THVUYekv0MRaMXN65MX7j0snf+0Z7rQBVabKx+66o3DvITj1vExbzKJ0dqLWfn+WQC/9XOG2SC6cZMbHOhjjl76OSByx3XNXp+qBVxAmpLdWKTPOONrjE8cz2YGK1RNDifiXKqjjPTPB/rI1RuG1cTX0mPwdnZBJgPJc8hPhBLGasmdvM9ng5Nb1k5/A2uhhAk38QLZhAyDBJabbpgfxyMIcgQTjz2XQGBLfpFF62/4KqltW8lAYtTRc1wGXSENvIBPZPp7nAzUOqXmlS9pBXWyyG2m/Pg20Z1ka77BruuAcnXo3TBVGl1NsKuba218oBdAhkZRSADXKDZwV9OdZsCKqV1SILSe5PJS6oXyOmvuN4PRii1pKYxxAHqjX31qYyuD7epDlE2uVtcF2EVI0kauRlxGhsAukMnp/iEfF10QUuUTlPjO5EO2OlOJEe1hiE7O1RUjiRk9wffzHkwk8Ow7Bfc1LN8mm5h24gM928G7/EGVYsCIwm0q5a9sjcCSB0mdZVZjuj0FUhdyBlf4ZWeOr8u1DO1USxmcHZXIhCEra6i9knw8gaBO4KMUUYlSujiNtqD7hA7cAFYnal+1yF1RXG01M+dYu4kE30ru6dJ7fekarspbnEGvdQM0heNA583UbHgVB/pDOcWFQgX2hOyzuZbBH46iAq10CsPx3hJTi2m9bzi71fgllwx5U+JABx8hoEa3sue6Ah5DH4BjTNl/oZ3nRCLuO8PpS2sb+i0Gx+bnA+Ny5yHTUpuaQmDnWr4jXQ02pXw8/FqK6QbjO+VVYsg1CgKfwhUK2lXbWO9SAj6ZjSfZ8/3327e27pzp8bT17ixKPIpoH4DTT0oz7Mz6RZEUimxexWgMHn6+kAf8UQWExFB+8RNvqicEo/drvPOMumrABAQo1nsqJHSe5RSmpHpImSosPwUDZyJxt2/LddDXWjC29byrAduHcfTDv/16aIrkrQOniDAGIt5bBxBkrEZVzJzY9pFacUDBBtSJU2+BKPjTIRBN1HXybsIIWixy1rDNdVNmObW5XZ7WsLS4EXQJZ/hCcIee/TJUh+M02bpXqn/6LQgINRUAoP+YPzboppH1wKdCGN/rfDNrBFrqbR+k1ZSUNedPNiroIrUQMoFAnhlfdH052AuSux7b2QvXClzRtSHNbfj4XkE33dozRg0PnHcisw9dPvdUd1r+xUc8+zuqtpkiw7NYWYf0HLde0+RqZ+wErU2TLXdgZ4921L/PFhrWL56rbvVWHUahJ24vic1wpKuGvhKOE/iUyHuJ2Fi3jZrqu3sF2JhQrfISY06PxwQtxwEHjJIbRhCyBzyvOHS5wZPnxc8FsjgQ26mcIOVwGNJ1Nsrv5mbsGLTo5V7GA+9hMuGWAx86Wn5pr91f/v27UbFiFk8RVOpxWfWE8iUpLNiQgzAPPpRMKpaeyqIuy2u18zC8HpuWxUVmqgO64xYVqkGY67nFQNGhc17IyxL79UT36jXe6g0+qRY1x1bCAMKo7rgijIvbV6O9d2kMjaSYnW11sMZ1JX7p4+t2WhH1lkOnFUpSJYh2p7WactjAgkjtu0d9+tb9w2x9jUsSqLtRIoPAUaGtWl1Su1JFocJu+PoSAr7jS+BwPJUIThC/rGoEOpQk9DLvjs6yjGNzWTZRbfk07P50koS6yhsjKrewxusap9z61InQ/qwtW2ncFJjSYEWPrx+TOgi1F7wtumW08vpCzdcvxqESwYq2KMj/97YaUEccyrLfgTegvlirDVx9JzFPanKJznoEmgKV1MOMOIH/jUY12H03gblkeLVu2qBd1hHC8SoGFs1yvs7kVBE41L+wriT+3YQnMCY63HujnusFdwWVc2XZ8bD3KbO0C90TX1IsiqSaTrYOV+EnOH93cQoknN/MGXkd7MQwsYE4X+qiebGj0bb3Js/M6xt17pXqIOma2d8cO590b975879+4lJ7lZ3BO52kZhhnIcDxJzN0DvIwNbaSeXmUe/3OC3M6cCQeOAWwka2N5sNlkCNsEzs/bOSI2OyTqZOjJ3kszzsy8o2XCJgfANe0coD7PH8pBidwLrSbLS1oMtetn8k0FoQGLWu7kuWOMQ0aWTAs7CxC9Zh27WTwZ2lJQFm6rQ05EfMQxOtHay85lZcH92YJVd3PT+maTHaXs5berbt6gcoxCscHb3RIX0l8nO1ub83kkt/TSO3XMsm0Up8oe9LINj9O64PX6e4EsTWh6ct0tV6Sxvji/6DB9v37927c+tWg53RSjPfh5D3vFa6/V73TwjHgv9wIfkVtk07Z6HnafMWSif8JbbQq1xAZPusXyvJibenJt6D27fqt07X9lfcNr/6bLiC3dJlTPja++YX2iJ7l1kon79fXvGOwlZfIaE1zRFmiYCHuTAk1uU1CcvJhUQ7DKqL3ehYo0aEqbH8YAqCayRvgmnR7Xee/5rgJmzccId1YsSBVWvRxt30FjUuD5pIlrVVm1wSWG6idhaTeXwSSfKZHTVIzS9w0Aigrus2Ys0lygYbvJVrwzj/3GqtD/TzcZlrsEY0QsCdTG61gqgiu5y/ik/4dWSl4GL3R5KWifl9afnIVkVrUfL7Oy2sLAl/38eBtELeRg3/78jy3pUL81g1iAW7291rxfpKU+YKFOD9q1SA/aBXV3//FMhfXX29auG8qnT7bwlnul78ZJGlqlAuDNtMfY7QwzSxwGH6PdGxl4ZrX2MfgFs/L+0TmwC/IYXPO/7on1XnxVxN7A7ZNOAowW0+o4HqFt7BGcLEfe0EHl1CQj2JBgRWQBp4NrtYpHazYMNa560AG01LYYpGk9WecqZt6EuNzxohfDMozn4N1Tp8L7uvhaxUS2En+XKEvg0yn2ce6r0No0nxS3B6hQFhcvmQZLQ2JhwLCxkEmsoKLScKHyf6S1Asy+5GTwBC0TW9X70o8fzb5ymU6T/v1ltNAc3+yqS1TzGesB6LXoLpAts54y9qJo4Z5U5br8u9/b1n/fv3bt++fXdzO+V7mVmlbifR6Nuponh0guDyiiDW+tsH9+/f37p369ZaNwtljeRRUOOLmpwy3jzCPg1f6vrDsPUOfXFjuA4hK2LrdyBVivSS22xyYJVkdWJKBTNFlQrFuKzkSYDA2hEP9LrqLB+h+z3ZdwWdbaDDH2vCPC14JTGfYlTVcGlCz9TB4I0HlBvpDR+soCeDKWQ21+Bbc/UrOxl8wJScU/3Muwsyn4NMreccQwq6OlWnj0qFw8IAQnN17ICN8iqM84J+YoNZc0oxhi6gdlqCiQLngLPkSO6Psfp/JVpQ0S7QVHS3qyFxN8aGXskPIp+Di/6FCY1wPvtBCp0gCkEosVuXUIuHFqtPqerH8Hcmf1GGyIyYRhOhV1kZm7YoMwmKeCmTjathAA4Jg+SkDaAwToLsVSn/PR7kduV+dm8PtkC+Nrl/0ulih09G2mWjW+f3hVIErSR/P1kUTfzPdtdBZur/bivSHkLgrPF4xm+4Nx3rz1TvFu1cw2hdkbCeA8LVVCQaYJ2mWjB0sybEGmRR0CQCgtff6s6rYdw0ZtM+CLBRAhTYNHTKjRs1Idn5dJxsGCbCxkYzMgsPU28T5lMz1mRNZnQx885+r8+YZqsLL72fAiyqiYUW7N64c+IetIjrwHZJ1ZTMpJgGuC4m1tSuMII7wn11ii9Pc9T8Kt+UzX6EPeDpX218kG0VnprttgeV53ofryyMnBGenWqhToOqvNtIHLt7Br4HoHbVFv06//eimOUWYlVpLdjHETzrZcY/05ALCG+AgGfsfpxeS+ssPx7MxpO8qrreCIi8zEFTAZdECyMBnZmO3pgIdWDGvDiFC4UcLIWD2VLnJBh47eYbvZ+E/MiGoDZoNg3zEXD1Q4HIWEiIz9YNcd4fBtO5JWNqwgSGlhofOYhjgh1YS4NS4+wzJ+4r9pJ8+/pgm24BTdoCFVZAnrQMtW87zVilVhDsbGRmd6yz+RlLU+qyq9Lzt3V7TVbWNJhaLOrGKLjmlYBr4gNrR8bDHziGuhQCCuqADJx9zrl/AAglHwp3M+i1Xh4OEGsgo7SRk5UzWJgapVcTA3C9+bmj0+h7HlLBK6H1ycOavwHJDTXyiYzQ532twqP0mjTLGAfM/HpeVBid63CRsm+grW/Uae5/Dl6+6OnmiqOlDXZl8JBAiA0lvQnWUosrMeDOBOqfmJ+xb5JRuf/6V2gNVmgBSxvV54lizXhpgSwG+vRtmr5ujFwOGEPxxWgxvqlzEA8fckSKmHmyrl83dYVOUU6XZ6elPXxiz8BJD22K3ce4W0YxhFZj2nwY27oOtw0upnBsibRNO4FJhiZmwmmzk/2i+fjOvwLhuGOnCvzgr96q5chewwNf5FTrI66E+R0VYM2QZzzdk3lfjEl9q2352vYJqVv1J2WlUVdHbv6YR77YAPcT4NE+nKh3sk3/zjrwazl8LXC1d0EOhP1xLirhYj9atUaZ8RHigRiU7+KhF2dtZgvj0XJ/3PGpOq94f3nypL//aB+Cee7WXzRxezgZL8xGoNHJ6k5ssVIH9XE32qySuMoulusMI0jMgvOne2ri0KFF5k7Lv7Cp/WIZ78/OYDv131MLc9ugUfgYAd+EGFmZmlDFBxvrnxdg27BoNfbUTbpwOFzlzL32AnEHN4QjuEXCEoLNxhLXGdirs/pm1vmmZViypw8CZsBMEe5q5B9Uj8oz6OAVZYCwB+6Psw3cBMcOqN6g7enNADjr7uIwAYdWrlCJU9zdn3ogIv6ZYAHvT1/RnZbna/TNG3ijykpbQ0Kws+qhdBLfvxvyxxk0wcxEiaErMTWZiLynyc3ERUWpsychuyl+PrGNazrsnuS5urLe04fApsF3zdTbbvwc/tbMWHCNAdbDTWgFjJp3EV/K3pKxnI76EU/MR8DatqCMUR7UTqT3dLKTm54oBZmnztSjby8o2GVuztorgXg/e95/pYT55ub9W7drLlf5upKNU0EZkRlY5uWRhqwWAYmcgJDwh0yTg/H4FQiBV6asqyS2aKZCgmq9Resyz3RKKgKnVamZlk9/Aqzq6CmU3hXbeYOZqaIKP4vNqMJRfCfmkTHU4KTkGWaknvUb3bNQRehlJRsJbZKYshxvme1PZ9khPL1BhsRyp0LeHc+zG34UtNQ5zbnj8+4ICVKvhXc/PiseXjC5UD13/Q6PJfCt6z6PNg1WVauWP0hdQIU2/V//8ilxabl5jV1UaqGmbwAe5VqpGQMWuD8BmEGRW8t3F7+ut8J7bCW2W0jP1UyTP6Sxnpkx8caNlbChBbtiAn3aCWF7E1dDsRIuIr0dZyDkhtVEjyYfK811njaxtmWQtbZeikH2MLIgQfW17GI5BrDa3wVUGbB2aWjAH5hNUOd9wHrr9QHqWEaIRvenJ43BX0/0LwW7x3XVejqD0g+iwbKTNsvDuBD4UhpWhHTRct61WDFt+Bme6oap8mkIl2GrT9ZAZ5o/IYWDRMk0gYMG3q+gHhIpF2APtNYT00hE4aaiS+ojYIBE5RTpGhgEAoGwk/3iDDIeAkEENXD5ZAieQQKfwCev05YNAW7AZ8AD5uw4JjGNdN8ZWhjDuteSKAVCIEn4pV5FbOvEnKwTpi0a5NB9kDPkcNDNDofq/yP1/zHP9g1lHTK+MSKdE0B8mwkWb3hdQZ5vUOeGp21h9sEW+eBXUEWV9rS9yRIadg6HYbfqedDrMOh1KPWa1FxZp+aqt3M4CrvFN0HHo6Djker4zuZmmFuxczgOW7OX86y5cdDcWDV3a/NBnFppqBSzKp8ZE4UGCXtEnzkDHPuo2hBl1jhro1dOOapWl2aD0KBbesa8xDxy6j2rv55sFHFvg/ZSGDHriZQrWhHhHQYeCitA9ML5dQVo4roMiquiEqfyJ7aFKfaAaRdUDDHOxKicwIQKb2Th4xnt3NyP7nl4au0GhRBhaGI6zecn5dheOoY402DK0ocODWR6pq1armWNoiJgHhvGfgbKjwjog3112C1NqjmvyqyIUv2lMKpXRKi+cNlnz33W845z72ABki9nfnu2WfuScZre1h6BGVtIVdedBiJ0napd/vM6TmQP0kvfP+BXCf75bhITCIl2eWYwKgIc+QxIpB/QelbpvG2jcjZDD5axy/QHaf2sddd4JAyw80zDrCPy0Kn6bv7GXE8Q0j4ZgwPZgSKww2NACCnRFZCjTWLnBGh0QpWoIMuyu1QBajofu9myi+14qcRwWLr6JshSab/7q1n5cSnW1lNBbENKlnc8G5z6PGA6vQJgN2lDhgHXN09Tbp2FC3cxDg3aIA4bFXxyrE4Sx0bXIO7OgzZoXR90wgceyb44O1OTotL6/gaA72sXzxL7jDrEwwU8416+3aCh0IMCGIDVOqxcCzYOJ4tZlXXGueHcOgX5c2wmLDR+pxi8GrDB8X9sQlgLnPXQxcz4oYpchwKXZbppfCWmB/053C7H8ycxK0OWW9eoJ1I+EK2JBR9tlTkdjlXteTMjl/SM6eB3W9fXaABOZtHLou+lJ0eSseo72ngtt2AqI84Edh8rDWSqO9ERzD7cS/OQVNOl0l+mSq4HmCX+IyXTaafYL6yYSnI6Kmxag3TClnVymkEvHtPhq8g53TUom9qlqqRo0oAp16O3NXGUKtVPpEElUjkYW/pkbDpkAUOpbDZUERH7imEjeQ+wiB7pRcxXXBVDP7qKjBdBe1LcAPAj+QWkZrkxLvERWuBhSm0TsfEDZENI+shehFOrLgVHgvk8MKPg3acZnmTY9QTiulQ4Gij6freAOJING608RmxiURPNR9y9iDFYiuK71hgb1O/vP+nfvX//HvEur4li84562WsfdaY/ttd9BHeXRPhbU8PasXSFdnWImtSsjvpZiUQbaCU1x6VzbbNRYFVTUFW/33+wdevO3dtrXerb183WjEe28eJDWjVMn9ML11LuNKhKGkdEzNLkkzPhhquj3kKVCLmmXTcmZfk+QyNuNi5H79FhUKeBx5ieIJec9d66Ccky4A9pw7M7Hk9q2WEqN2KZ64g8YZmmYhfqxIqh+rkhLOi8Gbq/ch00RU2sSN1q9EUXHLaeKU95KV9WICZ3qpvI0azFEMTACTsBIjv/TZiO53uTyR7669GMeKp7iF6n85P620O9zrpS1l6UkD5kBvnFB3Pt+7OYnZXqg0F1dYZFd081qeG0Cm7BiEyvev4OcqSZfGc5uOSDM1I5e5+V73H+Ijg9jCbLnkIT6BDl24FMPhlEeYA7KIqNOQIQnGOcGeQsLqdo1QHNHL3OK93v4Mx5nqpfwrZQzxXjt/hJF/RahOITMtslIjzO53v2mWa8KS+Zmlzt2MRkasXBsa6OuaaLCg5C8l24LNBmXrKEg0EzGAIeNQLTzunnEY3utl+oyZyxqDostpLeNb959vxgb6+/f7C9vf3g/jch2YHQEJqNSPO5d8zMlprkj8hP86f5z0kxzi+zpKDe/79LqoYrfy6p38+SevollpSe2ZdeUoLm3i4fdy7c60ubqL3xEguAzoNN9eaYvathry2PjqzlHbjgyHEG+FYJyANbfEgSOyPKeqa5Lik8hA8kUx3gqSSrBtPxsPyIEWwQcAJXy/NZgQlEK2+K+0ath/J8Y16ebUwHH4pjvJf5xpqcvSHUBNPptr6psm9M+99kg7lqdrgwKT3U1MewFLQDgXxBPRXEzlk+NTZC43VpPM3R9jcbFmPIFIoSE6QnCLiRmrpqdul29WArm1AEXSHBVKNj7XRb9koGrF7mRg606AV69Dm4pZNZfhTlVoWUelpEssQj5n5J06V+nEGTBYIa2TH10MR4VHzEYeuMN7rhw78gPeZ6mxLundyPJz7JrAZI6mjtf5DNdXJNAw9gEnL6mL5i+qHE84GZBkgi9gCdIhnr+u/KYghQW14cEuVpdXopvbzO5zbbp75XJe8M27vZ1np9nuI9tcOgQZ86Ep8O1IFbDQReZnqlkrR1p7CVVvODBfrZq/f76lA2LebL3YZLPbBYQJOJKz0j7HWfQQ3iFAVCBdFxoGTvI/oif4StB39um2Am9YdZMcV0NFmM9YKBMqaZpWtiiU0sbRNL28SyqYmQE3/XDVT6Jz3hxDyjJXdJNBBjPBSS0omZ8zgtXedKYrPM7FtuBkHGijYpqbfe+LnWQB0QGCxSGN3i71avJl3G/t7r27dv3b1T49sdDIM5rK8nkvMYRpMQUu85jEtjXcq3o2sJft1t3NTVSPbYUBLmxmAFQIIc37uYe0dPi6T5mX+MECvKAsSsNxHxbkWqaZc6URcopXoaSqNIqJXCp026WhLNklYLPCtTCDnadLAuQlQZ6eS1z2COuLmYniHWqbOYLvJW6Eyh8MTbcOggAlfiIZRzM4d96h9H+Uh6G7bmbD6JthK2nBWX9UH/9p07Dx6sRYNJcMOO8qQ4PpmA/9Qe+SQipcYZsMdq7CaarZyE7rDysLNsZMEjJVb+FpZbxuWWW+up7jRpQdiB/efj1k7UY1cqtx2V25bKLaP2lmJ7y6i9pdgekSA7WRCRSxOqIkejNxe7wqQRZrrJHBVNjxYYYg15F0yq4gFGzs01FudgjFZditHU0du/1jM1dr0O4l83Snsf7ImoaVa5Q/s5wfO7O0MYxwal31clAjfZN5VOIu1vdiVFsD6J4JfKUPXs+f7tW7dvbdciCWtDvTsOMg3ikO+rfaEoj1aRGrP7eOCzjzuE1j2kWgz9MJb08SXzet1GEgXUhVbxlKhvVAd+Ai7fffAglICi9CuI7aMJiU3IhpIEgEtfkwF1W4q4puwnyCA7pTuXuResseKzMJXoVE64oTc38Di9KltARVGTehjBDCXAC9SCP6xNTn2Tay65eObmY8Yzi/Mm1VFTMXxv/JsSkVOreXbW8MSZT2OiX01UwRM4EM9C99erWfbPf+IfvAlyxQ5EHdchvrnDhre+e+3SkXoNoFkhYFYlIGQJhU3jlYSG5YuHyFfsslu/xTv6yLDaqbUhGSdqP1t4af0W86L0NYrPWnOMSMOtWZMlbiVM7ufPD+7dvr1dvyFYmSl1txteJ/aS8b4tZKcSTbfu3r1fgw+XWr4mUpIIMHEVp1YyWc3xpyYrtMXqlpdLXZthlCdDInPoTIF7RguLJhGgV2tNdZ9BT34zUcdrIXnp6Z/U4BR5MwOzqCTSscbHcPAQxB/dmPcqA6Cp3e+gsFICKmvBG+D5Lst9slBtgiOIXB6Ha7zQEGCI76iYqfqb5ZNiMJwsdXsT57gNJ1pqDs1uGg96i7mF2DqjWVlV1o0fHRIGc8Dryo4G1QkBpY+0w1QkBbPxyKl2P8MB30uUwAlfCXRrs9TDFXM9t8zR2wD9SINS+jbIpL6dAG8gGR8AVxTx45oAhIyVX12wW5d1jYk/yI4mgzkspLGf0ARQDzWuqmsx3AzKHJ5h1KSagL0dHGRSc0ay7X2ZY8T3e30lprdubbYA2AnOCwnrYxIx52AxtMu8gwC6cI8KK3owXa7DGp5pCZDlQJyuq8rZGwUoOZyUo/c+Q0ECpYymmm8KZWFBSY2rigZd8vDMVDvEqLVaJGIKQddEO+RD9SmUsINbKsDLqXffVbNazT8XMPwa68RTSrcFKAA+2nsxL53XdLC8jG7z2tWyVHWuiOyaDmTS7fvvPs4RzOfHE/gQFQIrBsTjob2PeZuxqr2riUDk9NSf0UL748SKE0tm0U1Q6FAaVwl3fhNLLeKvhvu0BKXq5Gs3E9i1D4xXxYPPlmRRJIrCAUheWOizbpsQqwXKeT1XhLllErFU2kfEQz3lYSpxh4I4rfF3jzFfdQwvC/Isx0ujNiry3M0pPA7Ce9kpCcyXh/4aLTpENQfsko55fjbejapHSgYztWm1s2BGF29mxiiMOnjl/Ez54141X07yngOzXtva3Pw/a/WFTwczNfOh8GZDybMBolO0Kap0zNnRBMOo10aT4swVJxyrJzYuKBEalxKJjIslCKSBk8LECh/tJsyqGDM6R4w161Vg1MFSp9FbgJ5rXBwgUOZ8YDRnd28O8abSAmIg7zqYRev0eEOrRgV2/+yWW2wA4+wjKjmgtBRBZ5NHgVuWPiZMF6dDRS2CjiK+telWcU9HvBwVBoMPI8rxmFHNQRqcKl4BvwApEtQYtFYk9YskhvaXUc72+q+3N+/frzf2HOkUQIMxj0AlxKgv6WnVqkZnncRY49lUTchoXN7/J3ExSYy/jWX1Jebr8lx2RRYZBngADBW/9aWuyMx7925vbTeYSq3EBlb0GYhNzbgEnoSGaNrit8GVd3w7nLQxa/LoZBU1UI/DYbNMPSdVdoUm5+V8MFGFbJuU3r+xDuPrVF7324f0m8W3j/FIG+5W0/OT71B8QOrrDyZ99h2fD9TaPh187OAfSraqmUGn1002Tueek7zDpW1Tfm1EncvNADRLP0ZtbZ0yagWn0OgGPPAEDVGc2iTw6b8+gBV1a+XLYRRZB/ZG2KIueUfTeJzyCS78DILHgbSsMTkV4zxnc91Ly66NbEsgMvOpycFrjR6P35ReoRTG3zW0CVfRF4mL2LplwTaCK7yTJUp2cZTNfJdGw/aQ4j6TYJBO8A1garSovKtT9JwXVa6Hk9yV5f2Nmtcs2ogoK+3LXeZzpdQdwtLn4Ab+0LXTmwVv1OLhhXu6BdpmOYVdmhfbM5DFq7VdOpSUQAVgyAviGNSGWkdHIoM2GLZgQs/yqU5UNIW2lF5lcyZ59LSZR8UP09TbIhuZX/bQBmRhRCdPZjxTr3gD2OdG9sJ0Xanj5OgE5QKrV6O81a/KkV+L0FUyazbMIijA5II/hSGZMdy7FUoyMl2z8xRLNDZKuU0hXVrZxrGaAO3gusF7oVue6Gvn2hizL0t4K7lJvpBEbzh3n6iTjZ68qPrr7S6URuCKrP2/TaShA9WrN87azfULIZ/vHfTvbN+7d7/5Lo97/TkkdEeihz7XxZNQ505w6HItkPlkvPUODQH+Aojwbz4XEN5zRMevNkO/tx162PJl5UhU1muZiYOGtf/w8lynExK8rrbGZSVLyj6QXOcBnTo7COakiDLAyrkI5Lj9L0+40Vxhjggqe9sJQZoPXJejllPBuIYtYfk0b6TPvvrU5lkU9Gggb8KfU3ylKQ5KG31Z6KuEYvz/39xPzZjf3xpIqguROsAhdvT2uwGZx7Tt0RYG/fSsPMOwDlGJ7WvUJ6dHm5uupM7RsKNfdhFeTqdro9E5IJW0JpxZlQzdC7hCJwVHXC8C51AhFqKBTwWfcxftwZLDVOtVmIyew16710yCtUWltodW3QZtjnC4Jit8RGUiD/z1ujzwNXl9hfVUw7iYmuBsrp/umzTD9rdO4rDLMGbcO5Am++MAZ2ZzR7Qsy3A99ZKlBd6Q8QWIE75L/fXkrN20jSDGK5FLukVtu5HGzSZM08EXSAaOGN58IrQZGOudFBUXLQ3ahmd2Dgik25QeNQBiklnbJq9mHdzgky42aOta3+oLCP3j74khpuzb0RSqsYumGRuGYbQx2pnVsPWHWw307DafLbXfkJUe6CzjqnUop9jHrAH3QrZs70RaUEx18mjLEZ0C9eVMgpu7LEO/CjNu7QQhG5dhhTq3pxnRoMFd3fBiDl5mLIIRvuWArn5ICXGRFC8N8uD21Uz82q/9B5n2d66GFdFk+WNy4+5O+wv5y1y8P3n2ev/JFhjtmqKUnDOfSVnRvNiEVSBGZtVoObDFx+8215v36J3IcujUoc1w467b90VNof3CvvfFv1+rr0fj9iW8gtStdihr4xZqr6j/4J82rRIziRQzJbok/wLbz+oH5ct3zM6Eq5+IPu8s1O4UdPnzjwTXyLr7VpqsbY4c4jxL5WYTKed9Xkh3auph52gxRSikjg1xxiSz25oW+9J41j6ncVE2rMp6YW7zT51HjqTbxknexWONiw9W9rQO9Tw8g76FeE+kKYj5NOzJucckH2gvPTSwgiVf7sbseTMYPp6VZyRq7OvyaKw6P5wPhppHmgLCKaBNkUjIuzy7kkN1PEuW2I3bNK5sVrYcWKsY3IAiZZ8ybRjaybbc/DZbwUU3KLHdWOJWY4l7UQlV4J1AOYYUEujs/SMbltBmMJuum62vO46Ldb7cQUYFTx5mny4gK9C1mzfRynx4Wo4Xk7y6eYywYBva1ebmWM3Dm3l1enNe3TRJ7Myr3m/VNfCsNznYDI6Ymh4wfbND/jjHwI6Ks1fD7wnISrB4ZgvgqoEueDl7eQbMHkyY45X58+XsUTH1lgpE6n6KkTOq1GI6TL+s3hdn+9PCY2IvzvJZh9NuVgSjvO8pfAXXA+BdVX0urTxHk0g1LLNXir1gECM0cMcx42IOVCsyTByGrsULstiDGsJEdR4VVjUN6f1JXRuwMa9ZgboWoSjHw6U+8TUNh8G4K/KN+6HCoGomTD3QslQxe1g3AetuNMzdyeqDEmJJi8qF1slO3GTFvZy5sjw94WecRX541n9w//72rVYnEZsZMEiOSH/2TJnW1DP1OPIkVK2/HP6mKO9B/rDjaYf/+nTRFYlah5RjOlejlb7rzV/UihyN+A3+Xex7XTfREzYOQ/ywZgwaLkd2pnLxFzQoQ5yfVAWtm8e0HMrJmhgPGzqKceMjkKXGV7SXPQdMXg8WbzAgJxMHAuQw4014IcSPzvJjCPueQcy4vh0MgtO16F3MUOTpMJF8XmWLMwIjiej2szynN8L7R5YQHZiPJa2yBrE1aiDjJQALDcChUsNLZohBNDEB+aaHklXt6Xo+gw6LrWFT23jPAiAiRr4MDCLip39Oiun7YNvewd11/YLukd1sqHZYNXRw6ISYd91hXf0epkDDFxfIAJ2phtElIaO2p8nxfWpQnVwQ34DFqhnuWwVAPcGPx3hiyoAOocv4VGCm7U+fIzDBtaPDPxymUNNblsGuWgMVigUK+qAWvzBdgTid4eOXz815UCNO8bSNehx1OQxp9MXF5w433BW0mwt06KOLRAXCDzUKjmXjuBfEhKa0Ebr9yiNMkirJzUtulDa0GCJdn85PJ3vTsY5SO4CAvupJ6XeVUN7aLLi9w8Pjyb4FuNWmMzoULTG9xA7SSKqOK5+h6umb5890LjATK4eBhSBjTgfvXeRftSjmkOrDxMwNLCZHtRiaIqb1hUlUpla0uPgwpNCHEw6gBcNsTDMV7wZGNpzpz2ggk8nyd8L1EnW7etfwyTOzU9gy8kI7rLscmu5wrrQOVbSAEdqeO0rUHuUzQA1Z1zwjEZOObwMzVvMFDdGaoKOFmox51+RnUwfuKUBGIJgJ7139/eLlm5RUw+yFo2KmxIKeGoBXzxKDgljUPU9zHXY5trEa8GFw0AP2dTRuc8aAm20B+F4rcQrgzPV8g48yU4fZD4Pp3G5nunGbvCWHz6K2Ubz3n+mcaoPTM8VJdQg4Ub1jO6rDE41xjfMqBIpRe6w6UyqGLk1KOpdbrnHlMdsK4BcKwczwmAWEnAF8FsQegCiuTLJNnRTytlnLQZlfNt/RFv+9yGdLe8rfm0w6ayj9YSNcSzSw1aYBXNOpFrYbWlC6zBk4qaXq32qo3zueHL7P8zNb33k4gVazP/6o/Zzsj2/D9p1/mSkh4E2zChAlFlBoajpjuKMAjBGOAvsjpMARYApITpJTHfvDK/5iKhAjPJlJPV1Yh1agc57kRNUSQ4BGhhdKfMxweSiVYi1+ryPHPxRVMSwmxRxi+Nfwl5oiRDVHZIe98fixNqi9Ks+K6aPFfO6hIjRtH0OKAHxK7dgapi3af34E1QzCeYbYFmyoKKKh+ZdTRADieqCNeQqCMuYmRExngg3CwDjsZmIQYfSBnHtaEbZvCYvM/DSbrxR8gZV1f8LnS5tnM6GmbKvV1lrknoc8u/m3DEfqwc7q2lVD3bPpBtRqh1S+FoKJscRg8EIGrQAUsBitPD5SpW5gUIyNa189EIZllsnxilS4CnU0DI8ZBY+O27GVLm8y2rZVHGm1FSLVf6Q23fdS2nesvba+HgJe6CVLe477CYN/eP7yxDUfU8fCsCxj1QiXoKDCiTAx+murwph+zqU4fZgyPSS6D4YVNZi8mLMB1C1o9RdrxCxkrNs7WoB0mV3Kpu7L5E4SQ7kWYTJHRi8Tw6+OtgCHu3V/eqAWvRJxv5DutzlsYp+mAn9Rzl8724hSnpJmUlVwD81ZHG4xChY4BRy+Y9g3f/3LJ6DrYif7y6f/OXj5olchacXRskPGePHrroAsCWRo259pLx3yF07RwPpEWWu+EMmHHU1W0XaVzC0nlfYdplMiXDeUuKM06M2DKm819bTV3S2PzzGr9t/2X/ff3rp168GD+23SHohkUg57xtY727OLZXZbYm5AMaOJ1dwRyJtfPgQ3q1/hcoUdHgy0ITb5f3PQtiJi/6GBnHb0N3j9rCPn11nv6XhmpBRFQ2fteLKhO7DfROCEF9dmu6YWjog+iyvl08VIcEHujarlb3hSbYWim5ZTUkhRAQOdHKjPoL4KjAw9QYLmWIRC1EQt/KyZxYA9mzmWmVyka5GZhRGjI6Vr6XGAK6i0/khKqZGhPDsbzKo8pDmob+3+ruZr4SJAyRHsZ2mAAKVOabvChQZgM9mmO7xTAcldWAU0XgfOGRF0WJbJoFNyc41ZS9OEPExlztbDbvB4+dxBJnu6LAdSN1W6jzbVhVTVIuJbaqtocbnaki9JzLFW96sX6XgiJklqb+J2bFpjyw0v97rXZEKvORUK+uS7TevLeee30lwU3Se4+wK4T4R+Diu7T7A31nuCJWGzzhPWW4J3+V/2luA+El/WL4PgXtgrXqL0Vs8HZ4pXShf+5+Hhq7evvzs8VKzAPUW96bCK/ubQdbVCba3n0ePHCpUdH8xnfA3w19Pj1/m/F4Wihx0SAVmS6GEMz9+fGgM42Jp2043VUfiDsz9pPOU2pBorVRORtU1L7dXR+S/0eWxP46Q8BsO8rta1GdT/ZRxY6wlP9tW6g91rK13uR1f7Api1ntMmn44/TGCgOuahJOCpp1rUsThochcNVn1zrXsyn59VOzdvYoyURbGExPU3/73IK7yuuHl788H29p1bWzdPMJnmBhrzNoqjjcHGb4MPg2o0K87mG1a93ygq9YJIqAsDD60e5IMxIEC5O2UqCe01tV29bvn1o6bK2WotPBlA5eUTQ+EFwXsPSnamakMgZ6I+3dxsM/OpO5dmARo785CqbwOVcsk7ioC4nRVGYY4JXW/u4Mxub/b+bZD57nbTWl59s2rNVC/Pp69mpdoT5svO2tmsnJcw6LV1CbUgbg21kPpOAg+vujlR88ncZ1pvMMaMwpkyn14BkcG0CwkVplMTStJnSAFxulM2QhMvmlm54oxvMcv1FBcNYVvMlI6GDMuCPdKJ5bC3cr1j0ODGM9tctTNjGgF2DrQNPNdbphCBLjdzvRYmydvGfv3LJ3Gkt65J5r79am+Czine4EfGiGY6S+HFr+sS5nA4qIoMqivp8Dvy57c3dnxKWy84+9rMEU1H7POQnL6rz9xwbQmzNyiy0gwO6raYxf4Tr+mJ6miGhCRkQUQi+M8puvIU5bMumpTJKbDyNPVT1FkvU3NVJ7ZxxbQ7m00qokEe+TwoeQfDAQJ6m2JgICIZvEnvBhbfeJscsTb4NjAzqmsGG4/TAfTXou6VNgGQ9n1UrZ1iQgaTxoc6roDuBi1b7YsdVq36FV2VXICLCndQFCuKpuoLpzhiWiBNtE4sSbkJ/BgqFTZWdtvqm98Tsonk65uGa5RGJ4QsEcwBt2X7vnLtfDSFEP99MUvu+Sbdujq3q68HiPB+wWakczrFXNPGEfPPSft1Jy2dWq3nirCF2c/YVvGStivbhrxXkbhlmU57upHui8tJ3jsfzKadtefquFyAJ1ksZE0GoRxYRv3As5fTyVL76gFoN3kXTzYENV4Tdpwaoh+6odtFqAq/js1Jb8z2FKYGs9tWhdnUhpNcZ1XTUSeJ7e59vnS432bNoasa3g90ki1KYsLmu1Ky70NRLqoJXTGEzdp0PC+gHfBNnINr2RyR0BbzYgLJfnw93XiwXIdLDQze1e7eSp+aVBlOGeNF6MtLE95/rU5xRPqyaYD3j9QE1S6Nx+DTP5gymk2v1gXp14W9JP3V1H9RznMtCcg7PTMMi4sjK7DYF/EnZX3zHQPJmWuADUSjxfgC/cQWWgyV5KH4s15TIiMwtlQ7exBnjLzeFeYUuYhiAD08PCaaoranXSYosEExxItQsZri6WUDbyMVR3YZARLRF4USWQ2xqXnLFurz0XC4iR1GBGeP+J4k/K6f76bzJWdL5JXz54yxM4aw5gvOGvi46uuovXFXZk/aEcufb5mAN49tZ9pfwAwRg15CHMh+IBh9ZIx0x8sLNd31RuXHeX6mU8D9MJgscoy8SxIRewjQwexea2F5ZKwhE2C3wQSamF3Eq4fbNPr8ii7ytsHxtDZQBpMsHEfwOkBqFWwZkvsRHUpQZ5URJFyREolJHvWfPHm7tbm5yZ2ZhPtz288Xcav6/tmj/g/9tw/u3793rx14TnxNSC3Gu0KWIvMK8gr76/i4GURUgriIIDdbNGDWUBJ8aRULj/7nTvD75t/spbSj8XGZV0rHejr4gGmSCbXU0bDGAlSDqJNP4WBrmntVVgVMwL2h2q/AL1oafQAmqb3mfdoE4lLbtrZ8CYyWqcg3kRaKYS0NER/S17ZxasEWd8cN/dTevCY7bHUV3NBz8uo02WvjxW473Ly6q//ww8Uuj3rHZeqB27SlzbQbbwDX2KYepTow7euYwDbK3m6sSnq94Codaa3XW8Q598kSXD3OY89ZkFBiU4KA0rxYjeaaIA9RItctZ4l+utewplLb/xXJ9pUle2JH/f7Z2/49tYfdWiNOOT0MJmnhLOxr0Lw0jVKzjsnjXOloucDnFFLZkRIAOsckl4PWAYOAahmVnRh1HwH0Gtx8TAqgV9W0c8APTX32uFhnnaIctKGhZhlehc8OW5xXMrUTE/uyCV6+f/a0f9D/7s6dB7du1Wa+mV1yUaAoaVwJkn6TUG5uJ4Iq9kGX+cHSxUIlshvZmvrfjeRaSjoUmOLihPSNWfyv2jlJEOTzI1Y/rtPDIhutlgaW9V0QXpvYRNOdztj6pnxVfFSD7cDTiLJ5edZAGJRoSZcqWkeW7iugSj0kRKkN39TB9JB0HpmFJhbWsZK8NPOhaxHMckW+cH+I9f/DD/3XKAFu/ykBhOn0WAe9+2/PZxZ3e7z01Pp8b8U/xlz7176ZbHf+nGw10vE/NjED+8YJqFDF8HKm3cytsyEcbdzY8IcasdIwXyGoAzygBlIzv+hTRCwNH/RdBECfwja5TghuKvx8PBscH5SL2QiDMnE2f3dazOe6K+04vhji3wYhyLVE7/jh91MMl/Z/aVBHT8++/3r4k780+OHw9/9U5RRtlF2HGekLshADfMAWXPjgTWki4dUCgpeauY8mJYSKuaHop2FXNXZ9+vp7B4ccv5M5Yd/KT1Nk1BP52sCDS2/OX850Ply5ACYGil6RRKj4JG7ftxv85OUOCt3CQfGf/O20mH+nFAr8Dd26P4I6sMLQsjuYznG6vBngLGSuAfAA1Y6XM61QWF9Z9Gi6hrgXp4M5dOx/GZEHIsG+KPjMxNg1eAcL9/8B+gxRM0ltBAA=
-</script>
-<script id="@tomlarkworthy/golden-layout-2-6-0/lm_popout_black.png" 
-  type="text/plain"
-  data-encoding="base64"
-  data-mime="image/png"
->
-iVBORw0KGgoAAAANSUhEUgAAAAkAAAAJCAYAAADgkQYQAAAANUlEQVR4nI2QMQoAMAwCz5L/f9mOzZIaN0E9UDyZhaaQz6atgBHgambEJ5wBKoS0WaIvfT+6K2MIECN19MAAAAAASUVORK5CYII=
-</script>
-<script id="@tomlarkworthy/golden-layout-2-6-0/lm_close_black.png" 
-  type="text/plain"
-  data-encoding="base64"
-  data-mime="image/png"
->
-iVBORw0KGgoAAAANSUhEUgAAAAkAAAAJCAYAAADgkQYQAAAAKUlEQVR4nGNgYGD4z4Af/Mdg4FKASwCnDf8JKSBoAtEmEXQTQd8RDCcA6+4Q8OvIgasAAAAASUVORK5CYII=
-</script>
-<script id="@tomlarkworthy/golden-layout-2-6-0/lm_minimize_black.png" 
-  type="text/plain"
-  data-encoding="base64"
-  data-mime="image/png"
->
-iVBORw0KGgoAAAANSUhEUgAAAAkAAAAJCAYAAADgkQYQAAAAJklEQVR4nGP8//8/AyHARFDFUFbEwsDAwMDIyIgzHP7//89IlEkApSkHEScJTKoAAAAASUVORK5CYII=
-</script>
-<script id="@tomlarkworthy/golden-layout-2-6-0/lm_popin_black.png" 
-  type="text/plain"
-  data-encoding="base64"
-  data-mime="image/png"
->
-iVBORw0KGgoAAAANSUhEUgAAAA0AAAAJCAYAAADpeqZqAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH5AIMBA8Y4uozqQAAAB1pVFh0Q29tbWVudAAAAAAAQ3JlYXRlZCB3aXRoIEdJTVBkLmUHAAAAQ0lEQVQY072OMQ6AMAzEzhH//7I7oKKKoSULXjI5Z5KokgXAbEANoMq8WwGs3FOcvq/Ul5w311zqSNVdefJ+kUjSzhteChsRI/jXegAAAABJRU5ErkJggg==
-</script>
-<script id="@tomlarkworthy/golden-layout-2-6-0/lm_maximise_black.png" 
-  type="text/plain"
-  data-encoding="base64"
-  data-mime="image/png"
->
-iVBORw0KGgoAAAANSUhEUgAAAAkAAAAJCAYAAADgkQYQAAAAIklEQVR4nGNkYGD4z0AAMBFSAAOETPpPlEmDUREjAxHhBABPvAQLFv3qngAAAABJRU5ErkJggg==
-</script>
-<script id="@tomlarkworthy/golden-layout-2-6-0" 
-  type="text/plain"
-  data-mime="application/javascript"
->
-const _4d16qe = function _1(md){return(
-md`# golden-layout@2.6.0
-
-usage [example](https://observablehq.com/@tomlarkworthy/hello-golden-layout-2-6-0)`
-)};
-const _14q4rx6 = function _base_css(htl){return(
-htl.html`<style>
-.lm_root {
-  position: relative;
-}
-.lm_row > .lm_item {
-  float: left;
-}
-.lm_content {
-  overflow: scroll;
-  position: relative;
-}
-.lm_dragging,
-.lm_dragging * {
-  cursor: move !important;
-  -webkit-user-select: none;
-          user-select: none;
-}
-.lm_maximised {
-  position: absolute;
-  top: 0;
-  left: 0;
-  z-index: 40;
-}
-.lm_maximise_placeholder {
-  display: none;
-}
-.lm_splitter {
-  position: relative;
-  z-index: 2;
-  touch-action: none;
-}
-.lm_splitter.lm_vertical .lm_drag_handle {
-  width: 100%;
-  position: absolute;
-  cursor: ns-resize;
-  touch-action: none;
-  -webkit-user-select: none;
-          user-select: none;
-}
-.lm_splitter.lm_horizontal {
-  float: left;
-  height: 100%;
-}
-.lm_splitter.lm_horizontal .lm_drag_handle {
-  height: 100%;
-  position: absolute;
-  cursor: ew-resize;
-  touch-action: none;
-  -webkit-user-select: none;
-          user-select: none;
-}
-.lm_header {
-  overflow: visible;
-  position: relative;
-  z-index: 1;
-  -webkit-user-select: none;
-          user-select: none;
-}
-.lm_header [class^=lm_] {
-  box-sizing: content-box !important;
-}
-.lm_header .lm_controls {
-  position: absolute;
-  right: 3px;
-  display: flex;
-}
-.lm_header .lm_controls > * {
-  cursor: pointer;
-  float: left;
-  width: 18px;
-  height: 18px;
-  text-align: center;
-}
-.lm_header .lm_tabs {
-  position: absolute;
-  display: flex;
-}
-.lm_header .lm_tab {
-  cursor: pointer;
-  float: left;
-  height: 14px;
-  margin-top: 1px;
-  padding: 0px 10px 5px;
-  padding-right: 25px;
-  position: relative;
-  touch-action: none;
-}
-.lm_header .lm_tab i {
-  width: 2px;
-  height: 19px;
-  position: absolute;
-}
-.lm_header .lm_tab i.lm_left {
-  top: 0;
-  left: -2px;
-}
-.lm_header .lm_tab i.lm_right {
-  top: 0;
-  right: -2px;
-}
-.lm_header .lm_tab .lm_title {
-  display: inline-block;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-.lm_header .lm_tab .lm_close_tab {
-  width: 14px;
-  height: 14px;
-  position: absolute;
-  top: 0;
-  right: 0;
-  text-align: center;
-}
-.lm_stack {
-  position: relative;
-}
-.lm_stack > .lm_items {
-  overflow: hidden;
-}
-.lm_stack.lm_left > .lm_items {
-  position: absolute;
-  left: 20px;
-  top: 0;
-}
-.lm_stack.lm_right > .lm_items {
-  position: absolute;
-  right: 20px;
-  top: 0;
-}
-.lm_stack.lm_right > .lm_header {
-  position: absolute;
-  right: 0;
-  top: 0;
-}
-.lm_stack.lm_bottom > .lm_items {
-  position: absolute;
-  bottom: 20px;
-}
-.lm_stack.lm_bottom > .lm_header {
-  position: absolute;
-  bottom: 0;
-}
-.lm_left.lm_stack .lm_header,
-.lm_right.lm_stack .lm_header {
-  height: 100%;
-}
-.lm_left.lm_dragProxy .lm_header,
-.lm_right.lm_dragProxy .lm_header,
-.lm_left.lm_dragProxy .lm_items,
-.lm_right.lm_dragProxy .lm_items {
-  float: left;
-}
-.lm_left.lm_dragProxy .lm_header,
-.lm_right.lm_dragProxy .lm_header,
-.lm_left.lm_stack .lm_header,
-.lm_right.lm_stack .lm_header {
-  width: 20px;
-  vertical-align: top;
-}
-.lm_left.lm_dragProxy .lm_header .lm_tabs,
-.lm_right.lm_dragProxy .lm_header .lm_tabs,
-.lm_left.lm_stack .lm_header .lm_tabs,
-.lm_right.lm_stack .lm_header .lm_tabs {
-  transform-origin: left top;
-  top: 0;
-  width: 1000px;
-  /*hack*/
-}
-.lm_left.lm_dragProxy .lm_header .lm_controls,
-.lm_right.lm_dragProxy .lm_header .lm_controls,
-.lm_left.lm_stack .lm_header .lm_controls,
-.lm_right.lm_stack .lm_header .lm_controls {
-  bottom: 0;
-  flex-flow: column;
-}
-.lm_dragProxy.lm_left .lm_header .lm_tabs,
-.lm_stack.lm_left .lm_header .lm_tabs {
-  transform: rotate(-90deg) scaleX(-1);
-  left: 0;
-}
-.lm_dragProxy.lm_left .lm_header .lm_tabs .lm_tab,
-.lm_stack.lm_left .lm_header .lm_tabs .lm_tab {
-  transform: scaleX(-1);
-  margin-top: 1px;
-}
-.lm_dragProxy.lm_left .lm_header .lm_tabdropdown_list,
-.lm_stack.lm_left .lm_header .lm_tabdropdown_list {
-  top: initial;
-  right: initial;
-  left: 20px;
-}
-.lm_dragProxy.lm_right .lm_content {
-  float: left;
-}
-.lm_dragProxy.lm_right .lm_header .lm_tabs,
-.lm_stack.lm_right .lm_header .lm_tabs {
-  transform: rotate(90deg) scaleX(1);
-  left: 100%;
-  margin-left: 0;
-}
-.lm_dragProxy.lm_right .lm_header .lm_controls,
-.lm_stack.lm_right .lm_header .lm_controls {
-  left: 3px;
-}
-.lm_dragProxy.lm_right .lm_header .lm_tabdropdown_list,
-.lm_stack.lm_right .lm_header .lm_tabdropdown_list {
-  top: initial;
-  right: 20px;
-}
-.lm_dragProxy.lm_bottom .lm_header,
-.lm_stack.lm_bottom .lm_header {
-  width: 100%;
-}
-.lm_dragProxy.lm_bottom .lm_header .lm_tab,
-.lm_stack.lm_bottom .lm_header .lm_tab {
-  margin-top: 0;
-  border-top: none;
-}
-.lm_dragProxy.lm_bottom .lm_header .lm_controls,
-.lm_stack.lm_bottom .lm_header .lm_controls {
-  top: 3px;
-}
-.lm_dragProxy.lm_bottom .lm_header .lm_tabdropdown_list,
-.lm_stack.lm_bottom .lm_header .lm_tabdropdown_list {
-  top: initial;
-  bottom: 20px;
-}
-.lm_drop_tab_placeholder {
-  float: left;
-  width: 100px;
-  visibility: hidden;
-}
-.lm_header .lm_controls .lm_tabdropdown:before {
-  content: '';
-  width: 0;
-  height: 0;
-  vertical-align: middle;
-  display: inline-block;
-  border-top: 5px dashed;
-  border-right: 5px solid transparent;
-  border-left: 5px solid transparent;
-  color: white;
-}
-.lm_header .lm_tabdropdown_list {
-  position: absolute;
-  top: 20px;
-  right: 0;
-  z-index: 5;
-  overflow: hidden;
-}
-.lm_header .lm_tabdropdown_list .lm_tab {
-  clear: both;
-  padding-right: 10px;
-  margin: 0;
-}
-.lm_header .lm_tabdropdown_list .lm_tab .lm_title {
-  width: 100px;
-}
-.lm_header .lm_tabdropdown_list .lm_close_tab {
-  display: none !important;
-}
-/***********************************
-* Drag Proxy
-***********************************/
-.lm_dragProxy {
-  position: absolute;
-  top: 0;
-  left: 0;
-  z-index: 30;
-}
-.lm_dragProxy .lm_header {
-  background: transparent;
-}
-.lm_dragProxy .lm_content {
-  border-top: none;
-  overflow: hidden;
-}
-.lm_dropTargetIndicator {
-  display: none;
-  position: absolute;
-  z-index: 35;
-  transition: all 200ms ease;
-}
-.lm_dropTargetIndicator .lm_inner {
-  width: 100%;
-  height: 100%;
-  position: relative;
-  top: 0;
-  left: 0;
-}
-.lm_transition_indicator {
-  display: none;
-  width: 20px;
-  height: 20px;
-  position: absolute;
-  top: 0;
-  left: 0;
-  z-index: 20;
-}
-.lm_popin {
-  width: 20px;
-  height: 20px;
-  position: absolute;
-  bottom: 0;
-  right: 0;
-  z-index: 9999;
-}
-.lm_popin > * {
-  width: 100%;
-  height: 100%;
-  position: absolute;
-  top: 0;
-  left: 0;
-}
-.lm_popin > .lm_bg {
-  z-index: 10;
-}
-.lm_popin > .lm_icon {
-  z-index: 20;
-}
-</style>`
-)};
-const _1oj1z48 = function _light_theme_css(lm_close_black,lm_popout_black,lm_maximise_black,lm_minimize_black,lm_popin_black,htl){return(
-htl.html`<style>
-.lm_goldenlayout {
-}
-.lm_content {
-  border: 1px solid #cccccc;
-}
-.lm_dragProxy .lm_content {
-  box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.2);
-}
-.lm_dropTargetIndicator {
-  box-shadow: inset 0 0 30px rgba(0, 0, 0, 0.4);
-  outline: 1px dashed #cccccc;
-}
-.lm_dropTargetIndicator .lm_inner {
-  background: #000000;
-  opacity: 0.1;
-}
-.lm_splitter {
-  background: #999999;
-  opacity: 0.001;
-  transition: opacity 200ms ease;
-}
-.lm_splitter:hover,
-.lm_splitter.lm_dragging {
-  background: #bbbbbb;
-  opacity: 1;
-}
-.lm_header {
-  height: 20px;
-}
-.lm_header .lm_tab {
-  font-family: Arial, sans-serif;
-  font-size: 12px;
-  color: var(--theme-foreground);
-  background: var(--theme-background-alt);
-  margin-right: 2px;
-  padding-bottom: 4px;
-  border: 1px solid #cccccc;
-  border-bottom: none;
-}
-.lm_header .lm_tab .lm_title {
-  padding-top: 1px;
-}
-.lm_header .lm_tab .lm_close_tab {
-  width: 11px;
-  height: 11px;
-  background-image: url(${lm_close_black});
-  background-position: center center;
-  background-repeat: no-repeat;
-  top: 4px;
-  right: 6px;
-  opacity: 0.4;
-}
-.lm_header .lm_tab .lm_close_tab:hover {
-  opacity: 1;
-}
-.lm_header .lm_tab.lm_active {
-  border-bottom: none;
-  box-shadow: 2px -2px 2px -2px rgba(0, 0, 0, 0.2);
-  padding-bottom: 5px;
-}
-.lm_header .lm_tab.lm_active .lm_close_tab {
-  opacity: 1;
-}
-.lm_dragProxy.lm_right .lm_header .lm_tab.lm_active,
-.lm_stack.lm_right .lm_header .lm_tab.lm_active {
-  box-shadow: 2px -2px 2px -2px rgba(0, 0, 0, 0.2);
-}
-.lm_dragProxy.lm_bottom .lm_header .lm_tab.lm_active,
-.lm_stack.lm_bottom .lm_header .lm_tab.lm_active {
-  box-shadow: 2px 2px 2px -2px rgba(0, 0, 0, 0.2);
-}
-.lm_selected .lm_header {
-  background: var(--theme-background);
-}
-.lm_tab:hover,
-.lm_tab.lm_active {
-  color: var(--theme-foreground-focus);
-  background: var(--theme-background);
-}
-.lm_header .lm_controls .lm_tabdropdown:before {
-  color: #000000;
-}
-.lm_controls > * {
-  position: relative;
-  background-position: center center;
-  background-repeat: no-repeat;
-  opacity: 0.4;
-  transition: opacity 300ms ease;
-}
-.lm_controls > *:hover {
-  opacity: 1;
-}
-.lm_controls .lm_popout {
-  background-image: url(${lm_popout_black});
-}
-.lm_controls .lm_maximise {
-  background-image: url(${lm_maximise_black});
-}
-.lm_controls .lm_close {
-  background-image: url(${lm_close_black});
-}
-.lm_maximised .lm_header {
-  background-color: var(--theme-background);
-}
-.lm_maximised .lm_controls .lm_maximise {
-  background-image: url(${lm_minimize_black.png});
-}
-.lm_transition_indicator {
-  background-color: var(--theme-background);
-  border: 1px dashed #555555;
-}
-.lm_popin {
-  cursor: pointer;
-}
-.lm_popin .lm_bg {
-  background: #000000;
-  opacity: 0.7;
-}
-.lm_popin .lm_icon {
-  background-image: url(${lm_popin_black});
-  background-position: center center;
-  background-repeat: no-repeat;
-  opacity: 0.7;
-}
-.lm_popin:hover .lm_icon {
-  opacity: 1;
-}
-</style>`
-)};
-const _1awu90u = function _lm_close_black(FileAttachment){return(
-FileAttachment("lm_close_black.png").url()
-)};
-const _1dbo69v = function _lm_maximise_black(FileAttachment){return(
-FileAttachment("lm_maximise_black.png").url()
-)};
-const _cuzg9g = function _lm_minimize_black(FileAttachment){return(
-FileAttachment("lm_minimize_black.png").url()
-)};
-const _a4jg2y = function _lm_popin_black(FileAttachment){return(
-FileAttachment("lm_popin_black.png").url()
-)};
-const _18kpe1x = function _lm_popout_black(FileAttachment){return(
-FileAttachment("lm_popout_black.png").url()
-)};
-const _1p7i538 = async function _gl(unzip, FileAttachment) {
-    const blob = await unzip(FileAttachment('golden-layout-2.6.0.js.gz'));
-    const objectURL = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
-    try {
-        return await import(objectURL);
-    } finally {
-        URL.revokeObjectURL(objectURL);
-    }
-};
-const _17n6uge = function _unzip(Response,DecompressionStream){return(
-async (attachment) =>
-  await new Response(
-    (await attachment.stream()).pipeThrough(new DecompressionStream("gzip"))
-  ).blob()
-)};
-
-export default function define(runtime, observer) {
-  const main = runtime.module();
-  const $def = (pid, name, deps, fn) => {
-    main.variable(observer(name)).define(name, deps, fn).pid = pid;
-  };
-  const fileAttachments = new Map(["golden-layout-2.6.0.js.gz","lm_popout_black.png","lm_close_black.png","lm_minimize_black.png","lm_popin_black.png","lm_maximise_black.png"].map((name) => {
-    const module_name = "@tomlarkworthy/golden-layout-2-6-0";
-    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
-    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
-    return [name, {url: blob_url, mimeType: mime}]
-  }));
-  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
-
-  $def("_4d16qe", null, ["md"], _4d16qe);  
-  $def("_14q4rx6", "base_css", ["htl"], _14q4rx6);  
-  $def("_1oj1z48", "light_theme_css", ["lm_close_black","lm_popout_black","lm_maximise_black","lm_minimize_black","lm_popin_black","htl"], _1oj1z48);  
-  $def("_1awu90u", "lm_close_black", ["FileAttachment"], _1awu90u);  
-  $def("_1dbo69v", "lm_maximise_black", ["FileAttachment"], _1dbo69v);  
-  $def("_cuzg9g", "lm_minimize_black", ["FileAttachment"], _cuzg9g);  
-  $def("_a4jg2y", "lm_popin_black", ["FileAttachment"], _a4jg2y);  
-  $def("_18kpe1x", "lm_popout_black", ["FileAttachment"], _18kpe1x);  
-  $def("_1p7i538", "gl", ["unzip","FileAttachment"], _1p7i538);  
-  $def("_17n6uge", "unzip", ["Response","DecompressionStream"], _17n6uge);
-  return main;
-}</script>
-
-<script id="@tomlarkworthy/import-notebook" 
-  type="text/plain"
-  data-mime="application/javascript"
->
-const _1iogq99 = function _1(md){return(
-md`# Programmatic \`importNotebook\`
-
-\`importNotebook\` is a programmatic version of \`import\`. After an export, the import becomes "baked in" and offline-first.
-
-
-Issues:-
-- Observable dependancy resolution can miss, leading to new modules which look similar but are not the same
-- Would be better to import to an isolated module, reserialize, and depend on that.
-- By the time the module is running we lost import map magic though.
-- Maybe esModuleShim can help import a module but hook the resolution. Also supports dynamic import maps.`
-)};
-const _1n7w35r = function _2(runtime){return(
-runtime._modules
-)};
-const _1kixzlo = function _3(importNotebook)
-{
-  importNotebook("@tomlarkworthy/exporter-2", [
-    {
-      imported: "exporter",
-      /* optional */ local: "exporter2"
-    }
-  ]);
-};
-const _1w278sp = function _4(md){return(
-md`The following cell demonstrate the imported cell works. Also, its the exporter dependancy so you can see that the import continues to work after export, and even offline.`
-)};
-const _1phzazj = function _5(exporter2){return(
-exporter2()
-)};
-const _1g7x12j = function _importNotebook(runtime,resolutions_key,main,md){return(
-async (notebook, specifiers = []) => {
-  runtime;
-  let fn;
-  const importKeyword = window.importShim ? "importShim" : "import";
-  for (const url of [
-    notebook,
-    `https://api.observablehq.com/${notebook}.js?v=4&${resolutions_key}`
-  ]) {
-    try {
-      fn = eval(
-        `async () => runtime.module((await ${importKeyword}("${url}")).default)`
-      );
-      await fn();
-      break;
-    } catch {}
-  }
-  if (!fn) throw `Can't resolve ${notebook}`;
-
-  const module_variable = `module ${notebook}`;
-
-  if (!main._scope.has(module_variable)) {
-    main.define(module_variable, fn);
-  }
-
-  for (let { imported, local = null } of specifiers) {
-    if (!local) local = imported;
-    if (!main._scope.has(local)) {
-      main.define(local, [module_variable, "@variable"], (_, v) =>
-        v.import(imported, local, _)
-      );
-    } else {
-      main.redefine(local, [module_variable, "@variable"], (_, v) =>
-        v.import(imported, local, _)
-      );
-    }
-  }
-
-  return md`~~~js
-importNotebook("${notebook}", ${JSON.stringify(specifiers)})
-~~~`;
-}
-)};
-const _huzc31 = function _resolutions_key(isOnObservableCom,runtime)
-{
-  if (isOnObservableCom()) {
-    for (let v of runtime._variables) {
-      let match;
-      if (
-        v._value?._scope &&
-        (match = /(resolutions=[a-f0-9]+@\d+)/.exec(v._definition.toString()))
-      ) {
-        return match[1];
-      }
-    }
-  }
-};
-
-export default function define(runtime, observer) {
-  const main = runtime.module();
-  const $def = (pid, name, deps, fn) => {
-    main.variable(observer(name)).define(name, deps, fn).pid = pid;
-  };
-
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
-  $def("_1iogq99", null, ["md"], _1iogq99);  
-  $def("_1n7w35r", null, ["runtime"], _1n7w35r);  
-  $def("_1kixzlo", null, ["importNotebook"], _1kixzlo);  
-  $def("_1w278sp", null, ["md"], _1w278sp);  
-  $def("_1phzazj", null, ["exporter2"], _1phzazj);  
-  $def("_1g7x12j", "importNotebook", ["runtime","resolutions_key","main","md"], _1g7x12j);  
-  $def("_huzc31", "resolutions_key", ["isOnObservableCom","runtime"], _huzc31);  
-  main.define("keepalive", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("keepalive", _));  
-  main.define("thisModule", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("thisModule", _));  
-  main.define("isOnObservableCom", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("isOnObservableCom", _));  
-  main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
-  main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));
-  return main;
-}</script>
 <script id="@tomlarkworthy/inspector/inspector-5%401.0.1.js.gz" 
   type="text/plain"
   data-encoding="base64"
@@ -11861,6 +13570,146 @@ export default function define(runtime, observer) {
   $def("_g5fwfs", "unzip", ["Response","DecompressionStream"], _g5fwfs);  
   $def("_1u9tn3v", "Inspector", ["src","require"], _1u9tn3v);  
   $def("_b5ui8y", "isnode", ["Element","Text"], _b5ui8y);
+  return main;
+}</script>
+
+<script id="@tomlarkworthy/invoke-variable" 
+  type="text/plain"
+  data-mime="application/javascript"
+>
+const _zkje0r = function _1(md){return(
+md`# \`invokeVariable(<name>, <module>, overrides = {})\`
+
+Test individual variables by calling them with injected values. Lets you test different scenarios without changing your core logic. Pairs with [@tomlarkworthy/tester](https://observablehq.com/@tomlarkworthy/tester)`
+)};
+const _swiym2 = function _invokeVariable(lookupVariable)
+{
+  return async function invokeVariable(name, module, overrides = {}) {
+    if (overrides == null || typeof overrides !== 'object')
+      throw new TypeError('invokeVariable(name, module, {overrides}): overrides must be an object');
+    // Accept a Variable reference directly as the first arg (skip the lookupVariable stall when
+    // the caller already holds it); otherwise resolve by (name, module).
+    let variable;
+    if (name && typeof name === 'object' && typeof name._definition !== 'undefined') {
+      variable = name;
+      module = module ?? variable._module;
+    } else {
+      if (typeof name !== 'string' || !name.length)
+        throw new TypeError('invokeVariable(name, module, \u2026): name must be a non-empty string');
+      if (!module)
+        throw new TypeError('invokeVariable(name, module, \u2026): module is required');
+      variable = await lookupVariable(name, module);
+      if (!variable)
+        throw new Error(`invokeVariable: variable "${ name }" not found in module`);
+    }
+    module = module ?? variable._module;
+    const label = variable._name ?? (typeof name === 'string' ? name : '(anonymous)');
+    const inputs = Array.isArray(variable._inputs) ? variable._inputs : [];
+    const inputNames = inputs.map(v => v?._name);
+    for (const k of Object.keys(overrides)) {
+      if (!inputNames.includes(k)) {
+        throw new Error(`invokeVariable("${ label }"): override "${ k }" was provided but is not a declared dependency. Declared dependencies: ${ inputNames.filter(Boolean).join(', ') }`);
+      }
+    }
+    const hasOwn = (o, k) => Object.prototype.hasOwnProperty.call(o, k);
+    const resolveDependency = async depName => {
+      if (hasOwn(overrides, depName))
+        return overrides[depName];
+      const scopeVar = module?._scope?.get?.(depName) ?? module?._runtime?._builtin?._scope?.get?.(depName);
+      if (scopeVar) {
+        if (scopeVar._value !== undefined)
+          return scopeVar._value;
+        if (scopeVar._promise && typeof scopeVar._promise?.then === 'function')
+          return await scopeVar._promise;
+      }
+      if (typeof module?.value === 'function') {
+        try {
+          return await module.value(depName);
+        } catch (e) {
+        }
+      }
+      if (module?._runtime && typeof module._runtime._global === 'function') {
+        try {
+          const g = module._runtime._global(depName);
+          if (g !== undefined)
+            return g;
+        } catch (e) {
+        }
+      }
+      throw new Error(`invokeVariable("${ label }"): could not resolve dependency "${ depName }" (no override and not found in module/builtins/global)`);
+    };
+    const args = [];
+    for (const dep of inputs) {
+      const depName = dep?._name;
+      if (!depName) {
+        args.push(undefined);
+        continue;
+      }
+      args.push(await resolveDependency(depName));
+    }
+    const def = variable._definition;
+    if (typeof def !== 'function') {
+      throw new Error(`invokeVariable("${ label }"): target variable does not have an invokable function definition`);
+    }
+    return def(...args);
+  };
+};
+const _jtrr9m = function _3(md){return(
+md`### Example
+
+let c = a + b`
+)};
+const _1v2c0s1 = function _a(){return(
+1
+)};
+const _ywl8oh = function _b(){return(
+3
+)};
+const _1mc3tpl = function _c(a,b){return(
+a + b
+)};
+const _o5e50u = function _7(md){return(
+md`If we invoke c without any overrides we get the notebook behaviour (i.e. the answer is 4, as a is 1 and b is 3)`
+)};
+const _tnoyf9 = function _8(invokeVariable,invokeVariableModule){return(
+invokeVariable("c", invokeVariableModule)
+)};
+const _smh5by = function _9(md){return(
+md`But we can set b to 20, and then we get the answer 21.`
+)};
+const _d996jo = function _10(invokeVariable,invokeVariableModule){return(
+invokeVariable("c", invokeVariableModule, { b: 20 })
+)};
+const _qh0yhm = function _11(md){return(
+md`To call invokeVariable we need a reference to the module, which we can obtain with thisModule() (see runtime-sdk)`
+)};
+const _1hy0qcz = function _invokeVariableModule(thisModule){return(
+thisModule()
+)};
+const _jno7wc = (G, _) => G.input(_);
+
+export default function define(runtime, observer) {
+  const main = runtime.module();
+  const $def = (pid, name, deps, fn) => {
+    main.variable(observer(name)).define(name, deps, fn).pid = pid;
+  };
+
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  $def("_zkje0r", null, ["md"], _zkje0r);  
+  $def("_swiym2", "invokeVariable", ["lookupVariable"], _swiym2);  
+  $def("_jtrr9m", null, ["md"], _jtrr9m);  
+  $def("_1v2c0s1", "a", [], _1v2c0s1);  
+  $def("_ywl8oh", "b", [], _ywl8oh);  
+  $def("_1mc3tpl", "c", ["a","b"], _1mc3tpl);  
+  $def("_o5e50u", null, ["md"], _o5e50u);  
+  $def("_tnoyf9", null, ["invokeVariable","invokeVariableModule"], _tnoyf9);  
+  $def("_smh5by", null, ["md"], _smh5by);  
+  $def("_d996jo", null, ["invokeVariable","invokeVariableModule"], _d996jo);  
+  $def("_qh0yhm", null, ["md"], _qh0yhm);  
+  $def("_1hy0qcz", "viewof invokeVariableModule", ["thisModule"], _1hy0qcz);  
+  $def("_jno7wc", "invokeVariableModule", ["Generators","viewof invokeVariableModule"], _jno7wc);  
+  main.define("lookupVariable", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("lookupVariable", _));  
+  main.define("thisModule", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("thisModule", _));
   return main;
 }</script>
 <script id="@tomlarkworthy/isomorphic-git-1-30-1/isomorphic-git-1%401.30.1.bundle.js.gz" 
@@ -14230,1640 +16079,6 @@ export default function define(runtime, observer) {
   return main;
 }</script>
 
-<script id="@tomlarkworthy/lopepage" 
-  type="text/plain"
-  data-mime="application/javascript"
->
-const _1xyxga0 = function _page(htl,isOnObservableCom,lopeviz_handle_css,base_css,light_theme_css,commandPaletteStyles,commandPaletteOverlay,linkTo){return(
-htl.html`<div id="lopepage" style="height: ${
-  isOnObservableCom() ? "800px" : "100vh"
-}">
-  ${lopeviz_handle_css}
-  ${base_css}
-  ${light_theme_css}
-  ${commandPaletteStyles}
-${commandPaletteOverlay}
-  <style>
-    html body {
-      max-width: 100vw;
-    }
-    html {
-      padding: 0px !important;
-      margin: 0px !important;
-    }
-    #lopepage:has(.observablehq-root) > .module-explorer {
-      display: none;
-    }
-  </style>
-  <h1 style="display:none;">Lopepage</h1>
-  <div class="module-explorer">
-    <p>Lost? Open the <a href="${linkTo("@tomlarkworthy/module-selection", {
-      onObservable: false
-    })}">module explorer</a> or press CMD + K to open the command palatte.
-  </div>
-</div>`
-)};
-const _1ujnhdh = function _append_to_body(page)
-{
-    // If exported in headless mode, this will attach the page
-    if (!page.isConnected) {
-        document.body.appendChild(page);
-    }
-};
-const _1nv51s8 = function _testNavigation(htl,linkTo){return(
-htl.html`<h2>Manual Testing links</h2>
-<ul>
-<li><a href="https://observablehq.com/@tomlarkworthy/lopepage#testNavigation">refresh page</a></li>
-<li><a href="#testNavigation">reset view</a></li>
-<li><a href="${ linkTo('@tomlarkworthy/stream-operators', { onObservable: false }) }">stream-operators</a> module</li>
-<li><a href="${ linkTo('@tomlarkworthy/stream-operators#combineLatest', { onObservable: false }) }">stream-operators#combineLatest</a> 
-<li><a href="${ linkTo('@tomlarkworthy/runtime-sdk#observe', { onObservable: false }) }">runtime-sdk#observe</a> cell</li>
-</ul>`
-)};
-const _ydvyos = function _reload(Inputs){return(
-Inputs.button('reload')
-)};
-const _1we0ggl = (G, _) => G.input(_);
-const _plefwg = function _onLoadConfig(parseGoldenDSL,URLSearchParams,location)
-{
-    try {
-        return parseGoldenDSL(new URLSearchParams(location.hash.substring(1)).get('view'));
-    } catch (err) {
-        return undefined;
-    }
-};
-const _1nzpnqy = function _visualizer_cache(reload)
-{
-    reload;
-    return new Map();
-};
-const _1ojown8 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
-{
-  return function (container, component) {
-    appendScrollLog('modulePanel:enter', {
-      title: container?.title ?? null,
-      componentCell: component?.cell ?? null
-    });
-    const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
-    if (!moduleInfo) {
-      // Fall through to file attachment: titles like @user/notebook/path.ext
-      // resolve via the lopecode bootloader's contentSync DOM lookup.
-      const title = container?.title ?? null;
-      if (title) {
-        let node = file_attachment_cache.get(title);
-        if (!node) {
-          const r = window.lopecode?.contentSync?.(title);
-          if (r && r.status === 200 && r.bytes) {
-            node = renderFileAttachment(r.mime, r.bytes);
-            file_attachment_cache.set(title, node);
-            appendScrollLog('modulePanel:file_attachment_create', {
-              title,
-              mime: r.mime
-            });
-          }
-        }
-        if (node) {
-          const c_element = container.getElement();
-          if (node.parentNode !== c_element)
-            c_element.appendChild(node);
-          appendScrollLog('modulePanel:file_attachment_mount', { title });
-          return;
-        }
-      }
-      appendScrollLog('modulePanel:missing_moduleInfo', { title });
-      return;
-    }
-    const module = moduleInfo.module;
-    let node;
-    if (!visualizer_cache.has(module)) {
-      appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
-      node = visualizer(runtime, {
-        invalidation: new Promise(r => {
-        }),
-        module,
-        detachNodes: isOnObservableCom(),
-        filter: (cell_name, variables) => {
-          if (variables[0]._type !== 1)
-            return false;
-          if (typeof cell_name == 'string') {
-            if (cell_name.startsWith('dynamic '))
-              return false;
-          }
-          return true;
-        }
-      });
-      visualizer_cache.set(module, node);
-    } else {
-      node = visualizer_cache.get(module);
-      appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
-    }
-    const cell = module._scope.get(component.cell);
-    const scrollKey = scrollKeyFor(container);
-    fix_scroll(container, node, cell, scrollKey);
-    const el = container.getElement();
-    if (!el.__lope_scroll_bound) {
-      el.__lope_scroll_bound = true;
-      appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
-      const markUserScroll = () => {
-        el.__lope_user_scroll_at = Date.now();
-      };
-      el.addEventListener('wheel', markUserScroll, { passive: true });
-      el.addEventListener('touchmove', markUserScroll, { passive: true });
-      el.addEventListener('keydown', markUserScroll, { passive: true });
-      el.addEventListener('scroll', () => {
-        if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
-          appendScrollLog('scroll:skip_reflow', { title: container?.title ?? null });
-          return;
-        }
-        // Only cache scrolls following a genuine user gesture; reflow-induced
-        // scroll events (e.g. closing an adjacent panel) carry stale scrollTops.
-        if (Date.now() - (el.__lope_user_scroll_at || 0) > 400) {
-          appendScrollLog('scroll:skip_nonuser', { title: container?.title ?? null });
-          return;
-        }
-        const k = scrollKeyFor(container);
-        const scrollTop = el.scrollTop;
-        const scrollLeft = el.scrollLeft;
-        if (scrollTop == 0) {
-          appendScrollLog('modulePanel:skip 0 scroll', {
-            title: container?.title ?? null,
-            scrollKey
-          });
-          return;
-        }
-        scroll_cache.set(k, {
-          scrollTop,
-          scrollLeft,
-          t: Date.now()
-        });
-        appendScrollLog('scroll:event', {
-          k,
-          title: container?.title ?? null,
-          scrollTop,
-          scrollLeft
-        });
-      }, { passive: true });
-    }
-    // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
-    if (!container.__lope_destroy_bound) {
-      container.__lope_destroy_bound = true;
-      container.on('destroy', () => {
-        try {
-          if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
-            appendScrollLog('scroll:destroy_skip_reflow', { title: container?.title ?? null });
-            return;
-          }
-          const k = scrollKeyFor(container);
-          const scrollTop = el?.scrollTop;
-          const scrollLeft = el?.scrollLeft;
-          if (scrollTop == 0) {
-            appendScrollLog('scroll:skip 0 scroll', {
-              k,
-              key: container?.title ?? null,
-              scrollKey
-            });
-            return;
-          }
-          // do not skip 0 here: if the user is at top, preserve that state
-          scroll_cache.set(k, {
-            scrollTop,
-            scrollLeft,
-            t: Date.now()
-          });
-          appendScrollLog('scroll:destroy_capture', {
-            k,
-            title: container?.title ?? null,
-            scrollTop,
-            scrollLeft
-          });
-        } catch (e) {
-          appendScrollLog('scroll:destroy_capture:error', {
-            title: container?.title ?? null,
-            error: String(e)
-          });
-        }
-      });
-    }
-    // When GoldenLayout resizes this panel (e.g. an adjacent panel is closed) the
-    // browser can shift scrollTop; re-apply the user's cached position after the reflow.
-    if (!container.__lope_resize_bound) {
-      container.__lope_resize_bound = true;
-      container.on('resize', () => {
-        const rk = scrollKeyFor(container);
-        const cached = scroll_cache.get(rk);
-        if (!cached || cached.scrollTop == null)
-          return;
-        const c_el = container.getElement();
-        const at = Date.now();
-        scroll_cache.__reflowUntil = at + 800;
-        // The reflow can shift scrollTop in several passes (content relayout
-        // settles ~300ms later), so re-apply over a window. Bail if the user scrolls.
-        const apply = () => {
-          if ((c_el.__lope_user_scroll_at || 0) > at)
-            return;
-          if (c_el.scrollTop !== cached.scrollTop)
-            c_el.scrollTop = cached.scrollTop;
-          if (cached.scrollLeft != null && c_el.scrollLeft !== cached.scrollLeft)
-            c_el.scrollLeft = cached.scrollLeft;
-        };
-        requestAnimationFrame(apply);
-        for (const d of [
-            60,
-            150,
-            300,
-            450,
-            600
-          ])
-          setTimeout(apply, d);
-        appendScrollLog('scroll:resize_restore', {
-          k: rk,
-          title: container?.title ?? null,
-          scrollTop: cached.scrollTop
-        });
-      });
-    }
-    appendScrollLog('modulePanel:exit', {
-      title: container?.title ?? null,
-      scrollKey
-    });
-  };
-};
-const _1gm4gbf = function _blobPanel(){return(
-function (container, component) {
-    const node = document.createElement('iframe');
-    node.src = component.url;
-    const c_element = container.getElement();
-    const element = c_element.appendChild(node);
-}
-)};
-const _lxv2e2 = function _settings(){return(
-{
-    showMaximiseIcon: false,
-    showPopoutIcon: false,
-    showCloseIcon: true,
-    hasHeaders: true
-}
-)};
-const _lp1ggk = function _is_mobile(width){return(
-width < 800
-)};
-const _qbghwu = function _config(onLoadConfig,settings)
-{
-    if (onLoadConfig) {
-        return {
-            settings: settings,
-            content: [onLoadConfig]
-        };
-    }
-    return { settings: settings };
-};
-const _15lk82w = (M, _) => new M(_);
-const _1bki6eh = _ => _.generator;
-const _14z0bay = function _resize(Generators,addEventListener,invalidation,removeEventListener){return(
-Generators.observe(notify => {
-    notify(undefined);
-    addEventListener('resize', notify);
-    invalidation.then(() => removeEventListener('resize', notify));
-})
-)};
-const _18jv72h = function _layout(resize,gl,$0,page,modulePanel,blobPanel)
-{
-    // Removed resizing re-laying out because it causes problems with components that watch focus
-    // when the the layout is redone, the components are killed and removed, damaging focus state.
-    // mobile keyboards cause a resize, breaking the component that has focus
-    resize;
-    let layout = this;
-    if (!layout) {
-        layout = new gl.GoldenLayout($0.value, page);
-        layout.registerComponent('module', modulePanel);
-        layout.registerComponent('blob', blobPanel);
-        layout.init();
-    } else {
-        layout.updateSize();
-    }
-    // TODO layout destroy is destructive
-    // invalidation.then(() => {
-    //   // avoid layouts stacking up
-    //   layout.destroy();
-    // });
-    return layout;
-};
-const _tsjb2x = function _layout_state(appendScrollLog,layout,gl,$0)
-{
-    appendScrollLog('layout_state:bind', { hasLayout: !!layout });
-    return layout.on('stateChanged', () => {
-        appendScrollLog('layout:stateChanged', {});
-        const state = gl.LayoutConfig.fromResolved(layout.toConfig());
-        $0.value = state;
-        appendScrollLog('layout:stateChanged:config_updated', { rootType: state?.root?.type ?? null });
-    });
-};
-const _11nrwvj = function _lopepageModule(thisModule){return(
-thisModule()
-)};
-const _r97569 = (G, _) => G.input(_);
-const _1sp5wo4 = function _16(md){return(
-md`## Scrolling
-
-Scrolling has been a mess to develop. The thing that finally fixed it was \`scroll_fix_sync_layout\`. I suspect fix_scroll is over-complex.`
-)};
-const _1ts23ma = function _scrollDebug(Inputs){return(
-Inputs.toggle({
-    label: 'enable debug scroll?',
-    value: true
-})
-)};
-const _7jxivy = (G, _) => G.input(_);
-const _1f2wuqm = function _appendScrollLog($0,$1){return(
-(type, detail = {}) => {
-    if (!$0.value)
-        return null;
-    const evt = {
-        t: Date.now(),
-        type: String(type),
-        ...detail
-    };
-    $1.value = ($1.value || []).concat([evt]);
-    return evt;
-}
-)};
-const _1nbnzwx = function _scrollLog(scrollDebug){return(
-scrollDebug ? [] : []
-)};
-const _1f7xtz1 = (M, _) => new M(_);
-const _1dyz4o0 = _ => _.generator;
-const _1d1nkw9 = function _scrollKeyFor(appendScrollLog)
-{
-    return container => {
-        // can return undefined if the container is loading still
-        const key = container?.title;
-        appendScrollLog('scrollKeyFor:', { key });
-        return key;
-    };
-};
-const _tb217h = function _scroll_cache(){return(
-new Map()
-)};
-const _12p8mg7 = function _fix_scroll(scroll_cache,scrollKeyFor,appendScrollLog)
-{
-  return function (container, node, cell_variable, key) {
-    scroll_cache.__reflowUntil = Date.now() + 600;
-    // suppress reflow-induced scroll events that clobber the cache
-    const c_element = container.getElement();
-    let k = scrollKeyFor(container);
-    appendScrollLog('fix_scroll:enter', {
-      title: container?.title ?? null,
-      k,
-      cell: cell_variable?._name ?? null
-    });
-    if (node && node.parentNode !== c_element) {
-      c_element.appendChild(node);
-      appendScrollLog('fix_scroll:append_node', {
-        title: container?.title ?? null,
-        k
-      });
-    }
-    const writeCache = (scrollTop, scrollLeft, why) => {
-      scroll_cache.set(k, {
-        scrollTop,
-        scrollLeft,
-        t: Date.now()
-      });
-      appendScrollLog('scroll_cache:write', {
-        k,
-        scrollTop,
-        scrollLeft,
-        why
-      });
-    };
-    const scrollToCellIfPossible = why => {
-      if (!cell_variable)
-        return false;
-      const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
-      if (!dom) {
-        appendScrollLog('scroll:cell_dom_not_found', {
-          k,
-          why,
-          cell: cell_variable?._name ?? null
-        });
-        return false;
-      }
-      const top = dom.offsetTop - c_element.offsetTop;
-      const left = c_element.scrollLeft;
-      c_element.scrollTop = top;
-      appendScrollLog('scroll:set', {
-        k,
-        why: `${ why }:cell`,
-        scrollTop: top,
-        scrollLeft: left,
-        cell: cell_variable?._name ?? null
-      });
-      writeCache(top, left, `${ why }:cell`);
-      return true;
-    };
-    const restoreFromCache = why => {
-      k = scrollKeyFor(container);
-      const cached = scroll_cache.get(k);
-      appendScrollLog('scroll:restore_attempt', {
-        k,
-        why,
-        cachedScrollTop: cached?.scrollTop ?? null,
-        cachedScrollLeft: cached?.scrollLeft ?? null
-      });
-      if (!cached) {
-        appendScrollLog('scroll:restore_no_scroll', {
-          k,
-          why
-        });
-        return;
-      }
-      if (cached.scrollTop != null)
-        c_element.scrollTop = cached.scrollTop;
-      if (cached.scrollLeft != null)
-        c_element.scrollLeft = cached.scrollLeft;
-      appendScrollLog('scroll:restore_applied', {
-        k,
-        why,
-        scrollTop: cached.scrollTop ?? null,
-        scrollLeft: cached.scrollLeft ?? null,
-        scrollTopFinal: c_element.scrollTop,
-        scrollLeftFinal: c_element.scrollLeft
-      });
-    };
-    const setScroll = (why = 'setScroll') => {
-      if (scrollToCellIfPossible(why))
-        return;
-      restoreFromCache(why);
-    };
-    const retryFrames = 6;
-    for (let i = 0; i < retryFrames; i++) {
-      requestAnimationFrame(() => {
-        k = scrollKeyFor(container);
-        appendScrollLog('fix_scroll:raf_retry', {
-          i,
-          k,
-          title: container?.title ?? null
-        });
-        setScroll(`raf:${ i }`);
-      });
-    }
-    appendScrollLog('fix_scroll:exit', {
-      k,
-      title: container?.title ?? null
-    });
-  };
-};
-const _arfw00 = function _scroll_fix_sync_layout(sync_layout_to_url,layout,appendScrollLog,modulePanel)
-{
-    sync_layout_to_url;
-    let timeout = null;
-    const listComponentItems = () => {
-        const out = [];
-        const walk = item => {
-            if (!item)
-                return;
-            if (item.isComponent || item.type === 'component')
-                out.push(item);
-            const kids = item.contentItems || item.content || [];
-            for (const k of kids)
-                walk(k);
-        };
-        walk(layout.root);
-        return out;
-    };
-    const items = listComponentItems();
-    appendScrollLog('scroll:reapply_all:begin', { count: items.length });
-    for (const it of items) {
-        try {
-            const container = it.container;
-            const title = container?.title ?? it.title ?? null;
-            if (!container || !title)
-                continue;
-            const st = it.componentState ?? it.config?.componentState ?? it._config?.componentState ?? it._state ?? {};
-            modulePanel(container, { cell: st?.cell });
-        } catch (e) {
-            appendScrollLog('scroll:reapply_all:error', { error: String(e) });
-        }
-    }
-    return true;
-};
-const _3nwpp4 = function _URLrouting(md){return(
-md`## URL Sync
-
-### Goals
-1. **Non-destructive navigation:** mutate an existing GoldenLayout (GL) instance (add/remove/reorder items) rather than rebuilding.
-2. **Refresh restores what you see:** the URL eventually contains the full serialized GL tree in **\`view=\`**.
-3. **Links are “intents”:** in-app links should not rewrite \`view=\` at click time.
-
----
-
-## State model
-
-### Canonical, persistent state
-- **\`view=<DSL>\`** is the canonical serialized GL layout (single source of truth after boot).
-
-### One-shot intent params (cleared after commit)
-- \`open=<moduleOrModule#cell>\`
-- \`close=<...>\` (reserved)
-- \`focus=<...>\` (reserved)
-- \`from=<module>\` (optional placement hint)
-
----
-
-## Dataflow
-
-### 1) URL → desired layout (intent overlay)
-- Parse \`view\` with \`parseGoldenDSL\` to get the desired root config.
-- If \`open=\` exists, **overlay** it into the parsed config by inserting the target module into the *first stack* (and optional \`componentState.cell\`).
-
-Implemented in: **\`sync_layout_from_url\`**.
-
-### 2) Desired layout → live GL (non-destructive when possible)
-- Try **\`treeSyncGolden(layout, desiredRoot)\`** to:
-  - add missing module tabs
-  - remove extra module tabs
-  - reorder tabs to match the DSL
-  - ensure container shapes (row/column/stack) match where possible
-- If tree sync can’t reconcile safely, **fallback to \`layout.loadLayout(...)\`**.
-
-Implemented in: **\`treeSyncGolden\`** + \`sync_layout_from_url\`.
-
-### 3) Live GL → URL persistence (“commit then clear”)
-- GL emits \`stateChanged\` → update \`mutable config\` from \`layout.toConfig()\`.
-- Serialize \`config.root\` with \`serializeGoldenDSL\` and write it to **\`view=\`**.
-- Clear one-shot intent params (\`open/close/focus/from\`) so they are not re-applied on refresh.
-
-Implemented in: **\`sync_layout_to_url\`** via \`history.replaceState(...)\`.
-
----
-
-## Unit test gate (safety check)
-Before \`sync_layout_to_url\` is allowed to persist \`view=\`, a **roundtrip invariant** must hold:
-
-- Compute an expected “pre” DSL:
-  - normalize weights (e.g. S100/R100/C100)
-  - apply the same \`open=\` overlay used by \`sync_layout_from_url\`
-- Compare it to the “post” DSL obtained after applying the URL to the live layout and re-serializing.
-
-If **\`test_url_roundtrip\`** throws or returns non-\`true\`, **\`sync_layout_to_url\`** exits early (no canonical \`view=\` writes). This prevents committing a drifting/incorrect \`view=\` during development and makes URL persistence self-checking.
-
-Implemented in: **\`test_url_roundtrip\`** and enforced at the top of **\`sync_layout_to_url\`**.
-`
-)};
-const _14te9pl = function _sync_layout_from_url(reload,resize,URLSearchParams,hash,appendScrollLog,parseGoldenDSL,gl,layout,serializeGoldenDSL,treeSyncGolden,invalidation)
-{
-  reload;
-  resize;
-  const params = new URLSearchParams(String(hash || '').replace(/^#/, ''));
-  const view = params.get('view');
-  const open = params.get('open');
-  appendScrollLog('url:sync_from:begin', {
-    hash: String(hash || ''),
-    view,
-    open
-  });
-  const diag = {
-    preURL: view ?? null,
-    postURL: null,
-    method: null,
-    status: 'skipped',
-    reason: '',
-    error: null,
-    open: null,
-    openApplied: false
-  };
-  let desiredRoot;
-  try {
-    desiredRoot = parseGoldenDSL(view);
-  } catch (e) {
-    diag.method = 'parse';
-    diag.status = 'error';
-    diag.reason = 'parseGoldenDSL failed';
-    diag.error = String(e);
-    appendScrollLog('url:sync_from:error', {
-      where: 'parse',
-      error: diag.error
-    });
-    return diag;
-  }
-  if (!view && open) {
-    try {
-      const resolved = gl.LayoutConfig.fromResolved(layout.toConfig());
-      desiredRoot = resolved?.root ?? layout.toConfig()?.root ?? layout.toConfig()?.content?.[0];
-      if (desiredRoot) {
-        diag.preURL = serializeGoldenDSL(desiredRoot);
-        appendScrollLog('url:sync_from:fallback_to_current_layout', {
-          preURL: diag.preURL,
-          open
-        });
-      }
-    } catch (e) {
-      appendScrollLog('url:sync_from:fallback_to_current_layout:error', { error: String(e) });
-    }
-    if (!desiredRoot) {
-      // Lazily synthesize an empty stack so the open overlay below can populate it.
-      desiredRoot = {
-        type: 'stack',
-        content: []
-      };
-      try {
-        diag.preURL = serializeGoldenDSL(desiredRoot);
-      } catch {
-        diag.preURL = 'S100()';
-      }
-      appendScrollLog('url:sync_from:synthesize_empty_stack', {
-        preURL: diag.preURL,
-        open
-      });
-    }
-  }
-  if (!desiredRoot) {
-    diag.method = 'parse';
-    diag.status = 'error';
-    diag.reason = 'parseGoldenDSL returned falsy';
-    appendScrollLog('url:sync_from:error', {
-      where: 'parse',
-      error: diag.reason
-    });
-    return diag;
-  }
-  const findFirstStack = node => {
-    if (!node)
-      return null;
-    if (node.type === 'stack')
-      return node;
-    for (const c of node.content || []) {
-      const f = findFirstStack(c);
-      if (f)
-        return f;
-    }
-    return null;
-  };
-  const findExistingModule = (node, title) => {
-    if (!node)
-      return null;
-    if (node.type === 'component' && (node.componentType === 'module' || node.componentName === 'module') && node.title === title) {
-      return node;
-    }
-    for (const c of node.content || []) {
-      const f = findExistingModule(c, title);
-      if (f)
-        return f;
-    }
-    return null;
-  };
-  if (open) {
-    const [moduleTitleRaw, cellRaw] = String(open).split('#');
-    const moduleTitle = (moduleTitleRaw || '').trim();
-    const cell = (cellRaw || '').trim() || null;
-    if (moduleTitle) {
-      diag.open = {
-        moduleTitle,
-        cell
-      };
-      const existingAnywhere = findExistingModule(desiredRoot, moduleTitle);
-      if (existingAnywhere) {
-        existingAnywhere.componentState = existingAnywhere.componentState || {};
-        if (cell)
-          existingAnywhere.componentState.cell = cell;
-        appendScrollLog('url:sync_from:overlay_open:update_existing', {
-          moduleTitle,
-          cell
-        });
-        diag.openApplied = true;
-      } else {
-        const stack = findFirstStack(desiredRoot);
-        if (stack) {
-          stack.content = stack.content || [];
-          stack.content.push({
-            type: 'component',
-            title: moduleTitle,
-            componentType: 'module',
-            componentName: 'module',
-            componentState: cell ? { cell } : {}
-          });
-          appendScrollLog('url:sync_from:overlay_open:add', {
-            moduleTitle,
-            cell
-          });
-          diag.openApplied = true;
-        } else {
-          appendScrollLog('url:sync_from:overlay_open:no_stack_found', {
-            moduleTitle,
-            cell
-          });
-        }
-      }
-    }
-  }
-  const doLoadLayout = () => {
-    if (typeof layout?.loadLayout !== 'function')
-      throw new Error('layout.loadLayout not available');
-    appendScrollLog('layout:loadLayout:call', {
-      desiredType: desiredRoot?.type ?? null,
-      open: diag.open?.moduleTitle ?? null
-    });
-    layout.loadLayout({
-      settings: {},
-      content: [desiredRoot]
-    });
-  };
-  try {
-    const res = treeSyncGolden(layout, desiredRoot);
-    if (res?.status === 'fallback') {
-      diag.method = 'loadLayout';
-      diag.status = 'fallback';
-      diag.reason = res.reason || 'treeSync requested fallback';
-      appendScrollLog('url:sync_from:treesync_fallback', { reason: diag.reason });
-      try {
-        doLoadLayout();
-      } catch (e2) {
-        diag.status = 'error';
-        diag.reason = 'loadLayout failed after treeSync fallback';
-        diag.error = String(e2);
-        appendScrollLog('url:sync_from:error', {
-          where: 'loadLayout_after_fallback',
-          error: diag.error
-        });
-      }
-    } else {
-      diag.method = 'treeSync';
-      diag.status = 'synced';
-      appendScrollLog('url:sync_from:treesync_ok', {});
-    }
-  } catch (e) {
-    diag.method = 'loadLayout';
-    diag.status = 'fallback';
-    diag.reason = 'exception during treeSync';
-    diag.error = String(e);
-    appendScrollLog('url:sync_from:treesync_exception', { error: diag.error });
-    try {
-      doLoadLayout();
-    } catch (e2) {
-      diag.status = 'error';
-      diag.reason = 'loadLayout failed after treeSync exception';
-      diag.error = `${ String(e) }; loadLayout: ${ String(e2) }`;
-      appendScrollLog('url:sync_from:error', {
-        where: 'loadLayout_after_exception',
-        error: diag.error
-      });
-    }
-  }
-  try {
-    const resolved = gl?.LayoutConfig?.fromResolved ? gl.LayoutConfig.fromResolved(layout.toConfig()) : null;
-    const root = resolved?.root ?? layout.toConfig()?.root ?? layout.toConfig()?.content?.[0];
-    diag.postURL = root ? serializeGoldenDSL(root) : null;
-  } catch (e) {
-    diag.postURL = null;
-    if (!diag.error)
-      diag.error = `serialize failed: ${ String(e) }`;
-    appendScrollLog('url:sync_from:serialize_failed', { error: String(e) });
-  }
-  appendScrollLog('url:sync_from:end', {
-    status: diag.status,
-    method: diag.method,
-    reason: diag.reason || null,
-    preURL: diag.preURL,
-    postURL: diag.postURL
-  });
-  invalidation.then(() => {
-  });
-  return diag;
-};
-const _1l50a0d = function _sync_layout_to_url(appendScrollLog,sync_layout_from_url,config,test_url_roundtrip,serializeGoldenDSL,location,setHashURL)
-{
-    appendScrollLog('url:sync_to:tick', {
-        fromStatus: sync_layout_from_url?.status ?? null,
-        hasRoot: !!config?.root
-    });
-    if (test_url_roundtrip !== true) {
-        appendScrollLog('url:sync_to:blocked', { reason: 'test_url_roundtrip != true' });
-        return;
-    }
-    if (sync_layout_from_url?.status === 'error') {
-        appendScrollLog('url:sync_to:blocked', { reason: 'sync_layout_from_url status=error' });
-        return;
-    }
-    if (!config?.root) {
-        appendScrollLog('url:sync_to:blocked', { reason: 'config.root missing' });
-        return;
-    }
-    let dsl;
-    try {
-        dsl = serializeGoldenDSL(config.root);
-    } catch (e) {
-        appendScrollLog('url:sync_to:serialize_failed', { error: String(e) });
-        return;
-    }
-    // Parse hash manually to avoid URLSearchParams percent-encoding view= values
-    // like R100(S50(@tomlarkworthy/lopepage)) → R100%28S50%28%40tomlarkworthy%2Flopepage%29%29
-    const rawHash = String(location.hash || '').replace(/^#/, '');
-    const knownIntents = new Set([
-        'open',
-        'close',
-        'focus',
-        'from'
-    ]);
-    // Split into key=value pairs, preserving original encoding
-    const parts = rawHash.split('&').filter(Boolean);
-    const extra = [];
-    // unknown params to preserve (e.g. cc=TOKEN)
-    let currentView = null;
-    let hasIntent = false;
-    for (const part of parts) {
-        const eq = part.indexOf('=');
-        const key = eq >= 0 ? part.slice(0, eq) : part;
-        const val = eq >= 0 ? part.slice(eq + 1) : '';
-        if (key === 'view') {
-            currentView = decodeURIComponent(val);
-        } else if (knownIntents.has(key)) {
-            hasIntent = true;
-        } else {
-            extra.push(part);    // preserve verbatim
-        }
-    }
-    if (currentView === dsl) {
-        appendScrollLog('url:sync_to:no_change', { hasIntent });
-        if (hasIntent) {
-            // Rebuild without intents, keep view + extras
-            const newHash = '#view=' + dsl + (extra.length ? '&' + extra.join('&') : '');
-            const res = setHashURL(newHash);
-            appendScrollLog('url:sync_to:clear_intents', { result: res });
-        }
-        return;
-    }
-    const newHash = '#view=' + dsl + (extra.length ? '&' + extra.join('&') : '');
-    appendScrollLog('url:sync_to:write_view', {
-        oldHash: String(location.hash || ''),
-        newHash,
-        dsl
-    });
-    if (newHash !== location.hash) {
-        const res = setHashURL(newHash);
-        appendScrollLog('url:sync_to:setHashURL_result', { result: res });
-    }
-};
-const _jcy1xg = function _test_url_roundtrip(sync_layout_from_url)
-{
-    const d = sync_layout_from_url;
-    if (!d || d.status === 'skipped')
-        return true;
-    if (d.status === 'error')
-        throw new Error(d.error || d.reason || 'sync error');
-    if (d.postURL == null)
-        throw new Error(d.error || 'postURL missing');
-    const normalize = dsl => {
-        if (dsl == null)
-            return dsl;
-        let s = String(dsl);
-        s = s.replace(/S\d+(?=\()/g, 'S100').replace(/R\d+(?=\()/g, 'R100').replace(/C\d+(?=\()/g, 'C100');
-        s = s.replace(/S(?=\()/g, 'S100').replace(/R(?=\()/g, 'R100').replace(/C(?=\()/g, 'C100');
-        return s;
-    };
-    const overlayOpen = (dsl, openTarget) => {
-        if (!openTarget?.moduleTitle)
-            return dsl;
-        const title = String(openTarget.moduleTitle);
-        if (dsl && dsl.includes(title))
-            return dsl;
-        const s = String(dsl ?? '');
-        if (!/S100\(/.test(s)) {
-            return `S100(${ title })`;
-        }
-        return s.replace(/S100\(([^)]*)\)/, (m, inner) => {
-            const trimmed = String(inner || '').trim();
-            const next = trimmed ? `${ trimmed },${ title }` : title;
-            return `S100(${ next })`;
-        });
-    };
-    const preRaw = d.preURL ?? 'S()';
-    const preWithIntent = overlayOpen(normalize(preRaw), d.open);
-    const post = normalize(d.postURL);
-    if (preWithIntent !== post) {
-        throw new Error(`view URL drift: preURL != postURL\n` + `preURL=${ String(preRaw) }\n` + `open=${ d.open?.moduleTitle || '' }\n` + `postURL=${ String(d.postURL) }\n` + `normalizedPreWithIntent=${ String(preWithIntent) }\n` + `normalizedPost=${ String(post) }\n` + `method=${ d.method } status=${ d.status } reason=${ d.reason || '' }`);
-    }
-    return true;
-};
-const _1yxu9kf = function _setHashURL(location,appendScrollLog,history){return(
-function setHashURL(newHash) {
-    const h = String(newHash ?? '');
-    const hash = h.startsWith('#') ? h : `#${ h }`;
-    const url = new URL(location.href);
-    url.hash = hash;
-    const href = url.toString();
-    appendScrollLog('url:setHashURL:attempt', {
-        hash,
-        href
-    });
-    try {
-        history.replaceState(null, '', href);
-        const res = {
-            ok: true,
-            method: 'replaceState',
-            href,
-            hash
-        };
-        appendScrollLog('url:setHashURL:success', res);
-        return res;
-    } catch (e) {
-        const a = document.createElement('a');
-        a.href = href;
-        a.rel = 'noreferrer';
-        a.style.display = 'none';
-        (document.body || document.documentElement).appendChild(a);
-        a.click();
-        a.remove();
-        const res = {
-            ok: false,
-            method: 'synthetic-click',
-            href,
-            hash,
-            error: String(e)
-        };
-        appendScrollLog('url:setHashURL:fallback', res);
-        return res;
-    }
-}
-)};
-const _1zkl8r = function _treeSyncGolden(appendScrollLog,gl){return(
-function treeSyncGoldenFactory(gl) {
-    const isCompCfg = n => n && n.type === 'component';
-    const isContCfg = n => n && (n.type === 'row' || n.type === 'column' || n.type === 'stack');
-    const desiredModuleKey = cfg => isCompCfg(cfg) && (cfg.componentType === 'module' || cfg.componentName === 'module') && cfg.title ? `module:${ cfg.title }` : null;
-    const liveModuleKey = item => {
-        if (!item)
-            return null;
-        if (!(item.isComponent || item.type === 'component'))
-            return null;
-        const t = item.componentType || item.componentName;
-        return t === 'module' && item.title ? `module:${ item.title }` : null;
-    };
-    const cloneCfg = cfg => {
-        const c = JSON.parse(JSON.stringify(cfg));
-        if (c.type === 'component' && (c.componentType === 'module' || c.componentName === 'module')) {
-            c.componentType = 'module';
-            c.componentName = 'module';
-            c.componentState = c.componentState || {};
-        }
-        return c;
-    };
-    function indexLiveModules(stackLive) {
-        const map = new Map();
-        for (const child of stackLive?.contentItems || []) {
-            const k = liveModuleKey(child);
-            if (k)
-                map.set(k, child);
-        }
-        return map;
-    }
-    function setLiveComponentStateCell(liveItem, cell) {
-        if (!liveItem || !cell)
-            return false;
-        let changed = false;
-        liveItem.componentState = liveItem.componentState || {};
-        if (liveItem.componentState.cell !== cell) {
-            liveItem.componentState.cell = cell;
-            changed = true;
-        }
-        const configs = [
-            liveItem.config,
-            liveItem._config,
-            liveItem._state
-        ].filter(Boolean);
-        for (const cfg of configs) {
-            cfg.componentState = cfg.componentState || {};
-            if (cfg.componentState.cell !== cell) {
-                cfg.componentState.cell = cell;
-                changed = true;
-            }
-        }
-        return changed;
-    }
-    function syncStack(stackLive, desiredStackCfg) {
-        appendScrollLog('treeSync:syncStack:enter', {
-            title: stackLive?.parent?.title ?? stackLive?.title ?? null,
-            desiredCount: (desiredStackCfg?.content || []).length,
-            liveCount: (stackLive?.contentItems || []).length
-        });
-        const desiredComps = (desiredStackCfg.content || []).filter(isCompCfg);
-        let liveByKey = indexLiveModules(stackLive);
-        for (let i = 0; i < desiredComps.length; i++) {
-            const d = desiredComps[i];
-            const k = desiredModuleKey(d);
-            if (!k)
-                continue;
-            if (!liveByKey.has(k)) {
-                let before = null;
-                for (let j = i + 1; j < desiredComps.length; j++) {
-                    const k2 = desiredModuleKey(desiredComps[j]);
-                    if (k2 && liveByKey.has(k2)) {
-                        before = liveByKey.get(k2);
-                        break;
-                    }
-                }
-                const idx = before ? (stackLive.contentItems || []).indexOf(before) : (stackLive.contentItems || []).length;
-                appendScrollLog('treeSync:stack:addItem', {
-                    key: k,
-                    title: d?.title ?? null,
-                    idx,
-                    beforeKey: before ? liveModuleKey(before) : null
-                });
-                if (typeof stackLive.addItem !== 'function')
-                    return {
-                        status: 'fallback',
-                        reason: 'stack missing addItem'
-                    };
-                stackLive.addItem(cloneCfg(d), idx);
-                liveByKey = indexLiveModules(stackLive);
-            }
-        }
-        const desiredKeys = new Set(desiredComps.map(desiredModuleKey).filter(Boolean));
-        for (const child of Array.from(stackLive?.contentItems || [])) {
-            const k = liveModuleKey(child);
-            if (k && !desiredKeys.has(k) && typeof child.remove === 'function') {
-                appendScrollLog('treeSync:stack:remove', {
-                    key: k,
-                    title: child?.title ?? null
-                });
-                child.remove();
-            }
-        }
-        const order = desiredComps.map(desiredModuleKey).filter(Boolean);
-        const byKey = indexLiveModules(stackLive);
-        for (let i = 0; i < order.length; i++) {
-            const item = byKey.get(order[i]);
-            if (!item)
-                continue;
-            const curIdx = (stackLive.contentItems || []).indexOf(item);
-            if (curIdx !== i && typeof stackLive.removeChild === 'function' && typeof stackLive.addChild === 'function') {
-                appendScrollLog('treeSync:stack:reorder', {
-                    key: order[i],
-                    from: curIdx,
-                    to: i
-                });
-                stackLive.removeChild(item, true);
-                stackLive.addChild(item, i, false);
-            }
-        }
-        {
-            const byKey2 = indexLiveModules(stackLive);
-            for (const d of desiredComps) {
-                const k = desiredModuleKey(d);
-                const desiredCell = d?.componentState?.cell ?? null;
-                if (!k || !desiredCell)
-                    continue;
-                const liveItem = byKey2.get(k);
-                if (!liveItem)
-                    continue;
-                const changed = setLiveComponentStateCell(liveItem, desiredCell);
-                if (changed) {
-                    appendScrollLog('treeSync:stack:sync_componentState_cell', {
-                        key: k,
-                        title: liveItem?.title ?? null,
-                        cell: desiredCell
-                    });
-                }
-            }
-        }
-        appendScrollLog('treeSync:syncStack:exit', { liveCount: (stackLive?.contentItems || []).length });
-        return { status: 'synced' };
-    }
-    function ensureContainerChild(parentLive, idx, desiredChildCfg) {
-        const liveChild = parentLive?.contentItems?.[idx];
-        if (liveChild && liveChild.type === desiredChildCfg.type)
-            return liveChild;
-        if (liveChild && typeof liveChild.remove === 'function') {
-            appendScrollLog('treeSync:container:remove_child_for_type_mismatch', {
-                idx,
-                liveType: liveChild?.type ?? null,
-                desiredType: desiredChildCfg?.type ?? null
-            });
-            liveChild.remove();
-        }
-        if (typeof parentLive?.addItem !== 'function')
-            return null;
-        appendScrollLog('treeSync:container:addItem', {
-            idx,
-            type: desiredChildCfg?.type ?? null
-        });
-        parentLive.addItem({
-            type: desiredChildCfg.type,
-            content: []
-        }, idx);
-        return parentLive?.contentItems?.[idx] || null;
-    }
-    function isContainerItem(item) {
-        if (!item)
-            return false;
-        if (item.isComponent)
-            return false;
-        return item.type === 'row' || item.type === 'column' || item.type === 'stack';
-    }
-    function syncContainer(containerLive, desiredCfg) {
-        if (!containerLive || !desiredCfg || !Array.isArray(desiredCfg.content))
-            return { status: 'synced' };
-        const desiredChildren = desiredCfg.content.filter(isContCfg);
-        for (let i = 0; i < desiredChildren.length; i++)
-            ensureContainerChild(containerLive, i, desiredChildren[i]);
-        const liveContainers = (containerLive.contentItems || []).filter(isContainerItem);
-        while (liveContainers.length > desiredChildren.length) {
-            const last = (containerLive.contentItems || []).slice().reverse().find(isContainerItem);
-            if (!last)
-                break;
-            appendScrollLog('treeSync:container:remove_extra_container', { type: last?.type ?? null });
-            if (typeof last.remove === 'function')
-                last.remove();
-            liveContainers.pop();
-        }
-        for (let i = 0; i < desiredChildren.length; i++) {
-            const d = desiredChildren[i];
-            const l = containerLive.contentItems?.[i];
-            if (!l)
-                continue;
-            if (l.type !== d.type)
-                return {
-                    status: 'fallback',
-                    reason: `child type mismatch @${ i } live=${ l.type } desired=${ d.type }`
-                };
-            if (d.type === 'stack') {
-                const r = syncStack(l, d);
-                if (r?.status === 'fallback')
-                    return r;
-            } else {
-                const r = syncContainer(l, d);
-                if (r?.status === 'fallback')
-                    return r;
-            }
-        }
-        return { status: 'synced' };
-    }
-    return function treeSync(layout, desiredRootCfg) {
-        appendScrollLog('treeSync:enter', {
-            desiredType: desiredRootCfg?.type ?? null,
-            hasRoot: !!layout?.root
-        });
-        if (!layout?.root || !desiredRootCfg)
-            return { status: 'noop' };
-        const liveTop = layout.root.contentItems?.[0];
-        if (!liveTop)
-            return {
-                status: 'fallback',
-                reason: 'no live top'
-            };
-        if (liveTop.type !== desiredRootCfg.type) {
-            const out = {
-                status: 'fallback',
-                reason: `top type mismatch live=${ liveTop.type } desired=${ desiredRootCfg.type }`
-            };
-            appendScrollLog('treeSync:fallback', out);
-            return out;
-        }
-        const out = desiredRootCfg.type === 'stack' ? syncStack(liveTop, desiredRootCfg) : syncContainer(liveTop, desiredRootCfg);
-        if (out?.status === 'fallback')
-            appendScrollLog('treeSync:fallback', out);
-        else
-            appendScrollLog('treeSync:synced', { status: out?.status ?? 'synced' });
-        return out;
-    };
-}(gl)
-)};
-const _133ahw5 = function _background_jobs(onLoadConfig,layout_state,sync_layout_from_url,test_url_roundtrip,sync_layout_to_url,runtime,navigator_jobs,commandPaletteKeybinding,auto_attach,scroll_fix_sync_layout,commit_history,replay_git,change_listener,cc_chat)
-{
-  onLoadConfig;
-  layout_state;
-  sync_layout_from_url;
-  test_url_roundtrip;
-  sync_layout_to_url;
-  runtime;
-  navigator_jobs;
-  commandPaletteKeybinding;
-  auto_attach;
-  scroll_fix_sync_layout;
-  // history
-  commit_history;
-  replay_git;
-  change_listener;
-  cc_chat;
-};
-const _1n78po6 = function _imports(md){return(
-md`## Imports`
-)};
-const _b2c0kp = function _32(exporter){return(
-exporter()
-)};
-const _1ey5aow = function _dragOutGrips(layout,invalidation)
-{
-    function readModuleSource(name) {
-        const r = window.lopecode?.contentSync?.(name);
-        if (!r || r.status !== 200 || !r.bytes)
-            return null;
-        return new TextDecoder().decode(r.bytes);
-    }
-    function filenameFor(name) {
-        let m = name.match(/^@([A-Za-z0-9-]+)\/([A-Za-z0-9-]+)$/);
-        if (m)
-            return `at_${ m[1] }_${ m[2] }.js`;
-        m = name.match(/^d\/([A-Za-z0-9]+)(@\d+)?$/);
-        if (m)
-            return `d_${ m[1] }${ m[2] ?? '' }.js`;
-        return name.replace(/[/]/g, '_') + '.js';
-    }
-    function flashGrip(grip) {
-        const prev = grip.style.opacity;
-        grip.style.opacity = '1';
-        setTimeout(() => {
-            grip.style.opacity = prev;
-        }, 350);
-    }
-    function hookTab(tabEl) {
-        if (tabEl.__lopepageGripHooked)
-            return;
-        tabEl.__lopepageGripHooked = true;
-        const grip = document.createElement('span');
-        grip.className = 'lm_drag_out_grip';
-        grip.title = 'Click to copy source \xB7 Drag out as .js';
-        grip.setAttribute('draggable', 'true');
-        grip.innerHTML = `<svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round" style="display:block"><rect x="5.5" y="5.5" width="9" height="9" rx="1.5"/><path d="M2.5 10.5V3a.5.5 0 01.5-.5h7.5"/></svg>`;
-        Object.assign(grip.style, {
-            display: 'inline-block',
-            width: '12px',
-            height: '12px',
-            verticalAlign: '3.5px',
-            marginLeft: '-7px',
-            marginRight: '2px',
-            cursor: 'pointer',
-            opacity: '0.55',
-            userSelect: 'none',
-            lineHeight: '0',
-            color: 'currentColor'
-        });
-        [
-            'pointerdown',
-            'mousedown',
-            'touchstart'
-        ].forEach(ev => {
-            grip.addEventListener(ev, e => e.stopPropagation(), { capture: true });
-        });
-        grip.addEventListener('click', e => {
-            e.stopPropagation();
-            const t = tabEl.querySelector('.lm_title')?.textContent || '';
-            if (!t)
-                return;
-            const source = readModuleSource(t);
-            if (!source) {
-                console.warn('[grip click] no source for:', t);
-                return;
-            }
-            navigator.clipboard?.writeText?.(source).then(() => {
-                console.log('[grip click] copied source for:', t, `(${ source.length } chars)`);
-                flashGrip(grip);
-            }).catch(err => console.warn('[grip click] clipboard failed:', err));
-        });
-        grip.addEventListener('dragstart', e => {
-            e.stopPropagation();
-            const title = tabEl.querySelector('.lm_title')?.textContent || '';
-            const source = readModuleSource(title);
-            if (!source) {
-                e.dataTransfer.setData('text/plain', `// no source for ${ title }`);
-                return;
-            }
-            const filename = filenameFor(title);
-            const dataUrl = 'data:text/javascript;base64,' + btoa(unescape(encodeURIComponent(source)));
-            e.dataTransfer.setData('DownloadURL', `text/javascript:${ filename }:${ dataUrl }`);
-            e.dataTransfer.setData('text/plain', source);
-            e.dataTransfer.effectAllowed = 'copyMove';
-        });
-        const titleEl = tabEl.querySelector('.lm_title');
-        if (titleEl?.parentNode === tabEl)
-            tabEl.insertBefore(grip, titleEl);
-        else
-            tabEl.prepend(grip);
-    }
-    document.querySelectorAll('.lm_drag_out_grip').forEach(g => g.remove());
-    document.querySelectorAll('.lm_tab').forEach(t => {
-        t.__lopepageGripHooked = false;
-    });
-    document.querySelectorAll('.lm_tab').forEach(hookTab);
-    const handler = tab => hookTab(tab.element);
-    layout.on('tabCreated', handler);
-    invalidation.then(() => {
-        try {
-            layout.off?.('tabCreated', handler);
-        } catch (e) {
-        }
-    });
-    return 'drag-out grips installed';
-};
-const _1gkn0mq = function _dropInHandler(location, setHashURL, runtime, page, invalidation) {
-    const STYLE_ID = 'lopepage-dropzone-style';
-    const oldStyle = document.getElementById(STYLE_ID);
-    if (oldStyle)
-        oldStyle.remove();
-    const s = document.createElement('style');
-    s.id = STYLE_ID;
-    s.textContent = `.lm_header.lopepage-drop-target { outline: 2px dashed currentColor; outline-offset: -2px; background: color-mix(in srgb, currentColor 14%, transparent); }`;
-    document.head.appendChild(s);
-    function parseModuleName(filename) {
-        let m = filename.match(/^at_([A-Za-z0-9]+(?:-[A-Za-z0-9]+)*)_([A-Za-z0-9]+(?:-[A-Za-z0-9]+)*)\.js$/);
-        if (m)
-            return `@${ m[1] }/${ m[2] }`;
-        m = filename.match(/^d_([A-Za-z0-9]+)(@\d+)?\.js$/);
-        if (m)
-            return `d/${ m[1] }${ m[2] ?? '' }`;
-        return null;
-    }
-    function ensureDomScriptTag(name, source) {
-        let el = document.getElementById(name);
-        if (el?.tagName === 'SCRIPT' && el.getAttribute('type') === 'text/plain') {
-            el.textContent = source;
-            return el;
-        }
-        el = document.createElement('script');
-        el.type = 'text/plain';
-        el.id = name;
-        el.setAttribute('data-mime', 'application/javascript');
-        el.textContent = source;
-        document.body.appendChild(el);
-        return el;
-    }
-    function openModuleInHash(name) {
-        let h = location.hash.replace(/^#/, '');
-        if (/(^|&)open=[^&]*/.test(h)) {
-            h = h.replace(/(^|&)open=[^&]*/, `$1open=${ name }`);
-        } else {
-            h = h + (h ? '&' : '') + `open=${ name }`;
-        }
-        setHashURL(h);
-    }
-    function tearDownExistingModule(name) {
-        const existing = runtime.mains.get(name);
-        if (!existing)
-            return false;
-        try {
-            for (const v of Array.from(existing._scope.values())) {
-                try {
-                    v.delete();
-                } catch (e) {
-                }
-            }
-        } catch (e) {
-            console.warn('[lopepage drop-in] teardown scope:', e);
-        }
-        runtime.mains.delete(name);
-        return true;
-    }
-    async function installFromFile(file) {
-        const name = parseModuleName(file.name);
-        if (!name) {
-            console.warn('[lopepage drop-in] bad filename:', file.name);
-            return;
-        }
-        const src = await file.text();
-        const blob = new Blob([src], { type: 'text/javascript' });
-        const url = URL.createObjectURL(blob);
-        let imported;
-        try {
-            imported = await window.importShim(url, `file://${ name }`);
-        } catch (e) {
-            console.error('[lopepage drop-in] import failed:', e);
-            return;
-        }
-        if (typeof imported.default !== 'function') {
-            console.warn('[lopepage drop-in] default export not a function');
-            return;
-        }
-        const replaced = tearDownExistingModule(name);
-        const mod = runtime.module(imported.default);
-        runtime.mains.set(name, mod);
-        ensureDomScriptTag(name, src);
-        openModuleInHash(name);
-        console.log(`[lopepage drop-in] ${ replaced ? 'replaced' : 'installed' } + opened:`, name);
-    }
-    let activeHeader = null;
-    const clearHighlight = () => {
-        if (activeHeader) {
-            activeHeader.classList.remove('lopepage-drop-target');
-            activeHeader = null;
-        }
-    };
-    const isFilesDrag = e => [...e.dataTransfer?.types || []].includes('Files');
-    const onDragOver = e => {
-        if (!isFilesDrag(e))
-            return;
-        const header = e.target?.closest?.('.lm_header');
-        if (!header) {
-            clearHighlight();
-            return;
-        }
-        e.preventDefault();
-        e.dataTransfer.dropEffect = 'copy';
-        if (activeHeader !== header) {
-            activeHeader?.classList.remove('lopepage-drop-target');
-            header.classList.add('lopepage-drop-target');
-            activeHeader = header;
-        }
-    };
-    const onDragLeave = e => {
-        if (!page.contains(e.relatedTarget))
-            clearHighlight();
-    };
-    const onDrop = e => {
-        if (!isFilesDrag(e))
-            return;
-        const header = e.target?.closest?.('.lm_header');
-        if (!header)
-            return;
-        e.preventDefault();
-        clearHighlight();
-        const f = e.dataTransfer.files[0];
-        if (f)
-            installFromFile(f).catch(err => console.error('[lopepage drop-in] failed:', err));
-    };
-    page.addEventListener('dragover', onDragOver);
-    page.addEventListener('dragleave', onDragLeave);
-    page.addEventListener('drop', onDrop);
-    invalidation.then(() => {
-        page.removeEventListener('dragover', onDragOver);
-        page.removeEventListener('dragleave', onDragLeave);
-        page.removeEventListener('drop', onDrop);
-        clearHighlight();
-        document.getElementById(STYLE_ID)?.remove();
-    });
-    return 'drop-in handler installed';
-};
-const _1v605qi = function _file_attachment_cache(reload)
-{
-    reload;
-    return new Map();
-};
-const _1fgpmzl = function _renderFileAttachment()
-{
-    return function renderFileAttachment(mime, bytes) {
-        const m = String(mime || '').toLowerCase();
-        // HTML: srcdoc keeps the runtime same-origin-ish (opaque) but renders rich content
-        if (m === 'text/html' || m === 'application/xhtml+xml') {
-            const iframe = document.createElement('iframe');
-            iframe.setAttribute('srcdoc', new TextDecoder().decode(bytes));
-            Object.assign(iframe.style, {
-                width: '100%',
-                height: '100%',
-                border: '0',
-                display: 'block'
-            });
-            return iframe;
-        }
-        if (m.startsWith('image/')) {
-            const img = document.createElement('img');
-            img.src = URL.createObjectURL(new Blob([bytes], { type: mime }));
-            Object.assign(img.style, {
-                maxWidth: '100%',
-                maxHeight: '100%',
-                display: 'block',
-                margin: 'auto'
-            });
-            return img;
-        }
-        if (m.startsWith('audio/')) {
-            const audio = document.createElement('audio');
-            audio.controls = true;
-            audio.src = URL.createObjectURL(new Blob([bytes], { type: mime }));
-            Object.assign(audio.style, { width: '100%' });
-            return audio;
-        }
-        if (m.startsWith('video/')) {
-            const video = document.createElement('video');
-            video.controls = true;
-            video.src = URL.createObjectURL(new Blob([bytes], { type: mime }));
-            Object.assign(video.style, {
-                width: '100%',
-                height: '100%'
-            });
-            return video;
-        }
-        if (m === 'text/plain' || m === 'text/markdown' || m === 'application/json' || m.startsWith('text/')) {
-            const pre = document.createElement('pre');
-            pre.textContent = new TextDecoder().decode(bytes);
-            Object.assign(pre.style, {
-                margin: '0',
-                padding: '8px',
-                whiteSpace: 'pre-wrap',
-                overflow: 'auto',
-                width: '100%',
-                height: '100%',
-                boxSizing: 'border-box'
-            });
-            return pre;
-        }
-        // application/pdf and unknown: blob: iframe — browser picks the viewer
-        const iframe = document.createElement('iframe');
-        iframe.src = URL.createObjectURL(new Blob([bytes], { type: mime || 'application/octet-stream' }));
-        Object.assign(iframe.style, {
-            width: '100%',
-            height: '100%',
-            border: '0',
-            display: 'block'
-        });
-        return iframe;
-    };
-};
-
-export default function define(runtime, observer) {
-  const main = runtime.module();
-  const $def = (pid, name, deps, fn) => {
-    main.variable(observer(name)).define(name, deps, fn).pid = pid;
-  };
-
-  main.define("module @tomlarkworthy/golden-layout-2-6-0", async () => runtime.module((await import("/@tomlarkworthy/golden-layout-2-6-0.js?v=4")).default));  
-  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
-  main.define("module @tomlarkworthy/module-selection", async () => runtime.module((await import("/@tomlarkworthy/module-selection.js?v=4")).default));  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
-  main.define("module @tomlarkworthy/editor-5", async () => runtime.module((await import("/@tomlarkworthy/editor-5.js?v=4")).default));  
-  main.define("module @tomlarkworthy/exporter-3", async () => runtime.module((await import("/@tomlarkworthy/exporter-3.js?v=4")).default));  
-  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
-  main.define("module @tomlarkworthy/local-change-history", async () => runtime.module((await import("/@tomlarkworthy/local-change-history.js?v=4")).default));  
-  main.define("module @tomlarkworthy/claude-code-pairing", async () => runtime.module((await import("/@tomlarkworthy/claude-code-pairing.js?v=4")).default));  
-  main.define("module @tomlarkworthy/command-palette", async () => runtime.module((await import("/@tomlarkworthy/command-palette.js?v=4")).default));  
-  $def("_1xyxga0", "page", ["htl","isOnObservableCom","lopeviz_handle_css","base_css","light_theme_css","commandPaletteStyles","commandPaletteOverlay","linkTo"], _1xyxga0);  
-  $def("_1ujnhdh", "append_to_body", ["page"], _1ujnhdh);  
-  $def("_1nv51s8", "testNavigation", ["htl","linkTo"], _1nv51s8);  
-  $def("_ydvyos", "viewof reload", ["Inputs"], _ydvyos);  
-  $def("_1we0ggl", "reload", ["Generators","viewof reload"], _1we0ggl);  
-  $def("_plefwg", "onLoadConfig", ["parseGoldenDSL","URLSearchParams","location"], _plefwg);  
-  $def("_1nzpnqy", "visualizer_cache", ["reload"], _1nzpnqy);  
-  $def("_1ojown8", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1ojown8);  
-  $def("_1gm4gbf", "blobPanel", [], _1gm4gbf);  
-  $def("_lxv2e2", "settings", [], _lxv2e2);  
-  $def("_lp1ggk", "is_mobile", ["width"], _lp1ggk);  
-  $def("_qbghwu", "initial config", ["onLoadConfig","settings"], _qbghwu);  
-  $def("_15lk82w", "mutable config", ["Mutable","initial config"], _15lk82w);  
-  $def("_1bki6eh", "config", ["mutable config"], _1bki6eh);  
-  $def("_14z0bay", "resize", ["Generators","addEventListener","invalidation","removeEventListener"], _14z0bay);  
-  $def("_18jv72h", "layout", ["resize","gl","mutable config","page","modulePanel","blobPanel"], _18jv72h);  
-  $def("_tsjb2x", "layout_state", ["appendScrollLog","layout","gl","mutable config"], _tsjb2x);  
-  $def("_11nrwvj", "viewof lopepageModule", ["thisModule"], _11nrwvj);  
-  $def("_r97569", "lopepageModule", ["Generators","viewof lopepageModule"], _r97569);  
-  $def("_1sp5wo4", null, ["md"], _1sp5wo4);  
-  $def("_1ts23ma", "viewof scrollDebug", ["Inputs"], _1ts23ma);  
-  $def("_7jxivy", "scrollDebug", ["Generators","viewof scrollDebug"], _7jxivy);  
-  $def("_1f2wuqm", "appendScrollLog", ["viewof scrollDebug","mutable scrollLog"], _1f2wuqm);  
-  $def("_1nbnzwx", "initial scrollLog", ["scrollDebug"], _1nbnzwx);  
-  $def("_1f7xtz1", "mutable scrollLog", ["Mutable","initial scrollLog"], _1f7xtz1);  
-  $def("_1dyz4o0", "scrollLog", ["mutable scrollLog"], _1dyz4o0);  
-  $def("_1d1nkw9", "scrollKeyFor", ["appendScrollLog"], _1d1nkw9);  
-  $def("_tb217h", "scroll_cache", [], _tb217h);  
-  $def("_12p8mg7", "fix_scroll", ["scroll_cache","scrollKeyFor","appendScrollLog"], _12p8mg7);  
-  $def("_arfw00", "scroll_fix_sync_layout", ["sync_layout_to_url","layout","appendScrollLog","modulePanel"], _arfw00);  
-  $def("_3nwpp4", "URLrouting", ["md"], _3nwpp4);  
-  $def("_14te9pl", "sync_layout_from_url", ["reload","resize","URLSearchParams","hash","appendScrollLog","parseGoldenDSL","gl","layout","serializeGoldenDSL","treeSyncGolden","invalidation"], _14te9pl);  
-  $def("_1l50a0d", "sync_layout_to_url", ["appendScrollLog","sync_layout_from_url","config","test_url_roundtrip","serializeGoldenDSL","location","setHashURL"], _1l50a0d);  
-  $def("_jcy1xg", "test_url_roundtrip", ["sync_layout_from_url"], _jcy1xg);  
-  $def("_1yxu9kf", "setHashURL", ["location","appendScrollLog","history"], _1yxu9kf);  
-  $def("_1zkl8r", "treeSyncGolden", ["appendScrollLog","gl"], _1zkl8r);  
-  $def("_133ahw5", "background_jobs", ["onLoadConfig","layout_state","sync_layout_from_url","test_url_roundtrip","sync_layout_to_url","runtime","navigator_jobs","commandPaletteKeybinding","auto_attach","scroll_fix_sync_layout","commit_history","replay_git","change_listener","cc_chat"], _133ahw5);  
-  $def("_1n78po6", "imports", ["md"], _1n78po6);  
-  $def("_b2c0kp", null, ["exporter"], _b2c0kp);  
-  $def("_1ey5aow", "dragOutGrips", ["layout","invalidation"], _1ey5aow);  
-  $def("_1gkn0mq", "dropInHandler", ["location","setHashURL","runtime","page","invalidation"], _1gkn0mq);  
-  main.define("gl", ["module @tomlarkworthy/golden-layout-2-6-0", "@variable"], (_, v) => v.import("gl", _));  
-  main.define("base_css", ["module @tomlarkworthy/golden-layout-2-6-0", "@variable"], (_, v) => v.import("base_css", _));  
-  main.define("light_theme_css", ["module @tomlarkworthy/golden-layout-2-6-0", "@variable"], (_, v) => v.import("light_theme_css", _));  
-  main.define("unorderedSync", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("unorderedSync", _));  
-  main.define("runtime", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("runtime", _));  
-  main.define("visualizer", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("visualizer", _));  
-  main.define("Inspector", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("Inspector", _));  
-  main.define("lopeviz_handle_css", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("lopeviz_handle_css", _));  
-  main.define("viewof notebookModule", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("viewof notebookModule", _));  
-  main.define("notebookModule", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("notebookModule", _));  
-  main.define("currentModules", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("currentModules", _));  
-  main.define("viewof selected_modules", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("viewof selected_modules", _));  
-  main.define("selected_modules", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("selected_modules", _));  
-  main.define("navigator_jobs", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("navigator_jobs", _));  
-  main.define("serializeGoldenDSL", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("serializeGoldenDSL", _));  
-  main.define("parseGoldenDSL", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("parseGoldenDSL", _));  
-  main.define("linkTo", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("linkTo", _));  
-  main.define("persistedAttachments", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("persistedAttachments", _));  
-  main.define("getHashModules", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("getHashModules", _));  
-  main.define("lookupVariable", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("lookupVariable", _));  
-  main.define("getPromiseState", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("getPromiseState", _));  
-  main.define("thisModule", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("thisModule", _));  
-  main.define("ascendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("ascendants", _));  
-  main.define("toObject", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("toObject", _));  
-  main.define("isOnObservableCom", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("isOnObservableCom", _));  
-  main.define("auto_attach", ["module @tomlarkworthy/editor-5", "@variable"], (_, v) => v.import("auto_attach", _));  
-  main.define("exporter", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("exporter", _));  
-  main.define("hash", ["module d/57d79353bac56631@44", "@variable"], (_, v) => v.import("hash", _));  
-  main.define("commit_history", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("commit_history", _));  
-  main.define("change_listener", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("change_listener", _));  
-  main.define("replay_git", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("replay_git", _));  
-  main.define("cc_chat", ["module @tomlarkworthy/claude-code-pairing", "@variable"], (_, v) => v.import("cc_chat", _));  
-  main.define("commandPaletteStyles", ["module @tomlarkworthy/command-palette", "@variable"], (_, v) => v.import("commandPaletteStyles", _));  
-  main.define("commandPaletteKeybinding", ["module @tomlarkworthy/command-palette", "@variable"], (_, v) => v.import("commandPaletteKeybinding", _));  
-  main.define("commandPaletteOverlay", ["module @tomlarkworthy/command-palette", "@variable"], (_, v) => v.import("commandPaletteOverlay", _));  
-  $def("_1v605qi", "file_attachment_cache", ["reload"], _1v605qi);  
-  $def("_1fgpmzl", "renderFileAttachment", [], _1fgpmzl);
-  return main;
-}</script>
-
 <script id="@tomlarkworthy/lopepage-urls" 
   type="text/plain"
   data-mime="application/javascript"
@@ -16494,35 +16709,33 @@ module -> {
 }
 \`\`\``
 )};
-const _1798myt = function _moduleMap(runtime,keepalive,myModule,$0){return(
-async (
-  _runtime = runtime,
-  {
-    cache = new Map() // module -> {name}
-  } = {}
-) => {
-  if (!_runtime || !_runtime._variables)
-    throw "Invalid runtime passed to moduleMap";
-  keepalive(myModule, "submit_summary");
-  keepalive(myModule, "sync_modules");
-  keepalive(myModule, "currentModules");
-  return await $0.send({
-    runtime: _runtime,
-    cache: cache
-  });
-}
-)};
+const _1hn3uql = function _moduleMap(runtime,keepalive,myModule,$0)
+{
+  return async (_runtime = runtime, {
+    cache = new Map()  // module -> {name}
+  } = {}) => {
+    if (!_runtime || !_runtime._variables)
+      throw 'Invalid runtime passed to moduleMap';
+    keepalive(myModule, 'submit_summary');
+    keepalive(myModule, 'sync_modules');
+    keepalive(myModule, 'currentModules');
+    return await $0.send({
+      runtime: _runtime,
+      cache: cache
+    });
+  };
+};
 const _1yso65r = function _5(md){return(
 md`### \`currentModules\``
 )};
-const _1fcoh6x = async function _sync_modules(runtime_variables,moduleMap,_,$0,Event)
+const _1e3kr85 = async function _sync_modules(runtime_variables,moduleMap,_,$0,Event)
 {
   runtime_variables;
   const latest = await moduleMap();
   let dirty = !this || !_.isEqual(new Set(latest.keys()), new Set(this.keys()));
   if (dirty) {
     $0.value = latest;
-    $0.dispatchEvent(new Event("input"));
+    $0.dispatchEvent(new Event('input'));
   }
   return $0.value;
 };
@@ -16530,261 +16743,260 @@ const _wi39n0 = async function _currentModules(Inputs,moduleMap){return(
 Inputs.input(await moduleMap())
 )};
 const _1gxgyd6 = (G, _) => G.input(_);
-const _1qag34d = function _8(Inputs,currentModules){return(
+const _1kxoygl = function _8(Inputs,currentModules){return(
 Inputs.table([...currentModules.values()], {
   format: {
-    dom: (d) => d.innerHTML,
+    dom: d => d.innerHTML,
     specifiers: JSON.stringify,
-    variable: (v) => v._name
+    variable: v => v._name
   }
 })
 )};
 const _1xamz8j = function _9(md){return(
 md`### Visualization`
 )};
-const _1n4p4hn = function _tipTitle(){return(
-([k, c]) => 
-`${k}\ndependsOn: [\n  ${(c[3].dependsOn || []).join(
-  "\n  "
-)}\n]\ndependedBy: [\n  ${(c[3].dependedBy || []).join("\n  ")}\n]`
+const _1sglrv3 = function _tipTitle(){return(
+([k, c]) => `${ k }\ndependsOn: [\n  ${ (c[3].dependsOn || []).join('\n  ') }\n]\ndependedBy: [\n  ${ (c[3].dependedBy || []).join('\n  ') }\n]`
 )};
-const _1kdcb71 = function _visualizeModules(currentModules,htl,d3,spectralCircleOrder,improveOrderSifting,bestOfRandomOrders,Plot,tipTitle,linkTo,isOnObservableCom)
-{
-  return ({ useSpectral = true } = {}) => {
-    const modules = [...currentModules.values()].filter((m) => m && m.name);
-    const n = modules.length;
-    if (n === 0) return htl.svg`<svg width="1" height="1"></svg>`;
-
-    const indexOf = new Map(modules.map((m, i) => [m.name, i]));
-
-    const undirectedEdges = [];
-    const seen = new Set();
+const _5zbe1k = function _visualizeModules(currentModules,htl,d3,spectralCircleOrder,improveOrderSifting,bestOfRandomOrders,Plot,tipTitle,linkTo,isOnObservableCom){return(
+({
+  useSpectral = true
+} = {}) => {
+  const modules = [...currentModules.values()].filter(m => m && m.name);
+  const n = modules.length;
+  if (n === 0)
+    return htl.svg`<svg width="1" height="1"></svg>`;
+  const indexOf = new Map(modules.map((m, i) => [
+    m.name,
+    i
+  ]));
+  const undirectedEdges = [];
+  const seen = new Set();
+  for (let i = 0; i < n; i++) {
+    const from = modules[i];
+    for (const toName of from.dependsOn || []) {
+      const j = indexOf.get(toName);
+      if (j == null || j === i)
+        continue;
+      const a = Math.min(i, j), b = Math.max(i, j);
+      const k = `${ a },${ b }`;
+      if (seen.has(k))
+        continue;
+      seen.add(k);
+      undirectedEdges.push([
+        a,
+        b
+      ]);
+    }
+  }
+  const buildCSRLocal = (n, edges) => {
+    const adj = Array.from({ length: n }, () => []);
+    for (const [a0, b0] of edges) {
+      const a = a0 | 0, b = b0 | 0;
+      if (a === b)
+        continue;
+      if (a < 0 || b < 0 || a >= n || b >= n)
+        continue;
+      adj[a].push(b);
+      adj[b].push(a);
+    }
+    const deg = new Float64Array(n);
+    let nnz = 0;
     for (let i = 0; i < n; i++) {
-      const from = modules[i];
-      for (const toName of from.dependsOn || []) {
-        const j = indexOf.get(toName);
-        if (j == null || j === i) continue;
-        const a = Math.min(i, j),
-          b = Math.max(i, j);
-        const k = `${a},${b}`;
-        if (seen.has(k)) continue;
-        seen.add(k);
-        undirectedEdges.push([a, b]);
+      const row = adj[i];
+      row.sort((x, y) => x - y);
+      let w = 0;
+      for (let j = 0; j < row.length; j++)
+        if (w === 0 || row[j] !== row[w - 1])
+          row[w++] = row[j];
+      row.length = w;
+      deg[i] = w;
+      nnz += w;
+    }
+    const rowPtr = new Int32Array(n + 1);
+    const colIdx = new Int32Array(nnz);
+    const val = new Float64Array(nnz);
+    let p = 0;
+    for (let i = 0; i < n; i++) {
+      rowPtr[i] = p;
+      const row = adj[i];
+      for (let j = 0; j < row.length; j++) {
+        colIdx[p] = row[j];
+        val[p] = 1;
+        p++;
       }
     }
-
-    const buildCSRLocal = (n, edges) => {
-      const adj = Array.from({ length: n }, () => []);
-      for (const [a0, b0] of edges) {
-        const a = a0 | 0,
-          b = b0 | 0;
-        if (a === b) continue;
-        if (a < 0 || b < 0 || a >= n || b >= n) continue;
-        adj[a].push(b);
-        adj[b].push(a);
-      }
-      const deg = new Float64Array(n);
-      let nnz = 0;
-      for (let i = 0; i < n; i++) {
-        const row = adj[i];
-        row.sort((x, y) => x - y);
-        let w = 0;
-        for (let j = 0; j < row.length; j++)
-          if (w === 0 || row[j] !== row[w - 1]) row[w++] = row[j];
-        row.length = w;
-        deg[i] = w;
-        nnz += w;
-      }
-      const rowPtr = new Int32Array(n + 1);
-      const colIdx = new Int32Array(nnz);
-      const val = new Float64Array(nnz);
-      let p = 0;
-      for (let i = 0; i < n; i++) {
-        rowPtr[i] = p;
-        const row = adj[i];
-        for (let j = 0; j < row.length; j++) {
-          colIdx[p] = row[j];
-          val[p] = 1;
-          p++;
-        }
-      }
-      rowPtr[n] = p;
-      return { n, rowPtr, colIdx, val, deg };
+    rowPtr[n] = p;
+    return {
+      n,
+      rowPtr,
+      colIdx,
+      val,
+      deg
     };
-
-    const crossingsCountLocal = (n, edges, order) => {
-      const pos = new Int32Array(n);
-      for (let i = 0; i < n; i++) pos[order[i]] = i;
-
-      const intervals = [];
-      for (const [a0, b0] of edges) {
-        const a = a0 | 0,
-          b = b0 | 0;
-        if (a === b) continue;
-        const i = pos[a],
-          j = pos[b];
-        const s = Math.min(i, j),
-          t = Math.max(i, j);
-        if (s === t) continue;
-        intervals.push([s, t]);
-      }
-
-      intervals.sort((p, q) => p[0] - q[0] || p[1] - q[1]);
-      const bit = new Int32Array(n + 1);
-      const add = (i) => {
-        for (let x = i + 1; x <= n; x += x & -x) bit[x]++;
-      };
-      const sum = (i) => {
-        let s = 0;
-        for (let x = i + 1; x > 0; x -= x & -x) s += bit[x];
-        return s;
-      };
-      const range = (l, r) => (r < l ? 0 : sum(r) - (l > 0 ? sum(l - 1) : 0));
-
-      let crossings = 0;
-      let k = 0;
-      while (k < intervals.length) {
-        const s = intervals[k][0];
-        let k2 = k;
-        while (k2 < intervals.length && intervals[k2][0] === s) k2++;
-        for (let t = k; t < k2; t++)
-          crossings += range(s + 1, intervals[t][1] - 1);
-        for (let t = k; t < k2; t++) add(intervals[t][1]);
-        k = k2;
-      }
-      return crossings;
+  };
+  const crossingsCountLocal = (n, edges, order) => {
+    const pos = new Int32Array(n);
+    for (let i = 0; i < n; i++)
+      pos[order[i]] = i;
+    const intervals = [];
+    for (const [a0, b0] of edges) {
+      const a = a0 | 0, b = b0 | 0;
+      if (a === b)
+        continue;
+      const i = pos[a], j = pos[b];
+      const s = Math.min(i, j), t = Math.max(i, j);
+      if (s === t)
+        continue;
+      intervals.push([
+        s,
+        t
+      ]);
+    }
+    intervals.sort((p, q) => p[0] - q[0] || p[1] - q[1]);
+    const bit = new Int32Array(n + 1);
+    const add = i => {
+      for (let x = i + 1; x <= n; x += x & -x)
+        bit[x]++;
     };
-
-    let orderIdx;
-    if (n <= 2 || undirectedEdges.length === 0 || !useSpectral) {
-      orderIdx = Int32Array.from(d3.range(n));
-    } else {
-      const csr = buildCSRLocal(n, undirectedEdges);
-
-      const spectral = spectralCircleOrder(csr, {
-        alpha: 0.92,
-        maxIters: 80,
-        tol: 1e-4,
-        seed: 1,
-        passesOrtho: 1
-      });
-
-      const sifted = improveOrderSifting(n, undirectedEdges, spectral.order, {
-        passes: 1,
-        vertexSequence: "order"
-      });
-
-      const baseline = bestOfRandomOrders(n, undirectedEdges, {
-        R: Math.min(n, 12),
-        seed: 1,
-        postSiftPasses: 0
-      });
-
-      const cSift = crossingsCountLocal(n, undirectedEdges, sifted.order);
-      orderIdx =
-        baseline?.order && baseline.crossings < cSift
-          ? baseline.order
-          : sifted.order;
+    const sum = i => {
+      let s = 0;
+      for (let x = i + 1; x > 0; x -= x & -x)
+        s += bit[x];
+      return s;
+    };
+    const range = (l, r) => r < l ? 0 : sum(r) - (l > 0 ? sum(l - 1) : 0);
+    let crossings = 0;
+    let k = 0;
+    while (k < intervals.length) {
+      const s = intervals[k][0];
+      let k2 = k;
+      while (k2 < intervals.length && intervals[k2][0] === s)
+        k2++;
+      for (let t = k; t < k2; t++)
+        crossings += range(s + 1, intervals[t][1] - 1);
+      for (let t = k; t < k2; t++)
+        add(intervals[t][1]);
+      k = k2;
     }
-
-    const R = 100;
-    const nodes = new Map();
-    for (let p = 0; p < n; p++) {
-      const vid = orderIdx[p] | 0;
-      const a = (p * 2 * Math.PI) / n;
-      const [x, y] = d3.pointRadial(a, R);
-      const deg = (p * 360) / n;
-      nodes.set(modules[vid].name, [x, y, deg, modules[vid]]);
-    }
-
-    const edges = modules.flatMap((from) =>
-      (from.dependsOn || [])
-        .filter((to) => nodes.has(to))
-        .map((to) => [
-          [from.name, nodes.get(from.name)],
-          [to, nodes.get(to)]
-        ])
-    );
-
-    const plot = Plot.plot({
-      inset: 180,
-      aspectRatio: 1,
-      axis: null,
-      marks: [
-        () => htl.svg`<defs>
+    return crossings;
+  };
+  let orderIdx;
+  if (n <= 2 || undirectedEdges.length === 0 || !useSpectral) {
+    orderIdx = Int32Array.from(d3.range(n));
+  } else {
+    const csr = buildCSRLocal(n, undirectedEdges);
+    const spectral = spectralCircleOrder(csr, {
+      alpha: 0.92,
+      maxIters: 80,
+      tol: 0.0001,
+      seed: 1,
+      passesOrtho: 1
+    });
+    const sifted = improveOrderSifting(n, undirectedEdges, spectral.order, {
+      passes: 1,
+      vertexSequence: 'order'
+    });
+    const baseline = bestOfRandomOrders(n, undirectedEdges, {
+      R: Math.min(n, 12),
+      seed: 1,
+      postSiftPasses: 0
+    });
+    const cSift = crossingsCountLocal(n, undirectedEdges, sifted.order);
+    orderIdx = baseline?.order && baseline.crossings < cSift ? baseline.order : sifted.order;
+  }
+  const R = 100;
+  const nodes = new Map();
+  for (let p = 0; p < n; p++) {
+    const vid = orderIdx[p] | 0;
+    const a = p * 2 * Math.PI / n;
+    const [x, y] = d3.pointRadial(a, R);
+    const deg = p * 360 / n;
+    nodes.set(modules[vid].name, [
+      x,
+      y,
+      deg,
+      modules[vid]
+    ]);
+  }
+  const edges = modules.flatMap(from => (from.dependsOn || []).filter(to => nodes.has(to)).map(to => [
+    [
+      from.name,
+      nodes.get(from.name)
+    ],
+    [
+      to,
+      nodes.get(to)
+    ]
+  ]));
+  const plot = Plot.plot({
+    inset: 180,
+    aspectRatio: 1,
+    axis: null,
+    marks: [
+      () => htl.svg`<defs>
           <linearGradient id="gradient">
             <stop offset="15%" stop-color="red" />
             <stop offset="100%" stop-color="gold" />
           </linearGradient>
         </defs>`,
-        Plot.arrow(edges, {
-          x1: ([[, [x1]]]) => x1,
-          y1: ([[, [, y1]]]) => y1,
-          x2: ([, [, [x2]]]) => x2,
-          y2: ([, [, [, y2]]]) => y2,
-          bend: true,
-          stroke: "url(#gradient)",
-          strokeOpacity: 0.5,
-          strokeLinejoin: "miter",
-          headLength: 3,
-          inset: 5
-        }),
-        Plot.text(
-          [...nodes.entries()].filter(([, c]) => c[2] > 180),
-          {
-            textAnchor: "end",
-            x: ([, c]) => c[0],
-            y: ([, c]) => c[1],
-            rotate: ([, c]) => -c[2] - (c[2] > 180 ? 90 : -90),
-            text: ([k]) => k
-          }
-        ),
-        Plot.text(
-          [...nodes.entries()].filter(([, c]) => c[2] <= 180),
-          {
-            fontSize: 12,
-            textAnchor: "start",
-            x: ([, c]) => c[0],
-            y: ([, c]) => c[1],
-            rotate: ([, c]) => -c[2] - (c[2] > 180 ? 90 : -90),
-            text: ([k]) => k
-          }
-        ),
-        Plot.tip(
-          nodes.entries(),
-          Plot.pointer({
-            x: ([, c]) => c[0],
-            y: ([, c]) => c[1],
-            title: tipTitle,
-            maxRadius: Infinity
-          })
-        )
-      ]
-    });
-
-    const xmlns = "http://www.w3.org/2000/svg";
-    const xlink = "http://www.w3.org/1999/xlink";
-    for (const text of plot.querySelectorAll("text")) {
-      const moduleName = text.textContent;
-      let url;
-      try {
-        url = linkTo(moduleName);
-      } catch {
-        continue;
-      }
-      const a = document.createElementNS(xmlns, "a");
-      a.setAttributeNS(null, "href", url);
-      a.setAttributeNS(xlink, "href", url);
-      text.parentNode.insertBefore(a, text);
-      if (isOnObservableCom()) {
-        a.setAttribute("target", "_blank");
-      }
-      a.appendChild(text);
+      Plot.arrow(edges, {
+        x1: ([[, [x1]]]) => x1,
+        y1: ([[, [, y1]]]) => y1,
+        x2: ([, [, [x2]]]) => x2,
+        y2: ([, [, [, y2]]]) => y2,
+        bend: true,
+        stroke: 'url(#gradient)',
+        strokeOpacity: 0.5,
+        strokeLinejoin: 'miter',
+        headLength: 3,
+        inset: 5
+      }),
+      Plot.text([...nodes.entries()].filter(([, c]) => c[2] > 180), {
+        textAnchor: 'end',
+        x: ([, c]) => c[0],
+        y: ([, c]) => c[1],
+        rotate: ([, c]) => -c[2] - (c[2] > 180 ? 90 : -90),
+        text: ([k]) => k
+      }),
+      Plot.text([...nodes.entries()].filter(([, c]) => c[2] <= 180), {
+        fontSize: 12,
+        textAnchor: 'start',
+        x: ([, c]) => c[0],
+        y: ([, c]) => c[1],
+        rotate: ([, c]) => -c[2] - (c[2] > 180 ? 90 : -90),
+        text: ([k]) => k
+      }),
+      Plot.tip(nodes.entries(), Plot.pointer({
+        x: ([, c]) => c[0],
+        y: ([, c]) => c[1],
+        title: tipTitle,
+        maxRadius: Infinity
+      }))
+    ]
+  });
+  const xmlns = 'http://www.w3.org/2000/svg';
+  const xlink = 'http://www.w3.org/1999/xlink';
+  for (const text of plot.querySelectorAll('text')) {
+    const moduleName = text.textContent;
+    let url;
+    try {
+      url = linkTo(moduleName);
+    } catch {
+      continue;
     }
-
-    return plot;
-  };
-};
+    const a = document.createElementNS(xmlns, 'a');
+    a.setAttributeNS(null, 'href', url);
+    a.setAttributeNS(xlink, 'href', url);
+    text.parentNode.insertBefore(a, text);
+    if (isOnObservableCom()) {
+      a.setAttribute('target', '_blank');
+    }
+    a.appendChild(text);
+  }
+  return plot;
+}
+)};
 const _hgwvol = function _12(md){return(
 md`### Random helpers`
 )};
@@ -16795,88 +17007,85 @@ const _1cir47e = (G, _) => G.input(_);
 const _1nfaybn = function _tag(){return(
 Symbol()
 )};
-const _17qqkoj = function _forcePeek()
+const _1lkbrun = function _forcePeek()
 {
   //console.log("force peek");
-  return (variable, { forever = false } = {}) => {
-    if (variable._value) return variable._value;
+  return (variable, {
+    forever = false
+  } = {}) => {
+    if (variable._value)
+      return variable._value;
     let peeker;
     const promise = new Promise((fulfilled, rejected) => {
-      peeker = variable._module
-        .variable({
-          fulfilled,
-          rejected
-        })
-        .define([variable._name], (m) => m);
+      peeker = variable._module.variable({
+        fulfilled,
+        rejected
+      }).define([variable._name], m => m);
     });
-    if (!forever) promise.finally((v) => peeker.delete());
-    return Promise.race([promise, new Promise((_, r) => setTimeout(r, 1000))]);
+    if (!forever)
+      promise.finally(v => peeker.delete());
+    return Promise.race([
+      promise,
+      new Promise((_, r) => setTimeout(r, 1000))
+    ]);
   };
 };
-const _v9hg2i = function _observe(){return(
+const _1qva85d = function _observe(){return(
 (module, variable_name, observer) => {
-  const variable = module
-    .variable(observer)
-    .define(`dynamic observe ${variable_name}`, [variable_name], (m) => m);
+  const variable = module.variable(observer).define(`dynamic observe ${ variable_name }`, [variable_name], m => m);
   return () => variable.delete();
 }
 )};
 const _1bm642i = function _17(md){return(
 md`### Implementation`
 )};
-const _oothhq = function _queue(flowQueue){return(
-flowQueue({ timeout_ms: 15000, dedupe: true })
+const _1f31b1g = function _queue(flowQueue){return(
+flowQueue({
+  timeout_ms: 15000,
+  dedupe: true
+})
 )};
 const _648shl = (G, _) => G.input(_);
 const _1acbzli = function _19(md){return(
 md`We resolve what we can using variables named with prefix \`module\` that hold module values. We \`forcePeek\` the variables to make them resolve, which forces loading of the modules.`
 )};
-const _10dhunq = async function _module_definition_variables(notebookImports,queue)
+const _1g0cuj1 = async function _module_definition_variables(notebookImports,queue)
 {
-  console.log("module_definition_variables");
+  console.log('module_definition_variables');
   notebookImports;
   queue;
   let last_module_count = -1;
   let module_definition_variables = [];
   while (last_module_count < module_definition_variables.length) {
     last_module_count = module_definition_variables.length;
-    module_definition_variables = (
-      await Promise.all(
-        [...queue.runtime._variables]
-          .filter((v) => v._name && v._name.startsWith("module "))
-          .filter((v) => !v._name.startsWith("module <unknown"))
-          .map(async (v) => {
-            try {
-              v._value = await Promise.race([
-                v._definition(),
-                new Promise((_, reject) =>
-                  setTimeout(() => reject(new Error("timeout")), 1000)
-                )
-              ]);
-              return [v];
-            } catch (err) {
-              console.error("error loading module", v._name, err);
-              return [];
-            }
-          })
-      )
-    ).flat();
+    module_definition_variables = (await Promise.all([...queue.runtime._variables].filter(v => v._name && v._name.startsWith('module ')).filter(v => !v._name.startsWith('module <unknown')).map(async v => {
+      try {
+        v._value = await Promise.race([
+          v._definition(),
+          new Promise((_, reject) => setTimeout(() => reject(new Error('timeout')), 1000))
+        ]);
+        return [v];
+      } catch (err) {
+        console.error('error loading module', v._name, err);
+        return [];
+      }
+    }))).flat();
   }
   return module_definition_variables;
 };
-const _dcxoxy = function _modules(module_definition_variables,queue)
+const _17frsyf = function _modules(module_definition_variables,queue)
 {
-  console.log("modules");
+  console.log('modules');
   module_definition_variables;
-  return [...new Set([...queue.runtime._variables].map((v) => v._module))];
+  return [...new Set([...queue.runtime._variables].map(v => v._module))];
 };
 const _1dqpbvy = function _builtin(queue){return(
 queue.runtime._builtin
 )};
-const _ir3ob0 = function _main_modules(queue,modules,builtin)
+const _13mmmk9 = function _main_modules(queue,modules,builtin)
 {
   const imports = new Set(queue.runtime._modules.values());
-  return modules.filter((m) => !imports.has(m) && m !== builtin);
+  return modules.filter(m => !imports.has(m) && m !== builtin);
 };
 const _yflsv5 = function _bootloaded_mains(queue){return(
 queue.runtime.mains || new Map()
@@ -16884,16 +17093,16 @@ queue.runtime.mains || new Map()
 const _ox2g3b = function _bootloader(queue){return(
 queue.runtime.bootloader
 )};
-const _1turw8j = function _resolve_modules(modules,module_definition_variables,findModuleName)
+const _10ufqkh = function _resolve_modules(modules,module_definition_variables,findModuleName)
 {
-  console.log("resolve_modules");
+  console.log('resolve_modules');
   const module_definitions = new Map();
   const unresolved = [];
-  modules.forEach((m) => {
-    const md = module_definition_variables.find((md) => md._value == m);
+  modules.forEach(m => {
+    const md = module_definition_variables.find(md => md._value == m);
     if (md) {
       module_definitions.set(m, {
-        type: "module variable",
+        type: 'module variable',
         name: findModuleName(md._module._scope, m),
         variable: md
       });
@@ -16901,239 +17110,218 @@ const _1turw8j = function _resolve_modules(modules,module_definition_variables,f
       unresolved.push(m);
     }
   });
-  return { module_definitions, unresolved };
+  return {
+    module_definitions,
+    unresolved
+  };
 };
 const _9fbvam = function _27(md){return(
 md`modules imported via notebook imports do not have module variables, so they are trickier to figure out. We can sniff the page DOM to find the import expressions, and try to map them to the modules we could to resolve earlier`
 )};
-const _1h0lryb = function _notebookImports(main,parser)
+const _1t4ga3d = function _notebookImports(main,parser)
 {
-  console.log("notebookImports");
+  console.log('notebookImports');
   main;
-  return new Map(
-    [...document.querySelectorAll(".observablehq--import")]
-      .map((dom) => [dom, parser.parseCell(dom.textContent)])
-      .map(([dom, node]) => [
-        dom.parentElement,
-        node.body.specifiers.map((s) => ({
-          name: node.body.source.value,
-          dom: dom.parentElement,
-          ast: s,
-          local: s.local.name,
-          imported: s.imported.name
-        }))
-      ])
-  );
+  return new Map([...document.querySelectorAll('.observablehq--import')].map(dom => [
+    dom,
+    parser.parseCell(dom.textContent)
+  ]).map(([dom, node]) => [
+    dom.parentElement,
+    node.body.specifiers.map(s => ({
+      name: node.body.source.value,
+      dom: dom.parentElement,
+      ast: s,
+      local: s.local.name,
+      imported: s.imported.name
+    }))
+  ]));
 };
-const _7t198q = function _notebookImportVariables(runtime,notebookImports)
+const _994hn4 = function _notebookImportVariables(runtime,notebookImports)
 {
-  console.log("notebookImportVariables");
+  console.log('notebookImportVariables');
   return [
-    ...[...runtime._variables] // Observable DOM nodes are referenced in runtime variables
-      .filter(
-        (v) =>
-          v._observer &&
-          v._observer._node &&
-          notebookImports.get(v._observer._node)
-      )
-      .map((v) => ({
-        variable: v,
-        notebookImports: notebookImports.get(v._observer._node)
-      })),
-    ...[
-      ...[...notebookImports.entries()] // visualizer DOM nodes have the variable attached
-        .filter(([pi, vars]) => pi.variable)
-        .map(([pi, vars]) => ({
-          variable: pi.variable,
-          notebookImports: vars
-        }))
-    ]
-  ].sort((a, b) => b.notebookImports.length - a.notebookImports.length); // sort by complexity
+    ...[...runtime._variables]  // Observable DOM nodes are referenced in runtime variables
+.filter(v => v._observer && v._observer._node && notebookImports.get(v._observer._node)).map(v => ({
+      variable: v,
+      notebookImports: notebookImports.get(v._observer._node)
+    })),
+    ...[...[...notebookImports.entries()]  // visualizer DOM nodes have the variable attached
+.filter(([pi, vars]) => pi.variable).map(([pi, vars]) => ({
+        variable: pi.variable,
+        notebookImports: vars
+      }))]
+  ].sort((a, b) => b.notebookImports.length - a.notebookImports.length);  // sort by complexity
 };
-const _1lyens8 = function _pageImportMatch(){return(
-async (notebookImportVariables, modules) => {
-  console.log("pageImportMatch");
-  const backupHas = Map.prototype.has; // Save the original `has` method on Map.prototype
-
-  let currentImport = undefined;
-  const matches = new Map();
-  // Override `Map.prototype.has` to intercept calls to `has` on any Map instance
-  Map.prototype.has = function (...args) {
-    const module = modules.find((m) => m._scope == this);
-    if (currentImport && module) {
-      matches.set(module, {
-        name: currentImport.notebookImports[0].name,
-        type: "notebook import",
-        module: module,
-        dependsOn: [],
-        dependedBy: [],
-        dom: currentImport.notebookImports[0].dom,
-        specifiers: currentImport.notebookImports.map((pi) => ({
-          local: pi.local,
-          imported: pi.imported,
-          variable: pi.variable
-        }))
-      });
-    }
-    return backupHas.call(this, ...args); // Call the original `has` method
-  };
-
-  // Iterate through the notebook imports and define them while capturing `has` calls
-
-  await notebookImportVariables.reduce((chain, pageImportVariable) => {
-    // Call the definition chain
-    return chain.then(async () => {
-      currentImport = pageImportVariable;
-      try {
-        await pageImportVariable.variable._definition();
-      } catch (err) {
-        console.warn(err);
-      }
-      currentImport = undefined;
-    });
-  }, Promise.resolve());
-
-  // Restore the original `has` method after the operations are done
-  Map.prototype.has = backupHas;
-
-  return matches;
-}
-)};
-const _1akt4kz = function _notebookImportMatches(pageImportMatch,notebookImportVariables,modules)
+const _xanizk = function _pageImportMatch()
 {
-  console.log("notebookImportMatches");
+  return async (notebookImportVariables, modules) => {
+    console.log('pageImportMatch');
+    const backupHas = Map.prototype.has;
+    // Save the original `has` method on Map.prototype
+    let currentImport = undefined;
+    const matches = new Map();
+    // Override `Map.prototype.has` to intercept calls to `has` on any Map instance
+    Map.prototype.has = function (...args) {
+      const module = modules.find(m => m._scope == this);
+      if (currentImport && module) {
+        matches.set(module, {
+          name: currentImport.notebookImports[0].name,
+          type: 'notebook import',
+          module: module,
+          dependsOn: [],
+          dependedBy: [],
+          dom: currentImport.notebookImports[0].dom,
+          specifiers: currentImport.notebookImports.map(pi => ({
+            local: pi.local,
+            imported: pi.imported,
+            variable: pi.variable
+          }))
+        });
+      }
+      return backupHas.call(this, ...args);  // Call the original `has` method
+    };
+    // Iterate through the notebook imports and define them while capturing `has` calls
+    await notebookImportVariables.reduce((chain, pageImportVariable) => {
+      // Call the definition chain
+      return chain.then(async () => {
+        currentImport = pageImportVariable;
+        try {
+          await pageImportVariable.variable._definition();
+        } catch (err) {
+          console.warn(err);
+        }
+        currentImport = undefined;
+      });
+    }, Promise.resolve());
+    // Restore the original `has` method after the operations are done
+    Map.prototype.has = backupHas;
+    return matches;
+  };
+};
+const _1q5pc6n = function _notebookImportMatches(pageImportMatch,notebookImportVariables,modules)
+{
+  console.log('notebookImportMatches');
   return pageImportMatch(notebookImportVariables, modules);
 };
-const _1ang0sg = function _moduleTitle(observeVariable){return(
-async function moduleTitle(module) {
-  const runtime = module._runtime;
-  const vars = [...runtime._variables].filter(
-    (v) => v && v._module === module && v._definition
-  );
-  const candidates = vars.filter((v) => {
-    const n = v._name;
-    if (v._type != 1) return false;
-    if (n == null) return true;
-    if (typeof n !== "string") return true;
-    if (n.startsWith("dynamic observe ")) return false;
-    if (n.startsWith("module ")) return false;
-    return true;
-  });
-
-  if (candidates.length === 0) return null;
-
-  const first = candidates.find(
-    (v) => typeof v._id === "number" && Number.isFinite(v._id)
-  )
-    ? candidates.reduce((a, b) =>
-        (a._id ?? Infinity) <= (b._id ?? Infinity) ? a : b
-      )
-    : candidates[0];
-
-  const extract = (v) => {
-    // instanceof cannot be used hear for cross realm
-    if (v == null) return null;
-    if (typeof v === "string") return v.trim() || null;
-    if (v.tagName) {
-      if (v.tagName == "H1") return v.textContent;
-      const h1 = v.querySelector?.("h1");
-      if (h1) return (h1.textContent ?? "").trim() || null;
+const _12o3fj5 = function _moduleTitle(observeVariable)
+{
+  return async function moduleTitle(module) {
+    const runtime = module._runtime;
+    const vars = [...runtime._variables].filter(v => v && v._module === module && v._definition);
+    const candidates = vars.filter(v => {
+      const n = v._name;
+      if (v._type != 1)
+        return false;
+      if (n == null)
+        return true;
+      if (typeof n !== 'string')
+        return true;
+      if (n.startsWith('dynamic observe '))
+        return false;
+      if (n.startsWith('module '))
+        return false;
+      return true;
+    });
+    if (candidates.length === 0)
       return null;
-    }
-    if (v.textContent) return (v.textContent ?? "").trim() || null;
-    const maybeNode = v?.nodeType ? v : null;
-    if (maybeNode?.tagName) return extract(maybeNode);
-    return null;
-  };
-
-  // Read the title WITHOUT re-executing the cell. invokeVariable calls the cell's _definition
-  // directly, bypassing the runtime — for element cells (`htl.html`…${sharedNode}…``) that builds
-  // a *duplicate*, unmanaged DOM subtree and moves shared singleton nodes (e.g. golden-layout's
-  // base_css <style>) out of the live page, breaking the frame. Instead:
-  //  1. If already computed, read the settled _value (fast path, most modules — zero side-effects).
-  //  2. Else force the RUNTIME to compute the *single managed* variable via observe(): it marks the
-  //     existing variable reachable and replays its value, adding no intermediate variable (no
-  //     variable-set churn) and building only the one runtime-owned instance (no duplicate). We
-  //     attach a one-shot observer and fire its invalidation on first settle so it detaches again.
-  if (first._value !== undefined) return extract(first._value);
-  const peekValue = (v) =>
-    new Promise((resolve, reject) => {
+    const first = candidates.find(v => typeof v._id === 'number' && Number.isFinite(v._id)) ? candidates.reduce((a, b) => (a._id ?? Infinity) <= (b._id ?? Infinity) ? a : b) : candidates[0];
+    const extract = v => {
+      // instanceof cannot be used hear for cross realm
+      if (v == null)
+        return null;
+      if (typeof v === 'string')
+        return v.trim() || null;
+      if (v.tagName) {
+        if (v.tagName == 'H1')
+          return v.textContent;
+        const h1 = v.querySelector?.('h1');
+        if (h1)
+          return (h1.textContent ?? '').trim() || null;
+        return null;
+      }
+      if (v.textContent)
+        return (v.textContent ?? '').trim() || null;
+      const maybeNode = v?.nodeType ? v : null;
+      if (maybeNode?.tagName)
+        return extract(maybeNode);
+      return null;
+    };
+    // Read the title WITHOUT re-executing the cell. invokeVariable calls the cell's _definition
+    // directly, bypassing the runtime — for element cells (`htl.html`…${sharedNode}…``) that builds
+    // a *duplicate*, unmanaged DOM subtree and moves shared singleton nodes (e.g. golden-layout's
+    // base_css <style>) out of the live page, breaking the frame. Instead:
+    //  1. If already computed, read the settled _value (fast path, most modules — zero side-effects).
+    //  2. Else force the RUNTIME to compute the *single managed* variable via observe(): it marks the
+    //     existing variable reachable and replays its value, adding no intermediate variable (no
+    //     variable-set churn) and building only the one runtime-owned instance (no duplicate). We
+    //     attach a one-shot observer and fire its invalidation on first settle so it detaches again.
+    if (first._value !== undefined)
+      return extract(first._value);
+    const peekValue = v => new Promise((resolve, reject) => {
       let settled = false;
       let fireInvalidation;
-      const invalidation = new Promise((r) => (fireInvalidation = r));
+      const invalidation = new Promise(r => fireInvalidation = r);
       const finish = (fn, arg) => {
-        if (settled) return;
+        if (settled)
+          return;
         settled = true;
         fireInvalidation();
         fn(arg);
       };
-      observeVariable(
-        v,
-        {
-          fulfilled: (value) => finish(resolve, value),
-          rejected: (err) => finish(reject, err),
-          pending: () => {}
-        },
-        { invalidation }
-      );
+      observeVariable(v, {
+        fulfilled: value => finish(resolve, value),
+        rejected: err => finish(reject, err),
+        pending: () => {
+        }
+      }, { invalidation });
     });
-  try {
-    return extract(await peekValue(first));
-  } catch (err) {
-    return "Err";
-  }
-}
-)};
-const _197sgjt = async function _titles(modules,moduleTitle)
+    try {
+      return extract(await peekValue(first));
+    } catch (err) {
+      return 'Err';
+    }
+  };
+};
+const _ze3jk0 = async function _titles(modules,moduleTitle)
 {
-  const map = new Map(
-    await Promise.all(
-      [...modules].map(async (m) => [
-        m,
-        await Promise.race([
-          moduleTitle(m),
-          new Promise((resolve) =>
-            setTimeout(() => resolve("<TIMEOUT LOADING TITLE>"), 250)
-          )
-        ]).catch((e) => `err: ${e}`)
-      ])
-    )
-  );
+  const map = new Map(await Promise.all([...modules].map(async m => [
+    m,
+    await Promise.race([
+      moduleTitle(m),
+      new Promise(resolve => setTimeout(() => resolve('<TIMEOUT LOADING TITLE>'), 250))
+    ]).catch(e => `err: ${ e }`)
+  ])));
   return map;
 };
-const _11z3pt0 = function _summary(main_modules,titles,bootloader,builtin,queue,notebookImportMatches,bootloaded_mains,resolve_modules,module_definition_variables)
+const _pnpoh8 = function _summary(main_modules,titles,bootloader,builtin,queue,notebookImportMatches,bootloaded_mains,resolve_modules,module_definition_variables)
 {
-  console.log("generate summary");
+  console.log('generate summary');
   const modules = new Map([
-    ...main_modules.map((main_module) => [
+    ...main_modules.map(main_module => [
       main_module,
       {
-        name: "main",
+        name: 'main',
         module: main_module,
         title: titles.get(main_module),
         dependsOn: [],
         dependedBy: []
       }
     ]),
-    ...(bootloader
-      ? [
-          [
-            bootloader,
-            {
-              name: "bootloader",
-              title: "Bootloader",
-              module: bootloader,
-              dependsOn: [],
-              dependedBy: []
-            }
-          ]
-        ]
-      : []),
+    ...bootloader ? [[
+        bootloader,
+        {
+          name: 'bootloader',
+          title: 'Bootloader',
+          module: bootloader,
+          dependsOn: [],
+          dependedBy: []
+        }
+      ]] : [],
     [
       builtin,
       {
-        name: "builtin",
-        title: "Standard library",
+        name: 'builtin',
+        title: 'Standard library',
         module: builtin,
         dependsOn: [],
         dependedBy: []
@@ -17165,30 +17353,21 @@ const _11z3pt0 = function _summary(main_modules,titles,bootloader,builtin,queue,
   ]);
   // add cross links
   // notebookImportVariables[0].variable._module == main
-  [...notebookImportMatches.keys()].forEach((m) => {
+  [...notebookImportMatches.keys()].forEach(m => {
     const hostModule = modules.get(main_modules[0]);
     const importedModule = modules.get(m);
     if (!hostModule?.dependsOn || !importedModule?.dependedBy) {
-      console.error(
-        "error building module dependancy map",
-        hostModule,
-        importedModule
-      );
+      console.error('error building module dependancy map', hostModule, importedModule);
       return;
     }
     hostModule.dependsOn.push(importedModule.name);
     importedModule.dependedBy.push(main_modules[0].name);
   });
-
-  module_definition_variables.forEach((v) => {
+  module_definition_variables.forEach(v => {
     const hostModule = modules.get(v._module);
     const importedModule = modules.get(v._value);
     if (!hostModule?.dependsOn || !importedModule?.dependedBy) {
-      console.error(
-        "error building module dependancy map",
-        hostModule,
-        importedModule
-      );
+      console.error('error building module dependancy map', hostModule, importedModule);
       return;
     }
     hostModule.dependsOn.push(importedModule.name);
@@ -17196,11 +17375,11 @@ const _11z3pt0 = function _summary(main_modules,titles,bootloader,builtin,queue,
   });
   return modules;
 };
-const _1pou2g6 = function _submit_summary(resolve_modules,queue,notebookImports,$0,summary)
+const _hhecn4 = function _submit_summary(resolve_modules,queue,notebookImports,$0,summary)
 {
   resolve_modules;
   queue;
-  console.log("submit_summary");
+  console.log('submit_summary');
   notebookImports;
   $0.resolve(summary);
 };
@@ -17214,47 +17393,47 @@ export default function define(runtime, observer) {
   main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
   main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
   main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));
-  main.define("module @tomlarkworthy/invoke-variable", async () => runtime.module((await import("/@tomlarkworthy/invoke-variable.js?v=4")).default));
-  main.define("module @tomlarkworthy/spectral-layout", async () => runtime.module((await import("/@tomlarkworthy/spectral-layout.js?v=4")).default));
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/invoke-variable", async () => runtime.module((await import("/@tomlarkworthy/invoke-variable.js?v=4")).default));  
+  main.define("module @tomlarkworthy/spectral-layout", async () => runtime.module((await import("/@tomlarkworthy/spectral-layout.js?v=4")).default));  
   $def("_1w9yf3l", null, ["md"], _1w9yf3l);  
   $def("_b6n8js", null, ["visualizeModules"], _b6n8js);  
   $def("_1sznqfl", null, ["md"], _1sznqfl);  
-  $def("_1798myt", "moduleMap", ["runtime","keepalive","myModule","viewof queue"], _1798myt);  
+  $def("_1hn3uql", "moduleMap", ["runtime","keepalive","myModule","viewof queue"], _1hn3uql);  
   $def("_1yso65r", null, ["md"], _1yso65r);  
-  $def("_1fcoh6x", "sync_modules", ["runtime_variables","moduleMap","_","viewof currentModules","Event"], _1fcoh6x);  
+  $def("_1e3kr85", "sync_modules", ["runtime_variables","moduleMap","_","viewof currentModules","Event"], _1e3kr85);  
   $def("_wi39n0", "viewof currentModules", ["Inputs","moduleMap"], _wi39n0);  
   $def("_1gxgyd6", "currentModules", ["Generators","viewof currentModules"], _1gxgyd6);  
-  $def("_1qag34d", null, ["Inputs","currentModules"], _1qag34d);  
+  $def("_1kxoygl", null, ["Inputs","currentModules"], _1kxoygl);  
   $def("_1xamz8j", null, ["md"], _1xamz8j);  
-  $def("_1n4p4hn", "tipTitle", [], _1n4p4hn);  
-  $def("_1kdcb71", "visualizeModules", ["currentModules","htl","d3","spectralCircleOrder","improveOrderSifting","bestOfRandomOrders","Plot","tipTitle","linkTo","isOnObservableCom"], _1kdcb71);  
+  $def("_1sglrv3", "tipTitle", [], _1sglrv3);  
+  $def("_5zbe1k", "visualizeModules", ["currentModules","htl","d3","spectralCircleOrder","improveOrderSifting","bestOfRandomOrders","Plot","tipTitle","linkTo","isOnObservableCom"], _5zbe1k);  
   $def("_hgwvol", null, ["md"], _hgwvol);  
   $def("_14bivfb", "viewof myModule", ["thisModule"], _14bivfb);  
   $def("_1cir47e", "myModule", ["Generators","viewof myModule"], _1cir47e);  
   $def("_1nfaybn", "tag", [], _1nfaybn);  
-  $def("_17qqkoj", "forcePeek", [], _17qqkoj);  
-  $def("_v9hg2i", "observe", [], _v9hg2i);  
+  $def("_1lkbrun", "forcePeek", [], _1lkbrun);  
+  $def("_1qva85d", "observe", [], _1qva85d);  
   $def("_1bm642i", null, ["md"], _1bm642i);  
-  $def("_oothhq", "viewof queue", ["flowQueue"], _oothhq);  
+  $def("_1f31b1g", "viewof queue", ["flowQueue"], _1f31b1g);  
   $def("_648shl", "queue", ["Generators","viewof queue"], _648shl);  
   $def("_1acbzli", null, ["md"], _1acbzli);  
-  $def("_10dhunq", "module_definition_variables", ["notebookImports","queue"], _10dhunq);  
-  $def("_dcxoxy", "modules", ["module_definition_variables","queue"], _dcxoxy);  
+  $def("_1g0cuj1", "module_definition_variables", ["notebookImports","queue"], _1g0cuj1);  
+  $def("_17frsyf", "modules", ["module_definition_variables","queue"], _17frsyf);  
   $def("_1dqpbvy", "builtin", ["queue"], _1dqpbvy);  
-  $def("_ir3ob0", "main_modules", ["queue","modules","builtin"], _ir3ob0);  
+  $def("_13mmmk9", "main_modules", ["queue","modules","builtin"], _13mmmk9);  
   $def("_yflsv5", "bootloaded_mains", ["queue"], _yflsv5);  
   $def("_ox2g3b", "bootloader", ["queue"], _ox2g3b);  
-  $def("_1turw8j", "resolve_modules", ["modules","module_definition_variables","findModuleName"], _1turw8j);  
+  $def("_10ufqkh", "resolve_modules", ["modules","module_definition_variables","findModuleName"], _10ufqkh);  
   $def("_9fbvam", null, ["md"], _9fbvam);  
-  $def("_1h0lryb", "notebookImports", ["main","parser"], _1h0lryb);  
-  $def("_7t198q", "notebookImportVariables", ["runtime","notebookImports"], _7t198q);  
-  $def("_1lyens8", "pageImportMatch", [], _1lyens8);  
-  $def("_1akt4kz", "notebookImportMatches", ["pageImportMatch","notebookImportVariables","modules"], _1akt4kz);  
-  $def("_1ang0sg", "moduleTitle", ["observeVariable"], _1ang0sg);
-  $def("_197sgjt", "titles", ["modules","moduleTitle"], _197sgjt);  
-  $def("_11z3pt0", "summary", ["main_modules","titles","bootloader","builtin","queue","notebookImportMatches","bootloaded_mains","resolve_modules","module_definition_variables"], _11z3pt0);  
-  $def("_1pou2g6", "submit_summary", ["resolve_modules","queue","notebookImports","viewof queue","summary"], _1pou2g6);  
+  $def("_1t4ga3d", "notebookImports", ["main","parser"], _1t4ga3d);  
+  $def("_994hn4", "notebookImportVariables", ["runtime","notebookImports"], _994hn4);  
+  $def("_xanizk", "pageImportMatch", [], _xanizk);  
+  $def("_1q5pc6n", "notebookImportMatches", ["pageImportMatch","notebookImportVariables","modules"], _1q5pc6n);  
+  $def("_12o3fj5", "moduleTitle", ["observeVariable"], _12o3fj5);  
+  $def("_ze3jk0", "titles", ["modules","moduleTitle"], _ze3jk0);  
+  $def("_pnpoh8", "summary", ["main_modules","titles","bootloader","builtin","queue","notebookImportMatches","bootloaded_mains","resolve_modules","module_definition_variables"], _pnpoh8);  
+  $def("_hhecn4", "submit_summary", ["resolve_modules","queue","notebookImports","viewof queue","summary"], _hhecn4);  
   main.define("linkTo", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("linkTo", _));  
   main.define("flowQueue", ["module @tomlarkworthy/flow-queue", "@variable"], (_, v) => v.import("flowQueue", _));  
   main.define("parser", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("parser", _));  
@@ -17268,222 +17447,391 @@ export default function define(runtime, observer) {
   main.define("isOnObservableCom", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("isOnObservableCom", _));  
   main.define("viewof runtime_variables", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("viewof runtime_variables", _));  
   main.define("runtime_variables", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime_variables", _));  
-  main.define("observeVariable", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("observe", "observeVariable", _));
-  main.define("invokeVariable", ["module @tomlarkworthy/invoke-variable", "@variable"], (_, v) => v.import("invokeVariable", _));
+  main.define("observeVariable", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("observe", "observeVariable", _));  
+  main.define("invokeVariable", ["module @tomlarkworthy/invoke-variable", "@variable"], (_, v) => v.import("invokeVariable", _));  
   main.define("spectralCircleOrder", ["module @tomlarkworthy/spectral-layout", "@variable"], (_, v) => v.import("spectralCircleOrder", _));  
   main.define("improveOrderSifting", ["module @tomlarkworthy/spectral-layout", "@variable"], (_, v) => v.import("improveOrderSifting", _));  
   main.define("bestOfRandomOrders", ["module @tomlarkworthy/spectral-layout", "@variable"], (_, v) => v.import("bestOfRandomOrders", _));
   return main;
 }</script>
 
-<script id="@tomlarkworthy/module-selection" 
+<script id="@tomlarkworthy/modules" 
   type="text/plain"
   data-mime="application/javascript"
 >
-const _1umhlcn = function _1(md){return(
-md`# Explorer: Module Selector`
-)};
-const _b6n8js = function _2(visualizeModules){return(
-visualizeModules()
-)};
-const _1y97u4c = function _selected_modules(persistedAttachments,hash,getHashModules,currentModules,Inputs,html,linkTo)
-{
-  persistedAttachments; // load persisted modules as well
-  hash; // recompute if hash changes
-  const hashModules = getHashModules();
-  const modules = [...currentModules.values()].map((m) => ({
-    ...m,
-    cell: hashModules.get(m.name)?.cell
-  }));
-  return Inputs.table(modules, {
-    rows: Infinity,
-    sort: "name",
-    columns: ["name" /*, "cell"*/],
-    required: false,
-    value: modules.filter((m) => hashModules.get(m.name)),
-    format: {
-      name: (name) => html`<a href="${linkTo(name)}">${name}</a>`
-    }
-  });
-};
-const _1j5tq63 = (G, _) => G.input(_);
-const _yiedgc = function _4(currentModules){return(
-currentModules.values()
-)};
-const _y5ux30 = function _create_module(Inputs){return(
-Inputs.text({
-  label: "create module",
-  width: "400px",
-  submit: "create",
-  placeholder: "@user/scratch",
-  width: "400px",
-  pattern: "^@[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*/[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*$"
-})
-)};
-const _1ll7bx3 = (G, _) => G.input(_);
-const _1vrx9jk = function _additional_module(Inputs){return(
-Inputs.text({
-  label: "load module",
-  placeholder: "@tomlarkworthy/debugger",
-  width: "400px",
-  pattern: "^@[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*/[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*$",
-  submit: "import"
-})
-)};
-const _3ukf68 = (G, _) => G.input(_);
-const _au41oe = function _remove_module(Inputs,currentModules){return(
-Inputs.select([null, currentModules.values()], {
-  label: "remove module",
-  width: "400px",
-  format: (module) => module?.name
-})
-)};
-const _1iasv3r = (G, _) => G.input(_);
-const _hj6sn = function _9(md){return(
-md`## Additional Modules
+const _s7bl1p = function _1(md){return(
+md`# Modules
 
-Extra modules for dynamic loading are named as a JSON list in file attachment \`additionalModules.json\``
+\`modules(options?)\` is an async generator that yields a **cumulative \`Map\`** (module → \`{name, title, module, variable}\`) of every fully-formed record known so far, growing as modules resolve. 
+
+It's an effecient alternative to [moduleMap](https://observablehq.com/@tomlarkworthy/module-map) that blocks until all modules are loaded.
+`
 )};
-const _17w9o9j = function _notebookModule(thisModule){return(
+const _1eaa9lr = function _currentModules(modules){return(
+modules()
+)};
+const _dmem61 = function _modules(runtime, observeVariable, moduleTitle) {
+    const _runtime = runtime;
+    return function modules({runtime = _runtime, titleTimeoutMs = 2000, rescanMs = 1000, load = true} = {}) {
+        if (!runtime || !runtime._variables)
+            throw 'Invalid runtime passed to modules';
+        return async function* () {
+            const records = new Map();
+            const watchers = new Map();
+            const peeking = new Map();
+            let pending = false, wake = null, dirty = true;
+            const bump = () => {
+                pending = true;
+                if (wake) {
+                    const w = wake;
+                    wake = null;
+                    w();
+                }
+            };
+            const touch = () => {
+                dirty = true;
+                bump();
+            };
+            const slugFromDef = v => {
+                const m = v._definition && String(v._definition).match(/import(?:Shim)?\(\s*["'`]\/?([^"'`?]+?)\.js(?:[?"'`)]|$)/);
+                return m ? m[1].replace(/^\//, '') : null;
+            };
+            const scan = () => {
+                const out = new Map();
+                const put = (m, r) => {
+                    if (m && !out.has(m))
+                        out.set(m, r);
+                };
+                const builtin = runtime._builtin, bootloader = runtime.bootloader;
+                if (builtin)
+                    put(builtin, {
+                        name: 'builtin',
+                        title: 'Standard library'
+                    });
+                if (bootloader)
+                    put(bootloader, {
+                        name: 'bootloader',
+                        title: 'Bootloader'
+                    });
+                for (const [name, mod] of runtime.mains || new Map())
+                    put(mod, { name });
+                const imported = new Set((runtime._modules || new Map()).values());
+                const owners = new Set();
+                for (const v of runtime._variables)
+                    if (v._module)
+                        owners.add(v._module);
+                for (const m of owners)
+                    if (m !== builtin && m !== bootloader && !imported.has(m))
+                        put(m, { name: 'main' });
+                for (const v of runtime._variables) {
+                    if (!v._name || !v._name.startsWith('module ') || v._name.startsWith('module <unknown'))
+                        continue;
+                    const mod = v._value;
+                    if (mod && typeof mod === 'object')
+                        put(mod, {
+                            name: slugFromDef(v) || v._name.slice(7),
+                            variable: v
+                        });
+                    else if (load && !peeking.has(v))
+                        peeking.set(v, observeVariable(v, {
+                            fulfilled: bump,
+                            error: bump
+                        }));
+                }
+                return out;
+            };
+            const reconcile = () => {
+                const cand = scan();
+                for (const m of [...watchers.keys()]) {
+                    if (!cand.has(m)) {
+                        const cancel = watchers.get(m);
+                        watchers.delete(m);
+                        if (records.delete(m))
+                            touch();
+                        try {
+                            cancel();
+                        } catch (e) {
+                        }
+                    }
+                }
+                for (const [m, c] of cand) {
+                    if (watchers.has(m))
+                        continue;
+                    if (c.title != null) {
+                        records.set(m, {
+                            name: c.name,
+                            title: c.title,
+                            module: m,
+                            variable: c.variable
+                        });
+                        watchers.set(m, () => {
+                        });
+                        touch();
+                        continue;
+                    }
+                    const apply = title => {
+                        if (!watchers.has(m))
+                            return;
+                        const t = title ?? c.name;
+                        const prev = records.get(m);
+                        if (!prev) {
+                            records.set(m, {
+                                name: c.name,
+                                title: t,
+                                module: m,
+                                variable: c.variable
+                            });
+                            touch();
+                        } else if (prev.title !== t) {
+                            records.set(m, {
+                                ...prev,
+                                title: t
+                            });
+                            touch();
+                        }
+                    };
+                    const cancel = moduleTitle(m, apply);
+                    watchers.set(m, () => {
+                        try {
+                            cancel();
+                        } catch (e) {
+                        }
+                    });
+                    setTimeout(() => {
+                        if (watchers.has(m) && !records.has(m))
+                            apply(null);
+                    }, titleTimeoutMs);
+                }
+            };
+            let stopped = false;
+            (async () => {
+                while (!stopped) {
+                    try {
+                        reconcile();
+                    } catch (e) {
+                    }
+                    await new Promise(r => setTimeout(r, rescanMs));
+                }
+            })();
+            try {
+                while (true) {
+                    pending = false;
+                    if (dirty) {
+                        dirty = false;
+                        yield new Map(records);
+                    }
+                    if (!pending)
+                        await new Promise(resolve => {
+                            wake = resolve;
+                            if (pending) {
+                                wake = null;
+                                resolve();
+                            }
+                        });
+                }
+            } finally {
+                stopped = true;
+                for (const cancel of watchers.values()) {
+                    try {
+                        cancel();
+                    } catch (e) {
+                    }
+                }
+                for (const stop of peeking.values()) {
+                    try {
+                        stop();
+                    } catch (e) {
+                    }
+                }
+            }
+        }();
+    };
+};
+const _up9atj = function _moduleTitle(observeVariable)
+{
+  return function moduleTitle(module, onTitle) {
+    // Observes a module's title-defining cell and calls onTitle(title|null) on every change.
+    // Returns a cancel fn. The fixed observe() forces a lazy title cell to compute (and replays
+    // the current value on attach), so no in-module forcing helper is needed — works for named
+    // and anonymous cells alike, even in a fresh runtime nothing else observes.
+    const rt = module._runtime;
+    const candidates = [...rt._variables].filter(v => {
+      if (!v || v._module !== module || !v._definition || v._type != 1)
+        return false;
+      const n = v._name;
+      if (typeof n === 'string' && (n.startsWith('dynamic observe ') || n.startsWith('module ')))
+        return false;
+      return true;
+    });
+    if (candidates.length === 0) {
+      onTitle(null);
+      return () => {
+      };
+    }
+    const first = candidates.reduce((a, b) => (a._id ?? Infinity) <= (b._id ?? Infinity) ? a : b);
+    const extract = v => {
+      if (v == null)
+        return null;
+      if (typeof v === 'string')
+        return v.trim() || null;
+      if (v.tagName) {
+        if (v.tagName == 'H1')
+          return v.textContent;
+        const h1 = v.querySelector?.('h1');
+        if (h1)
+          return (h1.textContent ?? '').trim() || null;
+        return null;
+      }
+      if (v.textContent)
+        return (v.textContent ?? '').trim() || null;
+      return null;
+    };
+    const stop = observeVariable(first, {
+      fulfilled: value => onTitle(extract(value)),
+      error: () => onTitle('Err')
+    });
+    return () => {
+      try {
+        stop();
+      } catch (e) {
+      }
+    };
+  };
+};
+const _qpensj = function _5(Inputs,currentModules){return(
+Inputs.table([...currentModules.values()], {
+  columns: [
+    'name',
+    'title'
+  ],
+  format: { name: x => x }
+})
+)};
+const _1x0q6zt = function _7(md){return(
+md`## Tests`
+)};
+const _e0sbyj = function _8(tests,modulesModule){return(
+tests({
+  filter: (t) => t.variable._module == modulesModule
+})
+)};
+const _p3rq3v = function _modulesModule(thisModule){return(
 thisModule()
 )};
-const _1f136ll = (G, _) => G.input(_);
-const _ngwjdv = async function _persistedAttachments(getFileAttachments,notebookModule,importNotebook)
+const _16g1ab = (G, _) => G.input(_);
+const _cayyvt = function _testRuntime(Runtime){return(
+new Runtime()
+)};
+const _1j4p6g3 = function _testModulesLatest(modules,testRuntime){return(
+modules({
+  runtime: testRuntime
+})
+)};
+const _1oq6y7s = function _newModule(testRuntime)
 {
-  const attachments = getFileAttachments(notebookModule);
-  if (attachments.has("additionalModules.json")) {
-    const extras = new Set(
-      await attachments.get("additionalModules.json").json()
-    );
-    await Promise.all(
-      [...extras].map(async (notebook) => await importNotebook(notebook, []))
-    );
-    return extras;
-  } else return new Set();
+  const m = testRuntime.module();
+  m.variable().define("greeting", [], () => {
+    const div = document.createElement("div");
+    div.innerHTML = "<h1>New Module</h1>";
+    return div;
+  });
+  return m;
 };
-const _1huqss5 = function _additionalModules(persistedAttachments){return(
-persistedAttachments || new Set()
-)};
-const _a2tw23 = function _addModuleAndPersist(additionalModules,setFileAttachment,jsonFileAttachment,notebookModule){return(
-function addModuleAndPersist(name) {
-  additionalModules.add(name);
-  setFileAttachment(
-    jsonFileAttachment("additionalModules.json", [...additionalModules]),
-    notebookModule
-  );
-}
-)};
-const _vk2l4w = function _removeModuleAndPersist(additionalModules,setFileAttachment,jsonFileAttachment,notebookModule){return(
-(name) => {
-  additionalModules.delete(name);
-  setFileAttachment(
-    jsonFileAttachment("additionalModules.json", [...additionalModules]),
-    notebookModule
-  );
-}
-)};
-const _iz3nhl = function _createModule($0,invalidation,create_module,notebookModule,addModuleAndPersist)
+const _1li1bty = function _test_detectsBuiltin(testModulesLatest)
 {
-  const input = $0.querySelector("input");
-  const report = () => $0.reportValidity();
-  input.addEventListener("input", report);
-  invalidation.then(() => input.removeEventListener("input", report));
-
-  if (create_module && create_module !== "") {
-    const runtime = notebookModule._runtime;
-    const moduleSource = `export default function define(runtime, observer) {
-      const main = runtime.module();
-      main.variable(observer()).define(["md"], (md) => md\`# Untitled\`);
-    }`;
-    const blob = new Blob([moduleSource], { type: "text/javascript" });
-    const url = URL.createObjectURL(blob);
-    const variableSource = `async () => "${create_module}" && runtime.module((await import("${url}")).default)`;
-    let definition;
-    eval("definition = " + variableSource);
-    const moduleVariable = notebookModule.define(
-      `module ${create_module}`,
-      [],
-      definition
-    );
-    addModuleAndPersist(create_module);
-    return moduleVariable;
-  }
+  if (![...testModulesLatest.values()].find((m) => m.name == "builtin"))
+    throw Error();
+  return "ok";
 };
-const _qq8c6a = async function _addModule($0,invalidation,additional_module,additionalModules,importNotebook,addModuleAndPersist)
+const _vr1kp6 = function _test_detectsNewModule(testModulesLatest,newModule)
 {
-  const input = $0.querySelector("input");
-  const report = () => $0.reportValidity();
-  input.addEventListener("input", report);
-  invalidation.then(() => input.removeEventListener("input", report));
-  if (
-    additional_module &&
-    additional_module !== "" &&
-    !additionalModules.has(additional_module)
-  ) {
-    await importNotebook(additional_module, []);
-    addModuleAndPersist(additional_module);
-  }
+  const rec = testModulesLatest.get(newModule);
+  if (!rec) throw Error("newModule not detected yet");
+  if (rec.title !== "New Module")
+    throw Error(
+      "expected title 'New Module', got " + JSON.stringify(rec.title)
+    );
+  return "ok";
 };
-const _7048bu = function _removeModule(remove_module,removeModuleAndPersist)
+const _1p0sqk = async function _test_reflectsDelete(Runtime,modules)
 {
-  if (remove_module) {
-    removeModuleAndPersist(remove_module);
-    const variables = [...remove_module.module._runtime._variables].filter(
-      (v) =>
-        v._module == remove_module.module ||
-        v._name == `module ${remove_module.name}`
-    );
-    const entry = [...remove_module.module._runtime._modules.entries()].find(
-      ([key, value]) => value == remove_module.module
-    );
-
-    if (entry) {
-      const [define, module] = entry;
-      remove_module.module._runtime._modules.delete(define);
-    }
-
-    variables.forEach((v) => v.delete());
-    return remove_module;
-  }
-};
-const _krx5v2 = function _20(moduleMap){return(
-moduleMap()
-)};
-const _1y8y9do = function _21(md){return(
-md`## URL encoding`
-)};
-const _1tr0cuo = function _getHashModules(URLSearchParams,location,listModules){return(
-() => {
-  const hashParams = new URLSearchParams(location.hash.slice(1));
-  const view = hashParams.get("view");
-  const open = hashParams.get("open");
-
-  const base = (() => {
-    try {
-      const m = listModules(view);
-      return m instanceof Map ? m : new Map(m);
-    } catch (err) {
-      return new Map();
-    }
+  const rt = new Runtime();
+  const gen = modules({
+    runtime: rt,
+    rescanMs: 100,
+    titleTimeoutMs: 500
+  });
+  let snap = new Map();
+  (async () => {
+    for await (const s of gen) snap = s;
   })();
-
-  if (open) {
-    const [title, cell] = String(open).split("#");
-    if (title) base.set(title, { title, cell: cell || null });
+  const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+  const waitFor = async (pred, ms = 3000) => {
+    const t0 = Date.now();
+    while (Date.now() - t0 < ms) {
+      if (pred()) return true;
+      await wait(50);
+    }
+    return false;
+  };
+  try {
+    const m = rt.module();
+    m.variable().define("title", [], () => {
+      const d = document.createElement("div");
+      d.innerHTML = "<h1>Temp</h1>";
+      return d;
+    });
+    if (!(await waitFor(() => snap.has(m))))
+      throw Error("create not reflected");
+    for (const v of [...rt._variables]) if (v._module === m) v.delete();
+    if (!(await waitFor(() => !snap.has(m))))
+      throw Error("delete not reflected");
+    return "ok";
+  } finally {
+    if (gen.return) gen.return();
   }
-
-  return new Map(base);
-}
-)};
-const _lru2lz = function _25(md){return(
-md`## Model`
-)};
-const _wcovkr = function _26(md){return(
-md`## Background Tasks`
-)};
-const _a3xgg4 = function _navigator_jobs(updateNotebookImports,submit_summary,$0,currentModules)
+};
+const _1315qaf = async function _test_reflectsTitleUpdate(Runtime,modules)
 {
-  updateNotebookImports, submit_summary, $0, currentModules;
+  const rt = new Runtime();
+  const gen = modules({
+    runtime: rt,
+    rescanMs: 100,
+    titleTimeoutMs: 500
+  });
+  let snap = new Map();
+  (async () => {
+    for await (const s of gen) snap = s;
+  })();
+  const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+  const waitFor = async (pred, ms = 3000) => {
+    const t0 = Date.now();
+    while (Date.now() - t0 < ms) {
+      if (pred()) return true;
+      await wait(50);
+    }
+    return false;
+  };
+  try {
+    const m = rt.module();
+    const tv = m.variable().define("title", [], () => {
+      const d = document.createElement("div");
+      d.innerHTML = "<h1>First</h1>";
+      return d;
+    });
+    if (!(await waitFor(() => snap.get(m)?.title === "First")))
+      throw Error("initial title not detected");
+    tv.define("title", [], () => {
+      const d = document.createElement("div");
+      d.innerHTML = "<h1>Second</h1>";
+      return d;
+    });
+    if (!(await waitFor(() => snap.get(m)?.title === "Second")))
+      throw Error("title update not reflected");
+    return "ok";
+  } finally {
+    if (gen.return) gen.return();
+  }
 };
 
 export default function define(runtime, observer) {
@@ -17492,60 +17840,30 @@ export default function define(runtime, observer) {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
 
-  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
-  main.define("module @tomlarkworthy/import-notebook", async () => runtime.module((await import("/@tomlarkworthy/import-notebook.js?v=4")).default));  
-  main.define("module @tomlarkworthy/fileattachments", async () => runtime.module((await import("/@tomlarkworthy/fileattachments.js?v=4")).default));  
-  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
-  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
-  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
   main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
-  $def("_1umhlcn", null, ["md"], _1umhlcn);  
-  $def("_b6n8js", null, ["visualizeModules"], _b6n8js);  
-  $def("_1y97u4c", "viewof selected_modules", ["persistedAttachments","hash","getHashModules","currentModules","Inputs","html","linkTo"], _1y97u4c);  
-  $def("_1j5tq63", "selected_modules", ["Generators","viewof selected_modules"], _1j5tq63);  
-  $def("_yiedgc", null, ["currentModules"], _yiedgc);  
-  $def("_y5ux30", "viewof create_module", ["Inputs"], _y5ux30);  
-  $def("_1ll7bx3", "create_module", ["Generators","viewof create_module"], _1ll7bx3);  
-  $def("_1vrx9jk", "viewof additional_module", ["Inputs"], _1vrx9jk);  
-  $def("_3ukf68", "additional_module", ["Generators","viewof additional_module"], _3ukf68);  
-  $def("_au41oe", "viewof remove_module", ["Inputs","currentModules"], _au41oe);  
-  $def("_1iasv3r", "remove_module", ["Generators","viewof remove_module"], _1iasv3r);  
-  main.define("cellMap", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("cellMap", _));  
-  $def("_hj6sn", null, ["md"], _hj6sn);  
-  $def("_17w9o9j", "viewof notebookModule", ["thisModule"], _17w9o9j);  
-  $def("_1f136ll", "notebookModule", ["Generators","viewof notebookModule"], _1f136ll);  
-  main.define("importNotebook", ["module @tomlarkworthy/import-notebook", "@variable"], (_, v) => v.import("importNotebook", _));  
-  main.define("jsonFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("jsonFileAttachment", _));  
-  main.define("setFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("setFileAttachment", _));  
-  main.define("removeFileAttachment", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("removeFileAttachment", _));  
-  main.define("getFileAttachments", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachments", _));  
-  $def("_ngwjdv", "persistedAttachments", ["getFileAttachments","notebookModule","importNotebook"], _ngwjdv);  
-  $def("_1huqss5", "additionalModules", ["persistedAttachments"], _1huqss5);  
-  $def("_a2tw23", "addModuleAndPersist", ["additionalModules","setFileAttachment","jsonFileAttachment","notebookModule"], _a2tw23);  
-  $def("_vk2l4w", "removeModuleAndPersist", ["additionalModules","setFileAttachment","jsonFileAttachment","notebookModule"], _vk2l4w);  
-  $def("_iz3nhl", "createModule", ["viewof create_module","invalidation","create_module","notebookModule","addModuleAndPersist"], _iz3nhl);  
-  $def("_qq8c6a", "addModule", ["viewof additional_module","invalidation","additional_module","additionalModules","importNotebook","addModuleAndPersist"], _qq8c6a);  
-  $def("_7048bu", "removeModule", ["remove_module","removeModuleAndPersist"], _7048bu);  
-  $def("_krx5v2", null, ["moduleMap"], _krx5v2);  
-  $def("_1y8y9do", null, ["md"], _1y8y9do);  
-  main.define("parseGoldenDSL", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("parseGoldenDSL", _));  
-  main.define("listModules", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("listModules", _));  
-  main.define("serializeGoldenDSL", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("serializeGoldenDSL", _));  
-  main.define("linkTo", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("linkTo", _));  
-  main.define("updateNotebookImports", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("updateNotebookImports", _));  
-  $def("_1tr0cuo", "getHashModules", ["URLSearchParams","location","listModules"], _1tr0cuo);  
-  main.define("hash", ["module d/57d79353bac56631@44", "@variable"], (_, v) => v.import("hash", _));  
-  $def("_lru2lz", null, ["md"], _lru2lz);  
-  $def("_wcovkr", null, ["md"], _wcovkr);  
-  $def("_a3xgg4", "navigator_jobs", ["updateNotebookImports","submit_summary","viewof currentModules","currentModules"], _a3xgg4);  
-  main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
-  main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
-  main.define("viewof currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("viewof currentModules", _));  
-  main.define("currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("currentModules", _));  
-  main.define("visualizeModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("visualizeModules", _));  
-  main.define("thisModule", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("thisModule", _));  
+  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
+  main.define("module @tomlarkworthy/observable-runtime-v6", async () => runtime.module((await import("/@tomlarkworthy/observable-runtime-v6.js?v=4")).default));  
+  $def("_s7bl1p", null, ["md"], _s7bl1p);  
+  $def("_1eaa9lr", "currentModules", ["modules"], _1eaa9lr);  
+  $def("_dmem61", "modules", ["runtime","observeVariable","moduleTitle"], _dmem61);  
+  $def("_up9atj", "moduleTitle", ["observeVariable"], _up9atj);  
+  $def("_qpensj", null, ["Inputs","currentModules"], _qpensj);  
+  main.define("observeVariable", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("observe", "observeVariable", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
-  main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));
+  main.define("thisModule", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("thisModule", _));  
+  $def("_1x0q6zt", null, ["md"], _1x0q6zt);  
+  $def("_e0sbyj", null, ["tests","modulesModule"], _e0sbyj);  
+  main.define("tests", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("tests", _));  
+  main.define("Runtime", ["module @tomlarkworthy/observable-runtime-v6", "@variable"], (_, v) => v.import("Runtime", _));  
+  $def("_p3rq3v", "viewof modulesModule", ["thisModule"], _p3rq3v);  
+  $def("_16g1ab", "modulesModule", ["Generators","viewof modulesModule"], _16g1ab);  
+  $def("_cayyvt", "testRuntime", ["Runtime"], _cayyvt);  
+  $def("_1j4p6g3", "testModulesLatest", ["modules","testRuntime"], _1j4p6g3);  
+  $def("_1oq6y7s", "newModule", ["testRuntime"], _1oq6y7s);  
+  $def("_1li1bty", "test_detectsBuiltin", ["testModulesLatest"], _1li1bty);  
+  $def("_vr1kp6", "test_detectsNewModule", ["testModulesLatest","newModule"], _vr1kp6);  
+  $def("_1p0sqk", "test_reflectsDelete", ["Runtime","modules"], _1p0sqk);  
+  $def("_1315qaf", "test_reflectsTitleUpdate", ["Runtime","modules"], _1315qaf);
   return main;
 }</script>
 <script id="@tomlarkworthy/observable-runtime/runtime.js.gz" 
@@ -21219,6 +21537,68 @@ const _16fpgac = async function _test_decompileImport_stageB_notebook_id(stageB_
   expect(formatImportDeclaration(info)).toEqual(`import {hash} from "d/57d79353bac56631@44"`);
   return 'ok';
 };
+const _r2e0wl = function _test_extractModuleInfo_new_id_resolutions(expect,extractModuleInfo)
+{
+  // new.observablehq.com d/<id>@<ver> import with resolutions=.
+  expect(
+    extractModuleInfo(
+      'async () => runtime.module((await import("/d/e1c39d41e8e944b0@939.js?v=4&resolutions=a6a56ee61aba9799@437")).default)'
+    )
+  ).toEqual({ id: "e1c39d41e8e944b0", version: "939" });
+  return "ok";
+};
+const _1pg1y6s = function _test_extractModuleInfo_new_slug_resolutions(expect,extractModuleInfo)
+{
+  // new.observablehq.com slug import carries a resolutions= param.
+  expect(
+    extractModuleInfo(
+      'async () => runtime.module((await import("/@mootari/access-runtime.js?v=4&resolutions=98f34e974bb2e4bc@1392")).default)'
+    )
+  ).toEqual({ namespace: "mootari", notebook: "access-runtime", version: "1392" });
+  return "ok";
+};
+const _1vh26m0 = function _test_findModuleName_classic_bundle(expect,findModuleName)
+{
+  // classic observablehq.com bundles imports; the holder def is a bare slug import.
+  const m = {}; // module sentinel
+  const scope = new Map([
+    ["module 1", { _name: "module 1", _value: m,
+      _definition: 'async () => runtime.module((await import("@tomlarkworthy/flow-queue")).default)' }]
+  ]);
+  expect(findModuleName(scope, m)).toEqual("@tomlarkworthy/flow-queue");
+  return "ok";
+};
+const _1ltqcwj = function _test_findModuleName_kit_slug(expect,findModuleName)
+{
+  // Notebook Kit compiles observable imports to import("https://api.observablehq.com/@u/nb.js?v=4").
+  const m = {}; // module sentinel
+  const scope = new Map([
+    ["module 1", { _name: "module 1", _value: m,
+      _definition: 'async (__ojs_runtime) => __ojs_runtime.module((await import("https://api.observablehq.com/@d3/color-legend.js?v=4")).default)' }]
+  ]);
+  expect(findModuleName(scope, m)).toEqual("@d3/color-legend");
+  return "ok";
+};
+const _wq4poo = function _test_findModuleName_new_id(expect,findModuleName)
+{
+  const m = {}; // module sentinel
+  const scope = new Map([
+    ["module 1", { _name: "module 1", _value: m,
+      _definition: 'async () => runtime.module((await import("/d/e1c39d41e8e944b0@939.js?v=4&resolutions=a6a56ee61aba9799@437")).default)' }]
+  ]);
+  expect(findModuleName(scope, m)).toEqual("d/e1c39d41e8e944b0@939");
+  return "ok";
+};
+const _1j0hksu = function _test_findModuleName_new_slug(expect,findModuleName)
+{
+  const m = {}; // module sentinel
+  const scope = new Map([
+    ["module 1", { _name: "module 1", _value: m,
+      _definition: 'async () => runtime.module((await import("/@mootari/access-runtime.js?v=4&resolutions=98f34e974bb2e4bc@1392")).default)' }]
+  ]);
+  expect(findModuleName(scope, m)).toEqual("@mootari/access-runtime");
+  return "ok";
+};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -21428,7 +21808,254 @@ export default function define(runtime, observer) {
   $def("_sy7jfx", "test_decompileImport_returns_null_for_non_import", ["decompileImport","expect"], _sy7jfx);  
   $def("_rk7ku3", "test_decompileImport_compile_roundtrip_single", ["compile","expect","stageB_importFake","decompileImport","formatImportDeclaration"], _rk7ku3);  
   $def("_xynplo", "test_decompileImport_stageB_order_independent", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _xynplo);  
-  $def("_16fpgac", "test_decompileImport_stageB_notebook_id", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16fpgac);
+  $def("_16fpgac", "test_decompileImport_stageB_notebook_id", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16fpgac);  
+  $def("_r2e0wl", "test_extractModuleInfo_new_id_resolutions", ["expect","extractModuleInfo"], _r2e0wl);  
+  $def("_1pg1y6s", "test_extractModuleInfo_new_slug_resolutions", ["expect","extractModuleInfo"], _1pg1y6s);  
+  $def("_1vh26m0", "test_findModuleName_classic_bundle", ["expect","findModuleName"], _1vh26m0);  
+  $def("_1ltqcwj", "test_findModuleName_kit_slug", ["expect","findModuleName"], _1ltqcwj);  
+  $def("_wq4poo", "test_findModuleName_new_id", ["expect","findModuleName"], _wq4poo);  
+  $def("_1j0hksu", "test_findModuleName_new_slug", ["expect","findModuleName"], _1j0hksu);
+  return main;
+}</script>
+
+<script id="@tomlarkworthy/plugin-registry" 
+  type="text/plain"
+  data-mime="application/javascript"
+>
+const _1ej2r92 = function _intro(md){return(
+md`# Plugin Registry
+
+A foundational notebook for **decoupled reactive plugin wiring**.
+
+Consumers get a realtime stream of all registered providers under a name. Providers can register themselves under a name. Neither has direct references between each other. This allows you to add more consumers and providers without changing individual providers and consumers. Useful for reactive plugin systems like audio instruments, dyamic menus, LLM tools and entity component systems.
+`
+)};
+const _16jmxgh = function _diagram(htl){return(
+htl.html`<svg viewBox="0 0 720 300" width="100%" style="max-width:720px;font-family:system-ui,sans-serif">
+  <defs>
+    <marker id="pr-arr" markerWidth="9" markerHeight="9" refX="7" refY="4" orient="auto">
+      <path d="M0,0 L8,4 L0,8 Z" fill="var(--theme-foreground,#333)"></path>
+    </marker>
+    <style>
+      .pr-box{fill:var(--theme-background-alt,#f4f4f6);stroke:var(--theme-foreground-faint,#bbb);stroke-width:1.5}
+      .pr-hub{fill:var(--theme-foreground-faintest,#eef);stroke:var(--theme-foreground,#556);stroke-width:2}
+      .pr-t{fill:var(--theme-foreground,#222);font-size:13px}
+      .pr-s{fill:var(--theme-foreground-muted,#666);font-size:11px}
+      .pr-e{stroke:var(--theme-foreground,#333);stroke-width:1.5;fill:none;marker-end:url(#pr-arr)}
+    </style>
+  </defs>
+
+  <rect class="pr-box" x="10"  y="30"  width="170" height="48" rx="8"></rect>
+  <text class="pr-t" x="95" y="52" text-anchor="middle">Provider A</text>
+  <text class="pr-s" x="95" y="68" text-anchor="middle">plugins.add("x", v)</text>
+  <rect class="pr-box" x="10"  y="120" width="170" height="48" rx="8"></rect>
+  <text class="pr-t" x="95" y="142" text-anchor="middle">Provider B</text>
+  <text class="pr-s" x="95" y="158" text-anchor="middle">plugins.add("x", v, {invalidation})</text>
+  <text class="pr-s" x="95" y="215" text-anchor="middle">…N providers</text>
+
+  <rect class="pr-hub" x="270" y="78"  width="180" height="112" rx="10"></rect>
+  <text class="pr-t" x="360" y="104" text-anchor="middle" style="font-weight:600">plugins</text>
+  <text class="pr-s" x="360" y="128" text-anchor="middle">Map&lt;name, Set&lt;value&gt;&gt;</text>
+  <text class="pr-s" x="360" y="150" text-anchor="middle">add(name, value)</text>
+  <text class="pr-s" x="360" y="168" text-anchor="middle">get(name) → Generator</text>
+
+  <rect class="pr-box" x="540" y="30"  width="170" height="48" rx="8"></rect>
+  <text class="pr-t" x="625" y="52" text-anchor="middle">Consumer 1</text>
+  <text class="pr-s" x="625" y="68" text-anchor="middle">plugins.get("x")</text>
+  <rect class="pr-box" x="540" y="120" width="170" height="48" rx="8"></rect>
+  <text class="pr-t" x="625" y="142" text-anchor="middle">Consumer 2 (V2)</text>
+  <text class="pr-s" x="625" y="158" text-anchor="middle">plugins.get("x")</text>
+  <text class="pr-s" x="625" y="215" text-anchor="middle">…M consumers</text>
+
+  <path class="pr-e" d="M180,54 C225,54 235,116 268,126"></path>
+  <path class="pr-e" d="M180,144 C225,144 240,138 268,140"></path>
+  <path class="pr-e" d="M452,128 C500,116 510,54 538,54"></path>
+  <path class="pr-e" d="M452,142 C500,144 510,144 538,144"></path>
+</svg>`
+)};
+const _xnvzuh = function _contracts(md){return(
+md`## Contracts
+
+| Guarantee | How |
+|---|---|
+| **Named sets** | \`plugins\` maps a name → a set of values. Providers \`add\`, consumers \`get\`; they coordinate only by name. |
+| **Reactive** | \`get(name)\` is a Generator that yields the current set and re-yields on every add/remove for that name. |
+| **N↔M decoupling** | Providers and consumers share only \`plugins\`. Any number of each; a name is the whole contract. |
+| **Auto-cleanup** | \`add\` returns \`remove()\`. Pass \`{invalidation}\` (a cell's disposal promise) to remove automatically when the provider cell re-runs. |
+| **No leaks** | \`get\`'s Generator unsubscribes on disposal; per-name listeners are dropped when the last consumer leaves. |
+| **Eventual convergence** | Each consumer gets the current set immediately on \`get\`, then a full-set snapshot on every change — so any interleaving of add/remove/get converges. |`
+)};
+const _1ua5hud = function _apiReference(md){return(
+md`## API reference
+
+The whole API is two methods on \`plugins\`.
+
+**\`plugins.add(name, value, options?)\`** → \`remove()\`
+Add \`value\` to the set stored under \`name\` (creating the set on first use). Returns a \`remove()\` function
+that takes this value back out. \`options.invalidation\` (optional, may be null/omitted) is a promise — when
+it settles the value is removed automatically; pass a provider cell's built-in \`invalidation\` so re-running
+the cell replaces rather than duplicates. \`value\` is anything; for shared views it is commonly a factory
+\`() => element\` that each consumer calls to get its own instance.
+
+**\`plugins.get(name)\`** → Generator&lt;value[]&gt;
+Return a reactive Generator of the values currently in \`name\`'s set. It yields the current set immediately
+(so a late consumer still converges), then re-yields the full set on every add/remove. Use it from a cell
+and that cell recomputes on each change. Call it from as many consumers as you like (e.g. a module and its
+V2) — each call is an independent Generator that cleans up when its cell is torn down.`
+)};
+const _1pzt22q = function _createPlugins(Generators)
+{
+  return function createPlugins() {
+    const sets = new Map();
+    // name -> Set<value>
+    const listeners = new Map();
+    // name -> Set<() => void>
+    const notify = name => {
+      const ls = listeners.get(name);
+      if (ls)
+        for (const l of [...ls])
+          l();  // copy: a consumer may (un)subscribe while notifying
+    };
+    const add = (name, value, options) => {
+      let set = sets.get(name);
+      if (!set)
+        sets.set(name, set = new Set());
+      set.add(value);
+      notify(name);
+      const remove = () => {
+        const s = sets.get(name);
+        if (s && s.delete(value)) {
+          if (s.size === 0)
+            sets.delete(name);
+          notify(name);
+        }
+      };
+      const invalidation = options && options.invalidation;
+      if (invalidation)
+        Promise.resolve(invalidation).then(remove, remove);
+      return remove;
+    };
+    const get = name => Generators.observe(change => {
+      const push = () => change([...sets.get(name) ?? []]);
+      push();
+      // current set immediately → converges
+      let ls = listeners.get(name);
+      if (!ls)
+        listeners.set(name, ls = new Set());
+      ls.add(push);
+      return () => {
+        ls.delete(push);
+        if (ls.size === 0)
+          listeners.delete(name);
+      };  // leak-safe
+    });
+    return {
+      add,
+      get,
+      listenerCount: name => listeners.get(name)?.size ?? 0
+    };
+  };
+};
+const _1qu8dwj = function _plugins(createPlugins){return(
+createPlugins()
+)};
+const _a7p1z5 = function _testsHeader(md){return(
+md`## Tests`
+)};
+const _15xl311 = function _test_get_reflects_add(createPlugins){return(
+(async () => {
+  const p = createPlugins();
+  const gen = p.get('x');
+  if ((await (await gen.next()).value).length !== 0)
+    throw new Error('new set should start empty');
+  p.add('x', 1);
+  const after = await (await gen.next()).value;
+  if (after.length !== 1 || after[0] !== 1)
+    throw new Error('get did not reflect the add');
+  gen.return();
+  return '\u2705 get(name) yields the named set and updates on add';
+})()
+)};
+const _122zyhz = function _test_multi_provider_and_convergence(createPlugins)
+{
+  return (async () => {
+    const p = createPlugins();
+    const a = p.get('x'), b = p.get('x');
+    // two independent consumers
+    await (await a.next()).value;
+    await (await b.next()).value;
+    p.add('x', 'one');
+    // provider 1
+    p.add('x', 'two');
+    // provider 2
+    const va = (await (await a.next()).value).slice().sort().join(',');
+    const vb = (await (await b.next()).value).slice().sort().join(',');
+    if (va !== 'one,two' || vb !== 'one,two')
+      throw new Error('consumers did not converge to the full set');
+    a.return();
+    b.return();
+    return '\u2705 multiple providers accumulate; all consumers converge';
+  })();
+};
+const _1lojas7 = function _test_remove_and_names_isolated(createPlugins){return(
+(async () => {
+  const p = createPlugins();
+  const gx = p.get('x'), gy = p.get('y');
+  await (await gx.next()).value;
+  await (await gy.next()).value;
+  const remove = p.add('x', 1);
+  p.add('y', 2);
+  if ((await (await gx.next()).value).join() !== '1')
+    throw new Error('x set wrong');
+  if ((await (await gy.next()).value).join() !== '2')
+    throw new Error('names are not isolated');
+  remove();
+  if ((await (await gx.next()).value).length !== 0)
+    throw new Error('remove() did not take the value out');
+  gx.return();
+  gy.return();
+  return '\u2705 remove() works and names are isolated';
+})()
+)};
+const _8240yg = function _test_invalidation_and_no_leak(createPlugins){return(
+(async () => {
+  const p = createPlugins();
+  let settle;
+  p.add('x', 1, { invalidation: new Promise(r => settle = r) });
+  const gen = p.get('x');
+  if ((await (await gen.next()).value).length !== 1)
+    throw new Error('value should be present before invalidation');
+  if (p.listenerCount('x') !== 1)
+    throw new Error('get should have registered a listener');
+  settle();
+  await Promise.resolve();
+  await Promise.resolve();
+  if ((await (await gen.next()).value).length !== 0)
+    throw new Error('invalidation did not remove the value');
+  gen.return();
+  if (p.listenerCount('x') !== 0)
+    throw new Error('disposing the Generator leaked a listener');
+  return '\u2705 {invalidation} auto-removes and get() leaks no listeners';
+})()
+)};
+
+export default function define(runtime, observer) {
+  const main = runtime.module();
+  const $def = (pid, name, deps, fn) => {
+    main.variable(observer(name)).define(name, deps, fn).pid = pid;
+  };
+
+  $def("_1ej2r92", "intro", ["md"], _1ej2r92);  
+  $def("_16jmxgh", "diagram", ["htl"], _16jmxgh);  
+  $def("_xnvzuh", "contracts", ["md"], _xnvzuh);  
+  $def("_1ua5hud", "apiReference", ["md"], _1ua5hud);  
+  $def("_1pzt22q", "createPlugins", ["Generators"], _1pzt22q);  
+  $def("_1qu8dwj", "plugins", ["createPlugins"], _1qu8dwj);  
+  $def("_a7p1z5", "testsHeader", ["md"], _a7p1z5);  
+  $def("_15xl311", "test_get_reflects_add", ["createPlugins"], _15xl311);  
+  $def("_122zyhz", "test_multi_provider_and_convergence", ["createPlugins"], _122zyhz);  
+  $def("_1lojas7", "test_remove_and_names_isolated", ["createPlugins"], _1lojas7);  
+  $def("_8240yg", "test_invalidation_and_no_leak", ["createPlugins"], _8240yg);
   return main;
 }</script>
 
@@ -21791,213 +22418,229 @@ const _1hx65vf = function _no_observer(main)
     variable.delete();
     return symbol;
 };
-const _duwj4o = function _observe(Element,Text,trace_variable,$0,no_observer,queueMicrotask)
+const _1pdsfy5 = function _observe(Element,Text,trace_variable,$0,no_observer,queueMicrotask)
 {
-    return function observe(v, observer, {invalidation, detachNodes = false} = {}) {
-        // --- instrumentation (improved) ---
-        // Give each observe() call a stable id so you can correlate events.
-        const observe_id = `${ v?._name || '<anon>' }@${ Date.now() }@${ Math.random().toString(16).slice(2) }`;
-        const snapshot = (extra = {}) => ({
-            t: Date.now(),
-            observe_id,
-            var_name: v?._name,
-            var_version: v?._version,
-            var_reachable: v?._reachable,
-            has_observer: v?._observer != null,
-            observer_has_node: !!observer?._node,
-            v_value_defined: v?._value !== undefined,
-            v_value_ctor: v?._value?.constructor?.name,
-            v_value_is_node: v?._value instanceof Element || v?._value instanceof Text || false,
-            v_promise: !!v?._promise,
+  return function observe(
+    v,
+    observer,
+    { invalidation, detachNodes = false } = {}
+  ) {
+    // --- instrumentation (improved) ---
+    // Give each observe() call a stable id so you can correlate events.
+    const observe_id = `${v?._name || "<anon>"}@${Date.now()}@${Math.random()
+      .toString(16)
+      .slice(2)}`;
+    const snapshot = (extra = {}) => ({
+      t: Date.now(),
+      observe_id,
+      var_name: v?._name,
+      var_version: v?._version,
+      var_reachable: v?._reachable,
+      has_observer: v?._observer != null,
+      observer_has_node: !!observer?._node,
+      v_value_defined: v?._value !== undefined,
+      v_value_ctor: v?._value?.constructor?.name,
+      v_value_is_node:
+        v?._value instanceof Element || v?._value instanceof Text || false,
+      v_promise: !!v?._promise,
+      ...extra
+    });
+    const emit = (event, extra = {}) => {
+      if (v?._name !== trace_variable) return;
+      try {
+        $0.value = $0.value.concat([
+          snapshot({
+            event,
             ...extra
-        });
-        const emit = (event, extra = {}) => {
-            if (v?._name !== trace_variable)
-                return;
-            try {
-                $0.value = $0.value.concat([snapshot({
-                        event,
-                        ...extra
-                    })]);
-            } catch {
-            }
-        };
-        emit('observe:begin', { detachNodes });
-        const cancels = new Set();
-        let cancelled = false;
-        const cancel = () => {
-            emit('observe:cancel_called');
-            if (cancelled)
-                return;
-            cancelled = true;
-            for (const f of cancels) {
-                try {
-                    f();
-                } catch {
-                }
-            }
-            cancels.clear();
-        };
-        if (invalidation)
-            Promise.resolve(invalidation).then(() => {
-                emit('observe:invalidation_fired');
-                cancel();
-            });
-        const isNode = value => value instanceof Element || value instanceof Text;
-        const stealIfNeeded = (value, reason) => {
-            const canSteal = detachNodes && isNode(value) && observer?._node && observer._node !== value.parentNode;
-            emit('observe:steal_check', {
-                reason,
-                canSteal,
-                value_ctor: value?.constructor?.name,
-                value_parent: value?.parentNode?.constructor?.name
-            });
-            if (canSteal) {
-                try {
-                    value.remove();
-                } catch {
-                }
-                emit('observe:steal_detached', { reason });
-            }
-        };
-        const hasExistingObserver = v && v._observer != null && v._observer?.description !== no_observer.description;
-        // cross realm support
-        emit('observe:hasExistingObserver', { hasExistingObserver });
-        // --- attach/wrap ---
-        if (!hasExistingObserver) {
-            emit('observe:attach:direct_install');
-            if (v && !v._reachable) {
-                v._reachable = true;
-                v._module._runtime._dirty.add(v);
-                v._module._runtime._updates.add(v);
-                emit('observe:attach:marked_reachable');
-            }
-            const previous = v._observer;
-            v._observer = observer;
-            cancels.add(() => {
-                v._observer = previous;
-            });
-        } else {
-            emit('observe:attach:wrap_existing');
-            const prevObserver = v._observer;
-            for (const type of [
-                    'fulfilled',
-                    'rejected',
-                    'pending'
-                ]) {
-                const prev = prevObserver?.[type];
-                prevObserver[type] = (...args) => {
-                    emit(`observe:wrapped:${ type }:called`, { arg0_ctor: args[0]?.constructor?.name });
-                    // old observer first
-                    if (prev) {
-                        try {
-                            Reflect.apply(prev, prevObserver, args);
-                        } catch (e) {
-                            emit(`observe:wrapped:${ type }:prev_error`, { message: String(e) });
-                        }
-                        if (type === 'fulfilled')
-                            stealIfNeeded(args[0], 'wrap_existing:prev_fulfilled');
-                    }
-                    // then tap
-                    try {
-                        if (type === 'fulfilled')
-                            observer.fulfilled?.(args[0], v?._name);
-                        else if (type === 'rejected')
-                            observer.rejected?.(args[0], v?._name);
-                        else
-                            observer.pending?.();
-                        emit(`observe:wrapped:${ type }:tapped_ok`);
-                    } catch (e) {
-                        emit(`observe:wrapped:${ type }:tap_error`, { message: String(e) });
-                    }
-                };
-                cancels.add(() => {
-                    prevObserver[type] = prev;
-                });
-            }
-        }
-        // --- CATCH-UP REPLAY (BUG FIX) ---
-        // Snapshot version to avoid replaying stale results.
-        const versionAtAttach = v?._version;
-        emit('observe:catchup:scheduled', { versionAtAttach });
-        queueMicrotask(() => {
-            emit('observe:catchup:microtask_start', { cancelled });
-            if (cancelled)
-                return;
-            // mimic inspector: mark pending first
-            try {
-                observer.pending?.();
-                emit('observe:catchup:pending_sent');
-            } catch (e) {
-                emit('observe:catchup:pending_error', { message: String(e) });
-            }
-            // IMPORTANT: read CURRENT value at replay time
-            const valueNow = v?._value;
-            emit('observe:catchup:valueNow_snapshot', {
-                valueNow_defined: valueNow !== undefined,
-                valueNow_ctor: valueNow?.constructor?.name,
-                v_version_now: v?._version,
-                valueNow_outerHTML_prefix: v?._observer?._node?.outerHTML
-            });
-            if (valueNow !== undefined) {
-                if (v?._version !== versionAtAttach) {
-                    emit('observe:catchup:stale_skip_valueNow');
-                    return;
-                }
-                stealIfNeeded(valueNow, 'catchup:valueNow');
-                try {
-                    observer.fulfilled?.(valueNow, v?._name);
-                    emit('observe:catchup:fulfilled_sent_valueNow');
-                } catch (e) {
-                    emit('observe:catchup:fulfilled_error_valueNow', { message: String(e) });
-                }
-                return;
-            }
-            // optional fallback: attach-time promise (or current promise)
-            const p = v?._promise;
-            if (!p || typeof p.then !== 'function') {
-                emit('observe:catchup:no_value_no_promise');
-                return;
-            }
-            emit('observe:catchup:await_promise');
-            Promise.resolve(p).then(value => {
-                emit('observe:catchup:promise_fulfilled', {
-                    value_defined: value !== undefined,
-                    value_ctor: value?.constructor?.name,
-                    v_version_now: v?._version
-                });
-                if (cancelled)
-                    return;
-                if (v?._version !== versionAtAttach) {
-                    emit('observe:catchup:stale_skip_promise');
-                    return;
-                }
-                if (value === undefined)
-                    return;
-                stealIfNeeded(value, 'catchup:promise');
-                try {
-                    observer.fulfilled?.(value, v?._name);
-                    emit('observe:catchup:fulfilled_sent_promise');
-                } catch (e) {
-                    emit('observe:catchup:fulfilled_error_promise', { message: String(e) });
-                }
-            }, error => {
-                emit('observe:catchup:promise_rejected', { v_version_now: v?._version });
-                if (cancelled)
-                    return;
-                if (v?._version !== versionAtAttach)
-                    return;
-                try {
-                    observer.rejected?.(error, v?._name);
-                    emit('observe:catchup:rejected_sent_promise');
-                } catch (e) {
-                    emit('observe:catchup:rejected_error_promise', { message: String(e) });
-                }
-            });
-        });
-        emit('observe:end');
-        return cancel;
+          })
+        ]);
+      } catch {}
     };
+    emit("observe:begin", { detachNodes });
+    const cancels = new Set();
+    let cancelled = false;
+    const cancel = () => {
+      emit("observe:cancel_called");
+      if (cancelled) return;
+      cancelled = true;
+      for (const f of cancels) {
+        try {
+          f();
+        } catch {}
+      }
+      cancels.clear();
+    };
+    if (invalidation)
+      Promise.resolve(invalidation).then(() => {
+        emit("observe:invalidation_fired");
+        cancel();
+      });
+    const isNode = (value) => value instanceof Element || value instanceof Text;
+    const stealIfNeeded = (value, reason) => {
+      const canSteal =
+        detachNodes &&
+        isNode(value) &&
+        observer?._node &&
+        observer._node !== value.parentNode;
+      emit("observe:steal_check", {
+        reason,
+        canSteal,
+        value_ctor: value?.constructor?.name,
+        value_parent: value?.parentNode?.constructor?.name
+      });
+      if (canSteal) {
+        try {
+          value.remove();
+        } catch {}
+        emit("observe:steal_detached", { reason });
+      }
+    };
+    const hasExistingObserver =
+      v &&
+      v._observer != null &&
+      v._observer?.description !== no_observer.description;
+    // cross realm support
+    emit("observe:hasExistingObserver", { hasExistingObserver });
+    // --- attach/wrap ---
+    if (!hasExistingObserver) {
+      emit("observe:attach:direct_install");
+      if (v && !v._reachable) {
+        v._reachable = true;
+        v._module._runtime._dirty.add(v);
+        v._module._runtime._updates.add(v);
+        v._module._runtime._compute();
+        emit("observe:attach:marked_reachable");
+      }
+      const previous = v._observer;
+      v._observer = observer;
+      cancels.add(() => {
+        v._observer = previous;
+      });
+    } else {
+      emit("observe:attach:wrap_existing");
+      const prevObserver = v._observer;
+      for (const type of ["fulfilled", "rejected", "pending"]) {
+        const prev = prevObserver?.[type];
+        prevObserver[type] = (...args) => {
+          emit(`observe:wrapped:${type}:called`, {
+            arg0_ctor: args[0]?.constructor?.name
+          });
+          // old observer first
+          if (prev) {
+            try {
+              Reflect.apply(prev, prevObserver, args);
+            } catch (e) {
+              emit(`observe:wrapped:${type}:prev_error`, {
+                message: String(e)
+              });
+            }
+            if (type === "fulfilled")
+              stealIfNeeded(args[0], "wrap_existing:prev_fulfilled");
+          }
+          // then tap
+          try {
+            if (type === "fulfilled") observer.fulfilled?.(args[0], v?._name);
+            else if (type === "rejected")
+              observer.rejected?.(args[0], v?._name);
+            else observer.pending?.();
+            emit(`observe:wrapped:${type}:tapped_ok`);
+          } catch (e) {
+            emit(`observe:wrapped:${type}:tap_error`, { message: String(e) });
+          }
+        };
+        cancels.add(() => {
+          prevObserver[type] = prev;
+        });
+      }
+    }
+    // --- CATCH-UP REPLAY (BUG FIX) ---
+    // Snapshot version to avoid replaying stale results.
+    const versionAtAttach = v?._version;
+    emit("observe:catchup:scheduled", { versionAtAttach });
+    queueMicrotask(() => {
+      emit("observe:catchup:microtask_start", { cancelled });
+      if (cancelled) return;
+      // mimic inspector: mark pending first
+      try {
+        observer.pending?.();
+        emit("observe:catchup:pending_sent");
+      } catch (e) {
+        emit("observe:catchup:pending_error", { message: String(e) });
+      }
+      // IMPORTANT: read CURRENT value at replay time
+      const valueNow = v?._value;
+      emit("observe:catchup:valueNow_snapshot", {
+        valueNow_defined: valueNow !== undefined,
+        valueNow_ctor: valueNow?.constructor?.name,
+        v_version_now: v?._version,
+        valueNow_outerHTML_prefix: v?._observer?._node?.outerHTML
+      });
+      if (valueNow !== undefined) {
+        if (v?._version !== versionAtAttach) {
+          emit("observe:catchup:stale_skip_valueNow");
+          return;
+        }
+        stealIfNeeded(valueNow, "catchup:valueNow");
+        try {
+          observer.fulfilled?.(valueNow, v?._name);
+          emit("observe:catchup:fulfilled_sent_valueNow");
+        } catch (e) {
+          emit("observe:catchup:fulfilled_error_valueNow", {
+            message: String(e)
+          });
+        }
+        return;
+      }
+      // optional fallback: attach-time promise (or current promise)
+      const p = v?._promise;
+      if (!p || typeof p.then !== "function") {
+        emit("observe:catchup:no_value_no_promise");
+        return;
+      }
+      emit("observe:catchup:await_promise");
+      Promise.resolve(p).then(
+        (value) => {
+          emit("observe:catchup:promise_fulfilled", {
+            value_defined: value !== undefined,
+            value_ctor: value?.constructor?.name,
+            v_version_now: v?._version
+          });
+          if (cancelled) return;
+          if (v?._version !== versionAtAttach) {
+            emit("observe:catchup:stale_skip_promise");
+            return;
+          }
+          if (value === undefined) return;
+          stealIfNeeded(value, "catchup:promise");
+          try {
+            observer.fulfilled?.(value, v?._name);
+            emit("observe:catchup:fulfilled_sent_promise");
+          } catch (e) {
+            emit("observe:catchup:fulfilled_error_promise", {
+              message: String(e)
+            });
+          }
+        },
+        (error) => {
+          emit("observe:catchup:promise_rejected", {
+            v_version_now: v?._version
+          });
+          if (cancelled) return;
+          if (v?._version !== versionAtAttach) return;
+          try {
+            observer.rejected?.(error, v?._name);
+            emit("observe:catchup:rejected_sent_promise");
+          } catch (e) {
+            emit("observe:catchup:rejected_error_promise", {
+              message: String(e)
+            });
+          }
+        }
+      );
+    });
+    emit("observe:end");
+    return cancel;
+  };
 };
 const _16ohhcn = function _observeOld(trace_variable,_,no_observer,isnode,toObject,queueMicrotask,getPromiseState)
 {
@@ -22536,7 +23179,7 @@ export default function define(runtime, observer) {
   $def("_ya86a1", null, ["md"], _ya86a1);  
   $def("_tgfgv9", "trace_variable", [], _tgfgv9);  
   $def("_1hx65vf", "no_observer", ["main"], _1hx65vf);  
-  $def("_duwj4o", "observe", ["Element","Text","trace_variable","mutable trace_history","no_observer","queueMicrotask"], _duwj4o);  
+  $def("_1pdsfy5", "observe", ["Element","Text","trace_variable","mutable trace_history","no_observer","queueMicrotask"], _1pdsfy5);  
   $def("_16ohhcn", "observeOld", ["trace_variable","_","no_observer","isnode","toObject","queueMicrotask","getPromiseState"], _16ohhcn);  
   $def("_2kni3y", null, ["md"], _2kni3y);  
   $def("_1utnee9", "descendants", [], _1utnee9);  
@@ -24228,10 +24871,14 @@ const _1rosxg0 = function _data(){return(
   instance: new URL("https://google.com")
 }
 )};
-const _ygg2hv = function _summarizeJS(html,inspect,postProcess,MouseEvent){return(
+const _p715nx = function _summarizeJS(Node,html,inspect,postProcess,MouseEvent){return(
 function summarizeJS(value, { max_size = 5000 } = {}) {
   // Render the inspected HTML into a temporary <div>
-  const inspection = html`<div>${inspect(value)}`;
+  const inspected =
+    typeof Node !== "undefined" && value instanceof Node
+      ? value.cloneNode(true)
+      : value;
+  const inspection = html`<div>${inspect(inspected)}`;
   let text = postProcess(inspection);
   let prior = undefined;
 
@@ -24337,7 +24984,7 @@ export default function define(runtime, observer) {
   main.define("Inspector", ["module @tomlarkworthy/inspector", "@variable"], (_, v) => v.import("Inspector", _));  
   main.define("src", ["module @tomlarkworthy/inspector", "@variable"], (_, v) => v.import("src", _));  
   $def("_1rosxg0", "data", [], _1rosxg0);  
-  $def("_ygg2hv", "summarizeJS", ["html","inspect","postProcess","MouseEvent"], _ygg2hv);  
+  $def("_p715nx", "summarizeJS", ["Node","html","inspect","postProcess","MouseEvent"], _p715nx);  
   $def("_wtf5dq", "walked", ["postProcess","inspect","data"], _wtf5dq);  
   $def("_1l6vroc", "postProcess", ["walk"], _1l6vroc);  
   $def("_1brf10r", "TEXT", [], _1brf10r);  
@@ -25014,10 +25661,38 @@ const _yqy56c = async function _css(theme_assets,extra_css){return(
   extra_css
 ]
 )};
-const _16bhmn1 = function _extra_css(){return(
-[
-  'file://syntax.css',
-  `
+const _17wrwba = function _extra_css()
+{
+  // Only on ObservableHQ (the observableusercontent.com sandbox) do we bridge
+  // the theme vars onto the underscore '--syntax_*' vars that Observable's
+  // editor + inspector read. Off Observable we omit it so notebook authors use
+  // the real --theme-* / --syntax-* vars, not these compatibility aliases.
+  // Predicate mirrors @tomlarkworthy/runtime-sdk's isOnObservableCom.
+  const onObservable = window.location.href.includes('observableusercontent.com') && !window.location.href.includes('blob:');
+  const observableSyntaxBridge = onObservable ? `
+:root {
+  /* notebook-kit themes omit --syntax-normal (hyphen), so Observable's
+     "next" inspector falls back to its hardcoded #1b1e23 on
+     .observablehq--function/--gray/--expanded/etc. Alias just this one;
+     the other --syntax-* hyphen vars are already theme-defined (don't
+     re-alias them — that would self-reference). */
+  --syntax-normal: var(--theme-foreground, #1b1e23);
+  --syntax_normal: var(--theme-foreground, #1b1e23);
+  --syntax_comment: var(--syntax-comment, #a9b0bc);
+  --syntax_number: var(--syntax-literal, #20a5ba);
+  --syntax_keyword: var(--syntax-keyword, #c30771);
+  --syntax_atom: var(--syntax-atom, #10a778);
+  --syntax_string: var(--syntax-string, #008ec4);
+  --syntax_error: var(--syntax-invalid, var(--theme-foreground-error, #ffbedc));
+  --syntax_unknown_variable: var(--syntax-variable, #838383);
+  --syntax_known_variable: var(--syntax-definition, #005f87);
+  --syntax_matchbracket: var(--syntax-keyword, #20bbfc);
+  --syntax_key: var(--syntax-definition, #6636b4);
+}
+` : '';
+  return [
+    'file://syntax.css',
+    observableSyntaxBridge + `
 /* Center page */
 .lopecode-visualizer {
     max-width: 1200px;
@@ -25076,8 +25751,8 @@ const _16bhmn1 = function _extra_css(){return(
 .hljs-addition {
   color: var(--syntax-string);
 }`
-]
-)};
+  ];
+};
 const _rijq1n = function _current_theme(themes){return(
 [...themes.values()].find(assets => assets.every(url => document.getElementById(url)))
 )};
@@ -25101,7 +25776,7 @@ export default function define(runtime, observer) {
   $def("_p0at3d", "themes", [], _p0at3d);  
   $def("_m8taeu", "cssForTheme", ["themes","extra_css"], _m8taeu);  
   $def("_yqy56c", "css", ["theme_assets","extra_css"], _yqy56c);  
-  $def("_16bhmn1", "extra_css", [], _16bhmn1);  
+  $def("_17wrwba", "extra_css", [], _17wrwba);  
   $def("_rijq1n", "current_theme", ["themes"], _rijq1n);
   return main;
 }</script>
@@ -26985,7 +27660,7 @@ const _1xdl683 = function _renderImportCell(navHref){return(
   return span;
 }
 )};
-const _17pe3vk = function _syncers(observe,inspectors,$0,liveCellMap,createImportCellHeader,renderImportCell,variablesForCell,visualizers,$1)
+const _bbb3dg = function _syncers(observe,inspectors,$0,liveCellMap,createImportCellHeader,renderImportCell,variablesForCell,visualizers,$1)
 {
   const syncers = this || new Map();
 
@@ -27021,7 +27696,14 @@ const _17pe3vk = function _syncers(observe,inspectors,$0,liveCellMap,createImpor
       root,
       remove: () => {
         observers.delete(v);
-        observer?._node?.remove?.();
+        const node = observer?._node;
+        if (node) {
+          // Detach the variable's live element value
+          const val = v?._value;
+          if (val && val.nodeType && val.parentNode === node)
+            node.removeChild(val);
+          node.remove();
+        }
         unobserve?.();
       }
     };
@@ -27199,7 +27881,7 @@ export default function define(runtime, observer) {
   $def("_zodkh8", "createImportCellHeader", [], _zodkh8);  
   $def("_526jo", "variablesForCell", [], _526jo);  
   $def("_1xdl683", "renderImportCell", ["navHref"], _1xdl683);  
-  $def("_17pe3vk", "syncers", ["observe","inspectors","viewof visualizersToDelete","liveCellMap","createImportCellHeader","renderImportCell","variablesForCell","visualizers","viewof visualizers"], _17pe3vk);  
+  $def("_bbb3dg", "syncers", ["observe","inspectors","viewof visualizersToDelete","liveCellMap","createImportCellHeader","renderImportCell","variablesForCell","visualizers","viewof visualizers"], _bbb3dg);  
   $def("_een5pq", null, ["md"], _een5pq);  
   $def("_1wiz55o", "backgroundJobs", ["keepalive","visualizerModule"], _1wiz55o);  
   $def("_1oonsyz", "viewof visualizerModule", ["thisModule"], _1oonsyz);  
@@ -27280,175 +27962,14 @@ export default function define(runtime, observer) {
   return main;
 }</script>
 
-<script id="@tomlarkworthy/invoke-variable" 
-  type="text/plain"
-  data-mime="application/javascript"
->
-const _zkje0r = function _1(md){return(
-md`# \`invokeVariable(<name>, <module>, overrides = {})\`
-
-Test individual variables by calling them with injected values. Lets you test different scenarios without changing your core logic. Pairs with [@tomlarkworthy/tester](https://observablehq.com/@tomlarkworthy/tester)`
-)};
-const _kfe4ll = function _invokeVariable(lookupVariable){return(
-async function invokeVariable(name, module, overrides = {}) {
-  if (overrides == null || typeof overrides !== "object")
-    throw new TypeError(
-      "invokeVariable(name, module, {overrides}): overrides must be an object"
-    );
-
-  // Accept a Variable reference directly as the first arg (skip the lookupVariable stall when
-  // the caller already holds it); otherwise resolve by (name, module).
-  let variable;
-  if (name && typeof name === "object" && typeof name._definition !== "undefined") {
-    variable = name;
-    module = module ?? variable._module;
-  } else {
-    if (typeof name !== "string" || !name.length)
-      throw new TypeError(
-        "invokeVariable(name, module, …): name must be a non-empty string"
-      );
-    if (!module)
-      throw new TypeError("invokeVariable(name, module, …): module is required");
-    variable = await lookupVariable(name, module);
-    if (!variable)
-      throw new Error(`invokeVariable: variable "${name}" not found in module`);
-  }
-  module = module ?? variable._module;
-  const label = variable._name ?? (typeof name === "string" ? name : "(anonymous)");
-
-  const inputs = Array.isArray(variable._inputs) ? variable._inputs : [];
-  const inputNames = inputs.map((v) => v?._name);
-
-  for (const k of Object.keys(overrides)) {
-    if (!inputNames.includes(k)) {
-      throw new Error(
-        `invokeVariable("${label}"): override "${k}" was provided but is not a declared dependency. Declared dependencies: ${inputNames
-          .filter(Boolean)
-          .join(", ")}`
-      );
-    }
-  }
-
-  const hasOwn = (o, k) => Object.prototype.hasOwnProperty.call(o, k);
-
-  const resolveDependency = async (depName) => {
-    if (hasOwn(overrides, depName)) return overrides[depName];
-
-    const scopeVar =
-      module?._scope?.get?.(depName) ??
-      module?._runtime?._builtin?._scope?.get?.(depName);
-
-    if (scopeVar) {
-      if (scopeVar._value !== undefined) return scopeVar._value;
-      if (scopeVar._promise && typeof scopeVar._promise?.then === "function")
-        return await scopeVar._promise;
-    }
-
-    if (typeof module?.value === "function") {
-      try {
-        return await module.value(depName);
-      } catch (e) {}
-    }
-
-    if (module?._runtime && typeof module._runtime._global === "function") {
-      try {
-        const g = module._runtime._global(depName);
-        if (g !== undefined) return g;
-      } catch (e) {}
-    }
-
-    throw new Error(
-      `invokeVariable("${label}"): could not resolve dependency "${depName}" (no override and not found in module/builtins/global)`
-    );
-  };
-
-  const args = [];
-  for (const dep of inputs) {
-    const depName = dep?._name;
-    if (!depName) {
-      args.push(undefined);
-      continue;
-    }
-    args.push(await resolveDependency(depName));
-  }
-
-  const def = variable._definition;
-  if (typeof def !== "function") {
-    throw new Error(
-      `invokeVariable("${label}"): target variable does not have an invokable function definition`
-    );
-  }
-  return def(...args);
-}
-)};
-const _jtrr9m = function _3(md){return(
-md`### Example
-
-let c = a + b`
-)};
-const _1v2c0s1 = function _a(){return(
-1
-)};
-const _ywl8oh = function _b(){return(
-3
-)};
-const _1mc3tpl = function _c(a,b){return(
-a + b
-)};
-const _o5e50u = function _7(md){return(
-md`If we invoke c without any overrides we get the notebook behaviour (i.e. the answer is 4, as a is 1 and b is 3)`
-)};
-const _tnoyf9 = function _8(invokeVariable,invokeVariableModule){return(
-invokeVariable("c", invokeVariableModule)
-)};
-const _smh5by = function _9(md){return(
-md`But we can set b to 20, and then we get the answer 21.`
-)};
-const _d996jo = function _10(invokeVariable,invokeVariableModule){return(
-invokeVariable("c", invokeVariableModule, { b: 20 })
-)};
-const _qh0yhm = function _11(md){return(
-md`To call invokeVariable we need a reference to the module, which we can obtain with thisModule() (see runtime-sdk)`
-)};
-const _1hy0qcz = function _invokeVariableModule(thisModule){return(
-thisModule()
-)};
-const _jno7wc = (G, _) => G.input(_);
-
-export default function define(runtime, observer) {
-  const main = runtime.module();
-  const $def = (pid, name, deps, fn) => {
-    main.variable(observer(name)).define(name, deps, fn).pid = pid;
-  };
-
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
-  $def("_zkje0r", null, ["md"], _zkje0r);  
-  $def("_kfe4ll", "invokeVariable", ["lookupVariable"], _kfe4ll);  
-  $def("_jtrr9m", null, ["md"], _jtrr9m);  
-  $def("_1v2c0s1", "a", [], _1v2c0s1);  
-  $def("_ywl8oh", "b", [], _ywl8oh);  
-  $def("_1mc3tpl", "c", ["a","b"], _1mc3tpl);  
-  $def("_o5e50u", null, ["md"], _o5e50u);  
-  $def("_tnoyf9", null, ["invokeVariable","invokeVariableModule"], _tnoyf9);  
-  $def("_smh5by", null, ["md"], _smh5by);  
-  $def("_d996jo", null, ["invokeVariable","invokeVariableModule"], _d996jo);  
-  $def("_qh0yhm", null, ["md"], _qh0yhm);  
-  $def("_1hy0qcz", "viewof invokeVariableModule", ["thisModule"], _1hy0qcz);  
-  $def("_jno7wc", "invokeVariableModule", ["Generators","viewof invokeVariableModule"], _jno7wc);  
-  main.define("lookupVariable", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("lookupVariable", _));  
-  main.define("thisModule", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("thisModule", _));
-  return main;
-}
-</script>
-
 <!-- Bootloader -->
 <script id="bootconf.json"
         type="text/plain"
         data-mime="application/json"
 >
 {
-  "mains": ["@tomlarkworthy/lopepage","@tomlarkworthy/editor-5"],
-  "hash": "#view=S100(@tomlarkworthy/editor-5,@tomlarkworthy/module-selection)",
+  "mains": ["@tomlarkworthy/lopepage-2","@tomlarkworthy/editor-5","@tomlarkworthy/save-in-place"],
+  "hash": "#view=S100(@tomlarkworthy/editor-5)",
   "headless": true
 }
 </script>
@@ -27507,35 +28028,39 @@ function _boot(define_builtins,conf,__ojs_runtime,location,__ojs_observer)
 {
   define_builtins;
   const tickMode = conf.tick;
-  if (tickMode && tickMode !== 'raf') {
+  if (tickMode && tickMode !== "raf") {
     let tick;
-    if (tickMode === 'messageChannel') {
+    if (tickMode === "messageChannel") {
       const ch = new window.MessageChannel();
       const q = [];
       ch.port1.onmessage = () => {
         const f = q.shift();
-        if (f)
-          f();
+        if (f) f();
       };
-      tick = cb => {
+      tick = (cb) => {
         q.push(cb);
         ch.port2.postMessage(0);
       };
-    } else if (tickMode === 'microtask') {
-      tick = cb => window.queueMicrotask(cb);
-    } else if (tickMode === 'timeout') {
-      const delay = Number(conf.tickDelayMs) || 0;
-      tick = cb => setTimeout(cb, delay);
+    } else if (tickMode === "microtask") {
+      tick = (cb) => window.queueMicrotask(cb);
+    } else if (tickMode === "timeout") {
+      const delay = Number(conf.tickDelayMs) || 8;
+      tick = (cb) => setTimeout(cb, delay);
     } else {
-      console.warn('[bootloader] unknown tick mode: ' + tickMode);
+      console.warn("[bootloader] unknown tick mode: " + tickMode);
     }
     if (tick) {
       const Runtime = Object.getPrototypeOf(__ojs_runtime).constructor;
       Runtime.prototype._computeSoon = function () {
-        return new Promise(tick).then(() => this._disposed ? undefined : this._computeNow());
+        return new Promise(tick).then(() =>
+          this._disposed ? undefined : this._computeNow()
+        );
       };
-      const suffix = tickMode === 'timeout' ? ' delayMs=' + (Number(conf.tickDelayMs) || 0) : '';
-      console.log('[bootloader] tick=' + tickMode + suffix);
+      const suffix =
+        tickMode === "timeout"
+          ? " delayMs=" + (Number(conf.tickDelayMs) || 8)
+          : "";
+      console.log("[bootloader] tick=" + tickMode + suffix);
     }
   }
   if (conf.hash && !location.hash) {
@@ -27544,8 +28069,8 @@ function _boot(define_builtins,conf,__ojs_runtime,location,__ojs_observer)
   const observer = conf.headless ? () => ({}) : __ojs_observer;
   __ojs_runtime.mains = new Map();
   window.__ojs_runtime = __ojs_runtime;
-  conf.mains.map(async name => {
-    console.log(`Bootloader: loading ${ name }`);
+  conf.mains.map(async (name) => {
+    console.log(`Bootloader: loading ${name}`);
     const module = await import(name);
     const ojs_module = __ojs_runtime.module(module.default, observer);
     __ojs_runtime.mains.set(name, ojs_module);
@@ -27736,31 +28261,6 @@ export default function define(runtime, observer) {
 }
 </script>
 
-<script type="module" id="main">
-  await window.esmsInitOptions.fetch("file://es-module-shims@2.6.2").text().then(src => {
-    const script = document.createElement('script');
-    script.textContent = src;
-    document.head.appendChild(script);
-  });
-
-  const style0 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/global.css", { with: { type: 'css' } });
-  const style1 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/inspector.css", { with: { type: 'css' } });
-  const style2 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/highlight.css", { with: { type: 'css' } });
-  const style3 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/plot.css", { with: { type: 'css' } });
-  const style4 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/index.css", { with: { type: 'css' } });
-  const style5 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/theme-parchment.css", { with: { type: 'css' } });
-  const style6 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/abstract-light.css", { with: { type: 'css' } });
-  const style7 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/syntax-light.css", { with: { type: 'css' } });
-  const style8 = await importShim("file://syntax.css", { with: { type: 'css' } });
-  document.adoptedStyleSheets = [style0.default,style1.default,style2.default,style3.default,style4.default,style5.default,style6.default,style7.default,style8.default];
-
-  const { Runtime } = await importShim("@observablehq/runtime@6.0.0");
-  const { Inspector } = await importShim("@observablehq/inspector@5.0.1");
-  const notebook = document.querySelector("notebook");
-  const runtime = new Runtime({__ojs_runtime: () => runtime, __ojs_observer: () => observer});
-  const observer = Inspector.into(document.body);
-  const {default: define} = await importShim("@tomlarkworthy/bootloader");
-  runtime.bootloader = runtime.module(define, () => ({}));
-</script>
+<script id="streaming_sentinel">window.__lopeStreaming = false;</script>
 </body>
 </html>

--- a/notebooks/@tomlarkworthy_editor-5.json
+++ b/notebooks/@tomlarkworthy_editor-5.json
@@ -3,10 +3,11 @@
   "title": "@tomlarkworthy/editor-5",
   "bootconf": {
     "mains": [
-      "@tomlarkworthy/lopepage",
-      "@tomlarkworthy/editor-5"
+      "@tomlarkworthy/lopepage-2",
+      "@tomlarkworthy/editor-5",
+      "@tomlarkworthy/save-in-place"
     ],
-    "hash": "#view=S100(@tomlarkworthy/editor-5,@tomlarkworthy/module-selection)",
+    "hash": "#view=S100(@tomlarkworthy/editor-5)",
     "headless": true
   },
   "files": [
@@ -21,6 +22,56 @@
     },
     "@observablehq/inspector@5.0.1": {
       "hash": "5658858e85affa2e1e5cd1052924c622"
+    },
+    "@tomlarkworthy/editor-5": {
+      "hash": "bf9605f2f03111fd47511375544c8dbc",
+      "files": [
+        "cell_options.json"
+      ],
+      "dependsOn": [
+        "@tomlarkworthy/visualizer",
+        "@tomlarkworthy/modules",
+        "@tomlarkworthy/reversible-attachment",
+        "@tomlarkworthy/flow-queue",
+        "@tomlarkworthy/cell-map",
+        "d/57d79353bac56631@44",
+        "@tomlarkworthy/lopepage-urls",
+        "@tomlarkworthy/cells-to-clipboard",
+        "@tomlarkworthy/observablehq-lezer",
+        "@tomlarkworthy/dataflow-templating",
+        "@tomlarkworthy/fileattachments",
+        "@tomlarkworthy/runtime-sdk",
+        "@tomlarkworthy/codemirror-6-v2",
+        "@tomlarkworthy/observablejs-toolchain",
+        "@tomlarkworthy/module-map"
+      ],
+      "dependedBy": [
+        "@tomlarkworthy/lopepage-2"
+      ]
+    },
+    "@tomlarkworthy/lopepage-2": {
+      "hash": "b0d02fd83157589e9fe9bba0288aff02",
+      "dependsOn": [
+        "@tomlarkworthy/plugin-registry",
+        "@tomlarkworthy/runtime-sdk",
+        "@tomlarkworthy/visualizer",
+        "@tomlarkworthy/modules",
+        "@tomlarkworthy/claude-code-pairing",
+        "@tomlarkworthy/command-palette",
+        "@tomlarkworthy/themes",
+        "@tomlarkworthy/local-change-history",
+        "@tomlarkworthy/lopepage-urls",
+        "@tomlarkworthy/editor-5",
+        "@tomlarkworthy/exporter-3"
+      ]
+    },
+    "@tomlarkworthy/save-in-place": {
+      "hash": "aea6b315755118e76e8021177e76e917",
+      "dependsOn": [
+        "@tomlarkworthy/exporter-3",
+        "@tomlarkworthy/plugin-registry",
+        "@tomlarkworthy/runtime-sdk"
+      ]
     },
     "@mbostock/safe-local-storage": {
       "hash": "937d252019887842c8c48c634b76179a",
@@ -70,7 +121,7 @@
       ]
     },
     "@tomlarkworthy/claude-code-pairing": {
-      "hash": "9ef62cada1525cf5d4987907f0362236",
+      "hash": "8cdd769d2694a74bad1003b20625a618",
       "dependsOn": [
         "@tomlarkworthy/module-map",
         "@tomlarkworthy/exporter-3",
@@ -82,7 +133,7 @@
         "@tomlarkworthy/file-sync"
       ],
       "dependedBy": [
-        "@tomlarkworthy/lopepage"
+        "@tomlarkworthy/lopepage-2"
       ]
     },
     "@tomlarkworthy/codemirror-6-v2": {
@@ -95,14 +146,16 @@
       ]
     },
     "@tomlarkworthy/command-palette": {
-      "hash": "4b7ce022a1bc9a4affa98c47552f828d",
+      "hash": "a3617c1f57904cbab42a34b069bf092a",
       "dependsOn": [
         "@tomlarkworthy/cell-map",
         "@tomlarkworthy/lopepage-urls",
-        "@tomlarkworthy/themes"
+        "@tomlarkworthy/themes",
+        "@tomlarkworthy/module-map",
+        "@tomlarkworthy/plugin-registry"
       ],
       "dependedBy": [
-        "@tomlarkworthy/lopepage"
+        "@tomlarkworthy/lopepage-2"
       ]
     },
     "@tomlarkworthy/dataflow-templating": {
@@ -124,31 +177,6 @@
         "@tomlarkworthy/exporter-3"
       ]
     },
-    "@tomlarkworthy/editor-5": {
-      "hash": "a2515020f8ebd02054039cc37c1f9f07",
-      "files": [
-        "cell_options.json"
-      ],
-      "dependsOn": [
-        "@tomlarkworthy/visualizer",
-        "@tomlarkworthy/reversible-attachment",
-        "@tomlarkworthy/flow-queue",
-        "@tomlarkworthy/cell-map",
-        "d/57d79353bac56631@44",
-        "@tomlarkworthy/lopepage-urls",
-        "@tomlarkworthy/cells-to-clipboard",
-        "@tomlarkworthy/observablehq-lezer",
-        "@tomlarkworthy/dataflow-templating",
-        "@tomlarkworthy/fileattachments",
-        "@tomlarkworthy/runtime-sdk",
-        "@tomlarkworthy/codemirror-6-v2",
-        "@tomlarkworthy/observablejs-toolchain",
-        "@tomlarkworthy/module-map"
-      ],
-      "dependedBy": [
-        "@tomlarkworthy/lopepage"
-      ]
-    },
     "@tomlarkworthy/escodegen": {
       "hash": "d5e793114a390617e9a70bfdd61a42ec",
       "files": [
@@ -159,7 +187,7 @@
       ]
     },
     "@tomlarkworthy/exporter-3": {
-      "hash": "3872a7ba7029de95ffba3cdc17c0ce52",
+      "hash": "aed3ed9023c48e4a03ae1f8003eb3f7e",
       "dependsOn": [
         "@tomlarkworthy/observable-runtime-v6",
         "@tomlarkworthy/flow-queue",
@@ -178,11 +206,12 @@
         "@tomlarkworthy/claude-code-pairing",
         "@tomlarkworthy/file-sync",
         "@tomlarkworthy/local-change-history",
-        "@tomlarkworthy/lopepage"
+        "@tomlarkworthy/lopepage-2",
+        "@tomlarkworthy/save-in-place"
       ]
     },
     "@tomlarkworthy/file-sync": {
-      "hash": "adcaf784830574cbacb4c069959714d6",
+      "hash": "089777c0a995824b4a16291c5ab6412b",
       "dependsOn": [
         "@tomlarkworthy/module-map",
         "@tomlarkworthy/exporter-3",
@@ -201,8 +230,7 @@
       ],
       "dependedBy": [
         "@tomlarkworthy/editor-5",
-        "@tomlarkworthy/file-sync",
-        "@tomlarkworthy/module-selection"
+        "@tomlarkworthy/file-sync"
       ]
     },
     "@tomlarkworthy/flow-queue": {
@@ -216,29 +244,6 @@
         "@tomlarkworthy/module-map"
       ]
     },
-    "@tomlarkworthy/golden-layout-2-6-0": {
-      "hash": "24f5fad01bd508dd1bc3a49a99002770",
-      "files": [
-        "golden-layout-2.6.0.js.gz",
-        "lm_popout_black.png",
-        "lm_close_black.png",
-        "lm_minimize_black.png",
-        "lm_popin_black.png",
-        "lm_maximise_black.png"
-      ],
-      "dependedBy": [
-        "@tomlarkworthy/lopepage"
-      ]
-    },
-    "@tomlarkworthy/import-notebook": {
-      "hash": "b6b75803b1a4b7006005a06e0495ee65",
-      "dependsOn": [
-        "@tomlarkworthy/runtime-sdk"
-      ],
-      "dependedBy": [
-        "@tomlarkworthy/module-selection"
-      ]
-    },
     "@tomlarkworthy/inspector": {
       "hash": "4388a12127c9f7f4667923f96ebb6820",
       "files": [
@@ -250,6 +255,15 @@
         "@tomlarkworthy/summarizejs",
         "@tomlarkworthy/tests",
         "@tomlarkworthy/visualizer"
+      ]
+    },
+    "@tomlarkworthy/invoke-variable": {
+      "hash": "eb72dd569c9e7f0de6e0b518cbe12fb4",
+      "dependsOn": [
+        "@tomlarkworthy/runtime-sdk"
+      ],
+      "dependedBy": [
+        "@tomlarkworthy/module-map"
       ]
     },
     "@tomlarkworthy/isomorphic-git-1-30-1": {
@@ -304,7 +318,7 @@
       "dependedBy": [
         "@tomlarkworthy/claude-code-pairing",
         "@tomlarkworthy/file-sync",
-        "@tomlarkworthy/lopepage"
+        "@tomlarkworthy/lopepage-2"
       ]
     },
     "@tomlarkworthy/local-storage-view": {
@@ -317,21 +331,6 @@
         "@tomlarkworthy/exporter-3"
       ]
     },
-    "@tomlarkworthy/lopepage": {
-      "hash": "633f78d13e1da2ee746dc2c8598b5a24",
-      "dependsOn": [
-        "@tomlarkworthy/golden-layout-2-6-0",
-        "@tomlarkworthy/visualizer",
-        "@tomlarkworthy/module-selection",
-        "@tomlarkworthy/runtime-sdk",
-        "@tomlarkworthy/editor-5",
-        "@tomlarkworthy/exporter-3",
-        "d/57d79353bac56631@44",
-        "@tomlarkworthy/local-change-history",
-        "@tomlarkworthy/claude-code-pairing",
-        "@tomlarkworthy/command-palette"
-      ]
-    },
     "@tomlarkworthy/lopepage-urls": {
       "hash": "28f1a31190b2a69e3c9d3ac522c41bd4",
       "dependsOn": [
@@ -342,46 +341,44 @@
         "@tomlarkworthy/cell-map",
         "@tomlarkworthy/command-palette",
         "@tomlarkworthy/editor-5",
+        "@tomlarkworthy/lopepage-2",
         "@tomlarkworthy/module-map",
-        "@tomlarkworthy/module-selection",
         "@tomlarkworthy/tests",
         "@tomlarkworthy/visualizer"
       ]
     },
     "@tomlarkworthy/module-map": {
-      "hash": "ddf9b08467025d702a130fbeab912da7",
+      "hash": "18f327c993e00ae2ab3ab0cb21a27492",
       "dependsOn": [
         "@tomlarkworthy/lopepage-urls",
         "@tomlarkworthy/flow-queue",
         "@tomlarkworthy/observablejs-toolchain",
         "@tomlarkworthy/runtime-sdk",
+        "@tomlarkworthy/invoke-variable",
         "@tomlarkworthy/spectral-layout"
       ],
       "dependedBy": [
         "@tomlarkworthy/cell-map",
         "@tomlarkworthy/claude-code-pairing",
+        "@tomlarkworthy/command-palette",
         "@tomlarkworthy/editor-5",
         "@tomlarkworthy/exporter-3",
         "@tomlarkworthy/file-sync",
         "@tomlarkworthy/local-change-history",
-        "@tomlarkworthy/module-selection",
         "@tomlarkworthy/spectral-layout",
         "@tomlarkworthy/tests"
       ]
     },
-    "@tomlarkworthy/module-selection": {
-      "hash": "4a1faa9fa20cfe945828d87c5a758c51",
+    "@tomlarkworthy/modules": {
+      "hash": "383efc0f630704ea804c5ddf05ab44eb",
       "dependsOn": [
-        "@tomlarkworthy/observablejs-toolchain",
-        "@tomlarkworthy/import-notebook",
-        "@tomlarkworthy/fileattachments",
-        "@tomlarkworthy/lopepage-urls",
-        "d/57d79353bac56631@44",
-        "@tomlarkworthy/module-map",
-        "@tomlarkworthy/runtime-sdk"
+        "@tomlarkworthy/runtime-sdk",
+        "@tomlarkworthy/tests",
+        "@tomlarkworthy/observable-runtime-v6"
       ],
       "dependedBy": [
-        "@tomlarkworthy/lopepage"
+        "@tomlarkworthy/editor-5",
+        "@tomlarkworthy/lopepage-2"
       ]
     },
     "@tomlarkworthy/observable-runtime": {
@@ -396,7 +393,8 @@
     "@tomlarkworthy/observable-runtime-v6": {
       "hash": "6bc9db7b1881559c4d30c39f692e3969",
       "dependedBy": [
-        "@tomlarkworthy/exporter-3"
+        "@tomlarkworthy/exporter-3",
+        "@tomlarkworthy/modules"
       ]
     },
     "@tomlarkworthy/observablehq-lezer": {
@@ -410,7 +408,7 @@
       ]
     },
     "@tomlarkworthy/observablejs-toolchain": {
-      "hash": "b89f6c3ca92136704f5c6c025db14cf0",
+      "hash": "2962cab42a2656515423cb9740dc0f74",
       "files": [
         "acorn-walk-8.3.2.js.gz",
         "parser-6.1.0.js.gz"
@@ -428,8 +426,15 @@
         "@tomlarkworthy/claude-code-pairing",
         "@tomlarkworthy/editor-5",
         "@tomlarkworthy/exporter-3",
-        "@tomlarkworthy/module-map",
-        "@tomlarkworthy/module-selection"
+        "@tomlarkworthy/module-map"
+      ]
+    },
+    "@tomlarkworthy/plugin-registry": {
+      "hash": "428298afcf9c9c8bb13c412d7c23b191",
+      "dependedBy": [
+        "@tomlarkworthy/command-palette",
+        "@tomlarkworthy/lopepage-2",
+        "@tomlarkworthy/save-in-place"
       ]
     },
     "@tomlarkworthy/reversible-attachment": {
@@ -443,7 +448,7 @@
       ]
     },
     "@tomlarkworthy/runtime-sdk": {
-      "hash": "d6da0322104cb2ad8a836559a8e6cf15",
+      "hash": "a43c34b9eb2d7000763b6b2758e0a17d",
       "dependsOn": [
         "@mootari/access-runtime"
       ],
@@ -455,12 +460,13 @@
         "@tomlarkworthy/exporter-3",
         "@tomlarkworthy/file-sync",
         "@tomlarkworthy/fileattachments",
-        "@tomlarkworthy/import-notebook",
+        "@tomlarkworthy/invoke-variable",
         "@tomlarkworthy/local-change-history",
-        "@tomlarkworthy/lopepage",
+        "@tomlarkworthy/lopepage-2",
         "@tomlarkworthy/lopepage-urls",
         "@tomlarkworthy/module-map",
-        "@tomlarkworthy/module-selection",
+        "@tomlarkworthy/modules",
+        "@tomlarkworthy/save-in-place",
         "@tomlarkworthy/tests",
         "@tomlarkworthy/visualizer"
       ]
@@ -481,7 +487,7 @@
       ]
     },
     "@tomlarkworthy/summarizejs": {
-      "hash": "d5ca198f066bde101db6eed6086d55ed",
+      "hash": "6012d7554a1be7b899eb3e061154b130",
       "dependsOn": [
         "@tomlarkworthy/inspector"
       ],
@@ -501,14 +507,16 @@
       "dependedBy": [
         "@tomlarkworthy/cell-map",
         "@tomlarkworthy/lopepage-urls",
+        "@tomlarkworthy/modules",
         "@tomlarkworthy/observablejs-toolchain"
       ]
     },
     "@tomlarkworthy/themes": {
-      "hash": "0fe84814f727b3cc5f0f012ff9e556e9",
+      "hash": "e805ad68c19cf214655218d6cb106d70",
       "dependedBy": [
         "@tomlarkworthy/command-palette",
-        "@tomlarkworthy/exporter-3"
+        "@tomlarkworthy/exporter-3",
+        "@tomlarkworthy/lopepage-2"
       ]
     },
     "@tomlarkworthy/view": {
@@ -519,7 +527,7 @@
       ]
     },
     "@tomlarkworthy/visualizer": {
-      "hash": "006c7bdb86aaefd18519862f541538d9",
+      "hash": "72308ea706602b6b9d1d4836c0c3eea6",
       "dependsOn": [
         "@tomlarkworthy/inspector",
         "@tomlarkworthy/runtime-sdk",
@@ -528,21 +536,22 @@
       ],
       "dependedBy": [
         "@tomlarkworthy/editor-5",
-        "@tomlarkworthy/lopepage"
+        "@tomlarkworthy/lopepage-2"
       ]
     },
     "d/57d79353bac56631": {
       "hash": "913f1f6b56a3bbdfca30148905419a98"
     },
     "@tomlarkworthy/bootloader": {
-      "hash": "c54b8a089b467872c8065bac24d1a9ff"
+      "hash": "be266ec68b91aa7b1a605ce437344920"
     }
   },
   "upstreams": {
     "observablehq.com": {
-      "@tomlarkworthy/editor-5": "https://observablehq.com/@tomlarkworthy/editor-5"
+      "@tomlarkworthy/editor-5": "https://observablehq.com/@tomlarkworthy/editor-5",
+      "@tomlarkworthy/save-in-place": "https://observablehq.com/@tomlarkworthy/save-in-place"
     }
   },
-  "observable_version": 4000,
-  "observable_update_time": "2026-05-25T13:53:15.954Z"
+  "observable_version": 4004,
+  "observable_update_time": "2026-07-12T08:50:12.941Z"
 }


### PR DESCRIPTION
Follow-up to #193. After the reactive-`modules` fix was applied on ObservableHQ (the `modules` cell is now `import { currentModules as modules } from "@tomlarkworthy/modules"`), this re-jumpgates the canonical editor-5 notebook down from Observable and reframes it.

## Changes (editor-5's own notebook only)
- **Frame:** `@tomlarkworthy/lopepage` → `@tomlarkworthy/lopepage-2`
- **Mains:** `["@tomlarkworthy/lopepage-2","@tomlarkworthy/editor-5","@tomlarkworthy/save-in-place"]` (save-in-place added)
- **Hash:** `#view=S100(@tomlarkworthy/editor-5)`
- editor-5 module block regenerated from Observable — carries the reactive `modules` import.

Consumer notebooks are unaffected (they embed the editor-5 module `<script>` block, not editor-5's bootconf/frame).

## QA (isolated Playwright)
- Boots clean on lopepage-2, no console errors.
- editor-5 renders with edit affordances; lopepage-2 burger menu present; save-in-place bundled as a main.
- Runtime-created module → `findCell.module.module` set → `compile_and_update` applies → cell recomputes. ✅