### PR TITLE
Sync markdown-wiki self-register block into blank-notebook (export durability)

### DIFF
--- a/notebooks/@tomlarkworthy_blank-notebook.html
+++ b/notebooks/@tomlarkworthy_blank-notebook.html
@@ -23985,11 +23985,12 @@ const _1q8134j = function _wiki_summaries(wiki_files,wikiRead)
     summary: firstLine(wikiRead(name))
   }));
 };
-const _1172yeo = function _wiki_index(wiki_summaries)
-{
-  const base = '/content/@tomlarkworthy/markdown-wiki/';
-  const lines = wiki_summaries.map(({name, summary}) => `- ${ base }${ name } — ${ summary }`);
-  return 'KNOWLEDGE WIKI \u2014 a curated, authoritative set of docs about THIS project (lopecode / lopebooks / ' + 'robocoop / the notebook runtime and its tooling). When a task or question touches any of these topics, ' + 'read the relevant doc with read_file FIRST \u2014 before investigating the live notebook, fetching anything, ' + 'or answering from memory. These docs are current and take precedence over your priors; do not fabricate ' + 'an answer a doc already gives. Available docs:\n' + lines.join('\n');
+const _1172yeo = function _wiki_index(wiki_register,wiki_summaries) {
+    wiki_register;
+    // side-effect: register docs as FileAttachments for export durability
+    const base = '/content/@tomlarkworthy/markdown-wiki/';
+    const lines = wiki_summaries.map(({name, summary}) => `- ${ base }${ name } — ${ summary }`);
+    return 'KNOWLEDGE WIKI \u2014 a curated, authoritative set of docs about THIS project (lopecode / lopebooks / ' + 'robocoop / the notebook runtime and its tooling). When a task or question touches any of these topics, ' + 'read the relevant doc with read_file FIRST \u2014 before investigating the live notebook, fetching anything, ' + 'or answering from memory. These docs are current and take precedence over your priors; do not fabricate ' + 'an answer a doc already gives. Available docs:\n' + lines.join('\n');
 };
 const _xnpk0l = function _wiki_selection(Inputs,wiki_files){return(
 Inputs.select(wiki_files, {
@@ -24004,25 +24005,70 @@ const _p38mdz = function _wiki_content(wiki_selection,wikiRead)
     return '_(no documents \u2014 inject them with tools/sync-wiki.ts)_';
   return wikiRead(wiki_selection) ?? '_(document not found)_';
 };
-const _1k8md73 = function _wiki_view(html,md,wiki_content){return(
-html`<div style="max-height:70vh;overflow:auto;padding:0 1rem;line-height:1.5">${ md([wiki_content]) }</div>`
-)};
+const _1k8md73 = function _wiki_view(wiki_register,html,md,wiki_content) {
+    wiki_register;
+    // side-effect: register docs as FileAttachments for export durability
+    return html`<div style="max-height:70vh;overflow:auto;padding:0 1rem;line-height:1.5">${ md([wiki_content]) }</div>`;
+};
+const _ln9t7s = function _wikiModule(thisModule) {return (thisModule());};
+const _1q7cpig = (G, _) => G.input(_);
+const _icrlsb = function _wiki_register(wikiModule,wiki_files,runtime) {
+    // Register the wiki's content blocks as FileAttachments on THIS module so exporter-3
+    // (save-in-place) serializes them; without this the docs tree-shake on every round-trip.
+    // Pure, defensive runtime side-effect: never throws, no-ops off-kernel or pre-resolution.
+    try {
+        if (!wikiModule || typeof window === 'undefined' || !window.lopecode || typeof window.lopecode.contentSync !== 'function')
+            return 0;
+        const prefix = '@tomlarkworthy/markdown-wiki/';
+        const map = new Map();
+        for (const name of wiki_files) {
+            try {
+                const r = window.lopecode.contentSync(prefix + name);
+                if (!r || r.status !== 200 || !r.bytes)
+                    continue;
+                const url = URL.createObjectURL(new Blob([r.bytes], { type: r.mime || 'text/markdown' }));
+                map.set(name, {
+                    url,
+                    mimeType: r.mime || 'text/markdown'
+                });
+            } catch (e) {
+            }
+        }
+        wikiModule.builtin('FileAttachment', runtime.fileAttachments(name => map.get(name)));
+        return map.size;
+    } catch (e) {
+        return 0;
+    }
+};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
   const $def = (pid, name, deps, fn) => {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
+  const fileAttachments = new Map(["bulk-exporting-lopebooks.md","development-of-pairing-channel-and-claude-plugin.md","how-file-attachments-work.md","js-toolchain-notebook-kit-2-cells.md","live-collaboration-with-claude-code-pairing.md","lopecode-internal-networking.md","maintaining-and-updating-lopecode-and-lopebook-content-repositories.md","module-exporter-runtime-self-serialization.md","notebook-programming-concepts.md","pushing-cells-to-observablehq.md","querying-and-maintaining-the-lopecode-structured-knowledgebase.md","tinyemu-build-chain.md","what-makes-a-great-lopebook.md"].map((name) => {
+    const module_name = "@tomlarkworthy/markdown-wiki";
+    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
+    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
+    return [name, {url: blob_url, mimeType: mime}]
+  }));
+  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
 
   $def("_okuukn", "intro", ["md"], _okuukn);  
   $def("_1trbfb3", "wikiRead", [], _1trbfb3);  
   $def("_103elop", "wiki_files", [], _103elop);  
   $def("_1q8134j", "wiki_summaries", ["wiki_files","wikiRead"], _1q8134j);  
-  $def("_1172yeo", "wiki_index", ["wiki_summaries"], _1172yeo);  
+  $def("_1172yeo", "wiki_index", ["wiki_register","wiki_summaries"], _1172yeo);  
   $def("_xnpk0l", "viewof wiki_selection", ["Inputs","wiki_files"], _xnpk0l);  
   $def("_1ie98l", "wiki_selection", ["Generators","viewof wiki_selection"], _1ie98l);  
   $def("_p38mdz", "wiki_content", ["wiki_selection","wikiRead"], _p38mdz);  
-  $def("_1k8md73", "wiki_view", ["html","md","wiki_content"], _1k8md73);
+  $def("_1k8md73", "wiki_view", ["wiki_register","html","md","wiki_content"], _1k8md73);  
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
+  main.define("thisModule", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("thisModule", _));  
+  $def("_ln9t7s", "viewof wikiModule", ["thisModule"], _ln9t7s);  
+  $def("_1q7cpig", "wikiModule", ["Generators","viewof wikiModule"], _1q7cpig);  
+  $def("_icrlsb", "wiki_register", ["wikiModule","wiki_files","runtime"], _icrlsb);
   return main;
 }</script>
 


### PR DESCRIPTION
Companion to [lopebooks#117](https://github.com/tomlarkworthy/lopebooks/pull/117).

`@tomlarkworthy/markdown-wiki` read its docs via `contentSync` but held no FileAttachment loader map, so `exporter-3` save-in-place tree-shook all 13 docs on every round-trip. The module now registers its own DOM content blocks as FileAttachments at boot (`wiki_register` cell + `thisModule` from runtime-sdk), threaded through the observed sinks. This syncs the unified block into `lopecode`'s blank-notebook.

Block is byte-identical to the other consumers (md5 `3864c17`). Verified: fresh boot auto-registers 13 docs with working `blob:` URLs; clean boot (`errors: []`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)