### PR TITLE
Sync editable-md ASI-fix into consumers

### DIFF
--- a/notebooks/@tomlarkworthy_lopecode-tour.html
+++ b/notebooks/@tomlarkworthy_lopecode-tour.html
@@ -9478,9 +9478,9 @@ function isPasteableUrl(text) {
 }
 )};
 const _2mqz8v = function _linkifyPastedUrl(prosemirror,isPasteableUrl){return(
-// Pasting a URL over a selection links the selection instead of replacing it.
-// Returns true when handled, so prosemirror skips its default paste.
 function linkifyPastedUrl(view, event) {
+  // Pasting a URL over a selection links the selection instead of replacing it.
+  // Returns true when handled, so prosemirror skips its default paste.
   const linkType = prosemirror.schema.marks.link;
   if (!linkType) return false;
   const text = event.clipboardData && event.clipboardData.getData("text/plain");
@@ -9496,16 +9496,16 @@ function linkifyPastedUrl(view, event) {
 }
 )};
 const _3kmqp1 = function _escapeMarkdownInline(){return(
-// Mirrors the character set prosemirror's defaultMarkdownSerializer escapes inline,
-// so escape/unescape are exact inverses across a parse+serialize round trip.
 function escapeMarkdownInline(text) {
+  // Mirrors the character set prosemirror's defaultMarkdownSerializer escapes inline,
+  // so escape/unescape are exact inverses across a parse+serialize round trip.
   return text.replace(/[\\`*~\[\]_]/g, (c) => "\\" + c);
 }
 )};
 const _9wq3vz = function _unescapeMarkdownInline(){return(
-// Reverses a markdown backslash escape of any ASCII punctuation (CommonMark rule),
-// a superset of escapeMarkdownInline so serializer-added escapes are also removed.
 function unescapeMarkdownInline(text) {
+  // Reverses a markdown backslash escape of any ASCII punctuation (CommonMark rule),
+  // a superset of escapeMarkdownInline so serializer-added escapes are also removed.
   return text.replace(/\\([!-\/:-@\[-`{-~])/g, "$1");
 }
 )};

--- a/notebooks/@tomlarkworthy_lopecode-vision.html
+++ b/notebooks/@tomlarkworthy_lopecode-vision.html
@@ -6196,9 +6196,9 @@ function isPasteableUrl(text) {
 }
 )};
 const _2mqz8v = function _linkifyPastedUrl(prosemirror,isPasteableUrl){return(
-// Pasting a URL over a selection links the selection instead of replacing it.
-// Returns true when handled, so prosemirror skips its default paste.
 function linkifyPastedUrl(view, event) {
+  // Pasting a URL over a selection links the selection instead of replacing it.
+  // Returns true when handled, so prosemirror skips its default paste.
   const linkType = prosemirror.schema.marks.link;
   if (!linkType) return false;
   const text = event.clipboardData && event.clipboardData.getData("text/plain");
@@ -6214,16 +6214,16 @@ function linkifyPastedUrl(view, event) {
 }
 )};
 const _3kmqp1 = function _escapeMarkdownInline(){return(
-// Mirrors the character set prosemirror's defaultMarkdownSerializer escapes inline,
-// so escape/unescape are exact inverses across a parse+serialize round trip.
 function escapeMarkdownInline(text) {
+  // Mirrors the character set prosemirror's defaultMarkdownSerializer escapes inline,
+  // so escape/unescape are exact inverses across a parse+serialize round trip.
   return text.replace(/[\\`*~\[\]_]/g, (c) => "\\" + c);
 }
 )};
 const _9wq3vz = function _unescapeMarkdownInline(){return(
-// Reverses a markdown backslash escape of any ASCII punctuation (CommonMark rule),
-// a superset of escapeMarkdownInline so serializer-added escapes are also removed.
 function unescapeMarkdownInline(text) {
+  // Reverses a markdown backslash escape of any ASCII punctuation (CommonMark rule),
+  // a superset of escapeMarkdownInline so serializer-added escapes are also removed.
   return text.replace(/\\([!-\/:-@\[-`{-~])/g, "$1");
 }
 )};


### PR DESCRIPTION
Companion to tomlarkworthy/lopebooks#116. The editable-md helper cells led their returned expression with a comment, which decompiled to `return; …` (ASI) when pushed to ObservableHQ — "escapeMarkdownInline is not a function". Comments moved inside the function bodies. Behaviorally a no-op in these consumers (in-browser runtime was never affected); synced to keep canonical==consumers. Observable fixed and verified (v859).