### PR TITLE
toolchain + exporter-3: drop escodegen, fix stageB ASI break, align import tests

### DIFF
--- a/notebooks/@tomlarkworthy_exporter-3.html
+++ b/notebooks/@tomlarkworthy_exporter-3.html
@@ -2920,6 +2920,7 @@ export default function define(runtime, observer) {
   main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
   main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
   main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
+  main.define("module @tomlarkworthy/escodegen", async () => runtime.module((await import("/@tomlarkworthy/escodegen.js?v=4")).default));  
   main.define("module @tomlarkworthy/view", async () => runtime.module((await import("/@tomlarkworthy/view.js?v=4")).default));  
   main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
   main.define("module @tomlarkworthy/local-storage-view", async () => runtime.module((await import("/@tomlarkworthy/local-storage-view.js?v=4")).default));  
@@ -3029,7 +3030,7 @@ export default function define(runtime, observer) {
   main.define("parser", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("parser", _));  
   main.define("decompress_url", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("decompress_url", _));  
   main.define("acorn", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("acorn", _));  
-  main.define("escodegen", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("escodegen", _));  
+  main.define("escodegen", ["module @tomlarkworthy/escodegen", "@variable"], (_, v) => v.import("escodegen", _));  
   main.define("view", ["module @tomlarkworthy/view", "@variable"], (_, v) => v.import("view", _));  
   main.define("variable", ["module @tomlarkworthy/view", "@variable"], (_, v) => v.import("variable", _));  
   main.define("bindOneWay", ["module @tomlarkworthy/view", "@variable"], (_, v) => v.import("bindOneWay", _));  
@@ -19660,13 +19661,6 @@ export default function define(runtime, observer) {
   $def("_104y7ux", "observable_lezer_parser", ["lezerhighlight","lr"], _104y7ux);
   return main;
 }</script>
-<script id="@tomlarkworthy/observablejs-toolchain/acorn-walk-8.3.2.js.gz" 
-  type="text/plain"
-  data-encoding="base64"
-  data-mime="application/gzip"
->
-H4sICB8jLWcCA2Fjb3JuLXdhbGtAOC4zLjIuanMApVlbU+O4En6fX2E4VZQza5wAs8yC8XK47FZRNbcC5mydonhQbDnRjC17JRkmh+S/n5bkm2zHITsvjNWt7v76olYrM3779o311rrMaRjj0JourG/8GsfkiVk5J3Rm3aZxnGfW06H7/sQ9sBANrXvMOGbW06/uwYl76Er5z4zMCEWxFZEYn1pjmiVjFKSM7j+j+Pu/f3OP3MNxSLgYy7WbfOMgJQWvU+vT53uwha272xvrmYi5FS4oSkiA4nhhzTDFDAmAJjXzHetjyrBFaJSyBAmS0lNrLkTGT8fj5+dn9xsPFXg3SJOxcmCfM7Iv1e4XaveVIrA9fhPlNJA6LGELBzvUYU46eqHLpU39ZOQ02MBwyOjlCTEL+WS5ZK5YZNijD+hR8cTIwfC9t4cLymgFKtW/lRbcNCI1Ef/h0VtnDek93EelNSfz2Y7vkwfixpjOwKODRy/b2yNulvO5zUYOfeANOFzB0ZTlkgB+R+9OM7sHHu3Co+eRDYTl8ikloTUZnTJvpwFT7R69kAfYgRXER0UTSjs2tDNbjF4YFjmju1wwSMyu70uRNLLEebnNxuUmC/vAX52K5bJilrydyWolAaZ+xQJzoxcxJ9ylaYh94ahvLqByfLzyKhik4+QWCfCa8SWQCra3Z2NF4EDwWU9UUWmwritPYXdU9ncMowj0KKOZz6usBz1ZD8ysZ49KGFClDVRIJd3JgArQnMDMfQMjLzASDQDkbCQDAh7ZZOQJtngxcXJQqnAGflYFh0S2TfM49n0saRB7Js58PAI0mkwlGdPwd58CET0Ej0oVoO7IQe57BIEqJYkdAPyRmLP02aL42UqlHuUV/A2QCOay2ACPgEYB+mggqywdFZUlPC0qVnUIsjoEkCjwm4L7EAci89UNQF+iZAB27MKB33GB+Uz5QRoponYm4bfwI4Uf/VP8wT/AX+DVIHvdKZ3x8d5eAbuN2mu4tvopF/KmC+rkecXulj9Oy5WscqUI/ahbnNpN6Ye9Ay7qNqFoijOS/smqAj73a+/AqC7ThnsOrzFHuvFIa9T/PP2GA+EGDEPXsaEAIPRwTdmSC40G4I7oA3v0BfypXKt1xdp/SJ9SWjN+lAzV9BL/ZeUl7heWzhhK/MS9jNPg+53sdAmmAgjymwSKbDRIqaLC40+gKwh3moYLj52lRW/x2C/+gUSQAkaQ2K307oL7jtat7cSw+iPJxKIm/ZCkHxnDnIPJJqQviMHHHHPyPxzWW4BzNUeENihtwGWcbOHiapdEVssANDB8E9UG20qktMBctOUcyQhSyvHfOci1HHaEi2KBGQWKrI/Gsh0asP8BTTFMUOtBNDyRUe9RcQmVY2TyKqWC0BybIf4LhplhX1NVib3erjF9BxNSsEErjG8BIwmMebSj22sXVoA45t3K0nOFrC6PqJTIwJLe5FQqEajkPmkkykNnvNSLiorlMHh1KrZ27QrwdLwSFQQxDKHyqoawxaG5VZlvJva/BMfmObh4RkQMnAMoPjbLpXhRisWq7yjcy95qdATgo/CPeGNhDmpli+H6mMqO0z1DcySfFkzDLhbQ34ATyRcDdISCVy176vNKXilXMcp7s5ghaIVaifqUCr4gIQ/rcNn/NYe3QDNS12mLtFUrWWPlz5StVyhcQkmRVPkl5UHgBj5V+IYrFDbkWVg1KP29JbYbozSB8HlDK41x1IIpqfACnIutTZOuid3/IEbQNMbXOIghnZK3K18D6io/19fjqd7eqdJrPM1nM8zMlvlnYaKhceAYKN8Krtbag2jj1RrWe/n6bqE7RFt/ynoDT0Kzsvtqpx2Q0pG+wgsLUVNtp+upM8WHOl4lu2rku3ljnzdxnbYroRDvVsJNCHtIRDBrF4BTVUll+3T3I06mmDUsdYT0jlqkmLUaKSixyLIxdquJ5xbO4JZ9tI4NyF8whhbr3G3HHWtDG65RdYOahqQlPY2+1lTG0gwzQTbc2btf9L6FjCzRkbXlzZxkucChvsy/40VPGyDuE4pzbACFlDUCWuvUevqDuDKGTJWUe3jrG5fpXQ4gfZk/gUrEKqEq/AO37E9mwDh7dRK2MDiUB7NllOfanCIY3Py9nJ4OKGcjNcwEeJuQVFsHO0InFPc4yWI49R8IJBLFG+38nSNOBqNQShCQQC1k5AyVYqQQQw9kGFl5rmWhfKWILYwAflVX60CgNs1Pl6Sj80M6kz9zblBaXrede7X3xlVdBr5nVAIxq6Mir2sLTXPmALXWFrxRQiJ1bPTjlS+wDtt4dbXNf8LP5nsSxUM4SGQri7AL455hqkwgH7XrseJsVfXtG2mb55ow+mrVGxZ9YYB1ysQnlOCwOaOUjGscoTwWQ+OLMbBogw1CYbPHRn3HLpeGCIwV542L/rTtHE9zFhRzq/5e79hFHA9jx2pbGalyJZ8Zw+pvEh2e1491PMOBmkgGe9NrrG6oik3idyUQv3ZDZbnLkDnjGQqwwapmK/kDDSNPkCmDVnZq2Q/vEQzVYdUpNxx0NOs9yKql9/aQGHFu1q0ivep3IalQ7W7oev2wKwtRTgtKrCjGaj3wmqltXcL6J39nK3uFmKdwtCI5yusolMNLL7HHSbNh9A1iQo9hekM1kRkJ8fTxecEW4pb85ZbDe8RJ5GqKOHYC+QV4wk9piC8iiKOTGSSW5jR0uEETTt5cX2KIEHaIouVx7KDy66I0GElKgr6Da/KL4SBnnDzBu0IuOYFSxCVWK9Slb8n/MPDejMf/svTx+YiyjNDZ19sP/pgn42gSTN4fTw7fhYfRydFheHz07t0xOkYBmh5hdDJ5Nwl/C8LjSXR4go6O8WSCDkHz++gwPJkERweBm6Ds/8t9I8syHQAA
-</script>
 <script id="@tomlarkworthy/observablejs-toolchain/parser-6.1.0.js.gz" 
   type="text/plain"
   data-encoding="base64"
@@ -22913,7 +22907,7 @@ export default function define(runtime, observer) {
   const $def = (pid, name, deps, fn) => {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
-  const fileAttachments = new Map(["acorn-walk-8.3.2.js.gz","parser-6.1.0.js.gz"].map((name) => {
+  const fileAttachments = new Map(["parser-6.1.0.js.gz"].map((name) => {
     const module_name = "@tomlarkworthy/observablejs-toolchain";
     const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
     const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));

--- a/notebooks/@tomlarkworthy_exporter-3.html
+++ b/notebooks/@tomlarkworthy_exporter-3.html
@@ -1462,8 +1462,8 @@ const _4zsqot = function _actionHandler(Inputs,getSourceModule,notebook_name,_ru
     }
   };
 };
-const _lb3gzc = function _exportToHTML(_runtime, cssForTheme, css, location, keepalive, exporter_module, $0) {
-    return async function exportToHTML({mains = new Map(), runtime = _runtime, options = {}} = {}) {
+const _lb3gzc = function _exportToHTML(_runtime,cssForTheme,css,location,keepalive,exporter_module,$0){return(
+async function exportToHTML({mains = new Map(), runtime = _runtime, options = {}} = {}) {
         let conf = { headless: false };
         try {
             conf = (await import('file://bootconf.json')).default;
@@ -1484,9 +1484,15 @@ const _lb3gzc = function _exportToHTML(_runtime, cssForTheme, css, location, kee
         if (options.tickDelayMs == null) {
             options.tickDelayMs = conf.tickDelayMs;
         }
+        // Prerender defaults ON (matching the exporter UI toggle); only an explicit
+        // "prerender": false in bootconf.json turns it off. Flag persists across re-exports.
         if (options.prerender == null) {
             options.prerender = conf.prerender !== false;
         }
+        // Snapshot the live lopepage-2 DOM (only when exporting this running notebook).
+        // The snapshot keeps its id="lopepage-2" and scoped styles unchanged; book() nests
+        // it in a Declarative Shadow DOM so it is invisible to the booting runtime's
+        // document queries (otherwise duplicated editors/inputs corrupt the boot).
         if (options.prerender && runtime === _runtime && options.prerenderHTML == null) {
             try {
                 const src = document.getElementById('lopepage-2');
@@ -1514,14 +1520,13 @@ const _lb3gzc = function _exportToHTML(_runtime, cssForTheme, css, location, kee
                     options.description = ogContent('meta[property="og:description"]') || ogContent('meta[name="description"]');
                 if (options.image == null)
                     options.image = ogContent('meta[property="og:image"]');
-                const managed = new Set([
-                    'viewport',
-                    'og:title',
-                    'og:type',
-                    'og:description',
-                    'description',
-                    'og:image'
-                ]);
+                // Preserve arbitrary <meta> across re-export (at:*, twitter:*, keywords,
+                // theme-color, custom module metadata, …). Skip charset/viewport and the
+                // og/description tags lopebook regenerates from title/description/image.
+                // Merge, don't replace: caller-supplied options.metas win for any key they
+                // define; scanned tags for every other key are preserved. Repeatable keys
+                // (at:alternate, at:author) survive via full key+content dedup.
+                const managed = new Set(['viewport', 'og:title', 'og:type', 'og:description', 'description', 'og:image']);
                 const provided = Array.isArray(options.metas) ? options.metas : [];
                 const ownedKeys = new Set(provided.map(m => m.key));
                 const seen = new Set(provided.map(m => `${ m.key }\n${ m.content }`));
@@ -1529,20 +1534,13 @@ const _lb3gzc = function _exportToHTML(_runtime, cssForTheme, css, location, kee
                 for (const el of document.head.querySelectorAll('meta[property], meta[name]')) {
                     const key = el.getAttribute('property') || el.getAttribute('name');
                     const content = el.getAttribute('content');
-                    if (key == null || content == null || managed.has(key) || ownedKeys.has(key))
-                        continue;
+                    if (key == null || content == null || managed.has(key) || ownedKeys.has(key)) continue;
                     const dedup = `${ key }\n${ content }`;
-                    if (seen.has(dedup))
-                        continue;
+                    if (seen.has(dedup)) continue;
                     seen.add(dedup);
-                    merged.push({
-                        key,
-                        isProperty: el.hasAttribute('property'),
-                        content
-                    });
+                    merged.push({ key, isProperty: el.hasAttribute('property'), content });
                 }
-                if (merged.length)
-                    options.metas = merged;
+                if (merged.length) options.metas = merged;
             } catch (_) {
             }
         }
@@ -1553,29 +1551,31 @@ const _lb3gzc = function _exportToHTML(_runtime, cssForTheme, css, location, kee
             options
         });
         return response;
+    }
+)};
+const _43zr7 = function _getSourceModule(notebook_name,main,_runtime)
+{
+  return async state => {
+    // source picker was removed; the exporter always serialises this notebook
+    if (!state.source || state.source == 'this notebook')
+      return {
+        notebook: notebook_name,
+        module: main,
+        runtime: _runtime
+      };
+    const url = state.source == 'a notebook url' ? state.notebook_url.child : state.top_100.child;
+    const notebook = url.trim().replace('', '');
+    const [{Runtime, Inspector}, {default: define}] = await Promise.all([
+      import('https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js'),
+      import(`https://api.observablehq.com/${ notebook }.js?v=4`)
+    ]);
+    const runtime = new Runtime();
+    return {
+      notebook,
+      module: runtime.module(define),
+      runtime
     };
-};
-const _43zr7 = function _getSourceModule(notebook_name, main, _runtime) {
-    return async state => {
-        if (!state.source || state.source == 'this notebook')
-            return {
-                notebook: notebook_name,
-                module: main,
-                runtime: _runtime
-            };
-        const url = state.source == 'a notebook url' ? state.notebook_url.child : state.top_100.child;
-        const notebook = url.trim().replace('', '');
-        const [{Runtime, Inspector}, {default: define}] = await Promise.all([
-            import('https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js'),
-            import(`https://api.observablehq.com/${ notebook }.js?v=4`)
-        ]);
-        const runtime = new Runtime();
-        return {
-            notebook,
-            module: runtime.module(define),
-            runtime
-        };
-    };
+  };
 };
 const _tpv4tl = function _createShowable(variable,view)
 {
@@ -2175,27 +2175,27 @@ ${ await generate_define(spec, variables, fileAttachments, { moduleNames }) }`
 const _19ft5zb = function _generate_definitions(variableToDefinition){return(
 variables => variables.map(v => variableToDefinition(v)).join('')
 )};
-const _u3aown = function _generate_define(variableToDefine) {
-    return async (spec, variables, fileAttachments, {moduleNames} = {}) => {
-        const fileAttachmentExpression = fileAttachments?.size ? `  const fileAttachments = new Map(${ JSON.stringify([...fileAttachments.keys()]) }.map((name) => {
+const _u3aown = function _generate_define(variableToDefine){return(
+async (spec, variables, fileAttachments, {moduleNames} = {}) => {
+  const fileAttachmentExpression = fileAttachments?.size ? `  const fileAttachments = new Map(${ JSON.stringify([...fileAttachments.keys()]) }.map((name) => {
     const module_name = "${ spec.name }";
     const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
     const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
     return [name, {url: blob_url, mimeType: mime}]
   }));
   main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));\n` : '';
-        const varLines = (await Promise.all(variables.map(v => variableToDefine(v, { moduleNames })))).flat();
-        const definedModules = new Set(varLines.filter(l => l.includes('runtime.module(')).map(l => {
-            const m = l.match(/main\.define\("module ([^"]+)"/);
-            return m ? m[1] : null;
-        }).filter(Boolean));
-        const referencedModules = new Set(varLines.map(l => {
-            const m = l.match(/\["module ([^"]+)", "@variable"\]/);
-            return m ? m[1] : null;
-        }).filter(Boolean));
-        const missingModules = [...referencedModules].filter(m => !definedModules.has(m));
-        const moduleDefineLines = missingModules.map(m => `  main.define("module ${ m }", async () => runtime.module((await importShim("/${ m }.js?v=4")).default));`);
-        return `export default function define(runtime, observer) {
+  const varLines = (await Promise.all(variables.map(v => variableToDefine(v, { moduleNames })))).flat();
+  const definedModules = new Set(varLines.filter(l => l.includes('runtime.module(')).map(l => {
+    const m = l.match(/main\.define\("module ([^"]+)"/);
+    return m ? m[1] : null;
+  }).filter(Boolean));
+  const referencedModules = new Set(varLines.map(l => {
+    const m = l.match(/\["module ([^"]+)", "@variable"\]/);
+    return m ? m[1] : null;
+  }).filter(Boolean));
+  const missingModules = [...referencedModules].filter(m => !definedModules.has(m));
+  const moduleDefineLines = missingModules.map(m => `  main.define("module ${ m }", async () => runtime.module((await importShim("/${ m }.js?v=4")).default));`);
+  return `export default function define(runtime, observer) {
   const main = runtime.module();
   const $def = (pid, name, deps, fn) => {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
@@ -2204,8 +2204,8 @@ ${ fileAttachmentExpression }${ moduleDefineLines.join('  \n') }
 ${ varLines.join('  \n') }
   return main;
 }`;
-    };
-};
+}
+)};
 const _1hslsmt = function _isLiveImport(){return(
 v => !v._name && v._definition?.toString().includes('observablehq' + '--inspect ' + 'observablehq--import')
 )};
@@ -2222,7 +2222,7 @@ function variableToDefinition(v) {
   return `const ${ pid(v) } = ${ restoreCanonicalImports(v._definition.toString()) };\n`;
 }
 )};
-const _1ohymeb = function _restoreCanonicalImports(acorn,escodegen){return(
+const _79c94t = function _restoreCanonicalImports(acorn){return(
 source => {
   if (!/\bimportShim\s*\(/.test(source))
     return source;
@@ -2239,15 +2239,31 @@ source => {
     console.warn('[exporter-3] importShim AST parse failed; leaving cell unchanged:', e.message);
     return source;
   }
+  // The rewrite is local: only the callee identifier changes, plus the parent
+  // URL Observable appends. Collect character ranges and splice them, rather
+  // than regenerating the cell, so comments, quote style and indentation
+  // survive. Same approach as the toolchain's source-preserving observableToJs.
+  const edits = [];
   const visit = node => {
     if (!node || typeof node !== 'object')
       return;
     if (node.type === 'CallExpression' && node.callee && node.callee.type === 'Identifier' && node.callee.name === 'importShim' && node.arguments.length >= 1) {
-      const spec = node.arguments[0];
-      for (const k of Object.keys(node))
-        delete node[k];
-      node.type = 'ImportExpression';
-      node.source = spec;
+      edits.push([
+        node.callee.start,
+        node.callee.end,
+        'import'
+      ]);
+      // Observable compiles a cell's `import(x)` to `importShim(x, "<notebook
+      // url>")`, where argument 2 is the es-module-shims parent. Native import
+      // takes an options object there, so a string second argument is dropped
+      // and an object one (import attributes) is kept.
+      const [spec, second] = node.arguments;
+      if (node.arguments.length === 2 && second.type === 'Literal' && typeof second.value === 'string')
+        edits.push([
+          spec.end,
+          second.end,
+          ''
+        ]);
     }
     for (const k of Object.keys(node)) {
       const v = node[k];
@@ -2258,7 +2274,11 @@ source => {
     }
   };
   visit(ast);
-  return escodegen.generate(ast);
+  let out = source;
+  // Descending, so earlier offsets stay valid as we rewrite.
+  for (const [start, end, text] of edits.sort((a, b) => b[0] - a[0]))
+    out = out.slice(0, start) + text + out.slice(end);
+  return out;
 }
 )};
 const _1g13ozv = function _variableToDefine(isLiveImport,isDynamicVar,isModuleVar,isImportBridged,findImportedName3,pid)
@@ -2486,6 +2506,46 @@ const _18z61zg = function _test_streaming_order_runtime(Runtime,streamingModuleO
   expect(order.join(',')).toBe('@u/app,@u/junk,@u/lib');
   // main first, then the rest alphabetically
   return 'ok';
+};
+const _1didxs7 = function _test_restoreCanonicalImports(restoreCanonicalImports,expect)
+{
+  const R = restoreCanonicalImports;
+  // Nothing to rewrite: identity.
+  expect(R('async () => 1 + 2')).toBe('async () => 1 + 2');
+  // Callee position becomes the canonical dynamic import.
+  expect(R('async () => await importShim("/@a/b.js?v=4")')).toBe('async () => await import("/@a/b.js?v=4")');
+  // Several calls of differing length: the offsets must stay valid.
+  expect(R('async () => [await importShim("a"), await importShim("bb")]')).toBe('async () => [await import("a"), await import("bb")]');
+  expect(R('async () => importShim(await importShim("inner"))')).toBe('async () => import(await import("inner"))');
+  // Argument 2 is the es-module-shims parent URL that Observable appends when
+  // it compiles a cell's own `import(x)`. Native import has no such parameter.
+  expect(R("f = () => importShim(objectURL, 'https://api.observablehq.com/@a/b.js?v=4')")).toBe('f = () => import(objectURL)');
+  expect(R('f = () => importShim(`${ nb }.js?v=4`, "https://api.observablehq.com/@a/b.js?v=4")')).toBe('f = () => import(`${ nb }.js?v=4`)');
+  // ...but a real options object is import attributes, and must survive.
+  expect(R("async () => await importShim(url, { with: { type: 'css' } })")).toBe("async () => await import(url, { with: { type: 'css' } })");
+  // Callee position only. A bare `import` identifier is a syntax error, so a
+  // reference passed as a value has to be left alone.
+  expect(R('async () => register(importShim, importShim("real"))')).toBe('async () => register(importShim, import("real"))');
+  expect(R('async () => window.importShim("x") + importShim("y")')).toBe('async () => window.importShim("x") + import("y")');
+  expect(R('async () => importShim() || importShim("x")')).toBe('async () => importShim() || import("x")');
+  // A string that merely mentions importShim is not a call.
+  expect(R('async () => { const s = "call importShim(x) later"; return importShim("real"); }')).toBe('async () => { const s = "call importShim(x) later"; return import("real"); }');
+};
+const _ogm44p = function _test_restoreCanonicalImports_preserves_source(expect,restoreCanonicalImports)
+{
+  // Only the callee identifier changes, so the rest survives byte-for-byte —
+  // escodegen used to reformat the whole cell.
+  const src = [
+    'function _f() {',
+    "  // keep  this   comment",
+    "  const s = 'single-quoted';   /* and this */",
+    '  return importShim("tpl");',
+    '}'
+  ].join('\n');
+  expect(restoreCanonicalImports(src)).toBe(src.replace('return importShim("tpl")', 'return import("tpl")'));
+  // Unparseable input falls back to the original source.
+  const broken = 'async () => importShim("unclosed';
+  expect(restoreCanonicalImports(broken)).toBe(broken);
 };
 const _1vgrzwk = function _isNotebook(){return(
 id => /^(@[^/]+\/[^/]+|d\/[a-f0-9]{16})$/.test(id)
@@ -2771,20 +2831,22 @@ const _1s9g3fb = function _networking_script(normalize,isNotebook){return(
     }
   })();`
 )};
-const _kfs9ca = function _lopebook(diskDataUrl, networking_script) {
-    return ({blocks = '', cssUrls = [], bootloader = '@tomlarkworthy/bootloader', title = 'Lopecode notebook', description, image, metas = [], head, bodyPrepend = ''} = {}) => {
-        const styleImports = cssUrls.map((url, i) => `  const style${ i } = await importShim(${ JSON.stringify(url) }, { with: { type: 'css' } });`).join('\n');
-        const styleAdopt = cssUrls.map((_, i) => `style${ i }.default`).join(',');
-        const attr = s => String(s).replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-        const ogTags = [
-            `<meta property="og:title" content="${ attr(title) }">`,
-            `<meta property="og:type" content="website">`,
-            description ? `<meta name="description" content="${ attr(description) }">` : '',
-            description ? `<meta property="og:description" content="${ attr(description) }">` : '',
-            image ? `<meta property="og:image" content="${ attr(image) }">` : '',
-            ...(metas || []).map(m => `<meta ${ m.isProperty ? 'property' : 'name' }="${ attr(m.key) }" content="${ attr(m.content) }">`)
-        ].filter(Boolean).join('\n  ');
-        return `<!DOCTYPE html>
+const _kfs9ca = function _lopebook(diskDataUrl,networking_script)
+{
+  return ({blocks = '', cssUrls = [], bootloader = '@tomlarkworthy/bootloader', title = 'Lopecode notebook', description, image, metas = [], head, bodyPrepend = ''} = {}) => {
+    const styleImports = cssUrls.map((url, i) => `  const style${ i } = await importShim(${ JSON.stringify(url) }, { with: { type: 'css' } });`).join('\n');
+    const styleAdopt = cssUrls.map((_, i) => `style${ i }.default`).join(',');
+    const attr = s => String(s).replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    const ogTags = [
+      `<meta property="og:title" content="${ attr(title) }">`,
+      `<meta property="og:type" content="website">`,
+      description ? `<meta name="description" content="${ attr(description) }">` : '',
+      description ? `<meta property="og:description" content="${ attr(description) }">` : '',
+      image ? `<meta property="og:image" content="${ attr(image) }">` : '',
+      // Preserved <meta> carried across re-export by exportToHTML's head scan.
+      ...(metas || []).map(m => `<meta ${ m.isProperty ? 'property' : 'name' }="${ attr(m.key) }" content="${ attr(m.content) }">`)
+    ].filter(Boolean).join('\n  ');
+    return `<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
@@ -2824,7 +2886,7 @@ ${ blocks }
 <script id="streaming_sentinel">window.__lopeStreaming = false;</scr\ipt>
 </body>
 </html>`;
-    };
+  };
 };
 const _li7wcc = function _lopemodule(TRACE_MODULE,CSS,arrayBufferToBase64,inlineModule,escapeScriptTags)
 {
@@ -2872,10 +2934,10 @@ async function arrayBufferToBase64(buffer) {
   return btoa(binary);
 }
 )};
-const _1miwrx0 = function _79(md){return(
+const _1iz5onh = function _81(md){return(
 md`### Global Output`
 )};
-const _g3fd9a = function _80(md){return(
+const _b9np5w = function _82(md){return(
 md`## Utils`
 )};
 const _fw7q7v = function _getCompactISODate(){return(
@@ -2890,7 +2952,7 @@ function getCompactISODate() {
   return `${ year }${ month }${ day }T${ hours }${ minutes }${ seconds }Z`;
 }
 )};
-const _os8ogr = function _82(md){return(
+const _7vqfq9 = function _84(md){return(
 md`## Additional Tests`
 )};
 const _8765p8 = function _diskDataUrl(disk_svg){return(
@@ -2920,7 +2982,6 @@ export default function define(runtime, observer) {
   main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
   main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
   main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
-  main.define("module @tomlarkworthy/escodegen", async () => runtime.module((await import("/@tomlarkworthy/escodegen.js?v=4")).default));  
   main.define("module @tomlarkworthy/view", async () => runtime.module((await import("/@tomlarkworthy/view.js?v=4")).default));  
   main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
   main.define("module @tomlarkworthy/local-storage-view", async () => runtime.module((await import("/@tomlarkworthy/local-storage-view.js?v=4")).default));  
@@ -2988,7 +3049,7 @@ export default function define(runtime, observer) {
   $def("_u3aown", "generate_define", ["variableToDefine"], _u3aown);  
   $def("_1hslsmt", "isLiveImport", [], _1hslsmt);  
   $def("_4i5mmq", "variableToDefinition", ["isModuleVar","isImportBridged","isLiveImport","isDynamicVar","pid","restoreCanonicalImports"], _4i5mmq);  
-  $def("_1ohymeb", "restoreCanonicalImports", ["acorn","escodegen"], _1ohymeb);  
+  $def("_79c94t", "restoreCanonicalImports", ["acorn"], _79c94t);  
   $def("_1g13ozv", "variableToDefine", ["isLiveImport","isDynamicVar","isModuleVar","isImportBridged","findImportedName3","pid"], _1g13ozv);  
   $def("_8rymrb", null, ["md"], _8rymrb);  
   $def("_g33g3u", "es_module_shims", [], _g33g3u);  
@@ -3001,16 +3062,18 @@ export default function define(runtime, observer) {
   $def("_1d9ux6v", "test_lopebook_main_at_top_with_sentinel", ["lopebook","expect"], _1d9ux6v);  
   $def("_13d3rb0", "test_streaming_order_prioritizes_mains", ["expect","streamingModuleOrder"], _13d3rb0);  
   $def("_18z61zg", "test_streaming_order_runtime", ["Runtime","streamingModuleOrder","expect"], _18z61zg);  
+  $def("_1didxs7", "test_restoreCanonicalImports", ["restoreCanonicalImports","expect"], _1didxs7);  
+  $def("_ogm44p", "test_restoreCanonicalImports_preserves_source", ["expect","restoreCanonicalImports"], _ogm44p);  
   $def("_1vgrzwk", "isNotebook", [], _1vgrzwk);  
   $def("_1s9g3fb", "networking_script", ["normalize","isNotebook"], _1s9g3fb);  
   $def("_kfs9ca", "lopebook", ["diskDataUrl","networking_script"], _kfs9ca);  
   $def("_li7wcc", "lopemodule", ["TRACE_MODULE","CSS","arrayBufferToBase64","inlineModule","escapeScriptTags"], _li7wcc);  
   $def("_19l1umr", "escapeScriptTags", [], _19l1umr);  
   $def("_xpg7uv", "arrayBufferToBase64", [], _xpg7uv);  
-  $def("_1miwrx0", null, ["md"], _1miwrx0);  
-  $def("_g3fd9a", null, ["md"], _g3fd9a);  
+  $def("_1iz5onh", null, ["md"], _1iz5onh);  
+  $def("_b9np5w", null, ["md"], _b9np5w);  
   $def("_fw7q7v", "getCompactISODate", [], _fw7q7v);  
-  $def("_os8ogr", null, ["md"], _os8ogr);  
+  $def("_7vqfq9", null, ["md"], _7vqfq9);  
   $def("_8765p8", "diskDataUrl", ["disk_svg"], _8765p8);  
   $def("_z4k2or", "viewof task", ["flowQueue"], _z4k2or);  
   $def("_ngmf1x", "task", ["Generators","viewof task"], _ngmf1x);  
@@ -3030,7 +3093,6 @@ export default function define(runtime, observer) {
   main.define("parser", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("parser", _));  
   main.define("decompress_url", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("decompress_url", _));  
   main.define("acorn", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("acorn", _));  
-  main.define("escodegen", ["module @tomlarkworthy/escodegen", "@variable"], (_, v) => v.import("escodegen", _));  
   main.define("view", ["module @tomlarkworthy/view", "@variable"], (_, v) => v.import("view", _));  
   main.define("variable", ["module @tomlarkworthy/view", "@variable"], (_, v) => v.import("variable", _));  
   main.define("bindOneWay", ["module @tomlarkworthy/view", "@variable"], (_, v) => v.import("bindOneWay", _));  
@@ -4384,7 +4446,8 @@ const _1ey5aow = function _dragOutGrips(layout,invalidation)
     });
     return 'drag-out grips installed';
 };
-const _1gkn0mq = function _dropInHandler(location, setHashURL, runtime, page, invalidation) {
+const _1gkn0mq = function _dropInHandler(location,setHashURL,runtime,page,invalidation)
+{
     const STYLE_ID = 'lopepage-dropzone-style';
     const oldStyle = document.getElementById(STYLE_ID);
     if (oldStyle)
@@ -5065,12 +5128,12 @@ md`# [Acorn@8.11.3](https://github.com/acornjs/acorn) & acorn-walk@8.2.2
 import { acorn } from "@tomlarkworthy/acorn-8-11-3"
 \`\`\``
 )};
-const _1xdqqxo = function _acorn(acorn_url) {
-    return import(acorn_url);
-};
-const _vctqpi = function _acorn_walk(acorn_walk_url) {
-    return import(acorn_walk_url);
-};
+const _1xdqqxo = function _acorn(acorn_url){return(
+import(acorn_url)
+)};
+const _vctqpi = function _acorn_walk(acorn_walk_url){return(
+import(acorn_walk_url)
+)};
 const _1c0mco9 = async function _acorn_walk_url(unzip,FileAttachment)
 {
   const blob = await unzip(FileAttachment("acorn-walk-8.3.2.js.gz"));
@@ -8264,15 +8327,19 @@ codemirror.EditorView.theme({
 const _12m5h41 = function _9(md){return(
 md`---`
 )};
-const _1d6o6ga = async function _codemirror(unzip, FileAttachment) {
-    const blob = await unzip(FileAttachment('codemirror_javascript@5.js.gz'));
-    const objectURL = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
-    try {
-        console.log('Loading codemirror from', objectURL);
-        return await import(objectURL);
-    } finally {
-        URL.revokeObjectURL(objectURL);
-    }
+const _1d6o6ga = async function _codemirror(unzip,FileAttachment)
+{
+  const blob = await unzip(FileAttachment("codemirror_javascript@5.js.gz"));
+
+  const objectURL = URL.createObjectURL(
+    new Blob([blob], { type: "application/javascript" })
+  );
+  try {
+    console.log("Loading codemirror from", objectURL);
+    return await import(objectURL);
+  } finally {
+    URL.revokeObjectURL(objectURL); // Ensure URL is revoked after import
+  }
 };
 const _g5fwfs = function _unzip(Response,DecompressionStream){return(
 async (attachment) => {
@@ -11609,55 +11676,6 @@ export default function define(runtime, observer) {
   $def("_2rhl00", "dragReorder", ["divToVar","runtime","moveCellBeside","findCell"], _2rhl00);
   return main;
 }</script>
-<script id="@tomlarkworthy/escodegen/escodegen.browser.min.js.gz" 
-  type="text/plain"
-  data-encoding="base64"
-  data-mime="application/gzip"
->
-H4sICLP7DWcCA2VzY29kZWdlbi5icm93c2VyLm1pbi5qcwDsvQl3G7mxKPxXqJw8NXvYotncSanNy3XiZLbYM5nkysy83ki2RJEySdlWJL7f/tUCoNELKWkyuTf3fvY5hgg0lkKhUKgqFIDi7G7l76L1quiZD/J3wS16VmA+RLPiw768cLfff1r9sFnfhpvdfdl3l8uiC3/8RWh5prkJd3cbKMIpl970/KO7KYSOW96E2/XyYwg1n0NNJ6G5W2zWnwqr8FNhvNmsN0Vj4kbLMCjs1gWRt3CzDu6WYcEoQSGsx3ceoqDrWZvww120CbuuNYMiK/cmhMTw8+16s9t2H/bWcu0GYdA9sa1bdxOudt3A8hfRMoDf3cvp/jw4PQ3KMqV8e7ddFH1uYeZ45e0y8sNixfLKS3e7e7MKws/fz4rGK8Ms2eZ5poeOXxZNWyHjI07wrfj3DPADUYbNOalYeVXs3TJ3eutAP0QO/imQ4uhjxMAcHBZRFTTcUxForvtxHQWFClYahLNopddp+eaDntfx9wL1Ko8r2y24DmDFethFu2XYNTwYz224MayP4WYLGbvGR7tarlbLdtWwxMcu9DtcfcRBcjfzjzAa1ir8vPsx8q+7gPlw9+bmJgwidxc+PuoNwpcfo5twfbcrulbF3Fv+p6CrMsQAwYdFEG26OpJcx9vv90XzXHYXxnK3Xi+3r4A0Nvdnt+totStfbQ1LlfKtwAqtmflworVh3G3Dwna3ifydce6Vw62/DsJ5uHJcqFDFqCLftOIE0XUYcgBib1oaGMlSqi0g13Tz15Dwe+uP1o/W0lpZE6tv/WS5Fes7y7WtCGjrL5Zbtf5kuTVra/1sDayhdW+5dcttWB+tkfW19Vfre2tj/c36T+sHa2792XKb1i/WjfUP6xvLbVluO9W9ePIvtPG+LY8/3wId4uimSA6obXd/G5r7uGQnUfLdDgb1BjD+dEFXDehDBLMP5u/qbrm0PHcb8i+Y1fKnv77BSnGuz9abG3fXlWUetrt7JMsC/DO4MMy54Opuu/v2brmLljAEQ1V6D3T4CZO6xvuVYW1vXR/LGtbVFigZagdOcXfjIQXb1iL8DJPYj27cJUY/3K134bZrbKPVfBkaOPTubQjzZ4tfAUKobBdzo0W4hdwwEbbhTeSvl+sVx9wZwLPyAU0rFxFBJQDb4eZjOFi6q+tvALwtwXqz/kf3ASvehItwhcMRDwwgGhjJz9Fu0Yf4fCXRs4V0hOnrcBVu3N16QzVt13cbP/zWvWV0qujb9XqXSsIqh0CuWBnMsRBG6yNFNu4n7ABMew8Av9GLUX6M7+Px/QNwGaAM5ioG0Bowf/fRqZy7r/H/69eObXklxzPdU/v0tOjjT8l2fY1Mopi+Xl2+37xfTV/NyzAQwCI0atohC8C2gA2UYbGY7xaKh5+eLss4AcvRFnH7Y7i5iVaImqIHy4O7Qej7UN2Zber06QF/kJUy9IVoVfBML0PaJsJ/6U4dD4K8TrzltVXFQ23O4LRYzwBuxzHW3hXg2zg9xaZgJFc+fvqeUk9PT4qJ5LfhHMjB3BOAlh+DGJhBPohOAPBZIayCPVihEdbeW/oLnKyLf523sPiriK+64mlouYLihBRYiy1Ymq0AV3r/xIH8mcX+u7ubEFhNYRntgBqXhU+LNbCfj+7yLixE28J37ncGCQr+ReXx0QcUVE5P7VcQe3FVq3DuIqWK+qAq+1VFCir9noHUaXR/6hl2WK9UjC78LeEPzO0BfZZ86+Snx0dJPBc1WdY7D4GkIikflA3TOumfniZIp2JCe/X26WmI7QKqQwcECyVkAF1ZQJeUsglvl8B0ikZYMiwDwLVmkLcYgOyk2oBU8zVgojhzSq6oIwCpBCpxldwSQKXha4eynUE6w30WntmQrVSMM4amqiSESsySAY0GMBE/gWgUolinzQFRTSmAyUB9Ms/OAkkGwYkj2wsysMzER7fkQAdKM9NStV1IrD4+upDFf22HdvX09Ft3tyjPlmsYXR8b87G0Y1Q+w2CUd+t3sEit5kW7aZrpeoCaS64o4TmuaekE6oPsoISmont6VsXK29VatVf0esYdjP3793cg5hVdmW5UK9U2pMOfjmF2Md0GgqS/NSpFhWQZuwL0BCkbyMtQlmeb9c1Q4DHBmNzrYsDzZQ6zZQFzJrI8mDU+Ep7rBHFHYVDKzE5JCp8DfmGh8xfFV+9fFS///mr6lfn7V0B8cyV+05RfOPNLewrDYYBo4eBKhAESYOTICiVHDC+i81IpNL34izb4IQiuPRw/QCFKiFST2S3Oeh50ulMjgsQUjNZbPRxpQApFOzZ/rQCR6hXQt6pkJCBHltwShou9kuViVIEwa0nmorg3jlEP2vEMHpcqRmYc6eDvndFFIkhQDER+ugXWNwR5ABDbh7F8XW00ejTyJaMC/wxBvYqmSh7VCQR6otaLES//o2ge7ZBtQvmKgMPGyOfKgCjjM1WaU6VOCTfI9WnUCScCJe/hn3Euku1KnLyKU2tx6kalIuXG6XdEwtq3WvJbxzjPsNQ3K3+9wRV+eV/wQQvaRrMIVDMkCRBlQMbXoV9JOnaBhmFlJOLznO9w3QrWdx6IRD3jd0b3d8bvgBiB7QCNCbJzL0IgO+48LEIJhoNE4ji1jvkAXPh3IHFvQvd6L1h4rY7JUKNI9glzMPlLrqQfrxSU9Nm/lmAiUwc4adbRZKigsE1Q+/B7HoPnX8wBPF+MTQI8H3kugVcqwfRZwoojMAyglUpRIqneOj3tmx7PCvXlkOzhmsxggBIeoAxRx7m/Xu2i1V24l6VjUnyD4i4O0OYHkPzG7xq8qMNS5F7Uqo+PJ0WkchvTOMF9bVeBd3LtOLWSPcOlIG4P8hzgZABE6JwU9XF+fKSYe7dbg6wSXSxwEQt7ME5dGELrpBj2Ft1ImQlmJa/EiA9oEQTmlz8AWeQzqjuwsDKyanWYnSH2UaDZtA5CroSX0kyjj0AnY2BSSjTNJ1mPZSaQTvubjXsP40B/i6hrBxB2vRxx74pFXxy+gRJBDhVn4kHxxERRRJfw/qjJIEgPrvOwjy0Ty7XP5Xo4pf9YJHmcggF0zC2jweTxkSrucg4qU0YNYVdGJcjSE0BFubtZWQPA8kmlJ77QGsGVdDO1xh2+i3XzWW+GClX8bYFqNqM8pNmoMBY6KEvqC6BcqJAN9y6DaRdWwSsYMD3PPJHHhzyuk1zGpCgEApPnzJNyGlNUvcbkVG8AKeEP7/HxiYl25LMnZjLOf4+YeAMAs+5wRZ92VcGfFyC5vkONk+b+Mb6QV8Y7UgbICRqExiAEgXyq6zGfYl3jcmW50/jLWulM566zslYlZ2J5xZVprRx9Vb4tJrUgpWCd2aDHgRx5duaaRxhdUskChkS8XM1OVdmZ3uiH4jVaRljPwKk6t9BcsrAise5cl7e3oAqAcAQq4aNQDHEx+Y709/K3/b/+8pf+Nz+NgYGjOORlFqM5qWuaJBxcSNrShlsbgQQpgcgLC0Bw7r8OWLUClANgKAWz3a0HktnK8kA2AyJFdvmVgSISsK2CgSiegWTlo+p7dgb9clbmIUAjmAKfSE0T4oUPTVukoQ16UflqHa2KINJ3I4nSlbOwPJEOUoRGC2MWsJDlkDkGwcLRMnD8UPondUoybuMVimucRgxIrqt6umjz/vGRWfIKWbJcnLdlttaU2VhTzrfLnJ6CYr96v5m+Enq9AKMHVGC8+kq1VTK+eoVGt24mUSMcQI80OwRANJ51a32wbqwlmc/WQEAba2uFpCMCot0AmIoAYwuaSTpJjMXrCiHt1nGte1DjiQAzeS8rKIVfTkHU8Mrh510IfQ7euqs5iB2o+NGvhTMsb++8LXOzCMvMIADW5xQXSt5fvZrDbL+cSsUHFD2gJ5dt2H+gUQW1Dm2MlPKpOIY5Cv+6Ms9CfeMv1hpW3QDoa+4c6uM5kP95UCqZeV0LplofNok+rFH7UH3YHO7Dk+AjkOfbROUzrDyCgCrfvqBylqCeGqo/4ZiLmXBd/mGznm/cG0zz1sG9ttDAKsENMIHruLV2xStga9oShcuBnvsZeAdOcgjvS+cS25lSO8tUO8scqD5BLrSCi8itSTIcdHPj4qxTleOcv6dW018QPf+GRHyuhvSDc5LFunXjQK0Fw4IV66qIa501mSZykNmDhiLd47yxyGAFBuNDD2RYFDyAerD6Lv29mWqAWjfYB0oXXYI1BlaF+Rnw+hywyegBmREfsfFQWwvf8D6FlFo9WK94HfZhiQjOXZiyQ1wMHOK+IIKUSiIDrM8XHmUIGbxIWws+oJkEVwO5EF/4vUujCOizDNOAnmlMdRYLzbHmFyRWYBhuXsF8fQXzqXVaq6LSqoQ/8myKm1hGRKBmsfLvX27L0uIMU0CzlTL1GT3PgZ7MUJEMy+/CD3chyM5QGdkEcJ1DFQeGD1UUGCTQdsMAs5yw6KwndbUKsFY006Bl64qMGTG4tyDtxrHPmi0XxpYEZEu3AH2r26NAbne39yu/Z9Afo1T0eiAodkEaMLRl7J1uzp5LUz7QD7DA9T/KGSO/QlgPxIzSLFGXO5cWW0AnL5oWKsfnSYhYp0JgT/wybjrc7cKApqfWPmZ5Bx3GZrqGkTS8bYuuNN6QURWVjluLNoiUIiMrC9VGETR4QzZb2oPKZoy3PCCnNkJzM2vQ+Gl1vVp/AgkIZDQyrHcLKCikd552uM/GoC4c3Ieyrqy50koEZRQFsYVCeNFoDvCwSEk2tAvlyLympQrjjhQW5W2lvKKUgzMiB31bBE5pWhNIymkiW7GcBytRR3cFbHBihTmtIG8NQTg8VPexklY/LoSbZdZPcVxumlluxen3Tuyu+qJtoVnfwTdpQYhz8K6a5dpxdfHGGqxCKlVs3KGlQSbR9l0Mr9iCAxRHzsyZOCsHKfQvcX5tY85yq1o9aofO+pOWmt6ps9wafFV7YtbP0CHSjMMybVWC7hyW1T6aNVQxVBmsew2OzHbf6enwhJV5a+tARahSyB3l3h9xI0FWW35Hv77DHbc/0p40EvsvYiv/Fec7u3FvtZ+07QxadFwUKN6B+XptWoMe6thqQcLdv3eyreIDOl7gWMEfsdVHO4ZaNzG+R94ru0rc9vR0XsaGt+HunZ5e1BGUKhNXou1C9uZdrklbMdEq8IDqWfdKNwzciN3N/cF6sIy5/zGLNdA6Ni76M4TaT4E1EMBy8t+BBrN9tYy8V/RL5r12fiy/u1/t3M8wkx8kr+pWrL9F4TLo2pa2WWtb0PEgQspyl92q1Qce9mkimBTEh2sX2oLSNeub9Tzy3eX3b7t1+bv/3ajbsAbR7lO0DeFDU/7+K0RaMoK52tb4w50LK/V9t2O9DZeuaNGuyFzv/vBm8mPXBugChOdj2LWrFmlpsMD7LqfULODE6xUaP3jf2q5b/U9uBB1pWD+t3M09/vhhvd3Nos9du2l9f8sNDRdutIIh6tota+jCdLHb1nfhp67dsX505/Mw+DG8uQWowm61Yn0b0u571bZ+2ADXgEqr1b31e+fB6PWQa0ikWMbjI8YVZixgrVoCdByyYIJCkWX8XYv/lYpoCVQC+CmkSHxZxkkq7mQzJBOibTK22iWyX2DmeAws43U64cLJZMmkRKtsijQaZuq70PpIAw01vs5Ly0ksYZIkCss4S0a/wmiSTCzj/+QlvspL/IrKJ4lqb30EEXLkVK2vnbr1V6dtfe8AKW2cWtX6m9OsW//pjB6/tn5wPj6OQJCHEGJ/dj5abtP52voFEr4GNeCj9Q/4tbG+AWnfbcHP7y23DX/+at0C713v1riIAle594AFr/1rzelJ7j8FIIaGzm4RbZW86oDwJfxQHh9P3LSuZrmxIkm1KgkHRPLe5czCynLFH98EaTsuPL653d0nChvnRre4LmpOSoFzGYF6ER6oz5wCSw7M/YH+vrubwRx1ND8oKbg5Wf1E2bcPd++kqDCTY0MBDecEEOBas2mX/q6mXQgj+JsEUPblB3e3CzcrfVR0RUVDVWyL7aEY3k2gOCE4kgSf25rkuD+4oPpvE/5v5LtiISksUEBd4Maq1nqCYcetQXfJjQ8FkRPyAnOB8rdoFJC/NcuCSaYFajtOteNE0Kvz+gsa6iXJ6hXT+lzUMptTNtWxjvY0tD2uxgYavJxanrAnFA3hwEbgotBKW7u4b4OeCgl4z33QQnH7ZoFQyzKX/rQnakuMSrwAxlD7UytREPisAYt4nBWEfbObV5sglURV6YKWX7IvAvTY4L5Z6JxwroYo1ZtUPoWRchk9P0QMMY7FyRArMpiGqfYkj1PaYB3cJ/w7pQeP0noTfUwSKOSHJp+mQWlEmSkjiuG8NgjeMB58LZfvHJo9HlnD0ni1NB8Nkyzj0hHGeDDIJE7WBJ+sCQoIH20j2kDGTEk247ZR6czH4Bt0/cGeTtYbxX8czaHSsyKp6l5ChS7KJz0D5gIo2qBmlwxKMUDZxjSzNCsBjFPRd4n/BKdFY8ZsFyP8L+4mckGFGYX+0mVgeokConei3DUoUaW7Ymzm8nNYtsgbxFWSCe4b09wrbPn5I4MFYWRQriJad50F7vTij0v8daDYJpovdtmZgkO1V6AeGKDo8PhIf7M/hff66qJsGZex9Se2qF4ayRZzAPazoGoVTI2DAMWFnITXL24MxGYbvfILD+fOo/PRtD4UL48BRDh3TWtWmpdSq7uWM0iC7popBuWlliWli+Z4Yp+4Vej16Ybckc4NLBjPgofkqtzVVs+ZtpTBrHwwrGiakm5SJJwxf9/TjHaFAdi/tKdnPtDo6yraL4OEPRjTSzbnsUEMgaiyTRa5/alim4HJHvlza2EtrWsyLV47N9bs9K+Q+/rR+d4EOa9iLZwEUOfziwWsOXMT4Zo7wvOMcuCCmdnYIdgPfMWkpKU72x/qzaG+IPkeqPvx8U1RII32HFQ+lYQ7CHN09juR8M/P7GnG+IzSA3+d5shXbxJluW5bNTdPNwddWKA1GvG7Ma2DNcOw95ZOrpApi1jXZnfpHJBEtUxqwJdm7kZGEQYSxvTM7slSJTsHm560Y3fVL9PCoqpLcWeyKHxTTGOEkKR+eshwJaCfisae1su9NcAN69yZpdt1l64XLnsG7W6T2ZESyB5cIu6gpjY6fnA+I/tlj2YBcsp5bovSiecZjcqs+e2iCxgKJ9q5CmWWV3zj4Fq5kJqT9PWp0JaRPmuDixltr2Q2ePzDcgduuyTMvjANQaCbKf4f4aAd2YSLVCurWBba85pBXdaW8rye64LZpUF+cgZKylFAWze4yh6WnKIgBTzS1/YOXROxIuJMAA7zn61xpKa4ENRI9hZtwfdjAWOWv5rq0gYt4//gZXwkzZlPUNsWpsknxDn86VGYQ18uSuLKQGrmEdlo/TM6W+S05llqmwIwEqwFMrICyE2slApROa3aKlnStBA7lwY5eBgs7h3BMbofJMcLRaJ0N0Bfx9mC25wwHnfbUMeY9D48JlPSNDkXikeP1hEfa5MA5s4GkT0LHrKw+Z27CWglPlCWMqTKerSB54fFqlWxjEI0K6ANEzUtBdA05ofpwXDVYCCLHIXe3XwebnLHVQkwRiCyZXDqAkaTho9cMiSpZ0yH6EasLx6YvH7MtvjMHaAp9mN3fBCi/tG9EbPHELon8oQOkIEmiJu9nBmuzyUtLyKv+xRD0POnhNosndEM5e5+Bxw9eElnrWWCAOM+J2DovahzyIZuQ58sEMi79KjulifQ+kAEDay2q2dMWDS4cwMktncyR+8pHCbqSvHXblE1blrarItlYN4cV2sD2zRyeqLsGhnGunwSLD+zZgkjhBsbF16wbpWEKCL2NQSCLg30eDWOKB+yQGri5/CzhFKeIEHTorlJ49RfLnNJUJuhigQBLNqLtp6E0n0WlJ45JTDi829pPuEnzljNYrdFtacsz6s0TLTb81KO+5Xk1Kg59zXY7duu1vJ9MY/7b5q68+thINoEhMyaC0eb4ahXDoNB36vPBCeS4PiWy+e20jhhrwSxC39inydc0HVv1CS6zLgEu540aU4pP5CAPRmfU1nGQxR7GCB2JKyu5ZbykOcnkYeZ6HDBIfT5Jp85O4Y+mADigJ12IuWwWUCzrSWpGQRGJzXTrewRMiK4Gbn6LiiM2Lm4dnoanH6PtvW4/piHfsMn4k5PhW9AIhf5e+h+Aq4Te/mkV5yAdiLyGEHAa9GbG156nxCYU2vPoWXi0oioPsP6Z1kYAo5uVLLCKbH1FEvW7Og3mgSh1h0lzl8+a+lJ8/ipaeFqkW4VRfyThAuhZZhPgYarPXk3pBfFy5n1K4FTbnWwJD+kIJA+2HRsslc8rkk8f82LG9yjLd1MbGKl1MV40QNJhRTH7IJ8UH18ekF+Son8FQsy9kgpYL/VWhwgGeGCm7Yzrzfd7C6lB0Ldx968+5+xL1e0ina9y8NLbRSk7Y8w+XC/5dj6jJWmi027B3Zisi1ke5PgHL610Nbtq2LsYZ22iGvbjF7aOKTINuUMm2eZ8kjPiaeEbqA/nN+aO7Z1nQIrNkhek0EyA/b8uWATBb4MbrFH9STkYgmbW9eWh76kCe4MbNOnfQo8C7EAerrpfmPldvK13VsXr8wuDJGVv0wseJn4ER3zjmtylwA9+e8ZR+jO3czviIZSczdPNPxxc5+rfM7iVSlgx39cJ3ab+1z7Av4FnRbdww9aFigPHjouL9xVsAT2YspThSj0yMSMGnFckZTFkI+iUg1JMxBCltE/wg3IKSUbFpGAvYUPQaZVIe0fZrwbjEdLyAwQBn8QGdE9WyhA4YvADX81lGECOJJABdgoHqZOyalPeQj+dfj959GbwW7heS2zqSRu9TltqYbU1nKqvFh7MG2ZS9EqO1I1z853nyJUt/MUqJWcLOT0AOxCCHIwNMkdIphCW6pG2qyW+fJwEG39TYTS9CrPskaySClCM5Nf9t1tyFMJd4A82vURqXKsPdr28UwvtYUROJ8OmTtFDZceb0O4ct+JVvrg0EofL6iJzQCFPTxYriPuViJuRhx2lZKAE8gjWiZbY492aQ0E8CAGszZJQF3XoKMH0nDVRYM0zQ503V5tKe9OnrsIUHGIkxP2l7QrT3HmLHUCShUEItLszJ6DRyxx4hw42RALTivnBgYvUIMX4ODdniIRr2gEZzCCy/zhiwGAMVwlLN0ez1vR/OxQ83tWXma5C8SVvkBER3ZFUb2YSXqPXmJBJncs5+p0A8z2xqIDg9Rpr+wuUWqCWpQckJ3CMQKIhRxmGlpGN1G5pl7EOFBWJOJhxmH+paqx2FJExXDTYolkm4VXz28e8/fQ4BW2Tt2vI1+1PD4+5OkhnDo8loX5z3EHjqO+GST8fqNJXQc2q4SQrIb+P2NKNc6NGA8YsZhSclQt/7l0dbTyu9tAp6knq+f8hxow9QbQz+kpF5GATc1qTN+snthdStBerpdPEb1e8fS4qJrq/X72G9S7niXr/QZ3UMPgCfE1sdMK/Ng6sD8i6wUJVRwv1Ol6Ls1xeJVSvHOa2DUFmr/80+lp8LrSQ9Wmaxh4GBOvc8PLtIRp7eRPfJCd+GpxRtzlniQE9o3wjnkoeJp/AOdzNZcBmprsoSC/5nsoxGXzPBT0svGOe35z4eHlXJUAwR6FBtZ88NYZsq/TOhCmD9jd92SxXK8CX3kV+AmvghihMZx5XgXpXlDH1E9f86EFqhWD/6QdXXp3xkZO6x1ZfO9I+4oCdHmFP3hwzMp1GMStfCgBlPeWqnzSn0CqWz0USsSG22+inXUvZXWlPNXt8I7wc/l+Yn/Xf+nS/AJmRudj/ilIoYInAOVb4P5ZUPeW6xU1zzLdWcy09Dse44MqcVpXc6qcW4v4Jga+Zy6G7WKO3sHkL+fhiWq8RwXv+IlN0Fv9OCjdqXLcqJgoSxfW6dYksjDAXPfTDr0C4XhsM4G5vXbmJq9/Sefyw77K5GnpCs9Jt4yOjmiVE57lB/xwDzXzoXhsxmKP9fos4RUkDwvl1Q+1JzwatewX/nNcGtUEUUdsyLfR6B03amoyXMrREQt3jxeOJcUcJ0mtB4RicbInH7l+gpHJwcF9j16PfPUenb8JzjSI0HkmcTrAJwynP+j1R/FtJFegFuNdJPN4a/33l3GbUzxal4Dgq6+MXliWJ6MC6zrne9ANSrYVXES8en885o8taPEKQOLD7PrlONqW0jy+CEfcTnPsjhsFUnJXyuzBtObLbLQ+dj0H7/WJU47Dy5MGb3Sxkl1/ZdAFDAf8yF8ZqJEruHj3j3tjXKRLyn3MGn0+OTszekVPM+96sQM6Ak/30yWBidCr86Q4O/1o8kl4j0/CF5PZHh8TYGHS6akBYsbs9G+JcsiKQKMkX6FlLt3ShTbxuXfhmnBsfxGvfA5D6X38A0wUHyDhWRJvZvTKsQWcznII48ClIdfsrTGNbSqslj/lg50ojKp41ic74+MwSxtSUH2wotNR7wOd5qZeLMyudvEAYAsPDOYvRSSvhOX00cILl6f4SF4g/py1xcrWY3naOuLnZcCtme/CT/nQLXVbggc845rvIg3y8A5s4Or0ayC4vwAh03boL90/026SsQqPWMWDmAYAELJpnRShJpAM/wKiLF5Vo+2nqdGPHB9GOnrOSAfPG+koPdJu9iQMjzLCuQTE8eHO/NVrlu9veXjtUFIS0VAAJPVD98+4z64uL8D5/8TceMbZAw9FKDrVkLhgAtqbd3/RlOQpKsnFE71JCeThrXqVQ23Tx/cE+BmHAT9xDe0FqmSvLgHWv8qbk3z9orLk3ZWJi/XihQEP56n4a6dKpsLMxbaxLQ0vr1J9jvvaQ7R2DQ21nzXE4d4ZUwJTAKwDSAw7V54XSa7kQeoKUJIrpdAobgAp30DxhFsDpXRRJ8If2sEs7dyWKi0hS9YgU6mWGHiLZUoBO4oiPx0SFALrJrahEweIqdk7wpU0VUq69oKOD8AZZKULNHGTPNwuA03eiH/LcawK2x5mvs6SERCiNsbX2n15eOtPajXWrs7zxdV5vrw6D39ER6/O849fnReZvbw9WC+2N3kx8TBm0ERDp+kPScFBxuMqCJd4OzT6zRn3WPQrvMOVfxpoJxXYf4Y/tzZQBAS7dDN8nEDaAJ4yOySoqvtJF6hDL2Hu0KE0vFCFT6c9T+WmNrD5pObDyUSkZNN7WhehK3BAMoUlWRNjnweEJNap+g0kd0TJSBQWEjHSui4+xx9QKD+uU2nYzDGYTDW3iEBJg8qKkjjOGbHns55llvR9PqCskfsz7VcKF4ijqiVlTJ9MRrBFHflS4rW1lDo4yYkJE4NfBvLWb7FCj/IFesRlvrzGu8EvYdWzvF5EhkTNPnEtbsSxrsS90hXQZDJVnC8urkCIWJjxl8vFVM1ir3dN9wLJbbYDXnJxyYxsgV7Garm5Nq1FyQYuc5Vwn6LUi0QaXqQUdWd8gufJ7SgF7UqHlk8Sml3jcmqg0Wy7Gy+zBrN4SOlQcOmAG4wkdHmwJp9dBbH8/7/6mAms9ot1MMIXUaK0zVNdbuZpOLiEddndRb4xRQVURkp4hwCZmchjBVfIebgjfUzGtxDv+XT6ldKSfdVOqOL38B5f34kvuzoy0cWllNMu1O3O0Urz/IqfU6/FOiltE2SEoiS/Ptr1S9Ft1Nh/WwhhSd4u1psd+ib0RKq6RjSexGIKGD1meOl0WV+SYLvPB7VLEh5QU+9fMg7dyxfUd9zAFfc0weJAxeUnPfJZAjB76RqJC9wi5Uor5NIojNk9bhhlkoHXJ4zPwACOqjdQMnOaAretgcCiYuqiZpDasgvHDBYO4V2FJwVR9AXZ1NSVUXZxmzk2rCw5IJ/PaG2ZmTH3l66eT4I+yzh4zjJLxK8/KYgWigf0kcT7lSFpCovEw97QbcvPWf2fNiyjJyazASaRTK0+Xmgrlww8M41ryI3y0jnxs2iV1/kCwHwxHz4Skc2Gvr8mepAkCSJI3I9KcwHfVYtn/0nyZhI6GA0CTXxbJ0oSSyenRZAlliRLAFSphhcHGj4JYh6EbwOcVMTTANra+ZAr3lzJSbVQx1MXuUAF5GOkvIy93pUuI9zkSzQa6PmuxovfXFgRR1h/hJF/Usg3kD6AXN/h6n4oDy39kCkey0PE/JnO6+V70R8pA2IKzrXl2neXqnzW1b2bfKAtPtz2Fbk5+VSNz9Vk75OYlQx3a+CdG6XPdD+vOraQ04B4/401iKDMpwfCALfcPdraxw2tINmUi03hNyB8zoRGE6nD6q2jcuDLs1NPt06tpJvm01Rh8KtbFyanAyYWugo89ViUsXE/oT3759NTOvVr7jb3D8Q4fqbLDD6ZyplAs6Z6OVYuT9m15PKqZBioZk9nTPF6i32cHM7Dzz16J4Z/l2+ZA5b0tNnSnW+7ypqjjGdeNI9WOyMWTtSEKuGDPW6ZM/TkD5Eqy9O9n+KlqGzlyk60VsJCTi5hv+u5V8dyeev1MnRXCtKesdvchSBNzFx0quq616r03lK3vD5z+3KY/2KcugXrwHddBllaN7EnaAQEc5VyGddGOwc82gbBXf9LA73f8craFzxjR9rKCy8jiq8XsoSHNig9Ga/LgAzhMkPM8CNi+L5zdaBFyp5h7FbwuvL4+OLu9aQupa724VsnZhHuhiplj30Nj9/LxEVSUEm3vvjyJfPlY/D4+CvGIK0jPkEkAFtXXt6ToEnyaXjKqPf0tUwuclJ1C1NWIXrGBUzoZXsYC8nLl0T/vfJ61kOnsi5uKMrUw5XIq5gSEoPuyaj2xd5BKTc4bpK4JJvEMy2IKaUkeRvnIXuFPE/h/HA+Ox0BnbjOn+W22zHnAneu3Zl0ON+HO3cboQ2Qr/+03KY5Te7JJcGkaw4VzEdxIxkwrT2qTGZ9PLQpa/xfzcuawNy+dAtVFOMtNdlDbedUKUq/f9AP9jznuKmo9OD5OzOzE/t/eeZ9S3faPim+EQwCV2olYbnqOe4u8mRm0XjOMfAkX6E7LgTteGaeY1Nci5l7DZjm65QQg5TdSbsagq9MfHyMtQ4rvoIeha+UtBR/NHvuhhl7kfd6YMUQzehHwPBaxpA2Z/hqeTzdkQt1zg13+bfSUFvMbKeUJdGci81RM5afcwY5+/oF+pJGtPkkdwOTe4bxDViuM+hRjeJVy7fIy4qv3m9Lv39l4Zs0vnrvMk7EXrtk23frTvoZX/mE7157ibeSfIm3ol7ipQfIEu/wVuJ3eCvJd3jtxDu8NjTeoKvfxZ3coBCL96zptmeo4tqdh3TTOV2dLT5qLnsOFQLh1PUX0hnU+TGVADl+UO8L8Ouq+Mpi/Fg0auKT799+2//xl2/ffPdm8jfHrcdJo/Gk/9M3P75z3EbmUekkiMmJh1TiysfGnQd6Ot1Qr1BDh0I8lUN7t11jPPy2/46iBcxQUNf9G9ZifRPeQiNdY7Hb3XZfvZqDkHBHO+x4UTa/rh1Xe+NGK60duhTbg6SHcCux1jXKryDpVZxCuVSZ+LtWyZ4egN+CPPnNm+H4u3fj8uDdCNTot+P+6Ntx+SaA3x66h6faNhI4msYvllfLdrkCra7m9NbyA17u3TVeO01I3VM3dvAfcncvBfL+dre9uw4L7+7+cXcdQUnIs+wadzBD3RXoGaH7H3NMQswY1qfQy8PYEEhvFy75bmZjPwUSv11vI8D0ffeBXisw5rj9d7dZPgvhZcy9h8G8xbvrVn6EXYnvL+8af2+Uq9RPvq4cEiBarmLCLS4+kFCHBBsqkRv5o0RlRnyHPIgz/69SblLmIPyYzOf66w2g9e9tqK0OYw6LrBdtAkiplevlFg7P+lO4OQPtLdriY+z+MoLpAXX+HQYCQQQuExE4BLCB0bPws7+8C1ArknAbyNXWq6vtWQhdvP+0CDf0uVLuYCvzu+Wt6BNmxuhZuF1G3FKTW+LkmzU0gaktznwTraIbgI0gqpYbhsQIHrzmBmwDWQi0S6WgY4AJ9DlbIaqBIM+qZ3wdFOSj6QSIQa+MLrVYwGGJkCjvVtHuDD8Y8gv+thBMkUAQA3WAioh182sWNPYijanbu4uWwdkN3gYOsyZxQX0Z55B/tY1m9wUYvQIo0YuuqAMQDyNwu4ZGoJ7C60LmDfsy1MmTF1s4XvmL68b5vE+ysme+YJBUCHDx9svqrQKlYBx9EwEv7I+jZ4rVcW/NnOosrQ2cwPgK9Uua8EWZTAuyMtUAvsvw3JoxS7JGLP08rOZVo1CLzxNfWdfaeXyPlhRhqiLZzV8AVcDSivtw7M6vP+MA682ek/G5DseVb1TiQxlCD+KnJvFt4PiTp1flBPonsYWHjNiZ6R945wWf14PVXrzbcnpKmd0gKIZ87n326ykizKWI4MkKkd2KCqy586r4ftN7vzJfWQvHRu944/e//320jccNosa5R++X5rzC4cQP1xTX1k1icFbxg37CfoUGVoFEx7lbMTUE5oww4pvxO36hc90L+JXAa0uWQZsE/zrnEvi4jocOsBs0mLnLb/jZUBkd8qOh+CAwWyVBlhVIp5LQ2bV4Jmpu0qPUS0e3ycQ9i13XL6So2fMvw1Jp2lW92LOlFB/swTEwHx/jV4y8UrC3rhybHvpdECrkp5tyCCIZYPKWnpTTrtXFS91P4sdXry7UY0dhgD01V8WFtURPkatSCWvWn0EE6KYIAd8eRtfFFiuWVgMj5ywyzzFrnCkvC1SeSbawdRDmF440e+z5ocosnDxYElK06kYXmfrMFOBiiI8BjzrDcdhzId8DyMwEYNDVeOJBkdNThVJBkvISQphr8ilLfMtNkCG9IDmG4SumL+b3nJsk45nQbVfnnuQDxWv1Cw3pktKp5cy7NK64/HW2tzxNFQMI9ennEcmkn/I1vVwgFR/CvRLChXoT2gOe9fgofUA147LpCf4leax0guOi8YNXP0JZ8egVKLehD6gvuIWYpVgFrtEqrEFZxCfWANYCtBZn2UJ6ILJty4Wv17uCUYodoBGMJDJAh0ah7xkIQYsJbbbpb8UG+FZscHZmUgdFZYCKYPocxCSxcrfaLqLZ7t8EMZ/c5bWOFWlWOI/xgHfhJrug3WnEr24mPqOx2eM3FLB2qLKLB+1RJUdl/oEpv6utmShAigR6J4sX2a624Fqkyqi1dG8me4ETJK8XKGzlw47bttLfnLxyfBhh/yKAwfaxS5r1SvXLj+/+DmGyHsqSFDTUg7JZ3OuWBx362Kkohdi8npzZ8cX0jPSEQQPr6uYQZe9ZNTuqNlFRdn4bRiILdz/ZzzTHSsxClAFyJLHLAE09UJCtPZ45dfws5b5LSm9avXMeWsZiRVwblKEC7yI892C4k8jwpnT3WToxp0Vo5pxFBnZ5QCebbTGnO+Z5EppZGoJ5MWAhSnV5Bk2aeULqJX6ZpmaAtIs5CblEPHps6POfJ6XO7b0SLHnkC5pX40GB7lrWzw+aGQZPY1tO38oeJhXytRl6wwRoMAr5nbg5/4n4z1VC4skBEVe+B488sUtOLPAJ6QftmtiwFmUAREKvWMRvrnoRfk4xLPL4GNFvzv/4eEUxkgXRfAgLoJS8JNNShl4pRXYfqNNugnHJGveWEi5EPi+Rz1P5iL25grcBmlQ7cwEqiSqCF14JIBGnFbNLd3IkgH1mq9QSDQEOTkyiM5J1r2PPpuX5DEg04Xk/Q1MquutS1SBhylpxuSC3V0C8Xns3+O9Eqak+lEp7MatypnPycLmfL2tBeaZ4Jkl6vM/f761IV4a95yu0SuNSrd9ZrvXR+qQpGcsiHWBmdakQAa9Xr43iu7RSBlFnn2K/qJrM6KfFDSFq/M4ouSXjd4UIZIfCJvxwF21Q7hA1lfU32AP9aVd+K1k7Jdd72PqLEJFObxPc7Rbwqzq1FuvtDn7VphbadOFXHX659LUx3fO7h7rKnmVbQCJUMz/iKmN4RBe3n+hRd0A2tihz4O+S8R/kcoTty3T8TZtLAAmnoRskxyndjevA34lXYkPpiOU7VzBzAoiiHBHSqJyEXEA+p3vuO5xCmh+emwUh09sCDe7w+laQqXz1CPGr0qt49kXWgl56nsXi5xzFzzmIn5Ezw0v5aIejbPRmUgGZWzDBOBWSF6VSd4G3XhR5K6RXjDOWbGuBahnwDS3VqkIa1B/f9gDNs0rzyuCbaA0+13WNDi58WiqECU49dHzLK+ILrb5+e/AcyXUuS84dKqPVhHGxeKJ2jx5DuJwiFVN+HgBQ9hCC2enpyUyMuxm7ExVlmiIKGDCkSahlho5WTKTXZjwJuP4TSRYnbmLYOJk65DJ0dI9X8mRvz+8CzrTtoVdie4gcfXxtRhS5dmdB9ZndRYygG+YxrkSIywhy8aGauGKuV2xRV85Zh/bUWToXW8TrhCvCQxBXC3e7eyPP2sFXEnUvKopfsKOrqw4d44NL8uHzvxcv//7+1bTUff/K7L1/9dXvX8WvGuNFdVKWZW3JL9lS8S2XoaWSpmoz7UIG/Qbn+JC/9kL3KvkItdkzfg8zUn/De53OIYEHoteyXQmzyIkb3+gsrC6a1O9ddBJXRLv6quad2YjNTgNNUYn06oH0Gqbbtp35UOcPzcyHxqESTf5Qz3xo8Ydq5kP7AFAdTk9ebM00BD0EPQf5iY/8JNV/HwvWmnFB8aOivyDu6Z6Nfnw5bCANcYr+T+hCfb4aXLfCnQUpo1xeRmFfCtIGO8r8+BjK/GmDVJCxRSWqTxif9MwJSLBbLGIJ06BpJt6fT+DgiUpz0fFMqFU/8/Bs/QsR/CQO/OQFPMDGvF6lK025PbvryZ9ndtd97UHKmR0X3+jv8/wLEfhvir2txtL++O777/gV7qLG+//+3pzuDWDHq+lX71fsfRCXBwEc5MFImM9dsuXOcD28jMWG6Ym4pcK9rKjfxRnKS7TQzEquKb2FfFh8I5O98M2MiKiepP7p7TcFf323DAqr9a7ghQUCO+BFxueVlOrDuz0wll2NUJYhhYUlB84Vv1gGkg8sGuYeXc88EgvUgXx8NGCP9tpdfzN3lkJ2gDWr1y1evv9Uen9WnpbMLi5c719hIqR14b/5H2YPM5TPpl+ZkA4fghKeAyl/ZcL6eg1VBO7O7ZZL760yrOTnbvlus/wBe+YEFkW+lo4THu4VoNcF3kvq4HYCmZ4Wli7e5Tx/V3Cz14PM+OA7mlhx3Jf0trBzw2/K5dYhrQz+JgRgimT7t06Kxi+/kNr+yy8GaAZQXxEvNNDMJ868F3WBNJMWBkpdizNB7iYc3H8vSPkH3NpHxyznVv8ssRCo76Nwhn5ogfPheL43K5FvQzI2YFZZFN6sbu92zjY+msRfgNKc3Ys3BbPbYPEjKugah5dc6BwM5C/yAnyQOuEv6K1B3AWJDF1ZMcGwGNWcJX5MPpExTk5lv45u/wL0EpDvRLJI4pOBT9km2tiS+SQUachGkik3rEpz4jxZVBnFSL8SwuETWET/pWb97OPyA+MOr9949n7hjOwWT+Qmk/UZqNWiCB8qBpJEQ8cTZUVvz5bRVhUXxoRvIOnc14xXv0iPqJrlM9XnWbBmUmqelePRQ5sIoNMvPuDQd2foqRxa8fdusFcSzuzg9hwz1YwlJrX5FVs30rtQ+/PYzCV2gny5OaosJkH2m6c4STGwZCrdNijXKUdCkljjFCDJ5WxvyRMbqiHay5Y7plaom3TIG3z25PaX77jngTLX0dsnGtAu1SrJGF0W6bUTLUlsBws+mbuTNpcAh3k2HDodGO4tP7ldJrqRQyHzeNrOLEONFSrBiS8SeZID+ImvDKj8FiS+ITrFl/M8vvH4yKkfOSWUKJ/TBjbocH48RI6wIPspbqJwmUxldJoaNQWyBnnslHkPlQ9UeU7D0ur4seJIlPyQoPXunA11KUqHZGHW1OmxG8YDSKWSZKl/FqWFNdFnu1+AO0T+M/cgQimJ+k54nubxJ7lkms5laQjsFXMZMSw0+Qw6Z1E383n5pZfYFPHNqROITZl0VhzFcBnuwsIza7IyOxjpMmbiVd3i4dXGTOEeaGJ5n8uAA+tK3iM7c+gI7pVwaUDBNiDWKxIyQmnWu+Vgk9KsuS2E0W4R0uZp+BltX9GuwD0oEJfHjVXIINOAmt8b28Lv8NvvCvJWnXJhsN4tCp/CTVhY30Q7IGU0Zc0chnevXeOlUch5PEFnOiX5eBmssDTx2h7x3/PUjLpbbek03SSHq5Ier1xn6GkYfTadCJyy70ysskj5DJnmi1YF8zxMr06q/VBtXWS/eWwumsdOOzrjcnMWMV/PmoTOEawhDZ2jeEKYXLt40XJC6e2D6LhSq+n5lcx4siBOd2Weni6IkV3xAF2LZe9ceWecRJTzGnJGlPNa+kuk5LhFQoaLlBZ6eJHEccpb2eLuaPjVEJvEaAqV8Q23mTUREcKgJydvesVJbd6yHQS1P+0NL7EdF18Ipr6onTn5LTuv5WBSLeTOoFK4dAGUDNI/uYpt4eyscL++w/npud7yvnATuqtdYbem2UnzWdZQELOpgKeEATH3XP8KCwGbwKxqeSrcitlRLryZAUewQNndbguIWTwanl9vhG7SboBOGcBj+IK0At6bWwjxhVDkL1QBHebZlllx9k5PDewsam/4m7spYry9hdZ8uYNFCvSJjwfK4b80h8d+KMdq87WPfuKjf7ApXyX7enKQaDgzjG9WRDgSM92CUSJDB+v50exe36b05PIdxLuAYiXHzbsURW7DTUQK+LdS/8lsevO763hXQwUUfNzOrFg38H/lGAZJTGvrVjyYoLHY3ZoN28mt0A9OFG+FfqCtUCJ4J6KbG7BGPynWA30vcO9DGuzzPoclxzg3rEWptJcjN0OHFDTBeM/RpWE+AwBn9tQ05dPY51ipZezhT1AOV7g7qbctTFZzvno1bS7z0xz91knKiXLTQWkVlt7O7dmNCSi+tZKNJ+xq9tm1Sa9QJVMPFBHgXpl0l1PKzOYnWfva0WXSGFLi9In612cgey+dNbDCVckJpXFplaIxdZApId8kZZf4kFhQBhpKr8gn+VKUbBB9Ho5x6nPphaYLaq5SPYW4FoOcPNtFN23my2gg7fbyhcJgyruxeevAbo3TN8+95EGeTREaijhuJCpPiqfxFKPZLb/ysMXf5IyUhdMTvmjuE/4iZLZRuPRYboy/ZC03Wl7NnJPOdUAM14opwuCM+VQT57b05vj6Nf9JJx7dTBxzT2qQB6WIHHKRd57Af74FLWtd0a96mCfeuZux7V/uOCZNGmHanI8vPmS4zTxrwpcjGr4OQN2np3Hmrx3axn0OO0SQLpyK7kogPMt+IauTcvn/heVodLznONqonZSyClwprahW9kK0f7ZJLCAvQTW8KQk+3w2OgVViIR9WPe7XOyvG/QAk9LSoI84miFrVDZXFJCbs3FxpfzCanbm0qdem9FyuDBOLzxpBMz08pg7VHq8xja19L3GwSRkdY4vwnI9LP4Niwp3j91C6ARC6OQr7Mw2sSWPpEywcr09guRkaRZFZHSaQJy4yAxJKbTrgMwzaxi968WoP5c3IzTXgwyb4sNxcrSxBynsTdzryBt3vKeRQJomXebjTekF35BRVTmlEOE7TcltqBlj3umlXUBRfuG1UvjyzGyZWu3CH6F04OhWKfhdP5o+PkSl8O5Pkbs3x4gi9TyG+QblQBpZwB/IeSG5J0AGErFe5byYnBtTGoMaHMNBckOyW4n/Z3uyTbQr5Jq9dUXfc7jwkV3MSLx3lBTLbK0DmWUDQqSkNxNzM9OlyPt3nuZN5wp0MdbRoxQaVkDzJkoO+y3bAI9XCu8iOXbJ1+nLpTc8z7X+3LogrOguEJlDkvHtygn8pOxP8izxNoPBc7VW8hPekt1TUE8L0oulSYz4J95iLSq945l5c2GYJn1anHxXd1UU+hu6AvkfH2vF6VO/1a1t5cPXO0InmeSsWQ0kQosub07ACx7648NDLDVZCoNXzuRCgdYRdSWULVKAFFInQUhKsCwtYu0MreP36Naw/AXmiLR4dfPKhhLeysiC+MIV2hH74Euo54jkI0w0htoT96sZZyFvoI6HcrawAWkXyAXnhJmtRUIcpbtabsBDgpeJb8qGEXhea9cJfvvkzK+RCHw/4HVwCMvEoBXBMtNs7zpltHlR4GZfcDGq9C7nzO8c7y89XzslJMTgFZASnTmhFoJpcXFxb1yWgKsbHyjxfiuuWrvAOtSUoBrDgzfcvpbokxflWwmnF6A+Go/Hk6z+8+eOfvvn2u+9/+PPbdz/+9Jef//q3/3Q9H1qZL6Kr6+XNan37YbPd3X389Pn+HxW7Wqs3mq12p/TKEO6L6J/mpYlDTOfKhYMmjAs3NYnd5NTVDr58e7clxwIv3H0Kw1WhQhaaZq2rpnCKOmJ/0WYDyLWDhxQ7LbyosVqFsaq3YbVotGA5qNeAYOotUCarTSCbRlUdm7hw8GayCyfsuWde15fRGUT90lU3kAlzSAhK1+jksug1q/g36gFoZ/b+V+1UJ87Xapzhim9i1zaq/fjqGnV3hrSpaYc6hB6Zs8Fe5KuNtiHVuBUbFWRnBsF5ZnbxZ0A/dXffUF3djDsj3GD4vAZDU+7Q6TveQjk0EttfavN8a/A17nE6KYaGdTlN7KXl7rZf5VUoNDCZ5zqRR2qZBhoEDuz5Iz+YnzgJ1TY793+Cgbzly+4KUhsGggWZyhc7R8pphLfaHLYY8JJr0m8tj5kxJ0imjqa5hB9xKsE1eyk7QtfdJzbxnFksOhYjHQorlril2VrPG2jfXdGe0HOdAzr+oW54GV8PBBVobZ848EI6ua+nKHX7Ku0BcZ2AnF2VpNWdrAGaj/m1FPMTKp9TSV7vI9Q+mSy2JuhAAyUktiKyyaJ0/IH2HpLO7iGeWZcC+6EJFjx/ggX6BFsk0uXMN/5pis46qMwyDiqzc2YavKl0ph0JksUFOLCYJ2hkRsvGDH2ucnb8GCKyvkOGwgwfLcCFXNbGEufNLct/vC0nrWjaJv1shrdNJ/buAUNkFjetJDqFfZxF4gt5aohvhcTfp6fzC3k0JQfgUDgwU4vbwo1Y3NabIKRDFit0pFudrQHDS6ZkBFm5ewVWbJX4nuropswUYSlrp5iX7L0l15Yu+7Lo/ccbUdDxDxYtdSr9mWrrgo5MPyV80FtkoG+7G38hi81e6Bq00FyDli91XFqYz3An+nAX+ddnaGyQDVLKO0g4P+QzlPB5DZKZxMVQB72QtGRlJwzUDgbxCaFAsxyhbunSilpGtqiBp5FWs2h+t8FbBPH2KLx+KlQxGPmudnFBQsfJVie9O4jlKHtrktummbRcFrK17el1dL3rkj++vOfpkv9cx9O1/VP9TleW6TaqAG+24vO78NZl+6ym4mjPgagDJ4EZP8Dj4HbR4yP9sIwUnSWAzrErZhipR480hIIlKZZZSNZkED1/Pf5u/Lb/43j0y/dvR+O3Dt779f3bN1+/+a7/jUiqYra3Y8j07sdfvvn+5/HbXwbf//TdiPJ+M+5D6k8//KBSqwnoNRe6pM4XyTfJQnyph+hk5lyhPTgFEuh/W3raHtcPfJG+kMnSDVImekWifAn3uSiW7JgqlR5gUUi+YZ+zfF6v1p9WzOlxNziSDzijGYSX7RQxnWc3kYTyHnt2xPfHpFy4dsp5QjvClSNmzS0/R1Ay1aF830quL2njfnqtyRr2E15cKXeSlBNX5i4W7chmTmeFv9lO+HGgUYz2qZStfGGFac+j5TJrb54kJ57QrBYJGUEIA4EjEZPjx2cm+7pId08vIuQIq2LuycIgh1TuUa0CHiNylS/GZxTkL3V+63IqhL7LqaUXl/6A4sKhDMHGvokIrBFHhwIy74gbuBVlJzGLRK/lyTP/wES5DKdke5Sng/WLfR7YASe5HSy3zNHbICFiO86VOWdjrTz4K/Dray6Z3DvhfZkaBz2f7DbnxK2SYTY3Jn+dW2KvLjfO9rhUCqexefU6s3d9pIcLPU1oEM71/6Bu72M73lXO5WOwyMWzM+X4qM1bU89W9nNLZ2ZNLKSpc0UBkl6KzebvuKcyxZ5SCd9ZN20DT3lGiCOj/M40XyiSqy/L7YhSyTclhOk8eDWYE8TnVvnHGYj2wWGH9kjefe6nkBvoyF0BSeYaAzL78KjxrzF3nkEgytvVx9czfF1/j5JusmlFPjq4ae7nVe8npC+fVfuId/ktP6X+32BK2lTh/5N2igSV4It+POZLhCLrSCS3D6xbbDhH7gc2/oE+ZeRi4PRy9w69mDbOUpLN1cXm/Aq9kFg2Wl5eTS12Hr0+X6SMGmFqAV9k7BthZgmXHpxotpcL1VoReagWp0XaHTOx2C+ybpnpq9fEGxDQChtHtDbE8YIP4g0dky5H5p+KxxTz8HZ0IaNXJYJ8DS1fBQl0FURaKVEtP6xapCe73EHaJ9naYaF9Zn3msb0Vd8J9oPGvWFs0RsH/O3U5AN1L9xGvLbzC4AbpiS43DKw1PsBkfRKrTXhxZ/I6zKpFaLJGYd6WSlao3RBXyOayDBNy8NYlP0VAtGaljmk6t0CF4fni4u58AdSpGFu+7oMHskyTxWjIusaDHHyZGqrvvvPxcj0F5SUsAekJuicAfJwYsk8Lcyl3amZWCOqC9cm5ki9XwS/cOLHEEyOfxCFF5cRezRpsJmuQTgqu8P+2Ct7drrBaF5Qnqm4O8vU7Np6oiQqTs7KsUtWE/XT8feb4qhOVfLzIP3KCHFc9+U4W2gflFN1CAXtqbUsO/U0eYnU+wNcqMpvU4dZktAQUlz7S6mygaG0KFBhkvfAEIHUChGbxDnLXp9YOwajjAw7ioij072ADZ5AWe2JH4RuZdz8vrizvOWcPDxsfnJU1L948wRAOaPDOzT4rbeS6QNP5G2uGnhfiFrgLEIpzN7ewu8oIOKeVGf2I0VMYGPmHO3eJXsu2VZjzvW14nRg5CF8G04sDdfJIPF1rJa4Vb60THCsqs5mO+oF92KdEL1r+uI13t+4q5WqrXWp1LjftM8MQSzteUlfI5MRdQexuyX6iLmkzP1hPyZ7yHE1yKMdJ8Sy85CdH3M3OObwXTnjZ7vf5Zd6s6IXI+30ShzmHLVIXlbH6mbLsKoF8HpumU8q3nkXyk73yata1Qnn8IIOpjAqRVRWeNQktHRYvcrfGAYuQSQQdKb0xPDiG0ZT9UNIjuEiPYMrCH6YO2ulHDQMnYzcJeCsyI+ilNYIgz24iL7DRG9dP8klvmxiCmZMyZszM2PoSWEkNL0xr7fkKXpjV5jkj2VNme6mVyWbIkkYt0S9RHf2mErRJlSRi0H6k9+v3s/5yKaXpg94zSTG/l5OmHm5PDgl6khXxafe8Itv1TVjMPRnPO2smPY+gA54+QpOYeri7rRy1k00l3LR1Qk3bauaxIeRw/9EKwpxvfn5IH/WP6aO+9Ac/ptEiHcubC9KZTFN51Gl3TNAJZ7wuga8ZYssUX6jk8C64dJXT1eCZeayr+arxzKTpXDwJxLVO/JeuQjDzGuGrlF7eEJeb7vF+5MQgHrz9zM+6qynlmpzWgpwHToID7HyW4UeawZCdiw7Y/IAPKSvfQ/7s1Ow1RO7CFPiQOTyTXEFie+bTFkr0JM9ZQOb/ErOi3v7Ti8Yis2hkbFALsWYog/lcKqs6XnXG+SwLWvgiC1p41IK2f9EIoxlt4G4jP2tLw2ezn2VLC1O2tN3mzqfDAYkvT2rC4bM0YfGYVmy7cEE0dC+Su/5SInRBTcwTIWW+S3eqrH/qwKS8OBXK+toVvEcL4VWqal+E7r18voCmJIxDAlr4tIAW6vNr5iipWwkVAvbEOxGHbkfShFp2CjhwW1LP7WavSTpSWJ7tVSZehdHZNPYq9WPkHj5GnJKyz4pPwHxmq0mXlbyfKpyV6ntP9vLM7lZMC3lONyzjHxAdXigehf+MeBRPBXoNpph/Y5BE9IHq8VmlJBzHpB16/u7YbNNnVoLNKjrw8JrsMD27tPPJ5CN2rjvA+7gQz563EAdPLcThyxZi2dkQTVsHOhvKzmaIPhQapOptZsnOW+JN9g5WJzKZdWi15MEtbqwMpDu1nER0te6L5o644/ZZU2b5/Jmyj/2zj65fqWlx2MRJj7QetNuoczdHreILGNbFgWFdyGEN0sO6mFrXTqCNatYhQN3ECg1EF+oe5CgmlWvQTtE3XqtGUynVAdnzME+zDNITiG8dyt2Xz97Uggv6gYO5oVRH+WyptK7PEnAqxVMejk1f5jIzrVnuaVp5T8WVEjjDlLdAytxSKgZPk256zcwcTH6yFiDmVMO94Hn8PyEu+0d9FfxcX4WZ9GfMsVSRaHKljJ5Xh42eB2hd1rDfz4uHWnmuiVTV8LLtEhQ/3/ApmqwA+oI3m1K+dtqTTT5bTjXWIJ7fFAfq0CSIAfzypxYGTqB7qOsOed/iVYIbNLwX3RJH3FWwvimaXxW9M1e/P9HD0/PWXNxdMb8QQt413kGMLx8tnPmZfY5eWddWKHf48DkZ7WaA+fnsIqTrAKKij1cBLPH8KW5noRXdpcdYcc7Qr5INv8X0gci5BOAK5wBHriAPerX4sSNi4slP88GjJznxrRv1oOVLDoVk/DK1syEunw3REITHfqEDCKVke4TT2XINKCiGZ4H5qmqWAuvKiYqQEcfnJD7Jc4XXBPX87tXrSg9k1td2D3sZV9mdow9txq2kF17Iva0eeg53/a5/FlDpgDa0jpf2u6BE442jwd495JHm5nqkuUImd7RjF3MyirORKNRuPzLlZrz0Li7iJQZyS06Uwlt5c5XZ5IXMUIk4BnVmk4KL8lIxpBe7LyGNkEo3PPNe2dlZsFcHNY8Mvng4Ufnvbg+8Q3eiKW/GHUhm6Hnu7wxYP/D8sHusXlccFfdwK97PfQNOz+7HL79B/uvw/tN6ExwvIjKJUpmHRJ9V7lif/VSnk5dJC6dCl50KDeUmuTW6nACC72bmgtzHcfFmp4xtoo/AfVVsvaNTaDJ+5y0jX0S2O3enIstwZ3TlxcvKxVBeybzXjw9o3O/EOz2ly8Tv0Sve6J3AHGCX5DS35DtirmJvFmhF9lTtr5A7ZLWrXe+Lj7oDTdOvlfwVrA32nKwlssK0kDnwMXDxE6R9+XO3uRcF64mCuErJPKgnyN+EGPH74zoK5G+8WkflhwVVVNpIVErzS+aiWRRXC71WMKFKor6goURGGKXyC3rOysj27haWcG60mWiUf6u6SQhQWKOb2VQdhHvVC3r5VmGaXp4WDbQSDQjCUHjGlXt5H1cDOlmwFSXbiZKSILS+krISg+fdzeeqX3YlSQaAGHflY3eOEecscz+0gWJpTABxezOXRzpM0ev85VWkSf46uUkAePnoqgrUaxmG/m6BPE8IXDzgC+IzjJ9vjserL7TToSBPnvjlaPsGH4Wm98jf7dzNbvyugfcjJq5i9xyb3njR3gDCzdFsnV6mzh9yqsxe0r7UMVd0zxqNaqdpfmVXqvUSXkHfrFUrZqnZaNSa+v386oHumYXdn/OGQF73sRd4iVBOd5uWS5cNBMrKdzGD7vGdOB7qInH/XNMi0MQxUQcAszuUEQpY7mtnlsB4mCl9UqS+XDig6IRQvlWr1zTMeA4+nAJCFe7y4NH2+FMaekZsc59F5k2CDJFA8DGKFKElj4ZEnIkJeO8/f1n04pevo+2feBGD4QZNS4s2uwFE34bbcPMxDH4WWWaZtGZ3zmm0uHFq99rSe423M2DhRU5qsxslUjHfTSql2V3tn78q+5k3W9WT3yepazlwpfYOLc76Ufl6Wx7PbbRSb0Hk5Hh87LRkDGbD42OzIaOtygG28dqpt7l4IzHDEoylVmWm0uE/9LwD/hXJdrMCP14DBM0K3ioYe4y+dpKklqjVrojiNf7brsp24FctIQnwJZAXDk5q+fJDgU92ks/mUMwb6aTqOXkfdQnfPSMGYb5CtmGWmIdYfm45lfn/EI9hBhO/b+rnP/fhXtjVds+/dKfdefm79aq/9aMoxVD4knQE28x/EYQrCQ5V8sOhOm7zAZm9CJAP+YDMngMIsdCHA611X12+/9zvv/88aMB/+DusnL3/PGrC/zb8mMCPCfy4q1SHNoVNiowoMq5QZFyncEjhGMJaiz7UWnUKmxS2KOzzhxGFEwzb9LlNjdTafQqHFI4pqW9TWKPIpEFhCyP1tk0hVdmoYmWNmk2RRpPCDoZNTmpj+40RAdYYYzONCUcmVQibVYo06/il2RxTiFU2W1S+OapRiO03xxw2KaSsY8o6IVCakyGFmNSyKxRW8UOLYGzVRxTpYyWtAfahNaSCLQKrNalTSJ8nmNKuEGxtu0EhJVXrFLYxrPPnBkX6HBnQ90GTI4juTqWOkU6tQyElNSoUEu47TQSlw93ttOlLu8GRIYUIfadDHzo0HJ1+m0KCvjOgL4MqhU1Oora4+SEiqjOiqkaUMppQpjG1O6HSE/zdr1Cz/UqfQmy2T3js29Rsn7rdr1Kz/Rp9qVUprFHYoLBJIWWlPvcbHSrQGFKI4PRbNDB9ItQ+97bfHlFIwPU7BBB3t0/d7XN3+9TdPnW3P6B2B1yeOt2nTvdHlGnMIVU1wa8D7uGgMqQQezigHg64hwPq4YB7OKAeDqiHA+rhoMbFqVsDGsoB9WrQ4N8E+4AGdNCisE3luIcDmmUDnl8DGtBBp8qRBoVUb4dydajezphCArRPVfXrFBLpDPqUtc8VUv8H1PMh93NI/RxW6PuQOjrkKTGkjg65o0Pqz5D6M2SiHDaw5mGTilB/hkSZQ+7JkChzyD0ZUk+G3JMhjdWQx2pI4zPk8RkSfEMan+EI+zWk8RnS+AwnHCKyRwz9iKAfMfQjgn7E0I9qfQqxqlEdqxo1aJKNiAGNeBxGBPeIWd+ImN6IwR91KFuHvxArGA1qHBlQSDUPaUqPhph5XKH5OSaaGBNNjIkmxswFxnXKRaxx3KbP7TqFLQrbFPYpxMrHHQJ43KHPnQ5HEMZxn1ui4R4Ttxr3KReN9rg/oJCY2Zgmw5gmw5iQPSbQxwz6eEggcAdGQ0oaYRuTCpabMOiTeotCgmHSRKRPeFmY4DDbFWKDsO73MaxNMGxwUqNBYZ8jIwwR6RDSh2aTwjF9blUobFCkTbnaYwz7XNeQigxbFFJVI/4woXYnCL5drbcp7HMEs1UZlioOPYT0nSGqEkTVJn9v05c2f2nTlw5/QSRCWOVIg8I2RxDA6pC+D/k7gVkd8vcRtTmiSA0pFMIqRxoU8hecTHatTa3VkJ3bNe40rasQcrYJAlUnQrObOA4QTiiCxGs32/wF+YPd5AqaY4qMCcXNCXaxxcPVwtkDIX1p2YjvVpW/1ChS50iDIoyjFjXa4gFr0YC1GOoWEpfdGrUoxFxtrqyN8oXd5lxtJHkIWxRBTgAhAtge8HfqbocB7NiI3A6PXqeJfe+0OILLgt3hOjtI73aHK+gMgYfYfa6gbyP2+wxHv4Fl+jhRbObyNvFse1DnSB2rAXZMkX6FwjGFiNvBgOhigBKGPeT6h1UsPySxAf5gtiET1hDlKHvIAA6JsIbjDkVQGoOQMEg8DUKqc4LAjrjm0QArG3NkQqQyYVKZ2FjzhPs0qdOXOn8hYp8wuiaNFoUdCgcU8meilwnBN2H4JiiSQNjkyJBC7PmEKXoypO9D/j6k7zzzJih7QchfRtTMmL9QNycTrmBCFUw4Gwph1QoufhBOMKRZBn/wA3ARClsUIjKrtl2jsEFhh5NGGKKsBWGTwjaFXKLKnycUwcULwiFHsEWbhhz+0BdcH6o2EXjVxrGq8vjChMYvwxpHGhThbEOUrCEccIS+4MoEIcLKo1gdVRsUtihEkEZc16hJSSjGAm/gJFxxqqM+R/ocaXMEqx8N+MuAvgz4y4C+DPnLkL4M+cuQvoz4y4i+jPgLLqzVMQq8tQpNA/jTwrBqU6TawbDGERTYIGxzZIhhnb8guBCOOEK19fkLcuMac2P4g19sbodGpWZz1Tay9ppN/a3BHMNwwhEqUycU1kfIbes8EToTFPL7vNr067j09OsjjiBn7Df4SxMZW79pc8SeYIhLE4QDDOv8AVWJPjBOinSwPLPMPukM/ZaNTAr+UKRapQhSB4QDiuC49Fs0LvCnhSHpP/12xaawxpEGheJLn8IhRapVDBmcdquGYZvaaQ8oMuHIpEXhgEKEs0Pzot9B8gIJmMp3ULzod5ocaSEGOu06RXDx73eG2I/OmL8j+ULY5Ah9mXCdE+wU888+ifP9PgPYr1cprHMEoelza33UIyHsUzimJOSZ/T4KThA2KKRMgw59Rhmk38dlE0Kqd0Q47Y/oA0PZH1ONjIU+8hAQ7ZF44E+Twg5HEOSBzV9s+kLsEf5wpM0RysbYGuCCCyGNwwBlkf6gxV/GCA4zAJAMaxgOOIITDMIBRXA4JrxQTfq4Nk36LY6MYAJNBvyFAJ2w7gB/WhSOKJxQEmJ4wurEZFCjzDTb4M+QwjGG9QqFNoU1CusUNinrgD6MqBGSeWGiUPMjFCUmIxK8JyOUnCajCX8h+McM8hiXUwiptjHyZ2DciM7JBOVoYN8caVCkSdlohZjwCgF/WhT2OYKNTkb8ZURfRvxlNJy+svINI/8ac0flv9LcUeNI68W2jw5HSDBvDKgIdbKBUwPCOoUNCp8wlthsLCFThLScNDtsOUlYSzhC9hDW9pvjNoV5lhKygZABRtpIhHWEv+RYRJDVx/aPwVH7R3tEmk6b1Lz2mA0YzRqFbK0ge48ygNR+QwMIqTwdwnCHcNsZUkGa5co00jpkICFQxlyjsJDYbCGp/QvNJTWyk9RoQIktQ9iikDLVB/yB7BwN+4CBhVHbb1EbbYaaUPsbW1sIw32i3v6wxRH6wijuDxPmGEoitPYZrX0y4EnjjM3GmdpvbqkhKImrQtiikIozLgd1tt40KWwdsupQvYzXAZGsNPFU/1sMPQOOEBMZML8cEHUP2Ko5INSzPWhAND5gnA8I57wGwp/ar7cXUYSwOqS1Cv5Qtjpnq7NBqUFhM8e4RBHC65DxOiS8smIFf2q/jcWJRn9IXGDIiBoSooaMqOGQTVIE56ipm6foM9HrkHE3ZNwljFU2G6tqL7JcUYRQN2LUjQh1I0ZdyqjV0o1a1A6ji1SMtIWLgCLU/Xpr12hIYA65yRGBSZhhNQP+UFuMkxHhZMTYmNR0Y1lfN5Bhl8YNjtAy+V9vLaNWB4Ozo4Yy0rHgD33ntXg86hwwodltCvEza+3whyLE3Sc1Mq3VOGV8yNrGS9+EUDBpE1In1NUJd5W0dtC5mpo1DpVbZYfrjP7/ZEhrjDgy+W+3qtV1q1pdt6rVjlvVWlUKa5qFbZS2sLVQGLFbbHFpjXG825UB2dEq+KVts1HN7hwyxz1le+MynSpZ2GocqVGEeNLLrHIdprLOKGGiG+gmOmyUtUq7jzoshDQS/TaVYSrqdzrKktfnBkihtFnpkpY8JtYBmcAGTULLgPA5YAgHk5pmysN5aA95cIY0daRdL8eUxx0ZjqoU1s+U+W5IpDBEaUWZ8gitoG/9rzXlVThE+xYZ/6sV1FerFTS4Hjb0Mc+BPxQZU64xmeUquOP4P9IQ+HLjH5H3f7HxbzTmL6jdHbUETl5iCSSzYaf/P8QqmLQEkomwRZatZmukmQVRjPunLIHVVtbEx5EhmQUZ0DayxH6bzV559j622lVHmr0PF5C0vY8jZFbrkGjWJ2arzH4J416tqRv3yO7W4Aiymoxx7+wJW91Et9U1/4tsdfQF+ROECM1gwh+QAf+LjXj/DuY7hm+Myu9kXOVIlSKo40JIdj1ax+DP5LjFj2bGhCTVlPmvNvmtjYB4BvqL49MXx6cvjk9fHJ++OD59cXz64vj0xfHpf7fj0xdfpy++Ti/2dWo/x8Txxb0pbeH4LRybBl8cm744Nn1xbPri2PRcm8YjIA/U4kv4I5A8rAwoHFEEhwzCNkWwdQiHFI4onNCHOkUaXL5BkTZHkPuMRkSyoxH2azTmL2NcS0bjPkdQyQFUUGSCU3w0qXEE7QgjXjJHE3T7GPGaOJogjxhNuILJsEZhmyNUwcimyKghOmnrnaTCQ6akIa6REHIncSRGvFaMaJUY8fowoi3q0VgAicQxYoEbwCO4mhxptkSD1QRWGxS2KewzOikJt3AgbGuoZaRSpby0Aa00NaSiEjnibfwRrXAQ1ilsaLDbFKlyBJfbEa9qo9GAeoUUMyIxBjuFoc2DYVM/7QZHWhR2KFKjLwzSuDXMjOaQI0MqM+QyyNvU0FKXc7GGO4fx0NoChTUdhfW2hoMBdXsocSDy1zl/7SzGbJsjyAFHvAUGqGsTnmo8xohanqFAolUKKYlLjqil0ZCoaYSC1mg0IqoeDWN6GKNAjqijCC5sCjVolxuRwghhn5NGFE4YdRTpcKRP2QZiVowJdTQQE1xFISTStmm6cGMT5FkQ9hnB9KVGyKTRmtS4OBHAhGbtpEGZaLsZ8C9x3dBxXSN6qrcY8X0N8YxIwsNwSCRKwy1pq09UxXNpNBpoGKoSpdV1HtDv69O+IwBpEiB9MTepuclEI69JW2RsJSaYPrWqNEOQT8PUqVJSeyJKtbVSk45stKPX1RzHHR7Va9PHS8qDI9C2cZEagbaEIVNyu9mmsM8RykaK3qjdqk715iYSiJHeXHXMqbbOosb1pkjt66nEKNhGMRqj9DtiXw6YaCMNmYRsOdHqRAhNJhfU7yDkwZdIsQeXWmEaI0ElHS7VofrGFc5e1QEFRUKk6gxvLOdkdShSKRTEVp0k0E301RKcbqgRG82aYUewPTFWtQSlNogSG03OMoz5I4E87BOf6BOh9omJ9jtMx5SVTG0jMmVBSCvfgFc+WlGAwokGKsxYWxyh2c8L5MgmhmA3OTKkcKyx3NqAI2NtHST8jurEZMjygeyHwipPiwazAmamxJqH/IUYD1t+AMMUIckeZg+NGcMxodkLSxSP5lhbQYmyJ4zqCWF3wjxpQpxn0ufIkBjIsM6RgcC7TojMAeRag3OEshAdyRlf4QVTLCQ0havEJlHShpBYAS2x46pYYOhDrc4R+kJoHNeIk9Tpc53S65Re5/QRzxhqokFNNCgrEce4QQUaVKBBBUhGGTcof5PyNyl/k/I3aZzHRJbjJiObFoZxiyGjOTRudbR1sDXWWT41RXoJcHZqkbSxERkBcYA5Qtn6nG0gsNzUOdF41NTmpeQeTZ17iMGup7KM9bGySdqpJrO09MUV4BOpesGxPXqm63vrv839/Yvj+xfH9y+O718c3784vn9xfP/i+P7F8f2L4/v/bMf3Jm3C1ZAVf/GC//fzgu9/8YL/4gX/T3vB/3tsEf/Pc3z/TVzev7i5f3Fz/+Lm/sXN/d9mS3g0GR3dGB6Pn7k93P9tt4fFFlS/82WvOLFXnDDuU0hbnJXhs7aPa7yvQZQzrk1+xY5y879+R1nkJ8w2ea+pSftLLR6AQT+9vTyciJo6Gp7JVj/ijZkR9V1tPNe0jeeKttc85A2iIW0tcQNP7j+LnZPxb7ILPeZtJrGr19FwTyTw2+5PD7UNSNrnmdAYTciwNyLZWu1ft/RdbN7i5B0v2oGVm1ytet7+Nm9pS/bU0chA29OW4zlKTAiaKgPe4KbNObXbPdLGg/aexW53Q+zWdrTxGLR08u4k9sEp5H6RJ4FkdrXcHfJx59fskBNPGvJcFBvlCWyoXXNiIhzpt7T900Hzf+t+uuBGzU56c11NgoRLSzOz0y6WI0Lkr9h25/xjzvhvtPseL4wdgeAaccdRkzfJCWGj5kh3pOHd7zZF2pytTYsmbzSP+iPe1+URqn/Z4P/v2eCncJyYUrWmvpVPVD7mvo6bvONNnWjXeY+bF5GJvtUtK2onmFCTWRHvSxOB2QOetTaFNCrkGgCSJn/oH/Q/UBy6qTsj9LV1tdH54pnwv9QzAVNBfbvUhn48wVO6C+cSH6yw2nanikENgzoGDQyaGLQwaGPQsWDxqWBgYwAlqjVMa7csu1ptt61mo9rq4BOy+Oxrf7Nx74t2tW1a/Bgt/KRXcHx87c977XRa9CQMFH18hGizQdFOBWL43kaT/3Ya9BZNcLzO4Ok6+ZUPjx8JSbXg6q+yjEI/unGXo2ge7eiFlD+EnzlyBZHv/Z38hi+t/LyIduG7W9cPu0uI4tOPP4abm2jl7tab1Gsq8rmg7srKefGnu87L3Oze5mRudj+84FUW+YrbsUdZDr3EEsiHRxx6dDR+Xkc9KEZvkPP7aTQ848+3m3CLL42L5876EJmv8B2mzKcBvViYSR66y2U2cb0K6NVKN/ttIsDNfIgRJxK+geHauEsZW88jP6e+b0N8uTOT/F34KZPGb6lnkt+FH+7ClR9mPvy4iLaZxJ9y0fDTbeDuEjWot4vUe1zZF2KeM1Cj9c/4ZBrQ2I7eu5NoXG/erHIS00npwkfA8l4C1mC59q/TjQ3wPbd04lC8aJZOH4mXzTLp+R0e39zu7jOJCuG/Fj9vZumUb1wvXIZBOvktYSOd+o5Qk079EV+vyyRuMuD/xd1ErrcMgY0t3Y27i+kpFwU/R7vF84Zypj2Fg8P6+Oie0KCenvIo4pNrcibqre+1Fze1Rxf1kU9gTL2P7i5hsgInDbmdnpbS5dfTaZbtzo/hOGd8csfx+dgByLx1cL/X3jzX37TzxCNr+KCZR508AcToPUy8eebFnUrPEZdel1a9DNY0kxSu9SpxDA7UU4F6EPF7fobUlc82wdgm1r2Y7un5MVV318MVCNnmTp8T9GQZPxo85lcz6YWyHzZrIL4bfO5Sg687t3YbN1pGq3mc5j+5hkGZj+FmG2o/0y9+uqmVrODiK3f5i9lSPoDnOw97KOmRaOHiW/SBGZQX7vb7TyvowG242d3TC2/4nt2lO5VvPKO4YKyJ4wPGvRNGNL0rhQ/RmV365amHsXz9IanQmsmXBwloGBb1pKwP0owcHs9xX79+bVuB45c8i5+KNXtAC92i7wQl23LPHK9k5zWy4Efq6ClofPJ5tXNcfv/7Orx3vNTLoow5+ryit10tUXC3cDz+/Wnj3jo+/96EM/1pZg9khvz32ASvxxdKBd7cBN5koiLkLT04ZiSe/9KfN4Q81+X0QsvPpMn0H9wdEj8MGT7EigMYhVsDMnj6g2D08LR84Blnl3xm+dx9DSNwdubiG40eDCJjxHH8eBZlOeJNkTDIlaF86p0rDiHplbLERTZHimzC2yUIkqkSW34amghHPbjmfIBc+mPXCvk+vok9Dy8r09eu+kmTjF8MDYO3mOhcxl8t+dOeTi0kal/gBeg/VQyyOCi/q7IgiJ85tgXSdSUndyWR24bcbtyxHb9ALZFxObXm1gxo0kOueBJwIZMebS0gpsabDYycAQPt+ovh+oZe9oQvYbAtUF6YxzC2N7zo0CvMJwv13q32wjOTgE+PWMq0c/9idu6XHNucw0wOL32AdZ5GWcUKVMcRa/R++9w8x5cw3QBIWELluPETzsfaElVsi7LJhRk/qgdlbgBFDyE+QtzVXzSmR6kFv/AuXL2P/KI6wJkettcxYYiHprN5kN5Vrl7RT3fr8TGbBuOGjz2nUrlfAZLd9nYZAVF7lm2aXQ96vVcddNQTqb2oTHJeF6HPEJGC3Z5CxnfX0W0X3wguVP6/3q6vx3Ebh7/fp9h5GdtYzrR7j571FXdtURT30AO2LXAwjIETO4kbx87YTma3M/nuJfXHFillu33pPmRiipQoSqJ+JL0I/T72bCdU4Vz/RTstHb+vvGGNnRYeVNjnIjvZu40ZShKNpST5bzRVdSGLYNgKHZ6zDWztXttnL6EoLQ3HbrBQjdt1GQ0JuXg0mHrhoeZYunCeVFv/7Md1ii3UgBLPZcOV54QIeHyRyngDZDia+gEq8HAkleEJ8Ng1lbEstiP4/bYtEaBQ4/yALbuyYTMVBOSgX6b+D0JPbLNfDdXB26bRReCah/XNCcjRH/BhV3f0qAyDTB5N8LEeww0kEQjc0yvxPHiRXRoI9sCL89JA6AffNQNCg+bsdubTkE9Eh6kfLwIPFVMZOsL3Ckj/u23ZSoSolvc7/dvaAX6/xcrQD/dWAQlJt/wfjvVapT8s40xQHDLOTYPBL7ghVMoDKuCxVCpjK2r/acPbnWds9wPGNBhFQsgZhPzAD3VHsUo/uIwBYgRLdih1M0XgBi4syoIf1c+1ux1LiuVh8/FIC5daaWeZwnTLT+s8UrbRk/BbrIzH6nCYdFg658VARtGpH1eDlzZLA5k0kEm01E+rIc9U2oCL2pcn1bbrcVNjaNhMRp5TkEeFis4MBSEClrNLRQoPZFCR+vk8YAGGZZjvqf8NzRkN424lj0Rc/XYoD9SmviiKmfUyY/vNnbNPi4B+8dvG3JHzQC0soZR6GSbwE5NpKFkJH/BrWc2jsEdsPR1ppuoPPvGEVeplsAzHtyVdesv3CH4u0WVXP9cHjHwmptO1FpSxNKubICwc8+4WBORgWdhUZmWBJ9tSmXwDN++W8iwc/CJBhMzugkzspn6qFwJpvDSY2/M4+8Fn7HGV5B0nbziW60pF6gv+39Rt5aosCNEFuisoMo/aeoNdREOz3U1REcCPPosAj3lU69UdbeMiyluCqDGPjmiGw4gjUOqOOAVazKNy2J7UXAsJFHMr5AFET28BD7GdvCc2CFyYR+gt2xqPwDzuqLgWdGh0XlSWABFnvpi/cNDhrK8HDfOoqbDDkc6tanR6FxDxc6w+VvQMcQ0nom4kQL1tGkpYut2GgGIe0W+qI9eSCSWj2VynlhOQcTG7DxTzIoQLiSpRoDEjaAUKCQFRJAj68mhUWdGouA708qhyjnBxDd1xNlwMe6+R+cQoyyWo9gVSalo/NHbZaiYP7YkNxGAeLj9eN3byEJ2Uh1oWS+A+sf4umwv/rrIFUKDZgPLgBk93kDMEBD+z/ZwrHJf2R6b1n21BDxc6m8DHg/mVhbyCCfN5Ea+CQMnitjQHbzPYixHn6eE9e3Zmu/hozzvsHtTLbbYXbDr2k2Jz0F4eHfDRY+CQL4/2NZ3Ac9meyEIS7+EEOMC74lc9nJe7aeJCYDzR6EO8vJgR3exrnYlxnQOoTrK4gI5dRBLPscYAlHNPNKnOURyXVhAOZyLRGzqdZlwPDb3EoDY6VcJUZwuIC52I4jqaQ/Zyi9xPp3JsiFFAuLzwMFuumel88CkJ6EaiHKyxWTKgZg4/drkru6pVhx/XpGyb3/F74SE31pMH2lhrCK4x7z0GmPrBui7lawvwLiBjZbPFOEJzzphplxjN1fACqui1oY8tfTTZi84jrkGlCTe42Q79uU63F9jd4wGYeqrP2KpE5hTYeIkptwWmIltJUerQlZzLFArC3TejfqPH6S35xn2yKVE7BLxL4ObrJI1NRUoXTFS1E27eJRdYOcOrQhYb3Kl/rUC/mMAVKZPE5uu3c8b1Yf1++/D27TpZ6VxtSan6h7od6zeWklx0YY/qF1uoYKeqD0rJx8f1aVBzIX0Sp2hsXmzCHbzK/okrY9hVHrttxskOv3q/US857TwOSmHXcUVGp75tOpdIobGh4gZS9TfnFSBdiFGSRi5OnIoWcr++in6pQCitPqhsNzO8tk4F6wdtXjVnKnFen3OlXxbTBg5MXFXonCIoU8KoF9x6YgbUDRd+fKw/1uvTxHbuXLarwSnDnTpduq6gzni/YgGyeUVGOsCqQAprVWBe39OVpaYIlVIHvOleMdPdO2OGRA6HWvJJdT3eXZ9Cp9iqJARGdAru5jB1Yuol3vCThn6VPElUXONfi5MpHIPg3iZyPdS9qdx05pb+jdi5GRv0pbZ+PfT9ZOvXj4/P/bAni9GWk1Z0aNZual38lTKUDS7UqlzvNbG8n5+zLGrsGxLRN5JbowvyX+NcEWeydlIRbggpvHDOi0wdZR2OT18WEUU2Y5UqxI7N0xqXZ6pdvsRIJ8LWtmztbpQTjHrr76CBFXTwBC0cYEBPt8czPT2YfpdVUiIw0TUzOy27EHjxyHUg/0WnnKq8JKusO3/g5m7cdt5qWEyVj9V7Vxn22x9jqhFm2WRojaG1Vg1z2OPxXikEq4RvgCxbv762zrsAD2sTcF7U6zvqAFLfgR5V7fYLekRpY4Npnq0vtdFSm8QqQHJdplWAp6wzPnql3DLsM2fB86cCbvb0eoPYYMnMZilxZ243r/b+S7fv+me8vXC8NzTWm+jt09voPkI/nO2t79ZLEQ932bvkX9nXyjaHbJ8PBTr8Lj+gIhWbAr+DqyR52WaV6G3r9nZT5duCdXGMG1BERu3jJ6Bxk2SV6c1DPJAfAD+dxKvaQ3rOKPVbrHsKyCw7TnPPg+3sml0uTjeJ0lbp5ijGdnuFJ8nZxxf6J3ylh79OcHawzEf7xhleUVBCrV8qG+qNcbMxalFlmkIQqjbf9UWNsLDlpl7f3SXqjc0WcQ69G1Jv6O2yRQS3oN7wpe3zfWVq5Xd3Mw3nQUq16CcOgDcbeo4J/UWHPuQZPcgx6DXOCTyT12g9rzH4XuMpeyFfn57QYFnAdyBlhxsgIqYIvUg7n6vBfjNTbrnbaB238Wxog6FV8pCfF7dR3WQLIri9pce1/rPRf7a3t3ZlNHKtEojFId++vlb0J7m9/RgHPUfleI43T+q+Yy4poOLsh75ExdjTUXuY7PPaxkpdw6oh+ZfprtyDcWI3B3aAzZI9O0sWcIqV5xTH7MB9Ycd84YguqAv5ws7zhYe/4gtH7QsRRgjvNbne64hOcCrwHjzkR1Sk+YwvbPDs7vHK4r3tmS9s8n0hvN4INMLiwYgFcrwRuNdTB6SBfeL6PtVdSNI5VI7MPHArPCD2hJuidX1dA0e3lwMcE/J4bDdcEAN/+NRN5ccMwcWCRw707pVxhQN+56+BZROSftU48L8aHc3PPx3JTWbog+8pUzz0LUb+CBCr+3Xbd/X33bkZelWNcAGpDXvilwtCpOpCMR6Cpjj6aur7dvwK2YdPd8e+6dR/rkguDoqnjyT5xx9SVB3AzJABAA==
-</script>
-<script id="@tomlarkworthy/escodegen" 
-  type="text/plain"
-  data-mime="application/javascript"
->
-const _hsp23a = function _1(md){return(
-md`# [escodegen@2.1.0](https://github.com/estools/escodegen)
-
-JS AST to code (the inverse of Acorn)
-
-\`\`\`js
-import {escodegen} from '@tomlarkworthy/escodegen'
-\`\`\``
-)};
-const _rg6wi4 = async function _escodegen(Response,FileAttachment,DecompressionStream)
-{
-  const source = await new Response(
-    (
-      await FileAttachment("escodegen.browser.min.js.gz").stream()
-    ).pipeThrough(new DecompressionStream("gzip"))
-  ).text();
-  const fn = eval(source.replace(".call(this,this)", ""));
-  fn(window);
-  return window.escodegen;
-};
-
-export default function define(runtime, observer) {
-  const main = runtime.module();
-  const $def = (pid, name, deps, fn) => {
-    main.variable(observer(name)).define(name, deps, fn).pid = pid;
-  };
-  const fileAttachments = new Map(["escodegen.browser.min.js.gz"].map((name) => {
-    const module_name = "@tomlarkworthy/escodegen";
-    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
-    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
-    return [name, {url: blob_url, mimeType: mime}]
-  }));
-  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
-
-  $def("_hsp23a", null, ["md"], _hsp23a);  
-  $def("_rg6wi4", "escodegen", ["Response","FileAttachment","DecompressionStream"], _rg6wi4);
-  return main;
-}</script>
 
 <script id="@tomlarkworthy/file-sync" 
   type="text/plain"
@@ -11798,231 +11816,232 @@ const _yqx7l8 = function _syncEnabled(notebookId,htl)
     return container;
 };
 const _xltqf6 = (G, _) => G.input(_);
-const _1nuhj4u = function _disassemble(htl, directory, notebookId, manifestWriter, readFile, writeFile, syncableModules, exportModuleJS, hashSource, currentModules, runtime, probeDefine, tag, $0) {
-    const container = htl.html`<div>
+const _1nuhj4u = function _disassemble(htl,directory,notebookId,manifestWriter,readFile,writeFile,syncableModules,exportModuleJS,hashSource,currentModules,runtime,probeDefine,tag,$0)
+{
+  const container = htl.html`<div>
     <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
       <button class="disassemble" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Disassemble to disk</button>
       <button class="sync" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Sync from disk</button>
     </div>
     <pre style="font-size: 12px; max-height: 300px; overflow-y: auto; margin-top: 8px;"></pre>
   </div>`;
-    const disBtn = container.querySelector('.disassemble');
-    const syncBtn = container.querySelector('.sync');
-    const status = container.querySelector('pre');
-    if (directory) {
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
+  const disBtn = container.querySelector('.disassemble');
+  const syncBtn = container.querySelector('.sync');
+  const status = container.querySelector('pre');
+  if (directory) {
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  }
+  const log = msg => {
+    status.textContent += msg + '\n';
+    status.scrollTop = status.scrollHeight;
+  };
+  const prefix = notebookId + '/';
+  disBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    disBtn.textContent = 'Disassembling...';
+    let ok = 0, fail = 0;
+    const manifestUpdates = {};
+    await manifestWriter(directory, prefix, null, readFile, writeFile);
+    log('cleared manifest');
+    for (const moduleId of syncableModules) {
+      try {
+        log('Exporting ' + moduleId + '...');
+        const result = await exportModuleJS(moduleId);
+        const path = prefix + moduleId + '.js';
+        await writeFile(directory, path, result.source);
+        manifestUpdates[moduleId] = hashSource(result.source);
+        log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
+        if (result.fileAttachments && result.fileAttachments.size) {
+          for (const [name, entry] of result.fileAttachments) {
+            try {
+              const resp = await fetch(entry.url);
+              const bytes = await resp.arrayBuffer();
+              await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
+              log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
+            } catch (e) {
+              log('  attachment FAILED: ' + name + ' - ' + e.message);
+            }
+          }
+        }
+        ok++;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
     }
-    const log = msg => {
-        status.textContent += msg + '\n';
-        status.scrollTop = status.scrollHeight;
+    try {
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const bootconf = document.querySelector('script[id="bootconf.json"]');
+      if (bootconf) {
+        await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
+        log('wrote ' + prefix + 'bootconf.json');
+      }
+    } catch (e) {
+      log('bootconf.json FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
+    disBtn.textContent = 'Disassembled ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  syncBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    syncBtn.textContent = 'Syncing from disk...';
+    status.textContent = '';
+    const nameToModule = new window.Map();
+    const nameToVars = new window.Map();
+    for (const [mod, info] of currentModules) {
+      if (info.name === 'bootloader' || info.name === 'builtin')
+        continue;
+      if (!info.name.includes('/') && !info.name.startsWith('d/'))
+        continue;
+      nameToModule.set(info.name, info.module);
+      const vars = new window.Map();
+      for (const v of runtime._variables) {
+        if (v._module !== info.module)
+          continue;
+        if (v._name)
+          vars.set(v._name, v);
+        if (v.pid)
+          vars.set('__pid__' + v.pid, v);
+      }
+      nameToVars.set(info.name, vars);
+    }
+    const applyModule = (moduleId, defineFn) => {
+      const mod = nameToModule.get(moduleId);
+      if (!mod)
+        return;
+      const existingVars = nameToVars.get(moduleId) || new window.Map();
+      const cells = probeDefine(defineFn);
+      const seenPids = new Set();
+      for (const cell of cells) {
+        if (cell.type === 'import')
+          continue;
+        if (!cell.pid)
+          continue;
+        seenPids.add(cell.pid);
+        const existing = existingVars.get('__pid__' + cell.pid);
+        if (!existing) {
+          const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+          const v = mod.variable();
+          v.define(cell.name, cell.inputs, taggedDefn);
+          v.pid = cell.pid;
+          existingVars.set('__pid__' + cell.pid, v);
+          if (cell.name)
+            existingVars.set(cell.name, v);
+          continue;
+        }
+        if (existing._definition) {
+          const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
+          const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+          const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+          if (inputsMatch && defnMatch)
+            continue;
+        }
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      }
+      const ordered = [];
+      for (const cell of cells) {
+        if (!cell.pid)
+          continue;
+        const v = existingVars.get('__pid__' + cell.pid);
+        if (v)
+          ordered.push(v);
+      }
+      if (ordered.length) {
+        const orderedSet = new Set(ordered);
+        const arr = [...runtime._variables];
+        let oi = 0;
+        for (let i = 0; i < arr.length; i++) {
+          if (orderedSet.has(arr[i]))
+            arr[i] = ordered[oi++];
+        }
+        while (oi < ordered.length)
+          arr.push(ordered[oi++]);
+        runtime._variables.clear();
+        for (const v of arr)
+          runtime._variables.add(v);
+      }
     };
-    const prefix = notebookId + '/';
-    disBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        disBtn.textContent = 'Disassembling...';
-        let ok = 0, fail = 0;
-        const manifestUpdates = {};
-        await manifestWriter(directory, prefix, null, readFile, writeFile);
-        log('cleared manifest');
-        for (const moduleId of syncableModules) {
+    const manifestUpdates = {};
+    let ok = 0, fail = 0;
+    for (const moduleId of syncableModules) {
+      try {
+        let file;
+        try {
+          file = await readFile(directory, prefix + moduleId + '.js');
+        } catch (e) {
+          file = null;
+        }
+        if (!file) {
+          log('  skip ' + moduleId + ' (no .js on disk)');
+          continue;
+        }
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const mod = await import(url);
+          if (typeof mod.default === 'function') {
+            applyModule(moduleId, mod.default);
+            log('  applied ' + moduleId);
             try {
-                log('Exporting ' + moduleId + '...');
-                const result = await exportModuleJS(moduleId);
-                const path = prefix + moduleId + '.js';
-                await writeFile(directory, path, result.source);
-                manifestUpdates[moduleId] = hashSource(result.source);
-                log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
-                if (result.fileAttachments && result.fileAttachments.size) {
-                    for (const [name, entry] of result.fileAttachments) {
-                        try {
-                            const resp = await fetch(entry.url);
-                            const bytes = await resp.arrayBuffer();
-                            await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
-                            log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
-                        } catch (e) {
-                            log('  attachment FAILED: ' + name + ' - ' + e.message);
-                        }
-                    }
-                }
-                ok++;
+              const after = await exportModuleJS(moduleId);
+              manifestUpdates[moduleId] = hashSource(after.source);
             } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
+              manifestUpdates[moduleId] = hashSource(diskText);
             }
+            ok++;
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
         }
-        try {
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const bootconf = document.querySelector('script[id="bootconf.json"]');
-            if (bootconf) {
-                await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
-                log('wrote ' + prefix + 'bootconf.json');
-            }
-        } catch (e) {
-            log('bootconf.json FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
-        disBtn.textContent = 'Disassembled ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    syncBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        syncBtn.textContent = 'Syncing from disk...';
-        status.textContent = '';
-        const nameToModule = new window.Map();
-        const nameToVars = new window.Map();
-        for (const [mod, info] of currentModules) {
-            if (info.name === 'bootloader' || info.name === 'builtin')
-                continue;
-            if (!info.name.includes('/') && !info.name.startsWith('d/'))
-                continue;
-            nameToModule.set(info.name, info.module);
-            const vars = new window.Map();
-            for (const v of runtime._variables) {
-                if (v._module !== info.module)
-                    continue;
-                if (v._name)
-                    vars.set(v._name, v);
-                if (v.pid)
-                    vars.set('__pid__' + v.pid, v);
-            }
-            nameToVars.set(info.name, vars);
-        }
-        const applyModule = (moduleId, defineFn) => {
-            const mod = nameToModule.get(moduleId);
-            if (!mod)
-                return;
-            const existingVars = nameToVars.get(moduleId) || new window.Map();
-            const cells = probeDefine(defineFn);
-            const seenPids = new Set();
-            for (const cell of cells) {
-                if (cell.type === 'import')
-                    continue;
-                if (!cell.pid)
-                    continue;
-                seenPids.add(cell.pid);
-                const existing = existingVars.get('__pid__' + cell.pid);
-                if (!existing) {
-                    const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                    const v = mod.variable();
-                    v.define(cell.name, cell.inputs, taggedDefn);
-                    v.pid = cell.pid;
-                    existingVars.set('__pid__' + cell.pid, v);
-                    if (cell.name)
-                        existingVars.set(cell.name, v);
-                    continue;
-                }
-                if (existing._definition) {
-                    const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
-                    const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                    const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                    if (inputsMatch && defnMatch)
-                        continue;
-                }
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            }
-            const ordered = [];
-            for (const cell of cells) {
-                if (!cell.pid)
-                    continue;
-                const v = existingVars.get('__pid__' + cell.pid);
-                if (v)
-                    ordered.push(v);
-            }
-            if (ordered.length) {
-                const orderedSet = new Set(ordered);
-                const arr = [...runtime._variables];
-                let oi = 0;
-                for (let i = 0; i < arr.length; i++) {
-                    if (orderedSet.has(arr[i]))
-                        arr[i] = ordered[oi++];
-                }
-                while (oi < ordered.length)
-                    arr.push(ordered[oi++]);
-                runtime._variables.clear();
-                for (const v of arr)
-                    runtime._variables.add(v);
-            }
-        };
-        const manifestUpdates = {};
-        let ok = 0, fail = 0;
-        for (const moduleId of syncableModules) {
-            try {
-                let file;
-                try {
-                    file = await readFile(directory, prefix + moduleId + '.js');
-                } catch (e) {
-                    file = null;
-                }
-                if (!file) {
-                    log('  skip ' + moduleId + ' (no .js on disk)');
-                    continue;
-                }
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
-                try {
-                    const mod = await import(url);
-                    if (typeof mod.default === 'function') {
-                        applyModule(moduleId, mod.default);
-                        log('  applied ' + moduleId);
-                        try {
-                            const after = await exportModuleJS(moduleId);
-                            manifestUpdates[moduleId] = hashSource(after.source);
-                        } catch (e) {
-                            manifestUpdates[moduleId] = hashSource(diskText);
-                        }
-                        ok++;
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
-            }
-        }
-        try {
-            await manifestWriter(directory, prefix, null, readFile, writeFile);
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const view = $0;
-            const cb = view && view.querySelector ? view.querySelector('input') : null;
-            if (cb && !cb.checked) {
-                cb.checked = true;
-                view.value = true;
-                view.dispatchEvent(new window.Event('input', { bubbles: true }));
-                log('enabled Sync toggle');
-            } else if (cb && cb.checked) {
-                log('Sync toggle already enabled');
-            }
-        } catch (e) {
-            log('toggle enable FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
-        syncBtn.textContent = 'Synced ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    container.value = undefined;
-    return container;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
+    }
+    try {
+      await manifestWriter(directory, prefix, null, readFile, writeFile);
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const view = $0;
+      const cb = view && view.querySelector ? view.querySelector('input') : null;
+      if (cb && !cb.checked) {
+        cb.checked = true;
+        view.value = true;
+        view.dispatchEvent(new window.Event('input', { bubbles: true }));
+        log('enabled Sync toggle');
+      } else if (cb && cb.checked) {
+        log('Sync toggle already enabled');
+      }
+    } catch (e) {
+      log('toggle enable FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
+    syncBtn.textContent = 'Synced ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  container.value = undefined;
+  return container;
 };
 const _eoa5ga = (G, _) => G.input(_);
 const _1jyon1g = function _syncStatus(htl,directory,syncableModules,notebookToFiles,filesToNotebook){return(
@@ -12388,341 +12407,342 @@ const _1bf1rb4 = function _fileSyncLastSeen(directory)
     void directory;
     return new window.Map();
 };
-const _19e6n4y = function _filesToNotebook(directory, syncArmed, currentModules, fileSyncLastSeen, notebookId, runtime, probeDefine, tag, readFile, exportModuleJS, importShim, manifestWriter, hashSource, writeFile, getFileAttachmentsMap, invalidation) {
-    if (!directory)
-        return 'Waiting for directory...';
-    if (!syncArmed || !syncArmed.armed)
-        return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
-    const SKIP = new Set([
-        'bootloader',
-        'builtin'
-    ]);
-    const syncableModules = [];
-    for (const [mod, info] of currentModules) {
-        if (SKIP.has(info.name))
-            continue;
-        if (!info.name.includes('/') && !info.name.startsWith('d/'))
-            continue;
-        syncableModules.push(info.name);
+const _19e6n4y = function _filesToNotebook(directory,syncArmed,currentModules,fileSyncLastSeen,notebookId,runtime,probeDefine,tag,readFile,exportModuleJS,importShim,manifestWriter,hashSource,writeFile,getFileAttachmentsMap,invalidation)
+{
+  if (!directory)
+    return 'Waiting for directory...';
+  if (!syncArmed || !syncArmed.armed)
+    return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
+  const SKIP = new Set([
+    'bootloader',
+    'builtin'
+  ]);
+  const syncableModules = [];
+  for (const [mod, info] of currentModules) {
+    if (SKIP.has(info.name))
+      continue;
+    if (!info.name.includes('/') && !info.name.startsWith('d/'))
+      continue;
+    syncableModules.push(info.name);
+  }
+  const syncableSet = new Set(syncableModules);
+  const lastSeen = fileSyncLastSeen;
+  const POLL_MS = 1000;
+  const prefix = notebookId + '/';
+  const nameToModule = new window.Map();
+  const nameToVars = new window.Map();
+  for (const [mod, info] of currentModules) {
+    if (!syncableSet.has(info.name))
+      continue;
+    nameToModule.set(info.name, info.module);
+    const vars = new window.Map();
+    for (const v of runtime._variables) {
+      if (v._module !== info.module)
+        continue;
+      if (v._name)
+        vars.set(v._name, v);
+      if (v.pid)
+        vars.set('__pid__' + v.pid, v);
     }
-    const syncableSet = new Set(syncableModules);
-    const lastSeen = fileSyncLastSeen;
-    const POLL_MS = 1000;
-    const prefix = notebookId + '/';
-    const nameToModule = new window.Map();
-    const nameToVars = new window.Map();
-    for (const [mod, info] of currentModules) {
-        if (!syncableSet.has(info.name))
-            continue;
-        nameToModule.set(info.name, info.module);
-        const vars = new window.Map();
-        for (const v of runtime._variables) {
-            if (v._module !== info.module)
-                continue;
-            if (v._name)
-                vars.set(v._name, v);
-            if (v.pid)
-                vars.set('__pid__' + v.pid, v);
-        }
-        nameToVars.set(info.name, vars);
+    nameToVars.set(info.name, vars);
+  }
+  let pollTimer;
+  const knownFilePids = new window.Map();
+  let knownDiskModules = null;
+  const getModuleFA = mod => {
+    for (const v of runtime._variables) {
+      if (v._module === mod && v._name === 'FileAttachment' && v._value)
+        return v._value;
     }
-    let pollTimer;
-    const knownFilePids = new window.Map();
-    let knownDiskModules = null;
-    const getModuleFA = mod => {
-        for (const v of runtime._variables) {
-            if (v._module === mod && v._name === 'FileAttachment' && v._value)
-                return v._value;
-        }
-        return null;
-    };
-    const getSubDir = async (dirHandle, path) => {
-        let current = dirHandle;
-        for (const part of path.split('/').filter(Boolean)) {
-            current = await current.getDirectoryHandle(part);
-        }
-        return current;
-    };
-    const applyModule = (moduleId, defineFn) => {
-        const mod = nameToModule.get(moduleId);
-        if (!mod)
-            return;
-        const existingVars = nameToVars.get(moduleId) || new window.Map();
-        const cells = probeDefine(defineFn);
-        let redefinedSelf = false;
-        const seenPids = new Set();
-        for (const cell of cells) {
-            if (cell.type === 'import')
-                continue;
-            if (!cell.pid)
-                continue;
-            seenPids.add(cell.pid);
-            const existing = existingVars.get('__pid__' + cell.pid);
-            if (!existing) {
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                const v = mod.variable();
-                v.define(cell.name, cell.inputs, taggedDefn);
-                v.pid = cell.pid;
-                existingVars.set('__pid__' + cell.pid, v);
-                if (cell.name)
-                    existingVars.set(cell.name, v);
-                console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
-                continue;
-            }
-            if (existing._definition) {
-                const existingInputNames = existing._inputs.map(function (v) {
-                    return typeof v === 'string' ? v : v._name;
-                });
-                const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                if (inputsMatch && defnMatch)
-                    continue;
-            }
-            const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-            existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
-                redefinedSelf = true;
-            }
-        }
-        const prevKnown = knownFilePids.get(moduleId);
-        if (prevKnown) {
-            for (const pid of prevKnown) {
-                if (seenPids.has(pid))
-                    continue;
-                const v = existingVars.get('__pid__' + pid);
-                if (!v)
-                    continue;
-                console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
-                v.delete();
-                existingVars.delete('__pid__' + pid);
-                if (v._name)
-                    existingVars.delete(v._name);
-            }
-        }
-        knownFilePids.set(moduleId, seenPids);
-        const ordered = [];
-        for (const cell of cells) {
-            if (!cell.pid)
-                continue;
-            const v = existingVars.get('__pid__' + cell.pid);
-            if (v)
-                ordered.push(v);
-        }
-        if (ordered.length) {
-            const orderedSet = new Set(ordered);
-            const arr = [...runtime._variables];
-            let oi = 0;
-            for (let i = 0; i < arr.length; i++) {
-                if (orderedSet.has(arr[i]))
-                    arr[i] = ordered[oi++];
-            }
-            while (oi < ordered.length)
-                arr.push(ordered[oi++]);
-            runtime._variables.clear();
-            for (const v of arr)
-                runtime._variables.add(v);
-        }
-        if (redefinedSelf) {
-            clearInterval(pollTimer);
-            console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
-        }
-    };
-    const pollModule = async moduleId => {
-        try {
-            let file;
+    return null;
+  };
+  const getSubDir = async (dirHandle, path) => {
+    let current = dirHandle;
+    for (const part of path.split('/').filter(Boolean)) {
+      current = await current.getDirectoryHandle(part);
+    }
+    return current;
+  };
+  const applyModule = (moduleId, defineFn) => {
+    const mod = nameToModule.get(moduleId);
+    if (!mod)
+      return;
+    const existingVars = nameToVars.get(moduleId) || new window.Map();
+    const cells = probeDefine(defineFn);
+    let redefinedSelf = false;
+    const seenPids = new Set();
+    for (const cell of cells) {
+      if (cell.type === 'import')
+        continue;
+      if (!cell.pid)
+        continue;
+      seenPids.add(cell.pid);
+      const existing = existingVars.get('__pid__' + cell.pid);
+      if (!existing) {
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        const v = mod.variable();
+        v.define(cell.name, cell.inputs, taggedDefn);
+        v.pid = cell.pid;
+        existingVars.set('__pid__' + cell.pid, v);
+        if (cell.name)
+          existingVars.set(cell.name, v);
+        console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
+        continue;
+      }
+      if (existing._definition) {
+        const existingInputNames = existing._inputs.map(function (v) {
+          return typeof v === 'string' ? v : v._name;
+        });
+        const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+        const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+        if (inputsMatch && defnMatch)
+          continue;
+      }
+      const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+      existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
+        redefinedSelf = true;
+      }
+    }
+    const prevKnown = knownFilePids.get(moduleId);
+    if (prevKnown) {
+      for (const pid of prevKnown) {
+        if (seenPids.has(pid))
+          continue;
+        const v = existingVars.get('__pid__' + pid);
+        if (!v)
+          continue;
+        console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
+        v.delete();
+        existingVars.delete('__pid__' + pid);
+        if (v._name)
+          existingVars.delete(v._name);
+      }
+    }
+    knownFilePids.set(moduleId, seenPids);
+    const ordered = [];
+    for (const cell of cells) {
+      if (!cell.pid)
+        continue;
+      const v = existingVars.get('__pid__' + cell.pid);
+      if (v)
+        ordered.push(v);
+    }
+    if (ordered.length) {
+      const orderedSet = new Set(ordered);
+      const arr = [...runtime._variables];
+      let oi = 0;
+      for (let i = 0; i < arr.length; i++) {
+        if (orderedSet.has(arr[i]))
+          arr[i] = ordered[oi++];
+      }
+      while (oi < ordered.length)
+        arr.push(ordered[oi++]);
+      runtime._variables.clear();
+      for (const v of arr)
+        runtime._variables.add(v);
+    }
+    if (redefinedSelf) {
+      clearInterval(pollTimer);
+      console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
+    }
+  };
+  const pollModule = async moduleId => {
+    try {
+      let file;
+      try {
+        file = await readFile(directory, prefix + moduleId + '.js');
+      } catch (e) {
+        file = null;
+      }
+      if (file) {
+        const prev = lastSeen.get(moduleId);
+        const changed = !prev || file.lastModified !== prev.lastModified;
+        if (changed) {
+          lastSeen.set(moduleId, { lastModified: file.lastModified });
+          const diskText = await file.text();
+          let needsApply = true;
+          try {
+            const runtimeResult = await exportModuleJS(moduleId);
+            if (runtimeResult.source === diskText)
+              needsApply = false;
+          } catch (e) {
+          }
+          if (needsApply) {
+            const blob = new window.Blob([diskText], { type: 'text/javascript' });
+            const url = window.URL.createObjectURL(blob);
             try {
-                file = await readFile(directory, prefix + moduleId + '.js');
-            } catch (e) {
-                file = null;
-            }
-            if (file) {
-                const prev = lastSeen.get(moduleId);
-                const changed = !prev || file.lastModified !== prev.lastModified;
-                if (changed) {
-                    lastSeen.set(moduleId, { lastModified: file.lastModified });
-                    const diskText = await file.text();
-                    let needsApply = true;
-                    try {
-                        const runtimeResult = await exportModuleJS(moduleId);
-                        if (runtimeResult.source === diskText)
-                            needsApply = false;
-                    } catch (e) {
-                    }
-                    if (needsApply) {
-                        const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                        const url = window.URL.createObjectURL(blob);
-                        try {
-                            const mod = await import(url);
-                            if (typeof mod.default === 'function') {
-                                applyModule(moduleId, mod.default);
-                                console.log('[file-sync] applied ' + moduleId + ' from disk');
-                                try {
-                                    const after = await exportModuleJS(moduleId);
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
-                                } catch (e) {
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                                }
-                            }
-                        } finally {
-                            window.URL.revokeObjectURL(url);
-                        }
-                    }
-                }
-            }
-        } catch (e) {
-            console.error('[file-sync] poll error for ' + moduleId + ':', e);
-        }
-        try {
-            const attachDir = await getSubDir(directory, prefix + moduleId);
-            const mod = nameToModule.get(moduleId);
-            const FA = mod ? getModuleFA(mod) : null;
-            const faMap = FA ? getFileAttachmentsMap(FA) : null;
-            if (faMap) {
-                for (const key of [...faMap.keys()]) {
-                    if (key.endsWith('.crswap') || key.startsWith('.'))
-                        faMap.delete(key);
-                }
-            }
-            for await (const [name, handle] of attachDir) {
-                if (handle.kind !== 'file')
-                    continue;
-                if (name.endsWith('.crswap') || name.startsWith('.'))
-                    continue;
-                const file = await handle.getFile();
-                const attKey = '__att__' + moduleId + '/' + name;
-                const prevA = lastSeen.get(attKey);
-                if (prevA && file.lastModified === prevA.lastModified)
-                    continue;
-                lastSeen.set(attKey, { lastModified: file.lastModified });
-                const bytes = new Uint8Array(await file.arrayBuffer());
-                const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
-                const blobUrl = window.URL.createObjectURL(blob);
-                if (faMap) {
-                    faMap.set(name, {
-                        url: blobUrl,
-                        mimeType: file.type || 'application/octet-stream'
-                    });
-                    console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
-                }
-                const scriptId = moduleId + '/' + encodeURIComponent(name);
-                const script = document.getElementById(scriptId);
-                if (script) {
-                    const b64 = btoa(String.fromCharCode.apply(null, bytes));
-                    script.textContent = b64;
-                    script.setAttribute('data-encoding', 'base64');
-                    script.setAttribute('data-mime', file.type || 'application/octet-stream');
-                }
-            }
-        } catch (e) {
-            if (e.name !== 'NotFoundError')
-                console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
-        }
-    };
-    const scanDiskModules = async () => {
-        const diskModules = new Set();
-        try {
-            const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
-            for await (const [orgName, orgHandle] of notebookDir) {
-                if (orgHandle.kind !== 'directory')
-                    continue;
-                if (orgName.startsWith('@')) {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add(orgName + '/' + fname.slice(0, -3));
-                    }
-                } else if (orgName === 'd') {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add('d/' + fname.slice(0, -3));
-                    }
-                }
-            }
-        } catch (e) {
-        }
-        return diskModules;
-    };
-    const poll = async () => {
-        for (const moduleId of syncableModules)
-            await pollModule(moduleId);
-        const diskModules = await scanDiskModules();
-        const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
-        if (newOnDisk.length)
-            console.log('[file-sync] new modules on disk:', newOnDisk);
-        for (const moduleId of diskModules) {
-            if (syncableSet.has(moduleId))
-                continue;
-            if (nameToModule.has(moduleId))
-                continue;
-            try {
-                const file = await readFile(directory, prefix + moduleId + '.js');
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
+              const mod = await import(url);
+              if (typeof mod.default === 'function') {
+                applyModule(moduleId, mod.default);
+                console.log('[file-sync] applied ' + moduleId + ' from disk');
                 try {
-                    const imported = await import(url);
-                    if (typeof imported.default === 'function') {
-                        const newMod = runtime.module(imported.default, () => null);
-                        runtime.mains.set(moduleId, newMod);
-                        nameToModule.set(moduleId, newMod);
-                        syncableModules.push(moduleId);
-                        syncableSet.add(moduleId);
-                        const vars = new window.Map();
-                        for (const v of runtime._variables) {
-                            if (v._module !== newMod)
-                                continue;
-                            if (v._name)
-                                vars.set(v._name, v);
-                            if (v.pid)
-                                vars.set('__pid__' + v.pid, v);
-                        }
-                        nameToVars.set(moduleId, vars);
-                        console.log('[file-sync] added new module from disk: ' + moduleId);
-                        try {
-                            await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                        } catch (e) {
-                            console.error('[file-sync] manifest update for new module failed:', e);
-                        }
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                console.error('[file-sync] failed to add module ' + moduleId + ':', e);
-            }
-        }
-        if (knownDiskModules) {
-            for (const moduleId of knownDiskModules) {
-                if (diskModules.has(moduleId))
-                    continue;
-                if (!nameToModule.has(moduleId))
-                    continue;
-                const mod = nameToModule.get(moduleId);
-                for (const v of [...runtime._variables]) {
-                    if (v._module === mod)
-                        v.delete();
-                }
-                runtime.mains.delete(moduleId);
-                nameToModule.delete(moduleId);
-                nameToVars.delete(moduleId);
-                knownFilePids.delete(moduleId);
-                const idx = syncableModules.indexOf(moduleId);
-                if (idx !== -1)
-                    syncableModules.splice(idx, 1);
-                syncableSet.delete(moduleId);
-                console.log('[file-sync] removed module: ' + moduleId);
-                try {
-                    await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+                  const after = await exportModuleJS(moduleId);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
                 } catch (e) {
-                    console.error('[file-sync] manifest remove failed:', e);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
                 }
+              }
+            } finally {
+              window.URL.revokeObjectURL(url);
             }
+          }
         }
-        knownDiskModules = diskModules;
-    };
-    pollTimer = setInterval(poll, POLL_MS);
-    poll();
-    invalidation.then(() => clearInterval(pollTimer));
-    return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
+      }
+    } catch (e) {
+      console.error('[file-sync] poll error for ' + moduleId + ':', e);
+    }
+    try {
+      const attachDir = await getSubDir(directory, prefix + moduleId);
+      const mod = nameToModule.get(moduleId);
+      const FA = mod ? getModuleFA(mod) : null;
+      const faMap = FA ? getFileAttachmentsMap(FA) : null;
+      if (faMap) {
+        for (const key of [...faMap.keys()]) {
+          if (key.endsWith('.crswap') || key.startsWith('.'))
+            faMap.delete(key);
+        }
+      }
+      for await (const [name, handle] of attachDir) {
+        if (handle.kind !== 'file')
+          continue;
+        if (name.endsWith('.crswap') || name.startsWith('.'))
+          continue;
+        const file = await handle.getFile();
+        const attKey = '__att__' + moduleId + '/' + name;
+        const prevA = lastSeen.get(attKey);
+        if (prevA && file.lastModified === prevA.lastModified)
+          continue;
+        lastSeen.set(attKey, { lastModified: file.lastModified });
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
+        const blobUrl = window.URL.createObjectURL(blob);
+        if (faMap) {
+          faMap.set(name, {
+            url: blobUrl,
+            mimeType: file.type || 'application/octet-stream'
+          });
+          console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
+        }
+        const scriptId = moduleId + '/' + encodeURIComponent(name);
+        const script = document.getElementById(scriptId);
+        if (script) {
+          const b64 = btoa(String.fromCharCode.apply(null, bytes));
+          script.textContent = b64;
+          script.setAttribute('data-encoding', 'base64');
+          script.setAttribute('data-mime', file.type || 'application/octet-stream');
+        }
+      }
+    } catch (e) {
+      if (e.name !== 'NotFoundError')
+        console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
+    }
+  };
+  const scanDiskModules = async () => {
+    const diskModules = new Set();
+    try {
+      const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
+      for await (const [orgName, orgHandle] of notebookDir) {
+        if (orgHandle.kind !== 'directory')
+          continue;
+        if (orgName.startsWith('@')) {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add(orgName + '/' + fname.slice(0, -3));
+          }
+        } else if (orgName === 'd') {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add('d/' + fname.slice(0, -3));
+          }
+        }
+      }
+    } catch (e) {
+    }
+    return diskModules;
+  };
+  const poll = async () => {
+    for (const moduleId of syncableModules)
+      await pollModule(moduleId);
+    const diskModules = await scanDiskModules();
+    const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
+    if (newOnDisk.length)
+      console.log('[file-sync] new modules on disk:', newOnDisk);
+    for (const moduleId of diskModules) {
+      if (syncableSet.has(moduleId))
+        continue;
+      if (nameToModule.has(moduleId))
+        continue;
+      try {
+        const file = await readFile(directory, prefix + moduleId + '.js');
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const imported = await import(url);
+          if (typeof imported.default === 'function') {
+            const newMod = runtime.module(imported.default, () => null);
+            runtime.mains.set(moduleId, newMod);
+            nameToModule.set(moduleId, newMod);
+            syncableModules.push(moduleId);
+            syncableSet.add(moduleId);
+            const vars = new window.Map();
+            for (const v of runtime._variables) {
+              if (v._module !== newMod)
+                continue;
+              if (v._name)
+                vars.set(v._name, v);
+              if (v.pid)
+                vars.set('__pid__' + v.pid, v);
+            }
+            nameToVars.set(moduleId, vars);
+            console.log('[file-sync] added new module from disk: ' + moduleId);
+            try {
+              await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
+            } catch (e) {
+              console.error('[file-sync] manifest update for new module failed:', e);
+            }
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
+        }
+      } catch (e) {
+        console.error('[file-sync] failed to add module ' + moduleId + ':', e);
+      }
+    }
+    if (knownDiskModules) {
+      for (const moduleId of knownDiskModules) {
+        if (diskModules.has(moduleId))
+          continue;
+        if (!nameToModule.has(moduleId))
+          continue;
+        const mod = nameToModule.get(moduleId);
+        for (const v of [...runtime._variables]) {
+          if (v._module === mod)
+            v.delete();
+        }
+        runtime.mains.delete(moduleId);
+        nameToModule.delete(moduleId);
+        nameToVars.delete(moduleId);
+        knownFilePids.delete(moduleId);
+        const idx = syncableModules.indexOf(moduleId);
+        if (idx !== -1)
+          syncableModules.splice(idx, 1);
+        syncableSet.delete(moduleId);
+        console.log('[file-sync] removed module: ' + moduleId);
+        try {
+          await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+        } catch (e) {
+          console.error('[file-sync] manifest remove failed:', e);
+        }
+      }
+    }
+    knownDiskModules = diskModules;
+  };
+  pollTimer = setInterval(poll, POLL_MS);
+  poll();
+  invalidation.then(() => clearInterval(pollTimer));
+  return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
 };
 const _1b4kluo = function _21(md){return(
 md`## How It Works
@@ -12771,195 +12791,237 @@ md`## TODO
 - **Import cell validation**: verify import bridges survive round-trip correctly
 - **Conflict resolution**: when both disk and runtime edit the same cell simultaneously, detect and surface the conflict instead of last-write-wins`
 )};
-const _qq3v7b = function _jbApply(importShim) {
-    let pidSeq = 0;
-    const genPid = () => '_jb' + (pidSeq++).toString(36) + Math.floor(Math.random() * 1000000).toString(36);
-    const hasVarInput = inputs => (inputs || []).some(iv => (typeof iv === 'string' ? iv : iv && iv._name) === '@variable');
-    const importPath = defn => {
-        const m = (defn ? defn.toString() : '').match(/import\(\s*["'`]([^"'`]+)["'`]/);
-        return m ? m[1] : null;
+const _qq3v7b = function _jbApply(importShim)
+{
+  // Pure factory so any notebook can reuse it over its own runtime/fs. Build with
+  // jbApply({ currentModules, runtime, probeDefine, createModule, obj_observer }) -> applyModule(moduleId, defineFn).
+  // The file is canonical: applyModule makes the live module MATCH the file — creating/updating user
+  // cells, wiring cross-module imports, and DELETING anything live the file no longer contains.
+  //
+  // Import plumbing is NOT skipped — it is HOW a cross-module import reaches the runtime, so the agent
+  // can add imports by editing the file. exportModuleJS emits each import as a pair:
+  //   main.define("module @x", () => <child module>)                                  // loader
+  //   main.define("name", ["module @x","@variable"], (_,v)=>v.import("remote",_))      // binding
+  // The loader's original definition closes over the file's throwaway probe-runtime, so we REBUILD it
+  // against the real runtime (resolve the already-loaded child module by id, else importShim its path).
+  // The binding references only its inputs, so its definition is reused verbatim.
+  //
+  // Anonymous cells (name == null: md headers, expression/display cells) are the MAJORITY of a notebook
+  // and ARE editable — matched by pid, never skipped.
+  let pidSeq = 0;
+  const genPid = () => '_jb' + (pidSeq++).toString(36) + Math.floor(Math.random() * 1000000).toString(36);
+  const hasVarInput = inputs => (inputs || []).some(iv => (typeof iv === 'string' ? iv : iv && iv._name) === '@variable');
+  const importPath = defn => {
+    const m = (defn ? defn.toString() : '').match(/import\(\s*["'`]([^"'`]+)["'`]/);
+    return m ? m[1] : null;
+  };
+  return function makeApply({currentModules, runtime, probeDefine, createModule, obj_observer} = {}) {
+    const resolveModule = moduleId => {
+      if (currentModules)
+        for (const [, info] of currentModules)
+          if (info.name === moduleId)
+            return info.module;
+      const r = runtime;
+      if (r.mains && r.mains.has(moduleId))
+        return r.mains.get(moduleId);
+      if (typeof createModule === 'function') {
+        try {
+          return createModule(moduleId, r);
+        } catch (e) {
+          return null;
+        }
+      }
+      return null;
     };
-    return function makeApply({currentModules, runtime, probeDefine, createModule, obj_observer} = {}) {
-        const resolveModule = moduleId => {
-            if (currentModules)
-                for (const [, info] of currentModules)
-                    if (info.name === moduleId)
-                        return info.module;
-            const r = runtime;
-            if (r.mains && r.mains.has(moduleId))
-                return r.mains.get(moduleId);
-            if (typeof createModule === 'function') {
-                try {
-                    return createModule(moduleId, r);
-                } catch (e) {
-                    return null;
-                }
-            }
-            return null;
+    // Observer factory for newly-created user cells. obj_observer (from runtime-sdk) is the runtime's
+    // __ojs_observer builtin (name => observerObject); fall back to the builtin scope. Kept available for
+    // F6, but the default below stays {} — see the new-cell branch.
+    const obsFactory = (() => {
+      if (typeof obj_observer === 'function')
+        return obj_observer;
+      try {
+        const f = runtime && runtime._builtin && runtime._builtin._scope.get('__ojs_observer');
+        return f && typeof f._value === 'function' ? f._value : null;
+      } catch (e) {
+        return null;
+      }
+    })();
+    return function applyModule(moduleId, defineFn) {
+      const mod = resolveModule(moduleId);
+      if (!mod)
+        return {
+          applied: false,
+          reason: 'module not loaded and cannot create: ' + moduleId
         };
-        const obsFactory = (() => {
-            if (typeof obj_observer === 'function')
-                return obj_observer;
-            try {
-                const f = runtime && runtime._builtin && runtime._builtin._scope.get('__ojs_observer');
-                return f && typeof f._value === 'function' ? f._value : null;
-            } catch (e) {
-                return null;
+      const existingByName = new Map();
+      const existingByPid = new Map();
+      for (const v of runtime._variables) {
+        if (v._module !== mod)
+          continue;
+        if (v._name)
+          existingByName.set(v._name, v);
+        if (v.pid)
+          existingByPid.set(v.pid, v);
+      }
+      const cells = probeDefine(defineFn);
+      const seenPids = new Set();
+      const seenNames = new Set();
+      // import plumbing tracked by name (loaders/bindings carry no pid)
+      let changes = 0;
+      for (const cell of cells) {
+        // injected builtin — the runtime provides it; never (re)define
+        if (cell.name === '@variable')
+          continue;
+        // F7 (rc5): plumbing is UPSERTED, not create-only. Create-only meant a once-broken import
+        // (wrong inputs, bad path) could never be FIXED by editing the file — the corrected loader/
+        // binding was skipped with "0 cells changed" and the module stayed wedged (observed: an agent
+        // wrote a binding missing "@variable", then spiralled for 35 steps because its fix never
+        // applied). Loaders carry a semantic _jbKey ('live:'/'path:' + target) because their installed
+        // definition is locally rebuilt (toString comparison is meaningless); loaders from the module's
+        // ORIGINAL define (no _jbKey) are left untouched to avoid recompute churn. Bindings compare
+        // inputs + definition like ordinary cells (their definitions are closure-safe file text).
+        const upsertLoader = (loaderName, defn) => {
+          seenNames.add(loaderName);
+          const spec = loaderName.slice('module '.length);
+          const child = resolveModule(spec);
+          const path = importPath(defn);
+          const key = child ? 'live:' + spec : path ? 'path:' + path : null;
+          if (key == null)
+            return;
+          const make = child ? () => child : async () => runtime.module((await import(path)).default);
+          const existing = existingByName.get(loaderName);
+          if (existing) {
+            if (existing._jbKey !== undefined && existing._jbKey !== key) {
+              existing.define(loaderName, [], make);
+              existing._jbKey = key;
+              changes++;
             }
-        })();
-        return function applyModule(moduleId, defineFn) {
-            const mod = resolveModule(moduleId);
-            if (!mod)
-                return {
-                    applied: false,
-                    reason: 'module not loaded and cannot create: ' + moduleId
-                };
-            const existingByName = new Map();
-            const existingByPid = new Map();
-            for (const v of runtime._variables) {
-                if (v._module !== mod)
-                    continue;
-                if (v._name)
-                    existingByName.set(v._name, v);
-                if (v.pid)
-                    existingByPid.set(v.pid, v);
-            }
-            const cells = probeDefine(defineFn);
-            const seenPids = new Set();
-            const seenNames = new Set();
-            let changes = 0;
-            for (const cell of cells) {
-                if (cell.name === '@variable')
-                    continue;
-                const upsertLoader = (loaderName, defn) => {
-                    seenNames.add(loaderName);
-                    const spec = loaderName.slice('module '.length);
-                    const child = resolveModule(spec);
-                    const path = importPath(defn);
-                    const key = child ? 'live:' + spec : path ? 'path:' + path : null;
-                    if (key == null)
-                        return;
-                    const make = child ? () => child : async () => runtime.module((await import(path)).default);
-                    const existing = existingByName.get(loaderName);
-                    if (existing) {
-                        if (existing._jbKey !== undefined && existing._jbKey !== key) {
-                            existing.define(loaderName, [], make);
-                            existing._jbKey = key;
-                            changes++;
-                        }
-                        return;
-                    }
-                    const v = mod.variable(null);
-                    v.define(loaderName, [], make);
-                    v._jbKey = key;
-                    existingByName.set(loaderName, v);
-                    changes++;
-                };
-                const upsertBinding = (name, inputs, defn) => {
-                    seenNames.add(name);
-                    const existing = existingByName.get(name);
-                    if (!existing) {
-                        const v = mod.variable(null);
-                        v.define(name, inputs, defn);
-                        existingByName.set(name, v);
-                        changes++;
-                        return;
-                    }
-                    const existingInputNames = (existing._inputs || []).map(iv => typeof iv === 'string' ? iv : iv._name);
-                    const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(inputs);
-                    const defnMatch = existing._definition && existing._definition.toString() === (defn ? defn.toString() : '');
-                    if (!(inputsMatch && defnMatch)) {
-                        existing.define(name, inputs, defn);
-                        changes++;
-                    }
-                };
-                if (cell.type === 'import') {
-                    const spec = cell.from;
-                    const child = spec && resolveModule(spec);
-                    if (!child)
-                        continue;
-                    const loaderName = 'module ' + spec;
-                    seenNames.add(loaderName);
-                    if (!existingByName.has(loaderName)) {
-                        const lv = mod.variable(null);
-                        lv.define(loaderName, [], () => child);
-                        lv._jbKey = 'live:' + spec;
-                        existingByName.set(loaderName, lv);
-                        changes++;
-                    }
-                    const alias = cell.alias || cell.remote;
-                    upsertBinding(alias, [
-                        loaderName,
-                        '@variable'
-                    ], (_, vv) => vv.import(cell.remote, _));
-                    continue;
-                }
-                if (cell.name && cell.name.startsWith('module ')) {
-                    upsertLoader(cell.name, cell.definition);
-                    continue;
-                }
-                if (hasVarInput(cell.inputs)) {
-                    if (cell.name)
-                        upsertBinding(cell.name, cell.inputs, cell.definition);
-                    continue;
-                }
-                let pid = cell.pid;
-                if (!pid) {
-                    const byName = cell.name && existingByName.get(cell.name);
-                    pid = byName && byName.pid || genPid();
-                }
-                seenPids.add(pid);
-                if (cell.name)
-                    seenNames.add(cell.name);
-                const existing = existingByPid.get(pid) || cell.name && existingByName.get(cell.name);
-                if (!existing) {
-                    const v = mod.variable({});
-                    v.define(cell.name, cell.inputs, cell.definition);
-                    v.pid = pid;
-                    existingByPid.set(pid, v);
-                    if (cell.name)
-                        existingByName.set(cell.name, v);
-                    changes++;
-                    continue;
-                }
-                const existingInputNames = (existing._inputs || []).map(iv => typeof iv === 'string' ? iv : iv._name);
-                const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                const defnMatch = existing._definition && existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                if (inputsMatch && defnMatch) {
-                    if (!existing.pid)
-                        existing.pid = pid;
-                    continue;
-                }
-                existing.define(cell.name, cell.inputs, cell.definition).pid = pid;
-                changes++;
-            }
-            for (const v of [...runtime._variables]) {
-                if (v._module !== mod)
-                    continue;
-                const name = v._name;
-                if (name === '@variable')
-                    continue;
-                if (name && seenNames.has(name))
-                    continue;
-                if (name && name.startsWith('module ') || hasVarInput(v._inputs)) {
-                    if (name) {
-                        v.delete();
-                        changes++;
-                    }
-                    continue;
-                }
-                if (!v.pid || seenPids.has(v.pid))
-                    continue;
-                v.delete();
-                changes++;
-            }
-            return {
-                applied: true,
-                moduleId,
-                changes
-            };
+            return;
+          }
+          const v = mod.variable(null);
+          v.define(loaderName, [], make);
+          v._jbKey = key;
+          existingByName.set(loaderName, v);
+          changes++;
         };
+        const upsertBinding = (name, inputs, defn) => {
+          seenNames.add(name);
+          const existing = existingByName.get(name);
+          if (!existing) {
+            const v = mod.variable(null);
+            v.define(name, inputs, defn);
+            existingByName.set(name, v);
+            changes++;
+            return;
+          }
+          const existingInputNames = (existing._inputs || []).map(iv => typeof iv === 'string' ? iv : iv._name);
+          const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(inputs);
+          const defnMatch = existing._definition && existing._definition.toString() === (defn ? defn.toString() : '');
+          if (!(inputsMatch && defnMatch)) {
+            existing.define(name, inputs, defn);
+            changes++;
+          }
+        };
+        // explicit module.variable().import(remote, alias, from) form
+        if (cell.type === 'import') {
+          const spec = cell.from;
+          const child = spec && resolveModule(spec);
+          if (!child)
+            continue;
+          const loaderName = 'module ' + spec;
+          seenNames.add(loaderName);
+          if (!existingByName.has(loaderName)) {
+            const lv = mod.variable(null);
+            lv.define(loaderName, [], () => child);
+            lv._jbKey = 'live:' + spec;
+            existingByName.set(loaderName, lv);
+            changes++;
+          }
+          const alias = cell.alias || cell.remote;
+          upsertBinding(alias, [
+            loaderName,
+            '@variable'
+          ], (_, vv) => vv.import(cell.remote, _));
+          continue;
+        }
+        // import-loader plumbing: "module @x" — rebuild against the REAL runtime
+        if (cell.name && cell.name.startsWith('module ')) {
+          upsertLoader(cell.name, cell.definition);
+          continue;
+        }
+        // import-binding: inputs include "@variable" — definition is closure-safe, reuse verbatim
+        if (hasVarInput(cell.inputs)) {
+          if (cell.name)
+            upsertBinding(cell.name, cell.inputs, cell.definition);
+          continue;
+        }
+        // ordinary user cell — match by pid; mint one for pid-less hand-written cells so re-applies dedupe
+        let pid = cell.pid;
+        if (!pid) {
+          const byName = cell.name && existingByName.get(cell.name);
+          pid = byName && byName.pid || genPid();
+        }
+        seenPids.add(pid);
+        if (cell.name)
+          seenNames.add(cell.name);
+        const existing = existingByPid.get(pid) || cell.name && existingByName.get(cell.name);
+        if (!existing) {
+          // Empty observer ({}) so a pane's visualizer can render the cell; mod.variable(null)
+          // (unobserved) lets the apply-time probe own it → element parented outside any pane → blank.
+          const v = mod.variable({});
+          v.define(cell.name, cell.inputs, cell.definition);
+          v.pid = pid;
+          existingByPid.set(pid, v);
+          if (cell.name)
+            existingByName.set(cell.name, v);
+          changes++;
+          continue;
+        }
+        const existingInputNames = (existing._inputs || []).map(iv => typeof iv === 'string' ? iv : iv._name);
+        const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+        const defnMatch = existing._definition && existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+        if (inputsMatch && defnMatch) {
+          if (!existing.pid)
+            existing.pid = pid;
+          continue;
+        }
+        existing.define(cell.name, cell.inputs, cell.definition).pid = pid;
+        changes++;
+      }
+      // F4: prune anything the file no longer contains — reload-proof, no cross-call state.
+      //   user cells   → pid-bearing vars not seen this apply
+      //   import plumbing → "module @x" loaders / "@variable"-wired bindings whose name not seen
+      for (const v of [...runtime._variables]) {
+        if (v._module !== mod)
+          continue;
+        const name = v._name;
+        if (name === '@variable')
+          continue;
+        if (name && seenNames.has(name))
+          continue;
+        // present in file (user cell or import binding/loader) → keep, even if it acquired a pid via persistentId
+        // removed import plumbing ("module @x" loader, or a "@variable"-wired binding)
+        if (name && name.startsWith('module ') || hasVarInput(v._inputs)) {
+          if (name) {
+            v.delete();
+            changes++;
+          }
+          continue;
+        }
+        if (!v.pid || seenPids.has(v.pid))
+          continue;
+        // keep pid-less and still-present user cells
+        v.delete();
+        // orphaned user cell (removed / renamed)
+        changes++;
+      }
+      return {
+        applied: true,
+        moduleId,
+        changes
+      };
     };
+  };
 };
 
 export default function define(runtime, observer) {
@@ -13491,20 +13553,20 @@ const _1aloau2 = (G, _) => G.input(_);
 const _7s1qq7 = function _6($0,sqrt){return(
 $0.resolve(Math.sqrt(sqrt))
 )};
-const _3iwba4 = async function _testing(flowQueue) {
-    flowQueue;
-    const [{Runtime}, {default: define}] = await Promise.all([
-        import('https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js'),
-        import(`https://api.observablehq.com/@tomlarkworthy/testing.js?v=3`)
-    ]);
-    const module = new Runtime().module(define);
-    return Object.fromEntries(await Promise.all([
-        'expect',
-        'createSuite'
-    ].map(n => module.value(n).then(v => [
-        n,
-        v
-    ]))));
+const _3iwba4 = async function _testing(flowQueue)
+{
+  flowQueue;
+  // load after implementation
+  const [{ Runtime }, { default: define }] = await Promise.all([
+    import("https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js"),
+    import(`https://api.observablehq.com/@tomlarkworthy/testing.js?v=3`)
+  ]);
+  const module = new Runtime().module(define);
+  return Object.fromEntries(
+    await Promise.all(
+      ["expect", "createSuite"].map((n) => module.value(n).then((v) => [n, v]))
+    )
+  );
 };
 const _j8s3j1 = function _suite(testing){return(
 testing.createSuite({ name: 'Unit Tests' })
@@ -14146,14 +14208,18 @@ FileAttachment("lm_popin_black.png").url()
 const _18kpe1x = function _lm_popout_black(FileAttachment){return(
 FileAttachment("lm_popout_black.png").url()
 )};
-const _1p7i538 = async function _gl(unzip, FileAttachment) {
-    const blob = await unzip(FileAttachment('golden-layout-2.6.0.js.gz'));
-    const objectURL = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
-    try {
-        return await import(objectURL);
-    } finally {
-        URL.revokeObjectURL(objectURL);
-    }
+const _1p7i538 = async function _gl(unzip,FileAttachment)
+{
+  const blob = await unzip(FileAttachment("golden-layout-2.6.0.js.gz"));
+
+  const objectURL = URL.createObjectURL(
+    new Blob([blob], { type: "application/javascript" })
+  );
+  try {
+    return await import(objectURL);
+  } finally {
+    URL.revokeObjectURL(objectURL); // Ensure URL is revoked after import
+  }
 };
 const _17n6uge = function _unzip(Response,DecompressionStream){return(
 async (attachment) =>
@@ -14551,23 +14617,35 @@ import {git, http} from "@tomlarkworthy/isomorphic-git-1-30-1"
 import {FS} from "@tomlarkworthy/lightning-fs-4-6-0"
 ~~~`
 )};
-const _vz8us1 = async function _git(unzip, FileAttachment) {
-    const blob = await unzip(FileAttachment('isomorphic-git-1@1.30.1.bundle.js.gz'));
-    const objectURL = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
-    try {
-        return await import(objectURL);
-    } finally {
-        URL.revokeObjectURL(objectURL);
-    }
+const _vz8us1 = async function _git(unzip,FileAttachment)
+{
+  const blob = await unzip(
+    FileAttachment("isomorphic-git-1@1.30.1.bundle.js.gz")
+  );
+
+  const objectURL = URL.createObjectURL(
+    new Blob([blob], { type: "application/javascript" })
+  );
+  try {
+    return await import(objectURL);
+  } finally {
+    URL.revokeObjectURL(objectURL);
+  }
 };
-const _2acekr = async function _http(unzip, FileAttachment) {
-    const blob = await unzip(FileAttachment('isomorphic-git-http-1.0.0-beta.36.js.gz'));
-    const objectURL = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
-    try {
-        return await import(objectURL);
-    } finally {
-        URL.revokeObjectURL(objectURL);
-    }
+const _2acekr = async function _http(unzip,FileAttachment)
+{
+  const blob = await unzip(
+    FileAttachment("isomorphic-git-http-1.0.0-beta.36.js.gz")
+  );
+
+  const objectURL = URL.createObjectURL(
+    new Blob([blob], { type: "application/javascript" })
+  );
+  try {
+    return await import(objectURL);
+  } finally {
+    URL.revokeObjectURL(objectURL);
+  }
 };
 const _1emihnv = function _4(md){return(
 md`
@@ -14641,15 +14719,21 @@ md`# jest-expect-standalone@24.0.2
 import {expect} from "@tomlarkworthy/jest-expect-standalone"
 ~~~`
 )};
-const _mh1f13 = async function _expect(unzip, FileAttachment) {
-    const blob = await unzip(FileAttachment('jest-expect-standalone-24.0.2.js.gz'));
-    const objectURL = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
-    try {
-        await import(objectURL);
-        return window.expect;
-    } finally {
-        URL.revokeObjectURL(objectURL);
-    }
+const _mh1f13 = async function _expect(unzip,FileAttachment)
+{
+  const blob = await unzip(
+    FileAttachment("jest-expect-standalone-24.0.2.js.gz")
+  );
+
+  const objectURL = URL.createObjectURL(
+    new Blob([blob], { type: "application/javascript" })
+  );
+  try {
+    await import(objectURL);
+    return window.expect;
+  } finally {
+    URL.revokeObjectURL(objectURL);
+  }
 };
 const _17n6uge = function _unzip(Response,DecompressionStream){return(
 async (attachment) =>
@@ -14694,14 +14778,18 @@ md`# [jszip@3.10.1](https://stuk.github.io/jszip/)
 import {JSZip} from "@tomlarkworthy/jszip-3-10-1"
 ~~~`
 )};
-const _umavbe = async function _JSZip(unzip, FileAttachment) {
-    const blob = await unzip(FileAttachment('jszip-3.10.1.min.js.gz'));
-    const objectURL = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
-    try {
-        return (await import(objectURL)).default;
-    } finally {
-        URL.revokeObjectURL(objectURL);
-    }
+const _umavbe = async function _JSZip(unzip,FileAttachment)
+{
+  const blob = await unzip(FileAttachment("jszip-3.10.1.min.js.gz"));
+
+  const objectURL = URL.createObjectURL(
+    new Blob([blob], { type: "application/javascript" })
+  );
+  try {
+    return (await import(objectURL)).default;
+  } finally {
+    URL.revokeObjectURL(objectURL); // Ensure URL is revoked after import
+  }
 };
 const _g5fwfs = function _unzip(Response,DecompressionStream){return(
 async (attachment) => {
@@ -14753,14 +14841,18 @@ import {FS} from "@tomlarkworthy/lightning-fs-4-6-0"
 import {git, http} from "@tomlarkworthy/isomorphic-git-1-30-1" 
 ~~~`
 )};
-const _1tds3ro = async function _FS(unzip, FileAttachment) {
-    const blob = await unzip(FileAttachment('lightning-fs-4.6.0.js.gz'));
-    const objectURL = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
-    try {
-        return (await import(objectURL)).default;
-    } finally {
-        URL.revokeObjectURL(objectURL);
-    }
+const _1tds3ro = async function _FS(unzip,FileAttachment)
+{
+  const blob = await unzip(FileAttachment("lightning-fs-4.6.0.js.gz"));
+
+  const objectURL = URL.createObjectURL(
+    new Blob([blob], { type: "application/javascript" })
+  );
+  try {
+    return (await import(objectURL)).default;
+  } finally {
+    URL.revokeObjectURL(objectURL);
+  }
 };
 const _dqri64 = function _3(md){return(
 md`
@@ -18690,182 +18782,205 @@ It's an effecient alternative to [moduleMap](https://observablehq.com/@tomlarkwo
 const _1eaa9lr = function _currentModules(modules){return(
 modules()
 )};
-const _dmem61 = function _modules(runtime, observeVariable, moduleTitle) {
-    const _runtime = runtime;
-    return function modules({runtime = _runtime, titleTimeoutMs = 2000, rescanMs = 1000, load = true} = {}) {
-        if (!runtime || !runtime._variables)
-            throw 'Invalid runtime passed to modules';
-        return async function* () {
-            const records = new Map();
-            const watchers = new Map();
-            const peeking = new Map();
-            let pending = false, wake = null, dirty = true;
-            const bump = () => {
-                pending = true;
-                if (wake) {
-                    const w = wake;
-                    wake = null;
-                    w();
-                }
-            };
-            const touch = () => {
-                dirty = true;
-                bump();
-            };
-            const slugFromDef = v => {
-                const m = v._definition && String(v._definition).match(/import(?:Shim)?\(\s*["'`]\/?([^"'`?]+?)\.js(?:[?"'`)]|$)/);
-                return m ? m[1].replace(/^\//, '') : null;
-            };
-            const scan = () => {
-                const out = new Map();
-                const put = (m, r) => {
-                    if (m && !out.has(m))
-                        out.set(m, r);
-                };
-                const builtin = runtime._builtin, bootloader = runtime.bootloader;
-                if (builtin)
-                    put(builtin, {
-                        name: 'builtin',
-                        title: 'Standard library'
-                    });
-                if (bootloader)
-                    put(bootloader, {
-                        name: 'bootloader',
-                        title: 'Bootloader'
-                    });
-                for (const [name, mod] of runtime.mains || new Map())
-                    put(mod, { name });
-                const imported = new Set((runtime._modules || new Map()).values());
-                const owners = new Set();
-                for (const v of runtime._variables)
-                    if (v._module)
-                        owners.add(v._module);
-                for (const m of owners)
-                    if (m !== builtin && m !== bootloader && !imported.has(m))
-                        put(m, { name: 'main' });
-                for (const v of runtime._variables) {
-                    if (!v._name || !v._name.startsWith('module ') || v._name.startsWith('module <unknown'))
-                        continue;
-                    const mod = v._value;
-                    if (mod && typeof mod === 'object')
-                        put(mod, {
-                            name: slugFromDef(v) || v._name.slice(7),
-                            variable: v
-                        });
-                    else if (load && !peeking.has(v))
-                        peeking.set(v, observeVariable(v, {
-                            fulfilled: bump,
-                            error: bump
-                        }));
-                }
-                return out;
-            };
-            const reconcile = () => {
-                const cand = scan();
-                for (const m of [...watchers.keys()]) {
-                    if (!cand.has(m)) {
-                        const cancel = watchers.get(m);
-                        watchers.delete(m);
-                        if (records.delete(m))
-                            touch();
-                        try {
-                            cancel();
-                        } catch (e) {
-                        }
-                    }
-                }
-                for (const [m, c] of cand) {
-                    if (watchers.has(m))
-                        continue;
-                    if (c.title != null) {
-                        records.set(m, {
-                            name: c.name,
-                            title: c.title,
-                            module: m,
-                            variable: c.variable
-                        });
-                        watchers.set(m, () => {
-                        });
-                        touch();
-                        continue;
-                    }
-                    const apply = title => {
-                        if (!watchers.has(m))
-                            return;
-                        const t = title ?? c.name;
-                        const prev = records.get(m);
-                        if (!prev) {
-                            records.set(m, {
-                                name: c.name,
-                                title: t,
-                                module: m,
-                                variable: c.variable
-                            });
-                            touch();
-                        } else if (prev.title !== t) {
-                            records.set(m, {
-                                ...prev,
-                                title: t
-                            });
-                            touch();
-                        }
-                    };
-                    const cancel = moduleTitle(m, apply);
-                    watchers.set(m, () => {
-                        try {
-                            cancel();
-                        } catch (e) {
-                        }
-                    });
-                    setTimeout(() => {
-                        if (watchers.has(m) && !records.has(m))
-                            apply(null);
-                    }, titleTimeoutMs);
-                }
-            };
-            let stopped = false;
-            (async () => {
-                while (!stopped) {
-                    try {
-                        reconcile();
-                    } catch (e) {
-                    }
-                    await new Promise(r => setTimeout(r, rescanMs));
-                }
-            })();
+const _dmem61 = function _modules(runtime,observeVariable,moduleTitle)
+{
+  const _runtime = runtime;
+  // default: the current runtime
+  return function modules({runtime = _runtime, titleTimeoutMs = 2000, rescanMs = 1000, load = true} = {}) {
+    if (!runtime || !runtime._variables)
+      throw 'Invalid runtime passed to modules';
+    return async function* () {
+      const records = new Map();
+      // module -> fully-formed record (title resolved before it lands here)
+      const watchers = new Map();
+      // module -> cancel fn (stops its title watch)
+      const peeking = new Map();
+      // unresolved `module X` variable -> stop fn (its force-load observer)
+      let pending = false, wake = null, dirty = true;
+      const bump = () => {
+        pending = true;
+        if (wake) {
+          const w = wake;
+          wake = null;
+          w();
+        }
+      };
+      const touch = () => {
+        dirty = true;
+        bump();
+      };
+      // Recover a module's @user/slug from its loader definition. On Observable's runtime the
+      // `module X` variable is named numerically ("module 1"), so v._name.slice(7) is a useless id;
+      // the real slug lives in the loader's import URL — import("/@user/slug.js?…") or
+      // importShim("/@user/slug.js", …). Matches both runtimes; null if no URL is found.
+      const slugFromDef = v => {
+        const m = v._definition && String(v._definition).match(/import(?:Shim)?\(\s*["'`]\/?([^"'`?]+?)\.js(?:[?"'`)]|$)/);
+        return m ? m[1].replace(/^\//, '') : null;
+      };
+      // Live candidate modules: Map<module, {name, variable?, title?}>. Side effect: force-loads
+      // unresolved `module X` variables via observe (which marks them reachable) so their modules
+      // become resolvable on a later scan.
+      const scan = () => {
+        const out = new Map();
+        const put = (m, r) => {
+          if (m && !out.has(m))
+            out.set(m, r);
+        };
+        const builtin = runtime._builtin, bootloader = runtime.bootloader;
+        if (builtin)
+          put(builtin, {
+            name: 'builtin',
+            title: 'Standard library'
+          });
+        if (bootloader)
+          put(bootloader, {
+            name: 'bootloader',
+            title: 'Bootloader'
+          });
+        for (const [name, mod] of runtime.mains || new Map())
+          put(mod, { name });
+        // main modules: variable-graph roots — own variables but aren't imported (nor builtin/
+        // bootloader). Catches the top-level main of a plain runtime where runtime.mains is empty.
+        const imported = new Set((runtime._modules || new Map()).values());
+        const owners = new Set();
+        for (const v of runtime._variables)
+          if (v._module)
+            owners.add(v._module);
+        for (const m of owners)
+          if (m !== builtin && m !== bootloader && !imported.has(m))
+            put(m, { name: 'main' });
+        // imported modules carried by `module X` variables
+        for (const v of runtime._variables) {
+          if (!v._name || !v._name.startsWith('module ') || v._name.startsWith('module <unknown'))
+            continue;
+          const mod = v._value;
+          if (mod && typeof mod === 'object')
+            put(mod, {
+              name: slugFromDef(v) || v._name.slice(7),
+              variable: v
+            });
+          else if (load && !peeking.has(v))
+            peeking.set(v, observeVariable(v, {
+              fulfilled: bump,
+              error: bump
+            }));
+        }
+        return out;
+      };
+      // Reconcile the snapshot with the live runtime each scan.
+      const reconcile = () => {
+        const cand = scan();
+        // DELETE: drop modules no longer present; cancel their title watcher.
+        for (const m of [...watchers.keys()]) {
+          if (!cand.has(m)) {
+            const cancel = watchers.get(m);
+            watchers.delete(m);
+            if (records.delete(m))
+              touch();
             try {
-                while (true) {
-                    pending = false;
-                    if (dirty) {
-                        dirty = false;
-                        yield new Map(records);
-                    }
-                    if (!pending)
-                        await new Promise(resolve => {
-                            wake = resolve;
-                            if (pending) {
-                                wake = null;
-                                resolve();
-                            }
-                        });
-                }
-            } finally {
-                stopped = true;
-                for (const cancel of watchers.values()) {
-                    try {
-                        cancel();
-                    } catch (e) {
-                    }
-                }
-                for (const stop of peeking.values()) {
-                    try {
-                        stop();
-                    } catch (e) {
-                    }
-                }
+              cancel();
+            } catch (e) {
             }
-        }();
-    };
+          }
+        }
+        // CREATE: start a persistent title watch for each new module. The module enters `records`
+        // only once its title resolves (or the timeout fires). Later title changes update in place.
+        for (const [m, c] of cand) {
+          if (watchers.has(m))
+            continue;
+          if (c.title != null) {
+            // static title (builtin / bootloader)
+            records.set(m, {
+              name: c.name,
+              title: c.title,
+              module: m,
+              variable: c.variable
+            });
+            watchers.set(m, () => {
+            });
+            touch();
+            continue;
+          }
+          const apply = title => {
+            if (!watchers.has(m))
+              return;
+            // module was pruned -> ignore late title callbacks
+            const t = title ?? c.name;
+            const prev = records.get(m);
+            if (!prev) {
+              records.set(m, {
+                name: c.name,
+                title: t,
+                module: m,
+                variable: c.variable
+              });
+              touch();
+            } else if (prev.title !== t) {
+              records.set(m, {
+                ...prev,
+                title: t
+              });
+              touch();
+            }
+          };
+          const cancel = moduleTitle(m, apply);
+          watchers.set(m, () => {
+            try {
+              cancel();
+            } catch (e) {
+            }
+          });
+          // title never resolved within the budget -> show the name so the module isn't withheld.
+          setTimeout(() => {
+            if (watchers.has(m) && !records.has(m))
+              apply(null);
+          }, titleTimeoutMs);
+        }
+      };
+      let stopped = false;
+      (async () => {
+        while (!stopped) {
+          try {
+            reconcile();
+          } catch (e) {
+          }
+          await new Promise(r => setTimeout(r, rescanMs));
+        }
+      })();
+      try {
+        while (true) {
+          pending = false;
+          if (dirty) {
+            dirty = false;
+            yield new Map(records);
+          }
+          // cumulative snapshot
+          if (!pending)
+            await new Promise(resolve => {
+              wake = resolve;
+              if (pending) {
+                wake = null;
+                resolve();
+              }
+            });
+        }
+      } finally {
+        stopped = true;
+        for (const cancel of watchers.values()) {
+          try {
+            cancel();
+          } catch (e) {
+          }
+        }
+        for (const stop of peeking.values()) {
+          try {
+            stop();
+          } catch (e) {
+          }
+        }
+      }
+    }();
+  };
 };
 const _up9atj = function _moduleTitle(observeVariable)
 {
@@ -19116,14 +19231,18 @@ observable.Library
 const _1iyzb44 = function _RuntimeError(observable){return(
 observable.RuntimeError
 )};
-const _b2ba5g = async function _observable(unzip, FileAttachment) {
-    const blob = await unzip(FileAttachment('runtime.js.gz'));
-    const objectURL = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
-    try {
-        return await import(objectURL);
-    } finally {
-        URL.revokeObjectURL(objectURL);
-    }
+const _b2ba5g = async function _observable(unzip,FileAttachment)
+{
+  const blob = await unzip(FileAttachment("runtime.js.gz"));
+
+  const objectURL = URL.createObjectURL(
+    new Blob([blob], { type: "application/javascript" })
+  );
+  try {
+    return await import(objectURL);
+  } finally {
+    URL.revokeObjectURL(objectURL);
+  }
 };
 const _17n6uge = function _unzip(Response,DecompressionStream){return(
 async (attachment) =>
@@ -19174,10 +19293,13 @@ runtime.Runtime
 const _bfntg8 = function _RuntimeError(runtime){return(
 runtime.RuntimeError
 )};
-const _axblun = async function _runtime(gunzipBase64ToBlob, source_gz) {
-    const blob = await gunzipBase64ToBlob(source_gz);
-    const url = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
-    return import(url);
+const _axblun = async function _runtime(gunzipBase64ToBlob,source_gz)
+{
+  const blob = await gunzipBase64ToBlob(source_gz);
+  const url = URL.createObjectURL(
+    new Blob([blob], { type: "application/javascript" })
+  );
+  return import(url);
 };
 const _1ljam5l = function _gunzipBase64ToBlob(DecompressionStream,Response){return(
 async (b64) => {
@@ -19277,7 +19399,8 @@ Then re-attach the resulting \`.js.gz\` files to this notebook
 (notebook menu → Attachments → drag-and-drop, replacing the existing
 attachments of the same name).`
 )};
-const _3cxbvl = async function _lr(unzip, FileAttachment) {
+const _3cxbvl = async function _lr(unzip,FileAttachment)
+{
     const blob = await unzip(FileAttachment('lezer-lr-bundled.js.gz'));
     const objectURL = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
     try {
@@ -19286,7 +19409,8 @@ const _3cxbvl = async function _lr(unzip, FileAttachment) {
         URL.revokeObjectURL(objectURL);
     }
 };
-const _1v8kgvh = async function _lezerhighlight(unzip, FileAttachment) {
+const _1v8kgvh = async function _lezerhighlight(unzip,FileAttachment)
+{
     const blob = await unzip(FileAttachment('lezer-highlight-bundled.js.gz'));
     const objectURL = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
     try {
@@ -20294,9 +20418,9 @@ notebook_semantics_document.nodes.map((s) => ({
 const _1oevsow = function _28(md){return(
 md`### Runtime Representation (v4)`
 )};
-const _11lfflk = function _notebook_semantics_module() {
-    return import('https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4');
-};
+const _11lfflk = function _notebook_semantics_module(){return(
+import("https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4")
+)};
 const _gjten6 = function _31(md){return(
 md`### Imports`
 )};
@@ -21027,20 +21151,8 @@ const _1sl510 = async function _test_decompile_import_viewof_data_alias(decompil
 const _17dwb6r = function _80(md){return(
 md`### The Decompiler`
 )};
-const _1vs6mei = function _82(md){return(
+const _1ngipml = function _81(md){return(
 md`### \`decompile\``
-)};
-const _1g89k6a = function _escodegenOptions(escodegen){return(
-{
-  comment: true,
-  format: {
-    ...escodegen.FORMAT_DEFAULTS,
-    indent: {
-      ...escodegen.FORMAT_DEFAULTS.indent,
-      style: "  "
-    }
-  }
-}
 )};
 const _2d5g1 = function _decompile(decompileImport,formatImportDeclaration,acorn){return(
 async function decompile(variables) {
@@ -21215,7 +21327,7 @@ async function decompile(variables) {
     return source;
   }
 )};
-const _1pvis67 = function _85(md){return(
+const _1x0pvrl = function _83(md){return(
 md`### \`extractModuleInfo\` 
 static analysis of module imports`
 )};
@@ -21306,7 +21418,7 @@ const _iigmyv = function _test_extractModuleInfo_alias_hack(expect,extractModule
   });
   return "ok";
 };
-const _1tggbee = function _92(md){return(
+const _7t42k8 = function _90(md){return(
 md`### \`findModuleName\` and \`findImportedName\``
 )};
 const _kiaw33 = function _import_ast_example(parser){return(
@@ -21314,44 +21426,65 @@ parser.parseCell(
   'import {runtime, viewof main as foo} from "@mootari/access-runtime"'
 )
 )};
-const _1n7gw17 = function _findModuleName(extractModuleInfo) {
-    return (scope, module, {
-        unknown_id = Math.random()
-    } = {}) => {
-        try {
-            const scopedVariables = [...scope.values()];
-            const candidates = scopedVariables.filter(v => v && v._value === module && typeof v._name === 'string' && v._name.startsWith('module ') && !v._name.startsWith('module <unknown'));
-            const pickBestInfo = dfn => {
-                const s = String(dfn ?? '');
-                const m = s.match(/\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/);
-                const firstArg = m?.[2];
-                const info1 = firstArg ? extractModuleInfo(firstArg) : {};
-                if (info1?.id || info1?.notebook)
-                    return info1;
-                return extractModuleInfo(s);
-            };
-            for (const v of candidates) {
-                const info = pickBestInfo(v._definition?.toString?.());
-                if (info?.namespace)
-                    return `@${ info.namespace }/${ info.notebook }`;
-                if (info?.id)
-                    return `d/${ info.id }@${ info.version }`;
-            }
-            const any = scopedVariables.find(v => v && v._value === module);
-            if (any) {
-                const info = pickBestInfo(any._definition?.toString?.());
-                if (info?.namespace)
-                    return `@${ info.namespace }/${ info.notebook }`;
-                if (info?.id)
-                    return `d/${ info.id }@${ info.version }`;
-            }
-            return `<unknown ${ unknown_id }>`;
-        } catch (e) {
-            debugger;
-            return 'error';
-        }
+const _1n7gw17 = function _findModuleName(extractModuleInfo){return(
+(scope, module, { unknown_id = Math.random() } = {}) => {
+  try {
+    const scopedVariables = [...scope.values()];
+
+    // Prefer variables that *define* a module and have a real module-loader name.
+    const candidates = scopedVariables.filter(
+      (v) =>
+        v &&
+        v._value === module &&
+        typeof v._name === "string" &&
+        v._name.startsWith("module ") &&
+        !v._name.startsWith("module <unknown")
+    );
+
+    const pickBestInfo = (dfn) => {
+      // Avoid the parentUrl (2nd arg) confusing module identification.
+      // Typical patterns:
+      //   importShim("/d/<id>@<ver>.js?v=4", "https://api.observablehq.com/@ns/name.js?v=4")
+      //   import("/d/<id>@<ver>.js?v=4")
+      // Prefer the *first argument* inside importShim(...) / import(...) when present.
+      const s = String(dfn ?? "");
+
+      // Try to capture the first string literal argument to importShim(...) or import(...)
+      // Tolerates quotes ", ', ` and both importShim and plain import.
+      const m = s.match(
+        /\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/
+      );
+      const firstArg = m?.[2];
+
+      const info1 = firstArg ? extractModuleInfo(firstArg) : {};
+      if (info1?.id || info1?.notebook) return info1;
+
+      // Fallback: parse the whole definition string.
+      return extractModuleInfo(s);
     };
-};
+
+    // Try module loader cells first.
+    for (const v of candidates) {
+      const info = pickBestInfo(v._definition?.toString?.());
+      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
+      if (info?.id) return `d/${info.id}@${info.version}`;
+    }
+
+    // Fallback: any scoped variable with _value==module.
+    const any = scopedVariables.find((v) => v && v._value === module);
+    if (any) {
+      const info = pickBestInfo(any._definition?.toString?.());
+      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
+      if (info?.id) return `d/${info.id}@${info.version}`;
+    }
+
+    return `<unknown ${unknown_id}>`;
+  } catch (e) {
+    debugger;
+    return "error";
+  }
+}
+)};
 const _i47chb = function _findImportedName(){return(
 async (v) => {
   if (v._inputs.length == 1 && v._inputs[0]._name === "@variable") {
@@ -21372,10 +21505,10 @@ async (v) => {
   return v._name;
 }
 )};
-const _1effqg = function _96(md){return(
+const _ed3cy2 = function _94(md){return(
 md`### \`decompileImport\``
 )};
-const _b7vai6 = function _decompileImport(findModuleName,findImportedName)
+const _1a4j4gm = function _decompileImport(findModuleName,findImportedName)
 {
   return async function decompileImport(variables, options = {}) {
     if (!variables || variables.length === 0)
@@ -21414,7 +21547,7 @@ const _b7vai6 = function _decompileImport(findModuleName,findImportedName)
       if (!Array.isArray(inputs) || inputs.length !== 2)
         return false;
       const [i0, i1] = inputs;
-      return !!(i0 && typeof i0 === 'object' && typeof i0._name === 'string' && i0._name.startsWith('module @') && i1 && typeof i1 === 'object' && i1._name === '@variable');
+      return !!(i0 && typeof i0 === 'object' && typeof i0._name === 'string' && i0._name.startsWith('module ') && i1 && typeof i1 === 'object' && i1._name === '@variable');
     };
     const isStageC = v => {
       const inputs = v?._inputs;
@@ -21547,32 +21680,8 @@ const _1u6sfri = async function _test_decompileImport_alias(importFake,decompile
 
   return "ok";
 };
-const _1lqhutp = function _102(md){return(
+const _1lti0tv = function _100(md){return(
 md`## Javascript Source Normalization`
-)};
-const _ikzxev = function _normalizeJavascriptSource(acorn,escodegen){return(
-(source) => {
-  var comments = [];
-  var tokens = [];
-
-  var ast = acorn.parse(source, {
-    ranges: true,
-    onComment: comments,
-    onToken: tokens
-  });
-
-  escodegen.attachComments(ast, comments, tokens);
-  return escodegen.generate(ast, {
-    comment: true
-  });
-}
-)};
-const _az8lo6 = function _normalizeVariables(variableToObject,normalizeJavascriptSource){return(
-(variables) =>
-  variables.map(variableToObject).map((v) => ({
-    ...v,
-    _definition: normalizeJavascriptSource(v._definition)
-  }))
 )};
 const _3knb9v = function _variableToObject(){return(
 (v) => ({
@@ -21581,7 +21690,7 @@ const _3knb9v = function _variableToObject(){return(
   _inputs: v._inputs.map((v) => v._name || v)
 })
 )};
-const _263fcv = function _106(md){return(
+const _autn1v = function _102(md){return(
 md`## Observable Source Normalization`
 )};
 const _7zpsl9 = function _normalizeObservableSourceSelector(Inputs,notebook_semantics_source){return(
@@ -21591,94 +21700,10 @@ Inputs.select(
 )
 )};
 const _1ex8kus = (G, _) => G.input(_);
-const _17petbz = function _108(normalizeObservableSource,normalizeObservableSourceSelector){return(
-normalizeObservableSource(normalizeObservableSourceSelector)
-)};
 const _b2d0zc = function _parsed(parser,normalizeObservableSourceSelector){return(
 parser.parseCell(normalizeObservableSourceSelector)
 )};
-const _qtgjo9 = function _generate(escodegen){return(
-function generate(node, source) {
-  if (node.type == "Cell") {
-    if (
-      node.body.type != "BlockStatement" &&
-      source &&
-      source[node.body.start] == "{"
-    ) {
-      return `${node.id ? `${generate(node.id)} = ` : ""}(${escodegen.generate(
-        node.body
-      )})`;
-    } else {
-      return `${node.id ? `${generate(node.id)} = ` : ""}${escodegen.generate(
-        node.body
-      )}`;
-    }
-  } else if (node.type == "Identifier") {
-    return escodegen.generate(node);
-  } else if (node.type == "ViewExpression") {
-  } else {
-    throw node.type;
-  }
-}
-)};
-const _104j23i = function _normalizeObservableSource(parser,generate){return(
-{
-  prompt:
-    'I see some of the test are failing because the AST generator uses a different set of quotes than the original source and various formatting quirks. This should not count as failure. I would suggest normalizing. Its not super easy because source code is not vanilla JS, we need to normalize just the bit after the block expression, and replace the "viewof XX" and "mutable XXX" macros with a placeholder whic we can normalize and then undo. Write the normalizeObservableSource.',
-  time: 1729097489369
-} &&
-  function normalizeObservableSource(source) {
-    // Replace viewof and mutable with placeholders
-    const viewofRegex = /viewof\s+([a-zA-Z_][a-zA-Z0-9_]*)/g;
-    const mutableRegex = /mutable\s+([a-zA-Z_][a-zA-Z0-9_]*)/g;
-
-    // Temporary placeholders
-    const VIEWOF_PLACEHOLDER = "__VIEWOF_PLACEHOLDER__";
-    const MUTABLE_PLACEHOLDER = "__MUTABLE_PLACEHOLDER__";
-
-    // Maps to store original names
-    const viewOfMap = new Map();
-    const mutableMap = new Map();
-
-    // Replace viewof XX with placeholder and store mapping
-    source = source.replace(viewofRegex, (match, p1) => {
-      const placeholder = `${VIEWOF_PLACEHOLDER}_${p1}`;
-      viewOfMap.set(placeholder, p1);
-      return placeholder;
-    });
-
-    // Replace mutable XXX with placeholder and store mapping
-    source = source.replace(mutableRegex, (match, p1) => {
-      const placeholder = `${MUTABLE_PLACEHOLDER}_${p1}`;
-      mutableMap.set(placeholder, p1);
-      return placeholder;
-    });
-
-    // Normalize quotes: convert all to single quotes
-    const comments = [],
-      tokens = [];
-    const cell = parser.parseCell(source, {
-      ranges: true,
-      onComment: comments,
-      onToken: tokens
-    });
-    
-
-    source = generate(cell, source);
-
-    // Restore original viewof and mutable identifiers
-    viewOfMap.forEach((original, placeholder) => {
-      source = source.replaceAll(placeholder, `viewof ${original}`);
-    });
-
-    mutableMap.forEach((original, placeholder) => {
-      source = source.replaceAll(placeholder, `mutable ${original}`);
-    });
-
-    return source;
-  }
-)};
-const _vle3wv = function _112(md){return(
+const _14qm8or = function _105(md){return(
 md`## The Compiler
 
 `
@@ -22117,7 +22142,7 @@ Inputs.textarea({
   label: "compile test template"
 })
 )};
-const _1lmax86 = async function _test_compile_import_plain_single(compile,expect)
+const _1vg114c = async function _test_compile_import_plain_single(compile,expect)
 {
   const compiled = await compile(
     `import {dep} from "@tomlarkworthy/dependancy";`
@@ -22126,7 +22151,7 @@ const _1lmax86 = async function _test_compile_import_plain_single(compile,expect
     {
       _name: "module @tomlarkworthy/dependancy",
       _inputs: [],
-      _definition: `async () => runtime.module((await import("@tomlarkworthy/dependancy")).default)`
+      _definition: `async () => runtime.module((await import("/@tomlarkworthy/dependancy.js?v=4")).default)`
     },
     {
       _name: "dep",
@@ -22136,7 +22161,7 @@ const _1lmax86 = async function _test_compile_import_plain_single(compile,expect
   ]);
   return "ok";
 };
-const _17sgzdm = async function _test_compile_import_view_data_alias_single(compile,expect)
+const _18h6y38 = async function _test_compile_import_view_data_alias_single(compile,expect)
 {
   const compiled = await compile(
     `import {viewdep as aslias_viewdep_data} from "@tomlarkworthy/dependancy";`
@@ -22145,7 +22170,7 @@ const _17sgzdm = async function _test_compile_import_view_data_alias_single(comp
     {
       _name: "module @tomlarkworthy/dependancy",
       _inputs: [],
-      _definition: `async () => runtime.module((await import("@tomlarkworthy/dependancy")).default)`
+      _definition: `async () => runtime.module((await import("/@tomlarkworthy/dependancy.js?v=4")).default)`
     },
     {
       _name: "aslias_viewdep_data",
@@ -22155,7 +22180,7 @@ const _17sgzdm = async function _test_compile_import_view_data_alias_single(comp
   ]);
   return "ok";
 };
-const _1tqj4tp = async function _test_compile_import_mutable_data_alias_single(compile,expect)
+const _1svcdun = async function _test_compile_import_mutable_data_alias_single(compile,expect)
 {
   const compiled = await compile(
     `import {mutabledep as aslias_mutabledep_data} from "@tomlarkworthy/dependancy";`
@@ -22164,7 +22189,7 @@ const _1tqj4tp = async function _test_compile_import_mutable_data_alias_single(c
     {
       _name: "module @tomlarkworthy/dependancy",
       _inputs: [],
-      _definition: `async () => runtime.module((await import("@tomlarkworthy/dependancy")).default)`
+      _definition: `async () => runtime.module((await import("/@tomlarkworthy/dependancy.js?v=4")).default)`
     },
     {
       _name: "aslias_mutabledep_data",
@@ -22174,7 +22199,7 @@ const _1tqj4tp = async function _test_compile_import_mutable_data_alias_single(c
   ]);
   return "ok";
 };
-const _hv0te2 = async function _test_compile_import_mutable_single(compile,expect)
+const _tb4ops = async function _test_compile_import_mutable_single(compile,expect)
 {
   const compiled = await compile(
     `import {mutable mutabledep} from "@tomlarkworthy/dependancy";`
@@ -22183,7 +22208,7 @@ const _hv0te2 = async function _test_compile_import_mutable_single(compile,expec
     {
       _name: "module @tomlarkworthy/dependancy",
       _inputs: [],
-      _definition: `async () => runtime.module((await import("@tomlarkworthy/dependancy")).default)`
+      _definition: `async () => runtime.module((await import("/@tomlarkworthy/dependancy.js?v=4")).default)`
     },
     {
       _name: "mutable mutabledep",
@@ -22193,7 +22218,7 @@ const _hv0te2 = async function _test_compile_import_mutable_single(compile,expec
   ]);
   return "ok";
 };
-const _1mltqmr = async function _test_compile_import_viewof_single(compile,expect)
+const _vuzib9 = async function _test_compile_import_viewof_single(compile,expect)
 {
   const compiled = await compile(
     `import {viewof viewdep} from "@tomlarkworthy/dependancy";`
@@ -22202,7 +22227,7 @@ const _1mltqmr = async function _test_compile_import_viewof_single(compile,expec
     {
       _name: "module @tomlarkworthy/dependancy",
       _inputs: [],
-      _definition: `async () => runtime.module((await import("@tomlarkworthy/dependancy")).default)`
+      _definition: `async () => runtime.module((await import("/@tomlarkworthy/dependancy.js?v=4")).default)`
     },
     {
       _name: "viewof viewdep",
@@ -22212,7 +22237,7 @@ const _1mltqmr = async function _test_compile_import_viewof_single(compile,expec
   ]);
   return "ok";
 };
-const _1d18obr = async function _test_compile_import_alias_single(compile,expect)
+const _6ewshd = async function _test_compile_import_alias_single(compile,expect)
 {
   const compiled = await compile(
     `import {dep as dep_alias} from "@tomlarkworthy/dependancy";`
@@ -22221,7 +22246,7 @@ const _1d18obr = async function _test_compile_import_alias_single(compile,expect
     {
       _name: "module @tomlarkworthy/dependancy",
       _inputs: [],
-      _definition: `async () => runtime.module((await import("@tomlarkworthy/dependancy")).default)`
+      _definition: `async () => runtime.module((await import("/@tomlarkworthy/dependancy.js?v=4")).default)`
     },
     {
       _name: "dep_alias",
@@ -22231,7 +22256,7 @@ const _1d18obr = async function _test_compile_import_alias_single(compile,expect
   ]);
   return "ok";
 };
-const _1b5ghef = async function _test_compile_import_notebook(compile,expect)
+const _36migr = async function _test_compile_import_notebook(compile,expect)
 {
   const compiled = await compile(
     `import {escodegen} from "@tomlarkworthy/escodegen"`
@@ -22241,7 +22266,7 @@ const _1b5ghef = async function _test_compile_import_notebook(compile,expect)
       _name: `module @tomlarkworthy/escodegen`,
       _inputs: [],
       _definition:
-        'async () => runtime.module((await import("@tomlarkworthy/escodegen")).default)'
+        'async () => runtime.module((await import("/@tomlarkworthy/escodegen.js?v=4")).default)'
     },
     {
       _name: `escodegen`,
@@ -22261,13 +22286,13 @@ Inputs.select(
 )
 )};
 const _1e5ax6f = (G, _) => G.input(_);
-const _18e5b93 = function _153(test_case){return(
+const _7eic89 = function _146(test_case){return(
 test_case.value
 )};
 const _16q6oyc = async function _compiled(compile,test_case){return(
 await compile(test_case.value)
 )};
-const _1191170 = function _155(parser,test_case)
+const _61dayu = function _148(parser,test_case)
 {
   const comments = [];
   const tokens = [];
@@ -22283,24 +22308,7 @@ const _1191170 = function _155(parser,test_case)
     tokens
   };
 };
-const _1gh543z = function _compiled_selector(Inputs,compiled){return(
-Inputs.radio(compiled, {
-  format: (v) => v._name,
-  value: compiled[0]
-})
-)};
-const _1dmmuaf = (G, _) => G.input(_);
-const _1klx74n = function _157(compiled_selector,normalizeJavascriptSource){return(
-JSON.stringify(
-  {
-    ...compiled_selector,
-    _definition: normalizeJavascriptSource(compiled_selector._definition)
-  },
-  null,
-  2
-)
-)};
-const _eom91x = function _158(compile,test_case){return(
+const _cevs6r = function _149(compile,test_case){return(
 compile(test_case.value)
 )};
 const _mliwy8 = function _compile(parser,observableToJs){return(
@@ -22536,7 +22544,7 @@ const _16p8atj = function _observableToJs(acorn_walk,parser){return(
   return out;
 }
 )};
-const _1ayjluu = function _161(md){return(
+const _1hd7px0 = function _152(md){return(
 md`### Bundled deps`
 )};
 const _xhj6b8 = function _decompress_url(DecompressionStream,TextDecoderStream,TransformStream,TextEncoderStream,Response){return(
@@ -22573,19 +22581,19 @@ async (attachment, overrides) => {
   return URL.createObjectURL(blob);
 }
 )};
-const _s9w7ha = async function _parser(decompress_url, FileAttachment, acorn_url, acorn_walk_url) {
-    return import(await decompress_url(FileAttachment('parser-6.1.0.js.gz'), {
-        '/npm/acorn@8.11.3/+esm': acorn_url,
-        '/npm/acorn-walk@8.3.2/+esm': acorn_walk_url
-    }));
-};
-const _1rc67k0 = function _stageB_importFake()
+const _s9w7ha = async function _parser(decompress_url,FileAttachment,acorn_url,acorn_walk_url){return(
+import(await decompress_url(FileAttachment("parser-6.1.0.js.gz"), {
+    "/npm/acorn@8.11.3/+esm": acorn_url,
+    "/npm/acorn-walk@8.3.2/+esm": acorn_walk_url
+  }))
+)};
+const _j9n5de = function _stageB_importFake()
 {
-  return // Builds a Stage B (pre-observation, API-loaded) import group as POJOs.
+  // Builds a Stage B (pre-observation, API-loaded) import group as POJOs.
   // Mirrors what `runtime.define("name", ["module @X", "@variable"], (_, v) => v.import("name", _))`
   // produces structurally. Used by the test_decompileImport_stageB_* tests to
   // avoid spinning up a real Observable runtime per case.
-  function stageB_importFake(module_name, specifiers) {
+  return function stageB_importFake(module_name, specifiers) {
     const importerModule = { _scope: new Map() };
     const stitch = {
       _name: `module ${ module_name }`,
@@ -22739,10 +22747,10 @@ const _rk7ku3 = async function _test_decompileImport_compile_roundtrip_single(co
   expect(formatImportDeclaration(info)).toEqual(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
   return 'ok';
 };
-const _xynplo = async function _test_decompileImport_stageB_order_independent(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+const _1numivw = async function _test_decompileImport_stageB_order_independent(stageB_importFake,decompileImport,expect,formatImportDeclaration)
 {
   // The detection uses .find — it shouldn't matter whether the stitch is at
-  // index 0 or the aliases come first. Verify by reversing the array.
+  // index 0 or the aliases come first. Verify by moving it to the end.
   const vars = stageB_importFake('@user/y', [
     {
       imported: 'a',
@@ -22753,8 +22761,11 @@ const _xynplo = async function _test_decompileImport_stageB_order_independent(st
       local: 'b'
     }
   ]);
-  const reversed = [...vars].reverse();
-  const info = await decompileImport(reversed);
+  const [stitch, ...aliases] = vars;
+  const info = await decompileImport([
+    ...aliases,
+    stitch
+  ]);
   expect(info.meta.detection.stage).toEqual('B');
   expect(formatImportDeclaration(info)).toEqual(`import {a, b} from "@user/y"`);
   return 'ok';
@@ -22917,7 +22928,6 @@ export default function define(runtime, observer) {
 
   main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
   main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
-  main.define("module @tomlarkworthy/escodegen", async () => runtime.module((await import("/@tomlarkworthy/escodegen.js?v=4")).default));  
   main.define("module @tomlarkworthy/acorn-8-11-3", async () => runtime.module((await import("/@tomlarkworthy/acorn-8-11-3.js?v=4")).default));  
   main.define("module @tomlarkworthy/jest-expect-standalone", async () => runtime.module((await import("/@tomlarkworthy/jest-expect-standalone.js?v=4")).default));  
   main.define("module @tomlarkworthy/observable-runtime", async () => runtime.module((await import("/@tomlarkworthy/observable-runtime.js?v=4")).default));  
@@ -23005,39 +23015,32 @@ export default function define(runtime, observer) {
   $def("_1afcxhk", "test_decompile_import_viewof_alias", ["decompile","expect"], _1afcxhk);  
   $def("_1sl510", "test_decompile_import_viewof_data_alias", ["decompile","expect"], _1sl510);  
   $def("_17dwb6r", null, ["md"], _17dwb6r);  
-  main.define("escodegen", ["module @tomlarkworthy/escodegen", "@variable"], (_, v) => v.import("escodegen", _));  
-  $def("_1vs6mei", null, ["md"], _1vs6mei);  
-  $def("_1g89k6a", "escodegenOptions", ["escodegen"], _1g89k6a);  
+  $def("_1ngipml", null, ["md"], _1ngipml);  
   $def("_2d5g1", "decompile", ["decompileImport","formatImportDeclaration","acorn"], _2d5g1);  
-  $def("_1pvis67", null, ["md"], _1pvis67);  
+  $def("_1x0pvrl", null, ["md"], _1x0pvrl);  
   $def("_183j58u", "extractModuleInfo", [], _183j58u);  
   $def("_w445v0", "test_extractModuleInfo_notebook_resolution", ["expect","extractModuleInfo"], _w445v0);  
   $def("_uzqj4w", "test_extractModuleInfo_id_version_resolution", ["expect","extractModuleInfo"], _uzqj4w);  
   $def("_1sruec2", "test_extractModuleInfo_id_version", ["expect","extractModuleInfo"], _1sruec2);  
   $def("_ipn8zp", "test_extractModuleInfo_test_4", ["expect","extractModuleInfo"], _ipn8zp);  
   $def("_iigmyv", "test_extractModuleInfo_alias_hack", ["expect","extractModuleInfo"], _iigmyv);  
-  $def("_1tggbee", null, ["md"], _1tggbee);  
+  $def("_7t42k8", null, ["md"], _7t42k8);  
   $def("_kiaw33", "import_ast_example", ["parser"], _kiaw33);  
   $def("_1n7gw17", "findModuleName", ["extractModuleInfo"], _1n7gw17);  
   $def("_i47chb", "findImportedName", [], _i47chb);  
-  $def("_1effqg", null, ["md"], _1effqg);  
-  $def("_b7vai6", "decompileImport", ["findModuleName","findImportedName"], _b7vai6);  
+  $def("_ed3cy2", null, ["md"], _ed3cy2);  
+  $def("_1a4j4gm", "decompileImport", ["findModuleName","findImportedName"], _1a4j4gm);  
   $def("_1sylz7j", "formatImportDeclaration", [], _1sylz7j);  
   $def("_13dctdn", "test_decompileImport_basic", ["importFake","decompileImport","expect"], _13dctdn);  
   $def("_ujr0xn", "test_formatImportDeclaration_roundtrip", ["importFake","decompileImport","expect","formatImportDeclaration","decompile"], _ujr0xn);  
   $def("_1u6sfri", "test_decompileImport_alias", ["importFake","decompileImport","expect","formatImportDeclaration"], _1u6sfri);  
-  $def("_1lqhutp", null, ["md"], _1lqhutp);  
-  $def("_ikzxev", "normalizeJavascriptSource", ["acorn","escodegen"], _ikzxev);  
-  $def("_az8lo6", "normalizeVariables", ["variableToObject","normalizeJavascriptSource"], _az8lo6);  
+  $def("_1lti0tv", null, ["md"], _1lti0tv);  
   $def("_3knb9v", "variableToObject", [], _3knb9v);  
-  $def("_263fcv", null, ["md"], _263fcv);  
+  $def("_autn1v", null, ["md"], _autn1v);  
   $def("_7zpsl9", "viewof normalizeObservableSourceSelector", ["Inputs","notebook_semantics_source"], _7zpsl9);  
   $def("_1ex8kus", "normalizeObservableSourceSelector", ["Generators","viewof normalizeObservableSourceSelector"], _1ex8kus);  
-  $def("_17petbz", null, ["normalizeObservableSource","normalizeObservableSourceSelector"], _17petbz);  
   $def("_b2d0zc", "parsed", ["parser","normalizeObservableSourceSelector"], _b2d0zc);  
-  $def("_qtgjo9", "generate", ["escodegen"], _qtgjo9);  
-  $def("_104j23i", "normalizeObservableSource", ["parser","generate"], _104j23i);  
-  $def("_vle3wv", null, ["md"], _vle3wv);  
+  $def("_14qm8or", null, ["md"], _14qm8or);  
   $def("_10ofthe", "test_async_interpolation", ["compile"], _10ofthe);  
   $def("_1gb7c3c", "test_compile_syntax_error_viewof", ["compile","expect"], _1gb7c3c);  
   $def("_69vyub", "test_compile_syntax_error_anonymous", ["compile","expect"], _69vyub);  
@@ -23070,25 +23073,22 @@ export default function define(runtime, observer) {
   $def("_33oop5", "test_compile_event", ["compile","expect"], _33oop5);  
   $def("_9phvzk", "test_compile_tagged_literal", ["compile","expect"], _9phvzk);  
   $def("_1q0pie3", "compile_unit_test_template", ["Inputs","test_case","compiled"], _1q0pie3);  
-  $def("_1lmax86", "test_compile_import_plain_single", ["compile","expect"], _1lmax86);  
-  $def("_17sgzdm", "test_compile_import_view_data_alias_single", ["compile","expect"], _17sgzdm);  
-  $def("_1tqj4tp", "test_compile_import_mutable_data_alias_single", ["compile","expect"], _1tqj4tp);  
-  $def("_hv0te2", "test_compile_import_mutable_single", ["compile","expect"], _hv0te2);  
-  $def("_1mltqmr", "test_compile_import_viewof_single", ["compile","expect"], _1mltqmr);  
-  $def("_1d18obr", "test_compile_import_alias_single", ["compile","expect"], _1d18obr);  
-  $def("_1b5ghef", "test_compile_import_notebook", ["compile","expect"], _1b5ghef);  
+  $def("_1vg114c", "test_compile_import_plain_single", ["compile","expect"], _1vg114c);  
+  $def("_18h6y38", "test_compile_import_view_data_alias_single", ["compile","expect"], _18h6y38);  
+  $def("_1svcdun", "test_compile_import_mutable_data_alias_single", ["compile","expect"], _1svcdun);  
+  $def("_tb4ops", "test_compile_import_mutable_single", ["compile","expect"], _tb4ops);  
+  $def("_vuzib9", "test_compile_import_viewof_single", ["compile","expect"], _vuzib9);  
+  $def("_6ewshd", "test_compile_import_alias_single", ["compile","expect"], _6ewshd);  
+  $def("_36migr", "test_compile_import_notebook", ["compile","expect"], _36migr);  
   $def("_1nps9cr", "viewof test_case", ["Inputs","notebook_semantics_source"], _1nps9cr);  
   $def("_1e5ax6f", "test_case", ["Generators","viewof test_case"], _1e5ax6f);  
-  $def("_18e5b93", null, ["test_case"], _18e5b93);  
+  $def("_7eic89", null, ["test_case"], _7eic89);  
   $def("_16q6oyc", "compiled", ["compile","test_case"], _16q6oyc);  
-  $def("_1191170", null, ["parser","test_case"], _1191170);  
-  $def("_1gh543z", "viewof compiled_selector", ["Inputs","compiled"], _1gh543z);  
-  $def("_1dmmuaf", "compiled_selector", ["Generators","viewof compiled_selector"], _1dmmuaf);  
-  $def("_1klx74n", null, ["compiled_selector","normalizeJavascriptSource"], _1klx74n);  
-  $def("_eom91x", null, ["compile","test_case"], _eom91x);  
+  $def("_61dayu", null, ["parser","test_case"], _61dayu);  
+  $def("_cevs6r", null, ["compile","test_case"], _cevs6r);  
   $def("_mliwy8", "compile", ["parser","observableToJs"], _mliwy8);  
   $def("_16p8atj", "observableToJs", ["acorn_walk","parser"], _16p8atj);  
-  $def("_1ayjluu", null, ["md"], _1ayjluu);  
+  $def("_1hd7px0", null, ["md"], _1hd7px0);  
   $def("_xhj6b8", "decompress_url", ["DecompressionStream","TextDecoderStream","TransformStream","TextEncoderStream","Response"], _xhj6b8);  
   $def("_s9w7ha", "parser", ["decompress_url","FileAttachment","acorn_url","acorn_walk_url"], _s9w7ha);  
   main.define("acorn", ["module @tomlarkworthy/acorn-8-11-3", "@variable"], (_, v) => v.import("acorn", _));  
@@ -23100,7 +23100,7 @@ export default function define(runtime, observer) {
   main.define("Inspector", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Inspector", _));  
   main.define("Library", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Library", _));  
   main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));  
-  $def("_1rc67k0", "stageB_importFake", [], _1rc67k0);  
+  $def("_j9n5de", "stageB_importFake", [], _j9n5de);  
   $def("_1d53asg", "test_decompileImport_stageB_single", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1d53asg);  
   $def("_hv5gag", "test_decompileImport_stageB_aliased", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _hv5gag);  
   $def("_avc18y", "test_decompileImport_stageB_multiple", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _avc18y);  
@@ -23109,7 +23109,7 @@ export default function define(runtime, observer) {
   $def("_qwlsf2", "test_decompileImport_stageB_mutable", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _qwlsf2);  
   $def("_sy7jfx", "test_decompileImport_returns_null_for_non_import", ["decompileImport","expect"], _sy7jfx);  
   $def("_rk7ku3", "test_decompileImport_compile_roundtrip_single", ["compile","expect","stageB_importFake","decompileImport","formatImportDeclaration"], _rk7ku3);  
-  $def("_xynplo", "test_decompileImport_stageB_order_independent", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _xynplo);  
+  $def("_1numivw", "test_decompileImport_stageB_order_independent", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1numivw);  
   $def("_16fpgac", "test_decompileImport_stageB_notebook_id", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16fpgac);  
   $def("_r2e0wl", "test_extractModuleInfo_new_id_resolutions", ["expect","extractModuleInfo"], _r2e0wl);  
   $def("_1pg1y6s", "test_extractModuleInfo_new_slug_resolutions", ["expect","extractModuleInfo"], _1pg1y6s);  
@@ -24439,10 +24439,10 @@ md`### \`importShim\` polyfill
 
 Lopecode uses importShim which is not availible on Observablehq`
 )};
-const _12odeih = function _importShim() {
-    if (window.importShim)
-        return window.importShim;
-    return (url, options) => import(url);
+const _12odeih = function _importShim()
+{
+  if (window.importShim) return window.importShim;
+  return (url, options) => import(url);
 };
 const _1nrqtih = function _65(md){return(
 md`---`
@@ -28293,21 +28293,19 @@ md`## [Optional] Tests`
 const _11gtx14 = function _RUN_TESTS(){return(
 true
 )};
-const _46icxz = async function _testing(RUN_TESTS, invalidation) {
-    if (!RUN_TESTS)
-        return invalidation;
-    const [{Runtime}, {default: define}] = await Promise.all([
-        import('https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js'),
-        import(`https://api.observablehq.com/@tomlarkworthy/testing.js?v=3`)
-    ]);
-    const module = new Runtime().module(define);
-    return Object.fromEntries(await Promise.all([
-        'expect',
-        'createSuite'
-    ].map(n => module.value(n).then(v => [
-        n,
-        v
-    ]))));
+const _46icxz = async function _testing(RUN_TESTS,invalidation)
+{
+  if (!RUN_TESTS) return invalidation;
+  const [{ Runtime }, { default: define }] = await Promise.all([
+    import("https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js"),
+    import(`https://api.observablehq.com/@tomlarkworthy/testing.js?v=3`)
+  ]);
+  const module = new Runtime().module(define);
+  return Object.fromEntries(
+    await Promise.all(
+      ["expect", "createSuite"].map((n) => module.value(n).then((v) => [n, v]))
+    )
+  );
 };
 const _lf943y = function _suite(testing){return(
 testing.createSuite({
@@ -28543,13 +28541,14 @@ suite.test("Collection object creates matching keys", async () => {
   expect(v.value).toHaveProperty("a");
 })
 )};
-const _1qdb7yp = async function _toc() {
-    const [{Runtime}, {default: define}] = await Promise.all([
-        import('https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js'),
-        import(`https://api.observablehq.com/@nebrius/indented-toc.js?v=3`)
-    ]);
-    const module = new Runtime().module(define);
-    return module.value('toc');
+const _1qdb7yp = async function _toc()
+{
+  const [{ Runtime }, { default: define }] = await Promise.all([
+    import("https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js"),
+    import(`https://api.observablehq.com/@nebrius/indented-toc.js?v=3`)
+  ]);
+  const module = new Runtime().module(define);
+  return module.value("toc");
 };
 
 export default function define(runtime, observer) {

--- a/notebooks/@tomlarkworthy_exporter-3.json
+++ b/notebooks/@tomlarkworthy_exporter-3.json
@@ -24,13 +24,14 @@
       "hash": "5658858e85affa2e1e5cd1052924c622"
     },
     "@tomlarkworthy/exporter-3": {
-      "hash": "5a9e633da6399dfd1cfcc35308262bca",
+      "hash": "bf04e9247f3cbb2ae5880d8b59250a4b",
       "dependsOn": [
         "@tomlarkworthy/lopepage-urls",
         "@tomlarkworthy/observable-runtime-v6",
         "@tomlarkworthy/flow-queue",
         "@tomlarkworthy/cell-map",
         "@tomlarkworthy/observablejs-toolchain",
+        "@tomlarkworthy/escodegen",
         "@tomlarkworthy/view",
         "@tomlarkworthy/reversible-attachment",
         "@tomlarkworthy/local-storage-view",
@@ -198,6 +199,7 @@
         "escodegen.browser.min.js.gz"
       ],
       "dependedBy": [
+        "@tomlarkworthy/exporter-3",
         "@tomlarkworthy/observablejs-toolchain"
       ]
     },
@@ -439,9 +441,8 @@
       ]
     },
     "@tomlarkworthy/observablejs-toolchain": {
-      "hash": "bd9e26de1cdd73502a24925769e6de19",
+      "hash": "51012bee759fa75116e593e6ba9477d1",
       "files": [
-        "acorn-walk-8.3.2.js.gz",
         "parser-6.1.0.js.gz"
       ],
       "dependsOn": [
@@ -581,6 +582,6 @@
       "@tomlarkworthy/exporter-3": "https://observablehq.com/@tomlarkworthy/exporter-3"
     }
   },
-  "observable_version": 17192,
-  "observable_update_time": "2026-07-22T18:25:47.909Z"
+  "observable_version": 17198,
+  "observable_update_time": "2026-07-22T20:05:21.314Z"
 }

--- a/notebooks/@tomlarkworthy_exporter-3.json
+++ b/notebooks/@tomlarkworthy_exporter-3.json
@@ -24,14 +24,13 @@
       "hash": "5658858e85affa2e1e5cd1052924c622"
     },
     "@tomlarkworthy/exporter-3": {
-      "hash": "bf04e9247f3cbb2ae5880d8b59250a4b",
+      "hash": "9e5fcccf1ed23acb071ad881f1f2e1e0",
       "dependsOn": [
         "@tomlarkworthy/lopepage-urls",
         "@tomlarkworthy/observable-runtime-v6",
         "@tomlarkworthy/flow-queue",
         "@tomlarkworthy/cell-map",
         "@tomlarkworthy/observablejs-toolchain",
-        "@tomlarkworthy/escodegen",
         "@tomlarkworthy/view",
         "@tomlarkworthy/reversible-attachment",
         "@tomlarkworthy/local-storage-view",
@@ -49,7 +48,7 @@
       ]
     },
     "@tomlarkworthy/lopepage": {
-      "hash": "633f78d13e1da2ee746dc2c8598b5a24",
+      "hash": "ea085755ec5e24f0b29c4cc5f06a7a08",
       "dependsOn": [
         "@tomlarkworthy/golden-layout-2-6-0",
         "@tomlarkworthy/visualizer",
@@ -76,7 +75,7 @@
       ]
     },
     "@tomlarkworthy/acorn-8-11-3": {
-      "hash": "7d7821979f30fc573f0305942ef16d3a",
+      "hash": "a2c4eb96cb067e559536d9f841c2a8e1",
       "files": [
         "acorn-8.11.3.js.gz",
         "acorn-walk-8.3.2.js.gz"
@@ -127,7 +126,7 @@
       ]
     },
     "@tomlarkworthy/codemirror-6-v2": {
-      "hash": "80378ba570b5e43e8f978aa58a7aff02",
+      "hash": "4c719107756989ca8470b2b034bf7511",
       "files": [
         "codemirror_javascript%405.js.gz"
       ],
@@ -193,18 +192,8 @@
         "@tomlarkworthy/lopepage"
       ]
     },
-    "@tomlarkworthy/escodegen": {
-      "hash": "d5e793114a390617e9a70bfdd61a42ec",
-      "files": [
-        "escodegen.browser.min.js.gz"
-      ],
-      "dependedBy": [
-        "@tomlarkworthy/exporter-3",
-        "@tomlarkworthy/observablejs-toolchain"
-      ]
-    },
     "@tomlarkworthy/file-sync": {
-      "hash": "089777c0a995824b4a16291c5ab6412b",
+      "hash": "62a784a1a576c5e851d8be48957cd894",
       "dependsOn": [
         "@tomlarkworthy/module-map",
         "@tomlarkworthy/exporter-3",
@@ -228,7 +217,7 @@
       ]
     },
     "@tomlarkworthy/flow-queue": {
-      "hash": "97db7ca44c394ea3f73a3f60f0d2ef6c",
+      "hash": "dd7a035f809162d101be55d55be97880",
       "files": [
         "flowQuery%401.svg"
       ],
@@ -239,7 +228,7 @@
       ]
     },
     "@tomlarkworthy/golden-layout-2-6-0": {
-      "hash": "24f5fad01bd508dd1bc3a49a99002770",
+      "hash": "3331ddc9fc7e65a246bfc1137961c766",
       "files": [
         "golden-layout-2.6.0.js.gz",
         "lm_popout_black.png",
@@ -284,7 +273,7 @@
       ]
     },
     "@tomlarkworthy/isomorphic-git-1-30-1": {
-      "hash": "16fa79b79fb4e9e1a2d03cfc9221147c",
+      "hash": "0cb9679e97bac6b63cba20a792de5389",
       "files": [
         "isomorphic-git-1%401.30.1.bundle.js.gz",
         "isomorphic-git-http-1.0.0-beta.36.js.gz"
@@ -294,7 +283,7 @@
       ]
     },
     "@tomlarkworthy/jest-expect-standalone": {
-      "hash": "418ef3328580c7b2416be5b9fc940db4",
+      "hash": "bd4d80b0911cd2fc3cc10c4f007f447f",
       "files": [
         "jest-expect-standalone-24.0.2.js.gz"
       ],
@@ -305,7 +294,7 @@
       ]
     },
     "@tomlarkworthy/jszip-3-10-1": {
-      "hash": "2b119c57e9c2ce093b3a9c7d2932d010",
+      "hash": "b171464c98410d02c097e34a8f4d2b71",
       "files": [
         "jszip-3.10.1.min.js.gz"
       ],
@@ -314,7 +303,7 @@
       ]
     },
     "@tomlarkworthy/lightning-fs-4-6-0": {
-      "hash": "1f60955582df75104615d8061957d237",
+      "hash": "6eb7adeb763a8295f1bfab78e46f11af",
       "files": [
         "lightning-fs-4.6.0.js.gz"
       ],
@@ -404,7 +393,7 @@
       ]
     },
     "@tomlarkworthy/modules": {
-      "hash": "383efc0f630704ea804c5ddf05ab44eb",
+      "hash": "1a8195ade0cf1a14d350785eeec762cd",
       "dependsOn": [
         "@tomlarkworthy/runtime-sdk",
         "@tomlarkworthy/tests",
@@ -415,7 +404,7 @@
       ]
     },
     "@tomlarkworthy/observable-runtime": {
-      "hash": "4b60a23333fcadbc20650feae24d4039",
+      "hash": "e2e4c27c06b124cf3f3f880370d8755f",
       "files": [
         "runtime.js.gz"
       ],
@@ -424,14 +413,14 @@
       ]
     },
     "@tomlarkworthy/observable-runtime-v6": {
-      "hash": "6bc9db7b1881559c4d30c39f692e3969",
+      "hash": "cd421b0b3a2155578f1ef6d603b43258",
       "dependedBy": [
         "@tomlarkworthy/exporter-3",
         "@tomlarkworthy/modules"
       ]
     },
     "@tomlarkworthy/observablehq-lezer": {
-      "hash": "f827692f8b66b9b0f0cb8b9529f40815",
+      "hash": "49b46bb0bfedf68aea06e8d8a61d39d7",
       "files": [
         "lezer-lr-bundled.js.gz",
         "lezer-highlight-bundled.js.gz"
@@ -441,14 +430,13 @@
       ]
     },
     "@tomlarkworthy/observablejs-toolchain": {
-      "hash": "51012bee759fa75116e593e6ba9477d1",
+      "hash": "ee645d9c91a19f749128621e7ec3f99f",
       "files": [
         "parser-6.1.0.js.gz"
       ],
       "dependsOn": [
         "@tomlarkworthy/tests",
         "@tomlarkworthy/cell-map",
-        "@tomlarkworthy/escodegen",
         "@tomlarkworthy/acorn-8-11-3",
         "@tomlarkworthy/jest-expect-standalone",
         "@tomlarkworthy/observable-runtime"
@@ -479,7 +467,7 @@
       ]
     },
     "@tomlarkworthy/runtime-sdk": {
-      "hash": "9e3e70971cde0b4ebf012f3c1a280cc6",
+      "hash": "3c906717b0856e9bd1b4126925d91cf1",
       "dependsOn": [
         "@mootari/access-runtime"
       ],
@@ -551,7 +539,7 @@
       ]
     },
     "@tomlarkworthy/view": {
-      "hash": "970bf1f386002336660773d1215dd61f",
+      "hash": "c8bc708ea9f194c66bc203be5ed9bde5",
       "dependedBy": [
         "@tomlarkworthy/exporter-3",
         "@tomlarkworthy/reversible-attachment"
@@ -582,6 +570,6 @@
       "@tomlarkworthy/exporter-3": "https://observablehq.com/@tomlarkworthy/exporter-3"
     }
   },
-  "observable_version": 17198,
-  "observable_update_time": "2026-07-22T20:05:21.314Z"
+  "observable_version": 17204,
+  "observable_update_time": "2026-07-23T02:55:00.669Z"
 }

--- a/notebooks/@tomlarkworthy_observablejs-toolchain.html
+++ b/notebooks/@tomlarkworthy_observablejs-toolchain.html
@@ -8072,7 +8072,7 @@ const _4zsqot = function _actionHandler(Inputs,getSourceModule,notebook_name,_ru
     }
   };
 };
-const _dxt3kg = function _exportToHTML(_runtime, cssForTheme, css, location, keepalive, exporter_module, $0) {
+const _lb3gzc = function _exportToHTML(_runtime, cssForTheme, css, location, keepalive, exporter_module, $0) {
     return async function exportToHTML({mains = new Map(), runtime = _runtime, options = {}} = {}) {
         let conf = { headless: false };
         try {
@@ -8095,7 +8095,7 @@ const _dxt3kg = function _exportToHTML(_runtime, cssForTheme, css, location, kee
             options.tickDelayMs = conf.tickDelayMs;
         }
         if (options.prerender == null) {
-            options.prerender = conf.prerender;
+            options.prerender = conf.prerender !== false;
         }
         if (options.prerender && runtime === _runtime && options.prerenderHTML == null) {
             try {
@@ -9530,6 +9530,7 @@ export default function define(runtime, observer) {
   main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
   main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
   main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
+  main.define("module @tomlarkworthy/escodegen", async () => runtime.module((await import("/@tomlarkworthy/escodegen.js?v=4")).default));  
   main.define("module @tomlarkworthy/view", async () => runtime.module((await import("/@tomlarkworthy/view.js?v=4")).default));  
   main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
   main.define("module @tomlarkworthy/local-storage-view", async () => runtime.module((await import("/@tomlarkworthy/local-storage-view.js?v=4")).default));  
@@ -9538,7 +9539,6 @@ export default function define(runtime, observer) {
   main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("module @tomlarkworthy/jest-expect-standalone", async () => runtime.module((await import("/@tomlarkworthy/jest-expect-standalone.js?v=4")).default));  
   main.define("module @tomlarkworthy/themes", async () => runtime.module((await import("/@tomlarkworthy/themes.js?v=4")).default));  
-  main.define("module @tomlarkworthy/escodegen", async () => runtime.module((await import("/@tomlarkworthy/escodegen.js?v=4")).default));  
   $def("_1noor04", null, ["md"], _1noor04);  
   $def("_vpmotg", null, ["exporter","viewof output","Event"], _vpmotg);  
   $def("_16yvadj", null, ["md","downloadAnchor","forkAnchor"], _16yvadj);  
@@ -9557,7 +9557,7 @@ export default function define(runtime, observer) {
   $def("_1u2ju69", "forkAnchor", ["exportAnchor"], _1u2ju69);  
   $def("_1a8n42w", "downloadAnchor", ["exportAnchor"], _1a8n42w);  
   $def("_4zsqot", "actionHandler", ["Inputs","getSourceModule","notebook_name","_runtime","exportToHTML","htmlToConsoleSnippet","copyTextToClipboard","view","linkTo","location","getCompactISODate"], _4zsqot);  
-  $def("_dxt3kg", "exportToHTML", ["_runtime","cssForTheme","css","location","keepalive","exporter_module","viewof task"], _dxt3kg);  
+  $def("_lb3gzc", "exportToHTML", ["_runtime","cssForTheme","css","location","keepalive","exporter_module","viewof task"], _lb3gzc);  
   $def("_43zr7", "getSourceModule", ["notebook_name","main","_runtime"], _43zr7);  
   $def("_tpv4tl", "createShowable", ["variable","view"], _tpv4tl);  
   $def("_rnq9mt", "reportValidity", [], _rnq9mt);  

--- a/notebooks/@tomlarkworthy_observablejs-toolchain.html
+++ b/notebooks/@tomlarkworthy_observablejs-toolchain.html
@@ -4,12 +4,59 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
   <title>@tomlarkworthy/observablejs-toolchain</title>
+  <meta property="og:title" content="@tomlarkworthy/observablejs-toolchain">
+  <meta property="og:type" content="website">
   <link rel="icon" href="data:image/svg+xml;base64,PHN2ZyBmaWxsPSJ3aGl0ZSIgd2lkdGg9IjUwcHgiIGhlaWdodD0iNTBweCIgdmlld0JveD0iMCAwIDY0IDY0IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxyZWN0IGhlaWdodD0iNCIgd2lkdGg9IjQiIHg9IjIwIiB5PSI1MCI+PC9yZWN0PjxyZWN0IGhlaWdodD0iNCIgd2lkdGg9IjE2IiB4PSIyOCIgeT0iNTAiPjwvcmVjdD48cGF0aCBkPSJNMzIsMzhhOCw4LDAsMSwwLTgtOEE4LjAwOSw4LjAwOSwwLDAsMCwzMiwzOFptMC0xMmE0LDQsMCwxLDEtNCw0QTQsNCwwLDAsMSwzMiwyNloiPjwvcGF0aD48cGF0aCBkPSJNNiw2Mkg1OGEyLDIsMCwwLDAsMi0yVjE1YTIsMiwwLDAsMC0uNTg2LTEuNDE0bC0xMS0xMUEyLDIsMCwwLDAsNDcsMkg2QTIsMiwwLDAsMCw0LDRWNjBBMiwyLDAsMCwwLDYsNjJabTQyLTRIMTZWNDZINDhaTTE2LDZIMzF2NGg0VjZoNHY4SDE2Wk04LDZoNFYxNmEyLDIsMCwwLDAsMiwySDQxYTIsMiwwLDAsMCwyLTJWNmgzLjE3Mkw1NiwxNS44MjlWNThINTJWNDRhMiwyLDAsMCwwLTItMkgxNGEyLDIsMCwwLDAtMiwyVjU4SDhaIj48L3BhdGg+PC9zdmc+">
 </head>
 <body>
+
 <script id="networking_script">
   const normalize = url => url.replace(/^(?:https:\/\/api\.observablehq\.com)?\/(.*?)\.js(?:\?.*)?$/, '$1').replace(/^(d\/[a-f0-9]{16})@\d+$/, '$1');
   const isNotebook = id => /^(@[^/]+\/[^/]+|d\/[a-f0-9]{16})$/.test(id);
+
+  // --- streaming gate ---
+  // main runs from the TOP of the document, before the whole file has finished downloading, so a
+  // block a boot import needs may not have streamed in yet. __waitForId blocks until the block's
+  // <script> is fully parsed (el.nextSibling is non-null only after its </scr\ipt> is seen),
+  // bounded by window.__lopeStreaming, which flips to false once the document is fully parsed (so a
+  // genuinely-absent id resolves to a 404 rather than hanging).
+  //
+  // The wait is event-driven (MutationObserver + DOMContentLoaded/load), NOT a setTimeout poll:
+  // Safari throttles timers in background/unfocused tabs, and a fork opens via window.open into a
+  // tab that is often not foregrounded, so a poll loop stalls there (works in a foreground file://
+  // download but hangs in a backgrounded blob: fork). MutationObserver fires on the parser's node
+  // insertions regardless of timer throttling. The end-of-document sentinel stays as a redundant
+  // fast-path; DOMContentLoaded/load clear the flag even if that inline script never runs.
+  window.__lopeStreaming = true;
+  function __endStreaming() { window.__lopeStreaming = false; }
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", __endStreaming, { once: true });
+    window.addEventListener("load", __endStreaming, { once: true });
+  } else {
+    __endStreaming();
+  }
+  function __isComplete(el) { return !!el && (el.nextSibling != null || !window.__lopeStreaming); }
+  function __waitForId(id) {
+    if (__isComplete(document.getElementById(id)) || !window.__lopeStreaming) return Promise.resolve();
+    return new Promise((resolve) => {
+      let done = false;
+      const finish = () => {
+        if (done) return;
+        done = true;
+        mo.disconnect();
+        document.removeEventListener("DOMContentLoaded", onEnd);
+        window.removeEventListener("load", onEnd);
+        resolve();
+      };
+      const check = () => { if (__isComplete(document.getElementById(id)) || !window.__lopeStreaming) finish(); };
+      const onEnd = () => { __endStreaming(); finish(); };
+      const mo = new MutationObserver(check);
+      mo.observe(document.documentElement, { childList: true, subtree: true });
+      document.addEventListener("DOMContentLoaded", onEnd);
+      window.addEventListener("load", onEnd);
+      check();
+    });
+  }
 
   const b64ToBytes = (b64) => {
     const bin = atob(b64);
@@ -59,6 +106,7 @@
 
   // Async bytes for global fetch/XHR/blob URLs
   async function dvfBytes(id) {
+    await __waitForId(id);
     const el = document.getElementById(id);
     if (!el) return { status: 404 };
 
@@ -90,7 +138,11 @@
     return { status: 422 };
   }
 
-  // --- es-module-shims hooks (sync) ---
+  // --- es-module-shims hooks ---
+  // fetch and source are async and wait for not-yet-streamed blocks (es-module-shims awaits both:
+  // `c = await fetchHook(...)` and `await (sourceHook||default)(...)`). resolve is NOT awaited, so it
+  // stays synchronous — it just routes a not-yet-present notebook id to file:// (where fetch/source
+  // then wait) instead of rewriting it to the remote observablehq API.
   window.esmsInitOptions = {
     shimMode: true,
     resolve(id, parentUrl, defaultResolve) {
@@ -101,12 +153,14 @@
         if (el.href) return el.href;
         return `file://${id}`;
       }
+      if (window.__lopeStreaming && isNotebook(id)) return `file://${id}`;
       if (isNotebook(id)) id = `https://api.observablehq.com/${id}.js?v=4`;
       return defaultResolve(id, parentUrl);
     },
-    source(url, fetchOpts, parent, defaultSourceHook) {
+    async source(url, fetchOpts, parent, defaultSourceHook) {
       if (url.startsWith("file://")) {
         const id = url.slice(7);
+        await __waitForId(id);
         const el = document.getElementById(id);
         if (!el) return { type: "js", source: "throw new Error('DVF 404')" };
         const enc = (el.getAttribute("data-encoding") || "text").toLowerCase();
@@ -119,12 +173,13 @@
       }
       return defaultSourceHook(url, fetchOpts, parent);
     },
-    fetch(url, options, parent) {
+    async fetch(url, options, parent) {
       if (typeof url !== "string" || !url.startsWith("file://")) {
         return fetch(url, options);
       }
       const id = url.slice(7);
-      return dvfResponseSync(id); // must be synchronous
+      await __waitForId(id);
+      return dvfResponseSync(id);
     }
   };
 
@@ -234,6 +289,35 @@
       }
     }
   })();
+</script>
+
+<script id="main">
+(async () => {
+  await window.esmsInitOptions.fetch("file://es-module-shims@2.6.2").then(r => r.text()).then(src => {
+    const script = document.createElement('script');
+    script.textContent = src;
+    document.head.appendChild(script);
+  });
+
+  const style0 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/global.css", { with: { type: 'css' } });
+  const style1 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/inspector.css", { with: { type: 'css' } });
+  const style2 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/highlight.css", { with: { type: 'css' } });
+  const style3 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/plot.css", { with: { type: 'css' } });
+  const style4 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/index.css", { with: { type: 'css' } });
+  const style5 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/theme-parchment.css", { with: { type: 'css' } });
+  const style6 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/abstract-light.css", { with: { type: 'css' } });
+  const style7 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/syntax-light.css", { with: { type: 'css' } });
+  const style8 = await importShim("file://syntax.css", { with: { type: 'css' } });
+  document.adoptedStyleSheets = [style0.default,style1.default,style2.default,style3.default,style4.default,style5.default,style6.default,style7.default,style8.default];
+
+  const { Runtime } = await importShim("@observablehq/runtime@6.0.0");
+  const { Inspector } = await importShim("@observablehq/inspector@5.0.1");
+  const notebook = document.querySelector("notebook");
+  const runtime = new Runtime({__ojs_runtime: () => runtime, __ojs_observer: () => observer});
+  const observer = Inspector.into(document.body);
+  const {default: define} = await importShim("@tomlarkworthy/bootloader");
+  runtime.bootloader = runtime.module(define, () => ({}));
+})().catch((e) => console.error("boot error", e));
 </script>
 
 <!-- CSS -->
@@ -820,6 +904,4958 @@ H4sIAK6D82gAA7Uca2/cNvK7fwVjHAqpUTep+83bNC3uckCAJimatMDBMFx5V7bV7kp7ktaOz93/fiTn
   data-mime="application/javascript">
 H4sIAGWI82gAA+08/XfbOI6/969QdXlbuXHs2O112qRpm0ncndzko69J566X5BLFomNNZckryfnY1P/7AQRJkfqwZW96s7Pv+l5jiQRBEAABECTVblth5LGLUeRNApa0P0RXCYtv3KuADf/W9sNkzPppFLeTuN/2/GTspv1h6/fkyWAS9lM/Ci1Z6CCappXej+Gvx1LXDxrWwxNLPFtb8uH7d+thugkVN25seVF/MmJh2oV6RNCKbkMW74rSpsVu4AfbSriWxwbuJEh/89lta2eSpNGohzCI0B9YDvYfDWS7rS3LlpTaRI6lcIbslp4dIvpBUjhtILapxYKE5dpkdPRj5qaM9+3Y/MfmzQRsyw/9tKdhH7iATfwYgDn+8K7hP+eGZC4h4vDQdvrkSXsBsblx7N4bMvMTXubcuMGEEVtilk7i0NrmsH6yrdeDxPiTBXhTN+wjg/fC9DUHqqrtvJpZ/aJbXf3Fn4mcV+8E7mjMvNlQs2jA+llEfAwidz7Aq5ccAGWicdcPPXbnfGP3Bm/hnWskVljfrfWGtWrZ9sLiFG+H7oiZQs3KnRD+UN/9CCi2Qk11peYGbMR1FzQsJNUNW/3ATRLEAPC2TsPaWp8FAaK1CTJld+lOFKY0LS5XHrBuio+b2YjDhQc3iOKRmx7fj66iAEeHNiLhbyfRcRr74TV0IarHcZRGOLlaqajbzLihI3IIgyEME2mr7wYKbGGio6vf4UWS+2Bds/ToNvwUR2MWp/dEQ9K0FL0bADN0Ew0GjA3y7ogj2hRo5KhO3GteS4io9uPR55/3dnd7h1CO1jTjUwKquVVOwqauo2BoHSK8aeU11SSOmKPDGuqeutfRQFQbWKjoVBvGOU4kwS2umPEEmWj95S8lpS3UKGxgE1tso1c+HVW/2hDS+F7YbFJ9mrdbkhqAOyfri95CGDj+o/dNEGIcvJY8Qh+NseX412EUM+lPBJgSCVnwRWf1aDRJsUaq0fHXg5+P9o+B8lPA9yCku2HZHz5cXOwdHHw52f55v3exd7jb+6/e7sXFhw9200KWAcge2h/mQQF07Q98Fm8AX4AN0+YsXL/2vuYx/cruF8ezv3d8YqLZ95MU3rjX8ZNhLSwH259MJAfu2BZtON8r2h193u19luPggKL9UeyxGEfDC80RUdk4ZgP/jkpQiDPp+9zbga5MEj+zfhR7dag87p0UKTxmqSgwOUVlCUtVyVzqjk+2d341iTtO3f63Eik8OdcNg9RD7kdg0uRnVcBSaWnQJpGWtgZ+kLLYcSQ9EENZW+9w0p1SwTl3fdhhI5t+TwWiVsDC63TYEFNpU5u+ITkjCTgA1+o4CUf+NGlJITb0JiRFDPDQRRICDAS5/oCpKcOVoeIQLcJhoJVs06hJIuCRwiABjFYktMo2VN0w7A3xWSoFuFYxoPdiZDQkEKg9JbfLC6aXTdFO9CRfM3GrEcAQn1LPqg1/4y9Tw9TlrVw4CYKlDBy7gzjDY57hJj9Jl3g0aOZ81i5L+rE/huZJwTeSLVeNyd9puJwHDOHzkVFPUKB8xgVNDeGZaaCo3pqkZaQs3NumgACfB6G8zwIP/HoIoVDTCuUKhED1SBEUT3KxHKDo/BpKC6ArjKoAh7PyIAAT/+9s2rjcFCBECFILcxBCO4ClKmMJI1HhPHAadlVjyWfePlsGlRMOBusfHhngqD0ygJ01MkS11MjU1BUYBWmKrHxYMs0oJtOlaM53KpYHRm8YjRfsLKpXrvs9FRPAPKd+5QNZNOlu3oMtAINwWeDjVFClaXSo7FSO4KwC8Anq90a0/tmAWmHJtDpgN9So14y/2li1qSXHZQSM5Vzjc7mwCK/dXKNELYFwmVNrFYRPsxZC0pDZcsJniy3R2B2PWejtDP3AcwqrsoZJlouuId+oikjXpuZuyw9DFv9ycrCPevI2ubm2bn0vHW69tobMvx6m8MCHsPUst4pzwY4/e8dpfTt206HlbT07eGn9tL9udYav//4MeBkEW8/6kziGLneiIIqfWW1s8LYN3by7pP5nUHsC5vAQvIID0wdkBSqr6ZVtnaKm2taDPb2Ug3E9jyc4MEpkMC7HHkWThE3GEKxIIy6SH3o6ppWk0RjdhXvtchDlRseB22cOsrUpjT+MJHDHiWb90ZOZDoBEw/8qjaIHXd1gZWk56AR8qF7ftJ466AAUaAvfnEaj5UUhQ0/rW2+tLsCtrvqVWoJtWrQYkerB4yNejogaxprG7S6jNcDq7izF5vTbCjJJ7wPKQAVgAQD6KoggflT1tVTAss4m3fXuKwi3Y3ap0bG4zOdIXXAVxA3Rw88MpMQ0tjapFgafcooxwLvxocdj/yqAxalCsox0O28M6T4aLVPxy41Mpgm8dcxG0Q0j7tdEpzK1NDHsIHI9mbOcKr2bp1ZKtvqsPueTeioUTaZYAJO+Zn+uxSfOSMZEnOGk1rg4b9Jy+9yC4GGUxU33yH2R1IHmH/HVycAV9RzuuekHeF+lhGC8kMgQRiOEcgZAQZLFNzoF0I4oqNE5oijtnPvPx+u+pAdK4nI5aX0o5W7ytCBlhymK2eTqHBrajMrngxW1NDx5gogav6myMhwWbG+jmTcyPDWqtE4wThs75kbznXFTaGRVceLxDJboCAtnkZZpSkYctimQB4UziBNrW5SMzLUJ9paJibrO7EohHykXXznCcrU5CqnW5pXVoheBmy58LvcOt2rmqDItwKhxE4GkEnSqx+V3RCahBWsveANeqtV9KUk8pjPyhEWxVy4B8xHyHBHrWcFqGdeQ7txuFxCvJGph+WaJDeBgcbGrxSYq4sYZQg9Pt7by6+Wy0ahKEbFXilGYtdly1GuFCSkknGvP13rCrD1h/1+kRWMxW6h5v2xKd5b0Zs29aX6zJqNX25ckCoDQ0YzFm+ffEFZjqYeNagXItPYjbmObWjHyvGWi2u3hY1YtcvtmuAqTgLS2mke1ir9siLg0oksWnY6QwU3ke+ju87/cXusRGyLaLAqmKFU17j+bkNRztUBWHmCk0x8jizrcLgtvl+ByfSbVH6U1d5TcsC+IdOvd4zEvFxr/afhWPcCFkux9meUwTgYM3eSYBUysqWHEOl8ShmdPbiG4jm4xlMsgjbUcC1qUaud5Rze8ZnwvxcEKQJS6QAgfLOIXpgU3b/FVAXBoN+wPoxhhKwAGwEaOq2FuNFdmcpKhGwTR7b9uNr87K+ldJ50vETz558vnzxxbnYR++dh+cEa/m0tz/+lS+t3qnH63mNTXh7tULr6rpzXFfDVzmuiMu7US9OS4Z6YyRQ9Cc/JJeolgfp5e5uCK8FW2HjjSMKhcJtGJBBtGm6NqmPvjc/Oheh68W5kIVwM1N6F5I3Ot8mg7KMpL/QttofxkvdzvWK9/W/8jtlBo9AsrWqma5bRs8Z2WwjZ71UaLljD6sdstlMJ8hycua2e3gWm2PpEX3a5ZpCPaIrF1Wf7o/Hv3MRLw3boZ+O7MFHx3wSR4bnWrZR2rep+dg3+8/qsTsd1CJnYdVHit01w+Jcu1ugNqDahWLSjWRdQbjdN7rF7D6jWo3iwZQVX+1iLy/I6u3Qv1VbUbsTQf1AZFNSeKexRLsahUzNqeRo5TBq+yJOQSXf/oXZDuH7gN0nVK06lVWx8VGdR5Wenuj01Ld//QvPQ8FuZz0QvzUAX7j5QH7i6bCKbpYWRvHu/0DuKuSsfSGqyDHpXgcAXGn6yzu92frJUHNtXvN+Q9bPXoSxOmg9i9Hpn3isTA5AWojwLCKSZOZeNFk6cLp0RhGNw61eivJB9a2qzMg+qRi2w0IzvarUiPLsrTmfTxLjLqFmOBltf8h5lQSAKC3SJ+aLdmjJwfFTkekMQvnQVXbv8bMYo7El6jZ3Z24R2MDy/estrPrQ8XF5++fO5dXFjP2/yuHEI4qwigNqZ8UJxDjkotGyxxA0/2mbuEB3NL1lA7mGKyINPxYTSJcTmAEBiffDnZ+QWL9Hkw8sNJynJQB1RozBcGv14O7pgKTXxB4JcCH2g1RlYUlmfE56/MjR2txUdY8vAyMMMvG9O1lYex6+kABzC9hg7eAIPQp1sGwbnd4JUrD8SP79/VoOFRkspLNdLfW5cnhI234hg2qEC0FkhnIBDwokTA54FaEmlW3LReNKaXaDUv5c9/y9eSycxZdA9/jHtDWABB3jr2IfiyhmVN6xUh5wDvrDfwD2FWCcYAyQpemklkrBAzji/3jZ5BnrxuetkCuOPUjVOHQ4H7WrcXvxhGo0RJlsxNLmCaAhoJxry190Kgx/f41Fu6/14cR7E8ds/wRbtLR5U1rtJxwJIbo3R3KsG7JTydr+Onm2NyfbgU8Z/Zde9uLKmP+ZtGvqiuQT9BlgzAxPkIJAtEguTD3n/u7x3ipaiDvROguLtevKXIGzgJ/9G2M+RJY0qeZMZbAHDLSveJtYi2H03At0lc7VP7LDxvXzest+DpzarL72crD1CVRbxZgPGiZiZWT9/xdrWSqrInDDR+Q1a/ECm8F4tGMzwVrbDMTAnzYdsljcxw5z+Ojw5bBOwP7gW3tJyqCvxe6AliGk/gh9whUaNWMg58IPdMcQt5xWHEchaMmKkeeDFHSj0vFs+/qbN/acoEipeXSL7xHyIP+9IGL5lCFB64KUqEGJgEfp85602TgY3W75EfEstzI+PCgIXO8uMSHIph8gKUt4OzCbAZAl0z6ZFNZef50wbHQ5jGKw8mzmnWB0eerwet4UuUxKZLYJeFXuayXVxisAstl9mtmLsRkSWKgfMqT1y0d/yqo2Wq5TQ/9QBFceItsnlkGqx6u0C5ySGP38/cEipXowyHIaXLMinBclPYAp72r7iGYiiBhn7ONBKGDb9BcGk/2taPydwavM1xdpGtHI2vqn1Ni5PB1zD+mbHurPOgFEJnYeClEfr39caUsvi5urWXbygg1fxIVfKgRDhamCLQypnUPj07uzy7W19fgz9v4P8VPHTenJNPb2rIdoZu3KjoCOuc/lAG4Biv9CHYwawAFLbwzw68b6fOOiUPbn1+K7TPT2+QAei7CbNeb5iz1D47uxJaxevfFOtTvb7TKQLcGADdIsDAAHhRBIhtqcaijA/urdV5hRPqDLiGkwILVdzodF7hklQAvugKwCo4qONVwCiDxWaoJb8VgPwNZZr7FpSbWU7MWuyO9aXIYUKuhpqWLP4JDfH2UZAi49A0C5pVVVnYjLAnXz/1LraPvx7uAPSDuhZvu8l92LfOJuudN13bmuaBL/7aO+x93j45+lzd7LnZbmd/+/jYhOYz2IT6+OVw52Tv6NAELKOjggK97/x5IskNZ6DH2Zxl/MM9eJoJjzoYC4SBMR0G+a9ZDArnS4zZYm8jR2THtlRccZc5Y6h0fVdg+L5t5tv/FR20Cx3MR5TxpRJlPWyz8IgvM+Watf+HC/Tsqg22NkkdCBze67LfMEVcwCs3U9Tps6xt7mq6SL5KcZL0bPH9A2OjdsTpct5vcM08S5433jtnt6sNeNp616b5mGXiZ6J3cPqPTjvn6EgbNTs7c+AHe4RSeGrCf+wea+CpsRAFvO/3GiGZixCo0R3w7WwiEa2WU5dSFfNxQs+QUfQE5HJi//lGMltc5KW1RsXsvdnEja+TpiW/fpQZh0fbkVCpURk/mX3NORCjgNX4JXEnNP+WCadk81lkf2P3t3hSzYA3oynuWcgGK0bUO9lwnZSeZFjGD2bfmzC+vyTN+YZ66uY+wpT3EzJtmEvPVJw6FdZPJMPVJ4Skx9DvbJD9vYqigLnS6lLZBAL8AawAPXtDrbboXMLqFv90WMEGT7XW4WR0xeJC0y35C7Z0HZ1Vx2qLIkq62mvrOLVER/P7ufKv/TCt7AcwhPNQiL3JIgpjy1MIQM32GQjVpMpQynPVOa9fRGoQRmuGAhYjcTdLMQyc0kMaBxQyaeBBKX1ZLXSIzk9Jjtj4qvhpMMC8MVz4YN2uyjUb6G3MNdvNHMt5drqM4XN7xJGob2GV9QcdXPmex0KtU/tUlZ7PG5yaQ3Li6jlbvUMS4ak4xUwJ4HNNljpRMbsGsRXYoGeNC4zI0ZdRmO+a587PVUBlWWDHhmk6Tjba7Ws/HU6uIF4ctYPIc5Oh/LkKoqv2yE1SFrf9RCbx/22/+6qil92jg95dn41RrauGydPzhVFquf1FBpkL+PCfmB4OTQE8WGweCsSjxblzqI3C/NENal74ufn+f5eiCJf0peGsPM/KAwqGkjf5fXflM6ryBfrpy6PAo88KHLJbbaOAaogCTOllFy0K17L5yIFmiUVr5HpeJbx07NjN2MUDr+jCZeSWfZ8AMDYlIG9kfI2A16oPEizs6D12J938/tHONq4jLg62T3Z+wYD2LFmFKNVb3YD/Z42V9oiWi3sShzwCkR0ioGUb/6CtcfiKCtJhHN3yDXGaNrYvNumwWiYZ06GftC5CyqXgDxXzj7rOYGx2Lxl1DH2LeUj+wSKcGKdgF4T1IoeWvg2RFxlN/UZ5kxIRx5MwRN+nSBpMAjzZzDzDUtSgT5xcw5r8J2U1ncFQpFCGV10vdEFkoUEuLBPf16WBDfxYfA0DsebLsnHPrq2cLSr32siZy5ssB1lr5ki7Vk+CUiKFw1SGaJHbBS4gH7Wtzyo43XuK/BSBqK+LZBIxmlGJ/lGSXDvNo0hYzUIIGRbwKutv3g6SOHRTnJ1Cztgqoi5paS7oE9X2ZOyJ/XS5YkT/CXrN+VhfrxeTWv2ZZ4izXAz1Oc6/sl136xB3xmas+aTu5jdS6u4yztl4UwtAEgRfezRUEsC07JjZaTQMnhqY/RvVZ076MgR6oLMK6tM3080nyie0YEGD1/JV+kNYAhZnzlUs7VQNHXQSCwZNfWRtxv+/TVh8T7cuwH9kqDO26kjFsqDgdjKYMEohkIPFoq7StEyR9Oe/4gho1GCz3mrFNlxdRLph84mRUDVMvLZ3UVyLCGylH9ZGNWgob6DXlHynd/oEjHEUp7w7NSQk638B7sve5NpeAAA=
 </script>
+
+<script id="@tomlarkworthy/lopepage" 
+  type="text/plain"
+  data-mime="application/javascript"
+>
+const _1xyxga0 = function _page(htl,isOnObservableCom,lopeviz_handle_css,base_css,light_theme_css,commandPaletteStyles,commandPaletteOverlay,linkTo){return(
+htl.html`<div id="lopepage" style="height: ${
+  isOnObservableCom() ? "800px" : "100vh"
+}">
+  ${lopeviz_handle_css}
+  ${base_css}
+  ${light_theme_css}
+  ${commandPaletteStyles}
+${commandPaletteOverlay}
+  <style>
+    html body {
+      max-width: 100vw;
+    }
+    html {
+      padding: 0px !important;
+      margin: 0px !important;
+    }
+    #lopepage:has(.observablehq-root) > .module-explorer {
+      display: none;
+    }
+  </style>
+  <h1 style="display:none;">Lopepage</h1>
+  <div class="module-explorer">
+    <p>Lost? Open the <a href="${linkTo("@tomlarkworthy/module-selection", {
+      onObservable: false
+    })}">module explorer</a> or press CMD + K to open the command palatte.
+  </div>
+</div>`
+)};
+const _1ujnhdh = function _append_to_body(page)
+{
+    // If exported in headless mode, this will attach the page
+    if (!page.isConnected) {
+        document.body.appendChild(page);
+    }
+};
+const _1nv51s8 = function _testNavigation(htl,linkTo){return(
+htl.html`<h2>Manual Testing links</h2>
+<ul>
+<li><a href="https://observablehq.com/@tomlarkworthy/lopepage#testNavigation">refresh page</a></li>
+<li><a href="#testNavigation">reset view</a></li>
+<li><a href="${ linkTo('@tomlarkworthy/stream-operators', { onObservable: false }) }">stream-operators</a> module</li>
+<li><a href="${ linkTo('@tomlarkworthy/stream-operators#combineLatest', { onObservable: false }) }">stream-operators#combineLatest</a> 
+<li><a href="${ linkTo('@tomlarkworthy/runtime-sdk#observe', { onObservable: false }) }">runtime-sdk#observe</a> cell</li>
+</ul>`
+)};
+const _ydvyos = function _reload(Inputs){return(
+Inputs.button('reload')
+)};
+const _1we0ggl = (G, _) => G.input(_);
+const _plefwg = function _onLoadConfig(parseGoldenDSL,URLSearchParams,location)
+{
+    try {
+        return parseGoldenDSL(new URLSearchParams(location.hash.substring(1)).get('view'));
+    } catch (err) {
+        return undefined;
+    }
+};
+const _1nzpnqy = function _visualizer_cache(reload)
+{
+    reload;
+    return new Map();
+};
+const _1ojown8 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
+{
+  return function (container, component) {
+    appendScrollLog('modulePanel:enter', {
+      title: container?.title ?? null,
+      componentCell: component?.cell ?? null
+    });
+    const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
+    if (!moduleInfo) {
+      // Fall through to file attachment: titles like @user/notebook/path.ext
+      // resolve via the lopecode bootloader's contentSync DOM lookup.
+      const title = container?.title ?? null;
+      if (title) {
+        let node = file_attachment_cache.get(title);
+        if (!node) {
+          const r = window.lopecode?.contentSync?.(title);
+          if (r && r.status === 200 && r.bytes) {
+            node = renderFileAttachment(r.mime, r.bytes);
+            file_attachment_cache.set(title, node);
+            appendScrollLog('modulePanel:file_attachment_create', {
+              title,
+              mime: r.mime
+            });
+          }
+        }
+        if (node) {
+          const c_element = container.getElement();
+          if (node.parentNode !== c_element)
+            c_element.appendChild(node);
+          appendScrollLog('modulePanel:file_attachment_mount', { title });
+          return;
+        }
+      }
+      appendScrollLog('modulePanel:missing_moduleInfo', { title });
+      return;
+    }
+    const module = moduleInfo.module;
+    let node;
+    if (!visualizer_cache.has(module)) {
+      appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
+      node = visualizer(runtime, {
+        invalidation: new Promise(r => {
+        }),
+        module,
+        detachNodes: isOnObservableCom(),
+        filter: (cell_name, variables) => {
+          if (variables[0]._type !== 1)
+            return false;
+          if (typeof cell_name == 'string') {
+            if (cell_name.startsWith('dynamic '))
+              return false;
+          }
+          return true;
+        }
+      });
+      visualizer_cache.set(module, node);
+    } else {
+      node = visualizer_cache.get(module);
+      appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+    }
+    const cell = module._scope.get(component.cell);
+    const scrollKey = scrollKeyFor(container);
+    fix_scroll(container, node, cell, scrollKey);
+    const el = container.getElement();
+    if (!el.__lope_scroll_bound) {
+      el.__lope_scroll_bound = true;
+      appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
+      const markUserScroll = () => {
+        el.__lope_user_scroll_at = Date.now();
+      };
+      el.addEventListener('wheel', markUserScroll, { passive: true });
+      el.addEventListener('touchmove', markUserScroll, { passive: true });
+      el.addEventListener('keydown', markUserScroll, { passive: true });
+      el.addEventListener('scroll', () => {
+        if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+          appendScrollLog('scroll:skip_reflow', { title: container?.title ?? null });
+          return;
+        }
+        // Only cache scrolls following a genuine user gesture; reflow-induced
+        // scroll events (e.g. closing an adjacent panel) carry stale scrollTops.
+        if (Date.now() - (el.__lope_user_scroll_at || 0) > 400) {
+          appendScrollLog('scroll:skip_nonuser', { title: container?.title ?? null });
+          return;
+        }
+        const k = scrollKeyFor(container);
+        const scrollTop = el.scrollTop;
+        const scrollLeft = el.scrollLeft;
+        if (scrollTop == 0) {
+          appendScrollLog('modulePanel:skip 0 scroll', {
+            title: container?.title ?? null,
+            scrollKey
+          });
+          return;
+        }
+        scroll_cache.set(k, {
+          scrollTop,
+          scrollLeft,
+          t: Date.now()
+        });
+        appendScrollLog('scroll:event', {
+          k,
+          title: container?.title ?? null,
+          scrollTop,
+          scrollLeft
+        });
+      }, { passive: true });
+    }
+    // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
+    if (!container.__lope_destroy_bound) {
+      container.__lope_destroy_bound = true;
+      container.on('destroy', () => {
+        try {
+          if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+            appendScrollLog('scroll:destroy_skip_reflow', { title: container?.title ?? null });
+            return;
+          }
+          const k = scrollKeyFor(container);
+          const scrollTop = el?.scrollTop;
+          const scrollLeft = el?.scrollLeft;
+          if (scrollTop == 0) {
+            appendScrollLog('scroll:skip 0 scroll', {
+              k,
+              key: container?.title ?? null,
+              scrollKey
+            });
+            return;
+          }
+          // do not skip 0 here: if the user is at top, preserve that state
+          scroll_cache.set(k, {
+            scrollTop,
+            scrollLeft,
+            t: Date.now()
+          });
+          appendScrollLog('scroll:destroy_capture', {
+            k,
+            title: container?.title ?? null,
+            scrollTop,
+            scrollLeft
+          });
+        } catch (e) {
+          appendScrollLog('scroll:destroy_capture:error', {
+            title: container?.title ?? null,
+            error: String(e)
+          });
+        }
+      });
+    }
+    // When GoldenLayout resizes this panel (e.g. an adjacent panel is closed) the
+    // browser can shift scrollTop; re-apply the user's cached position after the reflow.
+    if (!container.__lope_resize_bound) {
+      container.__lope_resize_bound = true;
+      container.on('resize', () => {
+        const rk = scrollKeyFor(container);
+        const cached = scroll_cache.get(rk);
+        if (!cached || cached.scrollTop == null)
+          return;
+        const c_el = container.getElement();
+        const at = Date.now();
+        scroll_cache.__reflowUntil = at + 800;
+        // The reflow can shift scrollTop in several passes (content relayout
+        // settles ~300ms later), so re-apply over a window. Bail if the user scrolls.
+        const apply = () => {
+          if ((c_el.__lope_user_scroll_at || 0) > at)
+            return;
+          if (c_el.scrollTop !== cached.scrollTop)
+            c_el.scrollTop = cached.scrollTop;
+          if (cached.scrollLeft != null && c_el.scrollLeft !== cached.scrollLeft)
+            c_el.scrollLeft = cached.scrollLeft;
+        };
+        requestAnimationFrame(apply);
+        for (const d of [
+            60,
+            150,
+            300,
+            450,
+            600
+          ])
+          setTimeout(apply, d);
+        appendScrollLog('scroll:resize_restore', {
+          k: rk,
+          title: container?.title ?? null,
+          scrollTop: cached.scrollTop
+        });
+      });
+    }
+    appendScrollLog('modulePanel:exit', {
+      title: container?.title ?? null,
+      scrollKey
+    });
+  };
+};
+const _1gm4gbf = function _blobPanel(){return(
+function (container, component) {
+    const node = document.createElement('iframe');
+    node.src = component.url;
+    const c_element = container.getElement();
+    const element = c_element.appendChild(node);
+}
+)};
+const _lxv2e2 = function _settings(){return(
+{
+    showMaximiseIcon: false,
+    showPopoutIcon: false,
+    showCloseIcon: true,
+    hasHeaders: true
+}
+)};
+const _lp1ggk = function _is_mobile(width){return(
+width < 800
+)};
+const _qbghwu = function _config(onLoadConfig,settings)
+{
+    if (onLoadConfig) {
+        return {
+            settings: settings,
+            content: [onLoadConfig]
+        };
+    }
+    return { settings: settings };
+};
+const _15lk82w = (M, _) => new M(_);
+const _1bki6eh = _ => _.generator;
+const _14z0bay = function _resize(Generators,addEventListener,invalidation,removeEventListener){return(
+Generators.observe(notify => {
+    notify(undefined);
+    addEventListener('resize', notify);
+    invalidation.then(() => removeEventListener('resize', notify));
+})
+)};
+const _18jv72h = function _layout(resize,gl,$0,page,modulePanel,blobPanel)
+{
+    // Removed resizing re-laying out because it causes problems with components that watch focus
+    // when the the layout is redone, the components are killed and removed, damaging focus state.
+    // mobile keyboards cause a resize, breaking the component that has focus
+    resize;
+    let layout = this;
+    if (!layout) {
+        layout = new gl.GoldenLayout($0.value, page);
+        layout.registerComponent('module', modulePanel);
+        layout.registerComponent('blob', blobPanel);
+        layout.init();
+    } else {
+        layout.updateSize();
+    }
+    // TODO layout destroy is destructive
+    // invalidation.then(() => {
+    //   // avoid layouts stacking up
+    //   layout.destroy();
+    // });
+    return layout;
+};
+const _tsjb2x = function _layout_state(appendScrollLog,layout,gl,$0)
+{
+    appendScrollLog('layout_state:bind', { hasLayout: !!layout });
+    return layout.on('stateChanged', () => {
+        appendScrollLog('layout:stateChanged', {});
+        const state = gl.LayoutConfig.fromResolved(layout.toConfig());
+        $0.value = state;
+        appendScrollLog('layout:stateChanged:config_updated', { rootType: state?.root?.type ?? null });
+    });
+};
+const _11nrwvj = function _lopepageModule(thisModule){return(
+thisModule()
+)};
+const _r97569 = (G, _) => G.input(_);
+const _1sp5wo4 = function _16(md){return(
+md`## Scrolling
+
+Scrolling has been a mess to develop. The thing that finally fixed it was \`scroll_fix_sync_layout\`. I suspect fix_scroll is over-complex.`
+)};
+const _1ts23ma = function _scrollDebug(Inputs){return(
+Inputs.toggle({
+    label: 'enable debug scroll?',
+    value: true
+})
+)};
+const _7jxivy = (G, _) => G.input(_);
+const _1f2wuqm = function _appendScrollLog($0,$1){return(
+(type, detail = {}) => {
+    if (!$0.value)
+        return null;
+    const evt = {
+        t: Date.now(),
+        type: String(type),
+        ...detail
+    };
+    $1.value = ($1.value || []).concat([evt]);
+    return evt;
+}
+)};
+const _1nbnzwx = function _scrollLog(scrollDebug){return(
+scrollDebug ? [] : []
+)};
+const _1f7xtz1 = (M, _) => new M(_);
+const _1dyz4o0 = _ => _.generator;
+const _1d1nkw9 = function _scrollKeyFor(appendScrollLog)
+{
+    return container => {
+        // can return undefined if the container is loading still
+        const key = container?.title;
+        appendScrollLog('scrollKeyFor:', { key });
+        return key;
+    };
+};
+const _tb217h = function _scroll_cache(){return(
+new Map()
+)};
+const _12p8mg7 = function _fix_scroll(scroll_cache,scrollKeyFor,appendScrollLog)
+{
+  return function (container, node, cell_variable, key) {
+    scroll_cache.__reflowUntil = Date.now() + 600;
+    // suppress reflow-induced scroll events that clobber the cache
+    const c_element = container.getElement();
+    let k = scrollKeyFor(container);
+    appendScrollLog('fix_scroll:enter', {
+      title: container?.title ?? null,
+      k,
+      cell: cell_variable?._name ?? null
+    });
+    if (node && node.parentNode !== c_element) {
+      c_element.appendChild(node);
+      appendScrollLog('fix_scroll:append_node', {
+        title: container?.title ?? null,
+        k
+      });
+    }
+    const writeCache = (scrollTop, scrollLeft, why) => {
+      scroll_cache.set(k, {
+        scrollTop,
+        scrollLeft,
+        t: Date.now()
+      });
+      appendScrollLog('scroll_cache:write', {
+        k,
+        scrollTop,
+        scrollLeft,
+        why
+      });
+    };
+    const scrollToCellIfPossible = why => {
+      if (!cell_variable)
+        return false;
+      const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
+      if (!dom) {
+        appendScrollLog('scroll:cell_dom_not_found', {
+          k,
+          why,
+          cell: cell_variable?._name ?? null
+        });
+        return false;
+      }
+      const top = dom.offsetTop - c_element.offsetTop;
+      const left = c_element.scrollLeft;
+      c_element.scrollTop = top;
+      appendScrollLog('scroll:set', {
+        k,
+        why: `${ why }:cell`,
+        scrollTop: top,
+        scrollLeft: left,
+        cell: cell_variable?._name ?? null
+      });
+      writeCache(top, left, `${ why }:cell`);
+      return true;
+    };
+    const restoreFromCache = why => {
+      k = scrollKeyFor(container);
+      const cached = scroll_cache.get(k);
+      appendScrollLog('scroll:restore_attempt', {
+        k,
+        why,
+        cachedScrollTop: cached?.scrollTop ?? null,
+        cachedScrollLeft: cached?.scrollLeft ?? null
+      });
+      if (!cached) {
+        appendScrollLog('scroll:restore_no_scroll', {
+          k,
+          why
+        });
+        return;
+      }
+      if (cached.scrollTop != null)
+        c_element.scrollTop = cached.scrollTop;
+      if (cached.scrollLeft != null)
+        c_element.scrollLeft = cached.scrollLeft;
+      appendScrollLog('scroll:restore_applied', {
+        k,
+        why,
+        scrollTop: cached.scrollTop ?? null,
+        scrollLeft: cached.scrollLeft ?? null,
+        scrollTopFinal: c_element.scrollTop,
+        scrollLeftFinal: c_element.scrollLeft
+      });
+    };
+    const setScroll = (why = 'setScroll') => {
+      if (scrollToCellIfPossible(why))
+        return;
+      restoreFromCache(why);
+    };
+    const retryFrames = 6;
+    for (let i = 0; i < retryFrames; i++) {
+      requestAnimationFrame(() => {
+        k = scrollKeyFor(container);
+        appendScrollLog('fix_scroll:raf_retry', {
+          i,
+          k,
+          title: container?.title ?? null
+        });
+        setScroll(`raf:${ i }`);
+      });
+    }
+    appendScrollLog('fix_scroll:exit', {
+      k,
+      title: container?.title ?? null
+    });
+  };
+};
+const _arfw00 = function _scroll_fix_sync_layout(sync_layout_to_url,layout,appendScrollLog,modulePanel)
+{
+    sync_layout_to_url;
+    let timeout = null;
+    const listComponentItems = () => {
+        const out = [];
+        const walk = item => {
+            if (!item)
+                return;
+            if (item.isComponent || item.type === 'component')
+                out.push(item);
+            const kids = item.contentItems || item.content || [];
+            for (const k of kids)
+                walk(k);
+        };
+        walk(layout.root);
+        return out;
+    };
+    const items = listComponentItems();
+    appendScrollLog('scroll:reapply_all:begin', { count: items.length });
+    for (const it of items) {
+        try {
+            const container = it.container;
+            const title = container?.title ?? it.title ?? null;
+            if (!container || !title)
+                continue;
+            const st = it.componentState ?? it.config?.componentState ?? it._config?.componentState ?? it._state ?? {};
+            modulePanel(container, { cell: st?.cell });
+        } catch (e) {
+            appendScrollLog('scroll:reapply_all:error', { error: String(e) });
+        }
+    }
+    return true;
+};
+const _3nwpp4 = function _URLrouting(md){return(
+md`## URL Sync
+
+### Goals
+1. **Non-destructive navigation:** mutate an existing GoldenLayout (GL) instance (add/remove/reorder items) rather than rebuilding.
+2. **Refresh restores what you see:** the URL eventually contains the full serialized GL tree in **\`view=\`**.
+3. **Links are “intents”:** in-app links should not rewrite \`view=\` at click time.
+
+---
+
+## State model
+
+### Canonical, persistent state
+- **\`view=<DSL>\`** is the canonical serialized GL layout (single source of truth after boot).
+
+### One-shot intent params (cleared after commit)
+- \`open=<moduleOrModule#cell>\`
+- \`close=<...>\` (reserved)
+- \`focus=<...>\` (reserved)
+- \`from=<module>\` (optional placement hint)
+
+---
+
+## Dataflow
+
+### 1) URL → desired layout (intent overlay)
+- Parse \`view\` with \`parseGoldenDSL\` to get the desired root config.
+- If \`open=\` exists, **overlay** it into the parsed config by inserting the target module into the *first stack* (and optional \`componentState.cell\`).
+
+Implemented in: **\`sync_layout_from_url\`**.
+
+### 2) Desired layout → live GL (non-destructive when possible)
+- Try **\`treeSyncGolden(layout, desiredRoot)\`** to:
+  - add missing module tabs
+  - remove extra module tabs
+  - reorder tabs to match the DSL
+  - ensure container shapes (row/column/stack) match where possible
+- If tree sync can’t reconcile safely, **fallback to \`layout.loadLayout(...)\`**.
+
+Implemented in: **\`treeSyncGolden\`** + \`sync_layout_from_url\`.
+
+### 3) Live GL → URL persistence (“commit then clear”)
+- GL emits \`stateChanged\` → update \`mutable config\` from \`layout.toConfig()\`.
+- Serialize \`config.root\` with \`serializeGoldenDSL\` and write it to **\`view=\`**.
+- Clear one-shot intent params (\`open/close/focus/from\`) so they are not re-applied on refresh.
+
+Implemented in: **\`sync_layout_to_url\`** via \`history.replaceState(...)\`.
+
+---
+
+## Unit test gate (safety check)
+Before \`sync_layout_to_url\` is allowed to persist \`view=\`, a **roundtrip invariant** must hold:
+
+- Compute an expected “pre” DSL:
+  - normalize weights (e.g. S100/R100/C100)
+  - apply the same \`open=\` overlay used by \`sync_layout_from_url\`
+- Compare it to the “post” DSL obtained after applying the URL to the live layout and re-serializing.
+
+If **\`test_url_roundtrip\`** throws or returns non-\`true\`, **\`sync_layout_to_url\`** exits early (no canonical \`view=\` writes). This prevents committing a drifting/incorrect \`view=\` during development and makes URL persistence self-checking.
+
+Implemented in: **\`test_url_roundtrip\`** and enforced at the top of **\`sync_layout_to_url\`**.
+`
+)};
+const _14te9pl = function _sync_layout_from_url(reload,resize,URLSearchParams,hash,appendScrollLog,parseGoldenDSL,gl,layout,serializeGoldenDSL,treeSyncGolden,invalidation)
+{
+  reload;
+  resize;
+  const params = new URLSearchParams(String(hash || '').replace(/^#/, ''));
+  const view = params.get('view');
+  const open = params.get('open');
+  appendScrollLog('url:sync_from:begin', {
+    hash: String(hash || ''),
+    view,
+    open
+  });
+  const diag = {
+    preURL: view ?? null,
+    postURL: null,
+    method: null,
+    status: 'skipped',
+    reason: '',
+    error: null,
+    open: null,
+    openApplied: false
+  };
+  let desiredRoot;
+  try {
+    desiredRoot = parseGoldenDSL(view);
+  } catch (e) {
+    diag.method = 'parse';
+    diag.status = 'error';
+    diag.reason = 'parseGoldenDSL failed';
+    diag.error = String(e);
+    appendScrollLog('url:sync_from:error', {
+      where: 'parse',
+      error: diag.error
+    });
+    return diag;
+  }
+  if (!view && open) {
+    try {
+      const resolved = gl.LayoutConfig.fromResolved(layout.toConfig());
+      desiredRoot = resolved?.root ?? layout.toConfig()?.root ?? layout.toConfig()?.content?.[0];
+      if (desiredRoot) {
+        diag.preURL = serializeGoldenDSL(desiredRoot);
+        appendScrollLog('url:sync_from:fallback_to_current_layout', {
+          preURL: diag.preURL,
+          open
+        });
+      }
+    } catch (e) {
+      appendScrollLog('url:sync_from:fallback_to_current_layout:error', { error: String(e) });
+    }
+    if (!desiredRoot) {
+      // Lazily synthesize an empty stack so the open overlay below can populate it.
+      desiredRoot = {
+        type: 'stack',
+        content: []
+      };
+      try {
+        diag.preURL = serializeGoldenDSL(desiredRoot);
+      } catch {
+        diag.preURL = 'S100()';
+      }
+      appendScrollLog('url:sync_from:synthesize_empty_stack', {
+        preURL: diag.preURL,
+        open
+      });
+    }
+  }
+  if (!desiredRoot) {
+    diag.method = 'parse';
+    diag.status = 'error';
+    diag.reason = 'parseGoldenDSL returned falsy';
+    appendScrollLog('url:sync_from:error', {
+      where: 'parse',
+      error: diag.reason
+    });
+    return diag;
+  }
+  const findFirstStack = node => {
+    if (!node)
+      return null;
+    if (node.type === 'stack')
+      return node;
+    for (const c of node.content || []) {
+      const f = findFirstStack(c);
+      if (f)
+        return f;
+    }
+    return null;
+  };
+  const findExistingModule = (node, title) => {
+    if (!node)
+      return null;
+    if (node.type === 'component' && (node.componentType === 'module' || node.componentName === 'module') && node.title === title) {
+      return node;
+    }
+    for (const c of node.content || []) {
+      const f = findExistingModule(c, title);
+      if (f)
+        return f;
+    }
+    return null;
+  };
+  if (open) {
+    const [moduleTitleRaw, cellRaw] = String(open).split('#');
+    const moduleTitle = (moduleTitleRaw || '').trim();
+    const cell = (cellRaw || '').trim() || null;
+    if (moduleTitle) {
+      diag.open = {
+        moduleTitle,
+        cell
+      };
+      const existingAnywhere = findExistingModule(desiredRoot, moduleTitle);
+      if (existingAnywhere) {
+        existingAnywhere.componentState = existingAnywhere.componentState || {};
+        if (cell)
+          existingAnywhere.componentState.cell = cell;
+        appendScrollLog('url:sync_from:overlay_open:update_existing', {
+          moduleTitle,
+          cell
+        });
+        diag.openApplied = true;
+      } else {
+        const stack = findFirstStack(desiredRoot);
+        if (stack) {
+          stack.content = stack.content || [];
+          stack.content.push({
+            type: 'component',
+            title: moduleTitle,
+            componentType: 'module',
+            componentName: 'module',
+            componentState: cell ? { cell } : {}
+          });
+          appendScrollLog('url:sync_from:overlay_open:add', {
+            moduleTitle,
+            cell
+          });
+          diag.openApplied = true;
+        } else {
+          appendScrollLog('url:sync_from:overlay_open:no_stack_found', {
+            moduleTitle,
+            cell
+          });
+        }
+      }
+    }
+  }
+  const doLoadLayout = () => {
+    if (typeof layout?.loadLayout !== 'function')
+      throw new Error('layout.loadLayout not available');
+    appendScrollLog('layout:loadLayout:call', {
+      desiredType: desiredRoot?.type ?? null,
+      open: diag.open?.moduleTitle ?? null
+    });
+    layout.loadLayout({
+      settings: {},
+      content: [desiredRoot]
+    });
+  };
+  try {
+    const res = treeSyncGolden(layout, desiredRoot);
+    if (res?.status === 'fallback') {
+      diag.method = 'loadLayout';
+      diag.status = 'fallback';
+      diag.reason = res.reason || 'treeSync requested fallback';
+      appendScrollLog('url:sync_from:treesync_fallback', { reason: diag.reason });
+      try {
+        doLoadLayout();
+      } catch (e2) {
+        diag.status = 'error';
+        diag.reason = 'loadLayout failed after treeSync fallback';
+        diag.error = String(e2);
+        appendScrollLog('url:sync_from:error', {
+          where: 'loadLayout_after_fallback',
+          error: diag.error
+        });
+      }
+    } else {
+      diag.method = 'treeSync';
+      diag.status = 'synced';
+      appendScrollLog('url:sync_from:treesync_ok', {});
+    }
+  } catch (e) {
+    diag.method = 'loadLayout';
+    diag.status = 'fallback';
+    diag.reason = 'exception during treeSync';
+    diag.error = String(e);
+    appendScrollLog('url:sync_from:treesync_exception', { error: diag.error });
+    try {
+      doLoadLayout();
+    } catch (e2) {
+      diag.status = 'error';
+      diag.reason = 'loadLayout failed after treeSync exception';
+      diag.error = `${ String(e) }; loadLayout: ${ String(e2) }`;
+      appendScrollLog('url:sync_from:error', {
+        where: 'loadLayout_after_exception',
+        error: diag.error
+      });
+    }
+  }
+  try {
+    const resolved = gl?.LayoutConfig?.fromResolved ? gl.LayoutConfig.fromResolved(layout.toConfig()) : null;
+    const root = resolved?.root ?? layout.toConfig()?.root ?? layout.toConfig()?.content?.[0];
+    diag.postURL = root ? serializeGoldenDSL(root) : null;
+  } catch (e) {
+    diag.postURL = null;
+    if (!diag.error)
+      diag.error = `serialize failed: ${ String(e) }`;
+    appendScrollLog('url:sync_from:serialize_failed', { error: String(e) });
+  }
+  appendScrollLog('url:sync_from:end', {
+    status: diag.status,
+    method: diag.method,
+    reason: diag.reason || null,
+    preURL: diag.preURL,
+    postURL: diag.postURL
+  });
+  invalidation.then(() => {
+  });
+  return diag;
+};
+const _1l50a0d = function _sync_layout_to_url(appendScrollLog,sync_layout_from_url,config,test_url_roundtrip,serializeGoldenDSL,location,setHashURL)
+{
+    appendScrollLog('url:sync_to:tick', {
+        fromStatus: sync_layout_from_url?.status ?? null,
+        hasRoot: !!config?.root
+    });
+    if (test_url_roundtrip !== true) {
+        appendScrollLog('url:sync_to:blocked', { reason: 'test_url_roundtrip != true' });
+        return;
+    }
+    if (sync_layout_from_url?.status === 'error') {
+        appendScrollLog('url:sync_to:blocked', { reason: 'sync_layout_from_url status=error' });
+        return;
+    }
+    if (!config?.root) {
+        appendScrollLog('url:sync_to:blocked', { reason: 'config.root missing' });
+        return;
+    }
+    let dsl;
+    try {
+        dsl = serializeGoldenDSL(config.root);
+    } catch (e) {
+        appendScrollLog('url:sync_to:serialize_failed', { error: String(e) });
+        return;
+    }
+    // Parse hash manually to avoid URLSearchParams percent-encoding view= values
+    // like R100(S50(@tomlarkworthy/lopepage)) → R100%28S50%28%40tomlarkworthy%2Flopepage%29%29
+    const rawHash = String(location.hash || '').replace(/^#/, '');
+    const knownIntents = new Set([
+        'open',
+        'close',
+        'focus',
+        'from'
+    ]);
+    // Split into key=value pairs, preserving original encoding
+    const parts = rawHash.split('&').filter(Boolean);
+    const extra = [];
+    // unknown params to preserve (e.g. cc=TOKEN)
+    let currentView = null;
+    let hasIntent = false;
+    for (const part of parts) {
+        const eq = part.indexOf('=');
+        const key = eq >= 0 ? part.slice(0, eq) : part;
+        const val = eq >= 0 ? part.slice(eq + 1) : '';
+        if (key === 'view') {
+            currentView = decodeURIComponent(val);
+        } else if (knownIntents.has(key)) {
+            hasIntent = true;
+        } else {
+            extra.push(part);    // preserve verbatim
+        }
+    }
+    if (currentView === dsl) {
+        appendScrollLog('url:sync_to:no_change', { hasIntent });
+        if (hasIntent) {
+            // Rebuild without intents, keep view + extras
+            const newHash = '#view=' + dsl + (extra.length ? '&' + extra.join('&') : '');
+            const res = setHashURL(newHash);
+            appendScrollLog('url:sync_to:clear_intents', { result: res });
+        }
+        return;
+    }
+    const newHash = '#view=' + dsl + (extra.length ? '&' + extra.join('&') : '');
+    appendScrollLog('url:sync_to:write_view', {
+        oldHash: String(location.hash || ''),
+        newHash,
+        dsl
+    });
+    if (newHash !== location.hash) {
+        const res = setHashURL(newHash);
+        appendScrollLog('url:sync_to:setHashURL_result', { result: res });
+    }
+};
+const _jcy1xg = function _test_url_roundtrip(sync_layout_from_url)
+{
+    const d = sync_layout_from_url;
+    if (!d || d.status === 'skipped')
+        return true;
+    if (d.status === 'error')
+        throw new Error(d.error || d.reason || 'sync error');
+    if (d.postURL == null)
+        throw new Error(d.error || 'postURL missing');
+    const normalize = dsl => {
+        if (dsl == null)
+            return dsl;
+        let s = String(dsl);
+        s = s.replace(/S\d+(?=\()/g, 'S100').replace(/R\d+(?=\()/g, 'R100').replace(/C\d+(?=\()/g, 'C100');
+        s = s.replace(/S(?=\()/g, 'S100').replace(/R(?=\()/g, 'R100').replace(/C(?=\()/g, 'C100');
+        return s;
+    };
+    const overlayOpen = (dsl, openTarget) => {
+        if (!openTarget?.moduleTitle)
+            return dsl;
+        const title = String(openTarget.moduleTitle);
+        if (dsl && dsl.includes(title))
+            return dsl;
+        const s = String(dsl ?? '');
+        if (!/S100\(/.test(s)) {
+            return `S100(${ title })`;
+        }
+        return s.replace(/S100\(([^)]*)\)/, (m, inner) => {
+            const trimmed = String(inner || '').trim();
+            const next = trimmed ? `${ trimmed },${ title }` : title;
+            return `S100(${ next })`;
+        });
+    };
+    const preRaw = d.preURL ?? 'S()';
+    const preWithIntent = overlayOpen(normalize(preRaw), d.open);
+    const post = normalize(d.postURL);
+    if (preWithIntent !== post) {
+        throw new Error(`view URL drift: preURL != postURL\n` + `preURL=${ String(preRaw) }\n` + `open=${ d.open?.moduleTitle || '' }\n` + `postURL=${ String(d.postURL) }\n` + `normalizedPreWithIntent=${ String(preWithIntent) }\n` + `normalizedPost=${ String(post) }\n` + `method=${ d.method } status=${ d.status } reason=${ d.reason || '' }`);
+    }
+    return true;
+};
+const _1yxu9kf = function _setHashURL(location,appendScrollLog,history){return(
+function setHashURL(newHash) {
+    const h = String(newHash ?? '');
+    const hash = h.startsWith('#') ? h : `#${ h }`;
+    const url = new URL(location.href);
+    url.hash = hash;
+    const href = url.toString();
+    appendScrollLog('url:setHashURL:attempt', {
+        hash,
+        href
+    });
+    try {
+        history.replaceState(null, '', href);
+        const res = {
+            ok: true,
+            method: 'replaceState',
+            href,
+            hash
+        };
+        appendScrollLog('url:setHashURL:success', res);
+        return res;
+    } catch (e) {
+        const a = document.createElement('a');
+        a.href = href;
+        a.rel = 'noreferrer';
+        a.style.display = 'none';
+        (document.body || document.documentElement).appendChild(a);
+        a.click();
+        a.remove();
+        const res = {
+            ok: false,
+            method: 'synthetic-click',
+            href,
+            hash,
+            error: String(e)
+        };
+        appendScrollLog('url:setHashURL:fallback', res);
+        return res;
+    }
+}
+)};
+const _1zkl8r = function _treeSyncGolden(appendScrollLog,gl){return(
+function treeSyncGoldenFactory(gl) {
+    const isCompCfg = n => n && n.type === 'component';
+    const isContCfg = n => n && (n.type === 'row' || n.type === 'column' || n.type === 'stack');
+    const desiredModuleKey = cfg => isCompCfg(cfg) && (cfg.componentType === 'module' || cfg.componentName === 'module') && cfg.title ? `module:${ cfg.title }` : null;
+    const liveModuleKey = item => {
+        if (!item)
+            return null;
+        if (!(item.isComponent || item.type === 'component'))
+            return null;
+        const t = item.componentType || item.componentName;
+        return t === 'module' && item.title ? `module:${ item.title }` : null;
+    };
+    const cloneCfg = cfg => {
+        const c = JSON.parse(JSON.stringify(cfg));
+        if (c.type === 'component' && (c.componentType === 'module' || c.componentName === 'module')) {
+            c.componentType = 'module';
+            c.componentName = 'module';
+            c.componentState = c.componentState || {};
+        }
+        return c;
+    };
+    function indexLiveModules(stackLive) {
+        const map = new Map();
+        for (const child of stackLive?.contentItems || []) {
+            const k = liveModuleKey(child);
+            if (k)
+                map.set(k, child);
+        }
+        return map;
+    }
+    function setLiveComponentStateCell(liveItem, cell) {
+        if (!liveItem || !cell)
+            return false;
+        let changed = false;
+        liveItem.componentState = liveItem.componentState || {};
+        if (liveItem.componentState.cell !== cell) {
+            liveItem.componentState.cell = cell;
+            changed = true;
+        }
+        const configs = [
+            liveItem.config,
+            liveItem._config,
+            liveItem._state
+        ].filter(Boolean);
+        for (const cfg of configs) {
+            cfg.componentState = cfg.componentState || {};
+            if (cfg.componentState.cell !== cell) {
+                cfg.componentState.cell = cell;
+                changed = true;
+            }
+        }
+        return changed;
+    }
+    function syncStack(stackLive, desiredStackCfg) {
+        appendScrollLog('treeSync:syncStack:enter', {
+            title: stackLive?.parent?.title ?? stackLive?.title ?? null,
+            desiredCount: (desiredStackCfg?.content || []).length,
+            liveCount: (stackLive?.contentItems || []).length
+        });
+        const desiredComps = (desiredStackCfg.content || []).filter(isCompCfg);
+        let liveByKey = indexLiveModules(stackLive);
+        for (let i = 0; i < desiredComps.length; i++) {
+            const d = desiredComps[i];
+            const k = desiredModuleKey(d);
+            if (!k)
+                continue;
+            if (!liveByKey.has(k)) {
+                let before = null;
+                for (let j = i + 1; j < desiredComps.length; j++) {
+                    const k2 = desiredModuleKey(desiredComps[j]);
+                    if (k2 && liveByKey.has(k2)) {
+                        before = liveByKey.get(k2);
+                        break;
+                    }
+                }
+                const idx = before ? (stackLive.contentItems || []).indexOf(before) : (stackLive.contentItems || []).length;
+                appendScrollLog('treeSync:stack:addItem', {
+                    key: k,
+                    title: d?.title ?? null,
+                    idx,
+                    beforeKey: before ? liveModuleKey(before) : null
+                });
+                if (typeof stackLive.addItem !== 'function')
+                    return {
+                        status: 'fallback',
+                        reason: 'stack missing addItem'
+                    };
+                stackLive.addItem(cloneCfg(d), idx);
+                liveByKey = indexLiveModules(stackLive);
+            }
+        }
+        const desiredKeys = new Set(desiredComps.map(desiredModuleKey).filter(Boolean));
+        for (const child of Array.from(stackLive?.contentItems || [])) {
+            const k = liveModuleKey(child);
+            if (k && !desiredKeys.has(k) && typeof child.remove === 'function') {
+                appendScrollLog('treeSync:stack:remove', {
+                    key: k,
+                    title: child?.title ?? null
+                });
+                child.remove();
+            }
+        }
+        const order = desiredComps.map(desiredModuleKey).filter(Boolean);
+        const byKey = indexLiveModules(stackLive);
+        for (let i = 0; i < order.length; i++) {
+            const item = byKey.get(order[i]);
+            if (!item)
+                continue;
+            const curIdx = (stackLive.contentItems || []).indexOf(item);
+            if (curIdx !== i && typeof stackLive.removeChild === 'function' && typeof stackLive.addChild === 'function') {
+                appendScrollLog('treeSync:stack:reorder', {
+                    key: order[i],
+                    from: curIdx,
+                    to: i
+                });
+                stackLive.removeChild(item, true);
+                stackLive.addChild(item, i, false);
+            }
+        }
+        {
+            const byKey2 = indexLiveModules(stackLive);
+            for (const d of desiredComps) {
+                const k = desiredModuleKey(d);
+                const desiredCell = d?.componentState?.cell ?? null;
+                if (!k || !desiredCell)
+                    continue;
+                const liveItem = byKey2.get(k);
+                if (!liveItem)
+                    continue;
+                const changed = setLiveComponentStateCell(liveItem, desiredCell);
+                if (changed) {
+                    appendScrollLog('treeSync:stack:sync_componentState_cell', {
+                        key: k,
+                        title: liveItem?.title ?? null,
+                        cell: desiredCell
+                    });
+                }
+            }
+        }
+        appendScrollLog('treeSync:syncStack:exit', { liveCount: (stackLive?.contentItems || []).length });
+        return { status: 'synced' };
+    }
+    function ensureContainerChild(parentLive, idx, desiredChildCfg) {
+        const liveChild = parentLive?.contentItems?.[idx];
+        if (liveChild && liveChild.type === desiredChildCfg.type)
+            return liveChild;
+        if (liveChild && typeof liveChild.remove === 'function') {
+            appendScrollLog('treeSync:container:remove_child_for_type_mismatch', {
+                idx,
+                liveType: liveChild?.type ?? null,
+                desiredType: desiredChildCfg?.type ?? null
+            });
+            liveChild.remove();
+        }
+        if (typeof parentLive?.addItem !== 'function')
+            return null;
+        appendScrollLog('treeSync:container:addItem', {
+            idx,
+            type: desiredChildCfg?.type ?? null
+        });
+        parentLive.addItem({
+            type: desiredChildCfg.type,
+            content: []
+        }, idx);
+        return parentLive?.contentItems?.[idx] || null;
+    }
+    function isContainerItem(item) {
+        if (!item)
+            return false;
+        if (item.isComponent)
+            return false;
+        return item.type === 'row' || item.type === 'column' || item.type === 'stack';
+    }
+    function syncContainer(containerLive, desiredCfg) {
+        if (!containerLive || !desiredCfg || !Array.isArray(desiredCfg.content))
+            return { status: 'synced' };
+        const desiredChildren = desiredCfg.content.filter(isContCfg);
+        for (let i = 0; i < desiredChildren.length; i++)
+            ensureContainerChild(containerLive, i, desiredChildren[i]);
+        const liveContainers = (containerLive.contentItems || []).filter(isContainerItem);
+        while (liveContainers.length > desiredChildren.length) {
+            const last = (containerLive.contentItems || []).slice().reverse().find(isContainerItem);
+            if (!last)
+                break;
+            appendScrollLog('treeSync:container:remove_extra_container', { type: last?.type ?? null });
+            if (typeof last.remove === 'function')
+                last.remove();
+            liveContainers.pop();
+        }
+        for (let i = 0; i < desiredChildren.length; i++) {
+            const d = desiredChildren[i];
+            const l = containerLive.contentItems?.[i];
+            if (!l)
+                continue;
+            if (l.type !== d.type)
+                return {
+                    status: 'fallback',
+                    reason: `child type mismatch @${ i } live=${ l.type } desired=${ d.type }`
+                };
+            if (d.type === 'stack') {
+                const r = syncStack(l, d);
+                if (r?.status === 'fallback')
+                    return r;
+            } else {
+                const r = syncContainer(l, d);
+                if (r?.status === 'fallback')
+                    return r;
+            }
+        }
+        return { status: 'synced' };
+    }
+    return function treeSync(layout, desiredRootCfg) {
+        appendScrollLog('treeSync:enter', {
+            desiredType: desiredRootCfg?.type ?? null,
+            hasRoot: !!layout?.root
+        });
+        if (!layout?.root || !desiredRootCfg)
+            return { status: 'noop' };
+        const liveTop = layout.root.contentItems?.[0];
+        if (!liveTop)
+            return {
+                status: 'fallback',
+                reason: 'no live top'
+            };
+        if (liveTop.type !== desiredRootCfg.type) {
+            const out = {
+                status: 'fallback',
+                reason: `top type mismatch live=${ liveTop.type } desired=${ desiredRootCfg.type }`
+            };
+            appendScrollLog('treeSync:fallback', out);
+            return out;
+        }
+        const out = desiredRootCfg.type === 'stack' ? syncStack(liveTop, desiredRootCfg) : syncContainer(liveTop, desiredRootCfg);
+        if (out?.status === 'fallback')
+            appendScrollLog('treeSync:fallback', out);
+        else
+            appendScrollLog('treeSync:synced', { status: out?.status ?? 'synced' });
+        return out;
+    };
+}(gl)
+)};
+const _133ahw5 = function _background_jobs(onLoadConfig,layout_state,sync_layout_from_url,test_url_roundtrip,sync_layout_to_url,runtime,navigator_jobs,commandPaletteKeybinding,auto_attach,scroll_fix_sync_layout,commit_history,replay_git,change_listener,cc_chat)
+{
+  onLoadConfig;
+  layout_state;
+  sync_layout_from_url;
+  test_url_roundtrip;
+  sync_layout_to_url;
+  runtime;
+  navigator_jobs;
+  commandPaletteKeybinding;
+  auto_attach;
+  scroll_fix_sync_layout;
+  // history
+  commit_history;
+  replay_git;
+  change_listener;
+  cc_chat;
+};
+const _1n78po6 = function _imports(md){return(
+md`## Imports`
+)};
+const _b2c0kp = function _32(exporter){return(
+exporter()
+)};
+const _1ey5aow = function _dragOutGrips(layout,invalidation)
+{
+    function readModuleSource(name) {
+        const r = window.lopecode?.contentSync?.(name);
+        if (!r || r.status !== 200 || !r.bytes)
+            return null;
+        return new TextDecoder().decode(r.bytes);
+    }
+    function filenameFor(name) {
+        let m = name.match(/^@([A-Za-z0-9-]+)\/([A-Za-z0-9-]+)$/);
+        if (m)
+            return `at_${ m[1] }_${ m[2] }.js`;
+        m = name.match(/^d\/([A-Za-z0-9]+)(@\d+)?$/);
+        if (m)
+            return `d_${ m[1] }${ m[2] ?? '' }.js`;
+        return name.replace(/[/]/g, '_') + '.js';
+    }
+    function flashGrip(grip) {
+        const prev = grip.style.opacity;
+        grip.style.opacity = '1';
+        setTimeout(() => {
+            grip.style.opacity = prev;
+        }, 350);
+    }
+    function hookTab(tabEl) {
+        if (tabEl.__lopepageGripHooked)
+            return;
+        tabEl.__lopepageGripHooked = true;
+        const grip = document.createElement('span');
+        grip.className = 'lm_drag_out_grip';
+        grip.title = 'Click to copy source \xB7 Drag out as .js';
+        grip.setAttribute('draggable', 'true');
+        grip.innerHTML = `<svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round" style="display:block"><rect x="5.5" y="5.5" width="9" height="9" rx="1.5"/><path d="M2.5 10.5V3a.5.5 0 01.5-.5h7.5"/></svg>`;
+        Object.assign(grip.style, {
+            display: 'inline-block',
+            width: '12px',
+            height: '12px',
+            verticalAlign: '3.5px',
+            marginLeft: '-7px',
+            marginRight: '2px',
+            cursor: 'pointer',
+            opacity: '0.55',
+            userSelect: 'none',
+            lineHeight: '0',
+            color: 'currentColor'
+        });
+        [
+            'pointerdown',
+            'mousedown',
+            'touchstart'
+        ].forEach(ev => {
+            grip.addEventListener(ev, e => e.stopPropagation(), { capture: true });
+        });
+        grip.addEventListener('click', e => {
+            e.stopPropagation();
+            const t = tabEl.querySelector('.lm_title')?.textContent || '';
+            if (!t)
+                return;
+            const source = readModuleSource(t);
+            if (!source) {
+                console.warn('[grip click] no source for:', t);
+                return;
+            }
+            navigator.clipboard?.writeText?.(source).then(() => {
+                console.log('[grip click] copied source for:', t, `(${ source.length } chars)`);
+                flashGrip(grip);
+            }).catch(err => console.warn('[grip click] clipboard failed:', err));
+        });
+        grip.addEventListener('dragstart', e => {
+            e.stopPropagation();
+            const title = tabEl.querySelector('.lm_title')?.textContent || '';
+            const source = readModuleSource(title);
+            if (!source) {
+                e.dataTransfer.setData('text/plain', `// no source for ${ title }`);
+                return;
+            }
+            const filename = filenameFor(title);
+            const dataUrl = 'data:text/javascript;base64,' + btoa(unescape(encodeURIComponent(source)));
+            e.dataTransfer.setData('DownloadURL', `text/javascript:${ filename }:${ dataUrl }`);
+            e.dataTransfer.setData('text/plain', source);
+            e.dataTransfer.effectAllowed = 'copyMove';
+        });
+        const titleEl = tabEl.querySelector('.lm_title');
+        if (titleEl?.parentNode === tabEl)
+            tabEl.insertBefore(grip, titleEl);
+        else
+            tabEl.prepend(grip);
+    }
+    document.querySelectorAll('.lm_drag_out_grip').forEach(g => g.remove());
+    document.querySelectorAll('.lm_tab').forEach(t => {
+        t.__lopepageGripHooked = false;
+    });
+    document.querySelectorAll('.lm_tab').forEach(hookTab);
+    const handler = tab => hookTab(tab.element);
+    layout.on('tabCreated', handler);
+    invalidation.then(() => {
+        try {
+            layout.off?.('tabCreated', handler);
+        } catch (e) {
+        }
+    });
+    return 'drag-out grips installed';
+};
+const _1gkn0mq = function _dropInHandler(location, setHashURL, runtime, page, invalidation) {
+    const STYLE_ID = 'lopepage-dropzone-style';
+    const oldStyle = document.getElementById(STYLE_ID);
+    if (oldStyle)
+        oldStyle.remove();
+    const s = document.createElement('style');
+    s.id = STYLE_ID;
+    s.textContent = `.lm_header.lopepage-drop-target { outline: 2px dashed currentColor; outline-offset: -2px; background: color-mix(in srgb, currentColor 14%, transparent); }`;
+    document.head.appendChild(s);
+    function parseModuleName(filename) {
+        let m = filename.match(/^at_([A-Za-z0-9]+(?:-[A-Za-z0-9]+)*)_([A-Za-z0-9]+(?:-[A-Za-z0-9]+)*)\.js$/);
+        if (m)
+            return `@${ m[1] }/${ m[2] }`;
+        m = filename.match(/^d_([A-Za-z0-9]+)(@\d+)?\.js$/);
+        if (m)
+            return `d/${ m[1] }${ m[2] ?? '' }`;
+        return null;
+    }
+    function ensureDomScriptTag(name, source) {
+        let el = document.getElementById(name);
+        if (el?.tagName === 'SCRIPT' && el.getAttribute('type') === 'text/plain') {
+            el.textContent = source;
+            return el;
+        }
+        el = document.createElement('script');
+        el.type = 'text/plain';
+        el.id = name;
+        el.setAttribute('data-mime', 'application/javascript');
+        el.textContent = source;
+        document.body.appendChild(el);
+        return el;
+    }
+    function openModuleInHash(name) {
+        let h = location.hash.replace(/^#/, '');
+        if (/(^|&)open=[^&]*/.test(h)) {
+            h = h.replace(/(^|&)open=[^&]*/, `$1open=${ name }`);
+        } else {
+            h = h + (h ? '&' : '') + `open=${ name }`;
+        }
+        setHashURL(h);
+    }
+    function tearDownExistingModule(name) {
+        const existing = runtime.mains.get(name);
+        if (!existing)
+            return false;
+        try {
+            for (const v of Array.from(existing._scope.values())) {
+                try {
+                    v.delete();
+                } catch (e) {
+                }
+            }
+        } catch (e) {
+            console.warn('[lopepage drop-in] teardown scope:', e);
+        }
+        runtime.mains.delete(name);
+        return true;
+    }
+    async function installFromFile(file) {
+        const name = parseModuleName(file.name);
+        if (!name) {
+            console.warn('[lopepage drop-in] bad filename:', file.name);
+            return;
+        }
+        const src = await file.text();
+        const blob = new Blob([src], { type: 'text/javascript' });
+        const url = URL.createObjectURL(blob);
+        let imported;
+        try {
+            imported = await window.importShim(url, `file://${ name }`);
+        } catch (e) {
+            console.error('[lopepage drop-in] import failed:', e);
+            return;
+        }
+        if (typeof imported.default !== 'function') {
+            console.warn('[lopepage drop-in] default export not a function');
+            return;
+        }
+        const replaced = tearDownExistingModule(name);
+        const mod = runtime.module(imported.default);
+        runtime.mains.set(name, mod);
+        ensureDomScriptTag(name, src);
+        openModuleInHash(name);
+        console.log(`[lopepage drop-in] ${ replaced ? 'replaced' : 'installed' } + opened:`, name);
+    }
+    let activeHeader = null;
+    const clearHighlight = () => {
+        if (activeHeader) {
+            activeHeader.classList.remove('lopepage-drop-target');
+            activeHeader = null;
+        }
+    };
+    const isFilesDrag = e => [...e.dataTransfer?.types || []].includes('Files');
+    const onDragOver = e => {
+        if (!isFilesDrag(e))
+            return;
+        const header = e.target?.closest?.('.lm_header');
+        if (!header) {
+            clearHighlight();
+            return;
+        }
+        e.preventDefault();
+        e.dataTransfer.dropEffect = 'copy';
+        if (activeHeader !== header) {
+            activeHeader?.classList.remove('lopepage-drop-target');
+            header.classList.add('lopepage-drop-target');
+            activeHeader = header;
+        }
+    };
+    const onDragLeave = e => {
+        if (!page.contains(e.relatedTarget))
+            clearHighlight();
+    };
+    const onDrop = e => {
+        if (!isFilesDrag(e))
+            return;
+        const header = e.target?.closest?.('.lm_header');
+        if (!header)
+            return;
+        e.preventDefault();
+        clearHighlight();
+        const f = e.dataTransfer.files[0];
+        if (f)
+            installFromFile(f).catch(err => console.error('[lopepage drop-in] failed:', err));
+    };
+    page.addEventListener('dragover', onDragOver);
+    page.addEventListener('dragleave', onDragLeave);
+    page.addEventListener('drop', onDrop);
+    invalidation.then(() => {
+        page.removeEventListener('dragover', onDragOver);
+        page.removeEventListener('dragleave', onDragLeave);
+        page.removeEventListener('drop', onDrop);
+        clearHighlight();
+        document.getElementById(STYLE_ID)?.remove();
+    });
+    return 'drop-in handler installed';
+};
+const _1v605qi = function _file_attachment_cache(reload)
+{
+    reload;
+    return new Map();
+};
+const _1fgpmzl = function _renderFileAttachment()
+{
+    return function renderFileAttachment(mime, bytes) {
+        const m = String(mime || '').toLowerCase();
+        // HTML: srcdoc keeps the runtime same-origin-ish (opaque) but renders rich content
+        if (m === 'text/html' || m === 'application/xhtml+xml') {
+            const iframe = document.createElement('iframe');
+            iframe.setAttribute('srcdoc', new TextDecoder().decode(bytes));
+            Object.assign(iframe.style, {
+                width: '100%',
+                height: '100%',
+                border: '0',
+                display: 'block'
+            });
+            return iframe;
+        }
+        if (m.startsWith('image/')) {
+            const img = document.createElement('img');
+            img.src = URL.createObjectURL(new Blob([bytes], { type: mime }));
+            Object.assign(img.style, {
+                maxWidth: '100%',
+                maxHeight: '100%',
+                display: 'block',
+                margin: 'auto'
+            });
+            return img;
+        }
+        if (m.startsWith('audio/')) {
+            const audio = document.createElement('audio');
+            audio.controls = true;
+            audio.src = URL.createObjectURL(new Blob([bytes], { type: mime }));
+            Object.assign(audio.style, { width: '100%' });
+            return audio;
+        }
+        if (m.startsWith('video/')) {
+            const video = document.createElement('video');
+            video.controls = true;
+            video.src = URL.createObjectURL(new Blob([bytes], { type: mime }));
+            Object.assign(video.style, {
+                width: '100%',
+                height: '100%'
+            });
+            return video;
+        }
+        if (m === 'text/plain' || m === 'text/markdown' || m === 'application/json' || m.startsWith('text/')) {
+            const pre = document.createElement('pre');
+            pre.textContent = new TextDecoder().decode(bytes);
+            Object.assign(pre.style, {
+                margin: '0',
+                padding: '8px',
+                whiteSpace: 'pre-wrap',
+                overflow: 'auto',
+                width: '100%',
+                height: '100%',
+                boxSizing: 'border-box'
+            });
+            return pre;
+        }
+        // application/pdf and unknown: blob: iframe — browser picks the viewer
+        const iframe = document.createElement('iframe');
+        iframe.src = URL.createObjectURL(new Blob([bytes], { type: mime || 'application/octet-stream' }));
+        Object.assign(iframe.style, {
+            width: '100%',
+            height: '100%',
+            border: '0',
+            display: 'block'
+        });
+        return iframe;
+    };
+};
+
+export default function define(runtime, observer) {
+  const main = runtime.module();
+  const $def = (pid, name, deps, fn) => {
+    main.variable(observer(name)).define(name, deps, fn).pid = pid;
+  };
+
+  main.define("module @tomlarkworthy/golden-layout-2-6-0", async () => runtime.module((await import("/@tomlarkworthy/golden-layout-2-6-0.js?v=4")).default));  
+  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
+  main.define("module @tomlarkworthy/module-selection", async () => runtime.module((await import("/@tomlarkworthy/module-selection.js?v=4")).default));  
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/editor-5", async () => runtime.module((await import("/@tomlarkworthy/editor-5.js?v=4")).default));  
+  main.define("module @tomlarkworthy/exporter-3", async () => runtime.module((await import("/@tomlarkworthy/exporter-3.js?v=4")).default));  
+  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
+  main.define("module @tomlarkworthy/local-change-history", async () => runtime.module((await import("/@tomlarkworthy/local-change-history.js?v=4")).default));  
+  main.define("module @tomlarkworthy/claude-code-pairing", async () => runtime.module((await import("/@tomlarkworthy/claude-code-pairing.js?v=4")).default));  
+  main.define("module @tomlarkworthy/command-palette", async () => runtime.module((await import("/@tomlarkworthy/command-palette.js?v=4")).default));  
+  $def("_1xyxga0", "page", ["htl","isOnObservableCom","lopeviz_handle_css","base_css","light_theme_css","commandPaletteStyles","commandPaletteOverlay","linkTo"], _1xyxga0);  
+  $def("_1ujnhdh", "append_to_body", ["page"], _1ujnhdh);  
+  $def("_1nv51s8", "testNavigation", ["htl","linkTo"], _1nv51s8);  
+  $def("_ydvyos", "viewof reload", ["Inputs"], _ydvyos);  
+  $def("_1we0ggl", "reload", ["Generators","viewof reload"], _1we0ggl);  
+  $def("_plefwg", "onLoadConfig", ["parseGoldenDSL","URLSearchParams","location"], _plefwg);  
+  $def("_1nzpnqy", "visualizer_cache", ["reload"], _1nzpnqy);  
+  $def("_1ojown8", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1ojown8);  
+  $def("_1gm4gbf", "blobPanel", [], _1gm4gbf);  
+  $def("_lxv2e2", "settings", [], _lxv2e2);  
+  $def("_lp1ggk", "is_mobile", ["width"], _lp1ggk);  
+  $def("_qbghwu", "initial config", ["onLoadConfig","settings"], _qbghwu);  
+  $def("_15lk82w", "mutable config", ["Mutable","initial config"], _15lk82w);  
+  $def("_1bki6eh", "config", ["mutable config"], _1bki6eh);  
+  $def("_14z0bay", "resize", ["Generators","addEventListener","invalidation","removeEventListener"], _14z0bay);  
+  $def("_18jv72h", "layout", ["resize","gl","mutable config","page","modulePanel","blobPanel"], _18jv72h);  
+  $def("_tsjb2x", "layout_state", ["appendScrollLog","layout","gl","mutable config"], _tsjb2x);  
+  $def("_11nrwvj", "viewof lopepageModule", ["thisModule"], _11nrwvj);  
+  $def("_r97569", "lopepageModule", ["Generators","viewof lopepageModule"], _r97569);  
+  $def("_1sp5wo4", null, ["md"], _1sp5wo4);  
+  $def("_1ts23ma", "viewof scrollDebug", ["Inputs"], _1ts23ma);  
+  $def("_7jxivy", "scrollDebug", ["Generators","viewof scrollDebug"], _7jxivy);  
+  $def("_1f2wuqm", "appendScrollLog", ["viewof scrollDebug","mutable scrollLog"], _1f2wuqm);  
+  $def("_1nbnzwx", "initial scrollLog", ["scrollDebug"], _1nbnzwx);  
+  $def("_1f7xtz1", "mutable scrollLog", ["Mutable","initial scrollLog"], _1f7xtz1);  
+  $def("_1dyz4o0", "scrollLog", ["mutable scrollLog"], _1dyz4o0);  
+  $def("_1d1nkw9", "scrollKeyFor", ["appendScrollLog"], _1d1nkw9);  
+  $def("_tb217h", "scroll_cache", [], _tb217h);  
+  $def("_12p8mg7", "fix_scroll", ["scroll_cache","scrollKeyFor","appendScrollLog"], _12p8mg7);  
+  $def("_arfw00", "scroll_fix_sync_layout", ["sync_layout_to_url","layout","appendScrollLog","modulePanel"], _arfw00);  
+  $def("_3nwpp4", "URLrouting", ["md"], _3nwpp4);  
+  $def("_14te9pl", "sync_layout_from_url", ["reload","resize","URLSearchParams","hash","appendScrollLog","parseGoldenDSL","gl","layout","serializeGoldenDSL","treeSyncGolden","invalidation"], _14te9pl);  
+  $def("_1l50a0d", "sync_layout_to_url", ["appendScrollLog","sync_layout_from_url","config","test_url_roundtrip","serializeGoldenDSL","location","setHashURL"], _1l50a0d);  
+  $def("_jcy1xg", "test_url_roundtrip", ["sync_layout_from_url"], _jcy1xg);  
+  $def("_1yxu9kf", "setHashURL", ["location","appendScrollLog","history"], _1yxu9kf);  
+  $def("_1zkl8r", "treeSyncGolden", ["appendScrollLog","gl"], _1zkl8r);  
+  $def("_133ahw5", "background_jobs", ["onLoadConfig","layout_state","sync_layout_from_url","test_url_roundtrip","sync_layout_to_url","runtime","navigator_jobs","commandPaletteKeybinding","auto_attach","scroll_fix_sync_layout","commit_history","replay_git","change_listener","cc_chat"], _133ahw5);  
+  $def("_1n78po6", "imports", ["md"], _1n78po6);  
+  $def("_b2c0kp", null, ["exporter"], _b2c0kp);  
+  $def("_1ey5aow", "dragOutGrips", ["layout","invalidation"], _1ey5aow);  
+  $def("_1gkn0mq", "dropInHandler", ["location","setHashURL","runtime","page","invalidation"], _1gkn0mq);  
+  main.define("gl", ["module @tomlarkworthy/golden-layout-2-6-0", "@variable"], (_, v) => v.import("gl", _));  
+  main.define("base_css", ["module @tomlarkworthy/golden-layout-2-6-0", "@variable"], (_, v) => v.import("base_css", _));  
+  main.define("light_theme_css", ["module @tomlarkworthy/golden-layout-2-6-0", "@variable"], (_, v) => v.import("light_theme_css", _));  
+  main.define("unorderedSync", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("unorderedSync", _));  
+  main.define("runtime", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("runtime", _));  
+  main.define("visualizer", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("visualizer", _));  
+  main.define("Inspector", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("Inspector", _));  
+  main.define("lopeviz_handle_css", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("lopeviz_handle_css", _));  
+  main.define("viewof notebookModule", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("viewof notebookModule", _));  
+  main.define("notebookModule", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("notebookModule", _));  
+  main.define("currentModules", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("currentModules", _));  
+  main.define("viewof selected_modules", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("viewof selected_modules", _));  
+  main.define("selected_modules", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("selected_modules", _));  
+  main.define("navigator_jobs", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("navigator_jobs", _));  
+  main.define("serializeGoldenDSL", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("serializeGoldenDSL", _));  
+  main.define("parseGoldenDSL", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("parseGoldenDSL", _));  
+  main.define("linkTo", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("linkTo", _));  
+  main.define("persistedAttachments", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("persistedAttachments", _));  
+  main.define("getHashModules", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("getHashModules", _));  
+  main.define("lookupVariable", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("lookupVariable", _));  
+  main.define("getPromiseState", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("getPromiseState", _));  
+  main.define("thisModule", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("thisModule", _));  
+  main.define("ascendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("ascendants", _));  
+  main.define("toObject", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("toObject", _));  
+  main.define("isOnObservableCom", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("isOnObservableCom", _));  
+  main.define("auto_attach", ["module @tomlarkworthy/editor-5", "@variable"], (_, v) => v.import("auto_attach", _));  
+  main.define("exporter", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("exporter", _));  
+  main.define("hash", ["module d/57d79353bac56631@44", "@variable"], (_, v) => v.import("hash", _));  
+  main.define("commit_history", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("commit_history", _));  
+  main.define("change_listener", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("change_listener", _));  
+  main.define("replay_git", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("replay_git", _));  
+  main.define("cc_chat", ["module @tomlarkworthy/claude-code-pairing", "@variable"], (_, v) => v.import("cc_chat", _));  
+  main.define("commandPaletteStyles", ["module @tomlarkworthy/command-palette", "@variable"], (_, v) => v.import("commandPaletteStyles", _));  
+  main.define("commandPaletteKeybinding", ["module @tomlarkworthy/command-palette", "@variable"], (_, v) => v.import("commandPaletteKeybinding", _));  
+  main.define("commandPaletteOverlay", ["module @tomlarkworthy/command-palette", "@variable"], (_, v) => v.import("commandPaletteOverlay", _));  
+  $def("_1v605qi", "file_attachment_cache", ["reload"], _1v605qi);  
+  $def("_1fgpmzl", "renderFileAttachment", [], _1fgpmzl);
+  return main;
+}</script>
+<script id="@tomlarkworthy/observablejs-toolchain/parser-6.1.0.js.gz" 
+  type="text/plain"
+  data-encoding="base64"
+  data-mime="application/gzip"
+>
+H4sICOAiLWcCA3BhcnNlckA2LjEuMC5qcwDtOmtz20aS3/MrIF6KAWIIFKX4ETCwYstKnW4V2yfJSW2ptKsh0KQmAgF6MJTEpfDfr3sewICknNzdbu1+2CqVOK/u6el3z2Dw7bdfed96bxdFlkPmjZfeb9U7yPmd8BYVL6beWZnni7l3tx+9/D4aeqzIvAsQFQjv7nk0/D7ajwj+g+BTXrDcm/AcYm9QzGeDH8sxLrtj4xxuPg/mjIB+fBENo71BJdIBLzJ4iH6rEJwwvCu99x8ucFPwzs9OvHsub7xsWbAZT1meL70pFCCYRBppi2rH+7kU4PFiUooZk7wsYu9GynkVDwb39/eIN1OniNJyNlAn2a0E3yW0uwbtrkKEew++4rN5KeTqorw9KgsJD9JjlQehLG8vlnOoqCfDj+oE1BbhFOQpL+AEt6eBop6IctZTx2ZpKYofX0XDYXQweAbVrDcy6GfsFmh1FbIihUqWChkPK5zP1Qxbx7N7z/JbRHYQ7Rtcd0x4ZVLAvXcO0r/svRGCLXuh/n27mExAYI/JckyDi4yX5kjYfZur0bdlmQMrqMWnJwXNjGXJ8CfFcYEjJLbc9i/4DMoFrUrLokJQaonlXJbYOFrgOWbHd6DQvGOS/cLhXjdpYQZpmcGnsxO3fVQiQwoNksEdT+Ejf4D8jORIQ2W6mOlZKFrwpu2CHwtR0oGhStmcNgRN+QRkeoO/P3FFL/2c8kqa5hmwTPHpp7xk8mDfMlF1X3zXdBdFSqqFzf9UEBW2TmZsCvaXDkztYsILLpeqKYcvLALstMix88ppE5W8+ongQDXfs/f4+1/nH+jnZzZX/yUdQs+8X8zGiuiC3fEpSpjaH8a/QUrHUval6LcdLdk5CGUiqHHY+4gI999RA/WMV6BbD0TSGSumYNl5BqhHyHB3INcbncH0+IGISwln/qbg2v5+EmxG+AR8XqByb4yjuuL/CqSjX9hrtetcCjRTaixn4zJXjUKyB0vCBSrxO6VCtndc2J684SQbsla7/BN3JUG9VhTUe9XpHOVsNofMjqE7BBQpZKrdKBcqX4P+7BT//wrsVouKWvqIv8L4vExvdbsUt4rAe3R35X3vKgjTpPJXJ8oj+MGqDslekKECqgq55aPXCUWwEj5EPMN27yRDTecTjmiCOvx5Icmh/mGAOhhNjBZ7cx9wHciFKBrVbhH1kiSBSCIHHx+baeR3zoSSY2ce+VTe/w4OVKwpyr4dqxtKcocSdErp7blEd6FsvkNFic7oyakPkyentk7Q8VsSFn8nZrQYb0gUwYqcpPREsqLZuOFCOC6zZXwJEf1e1WGhfDjqTohUGGOr4qpOYKSp8pgvwtURBr+WrBiS13qDFUVFgFiETEyVt6xiTsB84rsasJMkwpxDRBj2AAfk42MVqfD7YeKL4Ie9QO9IsEOc51EOxVTePD7u+L1TdE8CjRUPzC/3rhSufn/wl8tveleDSKKl+2pcsPsAeXUBGMuQ+dvB9mwXmiNVZrMgkDeoU552aBHDyWnhqzjXegH/+uuVrD1yMVxQXPYosmPszPV2XqV8iGd5ch2EqwJdRAxoB4pvl+wq4WGZuOdiirpDFqFTWkDMos8LVvGK6FQjmEOUt5Ch5a4qyYTEFeo3hCLDNv6vR0V0wyq/DA6LCHMDbETzRXXjp0FcRBUNhJfpFZpjmAZh0erMBHVmJdk0Rhtm9yjNKYZolldxEUZRhNqwqoNVDtLjJJxikec7iez3UXV5soyUm0cMlTmcx5KxGZQ0OPUZOoQiCO+pEYQ8wq0Shr+4WbKzI2rIMd/iSeaiMuo39XkIGhgbCFyj9leVl3noefHMmAZpVRSLFGMRwiLFqP/VAkOO3xXjCtIZ+wXjJ+nw8KAmfGp1DRQMztNyDq09evt91JVnz8ipRx/+apkVKsxRB6KGBy51x4FWgOlCoFHZyWiSs2nV7+/uPoG1xVPrUEq+R1u0wTtEVVkDRklE7J5xFIlvpli1LNJkZy8wiNeQaeRvCMb/MuYvIjQINLY/c8gzh31fRGfy6FKso7RYNE4ToFqkCrxA0ftBCFE1h1Q5mErv5MCcN1O4Uk2SdRFJ0V8p/bakNLh4QapCruCLuAwy9By42uS0C5b7PZUyK6LKhUgh6e6pPcJhi5m86RvMWf0gVoMY3hVKyCy9lMtVN+/Rb6DIepoS1/d3WOSSaHw/JJdXobA5+ojMt0BujzAP850z+DIaC5bCaTDa0cOsGTsLRmjiaPEBQg5H2kwna9BY2syYoZlN0CouBOM5nvaIJlpUwVhgcmJchGGycmDqiMGoiu4wB0ksDS5vaaKcIHeraKYzj2RHL+/3t603ixSArnogc6VKgcmyOb2B9PZTgX4c00HkfgvhLjgtMdJtzq3ty6pecIirclr9xzdUy7ftpieC2GJs93cX/8Lyc1W7WYiwh8LGwwsVDcygCruB4RdKqGqWmzBy3cZr75uvVy5Y/Y13Q3VhjhLMlt4YoPAypYqQXdM+LMu6+6AdqMizrsmV1eRGYXtBUBvjhrprGmtmryZ/Zssx/AmW96XInPTTqkjY6yayPcwGfh/Y6guWOuuJLSFw3JNDW63YdgR5jia35uiSvbDrN4fhpuMzY+QaUomWaVSqDSzD7zBTVLxTu9gUW7NEGFE6CiOUH8sSEer8LsHcINIEuNTgYEvFOlnWvTVxaJszInKs/zGkCet2dEaZ+VhTKEhezBcybK09UJ6oSlSGcoEZTYF78ISSipCpn5ErdIfJoevDtSH0+y4aNU2ZJckKitNDvuHK/XW3Q8bVgEE56fedfgUzjoHC2ZeUG0esuuGqSmdn/X6jRe3g46O/dlAHuUZVdDw/Lti2Xm0Nn3FjlvxzTWHTp60R3I0N8DkIOofQoaYjGFV5YRj03UGHJMxUVcKZMKcIcqhSpYJO7HtHlBtum0NJMGzyLLARnGSblrnawNpSS3c56Si+UXIeMqP1F+X8FO4g3+qjzGrMbGpZvlG5J3Gya8Bb+NtUc4cQa5+zBbx2DB6s0cmEDP/xEUZ+qZy+Vi8qhZrCrNcocDcKyO3+X1rPzzHFNrHq2uzuRK+2fG1NAoxuuxahx4wC6Y3BbvypsQDvVmskEQCGgGubH25uXa8HwK6LdMCcNV9mPLIxNox2DBOMh9eEa30kKbXeZC3HRAU67DnnwkrFKyeecoa92J2RZDjWmT5hlSr/t4kXr5yUA4I23dvIqLbmzPzJTKjj47FGqGuNeaY8OjLuuoc6TX8+JK8fIqr9iQAs+1RJtmxKsqxTkmGJBbYgU22HV+gRWHr734tSQuM6xJs8L+8xY9sZ1nQvyVluTtzUKpezKzf6GOm4sWJDHDbhV4456fVssSq28M29GMAs2uTOLdvs9cJxrq53/BWvLth0ClmMZ6Yin3JsYQr45LK4GjXk2DgzCroeJytzTKfe6kw87FDgZFIbvnHd4ZpcO7Sba9j/De2N2hRYpvO8yUuMAq1rigg3Lls2gsB2ZyqUX0c1a64hHlC+EBPvNL/mZfVDm0OYG5pm6tmzoMJKLjWs0WvSGyaOkK43JtLjOrIQhoXL9/vx01h3h02pj/MjU6oQ2MGLmC6k9g9sOfvkRs+GQWul2LcASrWMy200kheoiDyzvAs6QQRxJfsuy3R0XdMSTSVmzbUL3AVY28ZJyaIq5yn46x5MMczcsYz/33cs+/++Y/mXv2N5KpX5B1QzTV2yPc8DrZmOmf0D6xd0ej3X+Ux18pCUyoY1oYG6xt64eVHpAs0rcw4gaq/O7UR7m3S4MRLN2NynEArtdUIQY5hR9ytSLFcdjJbC/+O9ftW80soACyzcpjly2UWp74zBBoCdHUyL9RWCDJ58X2iBDvU1gEkxzYUzhM0bsZ64CoLOvTN6fNIENkMZleKYoTv3ZfIa8YSUWqiEpd+nTanlwGaaDhMCdPqmPb378BDfKESOQzdvlR+ZRM0sejFuL1BRhOTgkABEAm0QdGDVw5wDCjqIdgHRo22D/ai3WfZinNVpCK5xV5xBJU1Y1ots7r62TtcENNGQQqtzmDgrM5iwRS5j/Z5BUtBvFz3KoNNyWvC/YfY51wg8pU1e75nho2MX6hrmxqc7BX0d1U4ttQgoOxImwVcPP+2zJb37BCuK6CaFsuF2f1S8TvZGu7uFMrdulYJ6t/Alpk2B8yRUqhHMy+3YenlLrhBXmFLQF8m1rki8r1coFYUONUgXFVhTbC8D1jCYAmY7ihqp2qmUgYhg2zH+0FtSC0OVVlFKj+n0t+e+GjGdyJFk3HzJFgYQ/J4dqIFfmOB0nkZtSDLGkqk8kYFiNMlaGbHD/qfY1UpU882C/KFntFaRsQzyFCEM23eGTK8pArsvaJuWuHaO1jCDBzyNtC5tqwPYgG39wTbo1oxNsLwreUaiaE1605jXlzqG7chzrOX50Nqyzew4PcJa6TmhKFYQyWtjg+r2bIu1DZW19fs0T4qp7M7vIZ91LLvlRXY41yYX58b0lAWo5giirN1zw0vSgz8aQFCHW56ov0QhuP4A1imEgCjCgGEIwdZI+yGMAyHpfLthPAnV1c/fYWPY3f3SxrXeKG6jMkWwbowKjxjaIq5bVLC2UIU6FR90M6RT2AxDOezmYjyehWtX5c3Ie7SJao5FgDOl3nQ7emI0PF6GrSOIl+261vqcp/1xuBFdcOzTPKOSsV3WTUrWVTrsfheBCLrfUMRjRQWr1cVxnTLlukziRXbu5BcUv9WYvT6GCA9fsSk8S649/+uViHKMNXVMrbTMF7OiDq7p/aGkbKyF1AEsEWGGzkGCp+dq7ahAv0F3Ei9MlZqHicZG71ufq3Ktfn9LgrjTTRB1Skff+b2REg1HeaaE9EV9BtYOqvdD5DQbowc5ynm77l1nUL8zQorkmflz1VHjGEJQ1KmipIPj/cZE71+L9+scsinsJk/aGcuFdmTb+c1sK099xONEf+Tl9xSVyL7zZmRWZuZ9KjxpBq0a4OBtM0gRqud84HRH7FQeGJPv4xFJv40xnGIMXexifY4ZGBXT3ZJ5WAdNVluZq4tjFb69c7qJ4N3HCCU4umo4dp4l6PsW+wLRXMJ2BlUh5QzRnsk5XYlJXiygrpJbrCF4O9DduSkNHx/dUXVtQJhOWkDnKuV2jX74HDR3TYoK997lZG0xSSiwWEebjOj3OX0D8wPYL3ls6NSoTSStW4W3A/CgPovN6MtXKgz1B7bhkvr23sQZn9B4c/cY3qkuwO1JFqbUpk9l65FG6pkk3FPR56vB4D88/XUA6uKcF9NPZ6fJoJoNMjaewKv0OYwnr9hzdrB3MMmeP987eAUwefny1ffsJUvHL4bfPX+ZpbA3hvH4VXbwcnLA9sfP0zGkVFH+D3KMR1ZDLQAA
+</script>
+<script id="@tomlarkworthy/observablejs-toolchain" 
+  type="text/plain"
+  data-mime="application/javascript"
+>
+const _lp77pf = function _1(md){return(
+md`# Bidirectional Observable JS <=> Runtime Toolchain
+
+\`\`\`js
+import {decompile, compile, cellMap} from "@tomlarkworthy/observablejs-toolchain"
+\`\`\``
+)};
+const _n0sc6u = function _2(md){return(
+md`### Compilation, source to runtime variable(s)
+
+Compilation takes notebook source cells written in \`Observable Javascript\` and turns them into reactive variables for execution in the \`Observable Runtime\`. A cell is usually compiled to one runtime variable, however, mutable variables are more complicated and are represented as three runtime variables.
+
+ObservableHQ does the compilation process as part of the hosted notebook experience but in this notebook we provide a way to do it in userspace.`
+)};
+const _sgo04r = function _3(md){return(
+md`### Decompilation, Runtime variables(s) to source
+The aim of decompilation is to go from the live runtime variable definitions, back to the source as best as possible. ObseervableHQ does not have this feature. In this notebook we implement it in userspace.
+`
+)};
+const _aivd6y = function _4(md){return(
+md`### Codeveloped with AI
+
+This notebook is setup for was AI collaboration. Important runtime values, such as the test suite report, are highlighted to the LLM, which helps it decide how to fix test cases.`
+)};
+const _1q8w8vr = function _5(md){return(
+md`### Prior work
+
+_Alex Garcia_ pioneered the first third-party Observable **_compiler_** [[asg017/unofficial-observablehq-compiler](https://github.com/asg017/unofficial-observablehq-compiler)]. The compiler here differs by being entirely text/data based, _i.e._ the output is a string/JSON, not hydrated variables and functions.
+
+This is the first **_decompiler_**.`
+)};
+const _d17a1w = function _6(md){return(
+md`## TODO
+- Tagged templates (decompilation works, but there is no source compile for them)
+- notebook imports (WIP some decompilation works)
+   - need to dedupe some of the implied imports, e.g. \`viewof foo\` also imports \`foo\` but we don't need to explicitly import \`foo\`, it's implied
+- anonymous variables work, but the test cases fail due to naming mismatches
+- Bug with unobserved module imports, moduleSource does not resolve, we just adjusted source to avoid that problem now 
+- class body assignments can't be decompiled`
+)};
+const _1juriue = function _7(md){return(
+md`## Continuous Integration Testing
+
+We sniff the entire runtime to test that each cell is de-compilable`
+)};
+const _1k5oyj7 = function _9(tests){return(
+tests()
+)};
+const _1jrpa13 = function _10(md){return(
+md`### All cells are decompileable`
+)};
+const _1lc80et = function _cellMaps(cellMap){return(
+cellMap()
+)};
+const _zki07o = function _allCells(cellMaps){return(
+[...cellMaps.values()]
+  .map((cells) =>
+    [...cells.values()]
+      .filter((c) => c.module !== "builtin")
+      .map((c) => c.variables)
+  )
+  .flat()
+)};
+const _1nkhnnd = function _all_decompiled(allCells,decompile){return(
+Promise.all(
+  allCells.map(async (cell) => {
+    try {
+      return {
+        cell,
+        source: await decompile(cell)
+      };
+    } catch (error) {
+      return {
+        cell,
+        error
+      };
+    }
+  })
+)
+)};
+const _1ip1war = function _test_all_cells_decompilable(all_decompiled)
+{
+  const errors = all_decompiled.filter((s) => s.error);
+  if (errors.length > 0) throw errors;
+  return `${all_decompiled.length} cells decompiled without error`;
+};
+const _1w70b75 = function _15(md){return(
+md`### All decompiled cells can be recompiled`
+)};
+const _uscpdn = function _all_compiled(all_decompiled,compile){return(
+all_decompiled
+  .filter((source) => !source.error)
+  .map((source) => {
+    try {
+      return {
+        ...source,
+        compiled: compile(source.source)
+      };
+    } catch (error) {
+      return {
+        ...source,
+        error
+      };
+    }
+  })
+)};
+const _x55zzr = function _test_decompiled_cells_recompilable(all_compiled)
+{
+  const errored = all_compiled.filter((cell) => cell.error);
+  if (errored.length > 0) throw JSON.stringify(errored, null, 2);
+  return `${all_compiled.length} cells recompiled without error`;
+};
+const _100n7xr = function _18(md){return(
+md`### All cells roundtrip compile`
+)};
+const _1nm57o2 = function _roundtripped(all_compiled,decompile){return(
+Promise.all(
+  all_compiled
+    .filter((c) => !c.error)
+    .map(async (cell) => {
+      try {
+        const decompiled = await decompile(cell.compiled);
+        return {
+          ...cell,
+          decompiled
+        };
+      } catch (error) {
+        return {
+          ...cell,
+          error
+        };
+      }
+    })
+)
+)};
+const _1shi9or = function _test_all_cells_roundtrippable(roundtripped)
+{
+  const errored = roundtripped.filter((cell) => cell.error);
+  if (errored.length > 0) throw JSON.stringify(errored, null, 2);
+  return `${roundtripped.length} cells decompiled, recompiled and decompiled again without error`;
+};
+const _14nox99 = function _21(md){return(
+md`## Reference Data`
+)};
+const _1d3zr3i = function _22(md){return(
+md`### Source code
+The source code of a [reference notebook](https://observablehq.com/@tomlarkworthy/notebook-semantics?collection=@tomlarkworthy/lopebook) is extracted directly from the \`https://api.observablehq.com/document/...\` endpoint
+`
+)};
+const _12sqt9 = function _dependancy_document(){return(
+{
+  id: "1fb3132464653a8f",
+  slug: "dependancy",
+  trashed: false,
+  description: "",
+  likes: 0,
+  publish_level: "live_unlisted",
+  forks: 0,
+  fork_of: null,
+  has_importers: true,
+  update_time: "2024-10-15T18:06:59.080Z",
+  first_public_version: 16,
+  paused_version: null,
+  publish_time: "2024-10-15T18:07:25.850Z",
+  publish_version: 16,
+  latest_version: 16,
+  thumbnail: "52bb3d5b2f48b727e0eea931c0093fe5778fb9b809bebb1edfb949d2f4b5590a",
+  default_thumbnail:
+    "52bb3d5b2f48b727e0eea931c0093fe5778fb9b809bebb1edfb949d2f4b5590a",
+  roles: [],
+  sharing: null,
+  owner: {
+    id: "7db5ed2b0697d645",
+    avatar_url:
+      "https://avatars.observableusercontent.com/avatar/47327a8bc1966f2186dcb3ebf4b7ee6e4e7ab9a5c2a07405aff57200ea778f71",
+    login: "tomlarkworthy",
+    name: "Tom Larkworthy",
+    bio: "Tech Lead at Taktile.\nFormerly Firebase, Google",
+    home_url: "https://taktile.com",
+    type: "team",
+    tier: "starter_2024"
+  },
+  creator: {
+    id: "5215f6ec4a999d40",
+    avatar_url:
+      "https://avatars.observableusercontent.com/avatar/47327a8bc1966f2186dcb3ebf4b7ee6e4e7ab9a5c2a07405aff57200ea778f71",
+    login: "tomlarkworthy",
+    name: "Tom Larkworthy",
+    bio: "Tech Lead at Taktile.\nFormerly Firebase, Google",
+    home_url: "https://taktile.com",
+    tier: "pro"
+  },
+  authors: [
+    {
+      id: "5215f6ec4a999d40",
+      avatar_url:
+        "https://avatars.observableusercontent.com/avatar/47327a8bc1966f2186dcb3ebf4b7ee6e4e7ab9a5c2a07405aff57200ea778f71",
+      name: "Tom Larkworthy",
+      login: "tomlarkworthy",
+      bio: "Tech Lead at Taktile.\nFormerly Firebase, Google",
+      home_url: "https://taktile.com",
+      tier: "pro",
+      approved: true,
+      description: ""
+    }
+  ],
+  collections: [
+    {
+      id: "cf72f19f55f3a048",
+      type: "public",
+      slug: "lopebook",
+      title: "lopebook",
+      description: "",
+      update_time: "2024-10-11T18:10:59.078Z",
+      pinned: false,
+      ordered: false,
+      custom_thumbnail: null,
+      default_thumbnail: null,
+      thumbnail: null,
+      listing_count: 0,
+      parent_collection_count: 0,
+      owner: {
+        id: "7db5ed2b0697d645",
+        avatar_url:
+          "https://avatars.observableusercontent.com/avatar/47327a8bc1966f2186dcb3ebf4b7ee6e4e7ab9a5c2a07405aff57200ea778f71",
+        login: "tomlarkworthy",
+        name: "Tom Larkworthy",
+        bio: "Tech Lead at Taktile.\nFormerly Firebase, Google",
+        home_url: "https://taktile.com",
+        type: "team",
+        tier: "starter_2024"
+      }
+    }
+  ],
+  files: [],
+  comments: [],
+  commenting_lock: null,
+  suggestion_from: null,
+  suggestions_to: [],
+  version: 16,
+  title: "Dependancy",
+  license: null,
+  copyright: "",
+  nodes: [
+    {
+      id: 0,
+      value: "# Dependancy",
+      pinned: false,
+      mode: "md",
+      data: null,
+      name: ""
+    },
+    {
+      id: 7,
+      value: 'dep = "a"',
+      pinned: true,
+      mode: "js",
+      data: null,
+      name: null
+    },
+    {
+      id: 9,
+      value: "viewof viewdep = Inputs.input()",
+      pinned: true,
+      mode: "js",
+      data: null,
+      name: null
+    },
+    {
+      id: 11,
+      value: "mutable mutabledep = ({})",
+      pinned: false,
+      mode: "js",
+      data: null,
+      name: null
+    }
+  ],
+  resolutions: [],
+  schedule: null,
+  last_view_time: null
+}
+)};
+const _13q8314 = function _dependancy_source(dependancy_document){return(
+dependancy_document.nodes.map((s) => ({
+  value: s.value,
+  name: s.name
+}))
+)};
+const _ook1nq = function _25(md){return(
+md`
+\`\`\`
+curl https://api.observablehq.com/document/@tomlarkworthy/notebook-semantics
+\`\`\``
+)};
+const _jmn84r = function _notebook_semantics_document(){return(
+{
+  id: "483a346021943f64",
+  slug: "notebook-semantics",
+  trashed: false,
+  description: "",
+  likes: 0,
+  publish_level: "live_unlisted",
+  forks: 0,
+  fork_of: null,
+  has_importers: false,
+  update_time: "2025-03-17T18:36:45.520Z",
+  first_public_version: 90,
+  paused_version: null,
+  publish_time: "2024-10-15T18:29:58.853Z",
+  publish_version: 152,
+  latest_version: 152,
+  thumbnail: "10dc93e33f09bad8366c143415404f378b6bd94f1148589113ff5fb2d22573ee",
+  default_thumbnail:
+    "10dc93e33f09bad8366c143415404f378b6bd94f1148589113ff5fb2d22573ee",
+  roles: [],
+  sharing: null,
+  edits: [
+    { node_id: 48, value: 'file = FileAttachment("empty")' },
+    { node_id: 55, value: "mutable_dep_2 = {\n  file;\n  return q + 1;\n}" },
+    { node_id: 151, value: "thisReference = (this || 0) + 1" }
+  ],
+  owner: {
+    id: "7db5ed2b0697d645",
+    avatar_url:
+      "https://avatars.observableusercontent.com/avatar/47327a8bc1966f2186dcb3ebf4b7ee6e4e7ab9a5c2a07405aff57200ea778f71",
+    login: "tomlarkworthy",
+    name: "Tom Larkworthy",
+    bio: "Tech Lead at Taktile.\nFormerly Firebase, Google",
+    home_url: "https://taktile.com",
+    type: "team",
+    tier: "starter_2024"
+  },
+  creator: {
+    id: "5215f6ec4a999d40",
+    avatar_url:
+      "https://avatars.observableusercontent.com/avatar/47327a8bc1966f2186dcb3ebf4b7ee6e4e7ab9a5c2a07405aff57200ea778f71",
+    login: "tomlarkworthy",
+    name: "Tom Larkworthy",
+    bio: "Tech Lead at Taktile. ex Firebase, Google.\n🦋 larkworthy.bsky.social",
+    home_url: "https://bsky.app/profile/larkworthy.bsky.social",
+    tier: "pro"
+  },
+  authors: [
+    {
+      id: "5215f6ec4a999d40",
+      avatar_url:
+        "https://avatars.observableusercontent.com/avatar/47327a8bc1966f2186dcb3ebf4b7ee6e4e7ab9a5c2a07405aff57200ea778f71",
+      name: "Tom Larkworthy",
+      login: "tomlarkworthy",
+      bio: "Tech Lead at Taktile. ex Firebase, Google.\n🦋 larkworthy.bsky.social",
+      home_url: "https://bsky.app/profile/larkworthy.bsky.social",
+      tier: "pro",
+      approved: true,
+      description: ""
+    }
+  ],
+  collections: [
+    {
+      id: "cf72f19f55f3a048",
+      type: "public",
+      slug: "lopebook",
+      title: "lopecode",
+      description: "",
+      update_time: "2024-11-17T07:27:34.529Z",
+      pinned: false,
+      ordered: true,
+      custom_thumbnail: null,
+      default_thumbnail:
+        "dab1604ccf4a760060379630da0876da27b79509b738f8d5c300c9a9a320e38a",
+      thumbnail:
+        "dab1604ccf4a760060379630da0876da27b79509b738f8d5c300c9a9a320e38a",
+      listing_count: 9,
+      parent_collection_count: 0,
+      owner: {
+        id: "7db5ed2b0697d645",
+        avatar_url:
+          "https://avatars.observableusercontent.com/avatar/47327a8bc1966f2186dcb3ebf4b7ee6e4e7ab9a5c2a07405aff57200ea778f71",
+        login: "tomlarkworthy",
+        name: "Tom Larkworthy",
+        bio: "Tech Lead at Taktile.\nFormerly Firebase, Google",
+        home_url: "https://taktile.com",
+        type: "team",
+        tier: "starter_2024"
+      }
+    }
+  ],
+  files: [
+    {
+      id: "50cad75d56578d08f50d560a50a6f4a66919f1f0b9c189221c6768a04dc958323335dac14ca3526e6527019d02e9e00d21d247eb5c2646b38ec7720e0ddcaa7e",
+      url: "https://static.observableusercontent.com/files/50cad75d56578d08f50d560a50a6f4a66919f1f0b9c189221c6768a04dc958323335dac14ca3526e6527019d02e9e00d21d247eb5c2646b38ec7720e0ddcaa7e",
+      download_url:
+        "https://static.observableusercontent.com/files/50cad75d56578d08f50d560a50a6f4a66919f1f0b9c189221c6768a04dc958323335dac14ca3526e6527019d02e9e00d21d247eb5c2646b38ec7720e0ddcaa7e?response-content-disposition=attachment%3Bfilename*%3DUTF-8%27%27empty",
+      name: "empty",
+      create_time: "2024-10-15T18:03:32.575Z",
+      mime_type: "application/octet-stream",
+      status: "public",
+      size: 2,
+      content_encoding: null,
+      private_bucket_id: null
+    }
+  ],
+  comments: [],
+  commenting_lock: null,
+  suggestion_from: null,
+  suggestions_to: [],
+  version: 152,
+  title: "Test Notebook of Semantics",
+  license: "mit",
+  copyright: "Copyright 2024 Tom Larkworthy",
+  nodes: [
+    {
+      id: 0,
+      value: "# Test Notebook of Semantics",
+      pinned: false,
+      mode: "md",
+      data: null,
+      name: ""
+    },
+    { id: 9, value: "1", pinned: true, mode: "js", data: null, name: null },
+    {
+      id: 31,
+      value: '{\n  ("");\n}',
+      pinned: true,
+      mode: "js",
+      data: null,
+      name: null
+    },
+    {
+      id: 100,
+      value: "<div>",
+      pinned: false,
+      mode: "html",
+      data: null,
+      name: "html"
+    },
+    {
+      id: 115,
+      value: "obj_literal = ({})",
+      pinned: false,
+      mode: "js",
+      data: null,
+      name: null
+    },
+    {
+      id: 11,
+      value: 'x = ""',
+      pinned: true,
+      mode: "js",
+      data: null,
+      name: null
+    },
+    {
+      id: 13,
+      value: "y = x",
+      pinned: true,
+      mode: "js",
+      data: null,
+      name: null
+    },
+    {
+      id: 15,
+      value: 'z = {\n  ("");\n  return x + y;\n}',
+      pinned: true,
+      mode: "js",
+      data: null,
+      name: null
+    },
+    {
+      id: 145,
+      value: 'comments = {\n  // a comment\n  return "";\n}',
+      pinned: false,
+      mode: "js",
+      data: null,
+      name: null
+    },
+    {
+      id: 17,
+      value: "generator = {\n  yield x + y;\n}",
+      pinned: true,
+      mode: "js",
+      data: null,
+      name: null
+    },
+    {
+      id: 20,
+      value: "_function = function () {}",
+      pinned: true,
+      mode: "js",
+      data: null,
+      name: null
+    },
+    {
+      id: 71,
+      value: "asyncfunction = async function () {}",
+      pinned: true,
+      mode: "js",
+      data: null,
+      name: null
+    },
+    {
+      id: 25,
+      value: "named_function = function foo() {}",
+      pinned: true,
+      mode: "js",
+      data: null,
+      name: null
+    },
+    {
+      id: 151,
+      value: "thisReference = (this || 0) + 1",
+      pinned: true,
+      mode: "js",
+      data: null,
+      name: null
+    },
+    {
+      id: 22,
+      value: "lambda = () => {}",
+      pinned: true,
+      mode: "js",
+      data: null,
+      name: null
+    },
+    {
+      id: 33,
+      value: "error = {\n  throw new Error();\n}",
+      pinned: true,
+      mode: "js",
+      data: null,
+      name: null
+    },
+    {
+      id: 39,
+      value: "viewof view = Inputs.input()",
+      pinned: true,
+      mode: "js",
+      data: null,
+      name: null
+    },
+    {
+      id: 42,
+      value: "mutable q = 6",
+      pinned: true,
+      mode: "js",
+      data: null,
+      name: null
+    },
+    {
+      id: 45,
+      value: "inbuilt = _",
+      pinned: true,
+      mode: "js",
+      data: null,
+      name: null
+    },
+    {
+      id: 48,
+      value: 'file = FileAttachment("empty")',
+      pinned: true,
+      mode: "js",
+      data: null,
+      name: null
+    },
+    {
+      id: 52,
+      value:
+        "mutable_dep = {\n  viewof view;\n  lambda;\n  mutable q;\n  return mutable q;\n}",
+      pinned: true,
+      mode: "js",
+      data: null,
+      name: null
+    },
+    {
+      id: 55,
+      value: "mutable_dep_2 = {\n  file;\n  return q + 1;\n}",
+      pinned: true,
+      mode: "js",
+      data: null,
+      name: null
+    },
+    {
+      id: 57,
+      value: "viewofdep_inline = viewof view",
+      pinned: true,
+      mode: "js",
+      data: null,
+      name: null
+    },
+    {
+      id: 61,
+      value: "viewofdatadep = view",
+      pinned: true,
+      mode: "js",
+      data: null,
+      name: null
+    },
+    { id: 93, value: "dep", pinned: true, mode: "js", data: null, name: null },
+    {
+      id: 64,
+      value:
+        'import {\n  dep,\n  mutable mutabledep,\n  viewof viewdep,\n  dep as dep_alias,\n  mutable mutabledep as aslias_mutabledep,\n  viewof viewdep as aslias_viewdep,\n  mutabledep as aslias_mutabledep_data,\n  viewdep as aslias_viewdep_data\n} from "@tomlarkworthy/dependancy";',
+      pinned: true,
+      mode: "js",
+      data: null,
+      name: null
+    }
+  ],
+  resolutions: [],
+  schedule: null,
+  last_view_time: null
+}
+)};
+const _1juj7i6 = function _notebook_semantics_source(notebook_semantics_document,parser){return(
+notebook_semantics_document.nodes.map((s) => ({
+  value: s.value,
+  name: s.mode == "js" ? parser.parseCell(s.value)?.id?.name : null,
+  mode: s.mode
+}))
+)};
+const _1oevsow = function _28(md){return(
+md`### Runtime Representation (v4)`
+)};
+const _11lfflk = function _notebook_semantics_module() {
+    return import('https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4');
+};
+const _gjten6 = function _31(md){return(
+md`### Imports`
+)};
+const _n9rco8 = function _32(md){return(
+md`observed modules are variables in the parent notebook, so their module is the main, however, their dependency is something else. -- this holds even for live notebook. They can only have one dependancy (inputs.length = 1)`
+)};
+const _eog966 = function _33(md){return(
+md`### runtime in observable`
+)};
+const _n4ntwp = function _34(md){return(
+md`## Test cases`
+)};
+const _1lg9nnl = function _importFake(Runtime){return(
+async function (variable, module_name) {
+  const runtime = new Runtime({}, () => {});
+  const importer = runtime.module();
+  let _import_definition;
+  eval(`_import_definition = async () => "${module_name}" && runtime.module()`);
+  const importVariable = importer.define(
+    `module ${module_name}`,
+    _import_definition
+  );
+  const importee = (importVariable._value = await importVariable._definition());
+  importee.define(variable._inputs[0], [], () => null);
+  return importer.import([variable._inputs[0]], variable._name, importee);
+}
+)};
+const _25tjxa = async function _test_decompile_syntax_error_roundtrip(compile,decompile,expect)
+{
+  const compiled = await compile(`foo = () => return ""`);
+  const decompiled = await decompile(compiled);
+  expect(decompiled).toEqual(`foo = () => return ""`);
+  return "ok";
+};
+const _1jyrnzq = async function _test_decompile_$variable(decompile,expect)
+{
+  const decompiled = await decompile([
+    {
+      _name: "v",
+      _definition: "function _x($variable) {return ($variable);}",
+      _inputs: [
+        {
+          _name: "@variable"
+        }
+      ]
+    }
+  ]);
+  expect(decompiled).toEqual("v = $variable");
+  return "@variable support: ok";
+};
+const _1v1d8m3 = async function _test_decompile_import_variable(decompile,importFake,expect)
+{
+  const decompiled = await decompile([
+    await importFake(
+      {
+        _name: "dep",
+        _definition: "function Yn(e){return e}",
+        _inputs: ["dep"]
+      },
+      "@tomlarkworthy/dependancy"
+    )
+  ]);
+  expect(decompiled).toEqual(`import {dep} from "@tomlarkworthy/dependancy"`);
+  return "ok";
+};
+const _1ybjsqg = async function _test_decompile_dollar_in_string_literal(decompile,expect)
+{
+  // Regression: $N inside a string/regex/template literal must NOT be substituted
+  // with `viewof X` / `mutable X`. This is the cc_ws bug — regex backref $1
+  // collided with `viewof cc_watches` (input #1) and got rewritten blindly.
+  const decompiled = await decompile([
+    {
+      _name: "demo",
+      _definition: `function _demo($0,$1){return(
+"x".replace(/x/, '$1y')
+)}`,
+      _inputs: ["viewof a", "viewof b"]
+    }
+  ]);
+  expect(decompiled).toEqual(`demo = "x".replace(/x/, '$1y')`);
+  return "ok";
+};
+const _wgfrtq = async function _test_decompile_import_variable_alias(decompile,importFake,expect)
+{
+  const decompiled = await decompile([
+    await importFake(
+      {
+        _name: "alias",
+        _definition: "function Yn(e){return e}",
+        _inputs: ["dep"]
+      },
+      "@tomlarkworthy/dependancy"
+    )
+  ]);
+  expect(decompiled).toEqual(
+    `import {dep as alias} from "@tomlarkworthy/dependancy"`
+  );
+  return "ok";
+};
+const _1a8gnrc = async function _test_decompile_import_many(decompile,importFake,expect)
+{
+  const decompiled = await decompile([
+    await importFake(
+      {
+        _name: "dep",
+        _definition: "function Yn(e){return e}",
+        _inputs: ["dep"]
+      },
+      "@tomlarkworthy/dependancy"
+    ),
+    {
+      _name: "mutable mutabledep",
+      _definition: '(_, v) => v.import("mutable mutabledep", _)',
+      _inputs: ["module 1", "@variable"]
+    },
+    {
+      _name: "mutabledep",
+      _definition: '(_, v) => v.import("mutabledep", _)',
+      _inputs: ["module 1", "@variable"]
+    },
+    {
+      _name: "viewof viewdep",
+      _definition: '(_, v) => v.import("viewof viewdep", _)',
+      _inputs: ["module 1", "@variable"]
+    },
+    {
+      _name: "viewdep",
+      _definition: '(_, v) => v.import("viewdep", _)',
+      _inputs: ["module 1", "@variable"]
+    },
+    {
+      _name: "dep_alias",
+      _definition: '(_, v) => v.import("dep", "dep_alias", _)',
+      _inputs: ["module 1", "@variable"]
+    },
+    {
+      _name: "error_dep",
+      _definition: "function Yn(e){return e}",
+      _inputs: ["module 1", "error_dep"]
+    },
+    {
+      _name: "mutable aslias_mutabledep",
+      _definition:
+        '(_, v) => v.import("mutable mutabledep", "mutable aslias_mutabledep", _)',
+      _inputs: ["module 1", "@variable"]
+    },
+    {
+      _name: "aslias_mutabledep",
+      _definition: '(_, v) => v.import("mutabledep", "aslias_mutabledep", _)',
+      _inputs: ["module 1", "@variable"]
+    },
+    {
+      _name: "viewof aslias_viewdep",
+      _definition:
+        '(_, v) => v.import("viewof viewdep", "viewof aslias_viewdep", _)',
+      _inputs: ["module 1", "@variable"]
+    },
+    {
+      _name: "aslias_viewdep",
+      _definition: '(_, v) => v.import("viewdep", "aslias_viewdep", _)',
+      _inputs: ["module 1", "@variable"]
+    },
+    {
+      _name: "aslias_mutabledep_data",
+      _definition:
+        '(_, v) => v.import("mutabledep", "aslias_mutabledep_data", _)',
+      _inputs: ["module 1", "@variable"]
+    },
+    {
+      _name: "aslias_viewdep_data",
+      _definition: '(_, v) => v.import("viewdep", "aslias_viewdep_data", _)',
+      _inputs: ["module 1", "@variable"]
+    }
+  ]);
+  expect(decompiled).toEqual(
+    `import {dep, mutable mutabledep, mutabledep, viewof viewdep, viewdep, dep as dep_alias, error_dep, mutable mutabledep as mutable aslias_mutabledep, mutabledep as aslias_mutabledep, viewof viewdep as viewof aslias_viewdep, viewdep as aslias_viewdep, mutabledep as aslias_mutabledep_data, viewdep as aslias_viewdep_data} from "@tomlarkworthy/dependancy"`
+  );
+  return "ok";
+};
+const _7stpu3 = async function _test_decompile_markdown_cell(decompile,expect)
+{
+  const decompiled = await decompile([
+    {
+      _name: "v",
+      _definition: `function _1(md){return(\nmd\`# Test Notebook of Semantics\`\n)}`,
+      _inputs: [
+        {
+          _name: "md"
+        }
+      ]
+    }
+  ]);
+  expect(decompiled).toEqual(`v = md\`# Test Notebook of Semantics\``);
+  return "ok";
+};
+const _v4p1js = async function _test_decompile_constant(decompile,expect)
+{
+  const decompiled = await decompile([
+    {
+      _name: "v",
+      _definition: `function _2(){return(
+1
+)}`,
+      _inputs: []
+    }
+  ]);
+  expect(decompiled).toEqual(`v = 1`);
+  return "ok";
+};
+const _1puzspw = async function _test_decompile_string_literal(decompile,expect)
+{
+  const decompiled = await decompile([
+    {
+      _name: "v",
+      _definition: `function _3() {\n  ("");\n}`,
+      _inputs: []
+    }
+  ]);
+  // decompile preserves the original expression verbatim (source-slicing), so the
+  // parenthesized string and quote style survive — no escodegen re-quoting.
+  expect(decompiled).toEqual(`v = {\n  ("");\n}`);
+  return "ok";
+};
+const _a2zh99 = async function _test_decompile_html_cell(decompile,expect)
+{
+  const decompiled = await decompile([
+    {
+      _name: "html",
+      _definition: `function _html(htl){return(\nhtl.html\`<div>\`\n)}`,
+      _inputs: []
+    }
+  ]);
+  expect(decompiled).toEqual(`html = htl.html\`<div>\``);
+  return "ok";
+};
+const _1pt67ao = async function _test_decompile_class(decompile,expect)
+{
+  const decompiled = await decompile([
+    {
+      _name: "myclass",
+      _definition: `function _myclass(){return(
+class myclass {}
+)}`,
+      _inputs: []
+    }
+  ]);
+  expect(decompiled).toEqual(`myclass = class myclass {}`);
+  return "ok";
+};
+const _kf8c3f = function _test_decompile_class_with_property(decompile){return(
+decompile([
+  {
+    _inputs: [],
+    _definition: `function _Cls(){return(
+        class Cls {
+          d;
+        }
+    )}`
+  }
+])
+)};
+const _4vunhm = async function _test_decompile_object_literal(decompile,expect)
+{
+  const decompiled = await decompile([
+    {
+      _name: "obj_literal",
+      _definition: "function _obj_literal(){return(\n{}\n)}",
+      _inputs: []
+    }
+  ]);
+  expect(decompiled).toEqual(`obj_literal = ({})`);
+  return "ok";
+};
+const _s14e29 = async function _test_decompile_reference(decompile,expect)
+{
+  const decompiled = await decompile([
+    {
+      _name: "v",
+      _definition: `function _y(x){return(
+x
+)}`,
+      _inputs: []
+    }
+  ]);
+  expect(decompiled).toEqual(`v = x`);
+  return "ok";
+};
+const _14nvmno = async function _test_decompile_block(decompile,expect)
+{
+  const decompiled = await decompile([
+    {
+      _name: "v",
+      _definition: `function _z(x,y)
+{
+  ("");
+  return x + y;
+}`,
+      _inputs: []
+    }
+  ]);
+  expect(decompiled).toEqual(`v = {
+  ("");
+  return x + y;
+}`);
+  return "ok";
+};
+const _5kd9if = async function _test_decompile_comments(decompile,expect)
+{
+  const decompiled = await decompile([
+    {
+      _name: "comments",
+      _definition: `function _comments()
+{
+  // a comment
+  return "";
+}`,
+      _inputs: []
+    }
+  ]);
+  expect(decompiled).toEqual(`comments = {
+  // a comment
+  return "";
+}`);
+  return "ok";
+};
+const _1yn35e3 = async function _test_decompile_generator(decompile,expect)
+{
+  const decompiled = await decompile([
+    {
+      _name: "generator",
+      _definition: `function* _generator(x,y)
+{
+  yield x + y;
+}`,
+      _inputs: []
+    }
+  ]);
+  expect(decompiled).toEqual(`generator = {
+  yield x + y;
+}`);
+  return "ok";
+};
+const _10wf7cf = async function _test_decompile_function(decompile,expect)
+{
+  const decompiled = await decompile([
+    {
+      _name: "_function",
+      _definition: `function __function(){return(
+function () {}
+)}`,
+      _inputs: []
+    }
+  ]);
+  expect(decompiled).toEqual(`_function = function () {}`);
+  return "ok";
+};
+const _1191zxm = async function _test_decompile_async_function(decompile,expect)
+{
+  const decompiled = await decompile([
+    {
+      _name: "asyncfunction",
+      _definition: `function _asyncfunction(){return(
+async function () {}
+)}`,
+      _inputs: []
+    }
+  ]);
+  expect(decompiled).toEqual(`asyncfunction = async function () {}`);
+  return "ok";
+};
+const _vpu09i = async function _test_decompile_named_function(decompile,expect)
+{
+  const decompiled = await decompile([
+    {
+      _name: "named_function",
+      _definition: `function _named_function(){return(
+function foo() {}
+)}`,
+      _inputs: []
+    }
+  ]);
+  expect(decompiled).toEqual(`named_function = function foo() {}`);
+  return "ok";
+};
+const _1pghf4f = async function _test_decompile_this_reference(decompile,expect)
+{
+  const decompiled = await decompile([
+    {
+      _name: "thisReference",
+      _definition: `function _thisReference(){return(
+(this || 0) + 1
+)}`,
+      _inputs: []
+    }
+  ]);
+  expect(decompiled).toEqual(`thisReference = (this || 0) + 1`);
+  return "ok";
+};
+const _rajn7p = async function _test_decompile_lambda(decompile,expect)
+{
+  const decompiled = await decompile([
+    {
+      _name: "lambda",
+      _definition: `function _lambda(){return(
+() => {}
+)}`,
+      _inputs: []
+    }
+  ]);
+  expect(decompiled).toEqual(`lambda = () => {}`);
+  return "ok";
+};
+const _12ec5zd = async function _test_decompile_error(decompile,expect)
+{
+  const decompiled = await decompile([
+    {
+      _name: "error",
+      _definition: `function _error()
+{
+  throw new Error();
+}`,
+      _inputs: []
+    }
+  ]);
+  expect(decompiled).toEqual(`error = {
+  throw new Error();
+}`);
+  return "ok";
+};
+const _1c93ef9 = async function _test_decompile_error_object(decompile,expect)
+{
+  const decompiled = await decompile([
+    {
+      _name: "error_obj",
+      _definition: `function _error_obj()
+{
+  throw { foo: "bar" };
+}`,
+      _inputs: []
+    }
+  ]);
+  expect(decompiled).toEqual(`error_obj = {
+  throw { foo: "bar" };
+}`);
+  return "ok";
+};
+const _6iufw4 = function _60(md){return(
+md`⚠️ This cells have not been grouped correctly, should be a single import being decompiled`
+)};
+const _15idqib = async function _test_decompile_anon_error_dep(decompile,expect)
+{
+  const decompiled = await decompile([
+    {
+      _definition: `function _19(error_dep){return(
+error_dep
+)}`,
+      _inputs: ["error_dep"]
+    }
+  ]);
+  expect(decompiled).toEqual(`error_dep`);
+  return "ok";
+};
+const _mhm98c = async function _test_decompile_viewof(decompile,expect)
+{
+  const decompiled = await decompile([
+    {
+      _name: "viewof view",
+      _definition: `function _view(Inputs){return(
+Inputs.input()
+)}`,
+      _inputs: []
+    }
+  ]);
+  expect(decompiled).toEqual(`viewof view = Inputs.input()`);
+  return "ok";
+};
+const _15kgqrr = async function _test_decompile_mutable(decompile,expect)
+{
+  const decompiled = await decompile([
+    {
+      _name: "initial q",
+      _definition: `function _q(){return(
+6
+)}`,
+      _inputs: []
+    }
+  ]);
+  expect(decompiled).toEqual(`mutable q = 6`);
+  return "ok";
+};
+const _1onyv5c = async function _test_decompile_builtin(decompile,expect)
+{
+  const decompiled = await decompile([
+    {
+      _name: "inbuilt",
+      _definition: `function _inbuilt(_){return(
+_
+)}`,
+      _inputs: []
+    }
+  ]);
+  expect(decompiled).toEqual(`inbuilt = _`);
+  return "ok";
+};
+const _4z1dnp = async function _test_decompile_fileattachment(decompile,expect)
+{
+  const decompiled = await decompile([
+    {
+      _name: "file",
+      _definition: `function _file(FileAttachment){return(
+FileAttachment("empty")
+)}`,
+      _inputs: []
+    }
+  ]);
+  expect(decompiled).toEqual(`file = FileAttachment("empty")`);
+  return "ok";
+};
+const _g4z6de = async function _test_decompile_mutable_dependancy(decompile,expect)
+{
+  const decompiled = await decompile([
+    {
+      _name: "mutable_dep",
+      _definition: `function _mutable_dep($0,lambda,$1)
+{
+  $0;
+  lambda;
+  $1.value;
+  return $1.value;
+}`,
+      _inputs: ["viewof view", "mutable q"]
+    }
+  ]);
+  expect(decompiled).toEqual(`mutable_dep = {
+  viewof view;
+  lambda;
+  mutable q;
+  return mutable q;
+}`);
+  return "ok";
+};
+const _qo8sdl = async function _test_decompile_mutable_dependancy_2(decompile,expect)
+{
+  const decompiled = await decompile([
+    {
+      _name: "mutable_dep_2",
+      _definition: `function _mutable_dep_2(file,q)
+{
+  file;
+  return q + 1;
+}`,
+      _inputs: []
+    }
+  ]);
+  expect(decompiled).toEqual(`mutable_dep_2 = {
+  file;
+  return q + 1;
+}`);
+  return "ok";
+};
+const _15kwaz1 = async function _test_decompile_viewof_dep(decompile,expect)
+{
+  const decompiled = await decompile([
+    {
+      _name: "viewofdep_inline",
+      _definition: `function _viewofdep_inline($0){return(
+$0
+)}`,
+      _inputs: ["viewof view"]
+    }
+  ]);
+  expect(decompiled).toEqual(`viewofdep_inline = viewof view`);
+  return "ok";
+};
+const _1qjzk2s = async function _test_decompile_viewof_data_dep(decompile,expect)
+{
+  const decompiled = await decompile([
+    {
+      _name: "viewofdatadep",
+      _definition: `function _viewofdatadep(view){return(
+view
+)}`,
+      _inputs: []
+    }
+  ]);
+  expect(decompiled).toEqual(`viewofdatadep = view`);
+  return "ok";
+};
+const _b0y8zg = async function _test_decompile_viewof_param(decompile,expect)
+{
+  // Lopecode compiled form uses viewof_X as parameter name instead of $N
+  const decompiled = await decompile([
+    {
+      _name: "foo",
+      _definition: `function _foo(viewof_bar, x)
+{
+  viewof_bar.value = x;
+  viewof_bar.dispatchEvent(new Event("input"));
+}`,
+      _inputs: ["viewof bar"]
+    }
+  ]);
+  expect(decompiled).toEqual(`foo = {
+  viewof bar.value = x;
+  viewof bar.dispatchEvent(new Event("input"));
+}`);
+  return "ok";
+};
+const _oilkc0 = async function _test_decompile_anon_dep(decompile,expect)
+{
+  const decompiled = await decompile([
+    {
+      _definition: `function _28(dep){return(
+dep
+)}`,
+      _inputs: []
+    }
+  ]);
+  expect(decompiled).toEqual(`dep`);
+  return "ok";
+};
+const _1eqf4jq = async function _test_decompile_import_mutable(decompile,expect)
+{
+  const decompiled = await decompile([
+    {
+      _name: "mutable mutabledep",
+      _definition: `(_, v) => v.import("mutable mutabledep", _)`,
+      _inputs: []
+    }
+  ]);
+  expect(decompiled).toEqual(
+    `mutable mutabledep = v.import("mutable mutabledep", _)`
+  );
+  return "ok";
+};
+const _3damo4 = async function _test_decompile_import_viewof(decompile,expect)
+{
+  const decompiled = await decompile([
+    {
+      _name: "viewof viewdep",
+      _definition: `(_, v) => v.import("viewof viewdep", _)`,
+      _inputs: []
+    }
+  ]);
+  expect(decompiled).toEqual(`viewof viewdep = v.import("viewof viewdep", _)`);
+  return "ok";
+};
+const _1l9xqsw = async function _test_decompile_viewof_data(decompile,expect)
+{
+  const decompiled = await decompile([
+    {
+      _name: "viewdep",
+      _definition: `(_, v) => v.import("viewdep", _)`,
+      _inputs: []
+    }
+  ]);
+  expect(decompiled).toEqual(`viewdep = v.import("viewdep", _)`);
+  return "ok";
+};
+const _1cggvdk = async function _test_decompile_import_alias(decompile,expect)
+{
+  const decompiled = await decompile([
+    {
+      _name: "dep_alias",
+      _definition: `(_, v) => v.import("dep", "dep_alias", _)`,
+      _inputs: []
+    }
+  ]);
+  expect(decompiled).toEqual(`dep_alias = v.import("dep", "dep_alias", _)`);
+  return "ok";
+};
+const _xcwq4 = async function _test_decompile_import_mutable_alias(decompile,expect)
+{
+  const decompiled = await decompile([
+    {
+      _name: "mutable aslias_mutabledep",
+      _definition: `(_, v) => v.import("mutable mutabledep", "mutable aslias_mutabledep", _)`,
+      _inputs: []
+    }
+  ]);
+  expect(decompiled).toEqual(
+    `mutable aslias_mutabledep = v.import("mutable mutabledep", "mutable aslias_mutabledep", _)`
+  );
+  return "ok";
+};
+const _1868h0w = async function _test_decompile_import_mutable_data_alias(decompile,expect)
+{
+  const decompiled = await decompile([
+    {
+      _name: "aslias_mutabledep",
+      _definition: `(_, v) => v.import("mutabledep", "aslias_mutabledep", _)`,
+      _inputs: []
+    }
+  ]);
+  expect(decompiled).toEqual(
+    `aslias_mutabledep = v.import("mutabledep", "aslias_mutabledep", _)`
+  );
+  return "ok";
+};
+const _1afcxhk = async function _test_decompile_import_viewof_alias(decompile,expect)
+{
+  const decompiled = await decompile([
+    {
+      _name: "viewof aslias_viewdep",
+      _definition: `(_, v) => v.import("viewof viewdep", "viewof aslias_viewdep", _)`,
+      _inputs: []
+    }
+  ]);
+  expect(decompiled).toEqual(
+    `viewof aslias_viewdep = v.import("viewof viewdep", "viewof aslias_viewdep", _)`
+  );
+  return "ok";
+};
+const _1sl510 = async function _test_decompile_import_viewof_data_alias(decompile,expect)
+{
+  const decompiled = await decompile([
+    {
+      _name: "aslias_viewdep",
+      _definition: `(_, v) => v.import("viewdep", "aslias_viewdep", _)`,
+      _inputs: []
+    }
+  ]);
+  expect(decompiled).toEqual(
+    `aslias_viewdep = v.import("viewdep", "aslias_viewdep", _)`
+  );
+  return "ok";
+};
+const _17dwb6r = function _80(md){return(
+md`### The Decompiler`
+)};
+const _1ngipml = function _81(md){return(
+md`### \`decompile\``
+)};
+const _2d5g1 = function _decompile(decompileImport,formatImportDeclaration,acorn){return(
+async function decompile(variables) {
+    if (!variables || variables.length === 0)
+      throw new Error("no variables to decompile");
+    const importInfo = await decompileImport(variables);
+    if (importInfo) return formatImportDeclaration(importInfo);
+    const variable = variables[0];
+    const name = variable._name;
+    const compiled =
+      typeof variable._definition === "string"
+        ? variable._definition
+        : variable._definition.toString();
+    // Check for syntax-error cells that carry the original source
+    const sourceExprMatch = compiled.match(
+      /_sourceExpression:\s*("(?:[^"\\]|\\.)*")/
+    );
+    if (sourceExprMatch) {
+      try {
+        return JSON.parse(sourceExprMatch[1]);
+      } catch {}
+    }
+    const inputs = (variable._inputs || []).map((i) =>
+      typeof i === "string" ? i : i._name
+    );
+    const wrappedCode = "(" + compiled + ")";
+    const comments = [],
+      tokens = [];
+    const parsed = acorn.parse(wrappedCode, {
+      ecmaVersion: 2022,
+      sourceType: "module",
+      ranges: true,
+      onComment: comments,
+      onToken: tokens
+    });
+    const functionExpression = parsed.body[0].expression;
+    const body = functionExpression.body;
+    // Extract parameter names from AST for underscore-encoded name fixup
+    const params = (functionExpression.params || []).map((p) => p.name);
+    let varName = name;
+    let prefix = "";
+    if (name) {
+      if (name.startsWith("initial ")) {
+        prefix = "mutable ";
+        varName = name.replace(/^initial /, "");
+      } else if (name.startsWith("mutable ")) {
+        prefix = "mutable ";
+        varName = name.replace(/^mutable /, "");
+      } else if (name.startsWith("viewof ")) {
+        prefix = "viewof ";
+        varName = name.replace(/^viewof /, "");
+      }
+    }
+    // Pick the source range to return: the single returned expression for a
+    // normal `{ return <expr> }` cell, otherwise the whole body. We SLICE the
+    // original text rather than regenerate via escodegen, so comments, quote
+    // style, whitespace, ASI-sensitive grouping and class fields all survive
+    // byte-for-byte. (Regeneration was the root of the ASI, quote-drift and
+    // class-property-shim-gap bugs.)
+    let sliceNode = body;
+    let wrapObjectLiteral = false;
+    if (
+      body.type === "BlockStatement" &&
+      body.body.length === 1 &&
+      body.body[0].type === "ReturnStatement" &&
+      body.body[0].argument
+    ) {
+      const arg = body.body[0].argument;
+      // Unwrap `{ return <arg> }` to <arg> only when every comment lives INSIDE
+      // <arg>, so it survives the arg slice (a returned function's own comments
+      // are kept this way). A comment anywhere else in the block — before
+      // `return`, in the compiler's `return( … )` auto-wrap slot, or trailing
+      // after the value — would be dropped by unwrapping, so keep the (ASI-safe)
+      // block form to preserve it and round-trip exactly.
+      const hasCommentOutsideArg = comments.some(
+        (c) =>
+          c.start >= body.start &&
+          c.end <= body.end &&
+          (c.end <= arg.start || c.start >= arg.end)
+      );
+      if (!hasCommentOutsideArg) {
+        sliceNode = arg;
+        wrapObjectLiteral = wrappedCode[arg.start] === "{";
+      }
+    }
+    const sliceStart = sliceNode.start;
+    const sliceEnd = sliceNode.end;
+
+    // $N → Observable name. Positional over the qualifying inputs, matching the
+    // compiler's convention (same counting the old placeholder pass used).
+    const dollarValue = new Map();
+    {
+      let id = 0;
+      inputs.forEach((input) => {
+        if (input && input.startsWith("mutable ")) {
+          dollarValue.set(`$${id++}`, { name: input, mutable: true });
+        } else if (
+          input &&
+          (input.startsWith("viewof ") || input === "@variable")
+        ) {
+          dollarValue.set(`$${id++}`, { name: input, mutable: false });
+        }
+      });
+    }
+    // Underscore-encoded viewof/mutable params (lopecode compiled form) → spaced.
+    const underscoreParam = new Map();
+    inputs.forEach((input, i) => {
+      if (
+        input &&
+        (input.startsWith("viewof ") || input.startsWith("mutable "))
+      ) {
+        const underscoreForm = input.replace(" ", "_");
+        if (params[i] === underscoreForm) underscoreParam.set(underscoreForm, input);
+      }
+    });
+
+    // Collect identifier-node range rewrites within the sliced expression only.
+    // Keyed on Identifier/MemberExpression nodes, so string, regex and template
+    // text is never touched (this is what the old string replaceAll corrupted).
+    const edits = [];
+    const consumed = new Set();
+    const collect = (node) => {
+      if (!node || typeof node !== "object" || typeof node.type !== "string")
+        return;
+      // mutable `$N.value` → `mutable foo` (replace the whole member expression)
+      if (
+        node.type === "MemberExpression" &&
+        !node.computed &&
+        node.object &&
+        node.object.type === "Identifier" &&
+        node.property &&
+        node.property.type === "Identifier" &&
+        node.property.name === "value"
+      ) {
+        const dv = dollarValue.get(node.object.name);
+        if (dv && dv.mutable) {
+          edits.push({ start: node.start, end: node.end, text: dv.name });
+          consumed.add(node.object);
+        }
+      } else if (node.type === "Identifier" && !consumed.has(node)) {
+        const dv = dollarValue.get(node.name);
+        if (dv) {
+          // Non-mutable $N → input name. Bare mutable $N (no `.value`) stays $N.
+          if (!dv.mutable) edits.push({ start: node.start, end: node.end, text: dv.name });
+        } else if (underscoreParam.has(node.name)) {
+          edits.push({ start: node.start, end: node.end, text: underscoreParam.get(node.name) });
+        }
+      }
+      for (const k in node) {
+        if (k === "loc" || k === "range" || k === "start" || k === "end")
+          continue;
+        const c = node[k];
+        if (Array.isArray(c)) c.forEach(collect);
+        else if (c && typeof c === "object" && typeof c.type === "string")
+          collect(c);
+      }
+    };
+    collect(sliceNode);
+
+    // Apply edits right-to-left (descending start) so offsets stay valid.
+    let expression = wrappedCode.slice(sliceStart, sliceEnd);
+    edits
+      .sort((a, b) => b.start - a.start)
+      .forEach((e) => {
+        const s = e.start - sliceStart;
+        const t = e.end - sliceStart;
+        expression = expression.slice(0, s) + e.text + expression.slice(t);
+      });
+    if (wrapObjectLiteral) expression = `(${expression})`;
+
+    const source = `${varName ? `${prefix}${varName} = ` : ""}${expression}`;
+    return source;
+  }
+)};
+const _1x0pvrl = function _83(md){return(
+md`### \`extractModuleInfo\` 
+static analysis of module imports`
+)};
+const _183j58u = function _extractModuleInfo(){return(
+function extractModuleInfo(str) {
+  const named = /@([^/]+)\/([^.]+)\.js\?v=\d+(?:&resolutions=[^@]+@(\d+))?/;
+  const matchNamed = str.match(named);
+
+  if (matchNamed) {
+    const namespace = matchNamed[1];
+    const notebook = matchNamed[2];
+    const version = matchNamed[3];
+    return { namespace, notebook, version };
+  }
+  const id = /\/?d\/([^@]+)@?(\d+)/;
+  const matchId = str.match(id);
+
+  if (matchId) {
+    const notebook = matchId[1];
+    const version = matchId[2];
+    return { id: notebook, version };
+  }
+
+  const lopebook = /"@([^/]+)\/([^"]+)"/;
+  const lopebookId = str.match(lopebook);
+
+  if (lopebookId) {
+    const namespace = lopebookId[1];
+    const notebook = lopebookId[2];
+    return { namespace, notebook };
+  }
+
+  return {};
+}
+)};
+const _w445v0 = function _test_extractModuleInfo_notebook_resolution(expect,extractModuleInfo)
+{
+  expect(
+    extractModuleInfo(
+      'async () => runtime.module((await import("/@tomlarkworthy/whisper-input.js?v=4&resolutions=03dda470c56b93ff@4883")).default)'
+    )
+  ).toEqual({
+    namespace: "tomlarkworthy",
+    notebook: "whisper-input",
+    version: "4883"
+  });
+  return "ok";
+};
+const _uzqj4w = function _test_extractModuleInfo_id_version_resolution(expect,extractModuleInfo)
+{
+  expect(
+    extractModuleInfo(
+      'async () => runtime.module((await import("/d/c2dae147641e012a@46.js?v=4&resolutions=03dda470c56b93ff@4883")).default)'
+    )
+  ).toEqual({ id: "c2dae147641e012a", version: "46" });
+  return "ok";
+};
+const _1sruec2 = function _test_extractModuleInfo_id_version(expect,extractModuleInfo)
+{
+  expect(
+    extractModuleInfo(
+      'async () => runtime.module((await import("d/58f3eb7334551ae6@215")).default)'
+    )
+  ).toEqual({ id: "58f3eb7334551ae6", version: "215" });
+  return "ok";
+};
+const _ipn8zp = function _test_extractModuleInfo_test_4(expect,extractModuleInfo)
+{
+  expect(
+    extractModuleInfo(
+      'await import("https://api.observablehq.com/@tomlarkworthy/observable-notes.js?v=4"'
+    )
+  ).toEqual({
+    namespace: "tomlarkworthy",
+    notebook: "observable-notes"
+  });
+  return "ok";
+};
+const _iigmyv = function _test_extractModuleInfo_alias_hack(expect,extractModuleInfo)
+{
+  expect(
+    extractModuleInfo(
+      'async () => "@tom/blank" && runtime.module((await import("blob:https://tomlarkworthy.static.observableusercontent.com/4cdeb9db-e473-436b-b343-95abd7e4c16f")).default)'
+    )
+  ).toEqual({
+    namespace: "tom",
+    notebook: "blank"
+  });
+  return "ok";
+};
+const _7t42k8 = function _90(md){return(
+md`### \`findModuleName\` and \`findImportedName\``
+)};
+const _kiaw33 = function _import_ast_example(parser){return(
+parser.parseCell(
+  'import {runtime, viewof main as foo} from "@mootari/access-runtime"'
+)
+)};
+const _1n7gw17 = function _findModuleName(extractModuleInfo) {
+    return (scope, module, {
+        unknown_id = Math.random()
+    } = {}) => {
+        try {
+            const scopedVariables = [...scope.values()];
+            const candidates = scopedVariables.filter(v => v && v._value === module && typeof v._name === 'string' && v._name.startsWith('module ') && !v._name.startsWith('module <unknown'));
+            const pickBestInfo = dfn => {
+                const s = String(dfn ?? '');
+                const m = s.match(/\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/);
+                const firstArg = m?.[2];
+                const info1 = firstArg ? extractModuleInfo(firstArg) : {};
+                if (info1?.id || info1?.notebook)
+                    return info1;
+                return extractModuleInfo(s);
+            };
+            for (const v of candidates) {
+                const info = pickBestInfo(v._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            const any = scopedVariables.find(v => v && v._value === module);
+            if (any) {
+                const info = pickBestInfo(any._definition?.toString?.());
+                if (info?.namespace)
+                    return `@${ info.namespace }/${ info.notebook }`;
+                if (info?.id)
+                    return `d/${ info.id }@${ info.version }`;
+            }
+            return `<unknown ${ unknown_id }>`;
+        } catch (e) {
+            debugger;
+            return 'error';
+        }
+    };
+};
+const _i47chb = function _findImportedName(){return(
+async (v) => {
+  if (v._inputs.length == 1 && v._inputs[0]._name === "@variable") {
+    // import in a live-notebook hides the alias in a closure
+    let capture;
+    await v._definition({ import: (...args) => (capture = args) });
+    return capture[0];
+  }
+  if (v._inputs.length == 1) {
+    return v._inputs[0]._name;
+  }
+  const regex = /v\.import\("([^"]+)",\s*"([^"]+)"/;
+  const match = v._definition.toString().match(regex);
+  if (match) {
+    // Handle two cases (two arguments)
+    return match[1];
+  }
+  return v._name;
+}
+)};
+const _ed3cy2 = function _94(md){return(
+md`### \`decompileImport\``
+)};
+const _1a4j4gm = function _decompileImport(findModuleName,findImportedName)
+{
+  return async function decompileImport(variables, options = {}) {
+    if (!variables || variables.length === 0)
+      throw new Error('no variables');
+    // An import-cell group is `[module @X stitch, ...aliases]`. Each alias goes
+    // through three lifecycle stages (documented in observable-runtime-v6's
+    // `importedModule` helper, lines ~1992-2049 of @tomlarkworthy/observable-runtime-v6):
+    //
+    //   Stage A — post-observation:
+    //     `_inputs = [Variable in source module]` (length 1, cross-module).
+    //     The Observable runtime rewrites _inputs after the alias is observed
+    //     and resolved against the source module.
+    //
+    //   Stage B — pre-observation, API-loaded (canonical compiled-bundle shape):
+    //     `_inputs = [Variable("module @X"), Variable("@variable")]` (length 2,
+    //     both in the importer module). What `runtime.define("name",
+    //     ["module @X", "@variable"], (_, v) => v.import("name", _))` produces.
+    //     Also what `compile_and_update` outputs for freshly-defined user-typed
+    //     imports until they're observed.
+    //
+    //   Stage C — pre-observation, inline live-notebook:
+    //     `_inputs = [Variable("@variable")]` (length 1) AND the definition
+    //     calls `import(...)` inside. We extract the imported module reference
+    //     by invoking the definition with a stub `import` capture.
+    //
+    // Detection order is post→pre because Stage A is unambiguous when present.
+    const isStageA = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
+    };
+    const isStageB = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 2)
+        return false;
+      const [i0, i1] = inputs;
+      return !!(i0 && typeof i0 === 'object' && typeof i0._name === 'string' && i0._name.startsWith('module ') && i1 && typeof i1 === 'object' && i1._name === '@variable');
+    };
+    const isStageC = v => {
+      const inputs = v?._inputs;
+      if (!Array.isArray(inputs) || inputs.length !== 1)
+        return false;
+      const i0 = inputs[0];
+      return !!(i0 && typeof i0 === 'object' && i0._name === '@variable' && typeof v._definition !== 'undefined' && String(v._definition).includes('import('));
+    };
+    let v0, module_name, stage;
+    if (v0 = variables.find(isStageA)) {
+      stage = 'A';
+      module_name = findModuleName(v0._module._scope, v0._inputs[0]._module);
+    } else if (v0 = variables.find(isStageB)) {
+      stage = 'B';
+      module_name = v0._inputs[0]._name.replace(/^module /, '');
+    } else if (v0 = variables.find(isStageC)) {
+      stage = 'C';
+      let capturedModule;
+      try {
+        await v0._definition({
+          import: (...args) => {
+            capturedModule = args[args.length - 1];
+          }
+        });
+      } catch (e) {
+      }
+      if (capturedModule && v0._module?._scope) {
+        module_name = findModuleName(v0._module._scope, capturedModule);
+      }
+    } else {
+      return null;
+    }
+    if (module_name == null)
+      throw new Error('module name could not be resolved');
+    // Skip runtime-internal `module @foo` stitch variables — they belong to
+    // the import group but are not user-facing specifiers. Without this filter, an
+    // import group renders as `import {Range, module @foo} from "@foo"`.
+    const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
+      const imported = await findImportedName(v);
+      const local = v._name;
+      return {
+        imported,
+        local,
+        alias: imported !== local,
+        meta: { index }
+      };
+    }));
+    return {
+      type: 'import',
+      from: module_name,
+      specifiers,
+      meta: {
+        detection: { stage },
+        variables: variables.map(v => v?._name ?? null)
+      }
+    };
+  };
+};
+const _1sylz7j = function _formatImportDeclaration(){return(
+function formatImportDeclaration(importInfo) {
+  if (!importInfo || importInfo.type !== "import")
+    throw new Error("not an importInfo object");
+  const specifiers = (importInfo.specifiers || []).map((s) =>
+    s.imported === s.local ? s.local : `${s.imported} as ${s.local}`
+  );
+  return `import {${specifiers.join(", ")}} from "${importInfo.from}"`;
+}
+)};
+const _13dctdn = async function _test_decompileImport_basic(importFake,decompileImport,expect)
+{
+  const v = await importFake(
+    { _name: "dep", _definition: "function Yn(e){return e}", _inputs: ["dep"] },
+    "@tomlarkworthy/dependancy"
+  );
+  const info = await decompileImport([v]);
+
+  const simplified = {
+    type: info.type,
+    from: info.from,
+    specifiers: info.specifiers.map((s) => ({
+      imported: s.imported,
+      local: s.local,
+      alias: s.alias,
+      meta: { index: s.meta.index }
+    }))
+  };
+
+  expect(simplified).toEqual({
+    type: "import",
+    from: "@tomlarkworthy/dependancy",
+    specifiers: [
+      { imported: "dep", local: "dep", alias: false, meta: { index: 0 } }
+    ]
+  });
+
+  return "ok";
+};
+const _ujr0xn = async function _test_formatImportDeclaration_roundtrip(importFake,decompileImport,expect,formatImportDeclaration,decompile)
+{
+  const vars = [
+    await importFake(
+      {
+        _name: "dep",
+        _definition: "function Yn(e){return e}",
+        _inputs: ["dep"]
+      },
+      "@tomlarkworthy/dependancy"
+    )
+  ];
+  const info = await decompileImport(vars);
+  expect(formatImportDeclaration(info)).toEqual(await decompile(vars));
+  return "ok";
+};
+const _1u6sfri = async function _test_decompileImport_alias(importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const v = await importFake(
+    {
+      _name: "alias",
+      _definition: "function Yn(e){return e}",
+      _inputs: ["dep"]
+    },
+    "@tomlarkworthy/dependancy"
+  );
+  const info = await decompileImport([v]);
+
+  expect(info.specifiers[0].alias).toEqual(true);
+  expect(formatImportDeclaration(info)).toEqual(
+    `import {dep as alias} from "@tomlarkworthy/dependancy"`
+  );
+
+  return "ok";
+};
+const _1lti0tv = function _100(md){return(
+md`## Javascript Source Normalization`
+)};
+const _3knb9v = function _variableToObject(){return(
+(v) => ({
+  _name: v._name,
+  _definition: v._definition.toString(),
+  _inputs: v._inputs.map((v) => v._name || v)
+})
+)};
+const _autn1v = function _102(md){return(
+md`## Observable Source Normalization`
+)};
+const _7zpsl9 = function _normalizeObservableSourceSelector(Inputs,notebook_semantics_source){return(
+Inputs.select(
+  notebook_semantics_source.map((s) => s.value),
+  { label: "test case", value: "1" }
+)
+)};
+const _1ex8kus = (G, _) => G.input(_);
+const _b2d0zc = function _parsed(parser,normalizeObservableSourceSelector){return(
+parser.parseCell(normalizeObservableSourceSelector)
+)};
+const _14qm8or = function _105(md){return(
+md`## The Compiler
+
+`
+)};
+const _10ofthe = function _test_async_interpolation(compile){return(
+eval(
+  "let _fn = " +
+    compile("md`${await FileAttachment('image@1.png').url() }`")[0]._definition
+)
+)};
+const _1gb7c3c = async function _test_compile_syntax_error_viewof(compile,expect)
+{
+  const compiled = await compile(`viewof bar = () => return ""`);
+  expect(compiled.length).toEqual(1);
+  expect(compiled[0]._name).toEqual("viewof bar");
+  return "ok";
+};
+const _69vyub = async function _test_compile_syntax_error_anonymous(compile,expect)
+{
+  const compiled = await compile(`() => return ""`);
+  expect(compiled.length).toEqual(1);
+  expect(compiled[0]._name).toEqual(null);
+  expect(compiled[0]._inputs).toEqual([]);
+  let fn;
+  eval("fn = " + compiled[0]._definition);
+  let threw = false;
+  try {
+    fn();
+  } catch (e) {
+    threw = true;
+    expect(e instanceof SyntaxError).toEqual(true);
+    expect(e._sourceExpression).toEqual(`() => return ""`);
+  }
+  expect(threw).toEqual(true);
+  return "ok";
+};
+const _1c9p3om = async function _test_compile_syntax_error_named(compile,expect)
+{
+  const compiled = await compile(`foo = () => return ""`);
+  expect(compiled.length).toEqual(1);
+  expect(compiled[0]._name).toEqual("foo");
+  expect(compiled[0]._inputs).toEqual([]);
+  expect(compiled[0]._definition).toMatch(/function _foo\(\)/);
+  let fn;
+  eval("fn = " + compiled[0]._definition);
+  let threw = false;
+  try {
+    fn();
+  } catch (e) {
+    threw = true;
+    expect(e._sourceExpression).toEqual(`foo = () => return ""`);
+  }
+  expect(threw).toEqual(true);
+  return "ok";
+};
+const _x7zc8w = async function _test_compile_integer(compile,expect)
+{
+  const compiled = await compile("1");
+  expect(compiled).toEqual([
+    {
+      _definition: "function _anonymous() {return (1);}",
+      _inputs: [],
+      _name: null
+    }
+  ]);
+  return "ok";
+};
+const _1qp2ggw = async function _test_compile_string(compile,expect)
+{
+  const compiled = await compile(`""`);
+  expect(compiled).toEqual([
+    {
+      _name: null,
+      _inputs: [],
+      _definition: `function _anonymous() {return ("");}`
+    }
+  ]);
+  return "ok";
+};
+const _151bijp = async function _test_compile_obj_literal(compile,expect)
+{
+  const compiled = await compile(`obj_literal = ({})`);
+  expect(compiled).toEqual([
+    {
+      _name: "obj_literal",
+      _inputs: [],
+      _definition: "function _obj_literal() {return ({});}"
+    }
+  ]);
+  return "ok";
+};
+const _17z4vyt = async function _test_compile_assignment(compile,expect)
+{
+  const compiled = await compile(`x = ""`);
+  expect(compiled).toEqual([
+    {
+      _name: "x",
+      _inputs: [],
+      _definition: `function _x() {return ("");}`
+    }
+  ]);
+  return "ok";
+};
+const _1eb8vq = async function _test_compile_dependancy(compile,expect)
+{
+  const compiled = await compile(`y = x`);
+  expect(compiled).toEqual([
+    {
+      _name: "y",
+      _inputs: ["x"],
+      _definition: "function _y(x) {return (x);}"
+    }
+  ]);
+  return "ok";
+};
+const _5b8x33 = async function _test_compile_block_dependancy(compile,expect)
+{
+  const compiled = await compile(`z = {
+  ("");
+  return x + y;
+}`);
+  expect(compiled).toEqual([
+    {
+      _name: "z",
+      _inputs: ["x", "y"],
+      _definition: `function _z(x,y) {\n  ("");\n  return x + y;\n}`
+    }
+  ]);
+  return "ok";
+};
+const _9s1umz = async function _test_compile_comments(compile,expect)
+{
+  const compiled = await compile(`comments = {
+  // a comment
+  return "";
+}`);
+  expect(compiled).toEqual([
+    {
+      _name: "comments",
+      _inputs: [],
+      _definition: `function _comments() {\n  // a comment\n  return "";\n}`
+    }
+  ]);
+  return "ok";
+};
+const _1rbs7b6 = async function _test_compile_generator(compile,expect)
+{
+  const compiled = await compile(`generator = {
+  yield x + y;
+}`);
+  expect(compiled).toEqual([
+    {
+      _name: "generator",
+      _inputs: ["x", "y"],
+      _definition: "function* _generator(x,y) {\n  yield x + y;\n}"
+    }
+  ]);
+  return "ok";
+};
+const _1gaxmhs = async function _test_compile_function(compile,expect)
+{
+  const compiled = await compile(`_function = function () {}`);
+  expect(compiled).toEqual([
+    {
+      _name: "_function",
+      _inputs: [],
+      _definition: "function __function() {return (function () {});}"
+    }
+  ]);
+  return "ok";
+};
+const _2ozyn1 = async function _test_compile_async_function(compile,expect)
+{
+  const compiled = await compile(`asyncfunction = async function () {}`);
+  expect(compiled).toEqual([
+    {
+      _name: "asyncfunction",
+      _inputs: [],
+      _definition:
+        "function _asyncfunction() {return (async function () {});}"
+    }
+  ]);
+  return "ok";
+};
+const _1jn3lk9 = async function _test_compile_named_function(compile,expect)
+{
+  const compiled = await compile(`named_function = function foo() {}`);
+  expect(compiled).toEqual([
+    {
+      _name: "named_function",
+      _inputs: [],
+      _definition: "function _named_function() {return (function foo() {});}"
+    }
+  ]);
+  return "ok";
+};
+const _z3bqb8 = async function _test_compile_this_reference(compile,expect)
+{
+  const compiled = await compile(`thisReference = (this || 0) + 1`);
+  expect(compiled).toEqual([
+    {
+      _name: "thisReference",
+      _inputs: [],
+      _definition: "function _thisReference() {return ((this || 0) + 1);}"
+    }
+  ]);
+  return "ok";
+};
+const _1lyze5m = async function _test_compile_lambda(compile,expect)
+{
+  const compiled = await compile(`lambda = () => {}`);
+  expect(compiled).toEqual([
+    {
+      _name: "lambda",
+      _inputs: [],
+      _definition: "function _lambda() {return (() => {});}"
+    }
+  ]);
+  return "ok";
+};
+const _12k1xub = async function _test_compile_error(compile,expect)
+{
+  const compiled = await compile(`error = {
+  throw new Error();
+}`);
+  expect(compiled).toEqual([
+    {
+      _name: "error",
+      _inputs: [],
+      _definition: "function _error() {\n  throw new Error();\n}"
+    }
+  ]);
+  return "ok";
+};
+const _y271kb = async function _test_compile_viewof(compile,expect)
+{
+    const compiled = await compile(`viewof view = Inputs.input()`);
+    expect(compiled).toEqual([
+        {
+            _name: 'viewof view',
+            _inputs: ['Inputs'],
+            _definition: 'function _view(Inputs) {return (Inputs.input());}'
+        },
+        {
+            _name: 'view',
+            _inputs: [
+                'Generators',
+                'viewof view'
+            ],
+            _definition: '(G, _) => G.input(_)'
+        }
+    ]);
+    return 'ok';
+};
+const _1q4asyp = function _test_compile_viewof_and_value_coexist(compile,expect)
+{
+  const compiled = compile(`({
+    treeView: viewof growParameters,
+    tree: growParameters
+})`);
+  expect(compiled).toEqual([
+    {
+      _name: null,
+      _inputs: ["viewof growParameters", "growParameters"],
+      _definition:
+        "function _anonymous($0,growParameters) {return ({\n    treeView: $0,\n    tree: growParameters\n});}"
+    }
+  ]);
+  return "ok";
+};
+const _189jvkd = async function _test_compile_mutable(compile,expect)
+{
+    const compiled = await compile(`mutable q = 6`);
+    expect(compiled).toEqual([
+        {
+            _name: 'initial q',
+            _inputs: [],
+            _definition: 'function _q() {return (6);}'
+        },
+        {
+            _name: 'mutable q',
+            _inputs: [
+                'Mutable',
+                'initial q'
+            ],
+            _definition: '(M, _) => new M(_)'
+        },
+        {
+            _name: 'q',
+            _inputs: ['mutable q'],
+            _definition: '_ => _.generator'
+        }
+    ]);
+    return 'ok';
+};
+const _78egw8 = async function _test_compile_builtin(compile,expect)
+{
+  const compiled = await compile(`inbuilt = _`);
+  expect(compiled).toEqual([
+    {
+      _name: "inbuilt",
+      _inputs: ["_"],
+      _definition: "function _inbuilt(_) {return (_);}"
+    }
+  ]);
+  return "ok";
+};
+const _1o65727 = async function _test_compile_fileattachment(compile,expect)
+{
+  const compiled = await compile(`file = FileAttachment("empty")`);
+  expect(compiled).toEqual([
+    {
+      _name: "file",
+      _inputs: ["FileAttachment"],
+      _definition:
+        `function _file(FileAttachment) {return (FileAttachment("empty"));}`
+    }
+  ]);
+  return "ok";
+};
+const _14c9yxp = async function _test_compile_mutable_dep(compile,expect)
+{
+  const compiled = await compile(`mutable_dep = {
+  viewof view;
+  lambda;
+  mutable q;
+  return mutable q;
+}`);
+  expect(compiled).toEqual([
+    {
+      _name: "mutable_dep",
+      _inputs: ["viewof view", "lambda", "mutable q"],
+      _definition:
+        "function _mutable_dep($0,lambda,$1) {\n  $0;\n  lambda;\n  $1.value;\n  return $1.value;\n}"
+    }
+  ]);
+  return "ok";
+};
+const _133w84q = async function _test_compile_mutable_dep2(compile,expect)
+{
+  const compiled = await compile(`mutable_dep_2 = {
+  file;
+  return q + 1;
+}`);
+  expect(compiled).toEqual([
+    {
+      _name: "mutable_dep_2",
+      _inputs: ["file", "q"],
+      _definition:
+        "function _mutable_dep_2(file,q) {\n  file;\n  return q + 1;\n}"
+    }
+  ]);
+  return "ok";
+};
+const _ql80wk = async function _test_compile_inline_viewof(compile,expect)
+{
+  const compiled = await compile(`viewofdep_inline = viewof view`);
+  expect(compiled).toEqual([
+    {
+      _name: "viewofdep_inline",
+      _inputs: ["viewof view"],
+      _definition: "function _viewofdep_inline($0) {return ($0);}"
+    }
+  ]);
+  return "ok";
+};
+const _1k420gu = async function _test_compile_view_dep(compile,expect)
+{
+  const compiled = await compile(`viewofdatadep = view`);
+  expect(compiled).toEqual([
+    {
+      _name: "viewofdatadep",
+      _inputs: ["view"],
+      _definition: "function _viewofdatadep(view) {return (view);}"
+    }
+  ]);
+  return "ok";
+};
+const _1y1h47u = async function _test_compile_dep(compile,expect)
+{
+  const compiled = await compile(`dep`);
+  expect(compiled).toEqual([
+    {
+      _name: null,
+      _inputs: ["dep"],
+      _definition: "function _anonymous(dep) {return (dep);}"
+    }
+  ]);
+  return "ok";
+};
+const _1r711sh = async function _test_compile_class(compile,expect)
+{
+  const compiled = await compile(`v = class {}`);
+  expect(compiled).toEqual([
+    {
+      _name: "v",
+      _inputs: [],
+      _definition: `function _v() {return (class {});}`
+    }
+  ]);
+  return "ok";
+};
+const _33oop5 = async function _test_compile_event(compile,expect)
+{
+  const compiled = await compile(`event = new Event('input')`);
+  expect(compiled).toEqual([
+    {
+      _name: "event",
+      _inputs: ["Event"],
+      _definition: `function _event(Event) {return (new Event('input'));}`
+    }
+  ]);
+  return "ok";
+};
+const _9phvzk = async function _test_compile_tagged_literal(compile,expect)
+{
+  const compiled = await compile(`htl.html\`hi\``);
+  expect(compiled).toEqual([
+    {
+      _name: null,
+      _inputs: ["htl"],
+      _definition: `function _anonymous(htl) {return (htl.html\`hi\`);}`
+    }
+  ]);
+  return "ok";
+};
+const _1q0pie3 = function _compile_unit_test_template(Inputs,test_case,compiled){return(
+Inputs.textarea({
+  value: `test_compile_ = {
+  const compiled = await compile(\`${test_case.value}\`);
+  expect(compiled).toEqual(${JSON.stringify(compiled, null, 2)});
+  return "ok";
+}`,
+  disabled: true,
+  rows: 20,
+  label: "compile test template"
+})
+)};
+const _1vg114c = async function _test_compile_import_plain_single(compile,expect)
+{
+  const compiled = await compile(
+    `import {dep} from "@tomlarkworthy/dependancy";`
+  );
+  expect(compiled).toEqual([
+    {
+      _name: "module @tomlarkworthy/dependancy",
+      _inputs: [],
+      _definition: `async () => runtime.module((await import("/@tomlarkworthy/dependancy.js?v=4")).default)`
+    },
+    {
+      _name: "dep",
+      _inputs: ["module @tomlarkworthy/dependancy", "@variable"],
+      _definition: `(_, v) => v.import("dep", _)`
+    }
+  ]);
+  return "ok";
+};
+const _18h6y38 = async function _test_compile_import_view_data_alias_single(compile,expect)
+{
+  const compiled = await compile(
+    `import {viewdep as aslias_viewdep_data} from "@tomlarkworthy/dependancy";`
+  );
+  expect(compiled).toEqual([
+    {
+      _name: "module @tomlarkworthy/dependancy",
+      _inputs: [],
+      _definition: `async () => runtime.module((await import("/@tomlarkworthy/dependancy.js?v=4")).default)`
+    },
+    {
+      _name: "aslias_viewdep_data",
+      _inputs: ["module @tomlarkworthy/dependancy", "@variable"],
+      _definition: `(_, v) => v.import("viewdep", "aslias_viewdep_data", _)`
+    }
+  ]);
+  return "ok";
+};
+const _1svcdun = async function _test_compile_import_mutable_data_alias_single(compile,expect)
+{
+  const compiled = await compile(
+    `import {mutabledep as aslias_mutabledep_data} from "@tomlarkworthy/dependancy";`
+  );
+  expect(compiled).toEqual([
+    {
+      _name: "module @tomlarkworthy/dependancy",
+      _inputs: [],
+      _definition: `async () => runtime.module((await import("/@tomlarkworthy/dependancy.js?v=4")).default)`
+    },
+    {
+      _name: "aslias_mutabledep_data",
+      _inputs: ["module @tomlarkworthy/dependancy", "@variable"],
+      _definition: `(_, v) => v.import("mutabledep", "aslias_mutabledep_data", _)`
+    }
+  ]);
+  return "ok";
+};
+const _tb4ops = async function _test_compile_import_mutable_single(compile,expect)
+{
+  const compiled = await compile(
+    `import {mutable mutabledep} from "@tomlarkworthy/dependancy";`
+  );
+  expect(compiled).toEqual([
+    {
+      _name: "module @tomlarkworthy/dependancy",
+      _inputs: [],
+      _definition: `async () => runtime.module((await import("/@tomlarkworthy/dependancy.js?v=4")).default)`
+    },
+    {
+      _name: "mutable mutabledep",
+      _inputs: ["module @tomlarkworthy/dependancy", "@variable"],
+      _definition: `(_, v) => v.import("mutable mutabledep", _)`
+    }
+  ]);
+  return "ok";
+};
+const _vuzib9 = async function _test_compile_import_viewof_single(compile,expect)
+{
+  const compiled = await compile(
+    `import {viewof viewdep} from "@tomlarkworthy/dependancy";`
+  );
+  expect(compiled).toEqual([
+    {
+      _name: "module @tomlarkworthy/dependancy",
+      _inputs: [],
+      _definition: `async () => runtime.module((await import("/@tomlarkworthy/dependancy.js?v=4")).default)`
+    },
+    {
+      _name: "viewof viewdep",
+      _inputs: ["module @tomlarkworthy/dependancy", "@variable"],
+      _definition: `(_, v) => v.import("viewof viewdep", _)`
+    }
+  ]);
+  return "ok";
+};
+const _6ewshd = async function _test_compile_import_alias_single(compile,expect)
+{
+  const compiled = await compile(
+    `import {dep as dep_alias} from "@tomlarkworthy/dependancy";`
+  );
+  expect(compiled).toEqual([
+    {
+      _name: "module @tomlarkworthy/dependancy",
+      _inputs: [],
+      _definition: `async () => runtime.module((await import("/@tomlarkworthy/dependancy.js?v=4")).default)`
+    },
+    {
+      _name: "dep_alias",
+      _inputs: ["module @tomlarkworthy/dependancy", "@variable"],
+      _definition: `(_, v) => v.import("dep", "dep_alias", _)`
+    }
+  ]);
+  return "ok";
+};
+const _36migr = async function _test_compile_import_notebook(compile,expect)
+{
+  const compiled = await compile(
+    `import {escodegen} from "@tomlarkworthy/escodegen"`
+  );
+  expect(compiled).toEqual([
+    {
+      _name: `module @tomlarkworthy/escodegen`,
+      _inputs: [],
+      _definition:
+        'async () => runtime.module((await import("/@tomlarkworthy/escodegen.js?v=4")).default)'
+    },
+    {
+      _name: `escodegen`,
+      _inputs: ["module @tomlarkworthy/escodegen", "@variable"],
+      _definition: '(_, v) => v.import("escodegen", _)'
+    }
+  ]);
+  return "ok";
+};
+const _1nps9cr = function _test_case(Inputs,notebook_semantics_source){return(
+Inputs.select(
+  notebook_semantics_source.filter((s) => s.mode == "js"),
+  {
+    label: "compilation test case",
+    format: (v) => v.value
+  }
+)
+)};
+const _1e5ax6f = (G, _) => G.input(_);
+const _7eic89 = function _146(test_case){return(
+test_case.value
+)};
+const _16q6oyc = async function _compiled(compile,test_case){return(
+await compile(test_case.value)
+)};
+const _61dayu = function _148(parser,test_case)
+{
+  const comments = [];
+  const tokens = [];
+  const ast = parser.parseCell(test_case.value, {
+    ranges: true,
+    onComment: comments,
+    onToken: tokens
+  });
+
+  return {
+    ast,
+    comments,
+    tokens
+  };
+};
+const _cevs6r = function _149(compile,test_case){return(
+compile(test_case.value)
+)};
+const _mliwy8 = function _compile(parser,observableToJs){return(
+function compile(source, {
+  anonymousName = '_anonymous'
+} = {}) {
+  const comments = [], tokens = [];
+  let cell;
+  try {
+    cell = parser.parseCell(source, {
+      ranges: true,
+      onComment: comments,
+      onToken: tokens
+    });
+  } catch (e) {
+    if (e instanceof SyntaxError) {
+      const nameMatch = source.match(/^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/);
+      let _name = null;
+      let funcName = anonymousName;
+      if (nameMatch) {
+        const prefix = nameMatch[1] ? nameMatch[1] + ' ' : '';
+        _name = prefix + nameMatch[2];
+        funcName = '_' + nameMatch[2];
+      }
+      const escapedMsg = JSON.stringify(e.message);
+      const escapedSource = JSON.stringify(source);
+      return [{
+          _name,
+          _inputs: [],
+          _definition: `function ${ funcName }() { throw Object.assign(new SyntaxError(${ escapedMsg }), {_sourceExpression: ${ escapedSource }}); }`
+        }];
+    }
+    throw e;
+  }
+  if (!cell)
+    throw new Error('Unable to parse cell');
+  const parseImportSpecifierText = text => {
+    const t = String(text ?? '').trim().replace(/,$/, '').trim();
+    if (!t)
+      throw new Error('Empty import specifier');
+    const parts = t.split(/\s+as\s+/);
+    const left = parts[0].trim();
+    const right = parts[1]?.trim();
+    const parseSide = (side, {
+      defaultPrefix = ''
+    } = {}) => {
+      const s = String(side ?? '').trim();
+      const m = s.match(/^(viewof|mutable)\s+(.+)$/);
+      if (m)
+        return {
+          prefix: `${ m[1] } `,
+          name: m[2].trim()
+        };
+      return {
+        prefix: defaultPrefix,
+        name: s
+      };
+    };
+    const L = parseSide(left);
+    const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
+    const importedName = `${ L.prefix }${ L.name }`.trim();
+    const localName = `${ R.prefix }${ R.name }`.trim();
+    if (!importedName)
+      throw new Error(`Could not parse imported name from: ${ t }`);
+    if (!localName)
+      throw new Error(`Could not parse local name from: ${ t }`);
+    return {
+      importedName,
+      localName
+    };
+  };
+  if (!cell.id && cell.body?.type === 'ImportDeclaration') {
+    const module_name = cell.body.source.value;
+    const cell_variables = [{
+        _name: `module ${ module_name }`,
+        _inputs: [],
+        _definition: `async () => runtime.module((await import("/${ module_name }.js?v=4")).default)`
+      }];
+    for (const specifier of cell.body.specifiers ?? []) {
+      const specText = typeof specifier?.start === 'number' && typeof specifier?.end === 'number' ? source.slice(specifier.start, specifier.end) : (() => {
+        if (specifier?.imported?.name && specifier?.local?.name) {
+          return specifier.imported.name === specifier.local.name ? specifier.local.name : `${ specifier.imported.name } as ${ specifier.local.name }`;
+        }
+        throw new Error('Import specifier missing range information');
+      })();
+      const {importedName, localName} = parseImportSpecifierText(specText);
+      cell_variables.push({
+        _name: localName,
+        _inputs: [
+          `module ${ module_name }`,
+          '@variable'
+        ],
+        _definition: importedName === localName ? `(_, v) => v.import("${ importedName }", _)` : `(_, v) => v.import("${ importedName }", "${ localName }", _)`
+      });
+    }
+    return cell_variables;
+  }
+  let dollarIdx = 0;
+  const inputToArgMap = {};
+  const dollarToMacro = {};
+  const seen = new Set();
+  const inputs = Array.from(cell.references || []).flatMap(i => {
+    if (i.name) {
+      if (seen.has(i.name))
+        return [];
+      seen.add(i.name);
+      return i.name;
+    } else {
+      const dedupKey = i.type + ':' + i.id.name;
+      if (seen.has(dedupKey))
+        return [];
+      seen.add(dedupKey);
+      const dollarName = '$' + dollarIdx;
+      inputToArgMap[i.id.name] = dollarName;
+      dollarToMacro[dollarName] = i.type == 'ViewExpression' ? 'viewof ' + i.id.name : 'mutable ' + i.id.name;
+      dollarIdx++;
+      return dollarName;
+    }
+  });
+  let variables;
+  if (cell.id) {
+    if (cell.id.type === 'Identifier') {
+      variables = [{
+          functionName: '_' + cell.id.name,
+          name: cell.id.name,
+          inputs,
+          params: inputs.join(',')
+        }];
+    } else if (cell.id.type === 'ViewExpression') {
+      variables = [
+        {
+          functionName: '_' + cell.id.id.name,
+          name: 'viewof ' + cell.id.id.name,
+          inputs,
+          params: inputs.join(',')
+        },
+        {
+          functionName: '_' + cell.id.id.name,
+          name: cell.id.id.name,
+          _definition: '(G, _) => G.input(_)',
+          inputs: [
+            'Generators',
+            'viewof ' + cell.id.id.name
+          ],
+          params: inputs.join(',')
+        }
+      ];
+    } else if (cell.id.type === 'MutableExpression') {
+      variables = [
+        {
+          functionName: '_' + cell.id.id.name,
+          name: 'initial ' + cell.id.id.name,
+          inputs,
+          params: inputs.join(',')
+        },
+        {
+          functionName: '_' + cell.id.id.name,
+          name: 'mutable ' + cell.id.id.name,
+          _definition: '(M, _) => new M(_)',
+          inputs: [
+            'Mutable',
+            'initial ' + cell.id.id.name
+          ],
+          params: inputs.join(',')
+        },
+        {
+          functionName: '_' + cell.id.id.name,
+          name: cell.id.id.name,
+          _definition: '_ => _.generator',
+          inputs: ['mutable ' + cell.id.id.name],
+          params: inputs.join(',')
+        }
+      ];
+    } else {
+      throw new Error(`Unsupported cell id type: ${ cell.id.type }`);
+    }
+  } else {
+    variables = [{
+        functionName: anonymousName,
+        name: null,
+        inputs,
+        params: inputs.join(',')
+      }];
+  }
+  return variables.map(v => {
+    let _definition = v._definition;
+    if (!_definition) {
+      let functionBody;
+      if (cell.body.type === 'BlockStatement') {
+        functionBody = observableToJs(cell.body, inputToArgMap, source);
+      } else {
+        const bodyCode = observableToJs(cell.body, inputToArgMap, source);
+        functionBody = `{return (${ bodyCode });}`;
+      }
+      _definition = `${ cell.async ? 'async ' : '' }function${ cell.generator ? '*' : '' } ${ v.functionName }(${ v.inputs.join(',') }) ${ functionBody }`;
+    }
+    return {
+      _name: v.name,
+      _inputs: v.inputs.map(i => dollarToMacro[i] || (i === '$variable' ? '@variable' : i)),
+      _definition
+    };
+  });
+}
+)};
+const _16p8atj = function _observableToJs(acorn_walk,parser){return(
+(ast, inputMap, source) => {
+  // Source-preserving: slice the original body text verbatim and splice only the
+  // Observable-specific macro ranges (`viewof foo` → $N, `mutable foo` →
+  // $N.value). Regenerating via escodegen used to drop the ASI-protecting paren
+  // in `return( … )`, normalize quotes, respace `${ x }`, and reindent — all
+  // avoided by never regenerating. Ranges are offsets into `source`.
+  const edits = [];
+  acorn_walk.ancestor(
+    ast,
+    {
+      ViewExpression(node) {
+        edits.push({ start: node.start, end: node.end, text: inputMap[node.id.name] });
+      },
+      MutableExpression(node) {
+        // ".value" is not a valid identifier but is valid member access here.
+        edits.push({ start: node.start, end: node.end, text: inputMap[node.id.name] + ".value" });
+      }
+    },
+    parser.walk
+  );
+  const base = ast.start;
+  let out = source.slice(ast.start, ast.end);
+  edits
+    .sort((a, b) => b.start - a.start)
+    .forEach((e) => {
+      out = out.slice(0, e.start - base) + e.text + out.slice(e.end - base);
+    });
+  return out;
+}
+)};
+const _1hd7px0 = function _152(md){return(
+md`### Bundled deps`
+)};
+const _xhj6b8 = function _decompress_url(DecompressionStream,TextDecoderStream,TransformStream,TextEncoderStream,Response){return(
+async (attachment, overrides) => {
+  let decompressedStream;
+
+  if (!overrides) {
+    decompressedStream = (await attachment.stream()).pipeThrough(
+      new DecompressionStream("gzip")
+    );
+  } else {
+    decompressedStream = (await attachment.stream())
+      .pipeThrough(new DecompressionStream("gzip"))
+      .pipeThrough(new TextDecoderStream())
+      .pipeThrough(
+        new TransformStream({
+          transform(chunk, controller) {
+            // Rewrite URLs in the text
+            let modifiedChunk = chunk;
+            Object.entries(overrides).forEach(([override, replacement]) => {
+              modifiedChunk = modifiedChunk.replace(override, replacement);
+            });
+            controller.enqueue(modifiedChunk);
+          }
+        })
+      )
+      .pipeThrough(new TextEncoderStream());
+  }
+  const arrayBuffer = await new Response(decompressedStream).arrayBuffer();
+
+  // Create a Blob from the ArrayBuffer
+  const blob = new Blob([arrayBuffer], { type: "application/javascript" });
+
+  return URL.createObjectURL(blob);
+}
+)};
+const _s9w7ha = async function _parser(decompress_url, FileAttachment, acorn_url, acorn_walk_url) {
+    return import(await decompress_url(FileAttachment('parser-6.1.0.js.gz'), {
+        '/npm/acorn@8.11.3/+esm': acorn_url,
+        '/npm/acorn-walk@8.3.2/+esm': acorn_walk_url
+    }));
+};
+const _j9n5de = function _stageB_importFake()
+{
+  // Builds a Stage B (pre-observation, API-loaded) import group as POJOs.
+  // Mirrors what `runtime.define("name", ["module @X", "@variable"], (_, v) => v.import("name", _))`
+  // produces structurally. Used by the test_decompileImport_stageB_* tests to
+  // avoid spinning up a real Observable runtime per case.
+  return function stageB_importFake(module_name, specifiers) {
+    const importerModule = { _scope: new Map() };
+    const stitch = {
+      _name: `module ${ module_name }`,
+      _module: importerModule,
+      _inputs: [],
+      _definition: `async () => null`
+    };
+    const atVariable = {
+      _name: '@variable',
+      _module: importerModule
+    };
+    const aliases = specifiers.map(s => ({
+      _name: s.local,
+      _module: importerModule,
+      _inputs: [
+        stitch,
+        atVariable
+      ],
+      _definition: s.imported === s.local ? `(_, v) => v.import("${ s.imported }", _)` : `(_, v) => v.import("${ s.imported }", "${ s.local }", _)`
+    }));
+    return [
+      stitch,
+      ...aliases
+    ];
+  };
+};
+const _1d53asg = async function _test_decompileImport_stageB_single(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [{
+      imported: 'visualize',
+      local: 'visualize'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _hv5gag = async function _test_decompileImport_stageB_aliased(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'x',
+      local: 'z'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(info.specifiers[0].alias).toEqual(true);
+  expect(formatImportDeclaration(info)).toEqual(`import {x as z} from "@user/y"`);
+  return 'ok';
+};
+const _avc18y = async function _test_decompileImport_stageB_multiple(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    },
+    {
+      imported: 'c',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b, c} from "@user/y"`);
+  return 'ok';
+};
+const _16gia7i = async function _test_decompileImport_stageB_mixed_alias(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'c'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b as c} from "@user/y"`);
+  return 'ok';
+};
+const _1slhdwo = async function _test_decompileImport_stageB_viewof(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@tomlarkworthy/module-map', [{
+      imported: 'viewof currentModules',
+      local: 'viewof currentModules'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {viewof currentModules} from "@tomlarkworthy/module-map"`);
+  return 'ok';
+};
+const _qwlsf2 = async function _test_decompileImport_stageB_mutable(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  const vars = stageB_importFake('@user/y', [{
+      imported: 'mutable counter',
+      local: 'mutable counter'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {mutable counter} from "@user/y"`);
+  return 'ok';
+};
+const _sy7jfx = async function _test_decompileImport_returns_null_for_non_import(decompileImport,expect)
+{
+  // A regular cell — no stitch, no @variable input, no cross-module reference.
+  const info = await decompileImport([{
+      _name: 'x',
+      _module: {},
+      _inputs: [],
+      _definition: `() => 42`
+    }]);
+  expect(info).toEqual(null);
+  return 'ok';
+};
+const _rk7ku3 = async function _test_decompileImport_compile_roundtrip_single(compile,expect,stageB_importFake,decompileImport,formatImportDeclaration)
+{
+  // What `compile()` emits for `import {x} from "@user/y"` is structurally the
+  // same as our stageB_importFake fixture (after runtime.define resolves the
+  // input name strings to Variable refs). Verify the fixture matches the
+  // shape compile() would produce.
+  const pojos = compile(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  expect(pojos.length).toEqual(3);
+  expect(pojos[0]._name).toEqual('module @tomlarkworthy/visualizer');
+  expect(pojos[1]._name).toEqual('visualize');
+  expect(pojos[2]._name).toEqual('Group');
+  expect(pojos[1]._inputs).toEqual([
+    'module @tomlarkworthy/visualizer',
+    '@variable'
+  ]);
+  // Now run our fixture through decompileImport — confirms the round-trip
+  // shape compile()-output-shape-when-defined → decompileImport produces the
+  // canonical import source string.
+  const vars = stageB_importFake('@tomlarkworthy/visualizer', [
+    {
+      imported: 'visualize',
+      local: 'visualize'
+    },
+    {
+      imported: 'Group',
+      local: 'Group'
+    }
+  ]);
+  const info = await decompileImport(vars);
+  expect(formatImportDeclaration(info)).toEqual(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
+  return 'ok';
+};
+const _1numivw = async function _test_decompileImport_stageB_order_independent(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // The detection uses .find — it shouldn't matter whether the stitch is at
+  // index 0 or the aliases come first. Verify by moving it to the end.
+  const vars = stageB_importFake('@user/y', [
+    {
+      imported: 'a',
+      local: 'a'
+    },
+    {
+      imported: 'b',
+      local: 'b'
+    }
+  ]);
+  const [stitch, ...aliases] = vars;
+  const info = await decompileImport([
+    ...aliases,
+    stitch
+  ]);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {a, b} from "@user/y"`);
+  return 'ok';
+};
+const _16fpgac = async function _test_decompileImport_stageB_notebook_id(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+{
+  // Observable supports `import {x} from "d/<hash>@<version>"` notebook-id form.
+  const vars = stageB_importFake('d/57d79353bac56631@44', [{
+      imported: 'hash',
+      local: 'hash'
+    }]);
+  const info = await decompileImport(vars);
+  expect(info.meta.detection.stage).toEqual('B');
+  expect(formatImportDeclaration(info)).toEqual(`import {hash} from "d/57d79353bac56631@44"`);
+  return 'ok';
+};
+const _r2e0wl = function _test_extractModuleInfo_new_id_resolutions(expect,extractModuleInfo)
+{
+  // new.observablehq.com d/<id>@<ver> import with resolutions=.
+  expect(
+    extractModuleInfo(
+      'async () => runtime.module((await import("/d/e1c39d41e8e944b0@939.js?v=4&resolutions=a6a56ee61aba9799@437")).default)'
+    )
+  ).toEqual({ id: "e1c39d41e8e944b0", version: "939" });
+  return "ok";
+};
+const _1pg1y6s = function _test_extractModuleInfo_new_slug_resolutions(expect,extractModuleInfo)
+{
+  // new.observablehq.com slug import carries a resolutions= param.
+  expect(
+    extractModuleInfo(
+      'async () => runtime.module((await import("/@mootari/access-runtime.js?v=4&resolutions=98f34e974bb2e4bc@1392")).default)'
+    )
+  ).toEqual({ namespace: "mootari", notebook: "access-runtime", version: "1392" });
+  return "ok";
+};
+const _1vh26m0 = function _test_findModuleName_classic_bundle(expect,findModuleName)
+{
+  // classic observablehq.com bundles imports; the holder def is a bare slug import.
+  const m = {}; // module sentinel
+  const scope = new Map([
+    ["module 1", { _name: "module 1", _value: m,
+      _definition: 'async () => runtime.module((await import("@tomlarkworthy/flow-queue")).default)' }]
+  ]);
+  expect(findModuleName(scope, m)).toEqual("@tomlarkworthy/flow-queue");
+  return "ok";
+};
+const _1ltqcwj = function _test_findModuleName_kit_slug(expect,findModuleName)
+{
+  // Notebook Kit compiles observable imports to import("https://api.observablehq.com/@u/nb.js?v=4").
+  const m = {}; // module sentinel
+  const scope = new Map([
+    ["module 1", { _name: "module 1", _value: m,
+      _definition: 'async (__ojs_runtime) => __ojs_runtime.module((await import("https://api.observablehq.com/@d3/color-legend.js?v=4")).default)' }]
+  ]);
+  expect(findModuleName(scope, m)).toEqual("@d3/color-legend");
+  return "ok";
+};
+const _wq4poo = function _test_findModuleName_new_id(expect,findModuleName)
+{
+  const m = {}; // module sentinel
+  const scope = new Map([
+    ["module 1", { _name: "module 1", _value: m,
+      _definition: 'async () => runtime.module((await import("/d/e1c39d41e8e944b0@939.js?v=4&resolutions=a6a56ee61aba9799@437")).default)' }]
+  ]);
+  expect(findModuleName(scope, m)).toEqual("d/e1c39d41e8e944b0@939");
+  return "ok";
+};
+const _1j0hksu = function _test_findModuleName_new_slug(expect,findModuleName)
+{
+  const m = {}; // module sentinel
+  const scope = new Map([
+    ["module 1", { _name: "module 1", _value: m,
+      _definition: 'async () => runtime.module((await import("/@mootari/access-runtime.js?v=4&resolutions=98f34e974bb2e4bc@1392")).default)' }]
+  ]);
+  expect(findModuleName(scope, m)).toEqual("@mootari/access-runtime");
+  return "ok";
+};
+const _3en7eq = async function _test_decompile_leading_comment(decompile,expect,compile)
+{
+  // Regression: a comment in the compiler's auto-wrap slot (`return( // note\n42 )`)
+  // is preserved in ASI-safe block form — never the hazardous `return` + comment
+  // + newline WITHOUT the paren that evaluated to undefined on ObservableHQ.
+  const src = await decompile([
+    { _name: "c", _definition: `function _c(){return( // note\n42\n)}`, _inputs: [] }
+  ]);
+  expect(src).toEqual(`c = {return( // note\n42\n)}`);
+  // It keeps the ASI-protecting paren and round-trips through compile to 42.
+  const cell = compile(src);
+  const first = Array.isArray(cell) ? cell[0] : cell;
+  const def = first._definition || (first.cells && first.cells[0]._definition);
+  expect(eval(`(${def})`)()).toEqual(42);
+  return "ok";
+};
+const _z17nwa = async function _test_decompile_trailing_comment(decompile,expect)
+{
+  // Regression: a comment that survives compile inside the block (trailing on the
+  // return line, or before the closing brace) must survive decompile too — don't
+  // unwrap a single-return block when a comment sits outside the returned value.
+  const trailing = await decompile([
+    { _name: "x", _definition: `function _x(){\n  return 1; // done\n}`, _inputs: [] }
+  ]);
+  expect(trailing).toEqual(`x = {\n  return 1; // done\n}`);
+  const tail = await decompile([
+    { _name: "y", _definition: `function _y(){\n  return 1;\n  // tail\n}`, _inputs: [] }
+  ]);
+  expect(tail).toEqual(`y = {\n  return 1;\n  // tail\n}`);
+  return "ok";
+};
+const _q5y9bo = async function _test_decompile_param_in_string(decompile,expect)
+{
+  // Regression: renaming an underscore-encoded viewof/mutable param must rewrite
+  // only identifier references, never same-spelled text inside a string literal
+  // (range-based splice, not the old source.replaceAll).
+  const decompiled = await decompile([
+    {
+      _name: "u",
+      _definition: `function _u(viewof_x){return(\n"viewof_x literal" + viewof_x\n)}`,
+      _inputs: ["viewof x"]
+    }
+  ]);
+  expect(decompiled).toEqual(`u = "viewof_x literal" + viewof x`);
+  return "ok";
+};
+const _fm2sgc = async function _test_decompile_class_property_field(decompile,expect)
+{
+  // Regression: a class field declaration must decompile cleanly. Source-slicing
+  // sidesteps the escodegen shim gap that threw "this[d] is not a function".
+  const decompiled = await decompile([
+    {
+      _name: "Cls",
+      _definition: `function _Cls(){return(\nclass Cls {\n  d;\n}\n)}`,
+      _inputs: []
+    }
+  ]);
+  expect(decompiled).toEqual(`Cls = class Cls {\n  d;\n}`);
+  return "ok";
+};
+const _1xp8nli = async function _test_compile_preserves_formatting(compile,expect)
+{
+  // Source-preserving compile keeps quote style and template spacing verbatim;
+  // escodegen used to re-quote ("h1" -> 'h1') and respace (${s} -> ${ s }).
+  const compiled = await compile('x = { const s = "h1"; return `${s}`; }');
+  expect(compiled[0]._definition).toEqual('function _x() { const s = "h1"; return `${s}`; }');
+  return "ok";
+};
+
+export default function define(runtime, observer) {
+  const main = runtime.module();
+  const $def = (pid, name, deps, fn) => {
+    main.variable(observer(name)).define(name, deps, fn).pid = pid;
+  };
+  const fileAttachments = new Map(["parser-6.1.0.js.gz"].map((name) => {
+    const module_name = "@tomlarkworthy/observablejs-toolchain";
+    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
+    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
+    return [name, {url: blob_url, mimeType: mime}]
+  }));
+  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
+  main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
+  main.define("module @tomlarkworthy/acorn-8-11-3", async () => runtime.module((await import("/@tomlarkworthy/acorn-8-11-3.js?v=4")).default));  
+  main.define("module @tomlarkworthy/jest-expect-standalone", async () => runtime.module((await import("/@tomlarkworthy/jest-expect-standalone.js?v=4")).default));  
+  main.define("module @tomlarkworthy/observable-runtime", async () => runtime.module((await import("/@tomlarkworthy/observable-runtime.js?v=4")).default));  
+  $def("_lp77pf", null, ["md"], _lp77pf);  
+  $def("_n0sc6u", null, ["md"], _n0sc6u);  
+  $def("_sgo04r", null, ["md"], _sgo04r);  
+  $def("_aivd6y", null, ["md"], _aivd6y);  
+  $def("_1q8w8vr", null, ["md"], _1q8w8vr);  
+  $def("_d17a1w", null, ["md"], _d17a1w);  
+  $def("_1juriue", null, ["md"], _1juriue);  
+  main.define("tests", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("tests", _));  
+  main.define("viewof runtime_variables", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("viewof runtime_variables", _));  
+  main.define("runtime_variables", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("runtime_variables", _));  
+  main.define("modules", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("modules", _));  
+  $def("_1k5oyj7", null, ["tests"], _1k5oyj7);  
+  $def("_1jrpa13", null, ["md"], _1jrpa13);  
+  $def("_1lc80et", "cellMaps", ["cellMap"], _1lc80et);  
+  $def("_zki07o", "allCells", ["cellMaps"], _zki07o);  
+  $def("_1nkhnnd", "all_decompiled", ["allCells","decompile"], _1nkhnnd);  
+  $def("_1ip1war", "test_all_cells_decompilable", ["all_decompiled"], _1ip1war);  
+  $def("_1w70b75", null, ["md"], _1w70b75);  
+  $def("_uscpdn", "all_compiled", ["all_decompiled","compile"], _uscpdn);  
+  $def("_x55zzr", "test_decompiled_cells_recompilable", ["all_compiled"], _x55zzr);  
+  $def("_100n7xr", null, ["md"], _100n7xr);  
+  $def("_1nm57o2", "roundtripped", ["all_compiled","decompile"], _1nm57o2);  
+  $def("_1shi9or", "test_all_cells_roundtrippable", ["roundtripped"], _1shi9or);  
+  $def("_14nox99", null, ["md"], _14nox99);  
+  $def("_1d3zr3i", null, ["md"], _1d3zr3i);  
+  $def("_12sqt9", "dependancy_document", [], _12sqt9);  
+  $def("_13q8314", "dependancy_source", ["dependancy_document"], _13q8314);  
+  $def("_ook1nq", null, ["md"], _ook1nq);  
+  $def("_jmn84r", "notebook_semantics_document", [], _jmn84r);  
+  $def("_1juj7i6", "notebook_semantics_source", ["notebook_semantics_document","parser"], _1juj7i6);  
+  $def("_1oevsow", null, ["md"], _1oevsow);  
+  $def("_11lfflk", "notebook_semantics_module", [], _11lfflk);  
+  main.define("cellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("cellMap", _));  
+  main.define("moduleMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("moduleMap", _));  
+  $def("_gjten6", null, ["md"], _gjten6);  
+  $def("_n9rco8", null, ["md"], _n9rco8);  
+  $def("_eog966", null, ["md"], _eog966);  
+  $def("_n4ntwp", null, ["md"], _n4ntwp);  
+  $def("_1lg9nnl", "importFake", ["Runtime"], _1lg9nnl);  
+  $def("_25tjxa", "test_decompile_syntax_error_roundtrip", ["compile","decompile","expect"], _25tjxa);  
+  $def("_1jyrnzq", "test_decompile_$variable", ["decompile","expect"], _1jyrnzq);  
+  $def("_1v1d8m3", "test_decompile_import_variable", ["decompile","importFake","expect"], _1v1d8m3);  
+  $def("_1ybjsqg", "test_decompile_dollar_in_string_literal", ["decompile","expect"], _1ybjsqg);  
+  $def("_wgfrtq", "test_decompile_import_variable_alias", ["decompile","importFake","expect"], _wgfrtq);  
+  $def("_1a8gnrc", "test_decompile_import_many", ["decompile","importFake","expect"], _1a8gnrc);  
+  $def("_7stpu3", "test_decompile_markdown_cell", ["decompile","expect"], _7stpu3);  
+  $def("_v4p1js", "test_decompile_constant", ["decompile","expect"], _v4p1js);  
+  $def("_1puzspw", "test_decompile_string_literal", ["decompile","expect"], _1puzspw);  
+  $def("_a2zh99", "test_decompile_html_cell", ["decompile","expect"], _a2zh99);  
+  $def("_1pt67ao", "test_decompile_class", ["decompile","expect"], _1pt67ao);  
+  $def("_kf8c3f", "test_decompile_class_with_property", ["decompile"], _kf8c3f);  
+  $def("_4vunhm", "test_decompile_object_literal", ["decompile","expect"], _4vunhm);  
+  $def("_s14e29", "test_decompile_reference", ["decompile","expect"], _s14e29);  
+  $def("_14nvmno", "test_decompile_block", ["decompile","expect"], _14nvmno);  
+  $def("_5kd9if", "test_decompile_comments", ["decompile","expect"], _5kd9if);  
+  $def("_1yn35e3", "test_decompile_generator", ["decompile","expect"], _1yn35e3);  
+  $def("_10wf7cf", "test_decompile_function", ["decompile","expect"], _10wf7cf);  
+  $def("_1191zxm", "test_decompile_async_function", ["decompile","expect"], _1191zxm);  
+  $def("_vpu09i", "test_decompile_named_function", ["decompile","expect"], _vpu09i);  
+  $def("_1pghf4f", "test_decompile_this_reference", ["decompile","expect"], _1pghf4f);  
+  $def("_rajn7p", "test_decompile_lambda", ["decompile","expect"], _rajn7p);  
+  $def("_12ec5zd", "test_decompile_error", ["decompile","expect"], _12ec5zd);  
+  $def("_1c93ef9", "test_decompile_error_object", ["decompile","expect"], _1c93ef9);  
+  $def("_6iufw4", null, ["md"], _6iufw4);  
+  $def("_15idqib", "test_decompile_anon_error_dep", ["decompile","expect"], _15idqib);  
+  $def("_mhm98c", "test_decompile_viewof", ["decompile","expect"], _mhm98c);  
+  $def("_15kgqrr", "test_decompile_mutable", ["decompile","expect"], _15kgqrr);  
+  $def("_1onyv5c", "test_decompile_builtin", ["decompile","expect"], _1onyv5c);  
+  $def("_4z1dnp", "test_decompile_fileattachment", ["decompile","expect"], _4z1dnp);  
+  $def("_g4z6de", "test_decompile_mutable_dependancy", ["decompile","expect"], _g4z6de);  
+  $def("_qo8sdl", "test_decompile_mutable_dependancy_2", ["decompile","expect"], _qo8sdl);  
+  $def("_15kwaz1", "test_decompile_viewof_dep", ["decompile","expect"], _15kwaz1);  
+  $def("_1qjzk2s", "test_decompile_viewof_data_dep", ["decompile","expect"], _1qjzk2s);  
+  $def("_b0y8zg", "test_decompile_viewof_param", ["decompile","expect"], _b0y8zg);  
+  $def("_oilkc0", "test_decompile_anon_dep", ["decompile","expect"], _oilkc0);  
+  $def("_1eqf4jq", "test_decompile_import_mutable", ["decompile","expect"], _1eqf4jq);  
+  $def("_3damo4", "test_decompile_import_viewof", ["decompile","expect"], _3damo4);  
+  $def("_1l9xqsw", "test_decompile_viewof_data", ["decompile","expect"], _1l9xqsw);  
+  $def("_1cggvdk", "test_decompile_import_alias", ["decompile","expect"], _1cggvdk);  
+  $def("_xcwq4", "test_decompile_import_mutable_alias", ["decompile","expect"], _xcwq4);  
+  $def("_1868h0w", "test_decompile_import_mutable_data_alias", ["decompile","expect"], _1868h0w);  
+  $def("_1afcxhk", "test_decompile_import_viewof_alias", ["decompile","expect"], _1afcxhk);  
+  $def("_1sl510", "test_decompile_import_viewof_data_alias", ["decompile","expect"], _1sl510);  
+  $def("_17dwb6r", null, ["md"], _17dwb6r);  
+  $def("_1ngipml", null, ["md"], _1ngipml);  
+  $def("_2d5g1", "decompile", ["decompileImport","formatImportDeclaration","acorn"], _2d5g1);  
+  $def("_1x0pvrl", null, ["md"], _1x0pvrl);  
+  $def("_183j58u", "extractModuleInfo", [], _183j58u);  
+  $def("_w445v0", "test_extractModuleInfo_notebook_resolution", ["expect","extractModuleInfo"], _w445v0);  
+  $def("_uzqj4w", "test_extractModuleInfo_id_version_resolution", ["expect","extractModuleInfo"], _uzqj4w);  
+  $def("_1sruec2", "test_extractModuleInfo_id_version", ["expect","extractModuleInfo"], _1sruec2);  
+  $def("_ipn8zp", "test_extractModuleInfo_test_4", ["expect","extractModuleInfo"], _ipn8zp);  
+  $def("_iigmyv", "test_extractModuleInfo_alias_hack", ["expect","extractModuleInfo"], _iigmyv);  
+  $def("_7t42k8", null, ["md"], _7t42k8);  
+  $def("_kiaw33", "import_ast_example", ["parser"], _kiaw33);  
+  $def("_1n7gw17", "findModuleName", ["extractModuleInfo"], _1n7gw17);  
+  $def("_i47chb", "findImportedName", [], _i47chb);  
+  $def("_ed3cy2", null, ["md"], _ed3cy2);  
+  $def("_1a4j4gm", "decompileImport", ["findModuleName","findImportedName"], _1a4j4gm);  
+  $def("_1sylz7j", "formatImportDeclaration", [], _1sylz7j);  
+  $def("_13dctdn", "test_decompileImport_basic", ["importFake","decompileImport","expect"], _13dctdn);  
+  $def("_ujr0xn", "test_formatImportDeclaration_roundtrip", ["importFake","decompileImport","expect","formatImportDeclaration","decompile"], _ujr0xn);  
+  $def("_1u6sfri", "test_decompileImport_alias", ["importFake","decompileImport","expect","formatImportDeclaration"], _1u6sfri);  
+  $def("_1lti0tv", null, ["md"], _1lti0tv);  
+  $def("_3knb9v", "variableToObject", [], _3knb9v);  
+  $def("_autn1v", null, ["md"], _autn1v);  
+  $def("_7zpsl9", "viewof normalizeObservableSourceSelector", ["Inputs","notebook_semantics_source"], _7zpsl9);  
+  $def("_1ex8kus", "normalizeObservableSourceSelector", ["Generators","viewof normalizeObservableSourceSelector"], _1ex8kus);  
+  $def("_b2d0zc", "parsed", ["parser","normalizeObservableSourceSelector"], _b2d0zc);  
+  $def("_14qm8or", null, ["md"], _14qm8or);  
+  $def("_10ofthe", "test_async_interpolation", ["compile"], _10ofthe);  
+  $def("_1gb7c3c", "test_compile_syntax_error_viewof", ["compile","expect"], _1gb7c3c);  
+  $def("_69vyub", "test_compile_syntax_error_anonymous", ["compile","expect"], _69vyub);  
+  $def("_1c9p3om", "test_compile_syntax_error_named", ["compile","expect"], _1c9p3om);  
+  $def("_x7zc8w", "test_compile_integer", ["compile","expect"], _x7zc8w);  
+  $def("_1qp2ggw", "test_compile_string", ["compile","expect"], _1qp2ggw);  
+  $def("_151bijp", "test_compile_obj_literal", ["compile","expect"], _151bijp);  
+  $def("_17z4vyt", "test_compile_assignment", ["compile","expect"], _17z4vyt);  
+  $def("_1eb8vq", "test_compile_dependancy", ["compile","expect"], _1eb8vq);  
+  $def("_5b8x33", "test_compile_block_dependancy", ["compile","expect"], _5b8x33);  
+  $def("_9s1umz", "test_compile_comments", ["compile","expect"], _9s1umz);  
+  $def("_1rbs7b6", "test_compile_generator", ["compile","expect"], _1rbs7b6);  
+  $def("_1gaxmhs", "test_compile_function", ["compile","expect"], _1gaxmhs);  
+  $def("_2ozyn1", "test_compile_async_function", ["compile","expect"], _2ozyn1);  
+  $def("_1jn3lk9", "test_compile_named_function", ["compile","expect"], _1jn3lk9);  
+  $def("_z3bqb8", "test_compile_this_reference", ["compile","expect"], _z3bqb8);  
+  $def("_1lyze5m", "test_compile_lambda", ["compile","expect"], _1lyze5m);  
+  $def("_12k1xub", "test_compile_error", ["compile","expect"], _12k1xub);  
+  $def("_y271kb", "test_compile_viewof", ["compile","expect"], _y271kb);  
+  $def("_1q4asyp", "test_compile_viewof_and_value_coexist", ["compile","expect"], _1q4asyp);  
+  $def("_189jvkd", "test_compile_mutable", ["compile","expect"], _189jvkd);  
+  $def("_78egw8", "test_compile_builtin", ["compile","expect"], _78egw8);  
+  $def("_1o65727", "test_compile_fileattachment", ["compile","expect"], _1o65727);  
+  $def("_14c9yxp", "test_compile_mutable_dep", ["compile","expect"], _14c9yxp);  
+  $def("_133w84q", "test_compile_mutable_dep2", ["compile","expect"], _133w84q);  
+  $def("_ql80wk", "test_compile_inline_viewof", ["compile","expect"], _ql80wk);  
+  $def("_1k420gu", "test_compile_view_dep", ["compile","expect"], _1k420gu);  
+  $def("_1y1h47u", "test_compile_dep", ["compile","expect"], _1y1h47u);  
+  $def("_1r711sh", "test_compile_class", ["compile","expect"], _1r711sh);  
+  $def("_33oop5", "test_compile_event", ["compile","expect"], _33oop5);  
+  $def("_9phvzk", "test_compile_tagged_literal", ["compile","expect"], _9phvzk);  
+  $def("_1q0pie3", "compile_unit_test_template", ["Inputs","test_case","compiled"], _1q0pie3);  
+  $def("_1vg114c", "test_compile_import_plain_single", ["compile","expect"], _1vg114c);  
+  $def("_18h6y38", "test_compile_import_view_data_alias_single", ["compile","expect"], _18h6y38);  
+  $def("_1svcdun", "test_compile_import_mutable_data_alias_single", ["compile","expect"], _1svcdun);  
+  $def("_tb4ops", "test_compile_import_mutable_single", ["compile","expect"], _tb4ops);  
+  $def("_vuzib9", "test_compile_import_viewof_single", ["compile","expect"], _vuzib9);  
+  $def("_6ewshd", "test_compile_import_alias_single", ["compile","expect"], _6ewshd);  
+  $def("_36migr", "test_compile_import_notebook", ["compile","expect"], _36migr);  
+  $def("_1nps9cr", "viewof test_case", ["Inputs","notebook_semantics_source"], _1nps9cr);  
+  $def("_1e5ax6f", "test_case", ["Generators","viewof test_case"], _1e5ax6f);  
+  $def("_7eic89", null, ["test_case"], _7eic89);  
+  $def("_16q6oyc", "compiled", ["compile","test_case"], _16q6oyc);  
+  $def("_61dayu", null, ["parser","test_case"], _61dayu);  
+  $def("_cevs6r", null, ["compile","test_case"], _cevs6r);  
+  $def("_mliwy8", "compile", ["parser","observableToJs"], _mliwy8);  
+  $def("_16p8atj", "observableToJs", ["acorn_walk","parser"], _16p8atj);  
+  $def("_1hd7px0", null, ["md"], _1hd7px0);  
+  $def("_xhj6b8", "decompress_url", ["DecompressionStream","TextDecoderStream","TransformStream","TextEncoderStream","Response"], _xhj6b8);  
+  $def("_s9w7ha", "parser", ["decompress_url","FileAttachment","acorn_url","acorn_walk_url"], _s9w7ha);  
+  main.define("acorn", ["module @tomlarkworthy/acorn-8-11-3", "@variable"], (_, v) => v.import("acorn", _));  
+  main.define("acorn_url", ["module @tomlarkworthy/acorn-8-11-3", "@variable"], (_, v) => v.import("acorn_url", _));  
+  main.define("acorn_walk", ["module @tomlarkworthy/acorn-8-11-3", "@variable"], (_, v) => v.import("acorn_walk", _));  
+  main.define("acorn_walk_url", ["module @tomlarkworthy/acorn-8-11-3", "@variable"], (_, v) => v.import("acorn_walk_url", _));  
+  main.define("expect", ["module @tomlarkworthy/jest-expect-standalone", "@variable"], (_, v) => v.import("expect", _));  
+  main.define("Runtime", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Runtime", _));  
+  main.define("Inspector", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Inspector", _));  
+  main.define("Library", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Library", _));  
+  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));  
+  $def("_j9n5de", "stageB_importFake", [], _j9n5de);  
+  $def("_1d53asg", "test_decompileImport_stageB_single", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1d53asg);  
+  $def("_hv5gag", "test_decompileImport_stageB_aliased", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _hv5gag);  
+  $def("_avc18y", "test_decompileImport_stageB_multiple", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _avc18y);  
+  $def("_16gia7i", "test_decompileImport_stageB_mixed_alias", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16gia7i);  
+  $def("_1slhdwo", "test_decompileImport_stageB_viewof", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1slhdwo);  
+  $def("_qwlsf2", "test_decompileImport_stageB_mutable", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _qwlsf2);  
+  $def("_sy7jfx", "test_decompileImport_returns_null_for_non_import", ["decompileImport","expect"], _sy7jfx);  
+  $def("_rk7ku3", "test_decompileImport_compile_roundtrip_single", ["compile","expect","stageB_importFake","decompileImport","formatImportDeclaration"], _rk7ku3);  
+  $def("_1numivw", "test_decompileImport_stageB_order_independent", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1numivw);  
+  $def("_16fpgac", "test_decompileImport_stageB_notebook_id", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16fpgac);  
+  $def("_r2e0wl", "test_extractModuleInfo_new_id_resolutions", ["expect","extractModuleInfo"], _r2e0wl);  
+  $def("_1pg1y6s", "test_extractModuleInfo_new_slug_resolutions", ["expect","extractModuleInfo"], _1pg1y6s);  
+  $def("_1vh26m0", "test_findModuleName_classic_bundle", ["expect","findModuleName"], _1vh26m0);  
+  $def("_1ltqcwj", "test_findModuleName_kit_slug", ["expect","findModuleName"], _1ltqcwj);  
+  $def("_wq4poo", "test_findModuleName_new_id", ["expect","findModuleName"], _wq4poo);  
+  $def("_1j0hksu", "test_findModuleName_new_slug", ["expect","findModuleName"], _1j0hksu);  
+  $def("_3en7eq", "test_decompile_leading_comment", ["decompile","expect","compile"], _3en7eq);  
+  $def("_z17nwa", "test_decompile_trailing_comment", ["decompile","expect"], _z17nwa);  
+  $def("_q5y9bo", "test_decompile_param_in_string", ["decompile","expect"], _q5y9bo);  
+  $def("_fm2sgc", "test_decompile_class_property_field", ["decompile","expect"], _fm2sgc);  
+  $def("_1xp8nli", "test_compile_preserves_formatting", ["compile","expect"], _1xp8nli);
+  return main;
+}</script>
 
 <script id="@mbostock/safe-local-storage" 
   type="text/plain"
@@ -3536,212 +8572,227 @@ function handleCommand(cmd) {
     return handler(cmd, rt);
 }
 )};
-const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation)
+const _11jras6 = function _cc_ws(cc_config,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,sessionStorage,invalidation)
 {
-    return function () {
-        var port = cc_config.port, host = cc_config.host;
-        var ws = null;
-        var paired = false;
-        function connect(token) {
-            if (ws) {
-                ws.close();
-                ws = null;
-            }
-            if (token) {
-                try {
-                    sessionStorage.setItem('lopecode_cc_token', token);
-                } catch (e) {
-                }
-                var hash = location.hash || '#';
-                if (/[&?]cc=/.test(hash)) {
-                    hash = hash.replace(/([&?])cc=[^&]*/, '$1cc=' + token);
-                } else {
-                    hash += (hash.length > 1 ? '&' : '') + 'cc=' + token;
-                }
-                try {
-                    window.history.replaceState(null, '', hash);
-                } catch (e) {
-                }
-            }
-            var connectPort = port;
-            if (token) {
-                var parts = token.match(/^LOPE-(\d+)-[A-Z0-9]+$/);
-                if (parts)
-                    connectPort = parseInt(parts[1], 10);
-            }
-            cc_status.value = 'connecting';
-            cc_status.dispatchEvent(new Event('input'));
-            ws = new WebSocket('ws://' + host + ':' + connectPort + '/ws');
-            ws.onopen = function () {
-                if (token) {
-                    cc_status.value = 'pairing';
-                    cc_status.dispatchEvent(new Event('input'));
-                    var toolDescriptors = [];
-                    var _mcpToolsVal = $0 && $0.value;
-                    if (_mcpToolsVal && _mcpToolsVal.size > 0) {
-                        _mcpToolsVal.forEach(function (t, name) {
-                            toolDescriptors.push({
-                                name: name,
-                                description: t.description,
-                                inputSchema: t.inputSchema
-                            });
-                        });
-                    }
-                    ws.send(JSON.stringify({
-                        type: 'pair',
-                        token: token,
-                        url: cc_notebook_id,
-                        title: document.title || 'Untitled',
-                        tools: toolDescriptors
-                    }));
-                }
-            };
-            ws.onmessage = function (event) {
-                var msg;
-                try {
-                    msg = JSON.parse(event.data);
-                } catch (e) {
-                    return;
-                }
-                switch (msg.type) {
-                case 'paired':
-                    paired = true;
-                    cc_status.value = 'connected';
-                    cc_status.dispatchEvent(new Event('input'));
-                    // Provide send callback to watchers
-                    cc_watchers.setSend(function (m) {
-                        if (paired && ws)
-                            ws.send(JSON.stringify(m));
-                    });
-                    var modules = [];
-                    var rt = window.__ojs_runtime;
-                    if (rt) {
-                        var seen = new Set();
-                        for (var v of rt._variables) {
-                            var name = v._module && v._module._name;
-                            if (name && !seen.has(name)) {
-                                seen.add(name);
-                                modules.push(name);
-                            }
-                        }
-                    }
-                    ws.send(JSON.stringify({
-                        type: 'notebook-info',
-                        url: cc_notebook_id,
-                        title: document.title,
-                        modules: modules,
-                        hash: location.hash
-                    }));
-                    // Set up watches from cc_watches
-                    var rt2 = window.__ojs_runtime;
-                    if (rt2) {
-                        var initialWatches = $1.value || [];
-                        for (var i = 0; i < initialWatches.length; i++) {
-                            cc_watchers.watchVariable(rt2, initialWatches[i].name, initialWatches[i].module);
-                        }
-                    }
-                    break;
-                case 'pair-failed':
-                    paired = false;
-                    cc_status.value = 'disconnected';
-                    cc_status.dispatchEvent(new Event('input'));
-                    break;
-                case 'reply':
-                    var msgs = cc_messages.value.concat([{
-                            role: 'assistant',
-                            content: msg.markdown,
-                            timestamp: Date.now()
-                        }]);
-                    cc_messages.value = msgs;
-                    cc_messages.dispatchEvent(new Event('input'));
-                    break;
-                case 'tool-activity':
-                    // Update the activity status bar (not the chat messages)
-                    var activityEntry = {
-                        tool_name: msg.tool_name,
-                        content: msg.summary,
-                        timestamp: msg.timestamp || Date.now()
-                    };
-                    cc_activity.value = cc_activity.value.concat([activityEntry]).slice(-20);
-                    cc_activity.dispatchEvent(new Event('input'));
-                    break;
-                case 'command':
-                    Promise.resolve(cc_command_handlers(msg)).then(function (result) {
-                        ws.send(JSON.stringify({
-                            type: 'command-result',
-                            id: msg.id,
-                            ok: result.ok,
-                            result: result.result,
-                            error: result.error
-                        }));
-                    }).catch(function (e) {
-                        ws.send(JSON.stringify({
-                            type: 'command-result',
-                            id: msg.id,
-                            ok: false,
-                            error: e.message
-                        }));
-                    });
-                    break;
-                case 'assistant-text':
-                    // Side-comment: Claude's CLI text output from session log
-                    var sideMsg = cc_messages.value.concat([{
-                            role: 'side',
-                            content: msg.text,
-                            timestamp: msg.timestamp || Date.now()
-                        }]);
-                    cc_messages.value = sideMsg;
-                    cc_messages.dispatchEvent(new Event('input'));
-                    break;
-                }
-            };
-            ws.onclose = function () {
-                paired = false;
-                cc_watchers.setSend(null);
-                cc_status.value = 'disconnected';
-                cc_status.dispatchEvent(new Event('input'));
-                ws = null;
-            };
-            ws.onerror = function () {
-            };
+  return (function () {
+    var port = cc_config.port,
+      host = cc_config.host;
+    var ws = null;
+    var paired = false;
+    function connect(token) {
+      if (ws) {
+        ws.close();
+        ws = null;
+      }
+      if (token) {
+        try {
+          window.sessionStorage.setItem("lopecode_cc_token", token);
+        } catch (e) {}
+        var hash = location.hash || "#";
+        if (/[&?]cc=/.test(hash)) {
+          hash = hash.replace(/([&?])cc=[^&]*/, "$1cc=" + token);
+        } else {
+          hash += (hash.length > 1 ? "&" : "") + "cc=" + token;
         }
-        // Auto-connect: check hash param first, then sessionStorage fallback
-        (function autoConnect() {
-            var token = null;
-            var hash = location.hash || '';
-            var match = hash.match(/[&?]cc=(LOPE-[A-Z0-9-]+)/);
-            if (match) {
-                token = match[1];
-            }
-            if (!token) {
-                try {
-                    token = sessionStorage.getItem('lopecode_cc_token');
-                } catch (e) {
+        try {
+          window.history.replaceState(null, "", hash);
+        } catch (e) {}
+      }
+      var connectPort = port;
+      if (token) {
+        var parts = token.match(/^LOPE-(\d+)-[A-Z0-9]+$/);
+        if (parts) connectPort = parseInt(parts[1], 10);
+      }
+      cc_status.value = "connecting";
+      cc_status.dispatchEvent(new Event("input"));
+      ws = new WebSocket("ws://" + host + ":" + connectPort + "/ws");
+      ws.onopen = function () {
+        if (token) {
+          cc_status.value = "pairing";
+          cc_status.dispatchEvent(new Event("input"));
+          var toolDescriptors = [];
+          var _mcpToolsVal = $0 && $0.value;
+          if (_mcpToolsVal && _mcpToolsVal.size > 0) {
+            _mcpToolsVal.forEach(function (t, name) {
+              toolDescriptors.push({
+                name: name,
+                description: t.description,
+                inputSchema: t.inputSchema
+              });
+            });
+          }
+          ws.send(
+            JSON.stringify({
+              type: "pair",
+              token: token,
+              url: cc_notebook_id,
+              title: document.title || "Untitled",
+              tools: toolDescriptors
+            })
+          );
+        }
+      };
+      ws.onmessage = function (event) {
+        var msg;
+        try {
+          msg = JSON.parse(event.data);
+        } catch (e) {
+          return;
+        }
+        switch (msg.type) {
+          case "paired":
+            paired = true;
+            cc_status.value = "connected";
+            cc_status.dispatchEvent(new Event("input"));
+            // Provide send callback to watchers
+            cc_watchers.setSend(function (m) {
+              if (paired && ws) ws.send(JSON.stringify(m));
+            });
+            var modules = [];
+            var rt = window.__ojs_runtime;
+            if (rt) {
+              var seen = new Set();
+              for (var v of rt._variables) {
+                var name = v._module && v._module._name;
+                if (name && !seen.has(name)) {
+                  seen.add(name);
+                  modules.push(name);
                 }
+              }
             }
-            if (token) {
-                setTimeout(function () {
-                    connect(token);
-                }, 500);
+            ws.send(
+              JSON.stringify({
+                type: "notebook-info",
+                url: cc_notebook_id,
+                title: document.title,
+                modules: modules,
+                hash: location.hash
+              })
+            );
+            // Set up watches from cc_watches
+            var rt2 = window.__ojs_runtime;
+            if (rt2) {
+              var initialWatches = $1.value || [];
+              for (var i = 0; i < initialWatches.length; i++) {
+                cc_watchers.watchVariable(
+                  rt2,
+                  initialWatches[i].name,
+                  initialWatches[i].module
+                );
+              }
             }
-        }());
-        invalidation.then(function () {
-            cc_watchers.setSend(null);
-            if (ws) {
-                ws.close();
-                ws = null;
-            }
-        });
-        return {
-            connect: connect,
-            get paired() {
-                return paired;
-            },
-            get ws() {
-                return ws;
-            }
-        };
-    }();
+            break;
+          case "pair-failed":
+            paired = false;
+            cc_status.value = "disconnected";
+            cc_status.dispatchEvent(new Event("input"));
+            break;
+          case "reply":
+            var msgs = cc_messages.value.concat([
+              {
+                role: "assistant",
+                content: msg.markdown,
+                timestamp: Date.now()
+              }
+            ]);
+            cc_messages.value = msgs;
+            cc_messages.dispatchEvent(new Event("input"));
+            break;
+          case "tool-activity":
+            // Update the activity status bar (not the chat messages)
+            var activityEntry = {
+              tool_name: msg.tool_name,
+              content: msg.summary,
+              timestamp: msg.timestamp || Date.now()
+            };
+            cc_activity.value = cc_activity.value
+              .concat([activityEntry])
+              .slice(-20);
+            cc_activity.dispatchEvent(new Event("input"));
+            break;
+          case "command":
+            Promise.resolve(cc_command_handlers(msg))
+              .then(function (result) {
+                ws.send(
+                  JSON.stringify({
+                    type: "command-result",
+                    id: msg.id,
+                    ok: result.ok,
+                    result: result.result,
+                    error: result.error
+                  })
+                );
+              })
+              .catch(function (e) {
+                ws.send(
+                  JSON.stringify({
+                    type: "command-result",
+                    id: msg.id,
+                    ok: false,
+                    error: e.message
+                  })
+                );
+              });
+            break;
+          case "assistant-text":
+            // Side-comment: Claude's CLI text output from session log
+            var sideMsg = cc_messages.value.concat([
+              {
+                role: "side",
+                content: msg.text,
+                timestamp: msg.timestamp || Date.now()
+              }
+            ]);
+            cc_messages.value = sideMsg;
+            cc_messages.dispatchEvent(new Event("input"));
+            break;
+        }
+      };
+      ws.onclose = function () {
+        paired = false;
+        cc_watchers.setSend(null);
+        cc_status.value = "disconnected";
+        cc_status.dispatchEvent(new Event("input"));
+        ws = null;
+      };
+      ws.onerror = function () {};
+    }
+    // Auto-connect: check hash param first, then sessionStorage fallback
+    (function autoConnect() {
+      var token = null;
+      var hash = location.hash || "";
+      var match = hash.match(/[&?]cc=(LOPE-[A-Z0-9-]+)/);
+      if (match) {
+        token = match[1];
+      }
+      if (!token) {
+        try {
+          token = sessionStorage.getItem("lopecode_cc_token");
+        } catch (e) {}
+      }
+      if (token) {
+        setTimeout(function () {
+          connect(token);
+        }, 500);
+      }
+    })();
+    invalidation.then(function () {
+      cc_watchers.setSend(null);
+      if (ws) {
+        ws.close();
+        ws = null;
+      }
+    });
+    return {
+      connect: connect,
+      get paired() {
+        return paired;
+      },
+      get ws() {
+        return ws;
+      }
+    };
+  })();
 };
 const _agu8h7 = function _cc_doc_side_effects(md){return(
 md`---
@@ -4211,7 +9262,7 @@ export default function define(runtime, observer) {
   $def("_bzq7u5", null, ["viewof mcpTools","fileSyncTools","Event"], _bzq7u5);  
   $def("_npplqm", "cc_handle_call_tool", ["viewof mcpTools","cc_watchers","runtime"], _npplqm);  
   $def("_ptgn2x", "cc_command_handlers", ["runtime","cc_handle_get_variable","cc_handle_define_variable","cc_handle_define_cell","cc_handle_delete_variable","cc_handle_delete_cell","cc_handle_update_cell","cc_handle_list_variables","cc_handle_list_cells","cc_handle_run_tests","cc_handle_create_module","cc_handle_delete_module","cc_handle_eval","cc_handle_fork","cc_handle_export_module","cc_handle_watch","cc_handle_unwatch","cc_handle_call_tool"], _ptgn2x);  
-  $def("_1s8ywlt", "cc_ws", ["cc_config","sessionStorage","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1s8ywlt);  
+  $def("_11jras6", "cc_ws", ["cc_config","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","sessionStorage","invalidation"], _11jras6);  
   $def("_agu8h7", "cc_doc_side_effects", ["md"], _agu8h7);  
   $def("_d9cyj2", "cc_change_forwarder", ["cc_ws","history","invalidation"], _d9cyj2);  
   $def("_56tjlo", "cc_voice", ["voiceEnabled","KeyboardEvent","SpeechSynthesisUtterance","invalidation"], _56tjlo);  
@@ -4427,80 +9478,64 @@ export default function define(runtime, observer) {
   type="text/plain"
   data-mime="application/javascript"
 >
-const _13upker = function _1(md){return(
+const _tku1if = function _1(md){return(
 md`# Command Palette
 
-Plugin-driven command palette. Press **Cmd+K** (Mac) or **Ctrl+K** to open.
+Plugin-driven command palette. Press **Cmd+K** (Mac) or **Ctrl+K** to open, or pick **Command palette** from the lopepage-2 burger menu (registered on the shared \`"lp2-menu"\` plugin bus).
 
 \`\`\`js
 import {commandPaletteOverlay, commandPaletteStyles, commandPaletteKeybinding} from "@tomlarkworthy/command-palette"
 \`\`\`
 
-## Registering a plugin
+## Registering a command provider
 
-A plugin is a function \`(query: string) => Command[]\` where \`Command = {label, href, hint?, module?, badge?, snippet?, score?}\`. Plugins run on every keystroke; results are merged and sorted by \`score\` (descending).
+A provider is a function \`(query: string) => Command[]\` where \`Command = {label, href, hint?, module?, badge?, snippet?, score?}\`. Providers run on every keystroke; results are merged and sorted by \`score\` (descending).
+
+Providers register on the shared [\`@tomlarkworthy/plugin-registry\`](https://observablehq.com/@tomlarkworthy/plugin-registry) set named \`"lopecode_commands"\` — no import of this notebook needed, so any notebook can extend the palette:
 
 \`\`\`js
-import {viewof commands as commandsView} from "@tomlarkworthy/command-palette"
+import {plugins} from "@tomlarkworthy/plugin-registry"
 {
-  const myPlugin = (q) => [{label: "Hello " + q, href: "#" + q, score: 100}];
-  const unregister = commandsView.addCommand(myPlugin);
-  invalidation.then(unregister);
+  const provider = (q) => [{label: "Hello " + q, href: "#" + q, score: 100}];
+  plugins.add("lopecode_commands", provider, {invalidation});
 }
 \`\`\`
 
-## Built-in plugins
+## Built-in providers
 
 - **Module finder** — type a module name to open it.
 - **Cell search** — type to find cells across all loaded modules.`
 )};
-const _1eng7wy = function _commands(Inputs,Event)
-{
-    const input = Inputs.input([]);
-    input.addCommand = function (plugin) {
-        input.value.push(plugin);
-        input.dispatchEvent(new Event('input'));
-        return () => {
-            const i = input.value.indexOf(plugin);
-            if (i >= 0) {
-                input.value.splice(i, 1);
-                input.dispatchEvent(new Event('input'));
-            }
-        };
-    };
-    return input;
-};
-const _7bve6u = (G, _) => G.input(_);
-const _bpk8h7 = function _searchIndex(liveCellMap,modules){return(
+const _yavx6b = function _searchIndex(liveCellMap,modules){return(
 (() => {
-    const index = [];
-    for (const [mod, cells] of liveCellMap.entries()) {
-        const moduleName = modules?.get(mod)?.name ?? '<unknown>';
-        for (const cell of cells) {
-            if (!cell.name && cell.type !== 'import')
-                continue;
-            let source = null;
-            try {
-                const v = cell.variables?.[0];
-                if (v?._definition)
-                    source = v._definition.toString();
-            } catch (e) {
-            }
-            index.push({
-                module: moduleName,
-                name: cell.name ?? null,
-                type: cell.type ?? 'simple',
-                source
-            });
-        }
+  const index = [];
+  for (const [mod, cells] of liveCellMap.entries()) {
+    const moduleName = modules?.get(mod)?.name ?? '<unknown>';
+    for (const cell of cells) {
+      if (!cell.name && cell.type !== 'import')
+        continue;
+      let source = null;
+      try {
+        const v = cell.variables?.[0];
+        if (v?._definition)
+          source = v._definition.toString();
+      } catch (e) {
+      }
+      index.push({
+        module: moduleName,
+        name: cell.name ?? null,
+        type: cell.type ?? 'simple',
+        source
+      });
     }
-    return index;
+  }
+  return index;
 })()
 )};
-const _1ptnr90 = function _commandPaletteStyles(theme_assets,htl)
+const _rmjyys = function _commandPaletteStyles(theme_assets,htl)
 {
-    theme_assets;
-    return htl.html`<style>
+  theme_assets;
+  return htl.html`<style>
 .command-palette-overlay {
   position: fixed;
   inset: 0;
@@ -4622,15 +9657,15 @@ const _1ptnr90 = function _commandPaletteStyles(theme_assets,htl)
 }
 </style>`;
 };
-const _fomuvm = function _commandPaletteOverlay($0,Node,invalidation)
+const _1q8grv4 = function _commandPaletteOverlay(Node,invalidation)
 {
-    const $commands = $0;
-    let selectedIdx = 0;
-    let results = [];
-    const overlay = document.createElement('div');
-    overlay.className = 'command-palette-overlay';
-    overlay.hidden = true;
-    overlay.innerHTML = `<div class="command-palette-box">
+  let selectedIdx = 0;
+  let results = [];
+  let providers = [];
+  const overlay = document.createElement('div');
+  overlay.className = 'command-palette-overlay';
+  overlay.hidden = true;
+  overlay.innerHTML = `<div class="command-palette-box">
       <input class="command-palette-input" placeholder="Type a command..." autocomplete="off" />
       <div class="command-palette-results"></div>
       <div class="command-palette-hint">
@@ -4639,147 +9674,156 @@ const _fomuvm = function _commandPaletteOverlay($0,Node,invalidation)
         <span><kbd>Esc</kbd> close</span>
       </div>
     </div>`;
-    const input = overlay.querySelector('.command-palette-input');
-    const resultsContainer = overlay.querySelector('.command-palette-results');
-    function search(query) {
-        if (!query || query.length < 1)
-            return [];
-        const plugins = $commands.value || [];
-        let all = [];
-        for (const plugin of plugins) {
-            try {
-                const out = plugin(query);
-                if (Array.isArray(out))
-                    all = all.concat(out);
-            } catch (e) {
-                console.error('[command-palette] plugin error:', e);
-            }
-        }
-        all.sort((a, b) => (b.score ?? 0) - (a.score ?? 0));
-        return all.slice(0, 50);
+  const input = overlay.querySelector('.command-palette-input');
+  const resultsContainer = overlay.querySelector('.command-palette-results');
+  function search(query) {
+    if (!query || query.length < 1)
+      return [];
+    let all = [];
+    for (const provider of providers) {
+      try {
+        const out = provider(query);
+        if (Array.isArray(out))
+          all = all.concat(out);
+      } catch (e) {
+        console.error('[command-palette] provider error:', e);
+      }
     }
-    function render() {
-        resultsContainer.innerHTML = '';
-        if (results.length === 0 && input.value.length > 0) {
-            resultsContainer.innerHTML = '<div class="command-palette-empty">No results found</div>';
-            return;
+    all.sort((a, b) => (b.score ?? 0) - (a.score ?? 0));
+    return all.slice(0, 50);
+  }
+  function render() {
+    resultsContainer.innerHTML = '';
+    if (results.length === 0 && input.value.length > 0) {
+      resultsContainer.innerHTML = '<div class="command-palette-empty">No results found</div>';
+      return;
+    }
+    results.forEach((r, i) => {
+      const row = document.createElement('a');
+      row.className = 'command-palette-result' + (i === selectedIdx ? ' selected' : '');
+      row.href = r.href || '#';
+      row.style.textDecoration = 'none';
+      row.style.color = 'inherit';
+      if (r.module) {
+        const modSpan = document.createElement('span');
+        modSpan.className = 'command-palette-module';
+        modSpan.textContent = r.module;
+        row.appendChild(modSpan);
+      }
+      const labelSpan = document.createElement('span');
+      labelSpan.className = 'command-palette-label';
+      labelSpan.textContent = r.label ?? '';
+      row.appendChild(labelSpan);
+      if (r.badge) {
+        const badgeSpan = document.createElement('span');
+        badgeSpan.className = 'command-palette-badge';
+        badgeSpan.textContent = r.badge;
+        row.appendChild(badgeSpan);
+      }
+      if (r.hint) {
+        const hintSpan = document.createElement('span');
+        hintSpan.className = 'command-palette-hint-right';
+        hintSpan.textContent = r.hint;
+        row.appendChild(hintSpan);
+      }
+      row.addEventListener('click', e => {
+        e.preventDefault();
+        close();
+        window.location.href = row.href;
+      });
+      resultsContainer.appendChild(row);
+      if (r.snippet) {
+        const snippet = document.createElement('div');
+        snippet.className = 'command-palette-snippet';
+        if (i === selectedIdx)
+          snippet.style.background = '#eef4ff';
+        if (typeof r.snippet === 'string') {
+          snippet.textContent = r.snippet;
+        } else if (r.snippet instanceof Node) {
+          snippet.appendChild(r.snippet);
         }
-        results.forEach((r, i) => {
-            const row = document.createElement('a');
-            row.className = 'command-palette-result' + (i === selectedIdx ? ' selected' : '');
-            row.href = r.href || '#';
-            row.style.textDecoration = 'none';
-            row.style.color = 'inherit';
-            if (r.module) {
-                const modSpan = document.createElement('span');
-                modSpan.className = 'command-palette-module';
-                modSpan.textContent = r.module;
-                row.appendChild(modSpan);
-            }
-            const labelSpan = document.createElement('span');
-            labelSpan.className = 'command-palette-label';
-            labelSpan.textContent = r.label ?? '';
-            row.appendChild(labelSpan);
-            if (r.badge) {
-                const badgeSpan = document.createElement('span');
-                badgeSpan.className = 'command-palette-badge';
-                badgeSpan.textContent = r.badge;
-                row.appendChild(badgeSpan);
-            }
-            if (r.hint) {
-                const hintSpan = document.createElement('span');
-                hintSpan.className = 'command-palette-hint-right';
-                hintSpan.textContent = r.hint;
-                row.appendChild(hintSpan);
-            }
-            row.addEventListener('click', e => {
-                e.preventDefault();
-                close();
-                window.location.href = row.href;
-            });
-            resultsContainer.appendChild(row);
-            if (r.snippet) {
-                const snippet = document.createElement('div');
-                snippet.className = 'command-palette-snippet';
-                if (i === selectedIdx)
-                    snippet.style.background = '#eef4ff';
-                if (typeof r.snippet === 'string') {
-                    snippet.textContent = r.snippet;
-                } else if (r.snippet instanceof Node) {
-                    snippet.appendChild(r.snippet);
-                }
-                snippet.addEventListener('click', e => {
-                    e.preventDefault();
-                    close();
-                    window.location.href = row.href;
-                });
-                resultsContainer.appendChild(snippet);
-            }
+        snippet.addEventListener('click', e => {
+          e.preventDefault();
+          close();
+          window.location.href = row.href;
         });
-    }
-    function open() {
-        overlay.hidden = false;
-        input.value = '';
-        results = [];
-        selectedIdx = 0;
-        render();
-        requestAnimationFrame(() => input.focus());
-    }
-    function close() {
-        overlay.hidden = true;
-        input.blur();
-    }
-    function navigateToSelected() {
-        if (results[selectedIdx]) {
-            const r = results[selectedIdx];
-            close();
-            window.location.href = r.href || '#';
-        }
-    }
-    input.addEventListener('input', () => {
-        results = search(input.value);
-        selectedIdx = 0;
-        render();
+        resultsContainer.appendChild(snippet);
+      }
     });
-    input.addEventListener('keydown', e => {
-        if (e.key === 'ArrowDown') {
-            e.preventDefault();
-            selectedIdx = Math.min(selectedIdx + 1, results.length - 1);
-            render();
-            const sel = resultsContainer.querySelector('.selected');
-            if (sel)
-                sel.scrollIntoView({ block: 'nearest' });
-        } else if (e.key === 'ArrowUp') {
-            e.preventDefault();
-            selectedIdx = Math.max(selectedIdx - 1, 0);
-            render();
-            const sel = resultsContainer.querySelector('.selected');
-            if (sel)
-                sel.scrollIntoView({ block: 'nearest' });
-        } else if (e.key === 'Enter') {
-            e.preventDefault();
-            navigateToSelected();
-        } else if (e.key === 'Escape') {
-            e.preventDefault();
-            close();
-        }
-    });
-    overlay.addEventListener('click', e => {
-        if (e.target === overlay)
-            close();
-    });
-    invalidation.then(() => overlay.remove());
-    overlay._openPalette = open;
-    overlay._closePalette = close;
-    overlay._isOpen = () => !overlay.hidden;
-    return overlay;
+  }
+  function open() {
+    overlay.hidden = false;
+    input.value = '';
+    results = [];
+    selectedIdx = 0;
+    render();
+    requestAnimationFrame(() => input.focus());
+  }
+  function close() {
+    overlay.hidden = true;
+    input.blur();
+  }
+  function navigateToSelected() {
+    if (results[selectedIdx]) {
+      const r = results[selectedIdx];
+      close();
+      window.location.href = r.href || '#';
+    }
+  }
+  input.addEventListener('input', () => {
+    results = search(input.value);
+    selectedIdx = 0;
+    render();
+  });
+  input.addEventListener('keydown', e => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      selectedIdx = Math.min(selectedIdx + 1, results.length - 1);
+      render();
+      const sel = resultsContainer.querySelector('.selected');
+      if (sel)
+        sel.scrollIntoView({ block: 'nearest' });
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      selectedIdx = Math.max(selectedIdx - 1, 0);
+      render();
+      const sel = resultsContainer.querySelector('.selected');
+      if (sel)
+        sel.scrollIntoView({ block: 'nearest' });
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      navigateToSelected();
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      close();
+    }
+  });
+  overlay.addEventListener('click', e => {
+    if (e.target === overlay)
+      close();
+  });
+  invalidation.then(() => overlay.remove());
+  overlay._openPalette = open;
+  overlay._closePalette = close;
+  overlay._isOpen = () => !overlay.hidden;
+  // Stable setter fed by command_provider_sync; re-searches live if the palette is open.
+  overlay._setProviders = arr => {
+    providers = arr || [];
+    if (!overlay.hidden) {
+      results = search(input.value);
+      selectedIdx = 0;
+      render();
+    }
+  };
+  return overlay;
 };
-const _mqy6k9 = function _commandPaletteKeybinding(cellSearchPlugin,moduleFinderPlugin,commandPaletteOverlay,invalidation)
+const _1vuj6tn = function _commandPaletteKeybinding(cellSearchPlugin,moduleFinderPlugin,command_provider_sync,commandPaletteOverlay,invalidation)
 {
   cellSearchPlugin;
   moduleFinderPlugin;
-  const handler = (e) => {
-    if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+  command_provider_sync;
+  const handler = e => {
+    if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
       e.preventDefault();
       e.stopPropagation();
       if (commandPaletteOverlay._isOpen()) {
@@ -4789,24 +9833,23 @@ const _mqy6k9 = function _commandPaletteKeybinding(cellSearchPlugin,moduleFinder
       }
     }
   };
-  document.addEventListener("keydown", handler, true);
-  invalidation.then(() =>
-    document.removeEventListener("keydown", handler, true)
-  );
+  document.addEventListener('keydown', handler, true);
+  invalidation.then(() => document.removeEventListener('keydown', handler, true));
   return null;
 };
-const _k261kj = function _cellSearchPlugin(searchIndex,linkTo,$0,invalidation)
+const _104tbig = function _cellSearchPlugin(searchIndex,linkTo,plugins,invalidation)
 {
-  const plugin = (query) => {
-    if (!query || query.length < 1) return [];
+  const plugin = query => {
+    if (!query || query.length < 1)
+      return [];
     const q = query.toLowerCase();
     const out = [];
     for (const entry of searchIndex) {
       let score = 0;
       let nameMatch = false;
       let sourceMatch = false;
-      const name = String(entry.name ?? "").toLowerCase();
-      const mod = String(entry.module ?? "").toLowerCase();
+      const name = String(entry.name ?? '').toLowerCase();
+      const mod = String(entry.module ?? '').toLowerCase();
       if (name.length && name.startsWith(q)) {
         score += 150;
         nameMatch = true;
@@ -4821,50 +9864,42 @@ const _k261kj = function _cellSearchPlugin(searchIndex,linkTo,$0,invalidation)
         score += 10;
         sourceMatch = true;
       }
-      if (score === 0) continue;
-      const nameStr = String(entry.name ?? "");
-      const modStr = String(entry.module ?? "");
-      const href = linkTo(nameStr ? modStr + "#" + nameStr : modStr);
+      if (score === 0)
+        continue;
+      const nameStr = String(entry.name ?? '');
+      const modStr = String(entry.module ?? '');
+      const href = linkTo(nameStr ? modStr + '#' + nameStr : modStr);
       let snippet = null;
       if (entry.source) {
         const src = String(entry.source);
         const idx = src.toLowerCase().indexOf(q);
         const frag = document.createDocumentFragment();
         if (idx >= 0) {
-          const start = Math.max(
-            0,
-            src.lastIndexOf("\n", Math.max(0, idx - 40)) + 1
-          );
-          const endNL = src.indexOf("\n", idx + query.length + 40);
-          const lineEnd =
-            endNL < 0 ? Math.min(src.length, idx + query.length + 80) : endNL;
+          const start = Math.max(0, src.lastIndexOf('\n', Math.max(0, idx - 40)) + 1);
+          const endNL = src.indexOf('\n', idx + query.length + 40);
+          const lineEnd = endNL < 0 ? Math.min(src.length, idx + query.length + 80) : endNL;
           const before = src.slice(start, idx);
           const match = src.slice(idx, idx + query.length);
           const after = src.slice(idx + query.length, lineEnd);
           if (start > 0)
-            frag.appendChild(document.createTextNode("\u2026" + before));
-          else frag.appendChild(document.createTextNode(before));
-          const mark = document.createElement("mark");
+            frag.appendChild(document.createTextNode('\u2026' + before));
+          else
+            frag.appendChild(document.createTextNode(before));
+          const mark = document.createElement('mark');
           mark.textContent = match;
           frag.appendChild(mark);
-          frag.appendChild(
-            document.createTextNode(
-              after + (lineEnd < src.length ? "\u2026" : "")
-            )
-          );
+          frag.appendChild(document.createTextNode(after + (lineEnd < src.length ? '\u2026' : '')));
         } else {
-          const firstLine = src.slice(0, src.indexOf("\n", 0));
-          frag.appendChild(
-            document.createTextNode((firstLine || src).slice(0, 120))
-          );
+          const firstLine = src.slice(0, src.indexOf('\n', 0));
+          frag.appendChild(document.createTextNode((firstLine || src).slice(0, 120)));
         }
         snippet = frag;
       }
       out.push({
-        label: nameStr || "(anonymous)",
+        label: nameStr || '(anonymous)',
         module: modStr,
-        badge: entry.type && entry.type !== "simple" ? entry.type : null,
-        hint: sourceMatch && !nameMatch ? "source" : null,
+        badge: entry.type && entry.type !== 'simple' ? entry.type : null,
+        hint: sourceMatch && !nameMatch ? 'source' : null,
         snippet,
         href,
         score
@@ -4872,37 +9907,69 @@ const _k261kj = function _cellSearchPlugin(searchIndex,linkTo,$0,invalidation)
     }
     return out;
   };
-  const unregister = $0.addCommand(plugin);
-  invalidation.then(unregister);
-  return "cell-search plugin registered";
+  plugins.add('lopecode_commands', plugin, { invalidation });
+  return 'cell-search plugin registered';
 };
-const _lq3msy = function _moduleFinderPlugin(modules,linkTo,$0,invalidation)
+const _1opf5e1 = function _moduleFinderPlugin(currentModules,linkTo,plugins,invalidation)
 {
-  const plugin = (query) => {
-    if (!query || query.length < 1) return [];
+  // Use the REACTIVE module set (module-map currentModules), not cell-map's one-shot `modules` snapshot,
+  // so modules created live (e.g. by robocoop-4) are immediately findable. This cell recomputes whenever
+  // currentModules changes; the old plugin is unregistered via invalidation before the new one registers.
+  const plugin = query => {
+    if (!query || query.length < 1)
+      return [];
     const q = query.toLowerCase();
     const out = [];
-    for (const [, info] of modules.entries()) {
-      const name = info?.name ?? "";
-      if (!name) continue;
+    for (const [, info] of currentModules.entries()) {
+      const name = info?.name ?? '';
+      if (!name)
+        continue;
       const lower = name.toLowerCase();
       let score = 0;
-      if (lower === q) score = 1000;
-      else if (lower.startsWith(q)) score = 800;
-      else if (lower.includes(q)) score = 600;
-      if (score === 0) continue;
+      if (lower === q)
+        score = 1000;
+      else if (lower.startsWith(q))
+        score = 800;
+      else if (lower.includes(q))
+        score = 600;
+      if (score === 0)
+        continue;
       out.push({
         label: name,
         href: linkTo(name),
-        hint: "open module",
+        hint: 'open module',
         score
       });
     }
     return out;
   };
-  const unregister = $0.addCommand(plugin);
-  invalidation.then(unregister);
-  return "module-finder plugin registered";
+  plugins.add('lopecode_commands', plugin, { invalidation });
+  return 'module-finder plugin registered';
+};
+const _1seh1ei = function _cp_menu_register(plugins,commandPaletteOverlay,invalidation)
+{
+  // Surface the palette in the lopepage-2 burger menu so it's discoverable without knowing the
+  // Cmd/Ctrl+K shortcut. Registers straight onto the shared plugin-registry "lp2-menu" set — no
+  // import of lopepage-2; a notebook opts in by adding both modules to its bootconf mains.
+  const isMac = /Mac|iP(hone|ad|od)/.test(navigator.platform || navigator.userAgent || '');
+  plugins.add('lp2-menu', {
+    id: 'command-palette',
+    order: 3,
+    label: 'Command palette  ' + (isMac ? '\u2318K' : 'Ctrl+K'),
+    svg: '<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.3"><circle cx="7" cy="7" r="4.2"/><path d="M10.2 10.2 14 14"/></svg>',
+    action: () => commandPaletteOverlay._openPalette()
+  }, { invalidation });
+  return 'registered: command-palette menu item';
+};
+const _7c6wp9 = function _commandProviders(plugins){return(
+plugins.get('lopecode_commands')
+)};
+const _13y9cxb = function _command_provider_sync(commandPaletteOverlay,commandProviders)
+{
+  // Push the current provider set (from the "lopecode_commands" bus) into the stable overlay,
+  // so the overlay is built once yet always searches the live set. Recomputes on every add/remove.
+  commandPaletteOverlay._setProviders(commandProviders);
+  return `command providers: ${ commandProviders.length }`;
 };
 
 export default function define(runtime, observer) {
@@ -4914,20 +9981,25 @@ export default function define(runtime, observer) {
   main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
   main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
   main.define("module @tomlarkworthy/themes", async () => runtime.module((await import("/@tomlarkworthy/themes.js?v=4")).default));  
-  $def("_13upker", null, ["md"], _13upker);  
-  $def("_1eng7wy", "viewof commands", ["Inputs","Event"], _1eng7wy);  
-  $def("_7bve6u", "commands", ["Generators","viewof commands"], _7bve6u);  
-  $def("_bpk8h7", "searchIndex", ["liveCellMap","modules"], _bpk8h7);  
-  $def("_1ptnr90", "commandPaletteStyles", ["theme_assets","htl"], _1ptnr90);  
-  $def("_fomuvm", "commandPaletteOverlay", ["viewof commands","Node","invalidation"], _fomuvm);  
-  $def("_mqy6k9", "commandPaletteKeybinding", ["cellSearchPlugin","moduleFinderPlugin","commandPaletteOverlay","invalidation"], _mqy6k9);  
-  $def("_k261kj", "cellSearchPlugin", ["searchIndex","linkTo","viewof commands","invalidation"], _k261kj);  
-  $def("_lq3msy", "moduleFinderPlugin", ["modules","linkTo","viewof commands","invalidation"], _lq3msy);  
+  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
+  main.define("module @tomlarkworthy/plugin-registry", async () => runtime.module((await import("/@tomlarkworthy/plugin-registry.js?v=4")).default));  
+  $def("_tku1if", null, ["md"], _tku1if);  
+  $def("_yavx6b", "searchIndex", ["liveCellMap","modules"], _yavx6b);  
+  $def("_rmjyys", "commandPaletteStyles", ["theme_assets","htl"], _rmjyys);  
+  $def("_1q8grv4", "commandPaletteOverlay", ["Node","invalidation"], _1q8grv4);  
+  $def("_1vuj6tn", "commandPaletteKeybinding", ["cellSearchPlugin","moduleFinderPlugin","command_provider_sync","commandPaletteOverlay","invalidation"], _1vuj6tn);  
+  $def("_104tbig", "cellSearchPlugin", ["searchIndex","linkTo","plugins","invalidation"], _104tbig);  
+  $def("_1opf5e1", "moduleFinderPlugin", ["currentModules","linkTo","plugins","invalidation"], _1opf5e1);  
   main.define("viewof liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("viewof liveCellMap", _));  
   main.define("liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("liveCellMap", _));  
   main.define("modules", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("modules", _));  
   main.define("linkTo", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("linkTo", _));  
-  main.define("theme_assets", ["module @tomlarkworthy/themes", "@variable"], (_, v) => v.import("theme_assets", _));
+  main.define("theme_assets", ["module @tomlarkworthy/themes", "@variable"], (_, v) => v.import("theme_assets", _));  
+  main.define("currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("currentModules", _));  
+  main.define("plugins", ["module @tomlarkworthy/plugin-registry", "@variable"], (_, v) => v.import("plugins", _));  
+  $def("_1seh1ei", "cp_menu_register", ["plugins","commandPaletteOverlay","invalidation"], _1seh1ei);  
+  $def("_7c6wp9", "commandProviders", ["plugins"], _7c6wp9);  
+  $def("_13y9cxb", "command_provider_sync", ["commandPaletteOverlay","commandProviders"], _13y9cxb);
   return main;
 }</script>
 <script id="@tomlarkworthy/dataflow-templating/dataflow_templating%401.svg" 
@@ -5532,10 +10604,10 @@ function divToVar(runtime, div) {
   }
 }
 )};
-const _1usw8c2 = function _attachContextManu(Inputs,isOnObservableCom){return(
+const _8yv93h = async function _attachContextManu(Inputs,optionsFile,isOnObservableCom){return(
 Inputs.toggle({
-  label: "attach menu",
-  value: !isOnObservableCom()
+  label: 'attach menu',
+  value: (await optionsFile.json())?.__attachMenu ?? !isOnObservableCom()
 })
 )};
 const _1oaz8r1 = (G, _) => G.input(_);
@@ -5572,7 +10644,7 @@ lookupVariable(
   editorModule
 )
 )};
-const _1q95xt6 = function _cellEditor(cloneDataflow,editorTemplate,shellTemplate,getOption,Event,setOption,createCell,findCell,pinOnCreate){return(
+const _1p2yypw = function _cellEditor(cloneDataflow,editorTemplate,shellTemplate,createCell,findCell,dragReorder,pinOnCreate,getOption,Event,setOption){return(
 (variable, {
     pinned = undefined
 } = {}) => {
@@ -5661,6 +10733,20 @@ const _1q95xt6 = function _cellEditor(cloneDataflow,editorTemplate,shellTemplate
                             createCell({ cell: findCell(variable) });
                         });
                         hotbar.prepend(add);
+                    }
+                    // Drag the whole hotbar to reorder this cell (alternative to up/down arrows).
+                    if (hotbar && !hotbar.dataset.reorderable) {
+                        hotbar.dataset.reorderable = '1';
+                        hotbar.style.cursor = 'grab';
+                        const grip = document.createElement('span');
+                        grip.className = 'reorder-grip';
+                        grip.textContent = '⠿'; // ⠿ drag handle
+                        grip.title = 'Drag to reorder cell';
+                        // Float left so the grip sits at the far edge of the full-width
+                        // bar, while ➕/edit stay right-aligned via the shell's text-align.
+                        grip.style.cssText = 'float: left; margin-left: 4px; opacity: 0.55;';
+                        hotbar.prepend(grip);
+                        dragReorder(variable, hotbar);
                     }
                     if (body)
                         syncOpen();
@@ -6154,9 +11240,6 @@ async (cell, amount) =>
     }
   })
 )};
-const _pinoncr = function _pinOnCreate(){return(
-new Set()  // variable pids to open (pin) their editor as soon as the cell mounts
-)};
 const _19znal9 = function _createCell($0){return(
 async ({cell, source = "{}" } = {}) =>
   $0.send({
@@ -6218,7 +11301,7 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _2pkmxz = async function _command_processor(command,$0,compile_and_update,remove_variables,$1,findCellIndex,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2,pinOnCreate)
+const _g08ji8 = async function _command_processor(command,$0,compile_and_update,pinOnCreate,selectVariable,remove_variables,$1,findCellIndex,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,findCell,$2)
 {
     if (command.processed)
         return;
@@ -6274,6 +11357,35 @@ const _2pkmxz = async function _command_processor(command,$0,compile_and_update,
                     });
                 }
             }
+        }
+        result = true;
+    } else if (command.command == 'moveCellBeside') {
+        // Drag-drop reorder: place cell's variables immediately before (or, with
+        // placeAfter, after) the anchor cell that `target` belongs to. Repositions by
+        // variable identity, not cell index, so hidden/import/template variables
+        // between visible cells don't skew the destination. The anchor is resolved to
+        // its whole cell so multi-variable cells (viewof/mutable) aren't split, and a
+        // drop past the last visible cell anchors to it (placeAfter) rather than to the
+        // module's far-off last dynamic variable.
+        const { cell, target, placeAfter } = command.args;
+        const anchorCell = findCell(target);
+        const arr = Array.from(runtime._variables);
+        const groupSet = new Set(cell.variables);
+        const group = arr.filter(v => groupSet.has(v));
+        const without = arr.filter(v => !groupSet.has(v));
+        let insertAt = -1;
+        if (anchorCell?.variables?.length) {
+            const idxs = anchorCell.variables
+                .map(v => without.indexOf(v))
+                .filter(i => i >= 0);
+            if (idxs.length)
+                insertAt = placeAfter ? Math.max(...idxs) + 1 : Math.min(...idxs);
+        }
+        if (insertAt >= 0 && group.length) {
+            without.splice(insertAt, 0, ...group);
+            runtime._variables.clear();
+            without.forEach(v => runtime._variables.add(v));
+            await selectVariable(cell.variables[0], cell.dom);
         }
         result = true;
     }
@@ -6948,13 +12060,14 @@ const _w5q3yf = function _editorModule(thisModule){return(
 thisModule()
 )};
 const _18kaj2p = (G, _) => G.input(_);
-const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_options)
+const _yeikvo = function _editor_jobs(command_processor,submit_summary,save_options,persist_attach_menu)
 {
   //editedCell;
   command_processor;
   submit_summary;
   save_options;
-  return "editor_jobs";
+  persist_attach_menu;
+  return 'editor_jobs';
 };
 const _1whoy5n = function _91(md){return(
 md`### Apply Update`
@@ -7262,6 +12375,197 @@ const _bz6mai = function _test_completion_identifier_deferred(completionFixture)
     throw new Error('bare identifier (no dot) must defer');
   return 'identifier / no-dot bases deferred to the identifier-chain path';
 };
+const _y8yyf = function _pinOnCreate()
+{
+  return new Set()  // variable pids to open (pin) their editor as soon as the cell mounts
+;
+};
+const _y040tx = function _persist_attach_menu($0,attachContextManu,Event)
+{
+  // Bake the global edit-mode flag into cell_options.json so it survives export/fork.
+  // Depends on `viewof options` (element, stable), not `options` (value), so this
+  // write does not re-trigger itself; save_options then persists the attachment.
+  $0.value.__attachMenu = attachContextManu;
+  $0.dispatchEvent(new Event('input'));
+  return 'persist_attach_menu';
+};
+const _1jn7thk = function _moveCellBeside($0){return(
+async (cell, target, placeAfter = false) =>
+  $0.send({
+    command: "moveCellBeside",
+    args: {
+      cell,
+      target,
+      placeAfter
+    }
+  })
+)};
+const _2rhl00 = function _dragReorder(divToVar,runtime,moveCellBeside,findCell){return(
+(variable, handle) => {
+  if (!document.getElementById('lope-reorder-style')) {
+    const s = document.createElement('style');
+    s.id = 'lope-reorder-style';
+    s.textContent =
+      'body.lope-reordering, body.lope-reordering * { user-select: none !important; cursor: grabbing !important; }';
+    document.head.appendChild(s);
+  }
+
+  const THRESH = 5;
+  let pointerId = null, dragging = false, startX = 0, startY = 0;
+  let cells = null, ownIndex = -1, scroller = null, indicator = null;
+  const blockSelect = (ev) => ev.preventDefault();
+
+  // Same-module visible cells in DOM order; one entry per rendered .observablehq div.
+  const getModuleCells = () => {
+    const mod = variable._module;
+    const out = [];
+    for (const div of document.querySelectorAll('.observablehq')) {
+      const v = divToVar(runtime, div);
+      if (v && v._module === mod) out.push({ div, v });
+    }
+    return out;
+  };
+
+  const ensureIndicator = () => {
+    if (indicator) return indicator;
+    indicator = document.createElement('div');
+    indicator.style.cssText =
+      'position: fixed; height: 0; z-index: 2147483646; pointer-events: none;' +
+      'border-top: 2px solid var(--theme-foreground-focus, #3b5bdb);';
+    document.body.appendChild(indicator);
+    return indicator;
+  };
+  const removeIndicator = () => { if (indicator) { indicator.remove(); indicator = null; } };
+
+  // gap 0..N: how many cells sit above pointer Y (by their vertical midpoint).
+  const gapAt = (y) => {
+    for (let i = 0; i < cells.length; i++) {
+      const r = cells[i].div.getBoundingClientRect();
+      if (y < r.top + r.height / 2) return i;
+    }
+    return cells.length;
+  };
+
+  const drawIndicator = (g) => {
+    const ind = ensureIndicator();
+    const ref = cells[Math.min(ownIndex, cells.length - 1)].div.getBoundingClientRect();
+    const y = g < cells.length
+      ? cells[g].div.getBoundingClientRect().top
+      : cells[cells.length - 1].div.getBoundingClientRect().bottom;
+    ind.style.left = ref.left + 'px';
+    ind.style.width = ref.width + 'px';
+    ind.style.top = (y - 1) + 'px';
+  };
+
+  const autoScroll = (y) => {
+    if (!scroller) return;
+    const r = scroller.getBoundingClientRect
+      ? scroller.getBoundingClientRect()
+      : { top: 0, bottom: window.innerHeight };
+    const M = 36;
+    let dy = 0;
+    if (y < r.top + M) dy = -Math.ceil((r.top + M - y) / 3);
+    else if (y > r.bottom - M) dy = Math.ceil((y - (r.bottom - M)) / 3);
+    if (dy && scroller.scrollBy) scroller.scrollBy({ top: dy });
+  };
+
+  const beginDrag = () => {
+    cells = getModuleCells();
+    ownIndex = cells.findIndex(c => c.v === variable);
+    if (ownIndex < 0) return false;
+    dragging = true;
+    scroller = cells[ownIndex].div.closest('.lm_content')
+      || document.scrollingElement || document.documentElement;
+    document.body.classList.add('lope-reordering');
+    handle.style.cursor = 'grabbing';
+    // Drop any selection the gesture already started and block new ones for the drag.
+    const sel = window.getSelection && window.getSelection();
+    if (sel && sel.removeAllRanges) sel.removeAllRanges();
+    document.addEventListener('selectstart', blockSelect, true);
+    return true;
+  };
+
+  const onMove = (e) => {
+    if (pointerId == null) return;
+    if (!dragging) {
+      if (Math.abs(e.clientX - startX) < THRESH && Math.abs(e.clientY - startY) < THRESH) return;
+      if (!beginDrag()) return;
+    }
+    e.preventDefault();
+    drawIndicator(gapAt(e.clientY));
+    autoScroll(e.clientY);
+  };
+
+  const teardown = () => {
+    if (pointerId != null && handle.releasePointerCapture) {
+      try { handle.releasePointerCapture(pointerId); } catch (_) {}
+    }
+    handle.removeEventListener('pointermove', onMove);
+    handle.removeEventListener('pointerup', onUp);
+    handle.removeEventListener('pointercancel', onCancel);
+    document.removeEventListener('selectstart', blockSelect, true);
+    handle.style.cursor = '';
+    document.body.classList.remove('lope-reordering');
+    removeIndicator();
+  };
+
+  const onUp = (e) => {
+    const wasDragging = dragging;
+    let target, placeAfter = false, ownDiv = null, doMove = false;
+    if (wasDragging) {
+      ownDiv = cells[ownIndex].div;
+      const g = gapAt(e.clientY);
+      // Drop in own slot (just above or below self) is a no-op.
+      if (g !== ownIndex && g !== ownIndex + 1) {
+        doMove = true;
+        if (g < cells.length) {
+          target = cells[g].v;         // insert before the cell now at the gap
+        } else {
+          target = cells[cells.length - 1].v;  // dropped past the last visible cell
+          placeAfter = true;
+        }
+      }
+    }
+    teardown();
+    pointerId = null; dragging = false; cells = null; ownIndex = -1; scroller = null;
+    if (wasDragging) {
+      // Suppress the click that would otherwise toggle the editor open/closed.
+      const stop = (ev) => { ev.stopPropagation(); ev.preventDefault(); };
+      handle.addEventListener('click', stop, { capture: true, once: true });
+      setTimeout(() => handle.removeEventListener('click', stop, { capture: true }), 0);
+      if (doMove) moveCellBeside(findCell(variable, ownDiv), target, placeAfter);
+    }
+  };
+
+  const onCancel = () => {
+    teardown();
+    pointerId = null; dragging = false; cells = null; ownIndex = -1; scroller = null;
+  };
+
+  const onDown = (e) => {
+    if (e.button != null && e.button !== 0) return;
+    if (e.target && e.target.closest && e.target.closest('.add-cell-btn')) return;
+    pointerId = e.pointerId;
+    startX = e.clientX; startY = e.clientY;
+    dragging = false;
+    if (handle.setPointerCapture) { try { handle.setPointerCapture(e.pointerId); } catch (_) {} }
+    handle.addEventListener('pointermove', onMove);
+    handle.addEventListener('pointerup', onUp);
+    handle.addEventListener('pointercancel', onCancel);
+  };
+
+  handle.addEventListener('pointerdown', onDown);
+  // Suppress the native text-selection drag that would otherwise start on press.
+  // mousedown-preventDefault leaves `click` intact (same trick as the add button).
+  handle.addEventListener('mousedown', e => {
+    if (!(e.target && e.target.closest && e.target.closest('.add-cell-btn'))) e.preventDefault();
+  });
+  handle.addEventListener('selectstart', blockSelect);
+  handle.style.touchAction = 'none';
+  handle.style.userSelect = 'none';
+  return () => handle.removeEventListener('pointerdown', onDown);
+}
+)};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -7277,6 +12581,7 @@ export default function define(runtime, observer) {
   main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
 
   main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
+  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));  
   main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
   main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
   main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
@@ -7301,11 +12606,11 @@ export default function define(runtime, observer) {
   $def("_hdieof", "editors", [], _hdieof);  
   $def("_ipx6cz", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","editors","cellEditor"], _ipx6cz);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
-  $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
+  $def("_8yv93h", "viewof attachContextManu", ["Inputs","optionsFile","isOnObservableCom"], _8yv93h);  
   $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
   $def("_16ks4jz", null, ["md"], _16ks4jz);  
   $def("_199ztvl", "hotbarTemplate", ["lookupVariable","editorModule"], _199ztvl);  
-  $def("_1q95xt6", "cellEditor", ["cloneDataflow","editorTemplate","shellTemplate","getOption","Event","setOption","createCell","findCell","pinOnCreate"], _1q95xt6);
+  $def("_1p2yypw", "cellEditor", ["cloneDataflow","editorTemplate","shellTemplate","createCell","findCell","dragReorder","pinOnCreate","getOption","Event","setOption"], _1p2yypw);  
   $def("_x5ixji", "hotbar_shell", ["viewof edit","Event","htl","edit"], _x5ixji);  
   $def("_1ed5zb9", "editor_panel", ["viewof editedCell","htl","toolbar","nav","reversibleAttach","combine","code_editor"], _1ed5zb9);  
   $def("_yk7udl", "shellTemplate", ["viewof editedCell","editedCell","selectVariable","viewof edit","edit","hotbar_shell","lookupVariable","editorModule"], _yk7udl);  
@@ -7350,8 +12655,7 @@ export default function define(runtime, observer) {
   $def("_xvo1n6", "code_editor", ["code_editor_view"], _xvo1n6);  
   $def("_1imarq2", null, ["md"], _1imarq2);  
   $def("_470wv4", "moveCell", ["viewof command"], _470wv4);  
-  $def("_pinoncr", "pinOnCreate", [], _pinoncr);
-  $def("_19znal9", "createCell", ["viewof command"], _19znal9);
+  $def("_19znal9", "createCell", ["viewof command"], _19znal9);  
   $def("_d9nzys", "deleteCell", ["viewof command"], _d9nzys);  
   $def("_1toku21", null, ["md"], _1toku21);  
   $def("_d7ouqx", "viewof command", ["flowQueue"], _d7ouqx);  
@@ -7361,7 +12665,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_2pkmxz", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","viewof liveCellMap","findCellIndex","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command","pinOnCreate"], _2pkmxz);  
+  $def("_g08ji8", "command_processor", ["command","viewof edit","compile_and_update","pinOnCreate","selectVariable","remove_variables","viewof liveCellMap","findCellIndex","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","findCell","viewof command"], _g08ji8);  
   $def("_8iz5z2", null, ["md"], _8iz5z2);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -7391,11 +12695,12 @@ export default function define(runtime, observer) {
   $def("_1mfm13h", "normalizeObservableClipboardCell", ["inferCellGroupNameFromOJS","escapeTemplateLiteral"], _1mfm13h);  
   $def("_1pa2xc8", "readObservableClipboardCells", ["globalThis"], _1pa2xc8);  
   $def("_1w99cbu", "pasteObservableCellsIntoModule", ["viewof liveCellMap","normalizeObservableClipboardCell","findCell","compile_and_update"], _1w99cbu);  
-  $def("_z9vacx", null, ["md"], _z9vacx);
-  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);
+  $def("_z9vacx", null, ["md"], _z9vacx);  
+  main.define("modules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", "modules", _));  
+  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);  
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
-  $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
+  $def("_yeikvo", "editor_jobs", ["command_processor","submit_summary","save_options","persist_attach_menu"], _yeikvo);  
   $def("_1whoy5n", null, ["md"], _1whoy5n);  
   $def("_gk83fp", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _gk83fp);  
   $def("_1g3bdxp", null, ["md"], _1g3bdxp);  
@@ -7450,9 +12755,7 @@ export default function define(runtime, observer) {
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
-  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));
-  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));
-  main.define("modules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", "modules", _));
+  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
   $def("_lbftlp", "literalCompletions", ["codemirror"], _lbftlp);  
   $def("_scoiwp", "completionFixture", ["EditorState","observableJS_language","literalCompletions"], _scoiwp);  
   $def("_160qhf1", "test_completion_string_literal", ["completionFixture"], _160qhf1);  
@@ -7462,7 +12765,11 @@ export default function define(runtime, observer) {
   $def("_quyccp", "test_completion_bool_template_regexp", ["completionFixture"], _quyccp);  
   $def("_1cn3ucr", "test_completion_parenthesised_unwrap", ["completionFixture"], _1cn3ucr);  
   $def("_15vxhca", "test_completion_never_evaluates", ["completionFixture"], _15vxhca);  
-  $def("_bz6mai", "test_completion_identifier_deferred", ["completionFixture"], _bz6mai);
+  $def("_bz6mai", "test_completion_identifier_deferred", ["completionFixture"], _bz6mai);  
+  $def("_y8yyf", "pinOnCreate", [], _y8yyf);  
+  $def("_y040tx", "persist_attach_menu", ["viewof options","attachContextManu","Event"], _y040tx);  
+  $def("_1jn7thk", "moveCellBeside", ["viewof command"], _1jn7thk);  
+  $def("_2rhl00", "dragReorder", ["divToVar","runtime","moveCellBeside","findCell"], _2rhl00);
   return main;
 }</script>
 <script id="@tomlarkworthy/escodegen/escodegen.browser.min.js.gz" 
@@ -9668,8 +14975,7 @@ export default function define(runtime, observer) {
   main.define("css", ["module @tomlarkworthy/themes", "@variable"], (_, v) => v.import("css", _));  
   main.define("cssForTheme", ["module @tomlarkworthy/themes", "@variable"], (_, v) => v.import("cssForTheme", _));
   return main;
-}
-</script>
+}</script>
 
 <script id="@tomlarkworthy/file-sync" 
   type="text/plain"
@@ -9810,7 +15116,7 @@ const _yqx7l8 = function _syncEnabled(notebookId,htl)
     return container;
 };
 const _xltqf6 = (G, _) => G.input(_);
-const _1mb10vh = function _disassemble(htl, directory, notebookId, manifestWriter, readFile, writeFile, syncableModules, exportModuleJS, hashSource, currentModules, runtime, probeDefine, tag, importShim, $0) {
+const _1nuhj4u = function _disassemble(htl, directory, notebookId, manifestWriter, readFile, writeFile, syncableModules, exportModuleJS, hashSource, currentModules, runtime, probeDefine, tag, $0) {
     const container = htl.html`<div>
     <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
       <button class="disassemble" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Disassemble to disk</button>
@@ -10400,7 +15706,7 @@ const _1bf1rb4 = function _fileSyncLastSeen(directory)
     void directory;
     return new window.Map();
 };
-const _43mwl9 = function _filesToNotebook(directory, syncArmed, currentModules, fileSyncLastSeen, notebookId, runtime, probeDefine, tag, readFile, exportModuleJS, manifestWriter, hashSource, writeFile, getFileAttachmentsMap, invalidation) {
+const _19e6n4y = function _filesToNotebook(directory, syncArmed, currentModules, fileSyncLastSeen, notebookId, runtime, probeDefine, tag, readFile, exportModuleJS, importShim, manifestWriter, hashSource, writeFile, getFileAttachmentsMap, invalidation) {
     if (!directory)
         return 'Waiting for directory...';
     if (!syncArmed || !syncArmed.armed)
@@ -10564,7 +15870,7 @@ const _43mwl9 = function _filesToNotebook(directory, syncArmed, currentModules, 
                         const blob = new window.Blob([diskText], { type: 'text/javascript' });
                         const url = window.URL.createObjectURL(blob);
                         try {
-                            const mod = await window.importShim(url, 'file://@tomlarkworthy/file-sync');
+                            const mod = await import(url);
                             if (typeof mod.default === 'function') {
                                 applyModule(moduleId, mod.default);
                                 console.log('[file-sync] applied ' + moduleId + ' from disk');
@@ -10671,7 +15977,7 @@ const _43mwl9 = function _filesToNotebook(directory, syncArmed, currentModules, 
                 const blob = new window.Blob([diskText], { type: 'text/javascript' });
                 const url = window.URL.createObjectURL(blob);
                 try {
-                    const imported = await window.importShim(url, 'file://@tomlarkworthy/file-sync');
+                    const imported = await import(url);
                     if (typeof imported.default === 'function') {
                         const newMod = runtime.module(imported.default, () => null);
                         runtime.mains.set(moduleId, newMod);
@@ -10783,6 +16089,196 @@ md`## TODO
 - **Import cell validation**: verify import bridges survive round-trip correctly
 - **Conflict resolution**: when both disk and runtime edit the same cell simultaneously, detect and surface the conflict instead of last-write-wins`
 )};
+const _qq3v7b = function _jbApply(importShim) {
+    let pidSeq = 0;
+    const genPid = () => '_jb' + (pidSeq++).toString(36) + Math.floor(Math.random() * 1000000).toString(36);
+    const hasVarInput = inputs => (inputs || []).some(iv => (typeof iv === 'string' ? iv : iv && iv._name) === '@variable');
+    const importPath = defn => {
+        const m = (defn ? defn.toString() : '').match(/import\(\s*["'`]([^"'`]+)["'`]/);
+        return m ? m[1] : null;
+    };
+    return function makeApply({currentModules, runtime, probeDefine, createModule, obj_observer} = {}) {
+        const resolveModule = moduleId => {
+            if (currentModules)
+                for (const [, info] of currentModules)
+                    if (info.name === moduleId)
+                        return info.module;
+            const r = runtime;
+            if (r.mains && r.mains.has(moduleId))
+                return r.mains.get(moduleId);
+            if (typeof createModule === 'function') {
+                try {
+                    return createModule(moduleId, r);
+                } catch (e) {
+                    return null;
+                }
+            }
+            return null;
+        };
+        const obsFactory = (() => {
+            if (typeof obj_observer === 'function')
+                return obj_observer;
+            try {
+                const f = runtime && runtime._builtin && runtime._builtin._scope.get('__ojs_observer');
+                return f && typeof f._value === 'function' ? f._value : null;
+            } catch (e) {
+                return null;
+            }
+        })();
+        return function applyModule(moduleId, defineFn) {
+            const mod = resolveModule(moduleId);
+            if (!mod)
+                return {
+                    applied: false,
+                    reason: 'module not loaded and cannot create: ' + moduleId
+                };
+            const existingByName = new Map();
+            const existingByPid = new Map();
+            for (const v of runtime._variables) {
+                if (v._module !== mod)
+                    continue;
+                if (v._name)
+                    existingByName.set(v._name, v);
+                if (v.pid)
+                    existingByPid.set(v.pid, v);
+            }
+            const cells = probeDefine(defineFn);
+            const seenPids = new Set();
+            const seenNames = new Set();
+            let changes = 0;
+            for (const cell of cells) {
+                if (cell.name === '@variable')
+                    continue;
+                const upsertLoader = (loaderName, defn) => {
+                    seenNames.add(loaderName);
+                    const spec = loaderName.slice('module '.length);
+                    const child = resolveModule(spec);
+                    const path = importPath(defn);
+                    const key = child ? 'live:' + spec : path ? 'path:' + path : null;
+                    if (key == null)
+                        return;
+                    const make = child ? () => child : async () => runtime.module((await import(path)).default);
+                    const existing = existingByName.get(loaderName);
+                    if (existing) {
+                        if (existing._jbKey !== undefined && existing._jbKey !== key) {
+                            existing.define(loaderName, [], make);
+                            existing._jbKey = key;
+                            changes++;
+                        }
+                        return;
+                    }
+                    const v = mod.variable(null);
+                    v.define(loaderName, [], make);
+                    v._jbKey = key;
+                    existingByName.set(loaderName, v);
+                    changes++;
+                };
+                const upsertBinding = (name, inputs, defn) => {
+                    seenNames.add(name);
+                    const existing = existingByName.get(name);
+                    if (!existing) {
+                        const v = mod.variable(null);
+                        v.define(name, inputs, defn);
+                        existingByName.set(name, v);
+                        changes++;
+                        return;
+                    }
+                    const existingInputNames = (existing._inputs || []).map(iv => typeof iv === 'string' ? iv : iv._name);
+                    const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(inputs);
+                    const defnMatch = existing._definition && existing._definition.toString() === (defn ? defn.toString() : '');
+                    if (!(inputsMatch && defnMatch)) {
+                        existing.define(name, inputs, defn);
+                        changes++;
+                    }
+                };
+                if (cell.type === 'import') {
+                    const spec = cell.from;
+                    const child = spec && resolveModule(spec);
+                    if (!child)
+                        continue;
+                    const loaderName = 'module ' + spec;
+                    seenNames.add(loaderName);
+                    if (!existingByName.has(loaderName)) {
+                        const lv = mod.variable(null);
+                        lv.define(loaderName, [], () => child);
+                        lv._jbKey = 'live:' + spec;
+                        existingByName.set(loaderName, lv);
+                        changes++;
+                    }
+                    const alias = cell.alias || cell.remote;
+                    upsertBinding(alias, [
+                        loaderName,
+                        '@variable'
+                    ], (_, vv) => vv.import(cell.remote, _));
+                    continue;
+                }
+                if (cell.name && cell.name.startsWith('module ')) {
+                    upsertLoader(cell.name, cell.definition);
+                    continue;
+                }
+                if (hasVarInput(cell.inputs)) {
+                    if (cell.name)
+                        upsertBinding(cell.name, cell.inputs, cell.definition);
+                    continue;
+                }
+                let pid = cell.pid;
+                if (!pid) {
+                    const byName = cell.name && existingByName.get(cell.name);
+                    pid = byName && byName.pid || genPid();
+                }
+                seenPids.add(pid);
+                if (cell.name)
+                    seenNames.add(cell.name);
+                const existing = existingByPid.get(pid) || cell.name && existingByName.get(cell.name);
+                if (!existing) {
+                    const v = mod.variable({});
+                    v.define(cell.name, cell.inputs, cell.definition);
+                    v.pid = pid;
+                    existingByPid.set(pid, v);
+                    if (cell.name)
+                        existingByName.set(cell.name, v);
+                    changes++;
+                    continue;
+                }
+                const existingInputNames = (existing._inputs || []).map(iv => typeof iv === 'string' ? iv : iv._name);
+                const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+                const defnMatch = existing._definition && existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+                if (inputsMatch && defnMatch) {
+                    if (!existing.pid)
+                        existing.pid = pid;
+                    continue;
+                }
+                existing.define(cell.name, cell.inputs, cell.definition).pid = pid;
+                changes++;
+            }
+            for (const v of [...runtime._variables]) {
+                if (v._module !== mod)
+                    continue;
+                const name = v._name;
+                if (name === '@variable')
+                    continue;
+                if (name && seenNames.has(name))
+                    continue;
+                if (name && name.startsWith('module ') || hasVarInput(v._inputs)) {
+                    if (name) {
+                        v.delete();
+                        changes++;
+                    }
+                    continue;
+                }
+                if (!v.pid || seenPids.has(v.pid))
+                    continue;
+                v.delete();
+                changes++;
+            }
+            return {
+                applied: true,
+                moduleId,
+                changes
+            };
+        };
+    };
+};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -10800,7 +16296,7 @@ export default function define(runtime, observer) {
   $def("_jnt0bt", "directory", ["Generators","viewof directory"], _jnt0bt);  
   $def("_yqx7l8", "viewof syncEnabled", ["notebookId","htl"], _yqx7l8);  
   $def("_xltqf6", "syncEnabled", ["Generators","viewof syncEnabled"], _xltqf6);  
-  $def("_1mb10vh", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","importShim","viewof syncEnabled"], _1mb10vh);  
+  $def("_1nuhj4u", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","viewof syncEnabled"], _1nuhj4u);  
   $def("_eoa5ga", "disassemble", ["Generators","viewof disassemble"], _eoa5ga);  
   $def("_1jyon1g", "syncStatus", ["htl","directory","syncableModules","notebookToFiles","filesToNotebook"], _1jyon1g);  
   $def("_1dl3i63", null, ["md"], _1dl3i63);  
@@ -10817,7 +16313,7 @@ export default function define(runtime, observer) {
   $def("_1cy7bqk", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1cy7bqk);  
   $def("_3zm0bx", "notebookToFiles", ["directory","syncArmed","currentModules","notebookId","exportModuleJS","writeFile","manifestWriter","hashSource","readFile","onCodeChange","invalidation"], _3zm0bx);  
   $def("_1bf1rb4", "fileSyncLastSeen", ["directory"], _1bf1rb4);  
-  $def("_43mwl9", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _43mwl9);  
+  $def("_19e6n4y", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","importShim","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _19e6n4y);  
   $def("_1b4kluo", null, ["md"], _1b4kluo);  
   $def("_1h2nj16", null, ["md"], _1h2nj16);  
   main.define("viewof currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("viewof currentModules", _));  
@@ -10827,7 +16323,8 @@ export default function define(runtime, observer) {
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("importShim", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("importShim", _));  
   main.define("tag", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("tag", _));  
-  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));
+  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));  
+  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);
   return main;
 }</script>
 
@@ -12203,6 +17700,146 @@ export default function define(runtime, observer) {
   $def("_b5ui8y", "isnode", ["Element","Text"], _b5ui8y);
   return main;
 }</script>
+
+<script id="@tomlarkworthy/invoke-variable" 
+  type="text/plain"
+  data-mime="application/javascript"
+>
+const _zkje0r = function _1(md){return(
+md`# \`invokeVariable(<name>, <module>, overrides = {})\`
+
+Test individual variables by calling them with injected values. Lets you test different scenarios without changing your core logic. Pairs with [@tomlarkworthy/tester](https://observablehq.com/@tomlarkworthy/tester)`
+)};
+const _swiym2 = function _invokeVariable(lookupVariable)
+{
+  return async function invokeVariable(name, module, overrides = {}) {
+    if (overrides == null || typeof overrides !== 'object')
+      throw new TypeError('invokeVariable(name, module, {overrides}): overrides must be an object');
+    // Accept a Variable reference directly as the first arg (skip the lookupVariable stall when
+    // the caller already holds it); otherwise resolve by (name, module).
+    let variable;
+    if (name && typeof name === 'object' && typeof name._definition !== 'undefined') {
+      variable = name;
+      module = module ?? variable._module;
+    } else {
+      if (typeof name !== 'string' || !name.length)
+        throw new TypeError('invokeVariable(name, module, \u2026): name must be a non-empty string');
+      if (!module)
+        throw new TypeError('invokeVariable(name, module, \u2026): module is required');
+      variable = await lookupVariable(name, module);
+      if (!variable)
+        throw new Error(`invokeVariable: variable "${ name }" not found in module`);
+    }
+    module = module ?? variable._module;
+    const label = variable._name ?? (typeof name === 'string' ? name : '(anonymous)');
+    const inputs = Array.isArray(variable._inputs) ? variable._inputs : [];
+    const inputNames = inputs.map(v => v?._name);
+    for (const k of Object.keys(overrides)) {
+      if (!inputNames.includes(k)) {
+        throw new Error(`invokeVariable("${ label }"): override "${ k }" was provided but is not a declared dependency. Declared dependencies: ${ inputNames.filter(Boolean).join(', ') }`);
+      }
+    }
+    const hasOwn = (o, k) => Object.prototype.hasOwnProperty.call(o, k);
+    const resolveDependency = async depName => {
+      if (hasOwn(overrides, depName))
+        return overrides[depName];
+      const scopeVar = module?._scope?.get?.(depName) ?? module?._runtime?._builtin?._scope?.get?.(depName);
+      if (scopeVar) {
+        if (scopeVar._value !== undefined)
+          return scopeVar._value;
+        if (scopeVar._promise && typeof scopeVar._promise?.then === 'function')
+          return await scopeVar._promise;
+      }
+      if (typeof module?.value === 'function') {
+        try {
+          return await module.value(depName);
+        } catch (e) {
+        }
+      }
+      if (module?._runtime && typeof module._runtime._global === 'function') {
+        try {
+          const g = module._runtime._global(depName);
+          if (g !== undefined)
+            return g;
+        } catch (e) {
+        }
+      }
+      throw new Error(`invokeVariable("${ label }"): could not resolve dependency "${ depName }" (no override and not found in module/builtins/global)`);
+    };
+    const args = [];
+    for (const dep of inputs) {
+      const depName = dep?._name;
+      if (!depName) {
+        args.push(undefined);
+        continue;
+      }
+      args.push(await resolveDependency(depName));
+    }
+    const def = variable._definition;
+    if (typeof def !== 'function') {
+      throw new Error(`invokeVariable("${ label }"): target variable does not have an invokable function definition`);
+    }
+    return def(...args);
+  };
+};
+const _jtrr9m = function _3(md){return(
+md`### Example
+
+let c = a + b`
+)};
+const _1v2c0s1 = function _a(){return(
+1
+)};
+const _ywl8oh = function _b(){return(
+3
+)};
+const _1mc3tpl = function _c(a,b){return(
+a + b
+)};
+const _o5e50u = function _7(md){return(
+md`If we invoke c without any overrides we get the notebook behaviour (i.e. the answer is 4, as a is 1 and b is 3)`
+)};
+const _tnoyf9 = function _8(invokeVariable,invokeVariableModule){return(
+invokeVariable("c", invokeVariableModule)
+)};
+const _smh5by = function _9(md){return(
+md`But we can set b to 20, and then we get the answer 21.`
+)};
+const _d996jo = function _10(invokeVariable,invokeVariableModule){return(
+invokeVariable("c", invokeVariableModule, { b: 20 })
+)};
+const _qh0yhm = function _11(md){return(
+md`To call invokeVariable we need a reference to the module, which we can obtain with thisModule() (see runtime-sdk)`
+)};
+const _1hy0qcz = function _invokeVariableModule(thisModule){return(
+thisModule()
+)};
+const _jno7wc = (G, _) => G.input(_);
+
+export default function define(runtime, observer) {
+  const main = runtime.module();
+  const $def = (pid, name, deps, fn) => {
+    main.variable(observer(name)).define(name, deps, fn).pid = pid;
+  };
+
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  $def("_zkje0r", null, ["md"], _zkje0r);  
+  $def("_swiym2", "invokeVariable", ["lookupVariable"], _swiym2);  
+  $def("_jtrr9m", null, ["md"], _jtrr9m);  
+  $def("_1v2c0s1", "a", [], _1v2c0s1);  
+  $def("_ywl8oh", "b", [], _ywl8oh);  
+  $def("_1mc3tpl", "c", ["a","b"], _1mc3tpl);  
+  $def("_o5e50u", null, ["md"], _o5e50u);  
+  $def("_tnoyf9", null, ["invokeVariable","invokeVariableModule"], _tnoyf9);  
+  $def("_smh5by", null, ["md"], _smh5by);  
+  $def("_d996jo", null, ["invokeVariable","invokeVariableModule"], _d996jo);  
+  $def("_qh0yhm", null, ["md"], _qh0yhm);  
+  $def("_1hy0qcz", "viewof invokeVariableModule", ["thisModule"], _1hy0qcz);  
+  $def("_jno7wc", "invokeVariableModule", ["Generators","viewof invokeVariableModule"], _jno7wc);  
+  main.define("lookupVariable", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("lookupVariable", _));  
+  main.define("thisModule", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("thisModule", _));
+  return main;
+}</script>
 <script id="@tomlarkworthy/isomorphic-git-1-30-1/isomorphic-git-1%401.30.1.bundle.js.gz" 
   type="text/plain"
   data-encoding="base64"
@@ -13496,7 +19133,7 @@ async function listBranches({repo} = {}) {
   }
 }
 )};
-const _1bvisll = function _listFiles(ensure_branch,git,fs){return(
+const _bvp3oz = function _listFiles(ensure_branch,git,fs){return(
 async function listFiles({repo, branch, ref} = {}) {
   if (!repo)
     throw new Error('repo is required');
@@ -13515,7 +19152,6 @@ async function listFiles({repo, branch, ref} = {}) {
     });
   } catch (err) {
     console.error(err);
-    debugger;
     return [];
   }
 }
@@ -13673,91 +19309,105 @@ function read(def) {
 const _1l4hr6l = function _49(md){return(
 md`## History API Functions`
 )};
-const _zanj5n = function _revertVariables(getVariableByPersistentId,runtime,realize){return(
-async entries => {
-  const out = [];
-  for (const e of entries ?? []) {
-    const pid = e?.pid ?? null;
-    if (!pid)
-      continue;
-    const variable = getVariableByPersistentId(pid, runtime) || null;
-    if (!variable) {
-      out.push({
-        pid,
-        ok: false,
-        reason: 'no runtime variable'
-      });
-      continue;
-    }
-    const prev = e?.previous ?? null;
-    if (!prev) {
-      if (e?.op === 'new') {
-        try {
-          variable.delete?.();
-          out.push({
-            pid,
-            ok: true,
-            action: 'delete'
-          });
-        } catch (err) {
-          out.push({
-            pid,
-            ok: false,
-            action: 'delete',
-            reason: String(err?.message ?? err)
-          });
-        }
-      } else {
+const _1hhkam2 = function _revertVariables(getVariableByPersistentId,runtime,history,initial_state,realize)
+{
+  return async entries => {
+    const out = [];
+    // For each selected change, restore its variable to the state it had
+    // immediately BEFORE that change. Reconstructed from the history log +
+    // initial_state, since entries carry no `previous` field.
+    for (const e of entries ?? []) {
+      const pid = e?.pid ?? null;
+      if (!pid)
+        continue;
+      const variable = getVariableByPersistentId(pid, runtime) || null;
+      if (!variable) {
         out.push({
           pid,
           ok: false,
-          reason: 'no previous snapshot'
+          reason: 'no runtime variable'
+        });
+        continue;
+      }
+      // find the prior snapshot for this pid: the last same-pid entry before `e`
+      const at = history.indexOf(e);
+      const upTo = at === -1 ? history.length - 1 : at - 1;
+      let prev = null, firstForPid = null;
+      for (let idx = 0; idx <= upTo; idx++) {
+        const h = history[idx];
+        if (h?.pid !== pid)
+          continue;
+        if (firstForPid === null)
+          firstForPid = h;
+        prev = h;
+      }
+      if (!prev) {
+        // nothing earlier for this pid — either it existed before recording,
+        // or this change first created it (op 'new') so reverting deletes it
+        const base = initial_state instanceof Map ? initial_state.get(pid) ?? null : null;
+        if (e?.op === 'new' || !base) {
+          try {
+            variable.delete?.();
+            out.push({
+              pid,
+              ok: true,
+              action: 'delete'
+            });
+          } catch (err) {
+            out.push({
+              pid,
+              ok: false,
+              action: 'delete',
+              reason: String(err?.message ?? err)
+            });
+          }
+          continue;
+        }
+        prev = base;
+      }
+      const def = (await realize([prev._definition ?? ''], runtime))[0];
+      if (!def) {
+        out.push({
+          pid,
+          ok: false,
+          reason: 'could not realize previous definition'
+        });
+        continue;
+      }
+      const name = ((typeof prev._name === 'string' && prev._name.length) ? prev._name : null) ?? ((typeof variable._name === 'string' && variable._name.length) ? variable._name : null) ?? pid;
+      try {
+        variable.define(name, Array.isArray(prev._inputs) ? prev._inputs : [], def);
+        out.push({
+          pid,
+          ok: true,
+          action: 'define'
+        });
+      } catch (err) {
+        out.push({
+          pid,
+          ok: false,
+          action: 'define',
+          reason: String(err?.message ?? err)
         });
       }
-      continue;
     }
-    const def = (await realize([prev._definition ?? ''], runtime))[0];
-    if (!def) {
-      out.push({
-        pid,
-        ok: false,
-        reason: 'could not realize previous definition'
-      });
-      continue;
+    return out;
+  };
+};
+const _41vg0h = function _rewindToTime(history,applyHistoryState)
+{
+  return function rewindToTime(time) {
+    // history is sorted ascending by t; index = number of changes at or before `time`
+    let index = 0;
+    for (const entry of history) {
+      if ((entry?.t ?? 0) <= time)
+        index++;
+      else
+        break;
     }
-    const name = ((typeof prev._name === 'string' && prev._name.length) ? prev._name : null) ?? ((typeof variable._name === 'string' && variable._name.length) ? variable._name : null) ?? pid;
-    try {
-      variable.define(name, Array.isArray(prev._inputs) ? prev._inputs : [], def);
-      out.push({
-        pid,
-        ok: true,
-        action: 'define'
-      });
-    } catch (err) {
-      out.push({
-        pid,
-        ok: false,
-        action: 'define',
-        reason: String(err?.message ?? err)
-      });
-    }
-  }
-  return out;
-}
-)};
-const _1cvp8ui = function _rewindToTime(history,revertVariables){return(
-function (time) {
-  const byPid = new Map();
-  for (const entry of history) {
-    if (entry?.t > time) {
-      const pid = entry?.pid;
-      if (pid && !byPid.has(pid))
-        byPid.set(pid, entry);
-    }
-  }
-  revertVariables(Array.from(byPid.values()));
-}
-)};
+    return applyHistoryState(index);
+  };
+};
 const _1rfq6xd = function _52(md){return(
 md`## State`
 )};
@@ -13803,7 +19453,7 @@ const _qu2y2k = function _historyUtils(){return(
   }
 }
 )};
-const _84fm9q = function _change_listener(runtime,$0,persistentId,historyUtils,$1,read,onCodeChange,identity,modules,$2,Event,invalidation)
+const _5czkc4 = function _change_listener(runtime,$0,persistentId,historyUtils,$1,read,onCodeChange,playback_suspend,identity,modules,$2,Event,invalidation)
 {
   // scan the runtime for things that were loaded before we attached the hook
   if (!this) {
@@ -13819,6 +19469,9 @@ const _84fm9q = function _change_listener(runtime,$0,persistentId,historyUtils,$
     return read(currDef) ?? read(prevDef) ?? null;
   };
   const stop = onCodeChange(({variable, previous, t}) => {
+    // playback drives defines/deletes; suppress recording while it runs
+    if (playback_suspend && Date.now() < playback_suspend.until)
+      return;
     let v = variable || previous.variable;
     // lazyImport
     // Suprised the do not referentially match
@@ -13833,6 +19486,9 @@ const _84fm9q = function _change_listener(runtime,$0,persistentId,historyUtils,$
     const moduleName = modules.get(module)?.name || 'unknown';
     const prov = inferProvenance(variable, previous);
     const source = prov?.source ?? 'runtime';
+    // playback replays existing history; never record it as a fresh change
+    if (source === 'playback')
+      return;
     if (variable && !previous) {
       // new variable
       // record it as a base state
@@ -14266,6 +19922,120 @@ const _1tpet0t = function _historyModule(thisModule){return(
 thisModule()
 )};
 const _1ryokzy = (G, _) => G.input(_);
+const _sjnusq = function _playback(history,html,applyHistoryState,Event,invalidation)
+{
+  const n = history.length;
+  const form = html`<form style="display:flex;gap:.4em;align-items:center;font:13px system-ui,sans-serif;flex-wrap:wrap">
+    <button type=button name=first title="start">⏮</button>
+    <button type=button name=prev title="previous change">◀</button>
+    <button type=button name=play title="play / pause">▶ play</button>
+    <button type=button name=next title="next change">▶</button>
+    <button type=button name=last title="latest">⏭</button>
+    <input type=range name=range min=0 max=${ n } step=1 value=${ n } style="flex:1;min-width:120px">
+    <output name=out style="font:12px monospace">${ n } / ${ n }</output>
+  </form>`;
+  let value = n, timer = null;
+  const stop = () => {
+    if (timer) {
+      clearInterval(timer);
+      timer = null;
+      form.play.textContent = '\u25B6 play';
+    }
+  };
+  const go = async v => {
+    value = Math.max(0, Math.min(n, v | 0));
+    form.range.value = value;
+    form.out.value = `${ value } / ${ n }`;
+    form.value = value;
+    await applyHistoryState(value);
+    form.dispatchEvent(new Event('input', { bubbles: true }));
+  };
+  form.range.oninput = () => go(+form.range.value);
+  form.first.onclick = () => go(0);
+  form.prev.onclick = () => go(value - 1);
+  form.next.onclick = () => go(value + 1);
+  form.last.onclick = () => go(n);
+  form.play.onclick = () => {
+    if (timer)
+      return stop();
+    form.play.textContent = '\u23F8 pause';
+    timer = setInterval(() => go(value >= n ? 0 : value + 1), 700);
+  };
+  invalidation.then(stop);
+  form.value = value;
+  return form;
+};
+const _x7pc8l = (G, _) => G.input(_);
+const _ncb8n9 = function _applyHistoryState(modules,playback_suspend,history,initial_state,getVariableByPersistentId,runtime,replay_pid_map,realize,tag)
+{
+  const moduleByName = new Map();
+  if (modules instanceof Map)
+    for (const [m, meta] of modules)
+      if (meta?.name)
+        moduleByName.set(meta.name, m);
+  const defaultMod = moduleByName.get('main') ?? (modules instanceof Map ? modules.keys().next().value : null) ?? null;
+  // Reconstruct notebook state after the first `index` recorded changes, from the
+  // history log + initial_state base snapshots. Entries carry no `previous` field,
+  // so this also drives git-replayed history.
+  return async function applyHistoryState(index) {
+    // Suspend recording for the apply + a grace window: playback's redefines/deletes
+    // fire onCodeChange asynchronously and must not be logged as fresh changes.
+    playback_suspend.until = Date.now() + 4000;
+    const i = Math.max(0, Math.min(index | 0, history.length));
+    const byPid = new Map();
+    history.forEach((h, idx) => {
+      if (!h?.pid)
+        return;
+      let g = byPid.get(h.pid);
+      if (!g)
+        byPid.set(h.pid, g = {
+          first: h,
+          last: null
+        });
+      if (idx < i)
+        g.last = h;
+    });
+    for (const [pid, {first, last}] of byPid) {
+      const del = last ? last.op === 'del' : first.op === 'new';
+      const snap = del ? null : last ?? initial_state.get(pid) ?? null;
+      let v = getVariableByPersistentId(pid, runtime) ?? replay_pid_map.get(pid) ?? null;
+      if (del) {
+        if (v) {
+          try {
+            v.delete?.();
+          } catch {
+          }
+          replay_pid_map.delete(pid);
+        }
+        continue;
+      }
+      if (!snap)
+        continue;
+      if (!v) {
+        const mod = moduleByName.get((last ?? first)?.module ?? 'main') ?? defaultMod;
+        if (!mod)
+          continue;
+        replay_pid_map.set(pid, v = mod.variable());
+      }
+      let def = null;
+      try {
+        def = (await realize([snap._definition ?? ''], runtime))[0] ?? null;
+      } catch {
+      }
+      if (!def)
+        continue;
+      v.define(snap._name || pid, Array.isArray(snap._inputs) ? snap._inputs : [], tag(def, {
+        source: 'playback',
+        pid
+      }));
+    }
+    playback_suspend.until = Date.now() + 500;
+    return i;
+  };
+};
+const _v5cr66 = function _playback_suspend(){return(
+{ until: 0 }
+)};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -14322,7 +20092,7 @@ export default function define(runtime, observer) {
   $def("_1c4d7y5", "setFilesAndCommit", ["ensure_branch","git","fs","ensure_dir"], _1c4d7y5);  
   $def("_veyumo", "listRepos", ["fs"], _veyumo);  
   $def("_1rusr2m", "listBranches", ["ensure_repo","git","fs"], _1rusr2m);  
-  $def("_1bvisll", "listFiles", ["ensure_branch","git","fs"], _1bvisll);  
+  $def("_bvp3oz", "listFiles", ["ensure_branch","git","fs"], _bvp3oz);  
   $def("_xl9zth", "listCommits", ["ensure_branch","git","fs"], _xl9zth);  
   $def("_h6ylpe", "getCommitChanges", ["git","fs"], _h6ylpe);  
   $def("_fw7q7v", "getCompactISODate", [], _fw7q7v);  
@@ -14331,12 +20101,12 @@ export default function define(runtime, observer) {
   $def("_1intaie", "tag", [], _1intaie);  
   $def("_ziwv9c", "read", [], _ziwv9c);  
   $def("_1l4hr6l", null, ["md"], _1l4hr6l);  
-  $def("_zanj5n", "revertVariables", ["getVariableByPersistentId","runtime","realize"], _zanj5n);  
-  $def("_1cvp8ui", "rewindToTime", ["history","revertVariables"], _1cvp8ui);  
+  $def("_1hhkam2", "revertVariables", ["getVariableByPersistentId","runtime","history","initial_state","realize"], _1hhkam2);  
+  $def("_41vg0h", "rewindToTime", ["history","applyHistoryState"], _41vg0h);  
   $def("_1rfq6xd", null, ["md"], _1rfq6xd);  
   $def("_lh9ssh", "config", ["notebook_title","ensure_branch"], _lh9ssh);  
   $def("_qu2y2k", "historyUtils", [], _qu2y2k);  
-  $def("_84fm9q", "change_listener", ["runtime","viewof initial_state","persistentId","historyUtils","viewof module_load_time","read","onCodeChange","identity","modules","viewof history","Event","invalidation"], _84fm9q);  
+  $def("_5czkc4", "change_listener", ["runtime","viewof initial_state","persistentId","historyUtils","viewof module_load_time","read","onCodeChange","playback_suspend","identity","modules","viewof history","Event","invalidation"], _5czkc4);  
   $def("_1gmcocx", null, ["Inputs","history"], _1gmcocx);  
   $def("_ztvqq8", null, ["md"], _ztvqq8);  
   $def("_1klmxot", "commit_watermarks", [], _1klmxot);  
@@ -14375,7 +20145,11 @@ export default function define(runtime, observer) {
   main.define("http", ["module @tomlarkworthy/isomorphic-git-1-30-1", "@variable"], (_, v) => v.import("http", _));  
   main.define("JSZip", ["module @tomlarkworthy/jszip-3-10-1", "@variable"], (_, v) => v.import("JSZip", _));  
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
-  main.define("notebook_title", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("notebook_title", _));
+  main.define("notebook_title", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("notebook_title", _));  
+  $def("_sjnusq", "viewof playback", ["history","html","applyHistoryState","Event","invalidation"], _sjnusq);  
+  $def("_x7pc8l", "playback", ["Generators","viewof playback"], _x7pc8l);  
+  $def("_ncb8n9", "applyHistoryState", ["modules","playback_suspend","history","initial_state","getVariableByPersistentId","runtime","replay_pid_map","realize","tag"], _ncb8n9);  
+  $def("_v5cr66", "playback_suspend", [], _v5cr66);
   return main;
 }</script>
 
@@ -14567,1640 +20341,6 @@ export default function define(runtime, observer) {
   $def("_1vldl4e", "viewof example3", ["Inputs","localStorageView"], _1vldl4e);  
   $def("_fyim03", "example3", ["Generators","viewof example3"], _fyim03);  
   main.define("inspect", ["module @tomlarkworthy/inspector", "@variable"], (_, v) => v.import("inspect", _));
-  return main;
-}</script>
-
-<script id="@tomlarkworthy/lopepage" 
-  type="text/plain"
-  data-mime="application/javascript"
->
-const _1xyxga0 = function _page(htl,isOnObservableCom,lopeviz_handle_css,base_css,light_theme_css,commandPaletteStyles,commandPaletteOverlay,linkTo){return(
-htl.html`<div id="lopepage" style="height: ${
-  isOnObservableCom() ? "800px" : "100vh"
-}">
-  ${lopeviz_handle_css}
-  ${base_css}
-  ${light_theme_css}
-  ${commandPaletteStyles}
-${commandPaletteOverlay}
-  <style>
-    html body {
-      max-width: 100vw;
-    }
-    html {
-      padding: 0px !important;
-      margin: 0px !important;
-    }
-    #lopepage:has(.observablehq-root) > .module-explorer {
-      display: none;
-    }
-  </style>
-  <h1 style="display:none;">Lopepage</h1>
-  <div class="module-explorer">
-    <p>Lost? Open the <a href="${linkTo("@tomlarkworthy/module-selection", {
-      onObservable: false
-    })}">module explorer</a> or press CMD + K to open the command palatte.
-  </div>
-</div>`
-)};
-const _1ujnhdh = function _append_to_body(page)
-{
-    // If exported in headless mode, this will attach the page
-    if (!page.isConnected) {
-        document.body.appendChild(page);
-    }
-};
-const _1nv51s8 = function _testNavigation(htl,linkTo){return(
-htl.html`<h2>Manual Testing links</h2>
-<ul>
-<li><a href="https://observablehq.com/@tomlarkworthy/lopepage#testNavigation">refresh page</a></li>
-<li><a href="#testNavigation">reset view</a></li>
-<li><a href="${ linkTo('@tomlarkworthy/stream-operators', { onObservable: false }) }">stream-operators</a> module</li>
-<li><a href="${ linkTo('@tomlarkworthy/stream-operators#combineLatest', { onObservable: false }) }">stream-operators#combineLatest</a> 
-<li><a href="${ linkTo('@tomlarkworthy/runtime-sdk#observe', { onObservable: false }) }">runtime-sdk#observe</a> cell</li>
-</ul>`
-)};
-const _ydvyos = function _reload(Inputs){return(
-Inputs.button('reload')
-)};
-const _1we0ggl = (G, _) => G.input(_);
-const _plefwg = function _onLoadConfig(parseGoldenDSL,URLSearchParams,location)
-{
-    try {
-        return parseGoldenDSL(new URLSearchParams(location.hash.substring(1)).get('view'));
-    } catch (err) {
-        return undefined;
-    }
-};
-const _1nzpnqy = function _visualizer_cache(reload)
-{
-    reload;
-    return new Map();
-};
-const _1ojown8 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
-{
-  return function (container, component) {
-    appendScrollLog('modulePanel:enter', {
-      title: container?.title ?? null,
-      componentCell: component?.cell ?? null
-    });
-    const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
-    if (!moduleInfo) {
-      // Fall through to file attachment: titles like @user/notebook/path.ext
-      // resolve via the lopecode bootloader's contentSync DOM lookup.
-      const title = container?.title ?? null;
-      if (title) {
-        let node = file_attachment_cache.get(title);
-        if (!node) {
-          const r = window.lopecode?.contentSync?.(title);
-          if (r && r.status === 200 && r.bytes) {
-            node = renderFileAttachment(r.mime, r.bytes);
-            file_attachment_cache.set(title, node);
-            appendScrollLog('modulePanel:file_attachment_create', {
-              title,
-              mime: r.mime
-            });
-          }
-        }
-        if (node) {
-          const c_element = container.getElement();
-          if (node.parentNode !== c_element)
-            c_element.appendChild(node);
-          appendScrollLog('modulePanel:file_attachment_mount', { title });
-          return;
-        }
-      }
-      appendScrollLog('modulePanel:missing_moduleInfo', { title });
-      return;
-    }
-    const module = moduleInfo.module;
-    let node;
-    if (!visualizer_cache.has(module)) {
-      appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
-      node = visualizer(runtime, {
-        invalidation: new Promise(r => {
-        }),
-        module,
-        detachNodes: isOnObservableCom(),
-        filter: (cell_name, variables) => {
-          if (variables[0]._type !== 1)
-            return false;
-          if (typeof cell_name == 'string') {
-            if (cell_name.startsWith('dynamic '))
-              return false;
-          }
-          return true;
-        }
-      });
-      visualizer_cache.set(module, node);
-    } else {
-      node = visualizer_cache.get(module);
-      appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
-    }
-    const cell = module._scope.get(component.cell);
-    const scrollKey = scrollKeyFor(container);
-    fix_scroll(container, node, cell, scrollKey);
-    const el = container.getElement();
-    if (!el.__lope_scroll_bound) {
-      el.__lope_scroll_bound = true;
-      appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
-      const markUserScroll = () => {
-        el.__lope_user_scroll_at = Date.now();
-      };
-      el.addEventListener('wheel', markUserScroll, { passive: true });
-      el.addEventListener('touchmove', markUserScroll, { passive: true });
-      el.addEventListener('keydown', markUserScroll, { passive: true });
-      el.addEventListener('scroll', () => {
-        if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
-          appendScrollLog('scroll:skip_reflow', { title: container?.title ?? null });
-          return;
-        }
-        // Only cache scrolls following a genuine user gesture; reflow-induced
-        // scroll events (e.g. closing an adjacent panel) carry stale scrollTops.
-        if (Date.now() - (el.__lope_user_scroll_at || 0) > 400) {
-          appendScrollLog('scroll:skip_nonuser', { title: container?.title ?? null });
-          return;
-        }
-        const k = scrollKeyFor(container);
-        const scrollTop = el.scrollTop;
-        const scrollLeft = el.scrollLeft;
-        if (scrollTop == 0) {
-          appendScrollLog('modulePanel:skip 0 scroll', {
-            title: container?.title ?? null,
-            scrollKey
-          });
-          return;
-        }
-        scroll_cache.set(k, {
-          scrollTop,
-          scrollLeft,
-          t: Date.now()
-        });
-        appendScrollLog('scroll:event', {
-          k,
-          title: container?.title ?? null,
-          scrollTop,
-          scrollLeft
-        });
-      }, { passive: true });
-    }
-    // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
-    if (!container.__lope_destroy_bound) {
-      container.__lope_destroy_bound = true;
-      container.on('destroy', () => {
-        try {
-          if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
-            appendScrollLog('scroll:destroy_skip_reflow', { title: container?.title ?? null });
-            return;
-          }
-          const k = scrollKeyFor(container);
-          const scrollTop = el?.scrollTop;
-          const scrollLeft = el?.scrollLeft;
-          if (scrollTop == 0) {
-            appendScrollLog('scroll:skip 0 scroll', {
-              k,
-              key: container?.title ?? null,
-              scrollKey
-            });
-            return;
-          }
-          // do not skip 0 here: if the user is at top, preserve that state
-          scroll_cache.set(k, {
-            scrollTop,
-            scrollLeft,
-            t: Date.now()
-          });
-          appendScrollLog('scroll:destroy_capture', {
-            k,
-            title: container?.title ?? null,
-            scrollTop,
-            scrollLeft
-          });
-        } catch (e) {
-          appendScrollLog('scroll:destroy_capture:error', {
-            title: container?.title ?? null,
-            error: String(e)
-          });
-        }
-      });
-    }
-    // When GoldenLayout resizes this panel (e.g. an adjacent panel is closed) the
-    // browser can shift scrollTop; re-apply the user's cached position after the reflow.
-    if (!container.__lope_resize_bound) {
-      container.__lope_resize_bound = true;
-      container.on('resize', () => {
-        const rk = scrollKeyFor(container);
-        const cached = scroll_cache.get(rk);
-        if (!cached || cached.scrollTop == null)
-          return;
-        const c_el = container.getElement();
-        const at = Date.now();
-        scroll_cache.__reflowUntil = at + 800;
-        // The reflow can shift scrollTop in several passes (content relayout
-        // settles ~300ms later), so re-apply over a window. Bail if the user scrolls.
-        const apply = () => {
-          if ((c_el.__lope_user_scroll_at || 0) > at)
-            return;
-          if (c_el.scrollTop !== cached.scrollTop)
-            c_el.scrollTop = cached.scrollTop;
-          if (cached.scrollLeft != null && c_el.scrollLeft !== cached.scrollLeft)
-            c_el.scrollLeft = cached.scrollLeft;
-        };
-        requestAnimationFrame(apply);
-        for (const d of [
-            60,
-            150,
-            300,
-            450,
-            600
-          ])
-          setTimeout(apply, d);
-        appendScrollLog('scroll:resize_restore', {
-          k: rk,
-          title: container?.title ?? null,
-          scrollTop: cached.scrollTop
-        });
-      });
-    }
-    appendScrollLog('modulePanel:exit', {
-      title: container?.title ?? null,
-      scrollKey
-    });
-  };
-};
-const _1gm4gbf = function _blobPanel(){return(
-function (container, component) {
-    const node = document.createElement('iframe');
-    node.src = component.url;
-    const c_element = container.getElement();
-    const element = c_element.appendChild(node);
-}
-)};
-const _lxv2e2 = function _settings(){return(
-{
-    showMaximiseIcon: false,
-    showPopoutIcon: false,
-    showCloseIcon: true,
-    hasHeaders: true
-}
-)};
-const _lp1ggk = function _is_mobile(width){return(
-width < 800
-)};
-const _qbghwu = function _config(onLoadConfig,settings)
-{
-    if (onLoadConfig) {
-        return {
-            settings: settings,
-            content: [onLoadConfig]
-        };
-    }
-    return { settings: settings };
-};
-const _15lk82w = (M, _) => new M(_);
-const _1bki6eh = _ => _.generator;
-const _14z0bay = function _resize(Generators,addEventListener,invalidation,removeEventListener){return(
-Generators.observe(notify => {
-    notify(undefined);
-    addEventListener('resize', notify);
-    invalidation.then(() => removeEventListener('resize', notify));
-})
-)};
-const _18jv72h = function _layout(resize,gl,$0,page,modulePanel,blobPanel)
-{
-    // Removed resizing re-laying out because it causes problems with components that watch focus
-    // when the the layout is redone, the components are killed and removed, damaging focus state.
-    // mobile keyboards cause a resize, breaking the component that has focus
-    resize;
-    let layout = this;
-    if (!layout) {
-        layout = new gl.GoldenLayout($0.value, page);
-        layout.registerComponent('module', modulePanel);
-        layout.registerComponent('blob', blobPanel);
-        layout.init();
-    } else {
-        layout.updateSize();
-    }
-    // TODO layout destroy is destructive
-    // invalidation.then(() => {
-    //   // avoid layouts stacking up
-    //   layout.destroy();
-    // });
-    return layout;
-};
-const _tsjb2x = function _layout_state(appendScrollLog,layout,gl,$0)
-{
-    appendScrollLog('layout_state:bind', { hasLayout: !!layout });
-    return layout.on('stateChanged', () => {
-        appendScrollLog('layout:stateChanged', {});
-        const state = gl.LayoutConfig.fromResolved(layout.toConfig());
-        $0.value = state;
-        appendScrollLog('layout:stateChanged:config_updated', { rootType: state?.root?.type ?? null });
-    });
-};
-const _11nrwvj = function _lopepageModule(thisModule){return(
-thisModule()
-)};
-const _r97569 = (G, _) => G.input(_);
-const _1sp5wo4 = function _16(md){return(
-md`## Scrolling
-
-Scrolling has been a mess to develop. The thing that finally fixed it was \`scroll_fix_sync_layout\`. I suspect fix_scroll is over-complex.`
-)};
-const _1ts23ma = function _scrollDebug(Inputs){return(
-Inputs.toggle({
-    label: 'enable debug scroll?',
-    value: true
-})
-)};
-const _7jxivy = (G, _) => G.input(_);
-const _1f2wuqm = function _appendScrollLog($0,$1){return(
-(type, detail = {}) => {
-    if (!$0.value)
-        return null;
-    const evt = {
-        t: Date.now(),
-        type: String(type),
-        ...detail
-    };
-    $1.value = ($1.value || []).concat([evt]);
-    return evt;
-}
-)};
-const _1nbnzwx = function _scrollLog(scrollDebug){return(
-scrollDebug ? [] : []
-)};
-const _1f7xtz1 = (M, _) => new M(_);
-const _1dyz4o0 = _ => _.generator;
-const _1d1nkw9 = function _scrollKeyFor(appendScrollLog)
-{
-    return container => {
-        // can return undefined if the container is loading still
-        const key = container?.title;
-        appendScrollLog('scrollKeyFor:', { key });
-        return key;
-    };
-};
-const _tb217h = function _scroll_cache(){return(
-new Map()
-)};
-const _12p8mg7 = function _fix_scroll(scroll_cache,scrollKeyFor,appendScrollLog)
-{
-  return function (container, node, cell_variable, key) {
-    scroll_cache.__reflowUntil = Date.now() + 600;
-    // suppress reflow-induced scroll events that clobber the cache
-    const c_element = container.getElement();
-    let k = scrollKeyFor(container);
-    appendScrollLog('fix_scroll:enter', {
-      title: container?.title ?? null,
-      k,
-      cell: cell_variable?._name ?? null
-    });
-    if (node && node.parentNode !== c_element) {
-      c_element.appendChild(node);
-      appendScrollLog('fix_scroll:append_node', {
-        title: container?.title ?? null,
-        k
-      });
-    }
-    const writeCache = (scrollTop, scrollLeft, why) => {
-      scroll_cache.set(k, {
-        scrollTop,
-        scrollLeft,
-        t: Date.now()
-      });
-      appendScrollLog('scroll_cache:write', {
-        k,
-        scrollTop,
-        scrollLeft,
-        why
-      });
-    };
-    const scrollToCellIfPossible = why => {
-      if (!cell_variable)
-        return false;
-      const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
-      if (!dom) {
-        appendScrollLog('scroll:cell_dom_not_found', {
-          k,
-          why,
-          cell: cell_variable?._name ?? null
-        });
-        return false;
-      }
-      const top = dom.offsetTop - c_element.offsetTop;
-      const left = c_element.scrollLeft;
-      c_element.scrollTop = top;
-      appendScrollLog('scroll:set', {
-        k,
-        why: `${ why }:cell`,
-        scrollTop: top,
-        scrollLeft: left,
-        cell: cell_variable?._name ?? null
-      });
-      writeCache(top, left, `${ why }:cell`);
-      return true;
-    };
-    const restoreFromCache = why => {
-      k = scrollKeyFor(container);
-      const cached = scroll_cache.get(k);
-      appendScrollLog('scroll:restore_attempt', {
-        k,
-        why,
-        cachedScrollTop: cached?.scrollTop ?? null,
-        cachedScrollLeft: cached?.scrollLeft ?? null
-      });
-      if (!cached) {
-        appendScrollLog('scroll:restore_no_scroll', {
-          k,
-          why
-        });
-        return;
-      }
-      if (cached.scrollTop != null)
-        c_element.scrollTop = cached.scrollTop;
-      if (cached.scrollLeft != null)
-        c_element.scrollLeft = cached.scrollLeft;
-      appendScrollLog('scroll:restore_applied', {
-        k,
-        why,
-        scrollTop: cached.scrollTop ?? null,
-        scrollLeft: cached.scrollLeft ?? null,
-        scrollTopFinal: c_element.scrollTop,
-        scrollLeftFinal: c_element.scrollLeft
-      });
-    };
-    const setScroll = (why = 'setScroll') => {
-      if (scrollToCellIfPossible(why))
-        return;
-      restoreFromCache(why);
-    };
-    const retryFrames = 6;
-    for (let i = 0; i < retryFrames; i++) {
-      requestAnimationFrame(() => {
-        k = scrollKeyFor(container);
-        appendScrollLog('fix_scroll:raf_retry', {
-          i,
-          k,
-          title: container?.title ?? null
-        });
-        setScroll(`raf:${ i }`);
-      });
-    }
-    appendScrollLog('fix_scroll:exit', {
-      k,
-      title: container?.title ?? null
-    });
-  };
-};
-const _arfw00 = function _scroll_fix_sync_layout(sync_layout_to_url,layout,appendScrollLog,modulePanel)
-{
-    sync_layout_to_url;
-    let timeout = null;
-    const listComponentItems = () => {
-        const out = [];
-        const walk = item => {
-            if (!item)
-                return;
-            if (item.isComponent || item.type === 'component')
-                out.push(item);
-            const kids = item.contentItems || item.content || [];
-            for (const k of kids)
-                walk(k);
-        };
-        walk(layout.root);
-        return out;
-    };
-    const items = listComponentItems();
-    appendScrollLog('scroll:reapply_all:begin', { count: items.length });
-    for (const it of items) {
-        try {
-            const container = it.container;
-            const title = container?.title ?? it.title ?? null;
-            if (!container || !title)
-                continue;
-            const st = it.componentState ?? it.config?.componentState ?? it._config?.componentState ?? it._state ?? {};
-            modulePanel(container, { cell: st?.cell });
-        } catch (e) {
-            appendScrollLog('scroll:reapply_all:error', { error: String(e) });
-        }
-    }
-    return true;
-};
-const _3nwpp4 = function _URLrouting(md){return(
-md`## URL Sync
-
-### Goals
-1. **Non-destructive navigation:** mutate an existing GoldenLayout (GL) instance (add/remove/reorder items) rather than rebuilding.
-2. **Refresh restores what you see:** the URL eventually contains the full serialized GL tree in **\`view=\`**.
-3. **Links are “intents”:** in-app links should not rewrite \`view=\` at click time.
-
----
-
-## State model
-
-### Canonical, persistent state
-- **\`view=<DSL>\`** is the canonical serialized GL layout (single source of truth after boot).
-
-### One-shot intent params (cleared after commit)
-- \`open=<moduleOrModule#cell>\`
-- \`close=<...>\` (reserved)
-- \`focus=<...>\` (reserved)
-- \`from=<module>\` (optional placement hint)
-
----
-
-## Dataflow
-
-### 1) URL → desired layout (intent overlay)
-- Parse \`view\` with \`parseGoldenDSL\` to get the desired root config.
-- If \`open=\` exists, **overlay** it into the parsed config by inserting the target module into the *first stack* (and optional \`componentState.cell\`).
-
-Implemented in: **\`sync_layout_from_url\`**.
-
-### 2) Desired layout → live GL (non-destructive when possible)
-- Try **\`treeSyncGolden(layout, desiredRoot)\`** to:
-  - add missing module tabs
-  - remove extra module tabs
-  - reorder tabs to match the DSL
-  - ensure container shapes (row/column/stack) match where possible
-- If tree sync can’t reconcile safely, **fallback to \`layout.loadLayout(...)\`**.
-
-Implemented in: **\`treeSyncGolden\`** + \`sync_layout_from_url\`.
-
-### 3) Live GL → URL persistence (“commit then clear”)
-- GL emits \`stateChanged\` → update \`mutable config\` from \`layout.toConfig()\`.
-- Serialize \`config.root\` with \`serializeGoldenDSL\` and write it to **\`view=\`**.
-- Clear one-shot intent params (\`open/close/focus/from\`) so they are not re-applied on refresh.
-
-Implemented in: **\`sync_layout_to_url\`** via \`history.replaceState(...)\`.
-
----
-
-## Unit test gate (safety check)
-Before \`sync_layout_to_url\` is allowed to persist \`view=\`, a **roundtrip invariant** must hold:
-
-- Compute an expected “pre” DSL:
-  - normalize weights (e.g. S100/R100/C100)
-  - apply the same \`open=\` overlay used by \`sync_layout_from_url\`
-- Compare it to the “post” DSL obtained after applying the URL to the live layout and re-serializing.
-
-If **\`test_url_roundtrip\`** throws or returns non-\`true\`, **\`sync_layout_to_url\`** exits early (no canonical \`view=\` writes). This prevents committing a drifting/incorrect \`view=\` during development and makes URL persistence self-checking.
-
-Implemented in: **\`test_url_roundtrip\`** and enforced at the top of **\`sync_layout_to_url\`**.
-`
-)};
-const _14te9pl = function _sync_layout_from_url(reload,resize,URLSearchParams,hash,appendScrollLog,parseGoldenDSL,gl,layout,serializeGoldenDSL,treeSyncGolden,invalidation)
-{
-  reload;
-  resize;
-  const params = new URLSearchParams(String(hash || '').replace(/^#/, ''));
-  const view = params.get('view');
-  const open = params.get('open');
-  appendScrollLog('url:sync_from:begin', {
-    hash: String(hash || ''),
-    view,
-    open
-  });
-  const diag = {
-    preURL: view ?? null,
-    postURL: null,
-    method: null,
-    status: 'skipped',
-    reason: '',
-    error: null,
-    open: null,
-    openApplied: false
-  };
-  let desiredRoot;
-  try {
-    desiredRoot = parseGoldenDSL(view);
-  } catch (e) {
-    diag.method = 'parse';
-    diag.status = 'error';
-    diag.reason = 'parseGoldenDSL failed';
-    diag.error = String(e);
-    appendScrollLog('url:sync_from:error', {
-      where: 'parse',
-      error: diag.error
-    });
-    return diag;
-  }
-  if (!view && open) {
-    try {
-      const resolved = gl.LayoutConfig.fromResolved(layout.toConfig());
-      desiredRoot = resolved?.root ?? layout.toConfig()?.root ?? layout.toConfig()?.content?.[0];
-      if (desiredRoot) {
-        diag.preURL = serializeGoldenDSL(desiredRoot);
-        appendScrollLog('url:sync_from:fallback_to_current_layout', {
-          preURL: diag.preURL,
-          open
-        });
-      }
-    } catch (e) {
-      appendScrollLog('url:sync_from:fallback_to_current_layout:error', { error: String(e) });
-    }
-    if (!desiredRoot) {
-      // Lazily synthesize an empty stack so the open overlay below can populate it.
-      desiredRoot = {
-        type: 'stack',
-        content: []
-      };
-      try {
-        diag.preURL = serializeGoldenDSL(desiredRoot);
-      } catch {
-        diag.preURL = 'S100()';
-      }
-      appendScrollLog('url:sync_from:synthesize_empty_stack', {
-        preURL: diag.preURL,
-        open
-      });
-    }
-  }
-  if (!desiredRoot) {
-    diag.method = 'parse';
-    diag.status = 'error';
-    diag.reason = 'parseGoldenDSL returned falsy';
-    appendScrollLog('url:sync_from:error', {
-      where: 'parse',
-      error: diag.reason
-    });
-    return diag;
-  }
-  const findFirstStack = node => {
-    if (!node)
-      return null;
-    if (node.type === 'stack')
-      return node;
-    for (const c of node.content || []) {
-      const f = findFirstStack(c);
-      if (f)
-        return f;
-    }
-    return null;
-  };
-  const findExistingModule = (node, title) => {
-    if (!node)
-      return null;
-    if (node.type === 'component' && (node.componentType === 'module' || node.componentName === 'module') && node.title === title) {
-      return node;
-    }
-    for (const c of node.content || []) {
-      const f = findExistingModule(c, title);
-      if (f)
-        return f;
-    }
-    return null;
-  };
-  if (open) {
-    const [moduleTitleRaw, cellRaw] = String(open).split('#');
-    const moduleTitle = (moduleTitleRaw || '').trim();
-    const cell = (cellRaw || '').trim() || null;
-    if (moduleTitle) {
-      diag.open = {
-        moduleTitle,
-        cell
-      };
-      const existingAnywhere = findExistingModule(desiredRoot, moduleTitle);
-      if (existingAnywhere) {
-        existingAnywhere.componentState = existingAnywhere.componentState || {};
-        if (cell)
-          existingAnywhere.componentState.cell = cell;
-        appendScrollLog('url:sync_from:overlay_open:update_existing', {
-          moduleTitle,
-          cell
-        });
-        diag.openApplied = true;
-      } else {
-        const stack = findFirstStack(desiredRoot);
-        if (stack) {
-          stack.content = stack.content || [];
-          stack.content.push({
-            type: 'component',
-            title: moduleTitle,
-            componentType: 'module',
-            componentName: 'module',
-            componentState: cell ? { cell } : {}
-          });
-          appendScrollLog('url:sync_from:overlay_open:add', {
-            moduleTitle,
-            cell
-          });
-          diag.openApplied = true;
-        } else {
-          appendScrollLog('url:sync_from:overlay_open:no_stack_found', {
-            moduleTitle,
-            cell
-          });
-        }
-      }
-    }
-  }
-  const doLoadLayout = () => {
-    if (typeof layout?.loadLayout !== 'function')
-      throw new Error('layout.loadLayout not available');
-    appendScrollLog('layout:loadLayout:call', {
-      desiredType: desiredRoot?.type ?? null,
-      open: diag.open?.moduleTitle ?? null
-    });
-    layout.loadLayout({
-      settings: {},
-      content: [desiredRoot]
-    });
-  };
-  try {
-    const res = treeSyncGolden(layout, desiredRoot);
-    if (res?.status === 'fallback') {
-      diag.method = 'loadLayout';
-      diag.status = 'fallback';
-      diag.reason = res.reason || 'treeSync requested fallback';
-      appendScrollLog('url:sync_from:treesync_fallback', { reason: diag.reason });
-      try {
-        doLoadLayout();
-      } catch (e2) {
-        diag.status = 'error';
-        diag.reason = 'loadLayout failed after treeSync fallback';
-        diag.error = String(e2);
-        appendScrollLog('url:sync_from:error', {
-          where: 'loadLayout_after_fallback',
-          error: diag.error
-        });
-      }
-    } else {
-      diag.method = 'treeSync';
-      diag.status = 'synced';
-      appendScrollLog('url:sync_from:treesync_ok', {});
-    }
-  } catch (e) {
-    diag.method = 'loadLayout';
-    diag.status = 'fallback';
-    diag.reason = 'exception during treeSync';
-    diag.error = String(e);
-    appendScrollLog('url:sync_from:treesync_exception', { error: diag.error });
-    try {
-      doLoadLayout();
-    } catch (e2) {
-      diag.status = 'error';
-      diag.reason = 'loadLayout failed after treeSync exception';
-      diag.error = `${ String(e) }; loadLayout: ${ String(e2) }`;
-      appendScrollLog('url:sync_from:error', {
-        where: 'loadLayout_after_exception',
-        error: diag.error
-      });
-    }
-  }
-  try {
-    const resolved = gl?.LayoutConfig?.fromResolved ? gl.LayoutConfig.fromResolved(layout.toConfig()) : null;
-    const root = resolved?.root ?? layout.toConfig()?.root ?? layout.toConfig()?.content?.[0];
-    diag.postURL = root ? serializeGoldenDSL(root) : null;
-  } catch (e) {
-    diag.postURL = null;
-    if (!diag.error)
-      diag.error = `serialize failed: ${ String(e) }`;
-    appendScrollLog('url:sync_from:serialize_failed', { error: String(e) });
-  }
-  appendScrollLog('url:sync_from:end', {
-    status: diag.status,
-    method: diag.method,
-    reason: diag.reason || null,
-    preURL: diag.preURL,
-    postURL: diag.postURL
-  });
-  invalidation.then(() => {
-  });
-  return diag;
-};
-const _1l50a0d = function _sync_layout_to_url(appendScrollLog,sync_layout_from_url,config,test_url_roundtrip,serializeGoldenDSL,location,setHashURL)
-{
-    appendScrollLog('url:sync_to:tick', {
-        fromStatus: sync_layout_from_url?.status ?? null,
-        hasRoot: !!config?.root
-    });
-    if (test_url_roundtrip !== true) {
-        appendScrollLog('url:sync_to:blocked', { reason: 'test_url_roundtrip != true' });
-        return;
-    }
-    if (sync_layout_from_url?.status === 'error') {
-        appendScrollLog('url:sync_to:blocked', { reason: 'sync_layout_from_url status=error' });
-        return;
-    }
-    if (!config?.root) {
-        appendScrollLog('url:sync_to:blocked', { reason: 'config.root missing' });
-        return;
-    }
-    let dsl;
-    try {
-        dsl = serializeGoldenDSL(config.root);
-    } catch (e) {
-        appendScrollLog('url:sync_to:serialize_failed', { error: String(e) });
-        return;
-    }
-    // Parse hash manually to avoid URLSearchParams percent-encoding view= values
-    // like R100(S50(@tomlarkworthy/lopepage)) → R100%28S50%28%40tomlarkworthy%2Flopepage%29%29
-    const rawHash = String(location.hash || '').replace(/^#/, '');
-    const knownIntents = new Set([
-        'open',
-        'close',
-        'focus',
-        'from'
-    ]);
-    // Split into key=value pairs, preserving original encoding
-    const parts = rawHash.split('&').filter(Boolean);
-    const extra = [];
-    // unknown params to preserve (e.g. cc=TOKEN)
-    let currentView = null;
-    let hasIntent = false;
-    for (const part of parts) {
-        const eq = part.indexOf('=');
-        const key = eq >= 0 ? part.slice(0, eq) : part;
-        const val = eq >= 0 ? part.slice(eq + 1) : '';
-        if (key === 'view') {
-            currentView = decodeURIComponent(val);
-        } else if (knownIntents.has(key)) {
-            hasIntent = true;
-        } else {
-            extra.push(part);    // preserve verbatim
-        }
-    }
-    if (currentView === dsl) {
-        appendScrollLog('url:sync_to:no_change', { hasIntent });
-        if (hasIntent) {
-            // Rebuild without intents, keep view + extras
-            const newHash = '#view=' + dsl + (extra.length ? '&' + extra.join('&') : '');
-            const res = setHashURL(newHash);
-            appendScrollLog('url:sync_to:clear_intents', { result: res });
-        }
-        return;
-    }
-    const newHash = '#view=' + dsl + (extra.length ? '&' + extra.join('&') : '');
-    appendScrollLog('url:sync_to:write_view', {
-        oldHash: String(location.hash || ''),
-        newHash,
-        dsl
-    });
-    if (newHash !== location.hash) {
-        const res = setHashURL(newHash);
-        appendScrollLog('url:sync_to:setHashURL_result', { result: res });
-    }
-};
-const _jcy1xg = function _test_url_roundtrip(sync_layout_from_url)
-{
-    const d = sync_layout_from_url;
-    if (!d || d.status === 'skipped')
-        return true;
-    if (d.status === 'error')
-        throw new Error(d.error || d.reason || 'sync error');
-    if (d.postURL == null)
-        throw new Error(d.error || 'postURL missing');
-    const normalize = dsl => {
-        if (dsl == null)
-            return dsl;
-        let s = String(dsl);
-        s = s.replace(/S\d+(?=\()/g, 'S100').replace(/R\d+(?=\()/g, 'R100').replace(/C\d+(?=\()/g, 'C100');
-        s = s.replace(/S(?=\()/g, 'S100').replace(/R(?=\()/g, 'R100').replace(/C(?=\()/g, 'C100');
-        return s;
-    };
-    const overlayOpen = (dsl, openTarget) => {
-        if (!openTarget?.moduleTitle)
-            return dsl;
-        const title = String(openTarget.moduleTitle);
-        if (dsl && dsl.includes(title))
-            return dsl;
-        const s = String(dsl ?? '');
-        if (!/S100\(/.test(s)) {
-            return `S100(${ title })`;
-        }
-        return s.replace(/S100\(([^)]*)\)/, (m, inner) => {
-            const trimmed = String(inner || '').trim();
-            const next = trimmed ? `${ trimmed },${ title }` : title;
-            return `S100(${ next })`;
-        });
-    };
-    const preRaw = d.preURL ?? 'S()';
-    const preWithIntent = overlayOpen(normalize(preRaw), d.open);
-    const post = normalize(d.postURL);
-    if (preWithIntent !== post) {
-        throw new Error(`view URL drift: preURL != postURL\n` + `preURL=${ String(preRaw) }\n` + `open=${ d.open?.moduleTitle || '' }\n` + `postURL=${ String(d.postURL) }\n` + `normalizedPreWithIntent=${ String(preWithIntent) }\n` + `normalizedPost=${ String(post) }\n` + `method=${ d.method } status=${ d.status } reason=${ d.reason || '' }`);
-    }
-    return true;
-};
-const _1yxu9kf = function _setHashURL(location,appendScrollLog,history){return(
-function setHashURL(newHash) {
-    const h = String(newHash ?? '');
-    const hash = h.startsWith('#') ? h : `#${ h }`;
-    const url = new URL(location.href);
-    url.hash = hash;
-    const href = url.toString();
-    appendScrollLog('url:setHashURL:attempt', {
-        hash,
-        href
-    });
-    try {
-        history.replaceState(null, '', href);
-        const res = {
-            ok: true,
-            method: 'replaceState',
-            href,
-            hash
-        };
-        appendScrollLog('url:setHashURL:success', res);
-        return res;
-    } catch (e) {
-        const a = document.createElement('a');
-        a.href = href;
-        a.rel = 'noreferrer';
-        a.style.display = 'none';
-        (document.body || document.documentElement).appendChild(a);
-        a.click();
-        a.remove();
-        const res = {
-            ok: false,
-            method: 'synthetic-click',
-            href,
-            hash,
-            error: String(e)
-        };
-        appendScrollLog('url:setHashURL:fallback', res);
-        return res;
-    }
-}
-)};
-const _1zkl8r = function _treeSyncGolden(appendScrollLog,gl){return(
-function treeSyncGoldenFactory(gl) {
-    const isCompCfg = n => n && n.type === 'component';
-    const isContCfg = n => n && (n.type === 'row' || n.type === 'column' || n.type === 'stack');
-    const desiredModuleKey = cfg => isCompCfg(cfg) && (cfg.componentType === 'module' || cfg.componentName === 'module') && cfg.title ? `module:${ cfg.title }` : null;
-    const liveModuleKey = item => {
-        if (!item)
-            return null;
-        if (!(item.isComponent || item.type === 'component'))
-            return null;
-        const t = item.componentType || item.componentName;
-        return t === 'module' && item.title ? `module:${ item.title }` : null;
-    };
-    const cloneCfg = cfg => {
-        const c = JSON.parse(JSON.stringify(cfg));
-        if (c.type === 'component' && (c.componentType === 'module' || c.componentName === 'module')) {
-            c.componentType = 'module';
-            c.componentName = 'module';
-            c.componentState = c.componentState || {};
-        }
-        return c;
-    };
-    function indexLiveModules(stackLive) {
-        const map = new Map();
-        for (const child of stackLive?.contentItems || []) {
-            const k = liveModuleKey(child);
-            if (k)
-                map.set(k, child);
-        }
-        return map;
-    }
-    function setLiveComponentStateCell(liveItem, cell) {
-        if (!liveItem || !cell)
-            return false;
-        let changed = false;
-        liveItem.componentState = liveItem.componentState || {};
-        if (liveItem.componentState.cell !== cell) {
-            liveItem.componentState.cell = cell;
-            changed = true;
-        }
-        const configs = [
-            liveItem.config,
-            liveItem._config,
-            liveItem._state
-        ].filter(Boolean);
-        for (const cfg of configs) {
-            cfg.componentState = cfg.componentState || {};
-            if (cfg.componentState.cell !== cell) {
-                cfg.componentState.cell = cell;
-                changed = true;
-            }
-        }
-        return changed;
-    }
-    function syncStack(stackLive, desiredStackCfg) {
-        appendScrollLog('treeSync:syncStack:enter', {
-            title: stackLive?.parent?.title ?? stackLive?.title ?? null,
-            desiredCount: (desiredStackCfg?.content || []).length,
-            liveCount: (stackLive?.contentItems || []).length
-        });
-        const desiredComps = (desiredStackCfg.content || []).filter(isCompCfg);
-        let liveByKey = indexLiveModules(stackLive);
-        for (let i = 0; i < desiredComps.length; i++) {
-            const d = desiredComps[i];
-            const k = desiredModuleKey(d);
-            if (!k)
-                continue;
-            if (!liveByKey.has(k)) {
-                let before = null;
-                for (let j = i + 1; j < desiredComps.length; j++) {
-                    const k2 = desiredModuleKey(desiredComps[j]);
-                    if (k2 && liveByKey.has(k2)) {
-                        before = liveByKey.get(k2);
-                        break;
-                    }
-                }
-                const idx = before ? (stackLive.contentItems || []).indexOf(before) : (stackLive.contentItems || []).length;
-                appendScrollLog('treeSync:stack:addItem', {
-                    key: k,
-                    title: d?.title ?? null,
-                    idx,
-                    beforeKey: before ? liveModuleKey(before) : null
-                });
-                if (typeof stackLive.addItem !== 'function')
-                    return {
-                        status: 'fallback',
-                        reason: 'stack missing addItem'
-                    };
-                stackLive.addItem(cloneCfg(d), idx);
-                liveByKey = indexLiveModules(stackLive);
-            }
-        }
-        const desiredKeys = new Set(desiredComps.map(desiredModuleKey).filter(Boolean));
-        for (const child of Array.from(stackLive?.contentItems || [])) {
-            const k = liveModuleKey(child);
-            if (k && !desiredKeys.has(k) && typeof child.remove === 'function') {
-                appendScrollLog('treeSync:stack:remove', {
-                    key: k,
-                    title: child?.title ?? null
-                });
-                child.remove();
-            }
-        }
-        const order = desiredComps.map(desiredModuleKey).filter(Boolean);
-        const byKey = indexLiveModules(stackLive);
-        for (let i = 0; i < order.length; i++) {
-            const item = byKey.get(order[i]);
-            if (!item)
-                continue;
-            const curIdx = (stackLive.contentItems || []).indexOf(item);
-            if (curIdx !== i && typeof stackLive.removeChild === 'function' && typeof stackLive.addChild === 'function') {
-                appendScrollLog('treeSync:stack:reorder', {
-                    key: order[i],
-                    from: curIdx,
-                    to: i
-                });
-                stackLive.removeChild(item, true);
-                stackLive.addChild(item, i, false);
-            }
-        }
-        {
-            const byKey2 = indexLiveModules(stackLive);
-            for (const d of desiredComps) {
-                const k = desiredModuleKey(d);
-                const desiredCell = d?.componentState?.cell ?? null;
-                if (!k || !desiredCell)
-                    continue;
-                const liveItem = byKey2.get(k);
-                if (!liveItem)
-                    continue;
-                const changed = setLiveComponentStateCell(liveItem, desiredCell);
-                if (changed) {
-                    appendScrollLog('treeSync:stack:sync_componentState_cell', {
-                        key: k,
-                        title: liveItem?.title ?? null,
-                        cell: desiredCell
-                    });
-                }
-            }
-        }
-        appendScrollLog('treeSync:syncStack:exit', { liveCount: (stackLive?.contentItems || []).length });
-        return { status: 'synced' };
-    }
-    function ensureContainerChild(parentLive, idx, desiredChildCfg) {
-        const liveChild = parentLive?.contentItems?.[idx];
-        if (liveChild && liveChild.type === desiredChildCfg.type)
-            return liveChild;
-        if (liveChild && typeof liveChild.remove === 'function') {
-            appendScrollLog('treeSync:container:remove_child_for_type_mismatch', {
-                idx,
-                liveType: liveChild?.type ?? null,
-                desiredType: desiredChildCfg?.type ?? null
-            });
-            liveChild.remove();
-        }
-        if (typeof parentLive?.addItem !== 'function')
-            return null;
-        appendScrollLog('treeSync:container:addItem', {
-            idx,
-            type: desiredChildCfg?.type ?? null
-        });
-        parentLive.addItem({
-            type: desiredChildCfg.type,
-            content: []
-        }, idx);
-        return parentLive?.contentItems?.[idx] || null;
-    }
-    function isContainerItem(item) {
-        if (!item)
-            return false;
-        if (item.isComponent)
-            return false;
-        return item.type === 'row' || item.type === 'column' || item.type === 'stack';
-    }
-    function syncContainer(containerLive, desiredCfg) {
-        if (!containerLive || !desiredCfg || !Array.isArray(desiredCfg.content))
-            return { status: 'synced' };
-        const desiredChildren = desiredCfg.content.filter(isContCfg);
-        for (let i = 0; i < desiredChildren.length; i++)
-            ensureContainerChild(containerLive, i, desiredChildren[i]);
-        const liveContainers = (containerLive.contentItems || []).filter(isContainerItem);
-        while (liveContainers.length > desiredChildren.length) {
-            const last = (containerLive.contentItems || []).slice().reverse().find(isContainerItem);
-            if (!last)
-                break;
-            appendScrollLog('treeSync:container:remove_extra_container', { type: last?.type ?? null });
-            if (typeof last.remove === 'function')
-                last.remove();
-            liveContainers.pop();
-        }
-        for (let i = 0; i < desiredChildren.length; i++) {
-            const d = desiredChildren[i];
-            const l = containerLive.contentItems?.[i];
-            if (!l)
-                continue;
-            if (l.type !== d.type)
-                return {
-                    status: 'fallback',
-                    reason: `child type mismatch @${ i } live=${ l.type } desired=${ d.type }`
-                };
-            if (d.type === 'stack') {
-                const r = syncStack(l, d);
-                if (r?.status === 'fallback')
-                    return r;
-            } else {
-                const r = syncContainer(l, d);
-                if (r?.status === 'fallback')
-                    return r;
-            }
-        }
-        return { status: 'synced' };
-    }
-    return function treeSync(layout, desiredRootCfg) {
-        appendScrollLog('treeSync:enter', {
-            desiredType: desiredRootCfg?.type ?? null,
-            hasRoot: !!layout?.root
-        });
-        if (!layout?.root || !desiredRootCfg)
-            return { status: 'noop' };
-        const liveTop = layout.root.contentItems?.[0];
-        if (!liveTop)
-            return {
-                status: 'fallback',
-                reason: 'no live top'
-            };
-        if (liveTop.type !== desiredRootCfg.type) {
-            const out = {
-                status: 'fallback',
-                reason: `top type mismatch live=${ liveTop.type } desired=${ desiredRootCfg.type }`
-            };
-            appendScrollLog('treeSync:fallback', out);
-            return out;
-        }
-        const out = desiredRootCfg.type === 'stack' ? syncStack(liveTop, desiredRootCfg) : syncContainer(liveTop, desiredRootCfg);
-        if (out?.status === 'fallback')
-            appendScrollLog('treeSync:fallback', out);
-        else
-            appendScrollLog('treeSync:synced', { status: out?.status ?? 'synced' });
-        return out;
-    };
-}(gl)
-)};
-const _133ahw5 = function _background_jobs(onLoadConfig,layout_state,sync_layout_from_url,test_url_roundtrip,sync_layout_to_url,runtime,navigator_jobs,commandPaletteKeybinding,auto_attach,scroll_fix_sync_layout,commit_history,replay_git,change_listener,cc_chat)
-{
-  onLoadConfig;
-  layout_state;
-  sync_layout_from_url;
-  test_url_roundtrip;
-  sync_layout_to_url;
-  runtime;
-  navigator_jobs;
-  commandPaletteKeybinding;
-  auto_attach;
-  scroll_fix_sync_layout;
-  // history
-  commit_history;
-  replay_git;
-  change_listener;
-  cc_chat;
-};
-const _1n78po6 = function _imports(md){return(
-md`## Imports`
-)};
-const _b2c0kp = function _32(exporter){return(
-exporter()
-)};
-const _1ey5aow = function _dragOutGrips(layout,invalidation)
-{
-    function readModuleSource(name) {
-        const r = window.lopecode?.contentSync?.(name);
-        if (!r || r.status !== 200 || !r.bytes)
-            return null;
-        return new TextDecoder().decode(r.bytes);
-    }
-    function filenameFor(name) {
-        let m = name.match(/^@([A-Za-z0-9-]+)\/([A-Za-z0-9-]+)$/);
-        if (m)
-            return `at_${ m[1] }_${ m[2] }.js`;
-        m = name.match(/^d\/([A-Za-z0-9]+)(@\d+)?$/);
-        if (m)
-            return `d_${ m[1] }${ m[2] ?? '' }.js`;
-        return name.replace(/[/]/g, '_') + '.js';
-    }
-    function flashGrip(grip) {
-        const prev = grip.style.opacity;
-        grip.style.opacity = '1';
-        setTimeout(() => {
-            grip.style.opacity = prev;
-        }, 350);
-    }
-    function hookTab(tabEl) {
-        if (tabEl.__lopepageGripHooked)
-            return;
-        tabEl.__lopepageGripHooked = true;
-        const grip = document.createElement('span');
-        grip.className = 'lm_drag_out_grip';
-        grip.title = 'Click to copy source \xB7 Drag out as .js';
-        grip.setAttribute('draggable', 'true');
-        grip.innerHTML = `<svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round" style="display:block"><rect x="5.5" y="5.5" width="9" height="9" rx="1.5"/><path d="M2.5 10.5V3a.5.5 0 01.5-.5h7.5"/></svg>`;
-        Object.assign(grip.style, {
-            display: 'inline-block',
-            width: '12px',
-            height: '12px',
-            verticalAlign: '3.5px',
-            marginLeft: '-7px',
-            marginRight: '2px',
-            cursor: 'pointer',
-            opacity: '0.55',
-            userSelect: 'none',
-            lineHeight: '0',
-            color: 'currentColor'
-        });
-        [
-            'pointerdown',
-            'mousedown',
-            'touchstart'
-        ].forEach(ev => {
-            grip.addEventListener(ev, e => e.stopPropagation(), { capture: true });
-        });
-        grip.addEventListener('click', e => {
-            e.stopPropagation();
-            const t = tabEl.querySelector('.lm_title')?.textContent || '';
-            if (!t)
-                return;
-            const source = readModuleSource(t);
-            if (!source) {
-                console.warn('[grip click] no source for:', t);
-                return;
-            }
-            navigator.clipboard?.writeText?.(source).then(() => {
-                console.log('[grip click] copied source for:', t, `(${ source.length } chars)`);
-                flashGrip(grip);
-            }).catch(err => console.warn('[grip click] clipboard failed:', err));
-        });
-        grip.addEventListener('dragstart', e => {
-            e.stopPropagation();
-            const title = tabEl.querySelector('.lm_title')?.textContent || '';
-            const source = readModuleSource(title);
-            if (!source) {
-                e.dataTransfer.setData('text/plain', `// no source for ${ title }`);
-                return;
-            }
-            const filename = filenameFor(title);
-            const dataUrl = 'data:text/javascript;base64,' + btoa(unescape(encodeURIComponent(source)));
-            e.dataTransfer.setData('DownloadURL', `text/javascript:${ filename }:${ dataUrl }`);
-            e.dataTransfer.setData('text/plain', source);
-            e.dataTransfer.effectAllowed = 'copyMove';
-        });
-        const titleEl = tabEl.querySelector('.lm_title');
-        if (titleEl?.parentNode === tabEl)
-            tabEl.insertBefore(grip, titleEl);
-        else
-            tabEl.prepend(grip);
-    }
-    document.querySelectorAll('.lm_drag_out_grip').forEach(g => g.remove());
-    document.querySelectorAll('.lm_tab').forEach(t => {
-        t.__lopepageGripHooked = false;
-    });
-    document.querySelectorAll('.lm_tab').forEach(hookTab);
-    const handler = tab => hookTab(tab.element);
-    layout.on('tabCreated', handler);
-    invalidation.then(() => {
-        try {
-            layout.off?.('tabCreated', handler);
-        } catch (e) {
-        }
-    });
-    return 'drag-out grips installed';
-};
-const _1gkn0mq = function _dropInHandler(location, setHashURL, runtime, page, invalidation) {
-    const STYLE_ID = 'lopepage-dropzone-style';
-    const oldStyle = document.getElementById(STYLE_ID);
-    if (oldStyle)
-        oldStyle.remove();
-    const s = document.createElement('style');
-    s.id = STYLE_ID;
-    s.textContent = `.lm_header.lopepage-drop-target { outline: 2px dashed currentColor; outline-offset: -2px; background: color-mix(in srgb, currentColor 14%, transparent); }`;
-    document.head.appendChild(s);
-    function parseModuleName(filename) {
-        let m = filename.match(/^at_([A-Za-z0-9]+(?:-[A-Za-z0-9]+)*)_([A-Za-z0-9]+(?:-[A-Za-z0-9]+)*)\.js$/);
-        if (m)
-            return `@${ m[1] }/${ m[2] }`;
-        m = filename.match(/^d_([A-Za-z0-9]+)(@\d+)?\.js$/);
-        if (m)
-            return `d/${ m[1] }${ m[2] ?? '' }`;
-        return null;
-    }
-    function ensureDomScriptTag(name, source) {
-        let el = document.getElementById(name);
-        if (el?.tagName === 'SCRIPT' && el.getAttribute('type') === 'text/plain') {
-            el.textContent = source;
-            return el;
-        }
-        el = document.createElement('script');
-        el.type = 'text/plain';
-        el.id = name;
-        el.setAttribute('data-mime', 'application/javascript');
-        el.textContent = source;
-        document.body.appendChild(el);
-        return el;
-    }
-    function openModuleInHash(name) {
-        let h = location.hash.replace(/^#/, '');
-        if (/(^|&)open=[^&]*/.test(h)) {
-            h = h.replace(/(^|&)open=[^&]*/, `$1open=${ name }`);
-        } else {
-            h = h + (h ? '&' : '') + `open=${ name }`;
-        }
-        setHashURL(h);
-    }
-    function tearDownExistingModule(name) {
-        const existing = runtime.mains.get(name);
-        if (!existing)
-            return false;
-        try {
-            for (const v of Array.from(existing._scope.values())) {
-                try {
-                    v.delete();
-                } catch (e) {
-                }
-            }
-        } catch (e) {
-            console.warn('[lopepage drop-in] teardown scope:', e);
-        }
-        runtime.mains.delete(name);
-        return true;
-    }
-    async function installFromFile(file) {
-        const name = parseModuleName(file.name);
-        if (!name) {
-            console.warn('[lopepage drop-in] bad filename:', file.name);
-            return;
-        }
-        const src = await file.text();
-        const blob = new Blob([src], { type: 'text/javascript' });
-        const url = URL.createObjectURL(blob);
-        let imported;
-        try {
-            imported = await window.importShim(url, `file://${ name }`);
-        } catch (e) {
-            console.error('[lopepage drop-in] import failed:', e);
-            return;
-        }
-        if (typeof imported.default !== 'function') {
-            console.warn('[lopepage drop-in] default export not a function');
-            return;
-        }
-        const replaced = tearDownExistingModule(name);
-        const mod = runtime.module(imported.default);
-        runtime.mains.set(name, mod);
-        ensureDomScriptTag(name, src);
-        openModuleInHash(name);
-        console.log(`[lopepage drop-in] ${ replaced ? 'replaced' : 'installed' } + opened:`, name);
-    }
-    let activeHeader = null;
-    const clearHighlight = () => {
-        if (activeHeader) {
-            activeHeader.classList.remove('lopepage-drop-target');
-            activeHeader = null;
-        }
-    };
-    const isFilesDrag = e => [...e.dataTransfer?.types || []].includes('Files');
-    const onDragOver = e => {
-        if (!isFilesDrag(e))
-            return;
-        const header = e.target?.closest?.('.lm_header');
-        if (!header) {
-            clearHighlight();
-            return;
-        }
-        e.preventDefault();
-        e.dataTransfer.dropEffect = 'copy';
-        if (activeHeader !== header) {
-            activeHeader?.classList.remove('lopepage-drop-target');
-            header.classList.add('lopepage-drop-target');
-            activeHeader = header;
-        }
-    };
-    const onDragLeave = e => {
-        if (!page.contains(e.relatedTarget))
-            clearHighlight();
-    };
-    const onDrop = e => {
-        if (!isFilesDrag(e))
-            return;
-        const header = e.target?.closest?.('.lm_header');
-        if (!header)
-            return;
-        e.preventDefault();
-        clearHighlight();
-        const f = e.dataTransfer.files[0];
-        if (f)
-            installFromFile(f).catch(err => console.error('[lopepage drop-in] failed:', err));
-    };
-    page.addEventListener('dragover', onDragOver);
-    page.addEventListener('dragleave', onDragLeave);
-    page.addEventListener('drop', onDrop);
-    invalidation.then(() => {
-        page.removeEventListener('dragover', onDragOver);
-        page.removeEventListener('dragleave', onDragLeave);
-        page.removeEventListener('drop', onDrop);
-        clearHighlight();
-        document.getElementById(STYLE_ID)?.remove();
-    });
-    return 'drop-in handler installed';
-};
-const _1v605qi = function _file_attachment_cache(reload)
-{
-    reload;
-    return new Map();
-};
-const _1fgpmzl = function _renderFileAttachment()
-{
-    return function renderFileAttachment(mime, bytes) {
-        const m = String(mime || '').toLowerCase();
-        // HTML: srcdoc keeps the runtime same-origin-ish (opaque) but renders rich content
-        if (m === 'text/html' || m === 'application/xhtml+xml') {
-            const iframe = document.createElement('iframe');
-            iframe.setAttribute('srcdoc', new TextDecoder().decode(bytes));
-            Object.assign(iframe.style, {
-                width: '100%',
-                height: '100%',
-                border: '0',
-                display: 'block'
-            });
-            return iframe;
-        }
-        if (m.startsWith('image/')) {
-            const img = document.createElement('img');
-            img.src = URL.createObjectURL(new Blob([bytes], { type: mime }));
-            Object.assign(img.style, {
-                maxWidth: '100%',
-                maxHeight: '100%',
-                display: 'block',
-                margin: 'auto'
-            });
-            return img;
-        }
-        if (m.startsWith('audio/')) {
-            const audio = document.createElement('audio');
-            audio.controls = true;
-            audio.src = URL.createObjectURL(new Blob([bytes], { type: mime }));
-            Object.assign(audio.style, { width: '100%' });
-            return audio;
-        }
-        if (m.startsWith('video/')) {
-            const video = document.createElement('video');
-            video.controls = true;
-            video.src = URL.createObjectURL(new Blob([bytes], { type: mime }));
-            Object.assign(video.style, {
-                width: '100%',
-                height: '100%'
-            });
-            return video;
-        }
-        if (m === 'text/plain' || m === 'text/markdown' || m === 'application/json' || m.startsWith('text/')) {
-            const pre = document.createElement('pre');
-            pre.textContent = new TextDecoder().decode(bytes);
-            Object.assign(pre.style, {
-                margin: '0',
-                padding: '8px',
-                whiteSpace: 'pre-wrap',
-                overflow: 'auto',
-                width: '100%',
-                height: '100%',
-                boxSizing: 'border-box'
-            });
-            return pre;
-        }
-        // application/pdf and unknown: blob: iframe — browser picks the viewer
-        const iframe = document.createElement('iframe');
-        iframe.src = URL.createObjectURL(new Blob([bytes], { type: mime || 'application/octet-stream' }));
-        Object.assign(iframe.style, {
-            width: '100%',
-            height: '100%',
-            border: '0',
-            display: 'block'
-        });
-        return iframe;
-    };
-};
-
-export default function define(runtime, observer) {
-  const main = runtime.module();
-  const $def = (pid, name, deps, fn) => {
-    main.variable(observer(name)).define(name, deps, fn).pid = pid;
-  };
-
-  main.define("module @tomlarkworthy/golden-layout-2-6-0", async () => runtime.module((await import("/@tomlarkworthy/golden-layout-2-6-0.js?v=4")).default));  
-  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
-  main.define("module @tomlarkworthy/module-selection", async () => runtime.module((await import("/@tomlarkworthy/module-selection.js?v=4")).default));  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
-  main.define("module @tomlarkworthy/editor-5", async () => runtime.module((await import("/@tomlarkworthy/editor-5.js?v=4")).default));  
-  main.define("module @tomlarkworthy/exporter-3", async () => runtime.module((await import("/@tomlarkworthy/exporter-3.js?v=4")).default));  
-  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
-  main.define("module @tomlarkworthy/local-change-history", async () => runtime.module((await import("/@tomlarkworthy/local-change-history.js?v=4")).default));  
-  main.define("module @tomlarkworthy/claude-code-pairing", async () => runtime.module((await import("/@tomlarkworthy/claude-code-pairing.js?v=4")).default));  
-  main.define("module @tomlarkworthy/command-palette", async () => runtime.module((await import("/@tomlarkworthy/command-palette.js?v=4")).default));  
-  $def("_1xyxga0", "page", ["htl","isOnObservableCom","lopeviz_handle_css","base_css","light_theme_css","commandPaletteStyles","commandPaletteOverlay","linkTo"], _1xyxga0);  
-  $def("_1ujnhdh", "append_to_body", ["page"], _1ujnhdh);  
-  $def("_1nv51s8", "testNavigation", ["htl","linkTo"], _1nv51s8);  
-  $def("_ydvyos", "viewof reload", ["Inputs"], _ydvyos);  
-  $def("_1we0ggl", "reload", ["Generators","viewof reload"], _1we0ggl);  
-  $def("_plefwg", "onLoadConfig", ["parseGoldenDSL","URLSearchParams","location"], _plefwg);  
-  $def("_1nzpnqy", "visualizer_cache", ["reload"], _1nzpnqy);  
-  $def("_1ojown8", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1ojown8);  
-  $def("_1gm4gbf", "blobPanel", [], _1gm4gbf);  
-  $def("_lxv2e2", "settings", [], _lxv2e2);  
-  $def("_lp1ggk", "is_mobile", ["width"], _lp1ggk);  
-  $def("_qbghwu", "initial config", ["onLoadConfig","settings"], _qbghwu);  
-  $def("_15lk82w", "mutable config", ["Mutable","initial config"], _15lk82w);  
-  $def("_1bki6eh", "config", ["mutable config"], _1bki6eh);  
-  $def("_14z0bay", "resize", ["Generators","addEventListener","invalidation","removeEventListener"], _14z0bay);  
-  $def("_18jv72h", "layout", ["resize","gl","mutable config","page","modulePanel","blobPanel"], _18jv72h);  
-  $def("_tsjb2x", "layout_state", ["appendScrollLog","layout","gl","mutable config"], _tsjb2x);  
-  $def("_11nrwvj", "viewof lopepageModule", ["thisModule"], _11nrwvj);  
-  $def("_r97569", "lopepageModule", ["Generators","viewof lopepageModule"], _r97569);  
-  $def("_1sp5wo4", null, ["md"], _1sp5wo4);  
-  $def("_1ts23ma", "viewof scrollDebug", ["Inputs"], _1ts23ma);  
-  $def("_7jxivy", "scrollDebug", ["Generators","viewof scrollDebug"], _7jxivy);  
-  $def("_1f2wuqm", "appendScrollLog", ["viewof scrollDebug","mutable scrollLog"], _1f2wuqm);  
-  $def("_1nbnzwx", "initial scrollLog", ["scrollDebug"], _1nbnzwx);  
-  $def("_1f7xtz1", "mutable scrollLog", ["Mutable","initial scrollLog"], _1f7xtz1);  
-  $def("_1dyz4o0", "scrollLog", ["mutable scrollLog"], _1dyz4o0);  
-  $def("_1d1nkw9", "scrollKeyFor", ["appendScrollLog"], _1d1nkw9);  
-  $def("_tb217h", "scroll_cache", [], _tb217h);  
-  $def("_12p8mg7", "fix_scroll", ["scroll_cache","scrollKeyFor","appendScrollLog"], _12p8mg7);  
-  $def("_arfw00", "scroll_fix_sync_layout", ["sync_layout_to_url","layout","appendScrollLog","modulePanel"], _arfw00);  
-  $def("_3nwpp4", "URLrouting", ["md"], _3nwpp4);  
-  $def("_14te9pl", "sync_layout_from_url", ["reload","resize","URLSearchParams","hash","appendScrollLog","parseGoldenDSL","gl","layout","serializeGoldenDSL","treeSyncGolden","invalidation"], _14te9pl);  
-  $def("_1l50a0d", "sync_layout_to_url", ["appendScrollLog","sync_layout_from_url","config","test_url_roundtrip","serializeGoldenDSL","location","setHashURL"], _1l50a0d);  
-  $def("_jcy1xg", "test_url_roundtrip", ["sync_layout_from_url"], _jcy1xg);  
-  $def("_1yxu9kf", "setHashURL", ["location","appendScrollLog","history"], _1yxu9kf);  
-  $def("_1zkl8r", "treeSyncGolden", ["appendScrollLog","gl"], _1zkl8r);  
-  $def("_133ahw5", "background_jobs", ["onLoadConfig","layout_state","sync_layout_from_url","test_url_roundtrip","sync_layout_to_url","runtime","navigator_jobs","commandPaletteKeybinding","auto_attach","scroll_fix_sync_layout","commit_history","replay_git","change_listener","cc_chat"], _133ahw5);  
-  $def("_1n78po6", "imports", ["md"], _1n78po6);  
-  $def("_b2c0kp", null, ["exporter"], _b2c0kp);  
-  $def("_1ey5aow", "dragOutGrips", ["layout","invalidation"], _1ey5aow);  
-  $def("_1gkn0mq", "dropInHandler", ["location","setHashURL","runtime","page","invalidation"], _1gkn0mq);  
-  main.define("gl", ["module @tomlarkworthy/golden-layout-2-6-0", "@variable"], (_, v) => v.import("gl", _));  
-  main.define("base_css", ["module @tomlarkworthy/golden-layout-2-6-0", "@variable"], (_, v) => v.import("base_css", _));  
-  main.define("light_theme_css", ["module @tomlarkworthy/golden-layout-2-6-0", "@variable"], (_, v) => v.import("light_theme_css", _));  
-  main.define("unorderedSync", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("unorderedSync", _));  
-  main.define("runtime", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("runtime", _));  
-  main.define("visualizer", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("visualizer", _));  
-  main.define("Inspector", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("Inspector", _));  
-  main.define("lopeviz_handle_css", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("lopeviz_handle_css", _));  
-  main.define("viewof notebookModule", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("viewof notebookModule", _));  
-  main.define("notebookModule", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("notebookModule", _));  
-  main.define("currentModules", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("currentModules", _));  
-  main.define("viewof selected_modules", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("viewof selected_modules", _));  
-  main.define("selected_modules", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("selected_modules", _));  
-  main.define("navigator_jobs", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("navigator_jobs", _));  
-  main.define("serializeGoldenDSL", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("serializeGoldenDSL", _));  
-  main.define("parseGoldenDSL", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("parseGoldenDSL", _));  
-  main.define("linkTo", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("linkTo", _));  
-  main.define("persistedAttachments", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("persistedAttachments", _));  
-  main.define("getHashModules", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("getHashModules", _));  
-  main.define("lookupVariable", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("lookupVariable", _));  
-  main.define("getPromiseState", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("getPromiseState", _));  
-  main.define("thisModule", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("thisModule", _));  
-  main.define("ascendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("ascendants", _));  
-  main.define("toObject", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("toObject", _));  
-  main.define("isOnObservableCom", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("isOnObservableCom", _));  
-  main.define("auto_attach", ["module @tomlarkworthy/editor-5", "@variable"], (_, v) => v.import("auto_attach", _));  
-  main.define("exporter", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("exporter", _));  
-  main.define("hash", ["module d/57d79353bac56631@44", "@variable"], (_, v) => v.import("hash", _));  
-  main.define("commit_history", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("commit_history", _));  
-  main.define("change_listener", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("change_listener", _));  
-  main.define("replay_git", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("replay_git", _));  
-  main.define("cc_chat", ["module @tomlarkworthy/claude-code-pairing", "@variable"], (_, v) => v.import("cc_chat", _));  
-  main.define("commandPaletteStyles", ["module @tomlarkworthy/command-palette", "@variable"], (_, v) => v.import("commandPaletteStyles", _));  
-  main.define("commandPaletteKeybinding", ["module @tomlarkworthy/command-palette", "@variable"], (_, v) => v.import("commandPaletteKeybinding", _));  
-  main.define("commandPaletteOverlay", ["module @tomlarkworthy/command-palette", "@variable"], (_, v) => v.import("commandPaletteOverlay", _));  
-  $def("_1v605qi", "file_attachment_cache", ["reload"], _1v605qi);  
-  $def("_1fgpmzl", "renderFileAttachment", [], _1fgpmzl);
   return main;
 }</script>
 
@@ -16834,35 +20974,33 @@ module -> {
 }
 \`\`\``
 )};
-const _1798myt = function _moduleMap(runtime,keepalive,myModule,$0){return(
-async (
-  _runtime = runtime,
-  {
-    cache = new Map() // module -> {name}
-  } = {}
-) => {
-  if (!_runtime || !_runtime._variables)
-    throw "Invalid runtime passed to moduleMap";
-  keepalive(myModule, "submit_summary");
-  keepalive(myModule, "sync_modules");
-  keepalive(myModule, "currentModules");
-  return await $0.send({
-    runtime: _runtime,
-    cache: cache
-  });
-}
-)};
+const _1hn3uql = function _moduleMap(runtime,keepalive,myModule,$0)
+{
+  return async (_runtime = runtime, {
+    cache = new Map()  // module -> {name}
+  } = {}) => {
+    if (!_runtime || !_runtime._variables)
+      throw 'Invalid runtime passed to moduleMap';
+    keepalive(myModule, 'submit_summary');
+    keepalive(myModule, 'sync_modules');
+    keepalive(myModule, 'currentModules');
+    return await $0.send({
+      runtime: _runtime,
+      cache: cache
+    });
+  };
+};
 const _1yso65r = function _5(md){return(
 md`### \`currentModules\``
 )};
-const _1fcoh6x = async function _sync_modules(runtime_variables,moduleMap,_,$0,Event)
+const _1e3kr85 = async function _sync_modules(runtime_variables,moduleMap,_,$0,Event)
 {
   runtime_variables;
   const latest = await moduleMap();
   let dirty = !this || !_.isEqual(new Set(latest.keys()), new Set(this.keys()));
   if (dirty) {
     $0.value = latest;
-    $0.dispatchEvent(new Event("input"));
+    $0.dispatchEvent(new Event('input'));
   }
   return $0.value;
 };
@@ -16870,261 +21008,260 @@ const _wi39n0 = async function _currentModules(Inputs,moduleMap){return(
 Inputs.input(await moduleMap())
 )};
 const _1gxgyd6 = (G, _) => G.input(_);
-const _1qag34d = function _8(Inputs,currentModules){return(
+const _1kxoygl = function _8(Inputs,currentModules){return(
 Inputs.table([...currentModules.values()], {
   format: {
-    dom: (d) => d.innerHTML,
+    dom: d => d.innerHTML,
     specifiers: JSON.stringify,
-    variable: (v) => v._name
+    variable: v => v._name
   }
 })
 )};
 const _1xamz8j = function _9(md){return(
 md`### Visualization`
 )};
-const _1n4p4hn = function _tipTitle(){return(
-([k, c]) => 
-`${k}\ndependsOn: [\n  ${(c[3].dependsOn || []).join(
-  "\n  "
-)}\n]\ndependedBy: [\n  ${(c[3].dependedBy || []).join("\n  ")}\n]`
+const _1sglrv3 = function _tipTitle(){return(
+([k, c]) => `${ k }\ndependsOn: [\n  ${ (c[3].dependsOn || []).join('\n  ') }\n]\ndependedBy: [\n  ${ (c[3].dependedBy || []).join('\n  ') }\n]`
 )};
-const _1kdcb71 = function _visualizeModules(currentModules,htl,d3,spectralCircleOrder,improveOrderSifting,bestOfRandomOrders,Plot,tipTitle,linkTo,isOnObservableCom)
-{
-  return ({ useSpectral = true } = {}) => {
-    const modules = [...currentModules.values()].filter((m) => m && m.name);
-    const n = modules.length;
-    if (n === 0) return htl.svg`<svg width="1" height="1"></svg>`;
-
-    const indexOf = new Map(modules.map((m, i) => [m.name, i]));
-
-    const undirectedEdges = [];
-    const seen = new Set();
+const _5zbe1k = function _visualizeModules(currentModules,htl,d3,spectralCircleOrder,improveOrderSifting,bestOfRandomOrders,Plot,tipTitle,linkTo,isOnObservableCom){return(
+({
+  useSpectral = true
+} = {}) => {
+  const modules = [...currentModules.values()].filter(m => m && m.name);
+  const n = modules.length;
+  if (n === 0)
+    return htl.svg`<svg width="1" height="1"></svg>`;
+  const indexOf = new Map(modules.map((m, i) => [
+    m.name,
+    i
+  ]));
+  const undirectedEdges = [];
+  const seen = new Set();
+  for (let i = 0; i < n; i++) {
+    const from = modules[i];
+    for (const toName of from.dependsOn || []) {
+      const j = indexOf.get(toName);
+      if (j == null || j === i)
+        continue;
+      const a = Math.min(i, j), b = Math.max(i, j);
+      const k = `${ a },${ b }`;
+      if (seen.has(k))
+        continue;
+      seen.add(k);
+      undirectedEdges.push([
+        a,
+        b
+      ]);
+    }
+  }
+  const buildCSRLocal = (n, edges) => {
+    const adj = Array.from({ length: n }, () => []);
+    for (const [a0, b0] of edges) {
+      const a = a0 | 0, b = b0 | 0;
+      if (a === b)
+        continue;
+      if (a < 0 || b < 0 || a >= n || b >= n)
+        continue;
+      adj[a].push(b);
+      adj[b].push(a);
+    }
+    const deg = new Float64Array(n);
+    let nnz = 0;
     for (let i = 0; i < n; i++) {
-      const from = modules[i];
-      for (const toName of from.dependsOn || []) {
-        const j = indexOf.get(toName);
-        if (j == null || j === i) continue;
-        const a = Math.min(i, j),
-          b = Math.max(i, j);
-        const k = `${a},${b}`;
-        if (seen.has(k)) continue;
-        seen.add(k);
-        undirectedEdges.push([a, b]);
+      const row = adj[i];
+      row.sort((x, y) => x - y);
+      let w = 0;
+      for (let j = 0; j < row.length; j++)
+        if (w === 0 || row[j] !== row[w - 1])
+          row[w++] = row[j];
+      row.length = w;
+      deg[i] = w;
+      nnz += w;
+    }
+    const rowPtr = new Int32Array(n + 1);
+    const colIdx = new Int32Array(nnz);
+    const val = new Float64Array(nnz);
+    let p = 0;
+    for (let i = 0; i < n; i++) {
+      rowPtr[i] = p;
+      const row = adj[i];
+      for (let j = 0; j < row.length; j++) {
+        colIdx[p] = row[j];
+        val[p] = 1;
+        p++;
       }
     }
-
-    const buildCSRLocal = (n, edges) => {
-      const adj = Array.from({ length: n }, () => []);
-      for (const [a0, b0] of edges) {
-        const a = a0 | 0,
-          b = b0 | 0;
-        if (a === b) continue;
-        if (a < 0 || b < 0 || a >= n || b >= n) continue;
-        adj[a].push(b);
-        adj[b].push(a);
-      }
-      const deg = new Float64Array(n);
-      let nnz = 0;
-      for (let i = 0; i < n; i++) {
-        const row = adj[i];
-        row.sort((x, y) => x - y);
-        let w = 0;
-        for (let j = 0; j < row.length; j++)
-          if (w === 0 || row[j] !== row[w - 1]) row[w++] = row[j];
-        row.length = w;
-        deg[i] = w;
-        nnz += w;
-      }
-      const rowPtr = new Int32Array(n + 1);
-      const colIdx = new Int32Array(nnz);
-      const val = new Float64Array(nnz);
-      let p = 0;
-      for (let i = 0; i < n; i++) {
-        rowPtr[i] = p;
-        const row = adj[i];
-        for (let j = 0; j < row.length; j++) {
-          colIdx[p] = row[j];
-          val[p] = 1;
-          p++;
-        }
-      }
-      rowPtr[n] = p;
-      return { n, rowPtr, colIdx, val, deg };
+    rowPtr[n] = p;
+    return {
+      n,
+      rowPtr,
+      colIdx,
+      val,
+      deg
     };
-
-    const crossingsCountLocal = (n, edges, order) => {
-      const pos = new Int32Array(n);
-      for (let i = 0; i < n; i++) pos[order[i]] = i;
-
-      const intervals = [];
-      for (const [a0, b0] of edges) {
-        const a = a0 | 0,
-          b = b0 | 0;
-        if (a === b) continue;
-        const i = pos[a],
-          j = pos[b];
-        const s = Math.min(i, j),
-          t = Math.max(i, j);
-        if (s === t) continue;
-        intervals.push([s, t]);
-      }
-
-      intervals.sort((p, q) => p[0] - q[0] || p[1] - q[1]);
-      const bit = new Int32Array(n + 1);
-      const add = (i) => {
-        for (let x = i + 1; x <= n; x += x & -x) bit[x]++;
-      };
-      const sum = (i) => {
-        let s = 0;
-        for (let x = i + 1; x > 0; x -= x & -x) s += bit[x];
-        return s;
-      };
-      const range = (l, r) => (r < l ? 0 : sum(r) - (l > 0 ? sum(l - 1) : 0));
-
-      let crossings = 0;
-      let k = 0;
-      while (k < intervals.length) {
-        const s = intervals[k][0];
-        let k2 = k;
-        while (k2 < intervals.length && intervals[k2][0] === s) k2++;
-        for (let t = k; t < k2; t++)
-          crossings += range(s + 1, intervals[t][1] - 1);
-        for (let t = k; t < k2; t++) add(intervals[t][1]);
-        k = k2;
-      }
-      return crossings;
+  };
+  const crossingsCountLocal = (n, edges, order) => {
+    const pos = new Int32Array(n);
+    for (let i = 0; i < n; i++)
+      pos[order[i]] = i;
+    const intervals = [];
+    for (const [a0, b0] of edges) {
+      const a = a0 | 0, b = b0 | 0;
+      if (a === b)
+        continue;
+      const i = pos[a], j = pos[b];
+      const s = Math.min(i, j), t = Math.max(i, j);
+      if (s === t)
+        continue;
+      intervals.push([
+        s,
+        t
+      ]);
+    }
+    intervals.sort((p, q) => p[0] - q[0] || p[1] - q[1]);
+    const bit = new Int32Array(n + 1);
+    const add = i => {
+      for (let x = i + 1; x <= n; x += x & -x)
+        bit[x]++;
     };
-
-    let orderIdx;
-    if (n <= 2 || undirectedEdges.length === 0 || !useSpectral) {
-      orderIdx = Int32Array.from(d3.range(n));
-    } else {
-      const csr = buildCSRLocal(n, undirectedEdges);
-
-      const spectral = spectralCircleOrder(csr, {
-        alpha: 0.92,
-        maxIters: 80,
-        tol: 1e-4,
-        seed: 1,
-        passesOrtho: 1
-      });
-
-      const sifted = improveOrderSifting(n, undirectedEdges, spectral.order, {
-        passes: 1,
-        vertexSequence: "order"
-      });
-
-      const baseline = bestOfRandomOrders(n, undirectedEdges, {
-        R: Math.min(n, 12),
-        seed: 1,
-        postSiftPasses: 0
-      });
-
-      const cSift = crossingsCountLocal(n, undirectedEdges, sifted.order);
-      orderIdx =
-        baseline?.order && baseline.crossings < cSift
-          ? baseline.order
-          : sifted.order;
+    const sum = i => {
+      let s = 0;
+      for (let x = i + 1; x > 0; x -= x & -x)
+        s += bit[x];
+      return s;
+    };
+    const range = (l, r) => r < l ? 0 : sum(r) - (l > 0 ? sum(l - 1) : 0);
+    let crossings = 0;
+    let k = 0;
+    while (k < intervals.length) {
+      const s = intervals[k][0];
+      let k2 = k;
+      while (k2 < intervals.length && intervals[k2][0] === s)
+        k2++;
+      for (let t = k; t < k2; t++)
+        crossings += range(s + 1, intervals[t][1] - 1);
+      for (let t = k; t < k2; t++)
+        add(intervals[t][1]);
+      k = k2;
     }
-
-    const R = 100;
-    const nodes = new Map();
-    for (let p = 0; p < n; p++) {
-      const vid = orderIdx[p] | 0;
-      const a = (p * 2 * Math.PI) / n;
-      const [x, y] = d3.pointRadial(a, R);
-      const deg = (p * 360) / n;
-      nodes.set(modules[vid].name, [x, y, deg, modules[vid]]);
-    }
-
-    const edges = modules.flatMap((from) =>
-      (from.dependsOn || [])
-        .filter((to) => nodes.has(to))
-        .map((to) => [
-          [from.name, nodes.get(from.name)],
-          [to, nodes.get(to)]
-        ])
-    );
-
-    const plot = Plot.plot({
-      inset: 180,
-      aspectRatio: 1,
-      axis: null,
-      marks: [
-        () => htl.svg`<defs>
+    return crossings;
+  };
+  let orderIdx;
+  if (n <= 2 || undirectedEdges.length === 0 || !useSpectral) {
+    orderIdx = Int32Array.from(d3.range(n));
+  } else {
+    const csr = buildCSRLocal(n, undirectedEdges);
+    const spectral = spectralCircleOrder(csr, {
+      alpha: 0.92,
+      maxIters: 80,
+      tol: 0.0001,
+      seed: 1,
+      passesOrtho: 1
+    });
+    const sifted = improveOrderSifting(n, undirectedEdges, spectral.order, {
+      passes: 1,
+      vertexSequence: 'order'
+    });
+    const baseline = bestOfRandomOrders(n, undirectedEdges, {
+      R: Math.min(n, 12),
+      seed: 1,
+      postSiftPasses: 0
+    });
+    const cSift = crossingsCountLocal(n, undirectedEdges, sifted.order);
+    orderIdx = baseline?.order && baseline.crossings < cSift ? baseline.order : sifted.order;
+  }
+  const R = 100;
+  const nodes = new Map();
+  for (let p = 0; p < n; p++) {
+    const vid = orderIdx[p] | 0;
+    const a = p * 2 * Math.PI / n;
+    const [x, y] = d3.pointRadial(a, R);
+    const deg = p * 360 / n;
+    nodes.set(modules[vid].name, [
+      x,
+      y,
+      deg,
+      modules[vid]
+    ]);
+  }
+  const edges = modules.flatMap(from => (from.dependsOn || []).filter(to => nodes.has(to)).map(to => [
+    [
+      from.name,
+      nodes.get(from.name)
+    ],
+    [
+      to,
+      nodes.get(to)
+    ]
+  ]));
+  const plot = Plot.plot({
+    inset: 180,
+    aspectRatio: 1,
+    axis: null,
+    marks: [
+      () => htl.svg`<defs>
           <linearGradient id="gradient">
             <stop offset="15%" stop-color="red" />
             <stop offset="100%" stop-color="gold" />
           </linearGradient>
         </defs>`,
-        Plot.arrow(edges, {
-          x1: ([[, [x1]]]) => x1,
-          y1: ([[, [, y1]]]) => y1,
-          x2: ([, [, [x2]]]) => x2,
-          y2: ([, [, [, y2]]]) => y2,
-          bend: true,
-          stroke: "url(#gradient)",
-          strokeOpacity: 0.5,
-          strokeLinejoin: "miter",
-          headLength: 3,
-          inset: 5
-        }),
-        Plot.text(
-          [...nodes.entries()].filter(([, c]) => c[2] > 180),
-          {
-            textAnchor: "end",
-            x: ([, c]) => c[0],
-            y: ([, c]) => c[1],
-            rotate: ([, c]) => -c[2] - (c[2] > 180 ? 90 : -90),
-            text: ([k]) => k
-          }
-        ),
-        Plot.text(
-          [...nodes.entries()].filter(([, c]) => c[2] <= 180),
-          {
-            fontSize: 12,
-            textAnchor: "start",
-            x: ([, c]) => c[0],
-            y: ([, c]) => c[1],
-            rotate: ([, c]) => -c[2] - (c[2] > 180 ? 90 : -90),
-            text: ([k]) => k
-          }
-        ),
-        Plot.tip(
-          nodes.entries(),
-          Plot.pointer({
-            x: ([, c]) => c[0],
-            y: ([, c]) => c[1],
-            title: tipTitle,
-            maxRadius: Infinity
-          })
-        )
-      ]
-    });
-
-    const xmlns = "http://www.w3.org/2000/svg";
-    const xlink = "http://www.w3.org/1999/xlink";
-    for (const text of plot.querySelectorAll("text")) {
-      const moduleName = text.textContent;
-      let url;
-      try {
-        url = linkTo(moduleName);
-      } catch {
-        continue;
-      }
-      const a = document.createElementNS(xmlns, "a");
-      a.setAttributeNS(null, "href", url);
-      a.setAttributeNS(xlink, "href", url);
-      text.parentNode.insertBefore(a, text);
-      if (isOnObservableCom()) {
-        a.setAttribute("target", "_blank");
-      }
-      a.appendChild(text);
+      Plot.arrow(edges, {
+        x1: ([[, [x1]]]) => x1,
+        y1: ([[, [, y1]]]) => y1,
+        x2: ([, [, [x2]]]) => x2,
+        y2: ([, [, [, y2]]]) => y2,
+        bend: true,
+        stroke: 'url(#gradient)',
+        strokeOpacity: 0.5,
+        strokeLinejoin: 'miter',
+        headLength: 3,
+        inset: 5
+      }),
+      Plot.text([...nodes.entries()].filter(([, c]) => c[2] > 180), {
+        textAnchor: 'end',
+        x: ([, c]) => c[0],
+        y: ([, c]) => c[1],
+        rotate: ([, c]) => -c[2] - (c[2] > 180 ? 90 : -90),
+        text: ([k]) => k
+      }),
+      Plot.text([...nodes.entries()].filter(([, c]) => c[2] <= 180), {
+        fontSize: 12,
+        textAnchor: 'start',
+        x: ([, c]) => c[0],
+        y: ([, c]) => c[1],
+        rotate: ([, c]) => -c[2] - (c[2] > 180 ? 90 : -90),
+        text: ([k]) => k
+      }),
+      Plot.tip(nodes.entries(), Plot.pointer({
+        x: ([, c]) => c[0],
+        y: ([, c]) => c[1],
+        title: tipTitle,
+        maxRadius: Infinity
+      }))
+    ]
+  });
+  const xmlns = 'http://www.w3.org/2000/svg';
+  const xlink = 'http://www.w3.org/1999/xlink';
+  for (const text of plot.querySelectorAll('text')) {
+    const moduleName = text.textContent;
+    let url;
+    try {
+      url = linkTo(moduleName);
+    } catch {
+      continue;
     }
-
-    return plot;
-  };
-};
+    const a = document.createElementNS(xmlns, 'a');
+    a.setAttributeNS(null, 'href', url);
+    a.setAttributeNS(xlink, 'href', url);
+    text.parentNode.insertBefore(a, text);
+    if (isOnObservableCom()) {
+      a.setAttribute('target', '_blank');
+    }
+    a.appendChild(text);
+  }
+  return plot;
+}
+)};
 const _hgwvol = function _12(md){return(
 md`### Random helpers`
 )};
@@ -17135,88 +21272,85 @@ const _1cir47e = (G, _) => G.input(_);
 const _1nfaybn = function _tag(){return(
 Symbol()
 )};
-const _17qqkoj = function _forcePeek()
+const _1lkbrun = function _forcePeek()
 {
   //console.log("force peek");
-  return (variable, { forever = false } = {}) => {
-    if (variable._value) return variable._value;
+  return (variable, {
+    forever = false
+  } = {}) => {
+    if (variable._value)
+      return variable._value;
     let peeker;
     const promise = new Promise((fulfilled, rejected) => {
-      peeker = variable._module
-        .variable({
-          fulfilled,
-          rejected
-        })
-        .define([variable._name], (m) => m);
+      peeker = variable._module.variable({
+        fulfilled,
+        rejected
+      }).define([variable._name], m => m);
     });
-    if (!forever) promise.finally((v) => peeker.delete());
-    return Promise.race([promise, new Promise((_, r) => setTimeout(r, 1000))]);
+    if (!forever)
+      promise.finally(v => peeker.delete());
+    return Promise.race([
+      promise,
+      new Promise((_, r) => setTimeout(r, 1000))
+    ]);
   };
 };
-const _v9hg2i = function _observe(){return(
+const _1qva85d = function _observe(){return(
 (module, variable_name, observer) => {
-  const variable = module
-    .variable(observer)
-    .define(`dynamic observe ${variable_name}`, [variable_name], (m) => m);
+  const variable = module.variable(observer).define(`dynamic observe ${ variable_name }`, [variable_name], m => m);
   return () => variable.delete();
 }
 )};
 const _1bm642i = function _17(md){return(
 md`### Implementation`
 )};
-const _oothhq = function _queue(flowQueue){return(
-flowQueue({ timeout_ms: 15000, dedupe: true })
+const _1f31b1g = function _queue(flowQueue){return(
+flowQueue({
+  timeout_ms: 15000,
+  dedupe: true
+})
 )};
 const _648shl = (G, _) => G.input(_);
 const _1acbzli = function _19(md){return(
 md`We resolve what we can using variables named with prefix \`module\` that hold module values. We \`forcePeek\` the variables to make them resolve, which forces loading of the modules.`
 )};
-const _10dhunq = async function _module_definition_variables(notebookImports,queue)
+const _1g0cuj1 = async function _module_definition_variables(notebookImports,queue)
 {
-  console.log("module_definition_variables");
+  console.log('module_definition_variables');
   notebookImports;
   queue;
   let last_module_count = -1;
   let module_definition_variables = [];
   while (last_module_count < module_definition_variables.length) {
     last_module_count = module_definition_variables.length;
-    module_definition_variables = (
-      await Promise.all(
-        [...queue.runtime._variables]
-          .filter((v) => v._name && v._name.startsWith("module "))
-          .filter((v) => !v._name.startsWith("module <unknown"))
-          .map(async (v) => {
-            try {
-              v._value = await Promise.race([
-                v._definition(),
-                new Promise((_, reject) =>
-                  setTimeout(() => reject(new Error("timeout")), 1000)
-                )
-              ]);
-              return [v];
-            } catch (err) {
-              console.error("error loading module", v._name, err);
-              return [];
-            }
-          })
-      )
-    ).flat();
+    module_definition_variables = (await Promise.all([...queue.runtime._variables].filter(v => v._name && v._name.startsWith('module ')).filter(v => !v._name.startsWith('module <unknown')).map(async v => {
+      try {
+        v._value = await Promise.race([
+          v._definition(),
+          new Promise((_, reject) => setTimeout(() => reject(new Error('timeout')), 1000))
+        ]);
+        return [v];
+      } catch (err) {
+        console.error('error loading module', v._name, err);
+        return [];
+      }
+    }))).flat();
   }
   return module_definition_variables;
 };
-const _dcxoxy = function _modules(module_definition_variables,queue)
+const _17frsyf = function _modules(module_definition_variables,queue)
 {
-  console.log("modules");
+  console.log('modules');
   module_definition_variables;
-  return [...new Set([...queue.runtime._variables].map((v) => v._module))];
+  return [...new Set([...queue.runtime._variables].map(v => v._module))];
 };
 const _1dqpbvy = function _builtin(queue){return(
 queue.runtime._builtin
 )};
-const _ir3ob0 = function _main_modules(queue,modules,builtin)
+const _13mmmk9 = function _main_modules(queue,modules,builtin)
 {
   const imports = new Set(queue.runtime._modules.values());
-  return modules.filter((m) => !imports.has(m) && m !== builtin);
+  return modules.filter(m => !imports.has(m) && m !== builtin);
 };
 const _yflsv5 = function _bootloaded_mains(queue){return(
 queue.runtime.mains || new Map()
@@ -17224,16 +21358,16 @@ queue.runtime.mains || new Map()
 const _ox2g3b = function _bootloader(queue){return(
 queue.runtime.bootloader
 )};
-const _1turw8j = function _resolve_modules(modules,module_definition_variables,findModuleName)
+const _10ufqkh = function _resolve_modules(modules,module_definition_variables,findModuleName)
 {
-  console.log("resolve_modules");
+  console.log('resolve_modules');
   const module_definitions = new Map();
   const unresolved = [];
-  modules.forEach((m) => {
-    const md = module_definition_variables.find((md) => md._value == m);
+  modules.forEach(m => {
+    const md = module_definition_variables.find(md => md._value == m);
     if (md) {
       module_definitions.set(m, {
-        type: "module variable",
+        type: 'module variable',
         name: findModuleName(md._module._scope, m),
         variable: md
       });
@@ -17241,239 +21375,218 @@ const _1turw8j = function _resolve_modules(modules,module_definition_variables,f
       unresolved.push(m);
     }
   });
-  return { module_definitions, unresolved };
+  return {
+    module_definitions,
+    unresolved
+  };
 };
 const _9fbvam = function _27(md){return(
 md`modules imported via notebook imports do not have module variables, so they are trickier to figure out. We can sniff the page DOM to find the import expressions, and try to map them to the modules we could to resolve earlier`
 )};
-const _1h0lryb = function _notebookImports(main,parser)
+const _1t4ga3d = function _notebookImports(main,parser)
 {
-  console.log("notebookImports");
+  console.log('notebookImports');
   main;
-  return new Map(
-    [...document.querySelectorAll(".observablehq--import")]
-      .map((dom) => [dom, parser.parseCell(dom.textContent)])
-      .map(([dom, node]) => [
-        dom.parentElement,
-        node.body.specifiers.map((s) => ({
-          name: node.body.source.value,
-          dom: dom.parentElement,
-          ast: s,
-          local: s.local.name,
-          imported: s.imported.name
-        }))
-      ])
-  );
+  return new Map([...document.querySelectorAll('.observablehq--import')].map(dom => [
+    dom,
+    parser.parseCell(dom.textContent)
+  ]).map(([dom, node]) => [
+    dom.parentElement,
+    node.body.specifiers.map(s => ({
+      name: node.body.source.value,
+      dom: dom.parentElement,
+      ast: s,
+      local: s.local.name,
+      imported: s.imported.name
+    }))
+  ]));
 };
-const _7t198q = function _notebookImportVariables(runtime,notebookImports)
+const _994hn4 = function _notebookImportVariables(runtime,notebookImports)
 {
-  console.log("notebookImportVariables");
+  console.log('notebookImportVariables');
   return [
-    ...[...runtime._variables] // Observable DOM nodes are referenced in runtime variables
-      .filter(
-        (v) =>
-          v._observer &&
-          v._observer._node &&
-          notebookImports.get(v._observer._node)
-      )
-      .map((v) => ({
-        variable: v,
-        notebookImports: notebookImports.get(v._observer._node)
-      })),
-    ...[
-      ...[...notebookImports.entries()] // visualizer DOM nodes have the variable attached
-        .filter(([pi, vars]) => pi.variable)
-        .map(([pi, vars]) => ({
-          variable: pi.variable,
-          notebookImports: vars
-        }))
-    ]
-  ].sort((a, b) => b.notebookImports.length - a.notebookImports.length); // sort by complexity
+    ...[...runtime._variables]  // Observable DOM nodes are referenced in runtime variables
+.filter(v => v._observer && v._observer._node && notebookImports.get(v._observer._node)).map(v => ({
+      variable: v,
+      notebookImports: notebookImports.get(v._observer._node)
+    })),
+    ...[...[...notebookImports.entries()]  // visualizer DOM nodes have the variable attached
+.filter(([pi, vars]) => pi.variable).map(([pi, vars]) => ({
+        variable: pi.variable,
+        notebookImports: vars
+      }))]
+  ].sort((a, b) => b.notebookImports.length - a.notebookImports.length);  // sort by complexity
 };
-const _1lyens8 = function _pageImportMatch(){return(
-async (notebookImportVariables, modules) => {
-  console.log("pageImportMatch");
-  const backupHas = Map.prototype.has; // Save the original `has` method on Map.prototype
-
-  let currentImport = undefined;
-  const matches = new Map();
-  // Override `Map.prototype.has` to intercept calls to `has` on any Map instance
-  Map.prototype.has = function (...args) {
-    const module = modules.find((m) => m._scope == this);
-    if (currentImport && module) {
-      matches.set(module, {
-        name: currentImport.notebookImports[0].name,
-        type: "notebook import",
-        module: module,
-        dependsOn: [],
-        dependedBy: [],
-        dom: currentImport.notebookImports[0].dom,
-        specifiers: currentImport.notebookImports.map((pi) => ({
-          local: pi.local,
-          imported: pi.imported,
-          variable: pi.variable
-        }))
-      });
-    }
-    return backupHas.call(this, ...args); // Call the original `has` method
-  };
-
-  // Iterate through the notebook imports and define them while capturing `has` calls
-
-  await notebookImportVariables.reduce((chain, pageImportVariable) => {
-    // Call the definition chain
-    return chain.then(async () => {
-      currentImport = pageImportVariable;
-      try {
-        await pageImportVariable.variable._definition();
-      } catch (err) {
-        console.warn(err);
-      }
-      currentImport = undefined;
-    });
-  }, Promise.resolve());
-
-  // Restore the original `has` method after the operations are done
-  Map.prototype.has = backupHas;
-
-  return matches;
-}
-)};
-const _1akt4kz = function _notebookImportMatches(pageImportMatch,notebookImportVariables,modules)
+const _xanizk = function _pageImportMatch()
 {
-  console.log("notebookImportMatches");
+  return async (notebookImportVariables, modules) => {
+    console.log('pageImportMatch');
+    const backupHas = Map.prototype.has;
+    // Save the original `has` method on Map.prototype
+    let currentImport = undefined;
+    const matches = new Map();
+    // Override `Map.prototype.has` to intercept calls to `has` on any Map instance
+    Map.prototype.has = function (...args) {
+      const module = modules.find(m => m._scope == this);
+      if (currentImport && module) {
+        matches.set(module, {
+          name: currentImport.notebookImports[0].name,
+          type: 'notebook import',
+          module: module,
+          dependsOn: [],
+          dependedBy: [],
+          dom: currentImport.notebookImports[0].dom,
+          specifiers: currentImport.notebookImports.map(pi => ({
+            local: pi.local,
+            imported: pi.imported,
+            variable: pi.variable
+          }))
+        });
+      }
+      return backupHas.call(this, ...args);  // Call the original `has` method
+    };
+    // Iterate through the notebook imports and define them while capturing `has` calls
+    await notebookImportVariables.reduce((chain, pageImportVariable) => {
+      // Call the definition chain
+      return chain.then(async () => {
+        currentImport = pageImportVariable;
+        try {
+          await pageImportVariable.variable._definition();
+        } catch (err) {
+          console.warn(err);
+        }
+        currentImport = undefined;
+      });
+    }, Promise.resolve());
+    // Restore the original `has` method after the operations are done
+    Map.prototype.has = backupHas;
+    return matches;
+  };
+};
+const _1q5pc6n = function _notebookImportMatches(pageImportMatch,notebookImportVariables,modules)
+{
+  console.log('notebookImportMatches');
   return pageImportMatch(notebookImportVariables, modules);
 };
-const _1ang0sg = function _moduleTitle(observeVariable){return(
-async function moduleTitle(module) {
-  const runtime = module._runtime;
-  const vars = [...runtime._variables].filter(
-    (v) => v && v._module === module && v._definition
-  );
-  const candidates = vars.filter((v) => {
-    const n = v._name;
-    if (v._type != 1) return false;
-    if (n == null) return true;
-    if (typeof n !== "string") return true;
-    if (n.startsWith("dynamic observe ")) return false;
-    if (n.startsWith("module ")) return false;
-    return true;
-  });
-
-  if (candidates.length === 0) return null;
-
-  const first = candidates.find(
-    (v) => typeof v._id === "number" && Number.isFinite(v._id)
-  )
-    ? candidates.reduce((a, b) =>
-        (a._id ?? Infinity) <= (b._id ?? Infinity) ? a : b
-      )
-    : candidates[0];
-
-  const extract = (v) => {
-    // instanceof cannot be used hear for cross realm
-    if (v == null) return null;
-    if (typeof v === "string") return v.trim() || null;
-    if (v.tagName) {
-      if (v.tagName == "H1") return v.textContent;
-      const h1 = v.querySelector?.("h1");
-      if (h1) return (h1.textContent ?? "").trim() || null;
+const _12o3fj5 = function _moduleTitle(observeVariable)
+{
+  return async function moduleTitle(module) {
+    const runtime = module._runtime;
+    const vars = [...runtime._variables].filter(v => v && v._module === module && v._definition);
+    const candidates = vars.filter(v => {
+      const n = v._name;
+      if (v._type != 1)
+        return false;
+      if (n == null)
+        return true;
+      if (typeof n !== 'string')
+        return true;
+      if (n.startsWith('dynamic observe '))
+        return false;
+      if (n.startsWith('module '))
+        return false;
+      return true;
+    });
+    if (candidates.length === 0)
       return null;
-    }
-    if (v.textContent) return (v.textContent ?? "").trim() || null;
-    const maybeNode = v?.nodeType ? v : null;
-    if (maybeNode?.tagName) return extract(maybeNode);
-    return null;
-  };
-
-  // Read the title WITHOUT re-executing the cell. invokeVariable calls the cell's _definition
-  // directly, bypassing the runtime — for element cells (`htl.html`…${sharedNode}…``) that builds
-  // a *duplicate*, unmanaged DOM subtree and moves shared singleton nodes (e.g. golden-layout's
-  // base_css <style>) out of the live page, breaking the frame. Instead:
-  //  1. If already computed, read the settled _value (fast path, most modules — zero side-effects).
-  //  2. Else force the RUNTIME to compute the *single managed* variable via observe(): it marks the
-  //     existing variable reachable and replays its value, adding no intermediate variable (no
-  //     variable-set churn) and building only the one runtime-owned instance (no duplicate). We
-  //     attach a one-shot observer and fire its invalidation on first settle so it detaches again.
-  if (first._value !== undefined) return extract(first._value);
-  const peekValue = (v) =>
-    new Promise((resolve, reject) => {
+    const first = candidates.find(v => typeof v._id === 'number' && Number.isFinite(v._id)) ? candidates.reduce((a, b) => (a._id ?? Infinity) <= (b._id ?? Infinity) ? a : b) : candidates[0];
+    const extract = v => {
+      // instanceof cannot be used hear for cross realm
+      if (v == null)
+        return null;
+      if (typeof v === 'string')
+        return v.trim() || null;
+      if (v.tagName) {
+        if (v.tagName == 'H1')
+          return v.textContent;
+        const h1 = v.querySelector?.('h1');
+        if (h1)
+          return (h1.textContent ?? '').trim() || null;
+        return null;
+      }
+      if (v.textContent)
+        return (v.textContent ?? '').trim() || null;
+      const maybeNode = v?.nodeType ? v : null;
+      if (maybeNode?.tagName)
+        return extract(maybeNode);
+      return null;
+    };
+    // Read the title WITHOUT re-executing the cell. invokeVariable calls the cell's _definition
+    // directly, bypassing the runtime — for element cells (`htl.html`…${sharedNode}…``) that builds
+    // a *duplicate*, unmanaged DOM subtree and moves shared singleton nodes (e.g. golden-layout's
+    // base_css <style>) out of the live page, breaking the frame. Instead:
+    //  1. If already computed, read the settled _value (fast path, most modules — zero side-effects).
+    //  2. Else force the RUNTIME to compute the *single managed* variable via observe(): it marks the
+    //     existing variable reachable and replays its value, adding no intermediate variable (no
+    //     variable-set churn) and building only the one runtime-owned instance (no duplicate). We
+    //     attach a one-shot observer and fire its invalidation on first settle so it detaches again.
+    if (first._value !== undefined)
+      return extract(first._value);
+    const peekValue = v => new Promise((resolve, reject) => {
       let settled = false;
       let fireInvalidation;
-      const invalidation = new Promise((r) => (fireInvalidation = r));
+      const invalidation = new Promise(r => fireInvalidation = r);
       const finish = (fn, arg) => {
-        if (settled) return;
+        if (settled)
+          return;
         settled = true;
         fireInvalidation();
         fn(arg);
       };
-      observeVariable(
-        v,
-        {
-          fulfilled: (value) => finish(resolve, value),
-          rejected: (err) => finish(reject, err),
-          pending: () => {}
-        },
-        { invalidation }
-      );
+      observeVariable(v, {
+        fulfilled: value => finish(resolve, value),
+        rejected: err => finish(reject, err),
+        pending: () => {
+        }
+      }, { invalidation });
     });
-  try {
-    return extract(await peekValue(first));
-  } catch (err) {
-    return "Err";
-  }
-}
-)};
-const _197sgjt = async function _titles(modules,moduleTitle)
+    try {
+      return extract(await peekValue(first));
+    } catch (err) {
+      return 'Err';
+    }
+  };
+};
+const _ze3jk0 = async function _titles(modules,moduleTitle)
 {
-  const map = new Map(
-    await Promise.all(
-      [...modules].map(async (m) => [
-        m,
-        await Promise.race([
-          moduleTitle(m),
-          new Promise((resolve) =>
-            setTimeout(() => resolve("<TIMEOUT LOADING TITLE>"), 250)
-          )
-        ]).catch((e) => `err: ${e}`)
-      ])
-    )
-  );
+  const map = new Map(await Promise.all([...modules].map(async m => [
+    m,
+    await Promise.race([
+      moduleTitle(m),
+      new Promise(resolve => setTimeout(() => resolve('<TIMEOUT LOADING TITLE>'), 250))
+    ]).catch(e => `err: ${ e }`)
+  ])));
   return map;
 };
-const _11z3pt0 = function _summary(main_modules,titles,bootloader,builtin,queue,notebookImportMatches,bootloaded_mains,resolve_modules,module_definition_variables)
+const _pnpoh8 = function _summary(main_modules,titles,bootloader,builtin,queue,notebookImportMatches,bootloaded_mains,resolve_modules,module_definition_variables)
 {
-  console.log("generate summary");
+  console.log('generate summary');
   const modules = new Map([
-    ...main_modules.map((main_module) => [
+    ...main_modules.map(main_module => [
       main_module,
       {
-        name: "main",
+        name: 'main',
         module: main_module,
         title: titles.get(main_module),
         dependsOn: [],
         dependedBy: []
       }
     ]),
-    ...(bootloader
-      ? [
-          [
-            bootloader,
-            {
-              name: "bootloader",
-              title: "Bootloader",
-              module: bootloader,
-              dependsOn: [],
-              dependedBy: []
-            }
-          ]
-        ]
-      : []),
+    ...bootloader ? [[
+        bootloader,
+        {
+          name: 'bootloader',
+          title: 'Bootloader',
+          module: bootloader,
+          dependsOn: [],
+          dependedBy: []
+        }
+      ]] : [],
     [
       builtin,
       {
-        name: "builtin",
-        title: "Standard library",
+        name: 'builtin',
+        title: 'Standard library',
         module: builtin,
         dependsOn: [],
         dependedBy: []
@@ -17505,30 +21618,21 @@ const _11z3pt0 = function _summary(main_modules,titles,bootloader,builtin,queue,
   ]);
   // add cross links
   // notebookImportVariables[0].variable._module == main
-  [...notebookImportMatches.keys()].forEach((m) => {
+  [...notebookImportMatches.keys()].forEach(m => {
     const hostModule = modules.get(main_modules[0]);
     const importedModule = modules.get(m);
     if (!hostModule?.dependsOn || !importedModule?.dependedBy) {
-      console.error(
-        "error building module dependancy map",
-        hostModule,
-        importedModule
-      );
+      console.error('error building module dependancy map', hostModule, importedModule);
       return;
     }
     hostModule.dependsOn.push(importedModule.name);
     importedModule.dependedBy.push(main_modules[0].name);
   });
-
-  module_definition_variables.forEach((v) => {
+  module_definition_variables.forEach(v => {
     const hostModule = modules.get(v._module);
     const importedModule = modules.get(v._value);
     if (!hostModule?.dependsOn || !importedModule?.dependedBy) {
-      console.error(
-        "error building module dependancy map",
-        hostModule,
-        importedModule
-      );
+      console.error('error building module dependancy map', hostModule, importedModule);
       return;
     }
     hostModule.dependsOn.push(importedModule.name);
@@ -17536,11 +21640,11 @@ const _11z3pt0 = function _summary(main_modules,titles,bootloader,builtin,queue,
   });
   return modules;
 };
-const _1pou2g6 = function _submit_summary(resolve_modules,queue,notebookImports,$0,summary)
+const _hhecn4 = function _submit_summary(resolve_modules,queue,notebookImports,$0,summary)
 {
   resolve_modules;
   queue;
-  console.log("submit_summary");
+  console.log('submit_summary');
   notebookImports;
   $0.resolve(summary);
 };
@@ -17554,47 +21658,47 @@ export default function define(runtime, observer) {
   main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
   main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
   main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));
-  main.define("module @tomlarkworthy/invoke-variable", async () => runtime.module((await import("/@tomlarkworthy/invoke-variable.js?v=4")).default));
-  main.define("module @tomlarkworthy/spectral-layout", async () => runtime.module((await import("/@tomlarkworthy/spectral-layout.js?v=4")).default));
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/invoke-variable", async () => runtime.module((await import("/@tomlarkworthy/invoke-variable.js?v=4")).default));  
+  main.define("module @tomlarkworthy/spectral-layout", async () => runtime.module((await import("/@tomlarkworthy/spectral-layout.js?v=4")).default));  
   $def("_1w9yf3l", null, ["md"], _1w9yf3l);  
   $def("_b6n8js", null, ["visualizeModules"], _b6n8js);  
   $def("_1sznqfl", null, ["md"], _1sznqfl);  
-  $def("_1798myt", "moduleMap", ["runtime","keepalive","myModule","viewof queue"], _1798myt);  
+  $def("_1hn3uql", "moduleMap", ["runtime","keepalive","myModule","viewof queue"], _1hn3uql);  
   $def("_1yso65r", null, ["md"], _1yso65r);  
-  $def("_1fcoh6x", "sync_modules", ["runtime_variables","moduleMap","_","viewof currentModules","Event"], _1fcoh6x);  
+  $def("_1e3kr85", "sync_modules", ["runtime_variables","moduleMap","_","viewof currentModules","Event"], _1e3kr85);  
   $def("_wi39n0", "viewof currentModules", ["Inputs","moduleMap"], _wi39n0);  
   $def("_1gxgyd6", "currentModules", ["Generators","viewof currentModules"], _1gxgyd6);  
-  $def("_1qag34d", null, ["Inputs","currentModules"], _1qag34d);  
+  $def("_1kxoygl", null, ["Inputs","currentModules"], _1kxoygl);  
   $def("_1xamz8j", null, ["md"], _1xamz8j);  
-  $def("_1n4p4hn", "tipTitle", [], _1n4p4hn);  
-  $def("_1kdcb71", "visualizeModules", ["currentModules","htl","d3","spectralCircleOrder","improveOrderSifting","bestOfRandomOrders","Plot","tipTitle","linkTo","isOnObservableCom"], _1kdcb71);  
+  $def("_1sglrv3", "tipTitle", [], _1sglrv3);  
+  $def("_5zbe1k", "visualizeModules", ["currentModules","htl","d3","spectralCircleOrder","improveOrderSifting","bestOfRandomOrders","Plot","tipTitle","linkTo","isOnObservableCom"], _5zbe1k);  
   $def("_hgwvol", null, ["md"], _hgwvol);  
   $def("_14bivfb", "viewof myModule", ["thisModule"], _14bivfb);  
   $def("_1cir47e", "myModule", ["Generators","viewof myModule"], _1cir47e);  
   $def("_1nfaybn", "tag", [], _1nfaybn);  
-  $def("_17qqkoj", "forcePeek", [], _17qqkoj);  
-  $def("_v9hg2i", "observe", [], _v9hg2i);  
+  $def("_1lkbrun", "forcePeek", [], _1lkbrun);  
+  $def("_1qva85d", "observe", [], _1qva85d);  
   $def("_1bm642i", null, ["md"], _1bm642i);  
-  $def("_oothhq", "viewof queue", ["flowQueue"], _oothhq);  
+  $def("_1f31b1g", "viewof queue", ["flowQueue"], _1f31b1g);  
   $def("_648shl", "queue", ["Generators","viewof queue"], _648shl);  
   $def("_1acbzli", null, ["md"], _1acbzli);  
-  $def("_10dhunq", "module_definition_variables", ["notebookImports","queue"], _10dhunq);  
-  $def("_dcxoxy", "modules", ["module_definition_variables","queue"], _dcxoxy);  
+  $def("_1g0cuj1", "module_definition_variables", ["notebookImports","queue"], _1g0cuj1);  
+  $def("_17frsyf", "modules", ["module_definition_variables","queue"], _17frsyf);  
   $def("_1dqpbvy", "builtin", ["queue"], _1dqpbvy);  
-  $def("_ir3ob0", "main_modules", ["queue","modules","builtin"], _ir3ob0);  
+  $def("_13mmmk9", "main_modules", ["queue","modules","builtin"], _13mmmk9);  
   $def("_yflsv5", "bootloaded_mains", ["queue"], _yflsv5);  
   $def("_ox2g3b", "bootloader", ["queue"], _ox2g3b);  
-  $def("_1turw8j", "resolve_modules", ["modules","module_definition_variables","findModuleName"], _1turw8j);  
+  $def("_10ufqkh", "resolve_modules", ["modules","module_definition_variables","findModuleName"], _10ufqkh);  
   $def("_9fbvam", null, ["md"], _9fbvam);  
-  $def("_1h0lryb", "notebookImports", ["main","parser"], _1h0lryb);  
-  $def("_7t198q", "notebookImportVariables", ["runtime","notebookImports"], _7t198q);  
-  $def("_1lyens8", "pageImportMatch", [], _1lyens8);  
-  $def("_1akt4kz", "notebookImportMatches", ["pageImportMatch","notebookImportVariables","modules"], _1akt4kz);  
-  $def("_1ang0sg", "moduleTitle", ["observeVariable"], _1ang0sg);
-  $def("_197sgjt", "titles", ["modules","moduleTitle"], _197sgjt);  
-  $def("_11z3pt0", "summary", ["main_modules","titles","bootloader","builtin","queue","notebookImportMatches","bootloaded_mains","resolve_modules","module_definition_variables"], _11z3pt0);  
-  $def("_1pou2g6", "submit_summary", ["resolve_modules","queue","notebookImports","viewof queue","summary"], _1pou2g6);  
+  $def("_1t4ga3d", "notebookImports", ["main","parser"], _1t4ga3d);  
+  $def("_994hn4", "notebookImportVariables", ["runtime","notebookImports"], _994hn4);  
+  $def("_xanizk", "pageImportMatch", [], _xanizk);  
+  $def("_1q5pc6n", "notebookImportMatches", ["pageImportMatch","notebookImportVariables","modules"], _1q5pc6n);  
+  $def("_12o3fj5", "moduleTitle", ["observeVariable"], _12o3fj5);  
+  $def("_ze3jk0", "titles", ["modules","moduleTitle"], _ze3jk0);  
+  $def("_pnpoh8", "summary", ["main_modules","titles","bootloader","builtin","queue","notebookImportMatches","bootloaded_mains","resolve_modules","module_definition_variables"], _pnpoh8);  
+  $def("_hhecn4", "submit_summary", ["resolve_modules","queue","notebookImports","viewof queue","summary"], _hhecn4);  
   main.define("linkTo", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("linkTo", _));  
   main.define("flowQueue", ["module @tomlarkworthy/flow-queue", "@variable"], (_, v) => v.import("flowQueue", _));  
   main.define("parser", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("parser", _));  
@@ -17608,8 +21712,8 @@ export default function define(runtime, observer) {
   main.define("isOnObservableCom", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("isOnObservableCom", _));  
   main.define("viewof runtime_variables", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("viewof runtime_variables", _));  
   main.define("runtime_variables", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime_variables", _));  
-  main.define("observeVariable", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("observe", "observeVariable", _));
-  main.define("invokeVariable", ["module @tomlarkworthy/invoke-variable", "@variable"], (_, v) => v.import("invokeVariable", _));
+  main.define("observeVariable", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("observe", "observeVariable", _));  
+  main.define("invokeVariable", ["module @tomlarkworthy/invoke-variable", "@variable"], (_, v) => v.import("invokeVariable", _));  
   main.define("spectralCircleOrder", ["module @tomlarkworthy/spectral-layout", "@variable"], (_, v) => v.import("spectralCircleOrder", _));  
   main.define("improveOrderSifting", ["module @tomlarkworthy/spectral-layout", "@variable"], (_, v) => v.import("improveOrderSifting", _));  
   main.define("bestOfRandomOrders", ["module @tomlarkworthy/spectral-layout", "@variable"], (_, v) => v.import("bestOfRandomOrders", _));
@@ -17886,6 +21990,418 @@ export default function define(runtime, observer) {
   main.define("thisModule", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("thisModule", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));
+  return main;
+}</script>
+
+<script id="@tomlarkworthy/modules" 
+  type="text/plain"
+  data-mime="application/javascript"
+>
+const _s7bl1p = function _1(md){return(
+md`# Modules
+
+\`modules(options?)\` is an async generator that yields a **cumulative \`Map\`** (module → \`{name, title, module, variable}\`) of every fully-formed record known so far, growing as modules resolve. 
+
+It's an effecient alternative to [moduleMap](https://observablehq.com/@tomlarkworthy/module-map) that blocks until all modules are loaded.
+`
+)};
+const _1eaa9lr = function _currentModules(modules){return(
+modules()
+)};
+const _dmem61 = function _modules(runtime, observeVariable, moduleTitle) {
+    const _runtime = runtime;
+    return function modules({runtime = _runtime, titleTimeoutMs = 2000, rescanMs = 1000, load = true} = {}) {
+        if (!runtime || !runtime._variables)
+            throw 'Invalid runtime passed to modules';
+        return async function* () {
+            const records = new Map();
+            const watchers = new Map();
+            const peeking = new Map();
+            let pending = false, wake = null, dirty = true;
+            const bump = () => {
+                pending = true;
+                if (wake) {
+                    const w = wake;
+                    wake = null;
+                    w();
+                }
+            };
+            const touch = () => {
+                dirty = true;
+                bump();
+            };
+            const slugFromDef = v => {
+                const m = v._definition && String(v._definition).match(/import(?:Shim)?\(\s*["'`]\/?([^"'`?]+?)\.js(?:[?"'`)]|$)/);
+                return m ? m[1].replace(/^\//, '') : null;
+            };
+            const scan = () => {
+                const out = new Map();
+                const put = (m, r) => {
+                    if (m && !out.has(m))
+                        out.set(m, r);
+                };
+                const builtin = runtime._builtin, bootloader = runtime.bootloader;
+                if (builtin)
+                    put(builtin, {
+                        name: 'builtin',
+                        title: 'Standard library'
+                    });
+                if (bootloader)
+                    put(bootloader, {
+                        name: 'bootloader',
+                        title: 'Bootloader'
+                    });
+                for (const [name, mod] of runtime.mains || new Map())
+                    put(mod, { name });
+                const imported = new Set((runtime._modules || new Map()).values());
+                const owners = new Set();
+                for (const v of runtime._variables)
+                    if (v._module)
+                        owners.add(v._module);
+                for (const m of owners)
+                    if (m !== builtin && m !== bootloader && !imported.has(m))
+                        put(m, { name: 'main' });
+                for (const v of runtime._variables) {
+                    if (!v._name || !v._name.startsWith('module ') || v._name.startsWith('module <unknown'))
+                        continue;
+                    const mod = v._value;
+                    if (mod && typeof mod === 'object')
+                        put(mod, {
+                            name: slugFromDef(v) || v._name.slice(7),
+                            variable: v
+                        });
+                    else if (load && !peeking.has(v))
+                        peeking.set(v, observeVariable(v, {
+                            fulfilled: bump,
+                            error: bump
+                        }));
+                }
+                return out;
+            };
+            const reconcile = () => {
+                const cand = scan();
+                for (const m of [...watchers.keys()]) {
+                    if (!cand.has(m)) {
+                        const cancel = watchers.get(m);
+                        watchers.delete(m);
+                        if (records.delete(m))
+                            touch();
+                        try {
+                            cancel();
+                        } catch (e) {
+                        }
+                    }
+                }
+                for (const [m, c] of cand) {
+                    if (watchers.has(m))
+                        continue;
+                    if (c.title != null) {
+                        records.set(m, {
+                            name: c.name,
+                            title: c.title,
+                            module: m,
+                            variable: c.variable
+                        });
+                        watchers.set(m, () => {
+                        });
+                        touch();
+                        continue;
+                    }
+                    const apply = title => {
+                        if (!watchers.has(m))
+                            return;
+                        const t = title ?? c.name;
+                        const prev = records.get(m);
+                        if (!prev) {
+                            records.set(m, {
+                                name: c.name,
+                                title: t,
+                                module: m,
+                                variable: c.variable
+                            });
+                            touch();
+                        } else if (prev.title !== t) {
+                            records.set(m, {
+                                ...prev,
+                                title: t
+                            });
+                            touch();
+                        }
+                    };
+                    const cancel = moduleTitle(m, apply);
+                    watchers.set(m, () => {
+                        try {
+                            cancel();
+                        } catch (e) {
+                        }
+                    });
+                    setTimeout(() => {
+                        if (watchers.has(m) && !records.has(m))
+                            apply(null);
+                    }, titleTimeoutMs);
+                }
+            };
+            let stopped = false;
+            (async () => {
+                while (!stopped) {
+                    try {
+                        reconcile();
+                    } catch (e) {
+                    }
+                    await new Promise(r => setTimeout(r, rescanMs));
+                }
+            })();
+            try {
+                while (true) {
+                    pending = false;
+                    if (dirty) {
+                        dirty = false;
+                        yield new Map(records);
+                    }
+                    if (!pending)
+                        await new Promise(resolve => {
+                            wake = resolve;
+                            if (pending) {
+                                wake = null;
+                                resolve();
+                            }
+                        });
+                }
+            } finally {
+                stopped = true;
+                for (const cancel of watchers.values()) {
+                    try {
+                        cancel();
+                    } catch (e) {
+                    }
+                }
+                for (const stop of peeking.values()) {
+                    try {
+                        stop();
+                    } catch (e) {
+                    }
+                }
+            }
+        }();
+    };
+};
+const _up9atj = function _moduleTitle(observeVariable)
+{
+  return function moduleTitle(module, onTitle) {
+    // Observes a module's title-defining cell and calls onTitle(title|null) on every change.
+    // Returns a cancel fn. The fixed observe() forces a lazy title cell to compute (and replays
+    // the current value on attach), so no in-module forcing helper is needed — works for named
+    // and anonymous cells alike, even in a fresh runtime nothing else observes.
+    const rt = module._runtime;
+    const candidates = [...rt._variables].filter(v => {
+      if (!v || v._module !== module || !v._definition || v._type != 1)
+        return false;
+      const n = v._name;
+      if (typeof n === 'string' && (n.startsWith('dynamic observe ') || n.startsWith('module ')))
+        return false;
+      return true;
+    });
+    if (candidates.length === 0) {
+      onTitle(null);
+      return () => {
+      };
+    }
+    const first = candidates.reduce((a, b) => (a._id ?? Infinity) <= (b._id ?? Infinity) ? a : b);
+    const extract = v => {
+      if (v == null)
+        return null;
+      if (typeof v === 'string')
+        return v.trim() || null;
+      if (v.tagName) {
+        if (v.tagName == 'H1')
+          return v.textContent;
+        const h1 = v.querySelector?.('h1');
+        if (h1)
+          return (h1.textContent ?? '').trim() || null;
+        return null;
+      }
+      if (v.textContent)
+        return (v.textContent ?? '').trim() || null;
+      return null;
+    };
+    const stop = observeVariable(first, {
+      fulfilled: value => onTitle(extract(value)),
+      error: () => onTitle('Err')
+    });
+    return () => {
+      try {
+        stop();
+      } catch (e) {
+      }
+    };
+  };
+};
+const _qpensj = function _5(Inputs,currentModules){return(
+Inputs.table([...currentModules.values()], {
+  columns: [
+    'name',
+    'title'
+  ],
+  format: { name: x => x }
+})
+)};
+const _1x0q6zt = function _7(md){return(
+md`## Tests`
+)};
+const _e0sbyj = function _8(tests,modulesModule){return(
+tests({
+  filter: (t) => t.variable._module == modulesModule
+})
+)};
+const _p3rq3v = function _modulesModule(thisModule){return(
+thisModule()
+)};
+const _16g1ab = (G, _) => G.input(_);
+const _cayyvt = function _testRuntime(Runtime){return(
+new Runtime()
+)};
+const _1j4p6g3 = function _testModulesLatest(modules,testRuntime){return(
+modules({
+  runtime: testRuntime
+})
+)};
+const _1oq6y7s = function _newModule(testRuntime)
+{
+  const m = testRuntime.module();
+  m.variable().define("greeting", [], () => {
+    const div = document.createElement("div");
+    div.innerHTML = "<h1>New Module</h1>";
+    return div;
+  });
+  return m;
+};
+const _1li1bty = function _test_detectsBuiltin(testModulesLatest)
+{
+  if (![...testModulesLatest.values()].find((m) => m.name == "builtin"))
+    throw Error();
+  return "ok";
+};
+const _vr1kp6 = function _test_detectsNewModule(testModulesLatest,newModule)
+{
+  const rec = testModulesLatest.get(newModule);
+  if (!rec) throw Error("newModule not detected yet");
+  if (rec.title !== "New Module")
+    throw Error(
+      "expected title 'New Module', got " + JSON.stringify(rec.title)
+    );
+  return "ok";
+};
+const _1p0sqk = async function _test_reflectsDelete(Runtime,modules)
+{
+  const rt = new Runtime();
+  const gen = modules({
+    runtime: rt,
+    rescanMs: 100,
+    titleTimeoutMs: 500
+  });
+  let snap = new Map();
+  (async () => {
+    for await (const s of gen) snap = s;
+  })();
+  const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+  const waitFor = async (pred, ms = 3000) => {
+    const t0 = Date.now();
+    while (Date.now() - t0 < ms) {
+      if (pred()) return true;
+      await wait(50);
+    }
+    return false;
+  };
+  try {
+    const m = rt.module();
+    m.variable().define("title", [], () => {
+      const d = document.createElement("div");
+      d.innerHTML = "<h1>Temp</h1>";
+      return d;
+    });
+    if (!(await waitFor(() => snap.has(m))))
+      throw Error("create not reflected");
+    for (const v of [...rt._variables]) if (v._module === m) v.delete();
+    if (!(await waitFor(() => !snap.has(m))))
+      throw Error("delete not reflected");
+    return "ok";
+  } finally {
+    if (gen.return) gen.return();
+  }
+};
+const _1315qaf = async function _test_reflectsTitleUpdate(Runtime,modules)
+{
+  const rt = new Runtime();
+  const gen = modules({
+    runtime: rt,
+    rescanMs: 100,
+    titleTimeoutMs: 500
+  });
+  let snap = new Map();
+  (async () => {
+    for await (const s of gen) snap = s;
+  })();
+  const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+  const waitFor = async (pred, ms = 3000) => {
+    const t0 = Date.now();
+    while (Date.now() - t0 < ms) {
+      if (pred()) return true;
+      await wait(50);
+    }
+    return false;
+  };
+  try {
+    const m = rt.module();
+    const tv = m.variable().define("title", [], () => {
+      const d = document.createElement("div");
+      d.innerHTML = "<h1>First</h1>";
+      return d;
+    });
+    if (!(await waitFor(() => snap.get(m)?.title === "First")))
+      throw Error("initial title not detected");
+    tv.define("title", [], () => {
+      const d = document.createElement("div");
+      d.innerHTML = "<h1>Second</h1>";
+      return d;
+    });
+    if (!(await waitFor(() => snap.get(m)?.title === "Second")))
+      throw Error("title update not reflected");
+    return "ok";
+  } finally {
+    if (gen.return) gen.return();
+  }
+};
+
+export default function define(runtime, observer) {
+  const main = runtime.module();
+  const $def = (pid, name, deps, fn) => {
+    main.variable(observer(name)).define(name, deps, fn).pid = pid;
+  };
+
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
+  main.define("module @tomlarkworthy/observable-runtime-v6", async () => runtime.module((await import("/@tomlarkworthy/observable-runtime-v6.js?v=4")).default));  
+  $def("_s7bl1p", null, ["md"], _s7bl1p);  
+  $def("_1eaa9lr", "currentModules", ["modules"], _1eaa9lr);  
+  $def("_dmem61", "modules", ["runtime","observeVariable","moduleTitle"], _dmem61);  
+  $def("_up9atj", "moduleTitle", ["observeVariable"], _up9atj);  
+  $def("_qpensj", null, ["Inputs","currentModules"], _qpensj);  
+  main.define("observeVariable", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("observe", "observeVariable", _));  
+  main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
+  main.define("thisModule", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("thisModule", _));  
+  $def("_1x0q6zt", null, ["md"], _1x0q6zt);  
+  $def("_e0sbyj", null, ["tests","modulesModule"], _e0sbyj);  
+  main.define("tests", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("tests", _));  
+  main.define("Runtime", ["module @tomlarkworthy/observable-runtime-v6", "@variable"], (_, v) => v.import("Runtime", _));  
+  $def("_p3rq3v", "viewof modulesModule", ["thisModule"], _p3rq3v);  
+  $def("_16g1ab", "modulesModule", ["Generators","viewof modulesModule"], _16g1ab);  
+  $def("_cayyvt", "testRuntime", ["Runtime"], _cayyvt);  
+  $def("_1j4p6g3", "testModulesLatest", ["modules","testRuntime"], _1j4p6g3);  
+  $def("_1oq6y7s", "newModule", ["testRuntime"], _1oq6y7s);  
+  $def("_1li1bty", "test_detectsBuiltin", ["testModulesLatest"], _1li1bty);  
+  $def("_vr1kp6", "test_detectsNewModule", ["testModulesLatest","newModule"], _vr1kp6);  
+  $def("_1p0sqk", "test_reflectsDelete", ["Runtime","modules"], _1p0sqk);  
+  $def("_1315qaf", "test_reflectsTitleUpdate", ["Runtime","modules"], _1315qaf);
   return main;
 }</script>
 <script id="@tomlarkworthy/observable-runtime/runtime.js.gz" 
@@ -18463,3265 +22979,247 @@ export default function define(runtime, observer) {
   $def("_104y7ux", "observable_lezer_parser", ["lezerhighlight","lr"], _104y7ux);
   return main;
 }</script>
-<script id="@tomlarkworthy/observablejs-toolchain/acorn-walk-8.3.2.js.gz" 
-  type="text/plain"
-  data-encoding="base64"
-  data-mime="application/gzip"
->
-H4sICB8jLWcCA2Fjb3JuLXdhbGtAOC4zLjIuanMApVlbU+O4En6fX2E4VZQza5wAs8yC8XK47FZRNbcC5mydonhQbDnRjC17JRkmh+S/n5bkm2zHITsvjNWt7v76olYrM3779o311rrMaRjj0JourG/8GsfkiVk5J3Rm3aZxnGfW06H7/sQ9sBANrXvMOGbW06/uwYl76Er5z4zMCEWxFZEYn1pjmiVjFKSM7j+j+Pu/f3OP3MNxSLgYy7WbfOMgJQWvU+vT53uwha272xvrmYi5FS4oSkiA4nhhzTDFDAmAJjXzHetjyrBFaJSyBAmS0lNrLkTGT8fj5+dn9xsPFXg3SJOxcmCfM7Iv1e4XaveVIrA9fhPlNJA6LGELBzvUYU46eqHLpU39ZOQ02MBwyOjlCTEL+WS5ZK5YZNijD+hR8cTIwfC9t4cLymgFKtW/lRbcNCI1Ef/h0VtnDek93EelNSfz2Y7vkwfixpjOwKODRy/b2yNulvO5zUYOfeANOFzB0ZTlkgB+R+9OM7sHHu3Co+eRDYTl8ikloTUZnTJvpwFT7R69kAfYgRXER0UTSjs2tDNbjF4YFjmju1wwSMyu70uRNLLEebnNxuUmC/vAX52K5bJilrydyWolAaZ+xQJzoxcxJ9ylaYh94ahvLqByfLzyKhik4+QWCfCa8SWQCra3Z2NF4EDwWU9UUWmwritPYXdU9ncMowj0KKOZz6usBz1ZD8ysZ49KGFClDVRIJd3JgArQnMDMfQMjLzASDQDkbCQDAh7ZZOQJtngxcXJQqnAGflYFh0S2TfM49n0saRB7Js58PAI0mkwlGdPwd58CET0Ej0oVoO7IQe57BIEqJYkdAPyRmLP02aL42UqlHuUV/A2QCOay2ACPgEYB+mggqywdFZUlPC0qVnUIsjoEkCjwm4L7EAci89UNQF+iZAB27MKB33GB+Uz5QRoponYm4bfwI4Uf/VP8wT/AX+DVIHvdKZ3x8d5eAbuN2mu4tvopF/KmC+rkecXulj9Oy5WscqUI/ahbnNpN6Ye9Ay7qNqFoijOS/smqAj73a+/AqC7ThnsOrzFHuvFIa9T/PP2GA+EGDEPXsaEAIPRwTdmSC40G4I7oA3v0BfypXKt1xdp/SJ9SWjN+lAzV9BL/ZeUl7heWzhhK/MS9jNPg+53sdAmmAgjymwSKbDRIqaLC40+gKwh3moYLj52lRW/x2C/+gUSQAkaQ2K307oL7jtat7cSw+iPJxKIm/ZCkHxnDnIPJJqQviMHHHHPyPxzWW4BzNUeENihtwGWcbOHiapdEVssANDB8E9UG20qktMBctOUcyQhSyvHfOci1HHaEi2KBGQWKrI/Gsh0asP8BTTFMUOtBNDyRUe9RcQmVY2TyKqWC0BybIf4LhplhX1NVib3erjF9BxNSsEErjG8BIwmMebSj22sXVoA45t3K0nOFrC6PqJTIwJLe5FQqEajkPmkkykNnvNSLiorlMHh1KrZ27QrwdLwSFQQxDKHyqoawxaG5VZlvJva/BMfmObh4RkQMnAMoPjbLpXhRisWq7yjcy95qdATgo/CPeGNhDmpli+H6mMqO0z1DcySfFkzDLhbQ34ATyRcDdISCVy176vNKXilXMcp7s5ghaIVaifqUCr4gIQ/rcNn/NYe3QDNS12mLtFUrWWPlz5StVyhcQkmRVPkl5UHgBj5V+IYrFDbkWVg1KP29JbYbozSB8HlDK41x1IIpqfACnIutTZOuid3/IEbQNMbXOIghnZK3K18D6io/19fjqd7eqdJrPM1nM8zMlvlnYaKhceAYKN8Krtbag2jj1RrWe/n6bqE7RFt/ynoDT0Kzsvtqpx2Q0pG+wgsLUVNtp+upM8WHOl4lu2rku3ljnzdxnbYroRDvVsJNCHtIRDBrF4BTVUll+3T3I06mmDUsdYT0jlqkmLUaKSixyLIxdquJ5xbO4JZ9tI4NyF8whhbr3G3HHWtDG65RdYOahqQlPY2+1lTG0gwzQTbc2btf9L6FjCzRkbXlzZxkucChvsy/40VPGyDuE4pzbACFlDUCWuvUevqDuDKGTJWUe3jrG5fpXQ4gfZk/gUrEKqEq/AO37E9mwDh7dRK2MDiUB7NllOfanCIY3Py9nJ4OKGcjNcwEeJuQVFsHO0InFPc4yWI49R8IJBLFG+38nSNOBqNQShCQQC1k5AyVYqQQQw9kGFl5rmWhfKWILYwAflVX60CgNs1Pl6Sj80M6kz9zblBaXrede7X3xlVdBr5nVAIxq6Mir2sLTXPmALXWFrxRQiJ1bPTjlS+wDtt4dbXNf8LP5nsSxUM4SGQri7AL455hqkwgH7XrseJsVfXtG2mb55ow+mrVGxZ9YYB1ysQnlOCwOaOUjGscoTwWQ+OLMbBogw1CYbPHRn3HLpeGCIwV542L/rTtHE9zFhRzq/5e79hFHA9jx2pbGalyJZ8Zw+pvEh2e1491PMOBmkgGe9NrrG6oik3idyUQv3ZDZbnLkDnjGQqwwapmK/kDDSNPkCmDVnZq2Q/vEQzVYdUpNxx0NOs9yKql9/aQGHFu1q0ivep3IalQ7W7oev2wKwtRTgtKrCjGaj3wmqltXcL6J39nK3uFmKdwtCI5yusolMNLL7HHSbNh9A1iQo9hekM1kRkJ8fTxecEW4pb85ZbDe8RJ5GqKOHYC+QV4wk9piC8iiKOTGSSW5jR0uEETTt5cX2KIEHaIouVx7KDy66I0GElKgr6Da/KL4SBnnDzBu0IuOYFSxCVWK9Slb8n/MPDejMf/svTx+YiyjNDZ19sP/pgn42gSTN4fTw7fhYfRydFheHz07t0xOkYBmh5hdDJ5Nwl/C8LjSXR4go6O8WSCDkHz++gwPJkERweBm6Ds/8t9I8syHQAA
-</script>
-<script id="@tomlarkworthy/observablejs-toolchain/parser-6.1.0.js.gz" 
-  type="text/plain"
-  data-encoding="base64"
-  data-mime="application/gzip"
->
-H4sICOAiLWcCA3BhcnNlckA2LjEuMC5qcwDtOmtz20aS3/MrIF6KAWIIFKX4ETCwYstKnW4V2yfJSW2ptKsh0KQmAgF6MJTEpfDfr3sewICknNzdbu1+2CqVOK/u6el3z2Dw7bdfed96bxdFlkPmjZfeb9U7yPmd8BYVL6beWZnni7l3tx+9/D4aeqzIvAsQFQjv7nk0/D7ajwj+g+BTXrDcm/AcYm9QzGeDH8sxLrtj4xxuPg/mjIB+fBENo71BJdIBLzJ4iH6rEJwwvCu99x8ucFPwzs9OvHsub7xsWbAZT1meL70pFCCYRBppi2rH+7kU4PFiUooZk7wsYu9GynkVDwb39/eIN1OniNJyNlAn2a0E3yW0uwbtrkKEew++4rN5KeTqorw9KgsJD9JjlQehLG8vlnOoqCfDj+oE1BbhFOQpL+AEt6eBop6IctZTx2ZpKYofX0XDYXQweAbVrDcy6GfsFmh1FbIihUqWChkPK5zP1Qxbx7N7z/JbRHYQ7Rtcd0x4ZVLAvXcO0r/svRGCLXuh/n27mExAYI/JckyDi4yX5kjYfZur0bdlmQMrqMWnJwXNjGXJ8CfFcYEjJLbc9i/4DMoFrUrLokJQaonlXJbYOFrgOWbHd6DQvGOS/cLhXjdpYQZpmcGnsxO3fVQiQwoNksEdT+Ejf4D8jORIQ2W6mOlZKFrwpu2CHwtR0oGhStmcNgRN+QRkeoO/P3FFL/2c8kqa5hmwTPHpp7xk8mDfMlF1X3zXdBdFSqqFzf9UEBW2TmZsCvaXDkztYsILLpeqKYcvLALstMix88ppE5W8+ongQDXfs/f4+1/nH+jnZzZX/yUdQs+8X8zGiuiC3fEpSpjaH8a/QUrHUval6LcdLdk5CGUiqHHY+4gI999RA/WMV6BbD0TSGSumYNl5BqhHyHB3INcbncH0+IGISwln/qbg2v5+EmxG+AR8XqByb4yjuuL/CqSjX9hrtetcCjRTaixn4zJXjUKyB0vCBSrxO6VCtndc2J684SQbsla7/BN3JUG9VhTUe9XpHOVsNofMjqE7BBQpZKrdKBcqX4P+7BT//wrsVouKWvqIv8L4vExvdbsUt4rAe3R35X3vKgjTpPJXJ8oj+MGqDslekKECqgq55aPXCUWwEj5EPMN27yRDTecTjmiCOvx5Icmh/mGAOhhNjBZ7cx9wHciFKBrVbhH1kiSBSCIHHx+baeR3zoSSY2ce+VTe/w4OVKwpyr4dqxtKcocSdErp7blEd6FsvkNFic7oyakPkyentk7Q8VsSFn8nZrQYb0gUwYqcpPREsqLZuOFCOC6zZXwJEf1e1WGhfDjqTohUGGOr4qpOYKSp8pgvwtURBr+WrBiS13qDFUVFgFiETEyVt6xiTsB84rsasJMkwpxDRBj2AAfk42MVqfD7YeKL4Ie9QO9IsEOc51EOxVTePD7u+L1TdE8CjRUPzC/3rhSufn/wl8tveleDSKKl+2pcsPsAeXUBGMuQ+dvB9mwXmiNVZrMgkDeoU552aBHDyWnhqzjXegH/+uuVrD1yMVxQXPYosmPszPV2XqV8iGd5ch2EqwJdRAxoB4pvl+wq4WGZuOdiirpDFqFTWkDMos8LVvGK6FQjmEOUt5Ch5a4qyYTEFeo3hCLDNv6vR0V0wyq/DA6LCHMDbETzRXXjp0FcRBUNhJfpFZpjmAZh0erMBHVmJdk0Rhtm9yjNKYZolldxEUZRhNqwqoNVDtLjJJxikec7iez3UXV5soyUm0cMlTmcx5KxGZQ0OPUZOoQiCO+pEYQ8wq0Shr+4WbKzI2rIMd/iSeaiMuo39XkIGhgbCFyj9leVl3noefHMmAZpVRSLFGMRwiLFqP/VAkOO3xXjCtIZ+wXjJ+nw8KAmfGp1DRQMztNyDq09evt91JVnz8ipRx/+apkVKsxRB6KGBy51x4FWgOlCoFHZyWiSs2nV7+/uPoG1xVPrUEq+R1u0wTtEVVkDRklE7J5xFIlvpli1LNJkZy8wiNeQaeRvCMb/MuYvIjQINLY/c8gzh31fRGfy6FKso7RYNE4ToFqkCrxA0ftBCFE1h1Q5mErv5MCcN1O4Uk2SdRFJ0V8p/bakNLh4QapCruCLuAwy9By42uS0C5b7PZUyK6LKhUgh6e6pPcJhi5m86RvMWf0gVoMY3hVKyCy9lMtVN+/Rb6DIepoS1/d3WOSSaHw/JJdXobA5+ojMt0BujzAP850z+DIaC5bCaTDa0cOsGTsLRmjiaPEBQg5H2kwna9BY2syYoZlN0CouBOM5nvaIJlpUwVhgcmJchGGycmDqiMGoiu4wB0ksDS5vaaKcIHeraKYzj2RHL+/3t603ixSArnogc6VKgcmyOb2B9PZTgX4c00HkfgvhLjgtMdJtzq3ty6pecIirclr9xzdUy7ftpieC2GJs93cX/8Lyc1W7WYiwh8LGwwsVDcygCruB4RdKqGqWmzBy3cZr75uvVy5Y/Y13Q3VhjhLMlt4YoPAypYqQXdM+LMu6+6AdqMizrsmV1eRGYXtBUBvjhrprGmtmryZ/Zssx/AmW96XInPTTqkjY6yayPcwGfh/Y6guWOuuJLSFw3JNDW63YdgR5jia35uiSvbDrN4fhpuMzY+QaUomWaVSqDSzD7zBTVLxTu9gUW7NEGFE6CiOUH8sSEer8LsHcINIEuNTgYEvFOlnWvTVxaJszInKs/zGkCet2dEaZ+VhTKEhezBcybK09UJ6oSlSGcoEZTYF78ISSipCpn5ErdIfJoevDtSH0+y4aNU2ZJckKitNDvuHK/XW3Q8bVgEE56fedfgUzjoHC2ZeUG0esuuGqSmdn/X6jRe3g46O/dlAHuUZVdDw/Lti2Xm0Nn3FjlvxzTWHTp60R3I0N8DkIOofQoaYjGFV5YRj03UGHJMxUVcKZMKcIcqhSpYJO7HtHlBtum0NJMGzyLLARnGSblrnawNpSS3c56Si+UXIeMqP1F+X8FO4g3+qjzGrMbGpZvlG5J3Gya8Bb+NtUc4cQa5+zBbx2DB6s0cmEDP/xEUZ+qZy+Vi8qhZrCrNcocDcKyO3+X1rPzzHFNrHq2uzuRK+2fG1NAoxuuxahx4wC6Y3BbvypsQDvVmskEQCGgGubH25uXa8HwK6LdMCcNV9mPLIxNox2DBOMh9eEa30kKbXeZC3HRAU67DnnwkrFKyeecoa92J2RZDjWmT5hlSr/t4kXr5yUA4I23dvIqLbmzPzJTKjj47FGqGuNeaY8OjLuuoc6TX8+JK8fIqr9iQAs+1RJtmxKsqxTkmGJBbYgU22HV+gRWHr734tSQuM6xJs8L+8xY9sZ1nQvyVluTtzUKpezKzf6GOm4sWJDHDbhV4456fVssSq28M29GMAs2uTOLdvs9cJxrq53/BWvLth0ClmMZ6Yin3JsYQr45LK4GjXk2DgzCroeJytzTKfe6kw87FDgZFIbvnHd4ZpcO7Sba9j/De2N2hRYpvO8yUuMAq1rigg3Lls2gsB2ZyqUX0c1a64hHlC+EBPvNL/mZfVDm0OYG5pm6tmzoMJKLjWs0WvSGyaOkK43JtLjOrIQhoXL9/vx01h3h02pj/MjU6oQ2MGLmC6k9g9sOfvkRs+GQWul2LcASrWMy200kheoiDyzvAs6QQRxJfsuy3R0XdMSTSVmzbUL3AVY28ZJyaIq5yn46x5MMczcsYz/33cs+/++Y/mXv2N5KpX5B1QzTV2yPc8DrZmOmf0D6xd0ej3X+Ux18pCUyoY1oYG6xt64eVHpAs0rcw4gaq/O7UR7m3S4MRLN2NynEArtdUIQY5hR9ytSLFcdjJbC/+O9ftW80soACyzcpjly2UWp74zBBoCdHUyL9RWCDJ58X2iBDvU1gEkxzYUzhM0bsZ64CoLOvTN6fNIENkMZleKYoTv3ZfIa8YSUWqiEpd+nTanlwGaaDhMCdPqmPb378BDfKESOQzdvlR+ZRM0sejFuL1BRhOTgkABEAm0QdGDVw5wDCjqIdgHRo22D/ai3WfZinNVpCK5xV5xBJU1Y1ots7r62TtcENNGQQqtzmDgrM5iwRS5j/Z5BUtBvFz3KoNNyWvC/YfY51wg8pU1e75nho2MX6hrmxqc7BX0d1U4ttQgoOxImwVcPP+2zJb37BCuK6CaFsuF2f1S8TvZGu7uFMrdulYJ6t/Alpk2B8yRUqhHMy+3YenlLrhBXmFLQF8m1rki8r1coFYUONUgXFVhTbC8D1jCYAmY7ihqp2qmUgYhg2zH+0FtSC0OVVlFKj+n0t+e+GjGdyJFk3HzJFgYQ/J4dqIFfmOB0nkZtSDLGkqk8kYFiNMlaGbHD/qfY1UpU882C/KFntFaRsQzyFCEM23eGTK8pArsvaJuWuHaO1jCDBzyNtC5tqwPYgG39wTbo1oxNsLwreUaiaE1605jXlzqG7chzrOX50Nqyzew4PcJa6TmhKFYQyWtjg+r2bIu1DZW19fs0T4qp7M7vIZ91LLvlRXY41yYX58b0lAWo5giirN1zw0vSgz8aQFCHW56ov0QhuP4A1imEgCjCgGEIwdZI+yGMAyHpfLthPAnV1c/fYWPY3f3SxrXeKG6jMkWwbowKjxjaIq5bVLC2UIU6FR90M6RT2AxDOezmYjyehWtX5c3Ie7SJao5FgDOl3nQ7emI0PF6GrSOIl+261vqcp/1xuBFdcOzTPKOSsV3WTUrWVTrsfheBCLrfUMRjRQWr1cVxnTLlukziRXbu5BcUv9WYvT6GCA9fsSk8S649/+uViHKMNXVMrbTMF7OiDq7p/aGkbKyF1AEsEWGGzkGCp+dq7ahAv0F3Ei9MlZqHicZG71ufq3Ktfn9LgrjTTRB1Skff+b2REg1HeaaE9EV9BtYOqvdD5DQbowc5ynm77l1nUL8zQorkmflz1VHjGEJQ1KmipIPj/cZE71+L9+scsinsJk/aGcuFdmTb+c1sK099xONEf+Tl9xSVyL7zZmRWZuZ9KjxpBq0a4OBtM0gRqud84HRH7FQeGJPv4xFJv40xnGIMXexifY4ZGBXT3ZJ5WAdNVluZq4tjFb69c7qJ4N3HCCU4umo4dp4l6PsW+wLRXMJ2BlUh5QzRnsk5XYlJXiygrpJbrCF4O9DduSkNHx/dUXVtQJhOWkDnKuV2jX74HDR3TYoK997lZG0xSSiwWEebjOj3OX0D8wPYL3ls6NSoTSStW4W3A/CgPovN6MtXKgz1B7bhkvr23sQZn9B4c/cY3qkuwO1JFqbUpk9l65FG6pkk3FPR56vB4D88/XUA6uKcF9NPZ6fJoJoNMjaewKv0OYwnr9hzdrB3MMmeP987eAUwefny1ffsJUvHL4bfPX+ZpbA3hvH4VXbwcnLA9sfP0zGkVFH+D3KMR1ZDLQAA
-</script>
-<script id="@tomlarkworthy/observablejs-toolchain" 
+
+<script id="@tomlarkworthy/plugin-registry" 
   type="text/plain"
   data-mime="application/javascript"
 >
-const _lp77pf = function _1(md){return(
-md`# Bidirectional Observable JS <=> Runtime Toolchain
+const _1ej2r92 = function _intro(md){return(
+md`# Plugin Registry
 
-\`\`\`js
-import {decompile, compile, cellMap} from "@tomlarkworthy/observablejs-toolchain"
-\`\`\``
-)};
-const _n0sc6u = function _2(md){return(
-md`### Compilation, source to runtime variable(s)
+A foundational notebook for **decoupled reactive plugin wiring**.
 
-Compilation takes notebook source cells written in \`Observable Javascript\` and turns them into reactive variables for execution in the \`Observable Runtime\`. A cell is usually compiled to one runtime variable, however, mutable variables are more complicated and are represented as three runtime variables.
-
-ObservableHQ does the compilation process as part of the hosted notebook experience but in this notebook we provide a way to do it in userspace.`
-)};
-const _sgo04r = function _3(md){return(
-md`### Decompilation, Runtime variables(s) to source
-The aim of decompilation is to go from the live runtime variable definitions, back to the source as best as possible. ObseervableHQ does not have this feature. In this notebook we implement it in userspace.
+Consumers get a realtime stream of all registered providers under a name. Providers can register themselves under a name. Neither has direct references between each other. This allows you to add more consumers and providers without changing individual providers and consumers. Useful for reactive plugin systems like audio instruments, dyamic menus, LLM tools and entity component systems.
 `
 )};
-const _aivd6y = function _4(md){return(
-md`### Codeveloped with AI
+const _16jmxgh = function _diagram(htl){return(
+htl.html`<svg viewBox="0 0 720 300" width="100%" style="max-width:720px;font-family:system-ui,sans-serif">
+  <defs>
+    <marker id="pr-arr" markerWidth="9" markerHeight="9" refX="7" refY="4" orient="auto">
+      <path d="M0,0 L8,4 L0,8 Z" fill="var(--theme-foreground,#333)"></path>
+    </marker>
+    <style>
+      .pr-box{fill:var(--theme-background-alt,#f4f4f6);stroke:var(--theme-foreground-faint,#bbb);stroke-width:1.5}
+      .pr-hub{fill:var(--theme-foreground-faintest,#eef);stroke:var(--theme-foreground,#556);stroke-width:2}
+      .pr-t{fill:var(--theme-foreground,#222);font-size:13px}
+      .pr-s{fill:var(--theme-foreground-muted,#666);font-size:11px}
+      .pr-e{stroke:var(--theme-foreground,#333);stroke-width:1.5;fill:none;marker-end:url(#pr-arr)}
+    </style>
+  </defs>
 
-This notebook is setup for was AI collaboration. Important runtime values, such as the test suite report, are highlighted to the LLM, which helps it decide how to fix test cases.`
-)};
-const _1q8w8vr = function _5(md){return(
-md`### Prior work
+  <rect class="pr-box" x="10"  y="30"  width="170" height="48" rx="8"></rect>
+  <text class="pr-t" x="95" y="52" text-anchor="middle">Provider A</text>
+  <text class="pr-s" x="95" y="68" text-anchor="middle">plugins.add("x", v)</text>
+  <rect class="pr-box" x="10"  y="120" width="170" height="48" rx="8"></rect>
+  <text class="pr-t" x="95" y="142" text-anchor="middle">Provider B</text>
+  <text class="pr-s" x="95" y="158" text-anchor="middle">plugins.add("x", v, {invalidation})</text>
+  <text class="pr-s" x="95" y="215" text-anchor="middle">…N providers</text>
 
-_Alex Garcia_ pioneered the first third-party Observable **_compiler_** [[asg017/unofficial-observablehq-compiler](https://github.com/asg017/unofficial-observablehq-compiler)]. The compiler here differs by being entirely text/data based, _i.e._ the output is a string/JSON, not hydrated variables and functions.
+  <rect class="pr-hub" x="270" y="78"  width="180" height="112" rx="10"></rect>
+  <text class="pr-t" x="360" y="104" text-anchor="middle" style="font-weight:600">plugins</text>
+  <text class="pr-s" x="360" y="128" text-anchor="middle">Map&lt;name, Set&lt;value&gt;&gt;</text>
+  <text class="pr-s" x="360" y="150" text-anchor="middle">add(name, value)</text>
+  <text class="pr-s" x="360" y="168" text-anchor="middle">get(name) → Generator</text>
 
-This is the first **_decompiler_**.`
-)};
-const _d17a1w = function _6(md){return(
-md`## TODO
-- Tagged templates (decompilation works, but there is no source compile for them)
-- notebook imports (WIP some decompilation works)
-   - need to dedupe some of the implied imports, e.g. \`viewof foo\` also imports \`foo\` but we don't need to explicitly import \`foo\`, it's implied
-- anonymous variables work, but the test cases fail due to naming mismatches
-- Bug with unobserved module imports, moduleSource does not resolve, we just adjusted source to avoid that problem now 
-- class body assignments can't be decompiled`
-)};
-const _1juriue = function _7(md){return(
-md`## Continuous Integration Testing
+  <rect class="pr-box" x="540" y="30"  width="170" height="48" rx="8"></rect>
+  <text class="pr-t" x="625" y="52" text-anchor="middle">Consumer 1</text>
+  <text class="pr-s" x="625" y="68" text-anchor="middle">plugins.get("x")</text>
+  <rect class="pr-box" x="540" y="120" width="170" height="48" rx="8"></rect>
+  <text class="pr-t" x="625" y="142" text-anchor="middle">Consumer 2 (V2)</text>
+  <text class="pr-s" x="625" y="158" text-anchor="middle">plugins.get("x")</text>
+  <text class="pr-s" x="625" y="215" text-anchor="middle">…M consumers</text>
 
-We sniff the entire runtime to test that each cell is de-compilable`
+  <path class="pr-e" d="M180,54 C225,54 235,116 268,126"></path>
+  <path class="pr-e" d="M180,144 C225,144 240,138 268,140"></path>
+  <path class="pr-e" d="M452,128 C500,116 510,54 538,54"></path>
+  <path class="pr-e" d="M452,142 C500,144 510,144 538,144"></path>
+</svg>`
 )};
-const _1k5oyj7 = function _9(tests){return(
-tests()
+const _xnvzuh = function _contracts(md){return(
+md`## Contracts
+
+| Guarantee | How |
+|---|---|
+| **Named sets** | \`plugins\` maps a name → a set of values. Providers \`add\`, consumers \`get\`; they coordinate only by name. |
+| **Reactive** | \`get(name)\` is a Generator that yields the current set and re-yields on every add/remove for that name. |
+| **N↔M decoupling** | Providers and consumers share only \`plugins\`. Any number of each; a name is the whole contract. |
+| **Auto-cleanup** | \`add\` returns \`remove()\`. Pass \`{invalidation}\` (a cell's disposal promise) to remove automatically when the provider cell re-runs. |
+| **No leaks** | \`get\`'s Generator unsubscribes on disposal; per-name listeners are dropped when the last consumer leaves. |
+| **Eventual convergence** | Each consumer gets the current set immediately on \`get\`, then a full-set snapshot on every change — so any interleaving of add/remove/get converges. |`
 )};
-const _1jrpa13 = function _10(md){return(
-md`### All cells are decompileable`
+const _1ua5hud = function _apiReference(md){return(
+md`## API reference
+
+The whole API is two methods on \`plugins\`.
+
+**\`plugins.add(name, value, options?)\`** → \`remove()\`
+Add \`value\` to the set stored under \`name\` (creating the set on first use). Returns a \`remove()\` function
+that takes this value back out. \`options.invalidation\` (optional, may be null/omitted) is a promise — when
+it settles the value is removed automatically; pass a provider cell's built-in \`invalidation\` so re-running
+the cell replaces rather than duplicates. \`value\` is anything; for shared views it is commonly a factory
+\`() => element\` that each consumer calls to get its own instance.
+
+**\`plugins.get(name)\`** → Generator&lt;value[]&gt;
+Return a reactive Generator of the values currently in \`name\`'s set. It yields the current set immediately
+(so a late consumer still converges), then re-yields the full set on every add/remove. Use it from a cell
+and that cell recomputes on each change. Call it from as many consumers as you like (e.g. a module and its
+V2) — each call is an independent Generator that cleans up when its cell is torn down.`
 )};
-const _1lc80et = function _cellMaps(cellMap){return(
-cellMap()
-)};
-const _zki07o = function _allCells(cellMaps){return(
-[...cellMaps.values()]
-  .map((cells) =>
-    [...cells.values()]
-      .filter((c) => c.module !== "builtin")
-      .map((c) => c.variables)
-  )
-  .flat()
-)};
-const _1nkhnnd = function _all_decompiled(allCells,decompile){return(
-Promise.all(
-  allCells.map(async (cell) => {
-    try {
-      return {
-        cell,
-        source: await decompile(cell)
-      };
-    } catch (error) {
-      return {
-        cell,
-        error
-      };
-    }
-  })
-)
-)};
-const _1ip1war = function _test_all_cells_decompilable(all_decompiled)
+const _1pzt22q = function _createPlugins(Generators)
 {
-  const errors = all_decompiled.filter((s) => s.error);
-  if (errors.length > 0) throw errors;
-  return `${all_decompiled.length} cells decompiled without error`;
-};
-const _1w70b75 = function _15(md){return(
-md`### All decompiled cells can be recompiled`
-)};
-const _uscpdn = function _all_compiled(all_decompiled,compile){return(
-all_decompiled
-  .filter((source) => !source.error)
-  .map((source) => {
-    try {
-      return {
-        ...source,
-        compiled: compile(source.source)
-      };
-    } catch (error) {
-      return {
-        ...source,
-        error
-      };
-    }
-  })
-)};
-const _x55zzr = function _test_decompiled_cells_recompilable(all_compiled)
-{
-  const errored = all_compiled.filter((cell) => cell.error);
-  if (errored.length > 0) throw JSON.stringify(errored, null, 2);
-  return `${all_compiled.length} cells recompiled without error`;
-};
-const _100n7xr = function _18(md){return(
-md`### All cells roundtrip compile`
-)};
-const _1nm57o2 = function _roundtripped(all_compiled,decompile){return(
-Promise.all(
-  all_compiled
-    .filter((c) => !c.error)
-    .map(async (cell) => {
-      try {
-        const decompiled = await decompile(cell.compiled);
-        return {
-          ...cell,
-          decompiled
-        };
-      } catch (error) {
-        return {
-          ...cell,
-          error
-        };
-      }
-    })
-)
-)};
-const _18xo2td = function _test_all_cells_roundtrippable(roundtripped)
-{
-  const errored = roundtripped.filter((cell) => cell.error);
-  if (errored.length > 0) throw JSON.stringify(errored, null, 2);
-  return `${roundtripped.length} cells decompiled, recompiled and decompiled again without error`;
-};
-const _14nox99 = function _21(md){return(
-md`## Reference Data`
-)};
-const _1d3zr3i = function _22(md){return(
-md`### Source code
-The source code of a [reference notebook](https://observablehq.com/@tomlarkworthy/notebook-semantics?collection=@tomlarkworthy/lopebook) is extracted directly from the \`https://api.observablehq.com/document/...\` endpoint
-`
-)};
-const _12sqt9 = function _dependancy_document(){return(
-{
-  id: "1fb3132464653a8f",
-  slug: "dependancy",
-  trashed: false,
-  description: "",
-  likes: 0,
-  publish_level: "live_unlisted",
-  forks: 0,
-  fork_of: null,
-  has_importers: true,
-  update_time: "2024-10-15T18:06:59.080Z",
-  first_public_version: 16,
-  paused_version: null,
-  publish_time: "2024-10-15T18:07:25.850Z",
-  publish_version: 16,
-  latest_version: 16,
-  thumbnail: "52bb3d5b2f48b727e0eea931c0093fe5778fb9b809bebb1edfb949d2f4b5590a",
-  default_thumbnail:
-    "52bb3d5b2f48b727e0eea931c0093fe5778fb9b809bebb1edfb949d2f4b5590a",
-  roles: [],
-  sharing: null,
-  owner: {
-    id: "7db5ed2b0697d645",
-    avatar_url:
-      "https://avatars.observableusercontent.com/avatar/47327a8bc1966f2186dcb3ebf4b7ee6e4e7ab9a5c2a07405aff57200ea778f71",
-    login: "tomlarkworthy",
-    name: "Tom Larkworthy",
-    bio: "Tech Lead at Taktile.\nFormerly Firebase, Google",
-    home_url: "https://taktile.com",
-    type: "team",
-    tier: "starter_2024"
-  },
-  creator: {
-    id: "5215f6ec4a999d40",
-    avatar_url:
-      "https://avatars.observableusercontent.com/avatar/47327a8bc1966f2186dcb3ebf4b7ee6e4e7ab9a5c2a07405aff57200ea778f71",
-    login: "tomlarkworthy",
-    name: "Tom Larkworthy",
-    bio: "Tech Lead at Taktile.\nFormerly Firebase, Google",
-    home_url: "https://taktile.com",
-    tier: "pro"
-  },
-  authors: [
-    {
-      id: "5215f6ec4a999d40",
-      avatar_url:
-        "https://avatars.observableusercontent.com/avatar/47327a8bc1966f2186dcb3ebf4b7ee6e4e7ab9a5c2a07405aff57200ea778f71",
-      name: "Tom Larkworthy",
-      login: "tomlarkworthy",
-      bio: "Tech Lead at Taktile.\nFormerly Firebase, Google",
-      home_url: "https://taktile.com",
-      tier: "pro",
-      approved: true,
-      description: ""
-    }
-  ],
-  collections: [
-    {
-      id: "cf72f19f55f3a048",
-      type: "public",
-      slug: "lopebook",
-      title: "lopebook",
-      description: "",
-      update_time: "2024-10-11T18:10:59.078Z",
-      pinned: false,
-      ordered: false,
-      custom_thumbnail: null,
-      default_thumbnail: null,
-      thumbnail: null,
-      listing_count: 0,
-      parent_collection_count: 0,
-      owner: {
-        id: "7db5ed2b0697d645",
-        avatar_url:
-          "https://avatars.observableusercontent.com/avatar/47327a8bc1966f2186dcb3ebf4b7ee6e4e7ab9a5c2a07405aff57200ea778f71",
-        login: "tomlarkworthy",
-        name: "Tom Larkworthy",
-        bio: "Tech Lead at Taktile.\nFormerly Firebase, Google",
-        home_url: "https://taktile.com",
-        type: "team",
-        tier: "starter_2024"
-      }
-    }
-  ],
-  files: [],
-  comments: [],
-  commenting_lock: null,
-  suggestion_from: null,
-  suggestions_to: [],
-  version: 16,
-  title: "Dependancy",
-  license: null,
-  copyright: "",
-  nodes: [
-    {
-      id: 0,
-      value: "# Dependancy",
-      pinned: false,
-      mode: "md",
-      data: null,
-      name: ""
-    },
-    {
-      id: 7,
-      value: 'dep = "a"',
-      pinned: true,
-      mode: "js",
-      data: null,
-      name: null
-    },
-    {
-      id: 9,
-      value: "viewof viewdep = Inputs.input()",
-      pinned: true,
-      mode: "js",
-      data: null,
-      name: null
-    },
-    {
-      id: 11,
-      value: "mutable mutabledep = ({})",
-      pinned: false,
-      mode: "js",
-      data: null,
-      name: null
-    }
-  ],
-  resolutions: [],
-  schedule: null,
-  last_view_time: null
-}
-)};
-const _13q8314 = function _dependancy_source(dependancy_document){return(
-dependancy_document.nodes.map((s) => ({
-  value: s.value,
-  name: s.name
-}))
-)};
-const _ook1nq = function _25(md){return(
-md`
-\`\`\`
-curl https://api.observablehq.com/document/@tomlarkworthy/notebook-semantics
-\`\`\``
-)};
-const _jmn84r = function _notebook_semantics_document(){return(
-{
-  id: "483a346021943f64",
-  slug: "notebook-semantics",
-  trashed: false,
-  description: "",
-  likes: 0,
-  publish_level: "live_unlisted",
-  forks: 0,
-  fork_of: null,
-  has_importers: false,
-  update_time: "2025-03-17T18:36:45.520Z",
-  first_public_version: 90,
-  paused_version: null,
-  publish_time: "2024-10-15T18:29:58.853Z",
-  publish_version: 152,
-  latest_version: 152,
-  thumbnail: "10dc93e33f09bad8366c143415404f378b6bd94f1148589113ff5fb2d22573ee",
-  default_thumbnail:
-    "10dc93e33f09bad8366c143415404f378b6bd94f1148589113ff5fb2d22573ee",
-  roles: [],
-  sharing: null,
-  edits: [
-    { node_id: 48, value: 'file = FileAttachment("empty")' },
-    { node_id: 55, value: "mutable_dep_2 = {\n  file;\n  return q + 1;\n}" },
-    { node_id: 151, value: "thisReference = (this || 0) + 1" }
-  ],
-  owner: {
-    id: "7db5ed2b0697d645",
-    avatar_url:
-      "https://avatars.observableusercontent.com/avatar/47327a8bc1966f2186dcb3ebf4b7ee6e4e7ab9a5c2a07405aff57200ea778f71",
-    login: "tomlarkworthy",
-    name: "Tom Larkworthy",
-    bio: "Tech Lead at Taktile.\nFormerly Firebase, Google",
-    home_url: "https://taktile.com",
-    type: "team",
-    tier: "starter_2024"
-  },
-  creator: {
-    id: "5215f6ec4a999d40",
-    avatar_url:
-      "https://avatars.observableusercontent.com/avatar/47327a8bc1966f2186dcb3ebf4b7ee6e4e7ab9a5c2a07405aff57200ea778f71",
-    login: "tomlarkworthy",
-    name: "Tom Larkworthy",
-    bio: "Tech Lead at Taktile. ex Firebase, Google.\n🦋 larkworthy.bsky.social",
-    home_url: "https://bsky.app/profile/larkworthy.bsky.social",
-    tier: "pro"
-  },
-  authors: [
-    {
-      id: "5215f6ec4a999d40",
-      avatar_url:
-        "https://avatars.observableusercontent.com/avatar/47327a8bc1966f2186dcb3ebf4b7ee6e4e7ab9a5c2a07405aff57200ea778f71",
-      name: "Tom Larkworthy",
-      login: "tomlarkworthy",
-      bio: "Tech Lead at Taktile. ex Firebase, Google.\n🦋 larkworthy.bsky.social",
-      home_url: "https://bsky.app/profile/larkworthy.bsky.social",
-      tier: "pro",
-      approved: true,
-      description: ""
-    }
-  ],
-  collections: [
-    {
-      id: "cf72f19f55f3a048",
-      type: "public",
-      slug: "lopebook",
-      title: "lopecode",
-      description: "",
-      update_time: "2024-11-17T07:27:34.529Z",
-      pinned: false,
-      ordered: true,
-      custom_thumbnail: null,
-      default_thumbnail:
-        "dab1604ccf4a760060379630da0876da27b79509b738f8d5c300c9a9a320e38a",
-      thumbnail:
-        "dab1604ccf4a760060379630da0876da27b79509b738f8d5c300c9a9a320e38a",
-      listing_count: 9,
-      parent_collection_count: 0,
-      owner: {
-        id: "7db5ed2b0697d645",
-        avatar_url:
-          "https://avatars.observableusercontent.com/avatar/47327a8bc1966f2186dcb3ebf4b7ee6e4e7ab9a5c2a07405aff57200ea778f71",
-        login: "tomlarkworthy",
-        name: "Tom Larkworthy",
-        bio: "Tech Lead at Taktile.\nFormerly Firebase, Google",
-        home_url: "https://taktile.com",
-        type: "team",
-        tier: "starter_2024"
-      }
-    }
-  ],
-  files: [
-    {
-      id: "50cad75d56578d08f50d560a50a6f4a66919f1f0b9c189221c6768a04dc958323335dac14ca3526e6527019d02e9e00d21d247eb5c2646b38ec7720e0ddcaa7e",
-      url: "https://static.observableusercontent.com/files/50cad75d56578d08f50d560a50a6f4a66919f1f0b9c189221c6768a04dc958323335dac14ca3526e6527019d02e9e00d21d247eb5c2646b38ec7720e0ddcaa7e",
-      download_url:
-        "https://static.observableusercontent.com/files/50cad75d56578d08f50d560a50a6f4a66919f1f0b9c189221c6768a04dc958323335dac14ca3526e6527019d02e9e00d21d247eb5c2646b38ec7720e0ddcaa7e?response-content-disposition=attachment%3Bfilename*%3DUTF-8%27%27empty",
-      name: "empty",
-      create_time: "2024-10-15T18:03:32.575Z",
-      mime_type: "application/octet-stream",
-      status: "public",
-      size: 2,
-      content_encoding: null,
-      private_bucket_id: null
-    }
-  ],
-  comments: [],
-  commenting_lock: null,
-  suggestion_from: null,
-  suggestions_to: [],
-  version: 152,
-  title: "Test Notebook of Semantics",
-  license: "mit",
-  copyright: "Copyright 2024 Tom Larkworthy",
-  nodes: [
-    {
-      id: 0,
-      value: "# Test Notebook of Semantics",
-      pinned: false,
-      mode: "md",
-      data: null,
-      name: ""
-    },
-    { id: 9, value: "1", pinned: true, mode: "js", data: null, name: null },
-    {
-      id: 31,
-      value: '{\n  ("");\n}',
-      pinned: true,
-      mode: "js",
-      data: null,
-      name: null
-    },
-    {
-      id: 100,
-      value: "<div>",
-      pinned: false,
-      mode: "html",
-      data: null,
-      name: "html"
-    },
-    {
-      id: 115,
-      value: "obj_literal = ({})",
-      pinned: false,
-      mode: "js",
-      data: null,
-      name: null
-    },
-    {
-      id: 11,
-      value: 'x = ""',
-      pinned: true,
-      mode: "js",
-      data: null,
-      name: null
-    },
-    {
-      id: 13,
-      value: "y = x",
-      pinned: true,
-      mode: "js",
-      data: null,
-      name: null
-    },
-    {
-      id: 15,
-      value: 'z = {\n  ("");\n  return x + y;\n}',
-      pinned: true,
-      mode: "js",
-      data: null,
-      name: null
-    },
-    {
-      id: 145,
-      value: 'comments = {\n  // a comment\n  return "";\n}',
-      pinned: false,
-      mode: "js",
-      data: null,
-      name: null
-    },
-    {
-      id: 17,
-      value: "generator = {\n  yield x + y;\n}",
-      pinned: true,
-      mode: "js",
-      data: null,
-      name: null
-    },
-    {
-      id: 20,
-      value: "_function = function () {}",
-      pinned: true,
-      mode: "js",
-      data: null,
-      name: null
-    },
-    {
-      id: 71,
-      value: "asyncfunction = async function () {}",
-      pinned: true,
-      mode: "js",
-      data: null,
-      name: null
-    },
-    {
-      id: 25,
-      value: "named_function = function foo() {}",
-      pinned: true,
-      mode: "js",
-      data: null,
-      name: null
-    },
-    {
-      id: 151,
-      value: "thisReference = (this || 0) + 1",
-      pinned: true,
-      mode: "js",
-      data: null,
-      name: null
-    },
-    {
-      id: 22,
-      value: "lambda = () => {}",
-      pinned: true,
-      mode: "js",
-      data: null,
-      name: null
-    },
-    {
-      id: 33,
-      value: "error = {\n  throw new Error();\n}",
-      pinned: true,
-      mode: "js",
-      data: null,
-      name: null
-    },
-    {
-      id: 39,
-      value: "viewof view = Inputs.input()",
-      pinned: true,
-      mode: "js",
-      data: null,
-      name: null
-    },
-    {
-      id: 42,
-      value: "mutable q = 6",
-      pinned: true,
-      mode: "js",
-      data: null,
-      name: null
-    },
-    {
-      id: 45,
-      value: "inbuilt = _",
-      pinned: true,
-      mode: "js",
-      data: null,
-      name: null
-    },
-    {
-      id: 48,
-      value: 'file = FileAttachment("empty")',
-      pinned: true,
-      mode: "js",
-      data: null,
-      name: null
-    },
-    {
-      id: 52,
-      value:
-        "mutable_dep = {\n  viewof view;\n  lambda;\n  mutable q;\n  return mutable q;\n}",
-      pinned: true,
-      mode: "js",
-      data: null,
-      name: null
-    },
-    {
-      id: 55,
-      value: "mutable_dep_2 = {\n  file;\n  return q + 1;\n}",
-      pinned: true,
-      mode: "js",
-      data: null,
-      name: null
-    },
-    {
-      id: 57,
-      value: "viewofdep_inline = viewof view",
-      pinned: true,
-      mode: "js",
-      data: null,
-      name: null
-    },
-    {
-      id: 61,
-      value: "viewofdatadep = view",
-      pinned: true,
-      mode: "js",
-      data: null,
-      name: null
-    },
-    { id: 93, value: "dep", pinned: true, mode: "js", data: null, name: null },
-    {
-      id: 64,
-      value:
-        'import {\n  dep,\n  mutable mutabledep,\n  viewof viewdep,\n  dep as dep_alias,\n  mutable mutabledep as aslias_mutabledep,\n  viewof viewdep as aslias_viewdep,\n  mutabledep as aslias_mutabledep_data,\n  viewdep as aslias_viewdep_data\n} from "@tomlarkworthy/dependancy";',
-      pinned: true,
-      mode: "js",
-      data: null,
-      name: null
-    }
-  ],
-  resolutions: [],
-  schedule: null,
-  last_view_time: null
-}
-)};
-const _1juj7i6 = function _notebook_semantics_source(notebook_semantics_document,parser){return(
-notebook_semantics_document.nodes.map((s) => ({
-  value: s.value,
-  name: s.mode == "js" ? parser.parseCell(s.value)?.id?.name : null,
-  mode: s.mode
-}))
-)};
-const _1oevsow = function _28(md){return(
-md`### Runtime Representation (v4)`
-)};
-const _11lfflk = function _notebook_semantics_module() {
-    return import('https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4');
-};
-const _gjten6 = function _31(md){return(
-md`### Imports`
-)};
-const _n9rco8 = function _32(md){return(
-md`observed modules are variables in the parent notebook, so their module is the main, however, their dependency is something else. -- this holds even for live notebook. They can only have one dependancy (inputs.length = 1)`
-)};
-const _eog966 = function _33(md){return(
-md`### runtime in observable`
-)};
-const _n4ntwp = function _34(md){return(
-md`## Test cases`
-)};
-const _1lg9nnl = function _importFake(Runtime){return(
-async function (variable, module_name) {
-  const runtime = new Runtime({}, () => {});
-  const importer = runtime.module();
-  let _import_definition;
-  eval(`_import_definition = async () => "${module_name}" && runtime.module()`);
-  const importVariable = importer.define(
-    `module ${module_name}`,
-    _import_definition
-  );
-  const importee = (importVariable._value = await importVariable._definition());
-  importee.define(variable._inputs[0], [], () => null);
-  return importer.import([variable._inputs[0]], variable._name, importee);
-}
-)};
-const _25tjxa = async function _test_decompile_syntax_error_roundtrip(compile,decompile,expect)
-{
-  const compiled = await compile(`foo = () => return ""`);
-  const decompiled = await decompile(compiled);
-  expect(decompiled).toEqual(`foo = () => return ""`);
-  return "ok";
-};
-const _1jyrnzq = async function _test_decompile_$variable(decompile,expect)
-{
-  const decompiled = await decompile([
-    {
-      _name: "v",
-      _definition: "function _x($variable) {return ($variable);}",
-      _inputs: [
-        {
-          _name: "@variable"
+  return function createPlugins() {
+    const sets = new Map();
+    // name -> Set<value>
+    const listeners = new Map();
+    // name -> Set<() => void>
+    const notify = name => {
+      const ls = listeners.get(name);
+      if (ls)
+        for (const l of [...ls])
+          l();  // copy: a consumer may (un)subscribe while notifying
+    };
+    const add = (name, value, options) => {
+      let set = sets.get(name);
+      if (!set)
+        sets.set(name, set = new Set());
+      set.add(value);
+      notify(name);
+      const remove = () => {
+        const s = sets.get(name);
+        if (s && s.delete(value)) {
+          if (s.size === 0)
+            sets.delete(name);
+          notify(name);
         }
-      ]
-    }
-  ]);
-  expect(decompiled).toEqual("v = $variable");
-  return "@variable support: ok";
-};
-const _1v1d8m3 = async function _test_decompile_import_variable(decompile,importFake,expect)
-{
-  const decompiled = await decompile([
-    await importFake(
-      {
-        _name: "dep",
-        _definition: "function Yn(e){return e}",
-        _inputs: ["dep"]
-      },
-      "@tomlarkworthy/dependancy"
-    )
-  ]);
-  expect(decompiled).toEqual(`import {dep} from "@tomlarkworthy/dependancy"`);
-  return "ok";
-};
-const _fiyb80 = async function _test_decompile_dollar_in_string_literal(decompile,expect)
-{
-  // Regression: $N inside a string/regex/template literal must NOT be substituted
-  // with `viewof X` / `mutable X`. This is the cc_ws bug — regex backref $1
-  // collided with `viewof cc_watches` (input #1) and got rewritten blindly.
-  const decompiled = await decompile([
-    {
-      _name: "demo",
-      _definition: `function _demo($0,$1){return(
-"x".replace(/x/, '$1y')
-)}`,
-      _inputs: ["viewof a", "viewof b"]
-    }
-  ]);
-  expect(decompiled).toEqual(`demo = "x".replace(/x/, '$1y')`);
-  return "ok";
-};
-const _wgfrtq = async function _test_decompile_import_variable_alias(decompile,importFake,expect)
-{
-  const decompiled = await decompile([
-    await importFake(
-      {
-        _name: "alias",
-        _definition: "function Yn(e){return e}",
-        _inputs: ["dep"]
-      },
-      "@tomlarkworthy/dependancy"
-    )
-  ]);
-  expect(decompiled).toEqual(
-    `import {dep as alias} from "@tomlarkworthy/dependancy"`
-  );
-  return "ok";
-};
-const _1a8gnrc = async function _test_decompile_import_many(decompile,importFake,expect)
-{
-  const decompiled = await decompile([
-    await importFake(
-      {
-        _name: "dep",
-        _definition: "function Yn(e){return e}",
-        _inputs: ["dep"]
-      },
-      "@tomlarkworthy/dependancy"
-    ),
-    {
-      _name: "mutable mutabledep",
-      _definition: '(_, v) => v.import("mutable mutabledep", _)',
-      _inputs: ["module 1", "@variable"]
-    },
-    {
-      _name: "mutabledep",
-      _definition: '(_, v) => v.import("mutabledep", _)',
-      _inputs: ["module 1", "@variable"]
-    },
-    {
-      _name: "viewof viewdep",
-      _definition: '(_, v) => v.import("viewof viewdep", _)',
-      _inputs: ["module 1", "@variable"]
-    },
-    {
-      _name: "viewdep",
-      _definition: '(_, v) => v.import("viewdep", _)',
-      _inputs: ["module 1", "@variable"]
-    },
-    {
-      _name: "dep_alias",
-      _definition: '(_, v) => v.import("dep", "dep_alias", _)',
-      _inputs: ["module 1", "@variable"]
-    },
-    {
-      _name: "error_dep",
-      _definition: "function Yn(e){return e}",
-      _inputs: ["module 1", "error_dep"]
-    },
-    {
-      _name: "mutable aslias_mutabledep",
-      _definition:
-        '(_, v) => v.import("mutable mutabledep", "mutable aslias_mutabledep", _)',
-      _inputs: ["module 1", "@variable"]
-    },
-    {
-      _name: "aslias_mutabledep",
-      _definition: '(_, v) => v.import("mutabledep", "aslias_mutabledep", _)',
-      _inputs: ["module 1", "@variable"]
-    },
-    {
-      _name: "viewof aslias_viewdep",
-      _definition:
-        '(_, v) => v.import("viewof viewdep", "viewof aslias_viewdep", _)',
-      _inputs: ["module 1", "@variable"]
-    },
-    {
-      _name: "aslias_viewdep",
-      _definition: '(_, v) => v.import("viewdep", "aslias_viewdep", _)',
-      _inputs: ["module 1", "@variable"]
-    },
-    {
-      _name: "aslias_mutabledep_data",
-      _definition:
-        '(_, v) => v.import("mutabledep", "aslias_mutabledep_data", _)',
-      _inputs: ["module 1", "@variable"]
-    },
-    {
-      _name: "aslias_viewdep_data",
-      _definition: '(_, v) => v.import("viewdep", "aslias_viewdep_data", _)',
-      _inputs: ["module 1", "@variable"]
-    }
-  ]);
-  expect(decompiled).toEqual(
-    `import {dep, mutable mutabledep, mutabledep, viewof viewdep, viewdep, dep as dep_alias, error_dep, mutable mutabledep as mutable aslias_mutabledep, mutabledep as aslias_mutabledep, viewof viewdep as viewof aslias_viewdep, viewdep as aslias_viewdep, mutabledep as aslias_mutabledep_data, viewdep as aslias_viewdep_data} from "@tomlarkworthy/dependancy"`
-  );
-  return "ok";
-};
-const _7stpu3 = async function _test_decompile_markdown_cell(decompile,expect)
-{
-  const decompiled = await decompile([
-    {
-      _name: "v",
-      _definition: `function _1(md){return(\nmd\`# Test Notebook of Semantics\`\n)}`,
-      _inputs: [
-        {
-          _name: "md"
-        }
-      ]
-    }
-  ]);
-  expect(decompiled).toEqual(`v = md\`# Test Notebook of Semantics\``);
-  return "ok";
-};
-const _v4p1js = async function _test_decompile_constant(decompile,expect)
-{
-  const decompiled = await decompile([
-    {
-      _name: "v",
-      _definition: `function _2(){return(
-1
-)}`,
-      _inputs: []
-    }
-  ]);
-  expect(decompiled).toEqual(`v = 1`);
-  return "ok";
-};
-const _pcs4h = async function _test_decompile_string_literal(decompile,expect)
-{
-  const decompiled = await decompile([
-    {
-      _name: "v",
-      _definition: `function _3() {\n  ("");\n}`,
-      _inputs: []
-    }
-  ]);
-  // decompile preserves the original expression verbatim (source-slicing), so the
-  // parenthesized string and quote style survive — no escodegen re-quoting.
-  expect(decompiled).toEqual(`v = {\n  ("");\n}`);
-  return "ok";
-};
-const _a2zh99 = async function _test_decompile_html_cell(decompile,expect)
-{
-  const decompiled = await decompile([
-    {
-      _name: "html",
-      _definition: `function _html(htl){return(\nhtl.html\`<div>\`\n)}`,
-      _inputs: []
-    }
-  ]);
-  expect(decompiled).toEqual(`html = htl.html\`<div>\``);
-  return "ok";
-};
-const _pyp280 = async function _test_decompile_class(decompile,expect)
-{
-  const decompiled = await decompile([
-    {
-      _name: "myclass",
-      _definition: `function _myclass(){return(
-class myclass {}
-)}`,
-      _inputs: []
-    }
-  ]);
-  expect(decompiled).toEqual(`myclass = class myclass {}`);
-  return "ok";
-};
-const _kf8c3f = function _test_decompile_class_with_property(decompile){return(
-decompile([
-  {
-    _inputs: [],
-    _definition: `function _Cls(){return(
-        class Cls {
-          d;
-        }
-    )}`
-  }
-])
-)};
-const _4vunhm = async function _test_decompile_object_literal(decompile,expect)
-{
-  const decompiled = await decompile([
-    {
-      _name: "obj_literal",
-      _definition: "function _obj_literal(){return(\n{}\n)}",
-      _inputs: []
-    }
-  ]);
-  expect(decompiled).toEqual(`obj_literal = ({})`);
-  return "ok";
-};
-const _tstlc1 = async function _test_decompile_leading_comment(compile,decompile,expect)
-{
-  // Regression: a comment in the compiler's auto-wrap slot (`return( // note\n42 )`)
-  // is preserved in ASI-safe block form — never the hazardous `return` + comment
-  // + newline WITHOUT the paren that evaluated to undefined on ObservableHQ.
-  const src = await decompile([
-    { _name: "c", _definition: `function _c(){return( // note\n42\n)}`, _inputs: [] }
-  ]);
-  expect(src).toEqual(`c = {return( // note\n42\n)}`);
-  // It keeps the ASI-protecting paren and round-trips through compile to 42.
-  const cell = compile(src);
-  const first = Array.isArray(cell) ? cell[0] : cell;
-  const def = first._definition || (first.cells && first.cells[0]._definition);
-  expect(eval(`(${def})`)()).toEqual(42);
-  return "ok";
-};
-const _tsttc1 = async function _test_decompile_trailing_comment(decompile,expect)
-{
-  // Regression: a comment that survives compile inside the block (trailing on the
-  // return line, or before the closing brace) must survive decompile too — don't
-  // unwrap a single-return block when a comment sits outside the returned value.
-  const trailing = await decompile([
-    { _name: "x", _definition: `function _x(){\n  return 1; // done\n}`, _inputs: [] }
-  ]);
-  expect(trailing).toEqual(`x = {\n  return 1; // done\n}`);
-  const tail = await decompile([
-    { _name: "y", _definition: `function _y(){\n  return 1;\n  // tail\n}`, _inputs: [] }
-  ]);
-  expect(tail).toEqual(`y = {\n  return 1;\n  // tail\n}`);
-  return "ok";
-};
-const _tstpis = async function _test_decompile_param_in_string(decompile,expect)
-{
-  // Regression: renaming an underscore-encoded viewof/mutable param must rewrite
-  // only identifier references, never same-spelled text inside a string literal
-  // (range-based splice, not the old source.replaceAll).
-  const decompiled = await decompile([
-    {
-      _name: "u",
-      _definition: `function _u(viewof_x){return(\n"viewof_x literal" + viewof_x\n)}`,
-      _inputs: ["viewof x"]
-    }
-  ]);
-  expect(decompiled).toEqual(`u = "viewof_x literal" + viewof x`);
-  return "ok";
-};
-const _tstcpf = async function _test_decompile_class_property_field(decompile,expect)
-{
-  // Regression: a class field declaration must decompile cleanly. Source-slicing
-  // sidesteps the escodegen shim gap that threw "this[d] is not a function".
-  const decompiled = await decompile([
-    {
-      _name: "Cls",
-      _definition: `function _Cls(){return(\nclass Cls {\n  d;\n}\n)}`,
-      _inputs: []
-    }
-  ]);
-  expect(decompiled).toEqual(`Cls = class Cls {\n  d;\n}`);
-  return "ok";
-};
-const _s14e29 = async function _test_decompile_reference(decompile,expect)
-{
-  const decompiled = await decompile([
-    {
-      _name: "v",
-      _definition: `function _y(x){return(
-x
-)}`,
-      _inputs: []
-    }
-  ]);
-  expect(decompiled).toEqual(`v = x`);
-  return "ok";
-};
-const _4rsshj = async function _test_decompile_block(decompile,expect)
-{
-  const decompiled = await decompile([
-    {
-      _name: "v",
-      _definition: `function _z(x,y)
-{
-  ("");
-  return x + y;
-}`,
-      _inputs: []
-    }
-  ]);
-  expect(decompiled).toEqual(`v = {
-  ("");
-  return x + y;
-}`);
-  return "ok";
-};
-const _o7o1wl = async function _test_decompile_comments(decompile,expect)
-{
-  const decompiled = await decompile([
-    {
-      _name: "comments",
-      _definition: `function _comments()
-{
-  // a comment
-  return "";
-}`,
-      _inputs: []
-    }
-  ]);
-  expect(decompiled).toEqual(`comments = {
-  // a comment
-  return "";
-}`);
-  return "ok";
-};
-const _1yn35e3 = async function _test_decompile_generator(decompile,expect)
-{
-  const decompiled = await decompile([
-    {
-      _name: "generator",
-      _definition: `function* _generator(x,y)
-{
-  yield x + y;
-}`,
-      _inputs: []
-    }
-  ]);
-  expect(decompiled).toEqual(`generator = {
-  yield x + y;
-}`);
-  return "ok";
-};
-const _135eswd = async function _test_decompile_function(decompile,expect)
-{
-  const decompiled = await decompile([
-    {
-      _name: "_function",
-      _definition: `function __function(){return(
-function () {}
-)}`,
-      _inputs: []
-    }
-  ]);
-  expect(decompiled).toEqual(`_function = function () {}`);
-  return "ok";
-};
-const _1pitq2 = async function _test_decompile_async_function(decompile,expect)
-{
-  const decompiled = await decompile([
-    {
-      _name: "asyncfunction",
-      _definition: `function _asyncfunction(){return(
-async function () {}
-)}`,
-      _inputs: []
-    }
-  ]);
-  expect(decompiled).toEqual(`asyncfunction = async function () {}`);
-  return "ok";
-};
-const _1kxe1b2 = async function _test_decompile_named_function(decompile,expect)
-{
-  const decompiled = await decompile([
-    {
-      _name: "named_function",
-      _definition: `function _named_function(){return(
-function foo() {}
-)}`,
-      _inputs: []
-    }
-  ]);
-  expect(decompiled).toEqual(`named_function = function foo() {}`);
-  return "ok";
-};
-const _1pghf4f = async function _test_decompile_this_reference(decompile,expect)
-{
-  const decompiled = await decompile([
-    {
-      _name: "thisReference",
-      _definition: `function _thisReference(){return(
-(this || 0) + 1
-)}`,
-      _inputs: []
-    }
-  ]);
-  expect(decompiled).toEqual(`thisReference = (this || 0) + 1`);
-  return "ok";
-};
-const _4aeghn = async function _test_decompile_lambda(decompile,expect)
-{
-  const decompiled = await decompile([
-    {
-      _name: "lambda",
-      _definition: `function _lambda(){return(
-() => {}
-)}`,
-      _inputs: []
-    }
-  ]);
-  expect(decompiled).toEqual(`lambda = () => {}`);
-  return "ok";
-};
-const _12ec5zd = async function _test_decompile_error(decompile,expect)
-{
-  const decompiled = await decompile([
-    {
-      _name: "error",
-      _definition: `function _error()
-{
-  throw new Error();
-}`,
-      _inputs: []
-    }
-  ]);
-  expect(decompiled).toEqual(`error = {
-  throw new Error();
-}`);
-  return "ok";
-};
-const _3bj09h = async function _test_decompile_error_object(decompile,expect)
-{
-  const decompiled = await decompile([
-    {
-      _name: "error_obj",
-      _definition: `function _error_obj()
-{
-  throw { foo: "bar" };
-}`,
-      _inputs: []
-    }
-  ]);
-  expect(decompiled).toEqual(`error_obj = {
-  throw { foo: "bar" };
-}`);
-  return "ok";
-};
-const _6iufw4 = function _60(md){return(
-md`⚠️ This cells have not been grouped correctly, should be a single import being decompiled`
-)};
-const _15idqib = async function _test_decompile_anon_error_dep(decompile,expect)
-{
-  const decompiled = await decompile([
-    {
-      _definition: `function _19(error_dep){return(
-error_dep
-)}`,
-      _inputs: ["error_dep"]
-    }
-  ]);
-  expect(decompiled).toEqual(`error_dep`);
-  return "ok";
-};
-const _mhm98c = async function _test_decompile_viewof(decompile,expect)
-{
-  const decompiled = await decompile([
-    {
-      _name: "viewof view",
-      _definition: `function _view(Inputs){return(
-Inputs.input()
-)}`,
-      _inputs: []
-    }
-  ]);
-  expect(decompiled).toEqual(`viewof view = Inputs.input()`);
-  return "ok";
-};
-const _15kgqrr = async function _test_decompile_mutable(decompile,expect)
-{
-  const decompiled = await decompile([
-    {
-      _name: "initial q",
-      _definition: `function _q(){return(
-6
-)}`,
-      _inputs: []
-    }
-  ]);
-  expect(decompiled).toEqual(`mutable q = 6`);
-  return "ok";
-};
-const _1onyv5c = async function _test_decompile_builtin(decompile,expect)
-{
-  const decompiled = await decompile([
-    {
-      _name: "inbuilt",
-      _definition: `function _inbuilt(_){return(
-_
-)}`,
-      _inputs: []
-    }
-  ]);
-  expect(decompiled).toEqual(`inbuilt = _`);
-  return "ok";
-};
-const _1uv76xx = async function _test_decompile_fileattachment(decompile,expect)
-{
-  const decompiled = await decompile([
-    {
-      _name: "file",
-      _definition: `function _file(FileAttachment){return(
-FileAttachment("empty")
-)}`,
-      _inputs: []
-    }
-  ]);
-  expect(decompiled).toEqual(`file = FileAttachment("empty")`);
-  return "ok";
-};
-const _g4z6de = async function _test_decompile_mutable_dependancy(decompile,expect)
-{
-  const decompiled = await decompile([
-    {
-      _name: "mutable_dep",
-      _definition: `function _mutable_dep($0,lambda,$1)
-{
-  $0;
-  lambda;
-  $1.value;
-  return $1.value;
-}`,
-      _inputs: ["viewof view", "mutable q"]
-    }
-  ]);
-  expect(decompiled).toEqual(`mutable_dep = {
-  viewof view;
-  lambda;
-  mutable q;
-  return mutable q;
-}`);
-  return "ok";
-};
-const _qo8sdl = async function _test_decompile_mutable_dependancy_2(decompile,expect)
-{
-  const decompiled = await decompile([
-    {
-      _name: "mutable_dep_2",
-      _definition: `function _mutable_dep_2(file,q)
-{
-  file;
-  return q + 1;
-}`,
-      _inputs: []
-    }
-  ]);
-  expect(decompiled).toEqual(`mutable_dep_2 = {
-  file;
-  return q + 1;
-}`);
-  return "ok";
-};
-const _15kwaz1 = async function _test_decompile_viewof_dep(decompile,expect)
-{
-  const decompiled = await decompile([
-    {
-      _name: "viewofdep_inline",
-      _definition: `function _viewofdep_inline($0){return(
-$0
-)}`,
-      _inputs: ["viewof view"]
-    }
-  ]);
-  expect(decompiled).toEqual(`viewofdep_inline = viewof view`);
-  return "ok";
-};
-const _1qjzk2s = async function _test_decompile_viewof_data_dep(decompile,expect)
-{
-  const decompiled = await decompile([
-    {
-      _name: "viewofdatadep",
-      _definition: `function _viewofdatadep(view){return(
-view
-)}`,
-      _inputs: []
-    }
-  ]);
-  expect(decompiled).toEqual(`viewofdatadep = view`);
-  return "ok";
-};
-const _ehz2xk = async function _test_decompile_viewof_param(decompile,expect)
-{
-  // Lopecode compiled form uses viewof_X as parameter name instead of $N
-  const decompiled = await decompile([
-    {
-      _name: "foo",
-      _definition: `function _foo(viewof_bar, x)
-{
-  viewof_bar.value = x;
-  viewof_bar.dispatchEvent(new Event("input"));
-}`,
-      _inputs: ["viewof bar"]
-    }
-  ]);
-  expect(decompiled).toEqual(`foo = {
-  viewof bar.value = x;
-  viewof bar.dispatchEvent(new Event("input"));
-}`);
-  return "ok";
-};
-const _oilkc0 = async function _test_decompile_anon_dep(decompile,expect)
-{
-  const decompiled = await decompile([
-    {
-      _definition: `function _28(dep){return(
-dep
-)}`,
-      _inputs: []
-    }
-  ]);
-  expect(decompiled).toEqual(`dep`);
-  return "ok";
-};
-const _1jggajo = async function _test_decompile_import_mutable(decompile,expect)
-{
-  const decompiled = await decompile([
-    {
-      _name: "mutable mutabledep",
-      _definition: `(_, v) => v.import("mutable mutabledep", _)`,
-      _inputs: []
-    }
-  ]);
-  expect(decompiled).toEqual(
-    `mutable mutabledep = v.import("mutable mutabledep", _)`
-  );
-  return "ok";
-};
-const _di0abi = async function _test_decompile_import_viewof(decompile,expect)
-{
-  const decompiled = await decompile([
-    {
-      _name: "viewof viewdep",
-      _definition: `(_, v) => v.import("viewof viewdep", _)`,
-      _inputs: []
-    }
-  ]);
-  expect(decompiled).toEqual(`viewof viewdep = v.import("viewof viewdep", _)`);
-  return "ok";
-};
-const _14o5oio = async function _test_decompile_viewof_data(decompile,expect)
-{
-  const decompiled = await decompile([
-    {
-      _name: "viewdep",
-      _definition: `(_, v) => v.import("viewdep", _)`,
-      _inputs: []
-    }
-  ]);
-  expect(decompiled).toEqual(`viewdep = v.import("viewdep", _)`);
-  return "ok";
-};
-const _1lv4syw = async function _test_decompile_import_alias(decompile,expect)
-{
-  const decompiled = await decompile([
-    {
-      _name: "dep_alias",
-      _definition: `(_, v) => v.import("dep", "dep_alias", _)`,
-      _inputs: []
-    }
-  ]);
-  expect(decompiled).toEqual(`dep_alias = v.import("dep", "dep_alias", _)`);
-  return "ok";
-};
-const _l8b8hu = async function _test_decompile_import_mutable_alias(decompile,expect)
-{
-  const decompiled = await decompile([
-    {
-      _name: "mutable aslias_mutabledep",
-      _definition: `(_, v) => v.import("mutable mutabledep", "mutable aslias_mutabledep", _)`,
-      _inputs: []
-    }
-  ]);
-  expect(decompiled).toEqual(
-    `mutable aslias_mutabledep = v.import("mutable mutabledep", "mutable aslias_mutabledep", _)`
-  );
-  return "ok";
-};
-const _1g5n3sa = async function _test_decompile_import_mutable_data_alias(decompile,expect)
-{
-  const decompiled = await decompile([
-    {
-      _name: "aslias_mutabledep",
-      _definition: `(_, v) => v.import("mutabledep", "aslias_mutabledep", _)`,
-      _inputs: []
-    }
-  ]);
-  expect(decompiled).toEqual(
-    `aslias_mutabledep = v.import("mutabledep", "aslias_mutabledep", _)`
-  );
-  return "ok";
-};
-const _1lnngk6 = async function _test_decompile_import_viewof_alias(decompile,expect)
-{
-  const decompiled = await decompile([
-    {
-      _name: "viewof aslias_viewdep",
-      _definition: `(_, v) => v.import("viewof viewdep", "viewof aslias_viewdep", _)`,
-      _inputs: []
-    }
-  ]);
-  expect(decompiled).toEqual(
-    `viewof aslias_viewdep = v.import("viewof viewdep", "viewof aslias_viewdep", _)`
-  );
-  return "ok";
-};
-const _1na1e5i = async function _test_decompile_import_viewof_data_alias(decompile,expect)
-{
-  const decompiled = await decompile([
-    {
-      _name: "aslias_viewdep",
-      _definition: `(_, v) => v.import("viewdep", "aslias_viewdep", _)`,
-      _inputs: []
-    }
-  ]);
-  expect(decompiled).toEqual(
-    `aslias_viewdep = v.import("viewdep", "aslias_viewdep", _)`
-  );
-  return "ok";
-};
-const _17dwb6r = function _80(md){return(
-md`### The Decompiler`
-)};
-const _1vs6mei = function _82(md){return(
-md`### \`decompile\``
-)};
-const _llvq9s = function _decompile(decompileImport,formatImportDeclaration,acorn)
-{
-  return async function decompile(variables) {
-    if (!variables || variables.length === 0)
-      throw new Error("no variables to decompile");
-    const importInfo = await decompileImport(variables);
-    if (importInfo) return formatImportDeclaration(importInfo);
-    const variable = variables[0];
-    const name = variable._name;
-    const compiled =
-      typeof variable._definition === "string"
-        ? variable._definition
-        : variable._definition.toString();
-    // Check for syntax-error cells that carry the original source
-    const sourceExprMatch = compiled.match(
-      /_sourceExpression:\s*("(?:[^"\\]|\\.)*")/
-    );
-    if (sourceExprMatch) {
-      try {
-        return JSON.parse(sourceExprMatch[1]);
-      } catch {}
-    }
-    const inputs = (variable._inputs || []).map((i) =>
-      typeof i === "string" ? i : i._name
-    );
-    const wrappedCode = "(" + compiled + ")";
-    const comments = [],
-      tokens = [];
-    const parsed = acorn.parse(wrappedCode, {
-      ecmaVersion: 2022,
-      sourceType: "module",
-      ranges: true,
-      onComment: comments,
-      onToken: tokens
+      };
+      const invalidation = options && options.invalidation;
+      if (invalidation)
+        Promise.resolve(invalidation).then(remove, remove);
+      return remove;
+    };
+    const get = name => Generators.observe(change => {
+      const push = () => change([...sets.get(name) ?? []]);
+      push();
+      // current set immediately → converges
+      let ls = listeners.get(name);
+      if (!ls)
+        listeners.set(name, ls = new Set());
+      ls.add(push);
+      return () => {
+        ls.delete(push);
+        if (ls.size === 0)
+          listeners.delete(name);
+      };  // leak-safe
     });
-    const functionExpression = parsed.body[0].expression;
-    const body = functionExpression.body;
-    // Extract parameter names from AST for underscore-encoded name fixup
-    const params = (functionExpression.params || []).map((p) => p.name);
-    let varName = name;
-    let prefix = "";
-    if (name) {
-      if (name.startsWith("initial ")) {
-        prefix = "mutable ";
-        varName = name.replace(/^initial /, "");
-      } else if (name.startsWith("mutable ")) {
-        prefix = "mutable ";
-        varName = name.replace(/^mutable /, "");
-      } else if (name.startsWith("viewof ")) {
-        prefix = "viewof ";
-        varName = name.replace(/^viewof /, "");
-      }
-    }
-    // Pick the source range to return: the single returned expression for a
-    // normal `{ return <expr> }` cell, otherwise the whole body. We SLICE the
-    // original text rather than regenerate via escodegen, so comments, quote
-    // style, whitespace, ASI-sensitive grouping and class fields all survive
-    // byte-for-byte. (Regeneration was the root of the ASI, quote-drift and
-    // class-property-shim-gap bugs.)
-    let sliceNode = body;
-    let wrapObjectLiteral = false;
-    if (
-      body.type === "BlockStatement" &&
-      body.body.length === 1 &&
-      body.body[0].type === "ReturnStatement" &&
-      body.body[0].argument
-    ) {
-      const arg = body.body[0].argument;
-      // Unwrap `{ return <arg> }` to <arg> only when every comment lives INSIDE
-      // <arg>, so it survives the arg slice (a returned function's own comments
-      // are kept this way). A comment anywhere else in the block — before
-      // `return`, in the compiler's `return( … )` auto-wrap slot, or trailing
-      // after the value — would be dropped by unwrapping, so keep the (ASI-safe)
-      // block form to preserve it and round-trip exactly.
-      const hasCommentOutsideArg = comments.some(
-        (c) =>
-          c.start >= body.start &&
-          c.end <= body.end &&
-          (c.end <= arg.start || c.start >= arg.end)
-      );
-      if (!hasCommentOutsideArg) {
-        sliceNode = arg;
-        wrapObjectLiteral = wrappedCode[arg.start] === "{";
-      }
-    }
-    const sliceStart = sliceNode.start;
-    const sliceEnd = sliceNode.end;
-
-    // $N → Observable name. Positional over the qualifying inputs, matching the
-    // compiler's convention (same counting the old placeholder pass used).
-    const dollarValue = new Map();
-    {
-      let id = 0;
-      inputs.forEach((input) => {
-        if (input && input.startsWith("mutable ")) {
-          dollarValue.set(`$${id++}`, { name: input, mutable: true });
-        } else if (
-          input &&
-          (input.startsWith("viewof ") || input === "@variable")
-        ) {
-          dollarValue.set(`$${id++}`, { name: input, mutable: false });
-        }
-      });
-    }
-    // Underscore-encoded viewof/mutable params (lopecode compiled form) → spaced.
-    const underscoreParam = new Map();
-    inputs.forEach((input, i) => {
-      if (
-        input &&
-        (input.startsWith("viewof ") || input.startsWith("mutable "))
-      ) {
-        const underscoreForm = input.replace(" ", "_");
-        if (params[i] === underscoreForm) underscoreParam.set(underscoreForm, input);
-      }
-    });
-
-    // Collect identifier-node range rewrites within the sliced expression only.
-    // Keyed on Identifier/MemberExpression nodes, so string, regex and template
-    // text is never touched (this is what the old string replaceAll corrupted).
-    const edits = [];
-    const consumed = new Set();
-    const collect = (node) => {
-      if (!node || typeof node !== "object" || typeof node.type !== "string")
-        return;
-      // mutable `$N.value` → `mutable foo` (replace the whole member expression)
-      if (
-        node.type === "MemberExpression" &&
-        !node.computed &&
-        node.object &&
-        node.object.type === "Identifier" &&
-        node.property &&
-        node.property.type === "Identifier" &&
-        node.property.name === "value"
-      ) {
-        const dv = dollarValue.get(node.object.name);
-        if (dv && dv.mutable) {
-          edits.push({ start: node.start, end: node.end, text: dv.name });
-          consumed.add(node.object);
-        }
-      } else if (node.type === "Identifier" && !consumed.has(node)) {
-        const dv = dollarValue.get(node.name);
-        if (dv) {
-          // Non-mutable $N → input name. Bare mutable $N (no `.value`) stays $N.
-          if (!dv.mutable) edits.push({ start: node.start, end: node.end, text: dv.name });
-        } else if (underscoreParam.has(node.name)) {
-          edits.push({ start: node.start, end: node.end, text: underscoreParam.get(node.name) });
-        }
-      }
-      for (const k in node) {
-        if (k === "loc" || k === "range" || k === "start" || k === "end")
-          continue;
-        const c = node[k];
-        if (Array.isArray(c)) c.forEach(collect);
-        else if (c && typeof c === "object" && typeof c.type === "string")
-          collect(c);
-      }
-    };
-    collect(sliceNode);
-
-    // Apply edits right-to-left (descending start) so offsets stay valid.
-    let expression = wrappedCode.slice(sliceStart, sliceEnd);
-    edits
-      .sort((a, b) => b.start - a.start)
-      .forEach((e) => {
-        const s = e.start - sliceStart;
-        const t = e.end - sliceStart;
-        expression = expression.slice(0, s) + e.text + expression.slice(t);
-      });
-    if (wrapObjectLiteral) expression = `(${expression})`;
-
-    const source = `${varName ? `${prefix}${varName} = ` : ""}${expression}`;
-    return source;
-  };
-};
-const _1pvis67 = function _85(md){return(
-md`### \`extractModuleInfo\` 
-static analysis of module imports`
-)};
-const _183j58u = function _extractModuleInfo(){return(
-function extractModuleInfo(str) {
-  const named = /@([^/]+)\/([^.]+)\.js\?v=\d+(?:&resolutions=[^@]+@(\d+))?/;
-  const matchNamed = str.match(named);
-
-  if (matchNamed) {
-    const namespace = matchNamed[1];
-    const notebook = matchNamed[2];
-    const version = matchNamed[3];
-    return { namespace, notebook, version };
-  }
-  const id = /\/?d\/([^@]+)@?(\d+)/;
-  const matchId = str.match(id);
-
-  if (matchId) {
-    const notebook = matchId[1];
-    const version = matchId[2];
-    return { id: notebook, version };
-  }
-
-  const lopebook = /"@([^/]+)\/([^"]+)"/;
-  const lopebookId = str.match(lopebook);
-
-  if (lopebookId) {
-    const namespace = lopebookId[1];
-    const notebook = lopebookId[2];
-    return { namespace, notebook };
-  }
-
-  return {};
-}
-)};
-const _w445v0 = function _test_extractModuleInfo_notebook_resolution(expect,extractModuleInfo)
-{
-  expect(
-    extractModuleInfo(
-      'async () => runtime.module((await import("/@tomlarkworthy/whisper-input.js?v=4&resolutions=03dda470c56b93ff@4883")).default)'
-    )
-  ).toEqual({
-    namespace: "tomlarkworthy",
-    notebook: "whisper-input",
-    version: "4883"
-  });
-  return "ok";
-};
-const _uzqj4w = function _test_extractModuleInfo_id_version_resolution(expect,extractModuleInfo)
-{
-  expect(
-    extractModuleInfo(
-      'async () => runtime.module((await import("/d/c2dae147641e012a@46.js?v=4&resolutions=03dda470c56b93ff@4883")).default)'
-    )
-  ).toEqual({ id: "c2dae147641e012a", version: "46" });
-  return "ok";
-};
-const _1sruec2 = function _test_extractModuleInfo_id_version(expect,extractModuleInfo)
-{
-  expect(
-    extractModuleInfo(
-      'async () => runtime.module((await import("d/58f3eb7334551ae6@215")).default)'
-    )
-  ).toEqual({ id: "58f3eb7334551ae6", version: "215" });
-  return "ok";
-};
-const _ipn8zp = function _test_extractModuleInfo_test_4(expect,extractModuleInfo)
-{
-  expect(
-    extractModuleInfo(
-      'await import("https://api.observablehq.com/@tomlarkworthy/observable-notes.js?v=4"'
-    )
-  ).toEqual({
-    namespace: "tomlarkworthy",
-    notebook: "observable-notes"
-  });
-  return "ok";
-};
-const _iigmyv = function _test_extractModuleInfo_alias_hack(expect,extractModuleInfo)
-{
-  expect(
-    extractModuleInfo(
-      'async () => "@tom/blank" && runtime.module((await import("blob:https://tomlarkworthy.static.observableusercontent.com/4cdeb9db-e473-436b-b343-95abd7e4c16f")).default)'
-    )
-  ).toEqual({
-    namespace: "tom",
-    notebook: "blank"
-  });
-  return "ok";
-};
-const _1tggbee = function _92(md){return(
-md`### \`findModuleName\` and \`findImportedName\``
-)};
-const _kiaw33 = function _import_ast_example(parser){return(
-parser.parseCell(
-  'import {runtime, viewof main as foo} from "@mootari/access-runtime"'
-)
-)};
-const _1n7gw17 = function _findModuleName(extractModuleInfo) {
-    return (scope, module, {
-        unknown_id = Math.random()
-    } = {}) => {
-        try {
-            const scopedVariables = [...scope.values()];
-            const candidates = scopedVariables.filter(v => v && v._value === module && typeof v._name === 'string' && v._name.startsWith('module ') && !v._name.startsWith('module <unknown'));
-            const pickBestInfo = dfn => {
-                const s = String(dfn ?? '');
-                const m = s.match(/\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/);
-                const firstArg = m?.[2];
-                const info1 = firstArg ? extractModuleInfo(firstArg) : {};
-                if (info1?.id || info1?.notebook)
-                    return info1;
-                return extractModuleInfo(s);
-            };
-            for (const v of candidates) {
-                const info = pickBestInfo(v._definition?.toString?.());
-                if (info?.namespace)
-                    return `@${ info.namespace }/${ info.notebook }`;
-                if (info?.id)
-                    return `d/${ info.id }@${ info.version }`;
-            }
-            const any = scopedVariables.find(v => v && v._value === module);
-            if (any) {
-                const info = pickBestInfo(any._definition?.toString?.());
-                if (info?.namespace)
-                    return `@${ info.namespace }/${ info.notebook }`;
-                if (info?.id)
-                    return `d/${ info.id }@${ info.version }`;
-            }
-            return `<unknown ${ unknown_id }>`;
-        } catch (e) {
-            void 0;
-            return 'error';
-        }
-    };
-};
-const _i47chb = function _findImportedName(){return(
-async (v) => {
-  if (v._inputs.length == 1 && v._inputs[0]._name === "@variable") {
-    // import in a live-notebook hides the alias in a closure
-    let capture;
-    await v._definition({ import: (...args) => (capture = args) });
-    return capture[0];
-  }
-  if (v._inputs.length == 1) {
-    return v._inputs[0]._name;
-  }
-  const regex = /v\.import\("([^"]+)",\s*"([^"]+)"/;
-  const match = v._definition.toString().match(regex);
-  if (match) {
-    // Handle two cases (two arguments)
-    return match[1];
-  }
-  return v._name;
-}
-)};
-const _1effqg = function _96(md){return(
-md`### \`decompileImport\``
-)};
-const _b7vai6 = function _decompileImport(findModuleName,findImportedName)
-{
-  return async function decompileImport(variables, options = {}) {
-    if (!variables || variables.length === 0)
-      throw new Error('no variables');
-    // An import-cell group is `[module @X stitch, ...aliases]`. Each alias goes
-    // through three lifecycle stages (documented in observable-runtime-v6's
-    // `importedModule` helper, lines ~1992-2049 of @tomlarkworthy/observable-runtime-v6):
-    //
-    //   Stage A — post-observation:
-    //     `_inputs = [Variable in source module]` (length 1, cross-module).
-    //     The Observable runtime rewrites _inputs after the alias is observed
-    //     and resolved against the source module.
-    //
-    //   Stage B — pre-observation, API-loaded (canonical compiled-bundle shape):
-    //     `_inputs = [Variable("module @X"), Variable("@variable")]` (length 2,
-    //     both in the importer module). What `runtime.define("name",
-    //     ["module @X", "@variable"], (_, v) => v.import("name", _))` produces.
-    //     Also what `compile_and_update` outputs for freshly-defined user-typed
-    //     imports until they're observed.
-    //
-    //   Stage C — pre-observation, inline live-notebook:
-    //     `_inputs = [Variable("@variable")]` (length 1) AND the definition
-    //     calls `import(...)` inside. We extract the imported module reference
-    //     by invoking the definition with a stub `import` capture.
-    //
-    // Detection order is post→pre because Stage A is unambiguous when present.
-    const isStageA = v => {
-      const inputs = v?._inputs;
-      if (!Array.isArray(inputs) || inputs.length !== 1)
-        return false;
-      const i0 = inputs[0];
-      return !!(i0 && typeof i0 === 'object' && v._module && i0._module && v._module !== i0._module);
-    };
-    const isStageB = v => {
-      const inputs = v?._inputs;
-      if (!Array.isArray(inputs) || inputs.length !== 2)
-        return false;
-      const [i0, i1] = inputs;
-      return !!(i0 && typeof i0 === 'object' && typeof i0._name === 'string' && i0._name.startsWith('module ') && i1 && typeof i1 === 'object' && i1._name === '@variable');
-    };
-    const isStageC = v => {
-      const inputs = v?._inputs;
-      if (!Array.isArray(inputs) || inputs.length !== 1)
-        return false;
-      const i0 = inputs[0];
-      return !!(i0 && typeof i0 === 'object' && i0._name === '@variable' && typeof v._definition !== 'undefined' && String(v._definition).includes('import('));
-    };
-    let v0, module_name, stage;
-    if (v0 = variables.find(isStageA)) {
-      stage = 'A';
-      module_name = findModuleName(v0._module._scope, v0._inputs[0]._module);
-    } else if (v0 = variables.find(isStageB)) {
-      stage = 'B';
-      module_name = v0._inputs[0]._name.replace(/^module /, '');
-    } else if (v0 = variables.find(isStageC)) {
-      stage = 'C';
-      let capturedModule;
-      try {
-        await v0._definition({
-          import: (...args) => {
-            capturedModule = args[args.length - 1];
-          }
-        });
-      } catch (e) {
-      }
-      if (capturedModule && v0._module?._scope) {
-        module_name = findModuleName(v0._module._scope, capturedModule);
-      }
-    } else {
-      return null;
-    }
-    if (module_name == null)
-      throw new Error('module name could not be resolved');
-    // Skip runtime-internal `module @foo` stitch variables — they belong to
-    // the import group but are not user-facing specifiers. Without this filter, an
-    // import group renders as `import {Range, module @foo} from "@foo"`.
-    const specifiers = await Promise.all(variables.filter(v => typeof v?._name !== 'string' || !v._name.startsWith('module ')).map(async (v, index) => {
-      const imported = await findImportedName(v);
-      const local = v._name;
-      return {
-        imported,
-        local,
-        alias: imported !== local,
-        meta: { index }
-      };
-    }));
     return {
-      type: 'import',
-      from: module_name,
-      specifiers,
-      meta: {
-        detection: { stage },
-        variables: variables.map(v => v?._name ?? null)
-      }
+      add,
+      get,
+      listenerCount: name => listeners.get(name)?.size ?? 0
     };
   };
 };
-const _1sylz7j = function _formatImportDeclaration(){return(
-function formatImportDeclaration(importInfo) {
-  if (!importInfo || importInfo.type !== "import")
-    throw new Error("not an importInfo object");
-  const specifiers = (importInfo.specifiers || []).map((s) =>
-    s.imported === s.local ? s.local : `${s.imported} as ${s.local}`
-  );
-  return `import {${specifiers.join(", ")}} from "${importInfo.from}"`;
-}
+const _1qu8dwj = function _plugins(createPlugins){return(
+createPlugins()
 )};
-const _13dctdn = async function _test_decompileImport_basic(importFake,decompileImport,expect)
-{
-  const v = await importFake(
-    { _name: "dep", _definition: "function Yn(e){return e}", _inputs: ["dep"] },
-    "@tomlarkworthy/dependancy"
-  );
-  const info = await decompileImport([v]);
-
-  const simplified = {
-    type: info.type,
-    from: info.from,
-    specifiers: info.specifiers.map((s) => ({
-      imported: s.imported,
-      local: s.local,
-      alias: s.alias,
-      meta: { index: s.meta.index }
-    }))
-  };
-
-  expect(simplified).toEqual({
-    type: "import",
-    from: "@tomlarkworthy/dependancy",
-    specifiers: [
-      { imported: "dep", local: "dep", alias: false, meta: { index: 0 } }
-    ]
-  });
-
-  return "ok";
-};
-const _ujr0xn = async function _test_formatImportDeclaration_roundtrip(importFake,decompileImport,expect,formatImportDeclaration,decompile)
-{
-  const vars = [
-    await importFake(
-      {
-        _name: "dep",
-        _definition: "function Yn(e){return e}",
-        _inputs: ["dep"]
-      },
-      "@tomlarkworthy/dependancy"
-    )
-  ];
-  const info = await decompileImport(vars);
-  expect(formatImportDeclaration(info)).toEqual(await decompile(vars));
-  return "ok";
-};
-const _1u6sfri = async function _test_decompileImport_alias(importFake,decompileImport,expect,formatImportDeclaration)
-{
-  const v = await importFake(
-    {
-      _name: "alias",
-      _definition: "function Yn(e){return e}",
-      _inputs: ["dep"]
-    },
-    "@tomlarkworthy/dependancy"
-  );
-  const info = await decompileImport([v]);
-
-  expect(info.specifiers[0].alias).toEqual(true);
-  expect(formatImportDeclaration(info)).toEqual(
-    `import {dep as alias} from "@tomlarkworthy/dependancy"`
-  );
-
-  return "ok";
-};
-const _1lqhutp = function _102(md){return(
-md`## Javascript Source Normalization`
+const _a7p1z5 = function _testsHeader(md){return(
+md`## Tests`
 )};
-const _3knb9v = function _variableToObject(){return(
-(v) => ({
-  _name: v._name,
-  _definition: v._definition.toString(),
-  _inputs: v._inputs.map((v) => v._name || v)
-})
+const _15xl311 = function _test_get_reflects_add(createPlugins){return(
+(async () => {
+  const p = createPlugins();
+  const gen = p.get('x');
+  if ((await (await gen.next()).value).length !== 0)
+    throw new Error('new set should start empty');
+  p.add('x', 1);
+  const after = await (await gen.next()).value;
+  if (after.length !== 1 || after[0] !== 1)
+    throw new Error('get did not reflect the add');
+  gen.return();
+  return '\u2705 get(name) yields the named set and updates on add';
+})()
 )};
-const _263fcv = function _106(md){return(
-md`## Observable Source Normalization`
+const _122zyhz = function _test_multi_provider_and_convergence(createPlugins)
+{
+  return (async () => {
+    const p = createPlugins();
+    const a = p.get('x'), b = p.get('x');
+    // two independent consumers
+    await (await a.next()).value;
+    await (await b.next()).value;
+    p.add('x', 'one');
+    // provider 1
+    p.add('x', 'two');
+    // provider 2
+    const va = (await (await a.next()).value).slice().sort().join(',');
+    const vb = (await (await b.next()).value).slice().sort().join(',');
+    if (va !== 'one,two' || vb !== 'one,two')
+      throw new Error('consumers did not converge to the full set');
+    a.return();
+    b.return();
+    return '\u2705 multiple providers accumulate; all consumers converge';
+  })();
+};
+const _1lojas7 = function _test_remove_and_names_isolated(createPlugins){return(
+(async () => {
+  const p = createPlugins();
+  const gx = p.get('x'), gy = p.get('y');
+  await (await gx.next()).value;
+  await (await gy.next()).value;
+  const remove = p.add('x', 1);
+  p.add('y', 2);
+  if ((await (await gx.next()).value).join() !== '1')
+    throw new Error('x set wrong');
+  if ((await (await gy.next()).value).join() !== '2')
+    throw new Error('names are not isolated');
+  remove();
+  if ((await (await gx.next()).value).length !== 0)
+    throw new Error('remove() did not take the value out');
+  gx.return();
+  gy.return();
+  return '\u2705 remove() works and names are isolated';
+})()
 )};
-const _7zpsl9 = function _normalizeObservableSourceSelector(Inputs,notebook_semantics_source){return(
-Inputs.select(
-  notebook_semantics_source.map((s) => s.value),
-  { label: "test case", value: "1" }
-)
+const _8240yg = function _test_invalidation_and_no_leak(createPlugins){return(
+(async () => {
+  const p = createPlugins();
+  let settle;
+  p.add('x', 1, { invalidation: new Promise(r => settle = r) });
+  const gen = p.get('x');
+  if ((await (await gen.next()).value).length !== 1)
+    throw new Error('value should be present before invalidation');
+  if (p.listenerCount('x') !== 1)
+    throw new Error('get should have registered a listener');
+  settle();
+  await Promise.resolve();
+  await Promise.resolve();
+  if ((await (await gen.next()).value).length !== 0)
+    throw new Error('invalidation did not remove the value');
+  gen.return();
+  if (p.listenerCount('x') !== 0)
+    throw new Error('disposing the Generator leaked a listener');
+  return '\u2705 {invalidation} auto-removes and get() leaks no listeners';
+})()
 )};
-const _1ex8kus = (G, _) => G.input(_);
-const _b2d0zc = function _parsed(parser,normalizeObservableSourceSelector){return(
-parser.parseCell(normalizeObservableSourceSelector)
-)};
-const _vle3wv = function _112(md){return(
-md`## The Compiler
-
-`
-)};
-const _10ofthe = function _test_async_interpolation(compile){return(
-eval(
-  "let _fn = " +
-    compile("md`${await FileAttachment('image@1.png').url() }`")[0]._definition
-)
-)};
-const _1gb7c3c = async function _test_compile_syntax_error_viewof(compile,expect)
-{
-  const compiled = await compile(`viewof bar = () => return ""`);
-  expect(compiled.length).toEqual(1);
-  expect(compiled[0]._name).toEqual("viewof bar");
-  return "ok";
-};
-const _69vyub = async function _test_compile_syntax_error_anonymous(compile,expect)
-{
-  const compiled = await compile(`() => return ""`);
-  expect(compiled.length).toEqual(1);
-  expect(compiled[0]._name).toEqual(null);
-  expect(compiled[0]._inputs).toEqual([]);
-  let fn;
-  eval("fn = " + compiled[0]._definition);
-  let threw = false;
-  try {
-    fn();
-  } catch (e) {
-    threw = true;
-    expect(e instanceof SyntaxError).toEqual(true);
-    expect(e._sourceExpression).toEqual(`() => return ""`);
-  }
-  expect(threw).toEqual(true);
-  return "ok";
-};
-const _1c9p3om = async function _test_compile_syntax_error_named(compile,expect)
-{
-  const compiled = await compile(`foo = () => return ""`);
-  expect(compiled.length).toEqual(1);
-  expect(compiled[0]._name).toEqual("foo");
-  expect(compiled[0]._inputs).toEqual([]);
-  expect(compiled[0]._definition).toMatch(/function _foo\(\)/);
-  let fn;
-  eval("fn = " + compiled[0]._definition);
-  let threw = false;
-  try {
-    fn();
-  } catch (e) {
-    threw = true;
-    expect(e._sourceExpression).toEqual(`foo = () => return ""`);
-  }
-  expect(threw).toEqual(true);
-  return "ok";
-};
-const _x7zc8w = async function _test_compile_integer(compile,expect)
-{
-  const compiled = await compile("1");
-  expect(compiled).toEqual([
-    {
-      _definition: "function _anonymous() {return (1);}",
-      _inputs: [],
-      _name: null
-    }
-  ]);
-  return "ok";
-};
-const _1u7hlem = async function _test_compile_string(compile,expect)
-{
-  const compiled = await compile(`""`);
-  expect(compiled).toEqual([
-    {
-      _name: null,
-      _inputs: [],
-      _definition: `function _anonymous() {return ("");}`
-    }
-  ]);
-  return "ok";
-};
-const _151bijp = async function _test_compile_obj_literal(compile,expect)
-{
-  const compiled = await compile(`obj_literal = ({})`);
-  expect(compiled).toEqual([
-    {
-      _name: "obj_literal",
-      _inputs: [],
-      _definition: "function _obj_literal() {return ({});}"
-    }
-  ]);
-  return "ok";
-};
-const _tstcff = async function _test_compile_preserves_formatting(compile,expect)
-{
-  // Source-preserving compile keeps quote style and template spacing verbatim;
-  // escodegen used to re-quote ("h1" -> 'h1') and respace (${s} -> ${ s }).
-  const compiled = await compile('x = { const s = "h1"; return `${s}`; }');
-  expect(compiled[0]._definition).toEqual('function _x() { const s = "h1"; return `${s}`; }');
-  return "ok";
-};
-const _ti9okn = async function _test_compile_assignment(compile,expect)
-{
-  const compiled = await compile(`x = ""`);
-  expect(compiled).toEqual([
-    {
-      _name: "x",
-      _inputs: [],
-      _definition: `function _x() {return ("");}`
-    }
-  ]);
-  return "ok";
-};
-const _1eb8vq = async function _test_compile_dependancy(compile,expect)
-{
-  const compiled = await compile(`y = x`);
-  expect(compiled).toEqual([
-    {
-      _name: "y",
-      _inputs: ["x"],
-      _definition: "function _y(x) {return (x);}"
-    }
-  ]);
-  return "ok";
-};
-const _acs4l0 = async function _test_compile_block_dependancy(compile,expect)
-{
-  const compiled = await compile(`z = {
-  ("");
-  return x + y;
-}`);
-  expect(compiled).toEqual([
-    {
-      _name: "z",
-      _inputs: ["x", "y"],
-      _definition: `function _z(x,y) {\n  ("");\n  return x + y;\n}`
-    }
-  ]);
-  return "ok";
-};
-const _125ljg9 = async function _test_compile_comments(compile,expect)
-{
-  const compiled = await compile(`comments = {
-  // a comment
-  return "";
-}`);
-  expect(compiled).toEqual([
-    {
-      _name: "comments",
-      _inputs: [],
-      _definition: `function _comments() {\n  // a comment\n  return "";\n}`
-    }
-  ]);
-  return "ok";
-};
-const _li37je = async function _test_compile_generator(compile,expect)
-{
-  const compiled = await compile(`generator = {
-  yield x + y;
-}`);
-  expect(compiled).toEqual([
-    {
-      _name: "generator",
-      _inputs: ["x", "y"],
-      _definition: "function* _generator(x,y) {\n  yield x + y;\n}"
-    }
-  ]);
-  return "ok";
-};
-const _em4em6 = async function _test_compile_function(compile,expect)
-{
-  const compiled = await compile(`_function = function () {}`);
-  expect(compiled).toEqual([
-    {
-      _name: "_function",
-      _inputs: [],
-      _definition: "function __function() {return (function () {});}"
-    }
-  ]);
-  return "ok";
-};
-const _w3atfb = async function _test_compile_async_function(compile,expect)
-{
-  const compiled = await compile(`asyncfunction = async function () {}`);
-  expect(compiled).toEqual([
-    {
-      _name: "asyncfunction",
-      _inputs: [],
-      _definition:
-        "function _asyncfunction() {return (async function () {});}"
-    }
-  ]);
-  return "ok";
-};
-const _14gl6yr = async function _test_compile_named_function(compile,expect)
-{
-  const compiled = await compile(`named_function = function foo() {}`);
-  expect(compiled).toEqual([
-    {
-      _name: "named_function",
-      _inputs: [],
-      _definition: "function _named_function() {return (function foo() {});}"
-    }
-  ]);
-  return "ok";
-};
-const _z3bqb8 = async function _test_compile_this_reference(compile,expect)
-{
-  const compiled = await compile(`thisReference = (this || 0) + 1`);
-  expect(compiled).toEqual([
-    {
-      _name: "thisReference",
-      _inputs: [],
-      _definition: "function _thisReference() {return ((this || 0) + 1);}"
-    }
-  ]);
-  return "ok";
-};
-const _1sou7t0 = async function _test_compile_lambda(compile,expect)
-{
-  const compiled = await compile(`lambda = () => {}`);
-  expect(compiled).toEqual([
-    {
-      _name: "lambda",
-      _inputs: [],
-      _definition: "function _lambda() {return (() => {});}"
-    }
-  ]);
-  return "ok";
-};
-const _1o1u737 = async function _test_compile_error(compile,expect)
-{
-  const compiled = await compile(`error = {
-  throw new Error();
-}`);
-  expect(compiled).toEqual([
-    {
-      _name: "error",
-      _inputs: [],
-      _definition: "function _error() {\n  throw new Error();\n}"
-    }
-  ]);
-  return "ok";
-};
-const _y271kb = async function _test_compile_viewof(compile,expect)
-{
-    const compiled = await compile(`viewof view = Inputs.input()`);
-    expect(compiled).toEqual([
-        {
-            _name: 'viewof view',
-            _inputs: ['Inputs'],
-            _definition: 'function _view(Inputs) {return (Inputs.input());}'
-        },
-        {
-            _name: 'view',
-            _inputs: [
-                'Generators',
-                'viewof view'
-            ],
-            _definition: '(G, _) => G.input(_)'
-        }
-    ]);
-    return 'ok';
-};
-const _1q4asyp = function _test_compile_viewof_and_value_coexist(compile,expect)
-{
-  const compiled = compile(`({
-    treeView: viewof growParameters,
-    tree: growParameters
-})`);
-  expect(compiled).toEqual([
-    {
-      _name: null,
-      _inputs: ["viewof growParameters", "growParameters"],
-      _definition:
-        "function _anonymous($0,growParameters) {return ({\n    treeView: $0,\n    tree: growParameters\n});}"
-    }
-  ]);
-  return "ok";
-};
-const _189jvkd = async function _test_compile_mutable(compile,expect)
-{
-    const compiled = await compile(`mutable q = 6`);
-    expect(compiled).toEqual([
-        {
-            _name: 'initial q',
-            _inputs: [],
-            _definition: 'function _q() {return (6);}'
-        },
-        {
-            _name: 'mutable q',
-            _inputs: [
-                'Mutable',
-                'initial q'
-            ],
-            _definition: '(M, _) => new M(_)'
-        },
-        {
-            _name: 'q',
-            _inputs: ['mutable q'],
-            _definition: '_ => _.generator'
-        }
-    ]);
-    return 'ok';
-};
-const _78egw8 = async function _test_compile_builtin(compile,expect)
-{
-  const compiled = await compile(`inbuilt = _`);
-  expect(compiled).toEqual([
-    {
-      _name: "inbuilt",
-      _inputs: ["_"],
-      _definition: "function _inbuilt(_) {return (_);}"
-    }
-  ]);
-  return "ok";
-};
-const _lflzev = async function _test_compile_fileattachment(compile,expect)
-{
-  const compiled = await compile(`file = FileAttachment("empty")`);
-  expect(compiled).toEqual([
-    {
-      _name: "file",
-      _inputs: ["FileAttachment"],
-      _definition:
-        `function _file(FileAttachment) {return (FileAttachment("empty"));}`
-    }
-  ]);
-  return "ok";
-};
-const _1e555b1 = async function _test_compile_mutable_dep(compile,expect)
-{
-  const compiled = await compile(`mutable_dep = {
-  viewof view;
-  lambda;
-  mutable q;
-  return mutable q;
-}`);
-  expect(compiled).toEqual([
-    {
-      _name: "mutable_dep",
-      _inputs: ["viewof view", "lambda", "mutable q"],
-      _definition:
-        "function _mutable_dep($0,lambda,$1) {\n  $0;\n  lambda;\n  $1.value;\n  return $1.value;\n}"
-    }
-  ]);
-  return "ok";
-};
-const _1a2af6 = async function _test_compile_mutable_dep2(compile,expect)
-{
-  const compiled = await compile(`mutable_dep_2 = {
-  file;
-  return q + 1;
-}`);
-  expect(compiled).toEqual([
-    {
-      _name: "mutable_dep_2",
-      _inputs: ["file", "q"],
-      _definition:
-        "function _mutable_dep_2(file,q) {\n  file;\n  return q + 1;\n}"
-    }
-  ]);
-  return "ok";
-};
-const _ql80wk = async function _test_compile_inline_viewof(compile,expect)
-{
-  const compiled = await compile(`viewofdep_inline = viewof view`);
-  expect(compiled).toEqual([
-    {
-      _name: "viewofdep_inline",
-      _inputs: ["viewof view"],
-      _definition: "function _viewofdep_inline($0) {return ($0);}"
-    }
-  ]);
-  return "ok";
-};
-const _1k420gu = async function _test_compile_view_dep(compile,expect)
-{
-  const compiled = await compile(`viewofdatadep = view`);
-  expect(compiled).toEqual([
-    {
-      _name: "viewofdatadep",
-      _inputs: ["view"],
-      _definition: "function _viewofdatadep(view) {return (view);}"
-    }
-  ]);
-  return "ok";
-};
-const _1y1h47u = async function _test_compile_dep(compile,expect)
-{
-  const compiled = await compile(`dep`);
-  expect(compiled).toEqual([
-    {
-      _name: null,
-      _inputs: ["dep"],
-      _definition: "function _anonymous(dep) {return (dep);}"
-    }
-  ]);
-  return "ok";
-};
-const _kwdsyz = async function _test_compile_class(compile,expect)
-{
-  const compiled = await compile(`v = class {}`);
-  expect(compiled).toEqual([
-    {
-      _name: "v",
-      _inputs: [],
-      _definition: `function _v() {return (class {});}`
-    }
-  ]);
-  return "ok";
-};
-const _33oop5 = async function _test_compile_event(compile,expect)
-{
-  const compiled = await compile(`event = new Event('input')`);
-  expect(compiled).toEqual([
-    {
-      _name: "event",
-      _inputs: ["Event"],
-      _definition: `function _event(Event) {return (new Event('input'));}`
-    }
-  ]);
-  return "ok";
-};
-const _9phvzk = async function _test_compile_tagged_literal(compile,expect)
-{
-  const compiled = await compile(`htl.html\`hi\``);
-  expect(compiled).toEqual([
-    {
-      _name: null,
-      _inputs: ["htl"],
-      _definition: `function _anonymous(htl) {return (htl.html\`hi\`);}`
-    }
-  ]);
-  return "ok";
-};
-const _1q0pie3 = function _compile_unit_test_template(Inputs,test_case,compiled){return(
-Inputs.textarea({
-  value: `test_compile_ = {
-  const compiled = await compile(\`${test_case.value}\`);
-  expect(compiled).toEqual(${JSON.stringify(compiled, null, 2)});
-  return "ok";
-}`,
-  disabled: true,
-  rows: 20,
-  label: "compile test template"
-})
-)};
-const _1lmax86 = async function _test_compile_import_plain_single(compile,expect)
-{
-  const compiled = await compile(
-    `import {dep} from "@tomlarkworthy/dependancy";`
-  );
-  expect(compiled).toEqual([
-    {
-      _name: "module @tomlarkworthy/dependancy",
-      _inputs: [],
-      _definition: `async () => runtime.module((await import("/@tomlarkworthy/dependancy.js?v=4")).default)`
-    },
-    {
-      _name: "dep",
-      _inputs: ["module @tomlarkworthy/dependancy", "@variable"],
-      _definition: `(_, v) => v.import("dep", _)`
-    }
-  ]);
-  return "ok";
-};
-const _17sgzdm = async function _test_compile_import_view_data_alias_single(compile,expect)
-{
-  const compiled = await compile(
-    `import {viewdep as aslias_viewdep_data} from "@tomlarkworthy/dependancy";`
-  );
-  expect(compiled).toEqual([
-    {
-      _name: "module @tomlarkworthy/dependancy",
-      _inputs: [],
-      _definition: `async () => runtime.module((await import("/@tomlarkworthy/dependancy.js?v=4")).default)`
-    },
-    {
-      _name: "aslias_viewdep_data",
-      _inputs: ["module @tomlarkworthy/dependancy", "@variable"],
-      _definition: `(_, v) => v.import("viewdep", "aslias_viewdep_data", _)`
-    }
-  ]);
-  return "ok";
-};
-const _1tqj4tp = async function _test_compile_import_mutable_data_alias_single(compile,expect)
-{
-  const compiled = await compile(
-    `import {mutabledep as aslias_mutabledep_data} from "@tomlarkworthy/dependancy";`
-  );
-  expect(compiled).toEqual([
-    {
-      _name: "module @tomlarkworthy/dependancy",
-      _inputs: [],
-      _definition: `async () => runtime.module((await import("/@tomlarkworthy/dependancy.js?v=4")).default)`
-    },
-    {
-      _name: "aslias_mutabledep_data",
-      _inputs: ["module @tomlarkworthy/dependancy", "@variable"],
-      _definition: `(_, v) => v.import("mutabledep", "aslias_mutabledep_data", _)`
-    }
-  ]);
-  return "ok";
-};
-const _hv0te2 = async function _test_compile_import_mutable_single(compile,expect)
-{
-  const compiled = await compile(
-    `import {mutable mutabledep} from "@tomlarkworthy/dependancy";`
-  );
-  expect(compiled).toEqual([
-    {
-      _name: "module @tomlarkworthy/dependancy",
-      _inputs: [],
-      _definition: `async () => runtime.module((await import("/@tomlarkworthy/dependancy.js?v=4")).default)`
-    },
-    {
-      _name: "mutable mutabledep",
-      _inputs: ["module @tomlarkworthy/dependancy", "@variable"],
-      _definition: `(_, v) => v.import("mutable mutabledep", _)`
-    }
-  ]);
-  return "ok";
-};
-const _1mltqmr = async function _test_compile_import_viewof_single(compile,expect)
-{
-  const compiled = await compile(
-    `import {viewof viewdep} from "@tomlarkworthy/dependancy";`
-  );
-  expect(compiled).toEqual([
-    {
-      _name: "module @tomlarkworthy/dependancy",
-      _inputs: [],
-      _definition: `async () => runtime.module((await import("/@tomlarkworthy/dependancy.js?v=4")).default)`
-    },
-    {
-      _name: "viewof viewdep",
-      _inputs: ["module @tomlarkworthy/dependancy", "@variable"],
-      _definition: `(_, v) => v.import("viewof viewdep", _)`
-    }
-  ]);
-  return "ok";
-};
-const _1d18obr = async function _test_compile_import_alias_single(compile,expect)
-{
-  const compiled = await compile(
-    `import {dep as dep_alias} from "@tomlarkworthy/dependancy";`
-  );
-  expect(compiled).toEqual([
-    {
-      _name: "module @tomlarkworthy/dependancy",
-      _inputs: [],
-      _definition: `async () => runtime.module((await import("/@tomlarkworthy/dependancy.js?v=4")).default)`
-    },
-    {
-      _name: "dep_alias",
-      _inputs: ["module @tomlarkworthy/dependancy", "@variable"],
-      _definition: `(_, v) => v.import("dep", "dep_alias", _)`
-    }
-  ]);
-  return "ok";
-};
-const _1b5ghef = async function _test_compile_import_notebook(compile,expect)
-{
-  const compiled = await compile(
-    `import {escodegen} from "@tomlarkworthy/escodegen"`
-  );
-  expect(compiled).toEqual([
-    {
-      _name: `module @tomlarkworthy/escodegen`,
-      _inputs: [],
-      _definition:
-        'async () => runtime.module((await import("/@tomlarkworthy/escodegen.js?v=4")).default)'
-    },
-    {
-      _name: `escodegen`,
-      _inputs: ["module @tomlarkworthy/escodegen", "@variable"],
-      _definition: '(_, v) => v.import("escodegen", _)'
-    }
-  ]);
-  return "ok";
-};
-const _1nps9cr = function _test_case(Inputs,notebook_semantics_source){return(
-Inputs.select(
-  notebook_semantics_source.filter((s) => s.mode == "js"),
-  {
-    label: "compilation test case",
-    format: (v) => v.value
-  }
-)
-)};
-const _1e5ax6f = (G, _) => G.input(_);
-const _18e5b93 = function _153(test_case){return(
-test_case.value
-)};
-const _16q6oyc = async function _compiled(compile,test_case){return(
-await compile(test_case.value)
-)};
-const _1191170 = function _155(parser,test_case)
-{
-  const comments = [];
-  const tokens = [];
-  const ast = parser.parseCell(test_case.value, {
-    ranges: true,
-    onComment: comments,
-    onToken: tokens
-  });
-
-  return {
-    ast,
-    comments,
-    tokens
-  };
-};
-const _eom91x = function _158(compile,test_case){return(
-compile(test_case.value)
-)};
-const _ttos3c = function _compile(parser,observableToJs){return(
-function compile(source, {
-  anonymousName = '_anonymous'
-} = {}) {
-  const comments = [], tokens = [];
-  let cell;
-  try {
-    cell = parser.parseCell(source, {
-      ranges: true,
-      onComment: comments,
-      onToken: tokens
-    });
-  } catch (e) {
-    if (e instanceof SyntaxError) {
-      const nameMatch = source.match(/^\s*(?:(viewof|mutable)\s+)?([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=/);
-      let _name = null;
-      let funcName = anonymousName;
-      if (nameMatch) {
-        const prefix = nameMatch[1] ? nameMatch[1] + ' ' : '';
-        _name = prefix + nameMatch[2];
-        funcName = '_' + nameMatch[2];
-      }
-      const escapedMsg = JSON.stringify(e.message);
-      const escapedSource = JSON.stringify(source);
-      return [{
-          _name,
-          _inputs: [],
-          _definition: `function ${ funcName }() { throw Object.assign(new SyntaxError(${ escapedMsg }), {_sourceExpression: ${ escapedSource }}); }`
-        }];
-    }
-    throw e;
-  }
-  if (!cell)
-    throw new Error('Unable to parse cell');
-  const parseImportSpecifierText = text => {
-    const t = String(text ?? '').trim().replace(/,$/, '').trim();
-    if (!t)
-      throw new Error('Empty import specifier');
-    const parts = t.split(/\s+as\s+/);
-    const left = parts[0].trim();
-    const right = parts[1]?.trim();
-    const parseSide = (side, {
-      defaultPrefix = ''
-    } = {}) => {
-      const s = String(side ?? '').trim();
-      const m = s.match(/^(viewof|mutable)\s+(.+)$/);
-      if (m)
-        return {
-          prefix: `${ m[1] } `,
-          name: m[2].trim()
-        };
-      return {
-        prefix: defaultPrefix,
-        name: s
-      };
-    };
-    const L = parseSide(left);
-    const R = right ? parseSide(right, { defaultPrefix: L.prefix }) : L;
-    const importedName = `${ L.prefix }${ L.name }`.trim();
-    const localName = `${ R.prefix }${ R.name }`.trim();
-    if (!importedName)
-      throw new Error(`Could not parse imported name from: ${ t }`);
-    if (!localName)
-      throw new Error(`Could not parse local name from: ${ t }`);
-    return {
-      importedName,
-      localName
-    };
-  };
-  if (!cell.id && cell.body?.type === 'ImportDeclaration') {
-    const module_name = cell.body.source.value;
-    const cell_variables = [{
-        _name: `module ${ module_name }`,
-        _inputs: [],
-        _definition: `async () => runtime.module((await import("/${ module_name }.js?v=4")).default)`
-      }];
-    for (const specifier of cell.body.specifiers ?? []) {
-      const specText = typeof specifier?.start === 'number' && typeof specifier?.end === 'number' ? source.slice(specifier.start, specifier.end) : (() => {
-        if (specifier?.imported?.name && specifier?.local?.name) {
-          return specifier.imported.name === specifier.local.name ? specifier.local.name : `${ specifier.imported.name } as ${ specifier.local.name }`;
-        }
-        throw new Error('Import specifier missing range information');
-      })();
-      const {importedName, localName} = parseImportSpecifierText(specText);
-      cell_variables.push({
-        _name: localName,
-        _inputs: [
-          `module ${ module_name }`,
-          '@variable'
-        ],
-        _definition: importedName === localName ? `(_, v) => v.import("${ importedName }", _)` : `(_, v) => v.import("${ importedName }", "${ localName }", _)`
-      });
-    }
-    return cell_variables;
-  }
-  let dollarIdx = 0;
-  const inputToArgMap = {};
-  const dollarToMacro = {};
-  const seen = new Set();
-  const inputs = Array.from(cell.references || []).flatMap(i => {
-    if (i.name) {
-      if (seen.has(i.name))
-        return [];
-      seen.add(i.name);
-      return i.name;
-    } else {
-      const dedupKey = i.type + ':' + i.id.name;
-      if (seen.has(dedupKey))
-        return [];
-      seen.add(dedupKey);
-      const dollarName = '$' + dollarIdx;
-      inputToArgMap[i.id.name] = dollarName;
-      dollarToMacro[dollarName] = i.type == 'ViewExpression' ? 'viewof ' + i.id.name : 'mutable ' + i.id.name;
-      dollarIdx++;
-      return dollarName;
-    }
-  });
-  let variables;
-  if (cell.id) {
-    if (cell.id.type === 'Identifier') {
-      variables = [{
-          functionName: '_' + cell.id.name,
-          name: cell.id.name,
-          inputs,
-          params: inputs.join(',')
-        }];
-    } else if (cell.id.type === 'ViewExpression') {
-      variables = [
-        {
-          functionName: '_' + cell.id.id.name,
-          name: 'viewof ' + cell.id.id.name,
-          inputs,
-          params: inputs.join(',')
-        },
-        {
-          functionName: '_' + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: '(G, _) => G.input(_)',
-          inputs: [
-            'Generators',
-            'viewof ' + cell.id.id.name
-          ],
-          params: inputs.join(',')
-        }
-      ];
-    } else if (cell.id.type === 'MutableExpression') {
-      variables = [
-        {
-          functionName: '_' + cell.id.id.name,
-          name: 'initial ' + cell.id.id.name,
-          inputs,
-          params: inputs.join(',')
-        },
-        {
-          functionName: '_' + cell.id.id.name,
-          name: 'mutable ' + cell.id.id.name,
-          _definition: '(M, _) => new M(_)',
-          inputs: [
-            'Mutable',
-            'initial ' + cell.id.id.name
-          ],
-          params: inputs.join(',')
-        },
-        {
-          functionName: '_' + cell.id.id.name,
-          name: cell.id.id.name,
-          _definition: '_ => _.generator',
-          inputs: ['mutable ' + cell.id.id.name],
-          params: inputs.join(',')
-        }
-      ];
-    } else {
-      throw new Error(`Unsupported cell id type: ${ cell.id.type }`);
-    }
-  } else {
-    variables = [{
-        functionName: anonymousName,
-        name: null,
-        inputs,
-        params: inputs.join(',')
-      }];
-  }
-  return variables.map(v => {
-    let _definition = v._definition;
-    if (!_definition) {
-      let functionBody;
-      if (cell.body.type === 'BlockStatement') {
-        functionBody = observableToJs(cell.body, inputToArgMap, source);
-      } else {
-        const bodyCode = observableToJs(cell.body, inputToArgMap, source);
-        functionBody = `{return (${ bodyCode });}`;
-      }
-      _definition = `${ cell.async ? 'async ' : '' }function${ cell.generator ? '*' : '' } ${ v.functionName }(${ v.inputs.join(',') }) ${ functionBody }`;
-    }
-    return {
-      _name: v.name,
-      _inputs: v.inputs.map(i => dollarToMacro[i] || (i === '$variable' ? '@variable' : i)),
-      _definition
-    };
-  });
-}
-)};
-const _1v1i7wl = function _observableToJs(acorn_walk,parser){return(
-(ast, inputMap, source) => {
-  // Source-preserving: slice the original body text verbatim and splice only the
-  // Observable-specific macro ranges (`viewof foo` → $N, `mutable foo` →
-  // $N.value). Regenerating via escodegen used to drop the ASI-protecting paren
-  // in `return( … )`, normalize quotes, respace `${ x }`, and reindent — all
-  // avoided by never regenerating. Ranges are offsets into `source`.
-  const edits = [];
-  acorn_walk.ancestor(
-    ast,
-    {
-      ViewExpression(node) {
-        edits.push({ start: node.start, end: node.end, text: inputMap[node.id.name] });
-      },
-      MutableExpression(node) {
-        // ".value" is not a valid identifier but is valid member access here.
-        edits.push({ start: node.start, end: node.end, text: inputMap[node.id.name] + ".value" });
-      }
-    },
-    parser.walk
-  );
-  const base = ast.start;
-  let out = source.slice(ast.start, ast.end);
-  edits
-    .sort((a, b) => b.start - a.start)
-    .forEach((e) => {
-      out = out.slice(0, e.start - base) + e.text + out.slice(e.end - base);
-    });
-  return out;
-}
-)};
-const _1ayjluu = function _161(md){return(
-md`### Bundled deps`
-)};
-const _xhj6b8 = function _decompress_url(DecompressionStream,TextDecoderStream,TransformStream,TextEncoderStream,Response){return(
-async (attachment, overrides) => {
-  let decompressedStream;
-
-  if (!overrides) {
-    decompressedStream = (await attachment.stream()).pipeThrough(
-      new DecompressionStream("gzip")
-    );
-  } else {
-    decompressedStream = (await attachment.stream())
-      .pipeThrough(new DecompressionStream("gzip"))
-      .pipeThrough(new TextDecoderStream())
-      .pipeThrough(
-        new TransformStream({
-          transform(chunk, controller) {
-            // Rewrite URLs in the text
-            let modifiedChunk = chunk;
-            Object.entries(overrides).forEach(([override, replacement]) => {
-              modifiedChunk = modifiedChunk.replace(override, replacement);
-            });
-            controller.enqueue(modifiedChunk);
-          }
-        })
-      )
-      .pipeThrough(new TextEncoderStream());
-  }
-  const arrayBuffer = await new Response(decompressedStream).arrayBuffer();
-
-  // Create a Blob from the ArrayBuffer
-  const blob = new Blob([arrayBuffer], { type: "application/javascript" });
-
-  return URL.createObjectURL(blob);
-}
-)};
-const _s9w7ha = async function _parser(decompress_url, FileAttachment, acorn_url, acorn_walk_url) {
-    return import(await decompress_url(FileAttachment('parser-6.1.0.js.gz'), {
-        '/npm/acorn@8.11.3/+esm': acorn_url,
-        '/npm/acorn-walk@8.3.2/+esm': acorn_walk_url
-    }));
-};
-const _1rc67k0 = function _stageB_importFake()
-{
-  // Builds a Stage B (pre-observation, API-loaded) import group as POJOs.
-  // Mirrors what `runtime.define("name", ["module @X", "@variable"], (_, v) => v.import("name", _))`
-  // produces structurally. Used by the test_decompileImport_stageB_* tests to
-  // avoid spinning up a real Observable runtime per case.
-  return function stageB_importFake(module_name, specifiers) {
-    const importerModule = { _scope: new Map() };
-    const stitch = {
-      _name: `module ${ module_name }`,
-      _module: importerModule,
-      _inputs: [],
-      _definition: `async () => null`
-    };
-    const atVariable = {
-      _name: '@variable',
-      _module: importerModule
-    };
-    const aliases = specifiers.map(s => ({
-      _name: s.local,
-      _module: importerModule,
-      _inputs: [
-        stitch,
-        atVariable
-      ],
-      _definition: s.imported === s.local ? `(_, v) => v.import("${ s.imported }", _)` : `(_, v) => v.import("${ s.imported }", "${ s.local }", _)`
-    }));
-    return [
-      stitch,
-      ...aliases
-    ];
-  };
-};
-const _1d53asg = async function _test_decompileImport_stageB_single(stageB_importFake,decompileImport,expect,formatImportDeclaration)
-{
-  const vars = stageB_importFake('@tomlarkworthy/visualizer', [{
-      imported: 'visualize',
-      local: 'visualize'
-    }]);
-  const info = await decompileImport(vars);
-  expect(info.meta.detection.stage).toEqual('B');
-  expect(formatImportDeclaration(info)).toEqual(`import {visualize} from "@tomlarkworthy/visualizer"`);
-  return 'ok';
-};
-const _hv5gag = async function _test_decompileImport_stageB_aliased(stageB_importFake,decompileImport,expect,formatImportDeclaration)
-{
-  const vars = stageB_importFake('@user/y', [{
-      imported: 'x',
-      local: 'z'
-    }]);
-  const info = await decompileImport(vars);
-  expect(info.meta.detection.stage).toEqual('B');
-  expect(info.specifiers[0].alias).toEqual(true);
-  expect(formatImportDeclaration(info)).toEqual(`import {x as z} from "@user/y"`);
-  return 'ok';
-};
-const _avc18y = async function _test_decompileImport_stageB_multiple(stageB_importFake,decompileImport,expect,formatImportDeclaration)
-{
-  const vars = stageB_importFake('@user/y', [
-    {
-      imported: 'a',
-      local: 'a'
-    },
-    {
-      imported: 'b',
-      local: 'b'
-    },
-    {
-      imported: 'c',
-      local: 'c'
-    }
-  ]);
-  const info = await decompileImport(vars);
-  expect(info.meta.detection.stage).toEqual('B');
-  expect(formatImportDeclaration(info)).toEqual(`import {a, b, c} from "@user/y"`);
-  return 'ok';
-};
-const _16gia7i = async function _test_decompileImport_stageB_mixed_alias(stageB_importFake,decompileImport,expect,formatImportDeclaration)
-{
-  const vars = stageB_importFake('@user/y', [
-    {
-      imported: 'a',
-      local: 'a'
-    },
-    {
-      imported: 'b',
-      local: 'c'
-    }
-  ]);
-  const info = await decompileImport(vars);
-  expect(info.meta.detection.stage).toEqual('B');
-  expect(formatImportDeclaration(info)).toEqual(`import {a, b as c} from "@user/y"`);
-  return 'ok';
-};
-const _1slhdwo = async function _test_decompileImport_stageB_viewof(stageB_importFake,decompileImport,expect,formatImportDeclaration)
-{
-  const vars = stageB_importFake('@tomlarkworthy/module-map', [{
-      imported: 'viewof currentModules',
-      local: 'viewof currentModules'
-    }]);
-  const info = await decompileImport(vars);
-  expect(info.meta.detection.stage).toEqual('B');
-  expect(formatImportDeclaration(info)).toEqual(`import {viewof currentModules} from "@tomlarkworthy/module-map"`);
-  return 'ok';
-};
-const _qwlsf2 = async function _test_decompileImport_stageB_mutable(stageB_importFake,decompileImport,expect,formatImportDeclaration)
-{
-  const vars = stageB_importFake('@user/y', [{
-      imported: 'mutable counter',
-      local: 'mutable counter'
-    }]);
-  const info = await decompileImport(vars);
-  expect(info.meta.detection.stage).toEqual('B');
-  expect(formatImportDeclaration(info)).toEqual(`import {mutable counter} from "@user/y"`);
-  return 'ok';
-};
-const _sy7jfx = async function _test_decompileImport_returns_null_for_non_import(decompileImport,expect)
-{
-  // A regular cell — no stitch, no @variable input, no cross-module reference.
-  const info = await decompileImport([{
-      _name: 'x',
-      _module: {},
-      _inputs: [],
-      _definition: `() => 42`
-    }]);
-  expect(info).toEqual(null);
-  return 'ok';
-};
-const _rk7ku3 = async function _test_decompileImport_compile_roundtrip_single(compile,expect,stageB_importFake,decompileImport,formatImportDeclaration)
-{
-  // What `compile()` emits for `import {x} from "@user/y"` is structurally the
-  // same as our stageB_importFake fixture (after runtime.define resolves the
-  // input name strings to Variable refs). Verify the fixture matches the
-  // shape compile() would produce.
-  const pojos = compile(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
-  expect(pojos.length).toEqual(3);
-  expect(pojos[0]._name).toEqual('module @tomlarkworthy/visualizer');
-  expect(pojos[1]._name).toEqual('visualize');
-  expect(pojos[2]._name).toEqual('Group');
-  expect(pojos[1]._inputs).toEqual([
-    'module @tomlarkworthy/visualizer',
-    '@variable'
-  ]);
-  // Now run our fixture through decompileImport — confirms the round-trip
-  // shape compile()-output-shape-when-defined → decompileImport produces the
-  // canonical import source string.
-  const vars = stageB_importFake('@tomlarkworthy/visualizer', [
-    {
-      imported: 'visualize',
-      local: 'visualize'
-    },
-    {
-      imported: 'Group',
-      local: 'Group'
-    }
-  ]);
-  const info = await decompileImport(vars);
-  expect(formatImportDeclaration(info)).toEqual(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
-  return 'ok';
-};
-const _xynplo = async function _test_decompileImport_stageB_order_independent(stageB_importFake,decompileImport,expect,formatImportDeclaration)
-{
-  // The detection uses .find — it shouldn't matter whether the stitch is at
-  // index 0 or the aliases come first. Verify by reversing the array.
-  const vars = stageB_importFake('@user/y', [
-    {
-      imported: 'a',
-      local: 'a'
-    },
-    {
-      imported: 'b',
-      local: 'b'
-    }
-  ]);
-  const [stitch, ...aliases] = vars;
-  const info = await decompileImport([
-    ...aliases,
-    stitch
-  ]);
-  expect(info.meta.detection.stage).toEqual('B');
-  expect(formatImportDeclaration(info)).toEqual(`import {a, b} from "@user/y"`);
-  return 'ok';
-};
-const _16fpgac = async function _test_decompileImport_stageB_notebook_id(stageB_importFake,decompileImport,expect,formatImportDeclaration)
-{
-  // Observable supports `import {x} from "d/<hash>@<version>"` notebook-id form.
-  const vars = stageB_importFake('d/57d79353bac56631@44', [{
-      imported: 'hash',
-      local: 'hash'
-    }]);
-  const info = await decompileImport(vars);
-  expect(info.meta.detection.stage).toEqual('B');
-  expect(formatImportDeclaration(info)).toEqual(`import {hash} from "d/57d79353bac56631@44"`);
-  return 'ok';
-};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
   const $def = (pid, name, deps, fn) => {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
-  const fileAttachments = new Map(["acorn-walk-8.3.2.js.gz","parser-6.1.0.js.gz"].map((name) => {
-    const module_name = "@tomlarkworthy/observablejs-toolchain";
-    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
-    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
-    return [name, {url: blob_url, mimeType: mime}]
-  }));
-  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
 
-  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
-  main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
-  main.define("module @tomlarkworthy/acorn-8-11-3", async () => runtime.module((await import("/@tomlarkworthy/acorn-8-11-3.js?v=4")).default));  
-  main.define("module @tomlarkworthy/jest-expect-standalone", async () => runtime.module((await import("/@tomlarkworthy/jest-expect-standalone.js?v=4")).default));  
-  main.define("module @tomlarkworthy/observable-runtime", async () => runtime.module((await import("/@tomlarkworthy/observable-runtime.js?v=4")).default));  
-  $def("_lp77pf", null, ["md"], _lp77pf);  
-  $def("_n0sc6u", null, ["md"], _n0sc6u);  
-  $def("_sgo04r", null, ["md"], _sgo04r);  
-  $def("_aivd6y", null, ["md"], _aivd6y);  
-  $def("_1q8w8vr", null, ["md"], _1q8w8vr);  
-  $def("_d17a1w", null, ["md"], _d17a1w);  
-  $def("_1juriue", null, ["md"], _1juriue);  
-  main.define("tests", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("tests", _));  
-  main.define("viewof runtime_variables", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("viewof runtime_variables", _));  
-  main.define("runtime_variables", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("runtime_variables", _));  
-  main.define("modules", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("modules", _));  
-  $def("_1k5oyj7", null, ["tests"], _1k5oyj7);  
-  $def("_1jrpa13", null, ["md"], _1jrpa13);  
-  $def("_1lc80et", "cellMaps", ["cellMap"], _1lc80et);  
-  $def("_zki07o", "allCells", ["cellMaps"], _zki07o);  
-  $def("_1nkhnnd", "all_decompiled", ["allCells","decompile"], _1nkhnnd);  
-  $def("_1ip1war", "test_all_cells_decompilable", ["all_decompiled"], _1ip1war);  
-  $def("_1w70b75", null, ["md"], _1w70b75);  
-  $def("_uscpdn", "all_compiled", ["all_decompiled","compile"], _uscpdn);  
-  $def("_x55zzr", "test_decompiled_cells_recompilable", ["all_compiled"], _x55zzr);  
-  $def("_100n7xr", null, ["md"], _100n7xr);  
-  $def("_1nm57o2", "roundtripped", ["all_compiled","decompile"], _1nm57o2);  
-  $def("_18xo2td", "test_all_cells_roundtrippable", ["roundtripped"], _18xo2td);  
-  $def("_14nox99", null, ["md"], _14nox99);  
-  $def("_1d3zr3i", null, ["md"], _1d3zr3i);  
-  $def("_12sqt9", "dependancy_document", [], _12sqt9);  
-  $def("_13q8314", "dependancy_source", ["dependancy_document"], _13q8314);  
-  $def("_ook1nq", null, ["md"], _ook1nq);  
-  $def("_jmn84r", "notebook_semantics_document", [], _jmn84r);  
-  $def("_1juj7i6", "notebook_semantics_source", ["notebook_semantics_document","parser"], _1juj7i6);  
-  $def("_1oevsow", null, ["md"], _1oevsow);  
-  $def("_11lfflk", "notebook_semantics_module", [], _11lfflk);  
-  main.define("cellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("cellMap", _));  
-  main.define("moduleMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("moduleMap", _));  
-  $def("_gjten6", null, ["md"], _gjten6);  
-  $def("_n9rco8", null, ["md"], _n9rco8);  
-  $def("_eog966", null, ["md"], _eog966);  
-  $def("_n4ntwp", null, ["md"], _n4ntwp);  
-  $def("_1lg9nnl", "importFake", ["Runtime"], _1lg9nnl);  
-  $def("_25tjxa", "test_decompile_syntax_error_roundtrip", ["compile","decompile","expect"], _25tjxa);  
-  $def("_1jyrnzq", "test_decompile_$variable", ["decompile","expect"], _1jyrnzq);  
-  $def("_1v1d8m3", "test_decompile_import_variable", ["decompile","importFake","expect"], _1v1d8m3);  
-  $def("_fiyb80", "test_decompile_dollar_in_string_literal", ["decompile","expect"], _fiyb80);  
-  $def("_wgfrtq", "test_decompile_import_variable_alias", ["decompile","importFake","expect"], _wgfrtq);  
-  $def("_1a8gnrc", "test_decompile_import_many", ["decompile","importFake","expect"], _1a8gnrc);  
-  $def("_7stpu3", "test_decompile_markdown_cell", ["decompile","expect"], _7stpu3);  
-  $def("_v4p1js", "test_decompile_constant", ["decompile","expect"], _v4p1js);  
-  $def("_pcs4h", "test_decompile_string_literal", ["decompile","expect"], _pcs4h);  
-  $def("_a2zh99", "test_decompile_html_cell", ["decompile","expect"], _a2zh99);  
-  $def("_pyp280", "test_decompile_class", ["decompile","expect"], _pyp280);  
-  $def("_kf8c3f", "test_decompile_class_with_property", ["decompile"], _kf8c3f);  
-  $def("_4vunhm", "test_decompile_object_literal", ["decompile","expect"], _4vunhm);
-  $def("_tstlc1", "test_decompile_leading_comment", ["compile","decompile","expect"], _tstlc1);
-  $def("_tsttc1", "test_decompile_trailing_comment", ["decompile","expect"], _tsttc1);
-  $def("_tstpis", "test_decompile_param_in_string", ["decompile","expect"], _tstpis);
-  $def("_tstcpf", "test_decompile_class_property_field", ["decompile","expect"], _tstcpf);
-  $def("_s14e29", "test_decompile_reference", ["decompile","expect"], _s14e29);  
-  $def("_4rsshj", "test_decompile_block", ["decompile","expect"], _4rsshj);  
-  $def("_o7o1wl", "test_decompile_comments", ["decompile","expect"], _o7o1wl);  
-  $def("_1yn35e3", "test_decompile_generator", ["decompile","expect"], _1yn35e3);  
-  $def("_135eswd", "test_decompile_function", ["decompile","expect"], _135eswd);  
-  $def("_1pitq2", "test_decompile_async_function", ["decompile","expect"], _1pitq2);  
-  $def("_1kxe1b2", "test_decompile_named_function", ["decompile","expect"], _1kxe1b2);  
-  $def("_1pghf4f", "test_decompile_this_reference", ["decompile","expect"], _1pghf4f);  
-  $def("_4aeghn", "test_decompile_lambda", ["decompile","expect"], _4aeghn);  
-  $def("_12ec5zd", "test_decompile_error", ["decompile","expect"], _12ec5zd);  
-  $def("_3bj09h", "test_decompile_error_object", ["decompile","expect"], _3bj09h);  
-  $def("_6iufw4", null, ["md"], _6iufw4);  
-  $def("_15idqib", "test_decompile_anon_error_dep", ["decompile","expect"], _15idqib);  
-  $def("_mhm98c", "test_decompile_viewof", ["decompile","expect"], _mhm98c);  
-  $def("_15kgqrr", "test_decompile_mutable", ["decompile","expect"], _15kgqrr);  
-  $def("_1onyv5c", "test_decompile_builtin", ["decompile","expect"], _1onyv5c);  
-  $def("_1uv76xx", "test_decompile_fileattachment", ["decompile","expect"], _1uv76xx);  
-  $def("_g4z6de", "test_decompile_mutable_dependancy", ["decompile","expect"], _g4z6de);  
-  $def("_qo8sdl", "test_decompile_mutable_dependancy_2", ["decompile","expect"], _qo8sdl);  
-  $def("_15kwaz1", "test_decompile_viewof_dep", ["decompile","expect"], _15kwaz1);  
-  $def("_1qjzk2s", "test_decompile_viewof_data_dep", ["decompile","expect"], _1qjzk2s);  
-  $def("_ehz2xk", "test_decompile_viewof_param", ["decompile","expect"], _ehz2xk);  
-  $def("_oilkc0", "test_decompile_anon_dep", ["decompile","expect"], _oilkc0);  
-  $def("_1jggajo", "test_decompile_import_mutable", ["decompile","expect"], _1jggajo);  
-  $def("_di0abi", "test_decompile_import_viewof", ["decompile","expect"], _di0abi);  
-  $def("_14o5oio", "test_decompile_viewof_data", ["decompile","expect"], _14o5oio);  
-  $def("_1lv4syw", "test_decompile_import_alias", ["decompile","expect"], _1lv4syw);  
-  $def("_l8b8hu", "test_decompile_import_mutable_alias", ["decompile","expect"], _l8b8hu);  
-  $def("_1g5n3sa", "test_decompile_import_mutable_data_alias", ["decompile","expect"], _1g5n3sa);  
-  $def("_1lnngk6", "test_decompile_import_viewof_alias", ["decompile","expect"], _1lnngk6);  
-  $def("_1na1e5i", "test_decompile_import_viewof_data_alias", ["decompile","expect"], _1na1e5i);  
-  $def("_17dwb6r", null, ["md"], _17dwb6r);  
-  $def("_1vs6mei", null, ["md"], _1vs6mei);  
-  $def("_llvq9s", "decompile", ["decompileImport","formatImportDeclaration","acorn"], _llvq9s);  
-  $def("_1pvis67", null, ["md"], _1pvis67);  
-  $def("_183j58u", "extractModuleInfo", [], _183j58u);  
-  $def("_w445v0", "test_extractModuleInfo_notebook_resolution", ["expect","extractModuleInfo"], _w445v0);  
-  $def("_uzqj4w", "test_extractModuleInfo_id_version_resolution", ["expect","extractModuleInfo"], _uzqj4w);  
-  $def("_1sruec2", "test_extractModuleInfo_id_version", ["expect","extractModuleInfo"], _1sruec2);  
-  $def("_ipn8zp", "test_extractModuleInfo_test_4", ["expect","extractModuleInfo"], _ipn8zp);  
-  $def("_iigmyv", "test_extractModuleInfo_alias_hack", ["expect","extractModuleInfo"], _iigmyv);  
-  $def("_1tggbee", null, ["md"], _1tggbee);  
-  $def("_kiaw33", "import_ast_example", ["parser"], _kiaw33);  
-  $def("_1n7gw17", "findModuleName", ["extractModuleInfo"], _1n7gw17);  
-  $def("_i47chb", "findImportedName", [], _i47chb);  
-  $def("_1effqg", null, ["md"], _1effqg);  
-  $def("_b7vai6", "decompileImport", ["findModuleName","findImportedName"], _b7vai6);  
-  $def("_1sylz7j", "formatImportDeclaration", [], _1sylz7j);  
-  $def("_13dctdn", "test_decompileImport_basic", ["importFake","decompileImport","expect"], _13dctdn);  
-  $def("_ujr0xn", "test_formatImportDeclaration_roundtrip", ["importFake","decompileImport","expect","formatImportDeclaration","decompile"], _ujr0xn);  
-  $def("_1u6sfri", "test_decompileImport_alias", ["importFake","decompileImport","expect","formatImportDeclaration"], _1u6sfri);  
-  $def("_1lqhutp", null, ["md"], _1lqhutp);  
-  $def("_3knb9v", "variableToObject", [], _3knb9v);  
-  $def("_263fcv", null, ["md"], _263fcv);  
-  $def("_7zpsl9", "viewof normalizeObservableSourceSelector", ["Inputs","notebook_semantics_source"], _7zpsl9);  
-  $def("_1ex8kus", "normalizeObservableSourceSelector", ["Generators","viewof normalizeObservableSourceSelector"], _1ex8kus);  
-  $def("_b2d0zc", "parsed", ["parser","normalizeObservableSourceSelector"], _b2d0zc);  
-  $def("_vle3wv", null, ["md"], _vle3wv);  
-  $def("_10ofthe", "test_async_interpolation", ["compile"], _10ofthe);  
-  $def("_1gb7c3c", "test_compile_syntax_error_viewof", ["compile","expect"], _1gb7c3c);  
-  $def("_69vyub", "test_compile_syntax_error_anonymous", ["compile","expect"], _69vyub);  
-  $def("_1c9p3om", "test_compile_syntax_error_named", ["compile","expect"], _1c9p3om);  
-  $def("_x7zc8w", "test_compile_integer", ["compile","expect"], _x7zc8w);  
-  $def("_1u7hlem", "test_compile_string", ["compile","expect"], _1u7hlem);  
-  $def("_151bijp", "test_compile_obj_literal", ["compile","expect"], _151bijp);
-  $def("_tstcff", "test_compile_preserves_formatting", ["compile","expect"], _tstcff);  
-  $def("_ti9okn", "test_compile_assignment", ["compile","expect"], _ti9okn);  
-  $def("_1eb8vq", "test_compile_dependancy", ["compile","expect"], _1eb8vq);  
-  $def("_acs4l0", "test_compile_block_dependancy", ["compile","expect"], _acs4l0);  
-  $def("_125ljg9", "test_compile_comments", ["compile","expect"], _125ljg9);  
-  $def("_li37je", "test_compile_generator", ["compile","expect"], _li37je);  
-  $def("_em4em6", "test_compile_function", ["compile","expect"], _em4em6);  
-  $def("_w3atfb", "test_compile_async_function", ["compile","expect"], _w3atfb);  
-  $def("_14gl6yr", "test_compile_named_function", ["compile","expect"], _14gl6yr);  
-  $def("_z3bqb8", "test_compile_this_reference", ["compile","expect"], _z3bqb8);  
-  $def("_1sou7t0", "test_compile_lambda", ["compile","expect"], _1sou7t0);  
-  $def("_1o1u737", "test_compile_error", ["compile","expect"], _1o1u737);  
-  $def("_y271kb", "test_compile_viewof", ["compile","expect"], _y271kb);  
-  $def("_1q4asyp", "test_compile_viewof_and_value_coexist", ["compile","expect"], _1q4asyp);  
-  $def("_189jvkd", "test_compile_mutable", ["compile","expect"], _189jvkd);  
-  $def("_78egw8", "test_compile_builtin", ["compile","expect"], _78egw8);  
-  $def("_lflzev", "test_compile_fileattachment", ["compile","expect"], _lflzev);  
-  $def("_1e555b1", "test_compile_mutable_dep", ["compile","expect"], _1e555b1);  
-  $def("_1a2af6", "test_compile_mutable_dep2", ["compile","expect"], _1a2af6);  
-  $def("_ql80wk", "test_compile_inline_viewof", ["compile","expect"], _ql80wk);  
-  $def("_1k420gu", "test_compile_view_dep", ["compile","expect"], _1k420gu);  
-  $def("_1y1h47u", "test_compile_dep", ["compile","expect"], _1y1h47u);  
-  $def("_kwdsyz", "test_compile_class", ["compile","expect"], _kwdsyz);  
-  $def("_33oop5", "test_compile_event", ["compile","expect"], _33oop5);  
-  $def("_9phvzk", "test_compile_tagged_literal", ["compile","expect"], _9phvzk);  
-  $def("_1q0pie3", "compile_unit_test_template", ["Inputs","test_case","compiled"], _1q0pie3);  
-  $def("_1lmax86", "test_compile_import_plain_single", ["compile","expect"], _1lmax86);  
-  $def("_17sgzdm", "test_compile_import_view_data_alias_single", ["compile","expect"], _17sgzdm);  
-  $def("_1tqj4tp", "test_compile_import_mutable_data_alias_single", ["compile","expect"], _1tqj4tp);  
-  $def("_hv0te2", "test_compile_import_mutable_single", ["compile","expect"], _hv0te2);  
-  $def("_1mltqmr", "test_compile_import_viewof_single", ["compile","expect"], _1mltqmr);  
-  $def("_1d18obr", "test_compile_import_alias_single", ["compile","expect"], _1d18obr);  
-  $def("_1b5ghef", "test_compile_import_notebook", ["compile","expect"], _1b5ghef);  
-  $def("_1nps9cr", "viewof test_case", ["Inputs","notebook_semantics_source"], _1nps9cr);  
-  $def("_1e5ax6f", "test_case", ["Generators","viewof test_case"], _1e5ax6f);  
-  $def("_18e5b93", null, ["test_case"], _18e5b93);  
-  $def("_16q6oyc", "compiled", ["compile","test_case"], _16q6oyc);  
-  $def("_1191170", null, ["parser","test_case"], _1191170);  
-  $def("_eom91x", null, ["compile","test_case"], _eom91x);  
-  $def("_ttos3c", "compile", ["parser","observableToJs"], _ttos3c);  
-  $def("_1v1i7wl", "observableToJs", ["acorn_walk","parser"], _1v1i7wl);  
-  $def("_1ayjluu", null, ["md"], _1ayjluu);  
-  $def("_xhj6b8", "decompress_url", ["DecompressionStream","TextDecoderStream","TransformStream","TextEncoderStream","Response"], _xhj6b8);  
-  $def("_s9w7ha", "parser", ["decompress_url","FileAttachment","acorn_url","acorn_walk_url"], _s9w7ha);  
-  main.define("acorn", ["module @tomlarkworthy/acorn-8-11-3", "@variable"], (_, v) => v.import("acorn", _));  
-  main.define("acorn_url", ["module @tomlarkworthy/acorn-8-11-3", "@variable"], (_, v) => v.import("acorn_url", _));  
-  main.define("acorn_walk", ["module @tomlarkworthy/acorn-8-11-3", "@variable"], (_, v) => v.import("acorn_walk", _));  
-  main.define("acorn_walk_url", ["module @tomlarkworthy/acorn-8-11-3", "@variable"], (_, v) => v.import("acorn_walk_url", _));  
-  main.define("expect", ["module @tomlarkworthy/jest-expect-standalone", "@variable"], (_, v) => v.import("expect", _));  
-  main.define("Runtime", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Runtime", _));  
-  main.define("Inspector", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Inspector", _));  
-  main.define("Library", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Library", _));  
-  main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));  
-  $def("_1rc67k0", "stageB_importFake", [], _1rc67k0);  
-  $def("_1d53asg", "test_decompileImport_stageB_single", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1d53asg);  
-  $def("_hv5gag", "test_decompileImport_stageB_aliased", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _hv5gag);  
-  $def("_avc18y", "test_decompileImport_stageB_multiple", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _avc18y);  
-  $def("_16gia7i", "test_decompileImport_stageB_mixed_alias", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16gia7i);  
-  $def("_1slhdwo", "test_decompileImport_stageB_viewof", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1slhdwo);  
-  $def("_qwlsf2", "test_decompileImport_stageB_mutable", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _qwlsf2);  
-  $def("_sy7jfx", "test_decompileImport_returns_null_for_non_import", ["decompileImport","expect"], _sy7jfx);  
-  $def("_rk7ku3", "test_decompileImport_compile_roundtrip_single", ["compile","expect","stageB_importFake","decompileImport","formatImportDeclaration"], _rk7ku3);  
-  $def("_xynplo", "test_decompileImport_stageB_order_independent", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _xynplo);  
-  $def("_16fpgac", "test_decompileImport_stageB_notebook_id", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16fpgac);
+  $def("_1ej2r92", "intro", ["md"], _1ej2r92);  
+  $def("_16jmxgh", "diagram", ["htl"], _16jmxgh);  
+  $def("_xnvzuh", "contracts", ["md"], _xnvzuh);  
+  $def("_1ua5hud", "apiReference", ["md"], _1ua5hud);  
+  $def("_1pzt22q", "createPlugins", ["Generators"], _1pzt22q);  
+  $def("_1qu8dwj", "plugins", ["createPlugins"], _1qu8dwj);  
+  $def("_a7p1z5", "testsHeader", ["md"], _a7p1z5);  
+  $def("_15xl311", "test_get_reflects_add", ["createPlugins"], _15xl311);  
+  $def("_122zyhz", "test_multi_provider_and_convergence", ["createPlugins"], _122zyhz);  
+  $def("_1lojas7", "test_remove_and_names_isolated", ["createPlugins"], _1lojas7);  
+  $def("_8240yg", "test_invalidation_and_no_leak", ["createPlugins"], _8240yg);
   return main;
-}
-</script>
+}</script>
 
 <script id="@tomlarkworthy/reversible-attachment" 
   type="text/plain"
@@ -22068,7 +23566,7 @@ const _nv232r = function _check_for_code_change(runtime_variables,codeChangeList
 const _ya86a1 = function _21(md){return(
 md`### observe(variable)
 
-This was monstrously difficult to develop. Installs a single dispatcher observer per variable holding an explicit listener list; each \`observe\` call adds a listener and returns a cancel that removes it, so attach/cancel can interleave in any order (views remount). A pre-existing observer (e.g. a bootloader Inspector) is kept as a permanent first listener. Delivery of \`["fulfilled", "rejected", "pending"]\` runs in attach order; for element values, a listener with \`detachNodes: true\` detaches the node from its current parent before adopting, so the last-attached view owns the node. When the observer attaches, if the variable is already fulfilled, the observer is signalled.
+This was monstrously difficult to develop. Taps a variable, intercepting all observer calls \`["fulfilled", "rejected", "pending"]\` whilst preserving the behaviour of the existing observer attached to the variable. If \`detachNodes\` is \`true\` and the existing observer hosts a DOM node, the additional variable "steals" it for it's DOM tree. When the observer attaches, if the variable is already fulfilled, the observer is signalled.
 
 Unobserved variables are marked as reachable and become active when observed.`
 )};
@@ -22082,240 +23580,240 @@ const _1hx65vf = function _no_observer(main)
     variable.delete();
     return symbol;
 };
-const _duwj4o = function _observe(Element,Text,trace_variable,$0,no_observer,queueMicrotask)
+const _18fhvl5 = function _observe(Element,Text,trace_variable,$0,no_observer,queueMicrotask)
 {
-    // Multiple views may observe one variable (a lopepage pane + an embedding widget).
-    // Views remount, so cancels arrive in any order. A single dispatcher observer per
-    // variable holds an explicit listener list: attach = push, cancel = splice. Delivery
-    // runs in attach order, so for element values the last-attached view adopts last and
-    // owns the node. (The previous design wrapped observer methods in place and each
-    // cancel restored the methods captured at ITS attach time — correct only for LIFO
-    // cancel order; any remount orphaned the surviving listener.)
-    const DISPATCH = '__observe_listeners__';
-    // cross realm support: no_observer is a Symbol compared by description
-    return function observe(v, observer, {invalidation, detachNodes = false} = {}) {
-        const observe_id = `${ v?._name || '<anon>' }@${ Date.now() }@${ Math.random().toString(16).slice(2) }`;
-        const snapshot = (extra = {}) => ({
-            t: Date.now(),
-            observe_id,
-            var_name: v?._name,
-            var_version: v?._version,
-            var_reachable: v?._reachable,
-            has_observer: v?._observer != null,
-            observer_has_node: !!observer?._node,
-            v_value_defined: v?._value !== undefined,
-            v_value_ctor: v?._value?.constructor?.name,
-            v_value_is_node: v?._value instanceof Element || v?._value instanceof Text || false,
-            v_promise: !!v?._promise,
-            listener_count: v?._observer?.[DISPATCH]?.length,
+  // Multiple views may observe one variable (a lopepage pane + an embedding widget).
+  // Views remount, so cancels arrive in any order. A single dispatcher observer per
+  // variable holds an explicit listener list: attach = push, cancel = splice. Delivery
+  // runs in attach order, so for element values the last-attached view adopts last and
+  // owns the node. (The previous design wrapped observer methods in place and each
+  // cancel restored the methods captured at ITS attach time — correct only for LIFO
+  // cancel order; any remount orphaned the surviving listener.)
+  const DISPATCH = '__observe_listeners__';
+  // cross realm support: no_observer is a Symbol compared by description
+  return function observe(v, observer, {invalidation, detachNodes = false} = {}) {
+    const observe_id = `${ v?._name || '<anon>' }@${ Date.now() }@${ Math.random().toString(16).slice(2) }`;
+    const snapshot = (extra = {}) => ({
+      t: Date.now(),
+      observe_id,
+      var_name: v?._name,
+      var_version: v?._version,
+      var_reachable: v?._reachable,
+      has_observer: v?._observer != null,
+      observer_has_node: !!observer?._node,
+      v_value_defined: v?._value !== undefined,
+      v_value_ctor: v?._value?.constructor?.name,
+      v_value_is_node: v?._value instanceof Element || v?._value instanceof Text || false,
+      v_promise: !!v?._promise,
+      listener_count: v?._observer?.[DISPATCH]?.length,
+      ...extra
+    });
+    const emit = (event, extra = {}) => {
+      if (v?._name !== trace_variable)
+        return;
+      try {
+        $0.value = $0.value.concat([snapshot({
+            event,
             ...extra
-        });
-        const emit = (event, extra = {}) => {
-            if (v?._name !== trace_variable)
-                return;
-            try {
-                $0.value = $0.value.concat([snapshot({
-                        event,
-                        ...extra
-                    })]);
-            } catch {
-            }
-        };
-        emit('observe:begin', { detachNodes });
-        const isNode = value => value instanceof Element || value instanceof Text;
-        // Detach an element value from wherever it currently lives so this listener's
-        // fulfilled can adopt it into its own node.
-        const stealFor = (l, value, reason) => {
-            const canSteal = l.detachNodes && isNode(value) && l.observer?._node && l.observer._node !== value.parentNode;
-            emit('observe:steal_check', {
-                reason,
-                canSteal,
-                value_ctor: value?.constructor?.name,
-                value_parent: value?.parentNode?.constructor?.name
-            });
-            if (canSteal) {
-                try {
-                    value.remove();
-                } catch {
-                }
-                emit('observe:steal_detached', { reason });
-            }
-        };
-        // --- ensure dispatcher installed ---
-        let dispatch = v._observer && v._observer[DISPATCH] ? v._observer : null;
-        if (!dispatch) {
-            const listeners = [];
-            const deliver = type => (...args) => {
-                emit(`observe:deliver:${ type }`, { arg0_ctor: args[0]?.constructor?.name });
-                for (const l of [...listeners]) {
-                    try {
-                        if (type === 'fulfilled') {
-                            stealFor(l, args[0], 'deliver');
-                            l.observer.fulfilled?.(args[0], v?._name);
-                        } else if (type === 'rejected')
-                            l.observer.rejected?.(args[0], v?._name);
-                        else
-                            l.observer.pending?.();
-                    } catch (e) {
-                        emit(`observe:deliver:${ type }:listener_error`, { message: String(e) });
-                    }
-                }
-            };
-            const previous = v._observer;
-            dispatch = {
-                [DISPATCH]: listeners,
-                // Preserve the `variable._observer._node` contract editors (divToVar),
-                // module-map, and observablehq.com key on. The pre-existing observer
-                // (e.g. the notebook Inspector) owns the canonical node; otherwise the
-                // last-attached listener that has one (the view that adopted the value).
-                get _node() {
-                    const base = listeners.find(l => l.base);
-                    if (base?.observer?._node != null)
-                        return base.observer._node;
-                    for (let i = listeners.length - 1; i >= 0; i--) {
-                        const n = listeners[i].observer?._node;
-                        if (n != null)
-                            return n;
-                    }
-                    return undefined;
-                },
-                __restore: () => {
-                    if (v._observer === dispatch)
-                        v._observer = previous;
-                },
-                pending: deliver('pending'),
-                fulfilled: deliver('fulfilled'),
-                rejected: deliver('rejected')
-            };
-            const hasExistingObserver = previous != null && previous?.description !== no_observer.description;
-            if (hasExistingObserver) {
-                // pre-existing real observer (e.g. bootloader Inspector) stays first, permanently
-                listeners.push({
-                    observer: previous,
-                    detachNodes: false,
-                    base: true
-                });
-                emit('observe:attach:base_listener_kept');
-            }
-            if (v && !v._reachable) {
-                v._reachable = true;
-                v._module._runtime._dirty.add(v);
-                v._module._runtime._updates.add(v);
-                emit('observe:attach:marked_reachable');
-            }
-            v._observer = dispatch;
-            emit('observe:attach:dispatcher_installed', { hasExistingObserver });
-        }
-        // --- attach this listener ---
-        const listeners = dispatch[DISPATCH];
-        const entry = {
-            observer,
-            detachNodes
-        };
-        listeners.push(entry);
-        emit('observe:attach:listener_added');
-        let cancelled = false;
-        const cancel = () => {
-            emit('observe:cancel_called');
-            if (cancelled)
-                return;
-            cancelled = true;
-            const i = listeners.indexOf(entry);
-            if (i >= 0)
-                listeners.splice(i, 1);
-            if (!listeners.some(l => !l.base)) {
-                // no external listeners left: hand the variable back
-                dispatch.__restore();
-                emit('observe:cancel:dispatcher_removed');
-            }
-        };
-        if (invalidation)
-            Promise.resolve(invalidation).then(() => {
-                emit('observe:invalidation_fired');
-                cancel();
-            });
-        // --- CATCH-UP REPLAY (BUG FIX) ---
-        // Snapshot version to avoid replaying stale results.
-        const versionAtAttach = v?._version;
-        emit('observe:catchup:scheduled', { versionAtAttach });
-        queueMicrotask(() => {
-            emit('observe:catchup:microtask_start', { cancelled });
-            if (cancelled)
-                return;
-            // mimic inspector: mark pending first
-            try {
-                observer.pending?.();
-                emit('observe:catchup:pending_sent');
-            } catch (e) {
-                emit('observe:catchup:pending_error', { message: String(e) });
-            }
-            // IMPORTANT: read CURRENT value at replay time
-            const valueNow = v?._value;
-            emit('observe:catchup:valueNow_snapshot', {
-                valueNow_defined: valueNow !== undefined,
-                valueNow_ctor: valueNow?.constructor?.name,
-                v_version_now: v?._version,
-                valueNow_outerHTML_prefix: v?._observer?._node?.outerHTML
-            });
-            if (valueNow !== undefined) {
-                if (v?._version !== versionAtAttach) {
-                    emit('observe:catchup:stale_skip_valueNow');
-                    return;
-                }
-                stealFor(entry, valueNow, 'catchup:valueNow');
-                try {
-                    observer.fulfilled?.(valueNow, v?._name);
-                    emit('observe:catchup:fulfilled_sent_valueNow');
-                } catch (e) {
-                    emit('observe:catchup:fulfilled_error_valueNow', { message: String(e) });
-                }
-                return;
-            }
-            // optional fallback: attach-time promise (or current promise)
-            const p = v?._promise;
-            if (!p || typeof p.then !== 'function') {
-                emit('observe:catchup:no_value_no_promise');
-                return;
-            }
-            emit('observe:catchup:await_promise');
-            Promise.resolve(p).then(value => {
-                emit('observe:catchup:promise_fulfilled', {
-                    value_defined: value !== undefined,
-                    value_ctor: value?.constructor?.name,
-                    v_version_now: v?._version
-                });
-                if (cancelled)
-                    return;
-                if (v?._version !== versionAtAttach) {
-                    emit('observe:catchup:stale_skip_promise');
-                    return;
-                }
-                if (value === undefined)
-                    return;
-                stealFor(entry, value, 'catchup:promise');
-                try {
-                    observer.fulfilled?.(value, v?._name);
-                    emit('observe:catchup:fulfilled_sent_promise');
-                } catch (e) {
-                    emit('observe:catchup:fulfilled_error_promise', { message: String(e) });
-                }
-            }, error => {
-                emit('observe:catchup:promise_rejected', { v_version_now: v?._version });
-                if (cancelled)
-                    return;
-                if (v?._version !== versionAtAttach)
-                    return;
-                try {
-                    observer.rejected?.(error, v?._name);
-                    emit('observe:catchup:rejected_sent_promise');
-                } catch (e) {
-                    emit('observe:catchup:rejected_error_promise', { message: String(e) });
-                }
-            });
-        });
-        emit('observe:end');
-        return cancel;
+          })]);
+      } catch {
+      }
     };
+    emit('observe:begin', { detachNodes });
+    const isNode = value => value instanceof Element || value instanceof Text;
+    // Detach an element value from wherever it currently lives so this listener's
+    // fulfilled can adopt it into its own node.
+    const stealFor = (l, value, reason) => {
+      const canSteal = l.detachNodes && isNode(value) && l.observer?._node && l.observer._node !== value.parentNode;
+      emit('observe:steal_check', {
+        reason,
+        canSteal,
+        value_ctor: value?.constructor?.name,
+        value_parent: value?.parentNode?.constructor?.name
+      });
+      if (canSteal) {
+        try {
+          value.remove();
+        } catch {
+        }
+        emit('observe:steal_detached', { reason });
+      }
+    };
+    // --- ensure dispatcher installed ---
+    let dispatch = v._observer && v._observer[DISPATCH] ? v._observer : null;
+    if (!dispatch) {
+      const listeners = [];
+      const deliver = type => (...args) => {
+        emit(`observe:deliver:${ type }`, { arg0_ctor: args[0]?.constructor?.name });
+        for (const l of [...listeners]) {
+          try {
+            if (type === 'fulfilled') {
+              stealFor(l, args[0], 'deliver');
+              l.observer.fulfilled?.(args[0], v?._name);
+            } else if (type === 'rejected')
+              l.observer.rejected?.(args[0], v?._name);
+            else
+              l.observer.pending?.();
+          } catch (e) {
+            emit(`observe:deliver:${ type }:listener_error`, { message: String(e) });
+          }
+        }
+      };
+      const previous = v._observer;
+      dispatch = {
+        [DISPATCH]: listeners,
+        // Preserve the `variable._observer._node` contract editors (divToVar),
+        // module-map, and observablehq.com key on. The pre-existing observer
+        // (e.g. the notebook Inspector) owns the canonical node; otherwise the
+        // last-attached listener that has one (the view that adopted the value).
+        get _node() {
+          const base = listeners.find(l => l.base);
+          if (base?.observer?._node != null)
+            return base.observer._node;
+          for (let i = listeners.length - 1; i >= 0; i--) {
+            const n = listeners[i].observer?._node;
+            if (n != null)
+              return n;
+          }
+          return undefined;
+        },
+        __restore: () => {
+          if (v._observer === dispatch)
+            v._observer = previous;
+        },
+        pending: deliver('pending'),
+        fulfilled: deliver('fulfilled'),
+        rejected: deliver('rejected')
+      };
+      const hasExistingObserver = previous != null && previous?.description !== no_observer.description;
+      if (hasExistingObserver) {
+        // pre-existing real observer (e.g. bootloader Inspector) stays first, permanently
+        listeners.push({
+          observer: previous,
+          detachNodes: false,
+          base: true
+        });
+        emit('observe:attach:base_listener_kept');
+      }
+      if (v && !v._reachable) {
+        v._reachable = true;
+        v._module._runtime._dirty.add(v);
+        v._module._runtime._updates.add(v);
+        emit('observe:attach:marked_reachable');
+      }
+      v._observer = dispatch;
+      emit('observe:attach:dispatcher_installed', { hasExistingObserver });
+    }
+    // --- attach this listener ---
+    const listeners = dispatch[DISPATCH];
+    const entry = {
+      observer,
+      detachNodes
+    };
+    listeners.push(entry);
+    emit('observe:attach:listener_added');
+    let cancelled = false;
+    const cancel = () => {
+      emit('observe:cancel_called');
+      if (cancelled)
+        return;
+      cancelled = true;
+      const i = listeners.indexOf(entry);
+      if (i >= 0)
+        listeners.splice(i, 1);
+      if (!listeners.some(l => !l.base)) {
+        // no external listeners left: hand the variable back
+        dispatch.__restore();
+        emit('observe:cancel:dispatcher_removed');
+      }
+    };
+    if (invalidation)
+      Promise.resolve(invalidation).then(() => {
+        emit('observe:invalidation_fired');
+        cancel();
+      });
+    // --- CATCH-UP REPLAY (BUG FIX) ---
+    // Snapshot version to avoid replaying stale results.
+    const versionAtAttach = v?._version;
+    emit('observe:catchup:scheduled', { versionAtAttach });
+    queueMicrotask(() => {
+      emit('observe:catchup:microtask_start', { cancelled });
+      if (cancelled)
+        return;
+      // mimic inspector: mark pending first
+      try {
+        observer.pending?.();
+        emit('observe:catchup:pending_sent');
+      } catch (e) {
+        emit('observe:catchup:pending_error', { message: String(e) });
+      }
+      // IMPORTANT: read CURRENT value at replay time
+      const valueNow = v?._value;
+      emit('observe:catchup:valueNow_snapshot', {
+        valueNow_defined: valueNow !== undefined,
+        valueNow_ctor: valueNow?.constructor?.name,
+        v_version_now: v?._version,
+        valueNow_outerHTML_prefix: v?._observer?._node?.outerHTML
+      });
+      if (valueNow !== undefined) {
+        if (v?._version !== versionAtAttach) {
+          emit('observe:catchup:stale_skip_valueNow');
+          return;
+        }
+        stealFor(entry, valueNow, 'catchup:valueNow');
+        try {
+          observer.fulfilled?.(valueNow, v?._name);
+          emit('observe:catchup:fulfilled_sent_valueNow');
+        } catch (e) {
+          emit('observe:catchup:fulfilled_error_valueNow', { message: String(e) });
+        }
+        return;
+      }
+      // optional fallback: attach-time promise (or current promise)
+      const p = v?._promise;
+      if (!p || typeof p.then !== 'function') {
+        emit('observe:catchup:no_value_no_promise');
+        return;
+      }
+      emit('observe:catchup:await_promise');
+      Promise.resolve(p).then(value => {
+        emit('observe:catchup:promise_fulfilled', {
+          value_defined: value !== undefined,
+          value_ctor: value?.constructor?.name,
+          v_version_now: v?._version
+        });
+        if (cancelled)
+          return;
+        if (v?._version !== versionAtAttach) {
+          emit('observe:catchup:stale_skip_promise');
+          return;
+        }
+        if (value === undefined)
+          return;
+        stealFor(entry, value, 'catchup:promise');
+        try {
+          observer.fulfilled?.(value, v?._name);
+          emit('observe:catchup:fulfilled_sent_promise');
+        } catch (e) {
+          emit('observe:catchup:fulfilled_error_promise', { message: String(e) });
+        }
+      }, error => {
+        emit('observe:catchup:promise_rejected', { v_version_now: v?._version });
+        if (cancelled)
+          return;
+        if (v?._version !== versionAtAttach)
+          return;
+        try {
+          observer.rejected?.(error, v?._name);
+          emit('observe:catchup:rejected_sent_promise');
+        } catch (e) {
+          emit('observe:catchup:rejected_error_promise', { message: String(e) });
+        }
+      });
+    });
+    emit('observe:end');
+    return cancel;
+  };
 };
 const _16ohhcn = function _observeOld(trace_variable,_,no_observer,isnode,toObject,queueMicrotask,getPromiseState)
 {
@@ -22326,7 +23824,7 @@ const _16ohhcn = function _observeOld(trace_variable,_,no_observer,isnode,toObje
             invalidation.then(onCancel);
         if (v?._name === trace_variable) {
             console.log('observe', trace_variable, v);
-            void 0;
+            debugger;
         }
         if (_.isEqual(v._observer, {}) || v._observer === no_observer) {
             // No existing observer, so we install one
@@ -22350,7 +23848,7 @@ const _16ohhcn = function _observeOld(trace_variable,_,no_observer,isnode,toObje
                 const old = v._observer[type];
                 v._observer[type] = (...args) => {
                     if (v?._name === trace_variable) {
-                        void 0;
+                        debugger;
                         console.log(trace_variable, type, ...args);
                     }
                     // The old is often a prototype, so we use Reflect to call it
@@ -22377,7 +23875,7 @@ const _16ohhcn = function _observeOld(trace_variable,_,no_observer,isnode,toObje
                 cancels.add(() => v._observer[type] = old);
             });
             if (v?._name === trace_variable) {
-                void 0;
+                debugger;
                 console.log(`checking`, trace_variable, v, toObject(v), v._value);
             }
         }
@@ -22399,7 +23897,7 @@ const _16ohhcn = function _observeOld(trace_variable,_,no_observer,isnode,toObje
             // either in pending or error state, we can check by racing a promise
             getPromiseState(v._promise).then(({state, error, value}) => {
                 if (v?._name === trace_variable) {
-                    void 0;
+                    debugger;
                 }
                 if (state == 'rejected') {
                     if (observer.rejected)
@@ -22539,7 +24037,7 @@ Keep a named cell evaluated without a direct dataflow dependancy. Useful to keep
 const _12v8rf5 = function _keepalive(){return(
 (module, variable_name) => {
     if (variable_name === undefined)
-        void 0;
+        debugger;
     const name = `dynamic observe ${ variable_name }`;
     console.log(`keepalive: ${ name }`);
     if (module._scope.has(name))
@@ -22854,7 +24352,7 @@ export default function define(runtime, observer) {
   $def("_ya86a1", null, ["md"], _ya86a1);  
   $def("_tgfgv9", "trace_variable", [], _tgfgv9);  
   $def("_1hx65vf", "no_observer", ["main"], _1hx65vf);  
-  $def("_duwj4o", "observe", ["Element","Text","trace_variable","mutable trace_history","no_observer","queueMicrotask"], _duwj4o);  
+  $def("_18fhvl5", "observe", ["Element","Text","trace_variable","mutable trace_history","no_observer","queueMicrotask"], _18fhvl5);  
   $def("_16ohhcn", "observeOld", ["trace_variable","_","no_observer","isnode","toObject","queueMicrotask","getPromiseState"], _16ohhcn);  
   $def("_2kni3y", null, ["md"], _2kni3y);  
   $def("_1utnee9", "descendants", [], _1utnee9);  
@@ -24546,10 +26044,14 @@ const _1rosxg0 = function _data(){return(
   instance: new URL("https://google.com")
 }
 )};
-const _ygg2hv = function _summarizeJS(html,inspect,postProcess,MouseEvent){return(
+const _p715nx = function _summarizeJS(Node,html,inspect,postProcess,MouseEvent){return(
 function summarizeJS(value, { max_size = 5000 } = {}) {
   // Render the inspected HTML into a temporary <div>
-  const inspection = html`<div>${inspect(value)}`;
+  const inspected =
+    typeof Node !== "undefined" && value instanceof Node
+      ? value.cloneNode(true)
+      : value;
+  const inspection = html`<div>${inspect(inspected)}`;
   let text = postProcess(inspection);
   let prior = undefined;
 
@@ -24655,7 +26157,7 @@ export default function define(runtime, observer) {
   main.define("Inspector", ["module @tomlarkworthy/inspector", "@variable"], (_, v) => v.import("Inspector", _));  
   main.define("src", ["module @tomlarkworthy/inspector", "@variable"], (_, v) => v.import("src", _));  
   $def("_1rosxg0", "data", [], _1rosxg0);  
-  $def("_ygg2hv", "summarizeJS", ["html","inspect","postProcess","MouseEvent"], _ygg2hv);  
+  $def("_p715nx", "summarizeJS", ["Node","html","inspect","postProcess","MouseEvent"], _p715nx);  
   $def("_wtf5dq", "walked", ["postProcess","inspect","data"], _wtf5dq);  
   $def("_1l6vroc", "postProcess", ["walk"], _1l6vroc);  
   $def("_1brf10r", "TEXT", [], _1brf10r);  
@@ -25332,10 +26834,38 @@ const _yqy56c = async function _css(theme_assets,extra_css){return(
   extra_css
 ]
 )};
-const _16bhmn1 = function _extra_css(){return(
-[
-  'file://syntax.css',
-  `
+const _17wrwba = function _extra_css()
+{
+  // Only on ObservableHQ (the observableusercontent.com sandbox) do we bridge
+  // the theme vars onto the underscore '--syntax_*' vars that Observable's
+  // editor + inspector read. Off Observable we omit it so notebook authors use
+  // the real --theme-* / --syntax-* vars, not these compatibility aliases.
+  // Predicate mirrors @tomlarkworthy/runtime-sdk's isOnObservableCom.
+  const onObservable = window.location.href.includes('observableusercontent.com') && !window.location.href.includes('blob:');
+  const observableSyntaxBridge = onObservable ? `
+:root {
+  /* notebook-kit themes omit --syntax-normal (hyphen), so Observable's
+     "next" inspector falls back to its hardcoded #1b1e23 on
+     .observablehq--function/--gray/--expanded/etc. Alias just this one;
+     the other --syntax-* hyphen vars are already theme-defined (don't
+     re-alias them — that would self-reference). */
+  --syntax-normal: var(--theme-foreground, #1b1e23);
+  --syntax_normal: var(--theme-foreground, #1b1e23);
+  --syntax_comment: var(--syntax-comment, #a9b0bc);
+  --syntax_number: var(--syntax-literal, #20a5ba);
+  --syntax_keyword: var(--syntax-keyword, #c30771);
+  --syntax_atom: var(--syntax-atom, #10a778);
+  --syntax_string: var(--syntax-string, #008ec4);
+  --syntax_error: var(--syntax-invalid, var(--theme-foreground-error, #ffbedc));
+  --syntax_unknown_variable: var(--syntax-variable, #838383);
+  --syntax_known_variable: var(--syntax-definition, #005f87);
+  --syntax_matchbracket: var(--syntax-keyword, #20bbfc);
+  --syntax_key: var(--syntax-definition, #6636b4);
+}
+` : '';
+  return [
+    'file://syntax.css',
+    observableSyntaxBridge + `
 /* Center page */
 .lopecode-visualizer {
     max-width: 1200px;
@@ -25394,8 +26924,8 @@ const _16bhmn1 = function _extra_css(){return(
 .hljs-addition {
   color: var(--syntax-string);
 }`
-]
-)};
+  ];
+};
 const _rijq1n = function _current_theme(themes){return(
 [...themes.values()].find(assets => assets.every(url => document.getElementById(url)))
 )};
@@ -25419,7 +26949,7 @@ export default function define(runtime, observer) {
   $def("_p0at3d", "themes", [], _p0at3d);  
   $def("_m8taeu", "cssForTheme", ["themes","extra_css"], _m8taeu);  
   $def("_yqy56c", "css", ["theme_assets","extra_css"], _yqy56c);  
-  $def("_16bhmn1", "extra_css", [], _16bhmn1);  
+  $def("_17wrwba", "extra_css", [], _17wrwba);  
   $def("_rijq1n", "current_theme", ["themes"], _rijq1n);
   return main;
 }</script>
@@ -27303,7 +28833,7 @@ const _1xdl683 = function _renderImportCell(navHref){return(
   return span;
 }
 )};
-const _17pe3vk = function _syncers(observe,inspectors,$0,liveCellMap,createImportCellHeader,renderImportCell,variablesForCell,visualizers,$1)
+const _bbb3dg = function _syncers(observe,inspectors,$0,liveCellMap,createImportCellHeader,renderImportCell,variablesForCell,visualizers,$1)
 {
   const syncers = this || new Map();
 
@@ -27339,7 +28869,14 @@ const _17pe3vk = function _syncers(observe,inspectors,$0,liveCellMap,createImpor
       root,
       remove: () => {
         observers.delete(v);
-        observer?._node?.remove?.();
+        const node = observer?._node;
+        if (node) {
+          // Detach the variable's live element value
+          const val = v?._value;
+          if (val && val.nodeType && val.parentNode === node)
+            node.removeChild(val);
+          node.remove();
+        }
         unobserve?.();
       }
     };
@@ -27517,7 +29054,7 @@ export default function define(runtime, observer) {
   $def("_zodkh8", "createImportCellHeader", [], _zodkh8);  
   $def("_526jo", "variablesForCell", [], _526jo);  
   $def("_1xdl683", "renderImportCell", ["navHref"], _1xdl683);  
-  $def("_17pe3vk", "syncers", ["observe","inspectors","viewof visualizersToDelete","liveCellMap","createImportCellHeader","renderImportCell","variablesForCell","visualizers","viewof visualizers"], _17pe3vk);  
+  $def("_bbb3dg", "syncers", ["observe","inspectors","viewof visualizersToDelete","liveCellMap","createImportCellHeader","renderImportCell","variablesForCell","visualizers","viewof visualizers"], _bbb3dg);  
   $def("_een5pq", null, ["md"], _een5pq);  
   $def("_1wiz55o", "backgroundJobs", ["keepalive","visualizerModule"], _1wiz55o);  
   $def("_1oonsyz", "viewof visualizerModule", ["thisModule"], _1oonsyz);  
@@ -27598,167 +29135,6 @@ export default function define(runtime, observer) {
   return main;
 }</script>
 
-<script id="@tomlarkworthy/invoke-variable" 
-  type="text/plain"
-  data-mime="application/javascript"
->
-const _zkje0r = function _1(md){return(
-md`# \`invokeVariable(<name>, <module>, overrides = {})\`
-
-Test individual variables by calling them with injected values. Lets you test different scenarios without changing your core logic. Pairs with [@tomlarkworthy/tester](https://observablehq.com/@tomlarkworthy/tester)`
-)};
-const _kfe4ll = function _invokeVariable(lookupVariable){return(
-async function invokeVariable(name, module, overrides = {}) {
-  if (overrides == null || typeof overrides !== "object")
-    throw new TypeError(
-      "invokeVariable(name, module, {overrides}): overrides must be an object"
-    );
-
-  // Accept a Variable reference directly as the first arg (skip the lookupVariable stall when
-  // the caller already holds it); otherwise resolve by (name, module).
-  let variable;
-  if (name && typeof name === "object" && typeof name._definition !== "undefined") {
-    variable = name;
-    module = module ?? variable._module;
-  } else {
-    if (typeof name !== "string" || !name.length)
-      throw new TypeError(
-        "invokeVariable(name, module, …): name must be a non-empty string"
-      );
-    if (!module)
-      throw new TypeError("invokeVariable(name, module, …): module is required");
-    variable = await lookupVariable(name, module);
-    if (!variable)
-      throw new Error(`invokeVariable: variable "${name}" not found in module`);
-  }
-  module = module ?? variable._module;
-  const label = variable._name ?? (typeof name === "string" ? name : "(anonymous)");
-
-  const inputs = Array.isArray(variable._inputs) ? variable._inputs : [];
-  const inputNames = inputs.map((v) => v?._name);
-
-  for (const k of Object.keys(overrides)) {
-    if (!inputNames.includes(k)) {
-      throw new Error(
-        `invokeVariable("${label}"): override "${k}" was provided but is not a declared dependency. Declared dependencies: ${inputNames
-          .filter(Boolean)
-          .join(", ")}`
-      );
-    }
-  }
-
-  const hasOwn = (o, k) => Object.prototype.hasOwnProperty.call(o, k);
-
-  const resolveDependency = async (depName) => {
-    if (hasOwn(overrides, depName)) return overrides[depName];
-
-    const scopeVar =
-      module?._scope?.get?.(depName) ??
-      module?._runtime?._builtin?._scope?.get?.(depName);
-
-    if (scopeVar) {
-      if (scopeVar._value !== undefined) return scopeVar._value;
-      if (scopeVar._promise && typeof scopeVar._promise?.then === "function")
-        return await scopeVar._promise;
-    }
-
-    if (typeof module?.value === "function") {
-      try {
-        return await module.value(depName);
-      } catch (e) {}
-    }
-
-    if (module?._runtime && typeof module._runtime._global === "function") {
-      try {
-        const g = module._runtime._global(depName);
-        if (g !== undefined) return g;
-      } catch (e) {}
-    }
-
-    throw new Error(
-      `invokeVariable("${label}"): could not resolve dependency "${depName}" (no override and not found in module/builtins/global)`
-    );
-  };
-
-  const args = [];
-  for (const dep of inputs) {
-    const depName = dep?._name;
-    if (!depName) {
-      args.push(undefined);
-      continue;
-    }
-    args.push(await resolveDependency(depName));
-  }
-
-  const def = variable._definition;
-  if (typeof def !== "function") {
-    throw new Error(
-      `invokeVariable("${label}"): target variable does not have an invokable function definition`
-    );
-  }
-  return def(...args);
-}
-)};
-const _jtrr9m = function _3(md){return(
-md`### Example
-
-let c = a + b`
-)};
-const _1v2c0s1 = function _a(){return(
-1
-)};
-const _ywl8oh = function _b(){return(
-3
-)};
-const _1mc3tpl = function _c(a,b){return(
-a + b
-)};
-const _o5e50u = function _7(md){return(
-md`If we invoke c without any overrides we get the notebook behaviour (i.e. the answer is 4, as a is 1 and b is 3)`
-)};
-const _tnoyf9 = function _8(invokeVariable,invokeVariableModule){return(
-invokeVariable("c", invokeVariableModule)
-)};
-const _smh5by = function _9(md){return(
-md`But we can set b to 20, and then we get the answer 21.`
-)};
-const _d996jo = function _10(invokeVariable,invokeVariableModule){return(
-invokeVariable("c", invokeVariableModule, { b: 20 })
-)};
-const _qh0yhm = function _11(md){return(
-md`To call invokeVariable we need a reference to the module, which we can obtain with thisModule() (see runtime-sdk)`
-)};
-const _1hy0qcz = function _invokeVariableModule(thisModule){return(
-thisModule()
-)};
-const _jno7wc = (G, _) => G.input(_);
-
-export default function define(runtime, observer) {
-  const main = runtime.module();
-  const $def = (pid, name, deps, fn) => {
-    main.variable(observer(name)).define(name, deps, fn).pid = pid;
-  };
-
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
-  $def("_zkje0r", null, ["md"], _zkje0r);  
-  $def("_kfe4ll", "invokeVariable", ["lookupVariable"], _kfe4ll);  
-  $def("_jtrr9m", null, ["md"], _jtrr9m);  
-  $def("_1v2c0s1", "a", [], _1v2c0s1);  
-  $def("_ywl8oh", "b", [], _ywl8oh);  
-  $def("_1mc3tpl", "c", ["a","b"], _1mc3tpl);  
-  $def("_o5e50u", null, ["md"], _o5e50u);  
-  $def("_tnoyf9", null, ["invokeVariable","invokeVariableModule"], _tnoyf9);  
-  $def("_smh5by", null, ["md"], _smh5by);  
-  $def("_d996jo", null, ["invokeVariable","invokeVariableModule"], _d996jo);  
-  $def("_qh0yhm", null, ["md"], _qh0yhm);  
-  $def("_1hy0qcz", "viewof invokeVariableModule", ["thisModule"], _1hy0qcz);  
-  $def("_jno7wc", "invokeVariableModule", ["Generators","viewof invokeVariableModule"], _jno7wc);  
-  main.define("lookupVariable", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("lookupVariable", _));  
-  main.define("thisModule", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("thisModule", _));
-  return main;
-}
-</script>
-
 <!-- Bootloader -->
 <script id="bootconf.json"
         type="text/plain"
@@ -27767,7 +29143,8 @@ export default function define(runtime, observer) {
 {
   "mains": ["@tomlarkworthy/lopepage","@tomlarkworthy/observablejs-toolchain"],
   "hash": "#view=S100(@tomlarkworthy/observablejs-toolchain,@tomlarkworthy/module-selection)",
-  "headless": true
+  "headless": true,
+  "prerender": true
 }
 </script>
 <script id="@tomlarkworthy/bootloader" 
@@ -27823,68 +29200,68 @@ function _define_builtins(__ojs_runtime,stdlib,library,inputs)
 
 function _boot(define_builtins,conf,__ojs_runtime,location,__ojs_observer)
 {
-  define_builtins;
-  const tickMode = conf.tick;
-  if (tickMode && tickMode !== 'raf') {
-    let tick;
-    if (tickMode === 'messageChannel') {
-      const ch = new window.MessageChannel();
-      const q = [];
-      ch.port1.onmessage = () => {
-        const f = q.shift();
-        if (f)
-          f();
-      };
-      tick = cb => {
-        q.push(cb);
-        ch.port2.postMessage(0);
-      };
-    } else if (tickMode === 'microtask') {
-      tick = cb => window.queueMicrotask(cb);
-    } else if (tickMode === 'timeout') {
-      const delay = Number(conf.tickDelayMs) || 0;
-      tick = cb => setTimeout(cb, delay);
-    } else {
-      console.warn('[bootloader] unknown tick mode: ' + tickMode);
-    }
-    if (tick) {
-      const Runtime = Object.getPrototypeOf(__ojs_runtime).constructor;
-      Runtime.prototype._computeSoon = function () {
-        return new Promise(tick).then(() => this._disposed ? undefined : this._computeNow());
-      };
-      const suffix = tickMode === 'timeout' ? ' delayMs=' + (Number(conf.tickDelayMs) || 0) : '';
-      console.log('[bootloader] tick=' + tickMode + suffix);
-    }
-  }
-  if (conf.hash && !location.hash) {
-    location.hash = conf.hash;
-  }
-  const observer = conf.headless ? () => ({}) : __ojs_observer;
-  __ojs_runtime.mains = new Map();
-  window.__ojs_runtime = __ojs_runtime;
-  conf.mains.map(async name => {
-    console.log(`Bootloader: loading ${ name }`);
-    const module = await import(name);
-    const ojs_module = __ojs_runtime.module(module.default, observer);
-    if (conf.headless) {
-        // runtime.module() applies the observer only on first instantiation; if another main
-        // imported this module as a dependency first (e.g. save-in-place imports lopepage-2),
-        // the dedup drops the observer and the page's output cell is never observed -> blank
-        // page. Re-observe the module's unobserved cells IN PLACE (set the observer + mark
-        // dirty so the reachability pass enqueues them) so the mount is reachable regardless
-        // of load order, without adding synthetic variables the exporter would serialize.
-        let __reobserved = false;
-        for (const __v of __ojs_runtime._variables) {
-            if (__v._module === ojs_module && typeof __v._observer === 'symbol') {
-                __v._observer = observer(__v._name);
-                __ojs_runtime._dirty.add(__v);
-                __reobserved = true;
-            }
+    define_builtins;
+    const tickMode = conf.tick;
+    if (tickMode && tickMode !== 'raf') {
+        let tick;
+        if (tickMode === 'messageChannel') {
+            const ch = new window.MessageChannel();
+            const q = [];
+            ch.port1.onmessage = () => {
+                const f = q.shift();
+                if (f)
+                    f();
+            };
+            tick = cb => {
+                q.push(cb);
+                ch.port2.postMessage(0);
+            };
+        } else if (tickMode === 'microtask') {
+            tick = cb => window.queueMicrotask(cb);
+        } else if (tickMode === 'timeout') {
+            const delay = Number(conf.tickDelayMs) || 0;
+            tick = cb => setTimeout(cb, delay);
+        } else {
+            console.warn('[bootloader] unknown tick mode: ' + tickMode);
         }
-        if (__reobserved) __ojs_runtime._compute();
+        if (tick) {
+            const Runtime = Object.getPrototypeOf(__ojs_runtime).constructor;
+            Runtime.prototype._computeSoon = function () {
+                return new Promise(tick).then(() => this._disposed ? undefined : this._computeNow());
+            };
+            const suffix = tickMode === 'timeout' ? ' delayMs=' + (Number(conf.tickDelayMs) || 0) : '';
+            console.log('[bootloader] tick=' + tickMode + suffix);
+        }
     }
-    __ojs_runtime.mains.set(name, ojs_module);
-  });
+    if (conf.hash && !location.hash) {
+        location.hash = conf.hash;
+    }
+    const observer = conf.headless ? () => ({}) : __ojs_observer;
+    __ojs_runtime.mains = new Map();
+    window.__ojs_runtime = __ojs_runtime;
+    conf.mains.map(async name => {
+        console.log(`Bootloader: loading ${ name }`);
+        const module = await import(name);
+        const ojs_module = __ojs_runtime.module(module.default, observer);
+        if (conf.headless) {
+            // runtime.module() applies the observer only on first instantiation; if another main
+            // imported this module as a dependency first (e.g. save-in-place imports lopepage-2),
+            // the dedup drops the observer and the page's output cell is never observed -> blank
+            // page. Re-observe the module's unobserved cells IN PLACE (set the observer + mark
+            // dirty so the reachability pass enqueues them) so the mount is reachable regardless
+            // of load order, without adding synthetic variables the exporter would serialize.
+            let __reobserved = false;
+            for (const __v of __ojs_runtime._variables) {
+                if (__v._module === ojs_module && typeof __v._observer === 'symbol') {
+                    __v._observer = observer(__v._name);
+                    __ojs_runtime._dirty.add(__v);
+                    __reobserved = true;
+                }
+            }
+            if (__reobserved) __ojs_runtime._compute();
+        }
+        __ojs_runtime.mains.set(name, ojs_module);
+    });
 }
 
 
@@ -28071,31 +29448,6 @@ export default function define(runtime, observer) {
 }
 </script>
 
-<script type="module" id="main">
-  await window.esmsInitOptions.fetch("file://es-module-shims@2.6.2").text().then(src => {
-    const script = document.createElement('script');
-    script.textContent = src;
-    document.head.appendChild(script);
-  });
-
-  const style0 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/global.css", { with: { type: 'css' } });
-  const style1 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/inspector.css", { with: { type: 'css' } });
-  const style2 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/highlight.css", { with: { type: 'css' } });
-  const style3 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/plot.css", { with: { type: 'css' } });
-  const style4 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/index.css", { with: { type: 'css' } });
-  const style5 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/theme-parchment.css", { with: { type: 'css' } });
-  const style6 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/abstract-light.css", { with: { type: 'css' } });
-  const style7 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/syntax-light.css", { with: { type: 'css' } });
-  const style8 = await importShim("file://syntax.css", { with: { type: 'css' } });
-  document.adoptedStyleSheets = [style0.default,style1.default,style2.default,style3.default,style4.default,style5.default,style6.default,style7.default,style8.default];
-
-  const { Runtime } = await importShim("@observablehq/runtime@6.0.0");
-  const { Inspector } = await importShim("@observablehq/inspector@5.0.1");
-  const notebook = document.querySelector("notebook");
-  const runtime = new Runtime({__ojs_runtime: () => runtime, __ojs_observer: () => observer});
-  const observer = Inspector.into(document.body);
-  const {default: define} = await importShim("@tomlarkworthy/bootloader");
-  runtime.bootloader = runtime.module(define, () => ({}));
-</script>
+<script id="streaming_sentinel">window.__lopeStreaming = false;</script>
 </body>
 </html>

--- a/notebooks/@tomlarkworthy_observablejs-toolchain.html
+++ b/notebooks/@tomlarkworthy_observablejs-toolchain.html
@@ -9538,6 +9538,7 @@ export default function define(runtime, observer) {
   main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("module @tomlarkworthy/jest-expect-standalone", async () => runtime.module((await import("/@tomlarkworthy/jest-expect-standalone.js?v=4")).default));  
   main.define("module @tomlarkworthy/themes", async () => runtime.module((await import("/@tomlarkworthy/themes.js?v=4")).default));  
+  main.define("module @tomlarkworthy/escodegen", async () => runtime.module((await import("/@tomlarkworthy/escodegen.js?v=4")).default));  
   $def("_1noor04", null, ["md"], _1noor04);  
   $def("_vpmotg", null, ["exporter","viewof output","Event"], _vpmotg);  
   $def("_16yvadj", null, ["md","downloadAnchor","forkAnchor"], _16yvadj);  
@@ -9639,7 +9640,7 @@ export default function define(runtime, observer) {
   main.define("parser", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("parser", _));  
   main.define("decompress_url", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("decompress_url", _));  
   main.define("acorn", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("acorn", _));  
-  main.define("escodegen", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("escodegen", _));  
+  main.define("escodegen", ["module @tomlarkworthy/escodegen", "@variable"], (_, v) => v.import("escodegen", _));  
   main.define("view", ["module @tomlarkworthy/view", "@variable"], (_, v) => v.import("view", _));  
   main.define("variable", ["module @tomlarkworthy/view", "@variable"], (_, v) => v.import("variable", _));  
   main.define("bindOneWay", ["module @tomlarkworthy/view", "@variable"], (_, v) => v.import("bindOneWay", _));  
@@ -9667,7 +9668,8 @@ export default function define(runtime, observer) {
   main.define("css", ["module @tomlarkworthy/themes", "@variable"], (_, v) => v.import("css", _));  
   main.define("cssForTheme", ["module @tomlarkworthy/themes", "@variable"], (_, v) => v.import("cssForTheme", _));
   return main;
-}</script>
+}
+</script>
 
 <script id="@tomlarkworthy/file-sync" 
   type="text/plain"
@@ -19897,19 +19899,7 @@ md`### The Decompiler`
 const _1vs6mei = function _82(md){return(
 md`### \`decompile\``
 )};
-const _1g89k6a = function _escodegenOptions(escodegen){return(
-{
-  comment: true,
-  format: {
-    ...escodegen.FORMAT_DEFAULTS,
-    indent: {
-      ...escodegen.FORMAT_DEFAULTS.indent,
-      style: "  "
-    }
-  }
-}
-)};
-const _llvq9s = function _decompile(decompileImport,formatImportDeclaration,acorn,escodegen,escodegenOptions)
+const _llvq9s = function _decompile(decompileImport,formatImportDeclaration,acorn)
 {
   return async function decompile(variables) {
     if (!variables || variables.length === 0)
@@ -20282,7 +20272,7 @@ const _b7vai6 = function _decompileImport(findModuleName,findImportedName)
       if (!Array.isArray(inputs) || inputs.length !== 2)
         return false;
       const [i0, i1] = inputs;
-      return !!(i0 && typeof i0 === 'object' && typeof i0._name === 'string' && i0._name.startsWith('module @') && i1 && typeof i1 === 'object' && i1._name === '@variable');
+      return !!(i0 && typeof i0 === 'object' && typeof i0._name === 'string' && i0._name.startsWith('module ') && i1 && typeof i1 === 'object' && i1._name === '@variable');
     };
     const isStageC = v => {
       const inputs = v?._inputs;
@@ -20418,30 +20408,6 @@ const _1u6sfri = async function _test_decompileImport_alias(importFake,decompile
 const _1lqhutp = function _102(md){return(
 md`## Javascript Source Normalization`
 )};
-const _ikzxev = function _normalizeJavascriptSource(acorn,escodegen){return(
-(source) => {
-  var comments = [];
-  var tokens = [];
-
-  var ast = acorn.parse(source, {
-    ranges: true,
-    onComment: comments,
-    onToken: tokens
-  });
-
-  escodegen.attachComments(ast, comments, tokens);
-  return escodegen.generate(ast, {
-    comment: true
-  });
-}
-)};
-const _az8lo6 = function _normalizeVariables(variableToObject,normalizeJavascriptSource){return(
-(variables) =>
-  variables.map(variableToObject).map((v) => ({
-    ...v,
-    _definition: normalizeJavascriptSource(v._definition)
-  }))
-)};
 const _3knb9v = function _variableToObject(){return(
 (v) => ({
   _name: v._name,
@@ -20459,92 +20425,8 @@ Inputs.select(
 )
 )};
 const _1ex8kus = (G, _) => G.input(_);
-const _17petbz = function _108(normalizeObservableSource,normalizeObservableSourceSelector){return(
-normalizeObservableSource(normalizeObservableSourceSelector)
-)};
 const _b2d0zc = function _parsed(parser,normalizeObservableSourceSelector){return(
 parser.parseCell(normalizeObservableSourceSelector)
-)};
-const _qtgjo9 = function _generate(escodegen){return(
-function generate(node, source) {
-  if (node.type == "Cell") {
-    if (
-      node.body.type != "BlockStatement" &&
-      source &&
-      source[node.body.start] == "{"
-    ) {
-      return `${node.id ? `${generate(node.id)} = ` : ""}(${escodegen.generate(
-        node.body
-      )})`;
-    } else {
-      return `${node.id ? `${generate(node.id)} = ` : ""}${escodegen.generate(
-        node.body
-      )}`;
-    }
-  } else if (node.type == "Identifier") {
-    return escodegen.generate(node);
-  } else if (node.type == "ViewExpression") {
-  } else {
-    throw node.type;
-  }
-}
-)};
-const _104j23i = function _normalizeObservableSource(parser,generate){return(
-{
-  prompt:
-    'I see some of the test are failing because the AST generator uses a different set of quotes than the original source and various formatting quirks. This should not count as failure. I would suggest normalizing. Its not super easy because source code is not vanilla JS, we need to normalize just the bit after the block expression, and replace the "viewof XX" and "mutable XXX" macros with a placeholder whic we can normalize and then undo. Write the normalizeObservableSource.',
-  time: 1729097489369
-} &&
-  function normalizeObservableSource(source) {
-    // Replace viewof and mutable with placeholders
-    const viewofRegex = /viewof\s+([a-zA-Z_][a-zA-Z0-9_]*)/g;
-    const mutableRegex = /mutable\s+([a-zA-Z_][a-zA-Z0-9_]*)/g;
-
-    // Temporary placeholders
-    const VIEWOF_PLACEHOLDER = "__VIEWOF_PLACEHOLDER__";
-    const MUTABLE_PLACEHOLDER = "__MUTABLE_PLACEHOLDER__";
-
-    // Maps to store original names
-    const viewOfMap = new Map();
-    const mutableMap = new Map();
-
-    // Replace viewof XX with placeholder and store mapping
-    source = source.replace(viewofRegex, (match, p1) => {
-      const placeholder = `${VIEWOF_PLACEHOLDER}_${p1}`;
-      viewOfMap.set(placeholder, p1);
-      return placeholder;
-    });
-
-    // Replace mutable XXX with placeholder and store mapping
-    source = source.replace(mutableRegex, (match, p1) => {
-      const placeholder = `${MUTABLE_PLACEHOLDER}_${p1}`;
-      mutableMap.set(placeholder, p1);
-      return placeholder;
-    });
-
-    // Normalize quotes: convert all to single quotes
-    const comments = [],
-      tokens = [];
-    const cell = parser.parseCell(source, {
-      ranges: true,
-      onComment: comments,
-      onToken: tokens
-    });
-    
-
-    source = generate(cell, source);
-
-    // Restore original viewof and mutable identifiers
-    viewOfMap.forEach((original, placeholder) => {
-      source = source.replaceAll(placeholder, `viewof ${original}`);
-    });
-
-    mutableMap.forEach((original, placeholder) => {
-      source = source.replaceAll(placeholder, `mutable ${original}`);
-    });
-
-    return source;
-  }
 )};
 const _vle3wv = function _112(md){return(
 md`## The Compiler
@@ -21002,7 +20884,7 @@ const _1lmax86 = async function _test_compile_import_plain_single(compile,expect
     {
       _name: "module @tomlarkworthy/dependancy",
       _inputs: [],
-      _definition: `async () => runtime.module((await import("@tomlarkworthy/dependancy")).default)`
+      _definition: `async () => runtime.module((await import("/@tomlarkworthy/dependancy.js?v=4")).default)`
     },
     {
       _name: "dep",
@@ -21021,7 +20903,7 @@ const _17sgzdm = async function _test_compile_import_view_data_alias_single(comp
     {
       _name: "module @tomlarkworthy/dependancy",
       _inputs: [],
-      _definition: `async () => runtime.module((await import("@tomlarkworthy/dependancy")).default)`
+      _definition: `async () => runtime.module((await import("/@tomlarkworthy/dependancy.js?v=4")).default)`
     },
     {
       _name: "aslias_viewdep_data",
@@ -21040,7 +20922,7 @@ const _1tqj4tp = async function _test_compile_import_mutable_data_alias_single(c
     {
       _name: "module @tomlarkworthy/dependancy",
       _inputs: [],
-      _definition: `async () => runtime.module((await import("@tomlarkworthy/dependancy")).default)`
+      _definition: `async () => runtime.module((await import("/@tomlarkworthy/dependancy.js?v=4")).default)`
     },
     {
       _name: "aslias_mutabledep_data",
@@ -21059,7 +20941,7 @@ const _hv0te2 = async function _test_compile_import_mutable_single(compile,expec
     {
       _name: "module @tomlarkworthy/dependancy",
       _inputs: [],
-      _definition: `async () => runtime.module((await import("@tomlarkworthy/dependancy")).default)`
+      _definition: `async () => runtime.module((await import("/@tomlarkworthy/dependancy.js?v=4")).default)`
     },
     {
       _name: "mutable mutabledep",
@@ -21078,7 +20960,7 @@ const _1mltqmr = async function _test_compile_import_viewof_single(compile,expec
     {
       _name: "module @tomlarkworthy/dependancy",
       _inputs: [],
-      _definition: `async () => runtime.module((await import("@tomlarkworthy/dependancy")).default)`
+      _definition: `async () => runtime.module((await import("/@tomlarkworthy/dependancy.js?v=4")).default)`
     },
     {
       _name: "viewof viewdep",
@@ -21097,7 +20979,7 @@ const _1d18obr = async function _test_compile_import_alias_single(compile,expect
     {
       _name: "module @tomlarkworthy/dependancy",
       _inputs: [],
-      _definition: `async () => runtime.module((await import("@tomlarkworthy/dependancy")).default)`
+      _definition: `async () => runtime.module((await import("/@tomlarkworthy/dependancy.js?v=4")).default)`
     },
     {
       _name: "dep_alias",
@@ -21117,7 +20999,7 @@ const _1b5ghef = async function _test_compile_import_notebook(compile,expect)
       _name: `module @tomlarkworthy/escodegen`,
       _inputs: [],
       _definition:
-        'async () => runtime.module((await import("@tomlarkworthy/escodegen")).default)'
+        'async () => runtime.module((await import("/@tomlarkworthy/escodegen.js?v=4")).default)'
     },
     {
       _name: `escodegen`,
@@ -21159,23 +21041,6 @@ const _1191170 = function _155(parser,test_case)
     tokens
   };
 };
-const _1gh543z = function _compiled_selector(Inputs,compiled){return(
-Inputs.radio(compiled, {
-  format: (v) => v._name,
-  value: compiled[0]
-})
-)};
-const _1dmmuaf = (G, _) => G.input(_);
-const _1klx74n = function _157(compiled_selector,normalizeJavascriptSource){return(
-JSON.stringify(
-  {
-    ...compiled_selector,
-    _definition: normalizeJavascriptSource(compiled_selector._definition)
-  },
-  null,
-  2
-)
-)};
 const _eom91x = function _158(compile,test_case){return(
 compile(test_case.value)
 )};
@@ -21457,11 +21322,11 @@ const _s9w7ha = async function _parser(decompress_url, FileAttachment, acorn_url
 };
 const _1rc67k0 = function _stageB_importFake()
 {
-  return // Builds a Stage B (pre-observation, API-loaded) import group as POJOs.
+  // Builds a Stage B (pre-observation, API-loaded) import group as POJOs.
   // Mirrors what `runtime.define("name", ["module @X", "@variable"], (_, v) => v.import("name", _))`
   // produces structurally. Used by the test_decompileImport_stageB_* tests to
   // avoid spinning up a real Observable runtime per case.
-  function stageB_importFake(module_name, specifiers) {
+  return function stageB_importFake(module_name, specifiers) {
     const importerModule = { _scope: new Map() };
     const stitch = {
       _name: `module ${ module_name }`,
@@ -21629,8 +21494,11 @@ const _xynplo = async function _test_decompileImport_stageB_order_independent(st
       local: 'b'
     }
   ]);
-  const reversed = [...vars].reverse();
-  const info = await decompileImport(reversed);
+  const [stitch, ...aliases] = vars;
+  const info = await decompileImport([
+    ...aliases,
+    stitch
+  ]);
   expect(info.meta.detection.stage).toEqual('B');
   expect(formatImportDeclaration(info)).toEqual(`import {a, b} from "@user/y"`);
   return 'ok';
@@ -21663,7 +21531,6 @@ export default function define(runtime, observer) {
 
   main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
   main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
-  main.define("module @tomlarkworthy/escodegen", async () => runtime.module((await import("/@tomlarkworthy/escodegen.js?v=4")).default));  
   main.define("module @tomlarkworthy/acorn-8-11-3", async () => runtime.module((await import("/@tomlarkworthy/acorn-8-11-3.js?v=4")).default));  
   main.define("module @tomlarkworthy/jest-expect-standalone", async () => runtime.module((await import("/@tomlarkworthy/jest-expect-standalone.js?v=4")).default));  
   main.define("module @tomlarkworthy/observable-runtime", async () => runtime.module((await import("/@tomlarkworthy/observable-runtime.js?v=4")).default));  
@@ -21755,10 +21622,8 @@ export default function define(runtime, observer) {
   $def("_1lnngk6", "test_decompile_import_viewof_alias", ["decompile","expect"], _1lnngk6);  
   $def("_1na1e5i", "test_decompile_import_viewof_data_alias", ["decompile","expect"], _1na1e5i);  
   $def("_17dwb6r", null, ["md"], _17dwb6r);  
-  main.define("escodegen", ["module @tomlarkworthy/escodegen", "@variable"], (_, v) => v.import("escodegen", _));  
   $def("_1vs6mei", null, ["md"], _1vs6mei);  
-  $def("_1g89k6a", "escodegenOptions", ["escodegen"], _1g89k6a);  
-  $def("_llvq9s", "decompile", ["decompileImport","formatImportDeclaration","acorn","escodegen","escodegenOptions"], _llvq9s);  
+  $def("_llvq9s", "decompile", ["decompileImport","formatImportDeclaration","acorn"], _llvq9s);  
   $def("_1pvis67", null, ["md"], _1pvis67);  
   $def("_183j58u", "extractModuleInfo", [], _183j58u);  
   $def("_w445v0", "test_extractModuleInfo_notebook_resolution", ["expect","extractModuleInfo"], _w445v0);  
@@ -21777,16 +21642,11 @@ export default function define(runtime, observer) {
   $def("_ujr0xn", "test_formatImportDeclaration_roundtrip", ["importFake","decompileImport","expect","formatImportDeclaration","decompile"], _ujr0xn);  
   $def("_1u6sfri", "test_decompileImport_alias", ["importFake","decompileImport","expect","formatImportDeclaration"], _1u6sfri);  
   $def("_1lqhutp", null, ["md"], _1lqhutp);  
-  $def("_ikzxev", "normalizeJavascriptSource", ["acorn","escodegen"], _ikzxev);  
-  $def("_az8lo6", "normalizeVariables", ["variableToObject","normalizeJavascriptSource"], _az8lo6);  
   $def("_3knb9v", "variableToObject", [], _3knb9v);  
   $def("_263fcv", null, ["md"], _263fcv);  
   $def("_7zpsl9", "viewof normalizeObservableSourceSelector", ["Inputs","notebook_semantics_source"], _7zpsl9);  
   $def("_1ex8kus", "normalizeObservableSourceSelector", ["Generators","viewof normalizeObservableSourceSelector"], _1ex8kus);  
-  $def("_17petbz", null, ["normalizeObservableSource","normalizeObservableSourceSelector"], _17petbz);  
   $def("_b2d0zc", "parsed", ["parser","normalizeObservableSourceSelector"], _b2d0zc);  
-  $def("_qtgjo9", "generate", ["escodegen"], _qtgjo9);  
-  $def("_104j23i", "normalizeObservableSource", ["parser","generate"], _104j23i);  
   $def("_vle3wv", null, ["md"], _vle3wv);  
   $def("_10ofthe", "test_async_interpolation", ["compile"], _10ofthe);  
   $def("_1gb7c3c", "test_compile_syntax_error_viewof", ["compile","expect"], _1gb7c3c);  
@@ -21833,9 +21693,6 @@ export default function define(runtime, observer) {
   $def("_18e5b93", null, ["test_case"], _18e5b93);  
   $def("_16q6oyc", "compiled", ["compile","test_case"], _16q6oyc);  
   $def("_1191170", null, ["parser","test_case"], _1191170);  
-  $def("_1gh543z", "viewof compiled_selector", ["Inputs","compiled"], _1gh543z);  
-  $def("_1dmmuaf", "compiled_selector", ["Generators","viewof compiled_selector"], _1dmmuaf);  
-  $def("_1klx74n", null, ["compiled_selector","normalizeJavascriptSource"], _1klx74n);  
   $def("_eom91x", null, ["compile","test_case"], _eom91x);  
   $def("_ttos3c", "compile", ["parser","observableToJs"], _ttos3c);  
   $def("_1v1i7wl", "observableToJs", ["acorn_walk","parser"], _1v1i7wl);  
@@ -21863,7 +21720,8 @@ export default function define(runtime, observer) {
   $def("_xynplo", "test_decompileImport_stageB_order_independent", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _xynplo);  
   $def("_16fpgac", "test_decompileImport_stageB_notebook_id", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16fpgac);
   return main;
-}</script>
+}
+</script>
 
 <script id="@tomlarkworthy/reversible-attachment" 
   type="text/plain"

--- a/notebooks/@tomlarkworthy_observablejs-toolchain.html
+++ b/notebooks/@tomlarkworthy_observablejs-toolchain.html
@@ -2229,7 +2229,8 @@ const _1ey5aow = function _dragOutGrips(layout,invalidation)
     });
     return 'drag-out grips installed';
 };
-const _1gkn0mq = function _dropInHandler(location, setHashURL, runtime, page, invalidation) {
+const _1gkn0mq = function _dropInHandler(location,setHashURL,runtime,page,invalidation)
+{
     const STYLE_ID = 'lopepage-dropzone-style';
     const oldStyle = document.getElementById(STYLE_ID);
     if (oldStyle)
@@ -3171,9 +3172,9 @@ notebook_semantics_document.nodes.map((s) => ({
 const _1oevsow = function _28(md){return(
 md`### Runtime Representation (v4)`
 )};
-const _11lfflk = function _notebook_semantics_module() {
-    return import('https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4');
-};
+const _11lfflk = function _notebook_semantics_module(){return(
+import("https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4")
+)};
 const _gjten6 = function _31(md){return(
 md`### Imports`
 )};
@@ -4179,44 +4180,65 @@ parser.parseCell(
   'import {runtime, viewof main as foo} from "@mootari/access-runtime"'
 )
 )};
-const _1n7gw17 = function _findModuleName(extractModuleInfo) {
-    return (scope, module, {
-        unknown_id = Math.random()
-    } = {}) => {
-        try {
-            const scopedVariables = [...scope.values()];
-            const candidates = scopedVariables.filter(v => v && v._value === module && typeof v._name === 'string' && v._name.startsWith('module ') && !v._name.startsWith('module <unknown'));
-            const pickBestInfo = dfn => {
-                const s = String(dfn ?? '');
-                const m = s.match(/\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/);
-                const firstArg = m?.[2];
-                const info1 = firstArg ? extractModuleInfo(firstArg) : {};
-                if (info1?.id || info1?.notebook)
-                    return info1;
-                return extractModuleInfo(s);
-            };
-            for (const v of candidates) {
-                const info = pickBestInfo(v._definition?.toString?.());
-                if (info?.namespace)
-                    return `@${ info.namespace }/${ info.notebook }`;
-                if (info?.id)
-                    return `d/${ info.id }@${ info.version }`;
-            }
-            const any = scopedVariables.find(v => v && v._value === module);
-            if (any) {
-                const info = pickBestInfo(any._definition?.toString?.());
-                if (info?.namespace)
-                    return `@${ info.namespace }/${ info.notebook }`;
-                if (info?.id)
-                    return `d/${ info.id }@${ info.version }`;
-            }
-            return `<unknown ${ unknown_id }>`;
-        } catch (e) {
-            debugger;
-            return 'error';
-        }
+const _1n7gw17 = function _findModuleName(extractModuleInfo){return(
+(scope, module, { unknown_id = Math.random() } = {}) => {
+  try {
+    const scopedVariables = [...scope.values()];
+
+    // Prefer variables that *define* a module and have a real module-loader name.
+    const candidates = scopedVariables.filter(
+      (v) =>
+        v &&
+        v._value === module &&
+        typeof v._name === "string" &&
+        v._name.startsWith("module ") &&
+        !v._name.startsWith("module <unknown")
+    );
+
+    const pickBestInfo = (dfn) => {
+      // Avoid the parentUrl (2nd arg) confusing module identification.
+      // Typical patterns:
+      //   importShim("/d/<id>@<ver>.js?v=4", "https://api.observablehq.com/@ns/name.js?v=4")
+      //   import("/d/<id>@<ver>.js?v=4")
+      // Prefer the *first argument* inside importShim(...) / import(...) when present.
+      const s = String(dfn ?? "");
+
+      // Try to capture the first string literal argument to importShim(...) or import(...)
+      // Tolerates quotes ", ', ` and both importShim and plain import.
+      const m = s.match(
+        /\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/
+      );
+      const firstArg = m?.[2];
+
+      const info1 = firstArg ? extractModuleInfo(firstArg) : {};
+      if (info1?.id || info1?.notebook) return info1;
+
+      // Fallback: parse the whole definition string.
+      return extractModuleInfo(s);
     };
-};
+
+    // Try module loader cells first.
+    for (const v of candidates) {
+      const info = pickBestInfo(v._definition?.toString?.());
+      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
+      if (info?.id) return `d/${info.id}@${info.version}`;
+    }
+
+    // Fallback: any scoped variable with _value==module.
+    const any = scopedVariables.find((v) => v && v._value === module);
+    if (any) {
+      const info = pickBestInfo(any._definition?.toString?.());
+      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
+      if (info?.id) return `d/${info.id}@${info.version}`;
+    }
+
+    return `<unknown ${unknown_id}>`;
+  } catch (e) {
+    debugger;
+    return "error";
+  }
+}
+)};
 const _i47chb = function _findImportedName(){return(
 async (v) => {
   if (v._inputs.length == 1 && v._inputs[0]._name === "@variable") {
@@ -5313,12 +5335,12 @@ async (attachment, overrides) => {
   return URL.createObjectURL(blob);
 }
 )};
-const _s9w7ha = async function _parser(decompress_url, FileAttachment, acorn_url, acorn_walk_url) {
-    return import(await decompress_url(FileAttachment('parser-6.1.0.js.gz'), {
-        '/npm/acorn@8.11.3/+esm': acorn_url,
-        '/npm/acorn-walk@8.3.2/+esm': acorn_walk_url
-    }));
-};
+const _s9w7ha = async function _parser(decompress_url,FileAttachment,acorn_url,acorn_walk_url){return(
+import(await decompress_url(FileAttachment("parser-6.1.0.js.gz"), {
+    "/npm/acorn@8.11.3/+esm": acorn_url,
+    "/npm/acorn-walk@8.3.2/+esm": acorn_walk_url
+  }))
+)};
 const _j9n5de = function _stageB_importFake()
 {
   // Builds a Stage B (pre-observation, API-loaded) import group as POJOs.
@@ -6228,12 +6250,12 @@ md`# [Acorn@8.11.3](https://github.com/acornjs/acorn) & acorn-walk@8.2.2
 import { acorn } from "@tomlarkworthy/acorn-8-11-3"
 \`\`\``
 )};
-const _1xdqqxo = function _acorn(acorn_url) {
-    return import(acorn_url);
-};
-const _vctqpi = function _acorn_walk(acorn_walk_url) {
-    return import(acorn_walk_url);
-};
+const _1xdqqxo = function _acorn(acorn_url){return(
+import(acorn_url)
+)};
+const _vctqpi = function _acorn_walk(acorn_walk_url){return(
+import(acorn_walk_url)
+)};
 const _1c0mco9 = async function _acorn_walk_url(unzip,FileAttachment)
 {
   const blob = await unzip(FileAttachment("acorn-walk-8.3.2.js.gz"));
@@ -9427,15 +9449,19 @@ codemirror.EditorView.theme({
 const _12m5h41 = function _9(md){return(
 md`---`
 )};
-const _1d6o6ga = async function _codemirror(unzip, FileAttachment) {
-    const blob = await unzip(FileAttachment('codemirror_javascript@5.js.gz'));
-    const objectURL = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
-    try {
-        console.log('Loading codemirror from', objectURL);
-        return await import(objectURL);
-    } finally {
-        URL.revokeObjectURL(objectURL);
-    }
+const _1d6o6ga = async function _codemirror(unzip,FileAttachment)
+{
+  const blob = await unzip(FileAttachment("codemirror_javascript@5.js.gz"));
+
+  const objectURL = URL.createObjectURL(
+    new Blob([blob], { type: "application/javascript" })
+  );
+  try {
+    console.log("Loading codemirror from", objectURL);
+    return await import(objectURL);
+  } finally {
+    URL.revokeObjectURL(objectURL); // Ensure URL is revoked after import
+  }
 };
 const _g5fwfs = function _unzip(Response,DecompressionStream){return(
 async (attachment) => {
@@ -12772,55 +12798,6 @@ export default function define(runtime, observer) {
   $def("_2rhl00", "dragReorder", ["divToVar","runtime","moveCellBeside","findCell"], _2rhl00);
   return main;
 }</script>
-<script id="@tomlarkworthy/escodegen/escodegen.browser.min.js.gz" 
-  type="text/plain"
-  data-encoding="base64"
-  data-mime="application/gzip"
->
-H4sICLP7DWcCA2VzY29kZWdlbi5icm93c2VyLm1pbi5qcwDsvQl3G7mxKPxXqJw8NXvYotncSanNy3XiZLbYM5nkysy83ki2RJEySdlWJL7f/tUCoNELKWkyuTf3fvY5hgg0lkKhUKgqFIDi7G7l76L1quiZD/J3wS16VmA+RLPiw768cLfff1r9sFnfhpvdfdl3l8uiC3/8RWh5prkJd3cbKMIpl970/KO7KYSOW96E2/XyYwg1n0NNJ6G5W2zWnwqr8FNhvNmsN0Vj4kbLMCjs1gWRt3CzDu6WYcEoQSGsx3ceoqDrWZvww120CbuuNYMiK/cmhMTw8+16s9t2H/bWcu0GYdA9sa1bdxOudt3A8hfRMoDf3cvp/jw4PQ3KMqV8e7ddFH1uYeZ45e0y8sNixfLKS3e7e7MKws/fz4rGK8Ms2eZ5poeOXxZNWyHjI07wrfj3DPADUYbNOalYeVXs3TJ3eutAP0QO/imQ4uhjxMAcHBZRFTTcUxForvtxHQWFClYahLNopddp+eaDntfx9wL1Ko8r2y24DmDFethFu2XYNTwYz224MayP4WYLGbvGR7tarlbLdtWwxMcu9DtcfcRBcjfzjzAa1ir8vPsx8q+7gPlw9+bmJgwidxc+PuoNwpcfo5twfbcrulbF3Fv+p6CrMsQAwYdFEG26OpJcx9vv90XzXHYXxnK3Xi+3r4A0Nvdnt+totStfbQ1LlfKtwAqtmflworVh3G3Dwna3ifydce6Vw62/DsJ5uHJcqFDFqCLftOIE0XUYcgBib1oaGMlSqi0g13Tz15Dwe+uP1o/W0lpZE6tv/WS5Fes7y7WtCGjrL5Zbtf5kuTVra/1sDayhdW+5dcttWB+tkfW19Vfre2tj/c36T+sHa2792XKb1i/WjfUP6xvLbVluO9W9ePIvtPG+LY8/3wId4uimSA6obXd/G5r7uGQnUfLdDgb1BjD+dEFXDehDBLMP5u/qbrm0PHcb8i+Y1fKnv77BSnGuz9abG3fXlWUetrt7JMsC/DO4MMy54Opuu/v2brmLljAEQ1V6D3T4CZO6xvuVYW1vXR/LGtbVFigZagdOcXfjIQXb1iL8DJPYj27cJUY/3K134bZrbKPVfBkaOPTubQjzZ4tfAUKobBdzo0W4hdwwEbbhTeSvl+sVx9wZwLPyAU0rFxFBJQDb4eZjOFi6q+tvALwtwXqz/kf3ASvehItwhcMRDwwgGhjJz9Fu0Yf4fCXRs4V0hOnrcBVu3N16QzVt13cbP/zWvWV0qujb9XqXSsIqh0CuWBnMsRBG6yNFNu4n7ABMew8Av9GLUX6M7+Px/QNwGaAM5ioG0Bowf/fRqZy7r/H/69eObXklxzPdU/v0tOjjT8l2fY1Mopi+Xl2+37xfTV/NyzAQwCI0atohC8C2gA2UYbGY7xaKh5+eLss4AcvRFnH7Y7i5iVaImqIHy4O7Qej7UN2Zber06QF/kJUy9IVoVfBML0PaJsJ/6U4dD4K8TrzltVXFQ23O4LRYzwBuxzHW3hXg2zg9xaZgJFc+fvqeUk9PT4qJ5LfhHMjB3BOAlh+DGJhBPohOAPBZIayCPVihEdbeW/oLnKyLf523sPiriK+64mlouYLihBRYiy1Ymq0AV3r/xIH8mcX+u7ubEFhNYRntgBqXhU+LNbCfj+7yLixE28J37ncGCQr+ReXx0QcUVE5P7VcQe3FVq3DuIqWK+qAq+1VFCir9noHUaXR/6hl2WK9UjC78LeEPzO0BfZZ86+Snx0dJPBc1WdY7D4GkIikflA3TOumfniZIp2JCe/X26WmI7QKqQwcECyVkAF1ZQJeUsglvl8B0ikZYMiwDwLVmkLcYgOyk2oBU8zVgojhzSq6oIwCpBCpxldwSQKXha4eynUE6w30WntmQrVSMM4amqiSESsySAY0GMBE/gWgUolinzQFRTSmAyUB9Ms/OAkkGwYkj2wsysMzER7fkQAdKM9NStV1IrD4+upDFf22HdvX09Ft3tyjPlmsYXR8b87G0Y1Q+w2CUd+t3sEit5kW7aZrpeoCaS64o4TmuaekE6oPsoISmont6VsXK29VatVf0esYdjP3793cg5hVdmW5UK9U2pMOfjmF2Md0GgqS/NSpFhWQZuwL0BCkbyMtQlmeb9c1Q4DHBmNzrYsDzZQ6zZQFzJrI8mDU+Ep7rBHFHYVDKzE5JCp8DfmGh8xfFV+9fFS///mr6lfn7V0B8cyV+05RfOPNLewrDYYBo4eBKhAESYOTICiVHDC+i81IpNL34izb4IQiuPRw/QCFKiFST2S3Oeh50ulMjgsQUjNZbPRxpQApFOzZ/rQCR6hXQt6pkJCBHltwShou9kuViVIEwa0nmorg3jlEP2vEMHpcqRmYc6eDvndFFIkhQDER+ugXWNwR5ABDbh7F8XW00ejTyJaMC/wxBvYqmSh7VCQR6otaLES//o2ge7ZBtQvmKgMPGyOfKgCjjM1WaU6VOCTfI9WnUCScCJe/hn3Euku1KnLyKU2tx6kalIuXG6XdEwtq3WvJbxzjPsNQ3K3+9wRV+eV/wQQvaRrMIVDMkCRBlQMbXoV9JOnaBhmFlJOLznO9w3QrWdx6IRD3jd0b3d8bvgBiB7QCNCbJzL0IgO+48LEIJhoNE4ji1jvkAXPh3IHFvQvd6L1h4rY7JUKNI9glzMPlLrqQfrxSU9Nm/lmAiUwc4adbRZKigsE1Q+/B7HoPnX8wBPF+MTQI8H3kugVcqwfRZwoojMAyglUpRIqneOj3tmx7PCvXlkOzhmsxggBIeoAxRx7m/Xu2i1V24l6VjUnyD4i4O0OYHkPzG7xq8qMNS5F7Uqo+PJ0WkchvTOMF9bVeBd3LtOLWSPcOlIG4P8hzgZABE6JwU9XF+fKSYe7dbg6wSXSxwEQt7ME5dGELrpBj2Ft1ImQlmJa/EiA9oEQTmlz8AWeQzqjuwsDKyanWYnSH2UaDZtA5CroSX0kyjj0AnY2BSSjTNJ1mPZSaQTvubjXsP40B/i6hrBxB2vRxx74pFXxy+gRJBDhVn4kHxxERRRJfw/qjJIEgPrvOwjy0Ty7XP5Xo4pf9YJHmcggF0zC2jweTxkSrucg4qU0YNYVdGJcjSE0BFubtZWQPA8kmlJ77QGsGVdDO1xh2+i3XzWW+GClX8bYFqNqM8pNmoMBY6KEvqC6BcqJAN9y6DaRdWwSsYMD3PPJHHhzyuk1zGpCgEApPnzJNyGlNUvcbkVG8AKeEP7/HxiYl25LMnZjLOf4+YeAMAs+5wRZ92VcGfFyC5vkONk+b+Mb6QV8Y7UgbICRqExiAEgXyq6zGfYl3jcmW50/jLWulM566zslYlZ2J5xZVprRx9Vb4tJrUgpWCd2aDHgRx5duaaRxhdUskChkS8XM1OVdmZ3uiH4jVaRljPwKk6t9BcsrAise5cl7e3oAqAcAQq4aNQDHEx+Y709/K3/b/+8pf+Nz+NgYGjOORlFqM5qWuaJBxcSNrShlsbgQQpgcgLC0Bw7r8OWLUClANgKAWz3a0HktnK8kA2AyJFdvmVgSISsK2CgSiegWTlo+p7dgb9clbmIUAjmAKfSE0T4oUPTVukoQ16UflqHa2KINJ3I4nSlbOwPJEOUoRGC2MWsJDlkDkGwcLRMnD8UPondUoybuMVimucRgxIrqt6umjz/vGRWfIKWbJcnLdlttaU2VhTzrfLnJ6CYr96v5m+Enq9AKMHVGC8+kq1VTK+eoVGt24mUSMcQI80OwRANJ51a32wbqwlmc/WQEAba2uFpCMCot0AmIoAYwuaSTpJjMXrCiHt1nGte1DjiQAzeS8rKIVfTkHU8Mrh510IfQ7euqs5iB2o+NGvhTMsb++8LXOzCMvMIADW5xQXSt5fvZrDbL+cSsUHFD2gJ5dt2H+gUQW1Dm2MlPKpOIY5Cv+6Ms9CfeMv1hpW3QDoa+4c6uM5kP95UCqZeV0LplofNok+rFH7UH3YHO7Dk+AjkOfbROUzrDyCgCrfvqBylqCeGqo/4ZiLmXBd/mGznm/cG0zz1sG9ttDAKsENMIHruLV2xStga9oShcuBnvsZeAdOcgjvS+cS25lSO8tUO8scqD5BLrSCi8itSTIcdHPj4qxTleOcv6dW018QPf+GRHyuhvSDc5LFunXjQK0Fw4IV66qIa501mSZykNmDhiLd47yxyGAFBuNDD2RYFDyAerD6Lv29mWqAWjfYB0oXXYI1BlaF+Rnw+hywyegBmREfsfFQWwvf8D6FlFo9WK94HfZhiQjOXZiyQ1wMHOK+IIKUSiIDrM8XHmUIGbxIWws+oJkEVwO5EF/4vUujCOizDNOAnmlMdRYLzbHmFyRWYBhuXsF8fQXzqXVaq6LSqoQ/8myKm1hGRKBmsfLvX27L0uIMU0CzlTL1GT3PgZ7MUJEMy+/CD3chyM5QGdkEcJ1DFQeGD1UUGCTQdsMAs5yw6KwndbUKsFY006Bl64qMGTG4tyDtxrHPmi0XxpYEZEu3AH2r26NAbne39yu/Z9Afo1T0eiAodkEaMLRl7J1uzp5LUz7QD7DA9T/KGSO/QlgPxIzSLFGXO5cWW0AnL5oWKsfnSYhYp0JgT/wybjrc7cKApqfWPmZ5Bx3GZrqGkTS8bYuuNN6QURWVjluLNoiUIiMrC9VGETR4QzZb2oPKZoy3PCCnNkJzM2vQ+Gl1vVp/AgkIZDQyrHcLKCikd552uM/GoC4c3Ieyrqy50koEZRQFsYVCeNFoDvCwSEk2tAvlyLympQrjjhQW5W2lvKKUgzMiB31bBE5pWhNIymkiW7GcBytRR3cFbHBihTmtIG8NQTg8VPexklY/LoSbZdZPcVxumlluxen3Tuyu+qJtoVnfwTdpQYhz8K6a5dpxdfHGGqxCKlVs3KGlQSbR9l0Mr9iCAxRHzsyZOCsHKfQvcX5tY85yq1o9aofO+pOWmt6ps9wafFV7YtbP0CHSjMMybVWC7hyW1T6aNVQxVBmsew2OzHbf6enwhJV5a+tARahSyB3l3h9xI0FWW35Hv77DHbc/0p40EvsvYiv/Fec7u3FvtZ+07QxadFwUKN6B+XptWoMe6thqQcLdv3eyreIDOl7gWMEfsdVHO4ZaNzG+R94ru0rc9vR0XsaGt+HunZ5e1BGUKhNXou1C9uZdrklbMdEq8IDqWfdKNwzciN3N/cF6sIy5/zGLNdA6Ni76M4TaT4E1EMBy8t+BBrN9tYy8V/RL5r12fiy/u1/t3M8wkx8kr+pWrL9F4TLo2pa2WWtb0PEgQspyl92q1Qce9mkimBTEh2sX2oLSNeub9Tzy3eX3b7t1+bv/3ajbsAbR7lO0DeFDU/7+K0RaMoK52tb4w50LK/V9t2O9DZeuaNGuyFzv/vBm8mPXBugChOdj2LWrFmlpsMD7LqfULODE6xUaP3jf2q5b/U9uBB1pWD+t3M09/vhhvd3Nos9du2l9f8sNDRdutIIh6tota+jCdLHb1nfhp67dsX505/Mw+DG8uQWowm61Yn0b0u571bZ+2ADXgEqr1b31e+fB6PWQa0ikWMbjI8YVZixgrVoCdByyYIJCkWX8XYv/lYpoCVQC+CmkSHxZxkkq7mQzJBOibTK22iWyX2DmeAws43U64cLJZMmkRKtsijQaZuq70PpIAw01vs5Ly0ksYZIkCss4S0a/wmiSTCzj/+QlvspL/IrKJ4lqb30EEXLkVK2vnbr1V6dtfe8AKW2cWtX6m9OsW//pjB6/tn5wPj6OQJCHEGJ/dj5abtP52voFEr4GNeCj9Q/4tbG+AWnfbcHP7y23DX/+at0C713v1riIAle594AFr/1rzelJ7j8FIIaGzm4RbZW86oDwJfxQHh9P3LSuZrmxIkm1KgkHRPLe5czCynLFH98EaTsuPL653d0nChvnRre4LmpOSoFzGYF6ER6oz5wCSw7M/YH+vrubwRx1ND8oKbg5Wf1E2bcPd++kqDCTY0MBDecEEOBas2mX/q6mXQgj+JsEUPblB3e3CzcrfVR0RUVDVWyL7aEY3k2gOCE4kgSf25rkuD+4oPpvE/5v5LtiISksUEBd4Maq1nqCYcetQXfJjQ8FkRPyAnOB8rdoFJC/NcuCSaYFajtOteNE0Kvz+gsa6iXJ6hXT+lzUMptTNtWxjvY0tD2uxgYavJxanrAnFA3hwEbgotBKW7u4b4OeCgl4z33QQnH7ZoFQyzKX/rQnakuMSrwAxlD7UytREPisAYt4nBWEfbObV5sglURV6YKWX7IvAvTY4L5Z6JxwroYo1ZtUPoWRchk9P0QMMY7FyRArMpiGqfYkj1PaYB3cJ/w7pQeP0noTfUwSKOSHJp+mQWlEmSkjiuG8NgjeMB58LZfvHJo9HlnD0ni1NB8Nkyzj0hHGeDDIJE7WBJ+sCQoIH20j2kDGTEk247ZR6czH4Bt0/cGeTtYbxX8czaHSsyKp6l5ChS7KJz0D5gIo2qBmlwxKMUDZxjSzNCsBjFPRd4n/BKdFY8ZsFyP8L+4mckGFGYX+0mVgeokConei3DUoUaW7Ymzm8nNYtsgbxFWSCe4b09wrbPn5I4MFYWRQriJad50F7vTij0v8daDYJpovdtmZgkO1V6AeGKDo8PhIf7M/hff66qJsGZex9Se2qF4ayRZzAPazoGoVTI2DAMWFnITXL24MxGYbvfILD+fOo/PRtD4UL48BRDh3TWtWmpdSq7uWM0iC7popBuWlliWli+Z4Yp+4Vej16Ybckc4NLBjPgofkqtzVVs+ZtpTBrHwwrGiakm5SJJwxf9/TjHaFAdi/tKdnPtDo6yraL4OEPRjTSzbnsUEMgaiyTRa5/alim4HJHvlza2EtrWsyLV47N9bs9K+Q+/rR+d4EOa9iLZwEUOfziwWsOXMT4Zo7wvOMcuCCmdnYIdgPfMWkpKU72x/qzaG+IPkeqPvx8U1RII32HFQ+lYQ7CHN09juR8M/P7GnG+IzSA3+d5shXbxJluW5bNTdPNwddWKA1GvG7Ma2DNcOw95ZOrpApi1jXZnfpHJBEtUxqwJdm7kZGEQYSxvTM7slSJTsHm560Y3fVL9PCoqpLcWeyKHxTTGOEkKR+eshwJaCfisae1su9NcAN69yZpdt1l64XLnsG7W6T2ZESyB5cIu6gpjY6fnA+I/tlj2YBcsp5bovSiecZjcqs+e2iCxgKJ9q5CmWWV3zj4Fq5kJqT9PWp0JaRPmuDixltr2Q2ePzDcgduuyTMvjANQaCbKf4f4aAd2YSLVCurWBba85pBXdaW8rye64LZpUF+cgZKylFAWze4yh6WnKIgBTzS1/YOXROxIuJMAA7zn61xpKa4ENRI9hZtwfdjAWOWv5rq0gYt4//gZXwkzZlPUNsWpsknxDn86VGYQ18uSuLKQGrmEdlo/TM6W+S05llqmwIwEqwFMrICyE2slApROa3aKlnStBA7lwY5eBgs7h3BMbofJMcLRaJ0N0Bfx9mC25wwHnfbUMeY9D48JlPSNDkXikeP1hEfa5MA5s4GkT0LHrKw+Z27CWglPlCWMqTKerSB54fFqlWxjEI0K6ANEzUtBdA05ofpwXDVYCCLHIXe3XwebnLHVQkwRiCyZXDqAkaTho9cMiSpZ0yH6EasLx6YvH7MtvjMHaAp9mN3fBCi/tG9EbPHELon8oQOkIEmiJu9nBmuzyUtLyKv+xRD0POnhNosndEM5e5+Bxw9eElnrWWCAOM+J2DovahzyIZuQ58sEMi79KjulifQ+kAEDay2q2dMWDS4cwMktncyR+8pHCbqSvHXblE1blrarItlYN4cV2sD2zRyeqLsGhnGunwSLD+zZgkjhBsbF16wbpWEKCL2NQSCLg30eDWOKB+yQGri5/CzhFKeIEHTorlJ49RfLnNJUJuhigQBLNqLtp6E0n0WlJ45JTDi829pPuEnzljNYrdFtacsz6s0TLTb81KO+5Xk1Kg59zXY7duu1vJ9MY/7b5q68+thINoEhMyaC0eb4ahXDoNB36vPBCeS4PiWy+e20jhhrwSxC39inydc0HVv1CS6zLgEu540aU4pP5CAPRmfU1nGQxR7GCB2JKyu5ZbykOcnkYeZ6HDBIfT5Jp85O4Y+mADigJ12IuWwWUCzrSWpGQRGJzXTrewRMiK4Gbn6LiiM2Lm4dnoanH6PtvW4/piHfsMn4k5PhW9AIhf5e+h+Aq4Te/mkV5yAdiLyGEHAa9GbG156nxCYU2vPoWXi0oioPsP6Z1kYAo5uVLLCKbH1FEvW7Og3mgSh1h0lzl8+a+lJ8/ipaeFqkW4VRfyThAuhZZhPgYarPXk3pBfFy5n1K4FTbnWwJD+kIJA+2HRsslc8rkk8f82LG9yjLd1MbGKl1MV40QNJhRTH7IJ8UH18ekF+Son8FQsy9kgpYL/VWhwgGeGCm7Yzrzfd7C6lB0Ldx968+5+xL1e0ina9y8NLbRSk7Y8w+XC/5dj6jJWmi027B3Zisi1ke5PgHL610Nbtq2LsYZ22iGvbjF7aOKTINuUMm2eZ8kjPiaeEbqA/nN+aO7Z1nQIrNkhek0EyA/b8uWATBb4MbrFH9STkYgmbW9eWh76kCe4MbNOnfQo8C7EAerrpfmPldvK13VsXr8wuDJGVv0wseJn4ER3zjmtylwA9+e8ZR+jO3czviIZSczdPNPxxc5+rfM7iVSlgx39cJ3ab+1z7Av4FnRbdww9aFigPHjouL9xVsAT2YspThSj0yMSMGnFckZTFkI+iUg1JMxBCltE/wg3IKSUbFpGAvYUPQaZVIe0fZrwbjEdLyAwQBn8QGdE9WyhA4YvADX81lGECOJJABdgoHqZOyalPeQj+dfj959GbwW7heS2zqSRu9TltqYbU1nKqvFh7MG2ZS9EqO1I1z853nyJUt/MUqJWcLOT0AOxCCHIwNMkdIphCW6pG2qyW+fJwEG39TYTS9CrPskaySClCM5Nf9t1tyFMJd4A82vURqXKsPdr28UwvtYUROJ8OmTtFDZceb0O4ct+JVvrg0EofL6iJzQCFPTxYriPuViJuRhx2lZKAE8gjWiZbY492aQ0E8CAGszZJQF3XoKMH0nDVRYM0zQ503V5tKe9OnrsIUHGIkxP2l7QrT3HmLHUCShUEItLszJ6DRyxx4hw42RALTivnBgYvUIMX4ODdniIRr2gEZzCCy/zhiwGAMVwlLN0ez1vR/OxQ83tWXma5C8SVvkBER3ZFUb2YSXqPXmJBJncs5+p0A8z2xqIDg9Rpr+wuUWqCWpQckJ3CMQKIhRxmGlpGN1G5pl7EOFBWJOJhxmH+paqx2FJExXDTYolkm4VXz28e8/fQ4BW2Tt2vI1+1PD4+5OkhnDo8loX5z3EHjqO+GST8fqNJXQc2q4SQrIb+P2NKNc6NGA8YsZhSclQt/7l0dbTyu9tAp6knq+f8hxow9QbQz+kpF5GATc1qTN+snthdStBerpdPEb1e8fS4qJrq/X72G9S7niXr/QZ3UMPgCfE1sdMK/Ng6sD8i6wUJVRwv1Ol6Ls1xeJVSvHOa2DUFmr/80+lp8LrSQ9Wmaxh4GBOvc8PLtIRp7eRPfJCd+GpxRtzlniQE9o3wjnkoeJp/AOdzNZcBmprsoSC/5nsoxGXzPBT0svGOe35z4eHlXJUAwR6FBtZ88NYZsq/TOhCmD9jd92SxXK8CX3kV+AmvghihMZx5XgXpXlDH1E9f86EFqhWD/6QdXXp3xkZO6x1ZfO9I+4oCdHmFP3hwzMp1GMStfCgBlPeWqnzSn0CqWz0USsSG22+inXUvZXWlPNXt8I7wc/l+Yn/Xf+nS/AJmRudj/ilIoYInAOVb4P5ZUPeW6xU1zzLdWcy09Dse44MqcVpXc6qcW4v4Jga+Zy6G7WKO3sHkL+fhiWq8RwXv+IlN0Fv9OCjdqXLcqJgoSxfW6dYksjDAXPfTDr0C4XhsM4G5vXbmJq9/Sefyw77K5GnpCs9Jt4yOjmiVE57lB/xwDzXzoXhsxmKP9fos4RUkDwvl1Q+1JzwatewX/nNcGtUEUUdsyLfR6B03amoyXMrREQt3jxeOJcUcJ0mtB4RicbInH7l+gpHJwcF9j16PfPUenb8JzjSI0HkmcTrAJwynP+j1R/FtJFegFuNdJPN4a/33l3GbUzxal4Dgq6+MXliWJ6MC6zrne9ANSrYVXES8en885o8taPEKQOLD7PrlONqW0jy+CEfcTnPsjhsFUnJXyuzBtObLbLQ+dj0H7/WJU47Dy5MGb3Sxkl1/ZdAFDAf8yF8ZqJEruHj3j3tjXKRLyn3MGn0+OTszekVPM+96sQM6Ak/30yWBidCr86Q4O/1o8kl4j0/CF5PZHh8TYGHS6akBYsbs9G+JcsiKQKMkX6FlLt3ShTbxuXfhmnBsfxGvfA5D6X38A0wUHyDhWRJvZvTKsQWcznII48ClIdfsrTGNbSqslj/lg50ojKp41ic74+MwSxtSUH2wotNR7wOd5qZeLMyudvEAYAsPDOYvRSSvhOX00cILl6f4SF4g/py1xcrWY3naOuLnZcCtme/CT/nQLXVbggc845rvIg3y8A5s4Or0ayC4vwAh03boL90/026SsQqPWMWDmAYAELJpnRShJpAM/wKiLF5Vo+2nqdGPHB9GOnrOSAfPG+koPdJu9iQMjzLCuQTE8eHO/NVrlu9veXjtUFIS0VAAJPVD98+4z64uL8D5/8TceMbZAw9FKDrVkLhgAtqbd3/RlOQpKsnFE71JCeThrXqVQ23Tx/cE+BmHAT9xDe0FqmSvLgHWv8qbk3z9orLk3ZWJi/XihQEP56n4a6dKpsLMxbaxLQ0vr1J9jvvaQ7R2DQ21nzXE4d4ZUwJTAKwDSAw7V54XSa7kQeoKUJIrpdAobgAp30DxhFsDpXRRJ8If2sEs7dyWKi0hS9YgU6mWGHiLZUoBO4oiPx0SFALrJrahEweIqdk7wpU0VUq69oKOD8AZZKULNHGTPNwuA03eiH/LcawK2x5mvs6SERCiNsbX2n15eOtPajXWrs7zxdV5vrw6D39ER6/O849fnReZvbw9WC+2N3kx8TBm0ERDp+kPScFBxuMqCJd4OzT6zRn3WPQrvMOVfxpoJxXYf4Y/tzZQBAS7dDN8nEDaAJ4yOySoqvtJF6hDL2Hu0KE0vFCFT6c9T+WmNrD5pObDyUSkZNN7WhehK3BAMoUlWRNjnweEJNap+g0kd0TJSBQWEjHSui4+xx9QKD+uU2nYzDGYTDW3iEBJg8qKkjjOGbHns55llvR9PqCskfsz7VcKF4ijqiVlTJ9MRrBFHflS4rW1lDo4yYkJE4NfBvLWb7FCj/IFesRlvrzGu8EvYdWzvF5EhkTNPnEtbsSxrsS90hXQZDJVnC8urkCIWJjxl8vFVM1ir3dN9wLJbbYDXnJxyYxsgV7Garm5Nq1FyQYuc5Vwn6LUi0QaXqQUdWd8gufJ7SgF7UqHlk8Sml3jcmqg0Wy7Gy+zBrN4SOlQcOmAG4wkdHmwJp9dBbH8/7/6mAms9ot1MMIXUaK0zVNdbuZpOLiEddndRb4xRQVURkp4hwCZmchjBVfIebgjfUzGtxDv+XT6ldKSfdVOqOL38B5f34kvuzoy0cWllNMu1O3O0Urz/IqfU6/FOiltE2SEoiS/Ptr1S9Ft1Nh/WwhhSd4u1psd+ib0RKq6RjSexGIKGD1meOl0WV+SYLvPB7VLEh5QU+9fMg7dyxfUd9zAFfc0weJAxeUnPfJZAjB76RqJC9wi5Uor5NIojNk9bhhlkoHXJ4zPwACOqjdQMnOaAretgcCiYuqiZpDasgvHDBYO4V2FJwVR9AXZ1NSVUXZxmzk2rCw5IJ/PaG2ZmTH3l66eT4I+yzh4zjJLxK8/KYgWigf0kcT7lSFpCovEw97QbcvPWf2fNiyjJyazASaRTK0+Xmgrlww8M41ryI3y0jnxs2iV1/kCwHwxHz4Skc2Gvr8mepAkCSJI3I9KcwHfVYtn/0nyZhI6GA0CTXxbJ0oSSyenRZAlliRLAFSphhcHGj4JYh6EbwOcVMTTANra+ZAr3lzJSbVQx1MXuUAF5GOkvIy93pUuI9zkSzQa6PmuxovfXFgRR1h/hJF/Usg3kD6AXN/h6n4oDy39kCkey0PE/JnO6+V70R8pA2IKzrXl2neXqnzW1b2bfKAtPtz2Fbk5+VSNz9Vk75OYlQx3a+CdG6XPdD+vOraQ04B4/401iKDMpwfCALfcPdraxw2tINmUi03hNyB8zoRGE6nD6q2jcuDLs1NPt06tpJvm01Rh8KtbFyanAyYWugo89ViUsXE/oT3759NTOvVr7jb3D8Q4fqbLDD6ZyplAs6Z6OVYuT9m15PKqZBioZk9nTPF6i32cHM7Dzz16J4Z/l2+ZA5b0tNnSnW+7ypqjjGdeNI9WOyMWTtSEKuGDPW6ZM/TkD5Eqy9O9n+KlqGzlyk60VsJCTi5hv+u5V8dyeev1MnRXCtKesdvchSBNzFx0quq616r03lK3vD5z+3KY/2KcugXrwHddBllaN7EnaAQEc5VyGddGOwc82gbBXf9LA73f8craFzxjR9rKCy8jiq8XsoSHNig9Ga/LgAzhMkPM8CNi+L5zdaBFyp5h7FbwuvL4+OLu9aQupa724VsnZhHuhiplj30Nj9/LxEVSUEm3vvjyJfPlY/D4+CvGIK0jPkEkAFtXXt6ToEnyaXjKqPf0tUwuclJ1C1NWIXrGBUzoZXsYC8nLl0T/vfJ61kOnsi5uKMrUw5XIq5gSEoPuyaj2xd5BKTc4bpK4JJvEMy2IKaUkeRvnIXuFPE/h/HA+Ox0BnbjOn+W22zHnAneu3Zl0ON+HO3cboQ2Qr/+03KY5Te7JJcGkaw4VzEdxIxkwrT2qTGZ9PLQpa/xfzcuawNy+dAtVFOMtNdlDbedUKUq/f9AP9jznuKmo9OD5OzOzE/t/eeZ9S3faPim+EQwCV2olYbnqOe4u8mRm0XjOMfAkX6E7LgTteGaeY1Nci5l7DZjm65QQg5TdSbsagq9MfHyMtQ4rvoIeha+UtBR/NHvuhhl7kfd6YMUQzehHwPBaxpA2Z/hqeTzdkQt1zg13+bfSUFvMbKeUJdGci81RM5afcwY5+/oF+pJGtPkkdwOTe4bxDViuM+hRjeJVy7fIy4qv3m9Lv39l4Zs0vnrvMk7EXrtk23frTvoZX/mE7157ibeSfIm3ol7ipQfIEu/wVuJ3eCvJd3jtxDu8NjTeoKvfxZ3coBCL96zptmeo4tqdh3TTOV2dLT5qLnsOFQLh1PUX0hnU+TGVADl+UO8L8Ouq+Mpi/Fg0auKT799+2//xl2/ffPdm8jfHrcdJo/Gk/9M3P75z3EbmUekkiMmJh1TiysfGnQd6Ot1Qr1BDh0I8lUN7t11jPPy2/46iBcxQUNf9G9ZifRPeQiNdY7Hb3XZfvZqDkHBHO+x4UTa/rh1Xe+NGK60duhTbg6SHcCux1jXKryDpVZxCuVSZ+LtWyZ4egN+CPPnNm+H4u3fj8uDdCNTot+P+6Ntx+SaA3x66h6faNhI4msYvllfLdrkCra7m9NbyA17u3TVeO01I3VM3dvAfcncvBfL+dre9uw4L7+7+cXcdQUnIs+wadzBD3RXoGaH7H3NMQswY1qfQy8PYEEhvFy75bmZjPwUSv11vI8D0ffeBXisw5rj9d7dZPgvhZcy9h8G8xbvrVn6EXYnvL+8af2+Uq9RPvq4cEiBarmLCLS4+kFCHBBsqkRv5o0RlRnyHPIgz/69SblLmIPyYzOf66w2g9e9tqK0OYw6LrBdtAkiplevlFg7P+lO4OQPtLdriY+z+MoLpAXX+HQYCQQQuExE4BLCB0bPws7+8C1ArknAbyNXWq6vtWQhdvP+0CDf0uVLuYCvzu+Wt6BNmxuhZuF1G3FKTW+LkmzU0gaktznwTraIbgI0gqpYbhsQIHrzmBmwDWQi0S6WgY4AJ9DlbIaqBIM+qZ3wdFOSj6QSIQa+MLrVYwGGJkCjvVtHuDD8Y8gv+thBMkUAQA3WAioh182sWNPYijanbu4uWwdkN3gYOsyZxQX0Z55B/tY1m9wUYvQIo0YuuqAMQDyNwu4ZGoJ7C60LmDfsy1MmTF1s4XvmL68b5vE+ysme+YJBUCHDx9svqrQKlYBx9EwEv7I+jZ4rVcW/NnOosrQ2cwPgK9Uua8EWZTAuyMtUAvsvw3JoxS7JGLP08rOZVo1CLzxNfWdfaeXyPlhRhqiLZzV8AVcDSivtw7M6vP+MA682ek/G5DseVb1TiQxlCD+KnJvFt4PiTp1flBPonsYWHjNiZ6R945wWf14PVXrzbcnpKmd0gKIZ87n326ykizKWI4MkKkd2KCqy586r4ftN7vzJfWQvHRu944/e//320jccNosa5R++X5rzC4cQP1xTX1k1icFbxg37CfoUGVoFEx7lbMTUE5oww4pvxO36hc90L+JXAa0uWQZsE/zrnEvi4jocOsBs0mLnLb/jZUBkd8qOh+CAwWyVBlhVIp5LQ2bV4Jmpu0qPUS0e3ycQ9i13XL6So2fMvw1Jp2lW92LOlFB/swTEwHx/jV4y8UrC3rhybHvpdECrkp5tyCCIZYPKWnpTTrtXFS91P4sdXry7UY0dhgD01V8WFtURPkatSCWvWn0EE6KYIAd8eRtfFFiuWVgMj5ywyzzFrnCkvC1SeSbawdRDmF440e+z5ocosnDxYElK06kYXmfrMFOBiiI8BjzrDcdhzId8DyMwEYNDVeOJBkdNThVJBkvISQphr8ilLfMtNkCG9IDmG4SumL+b3nJsk45nQbVfnnuQDxWv1Cw3pktKp5cy7NK64/HW2tzxNFQMI9ennEcmkn/I1vVwgFR/CvRLChXoT2gOe9fgofUA147LpCf4leax0guOi8YNXP0JZ8egVKLehD6gvuIWYpVgFrtEqrEFZxCfWANYCtBZn2UJ6ILJty4Wv17uCUYodoBGMJDJAh0ah7xkIQYsJbbbpb8UG+FZscHZmUgdFZYCKYPocxCSxcrfaLqLZ7t8EMZ/c5bWOFWlWOI/xgHfhJrug3WnEr24mPqOx2eM3FLB2qLKLB+1RJUdl/oEpv6utmShAigR6J4sX2a624Fqkyqi1dG8me4ETJK8XKGzlw47bttLfnLxyfBhh/yKAwfaxS5r1SvXLj+/+DmGyHsqSFDTUg7JZ3OuWBx362Kkohdi8npzZ8cX0jPSEQQPr6uYQZe9ZNTuqNlFRdn4bRiILdz/ZzzTHSsxClAFyJLHLAE09UJCtPZ45dfws5b5LSm9avXMeWsZiRVwblKEC7yI892C4k8jwpnT3WToxp0Vo5pxFBnZ5QCebbTGnO+Z5EppZGoJ5MWAhSnV5Bk2aeULqJX6ZpmaAtIs5CblEPHps6POfJ6XO7b0SLHnkC5pX40GB7lrWzw+aGQZPY1tO38oeJhXytRl6wwRoMAr5nbg5/4n4z1VC4skBEVe+B488sUtOLPAJ6QftmtiwFmUAREKvWMRvrnoRfk4xLPL4GNFvzv/4eEUxkgXRfAgLoJS8JNNShl4pRXYfqNNugnHJGveWEi5EPi+Rz1P5iL25grcBmlQ7cwEqiSqCF14JIBGnFbNLd3IkgH1mq9QSDQEOTkyiM5J1r2PPpuX5DEg04Xk/Q1MquutS1SBhylpxuSC3V0C8Xns3+O9Eqak+lEp7MatypnPycLmfL2tBeaZ4Jkl6vM/f761IV4a95yu0SuNSrd9ZrvXR+qQpGcsiHWBmdakQAa9Xr43iu7RSBlFnn2K/qJrM6KfFDSFq/M4ouSXjd4UIZIfCJvxwF21Q7hA1lfU32AP9aVd+K1k7Jdd72PqLEJFObxPc7Rbwqzq1FuvtDn7VphbadOFXHX659LUx3fO7h7rKnmVbQCJUMz/iKmN4RBe3n+hRd0A2tihz4O+S8R/kcoTty3T8TZtLAAmnoRskxyndjevA34lXYkPpiOU7VzBzAoiiHBHSqJyEXEA+p3vuO5xCmh+emwUh09sCDe7w+laQqXz1CPGr0qt49kXWgl56nsXi5xzFzzmIn5Ezw0v5aIejbPRmUgGZWzDBOBWSF6VSd4G3XhR5K6RXjDOWbGuBahnwDS3VqkIa1B/f9gDNs0rzyuCbaA0+13WNDi58WiqECU49dHzLK+ILrb5+e/AcyXUuS84dKqPVhHGxeKJ2jx5DuJwiFVN+HgBQ9hCC2enpyUyMuxm7ExVlmiIKGDCkSahlho5WTKTXZjwJuP4TSRYnbmLYOJk65DJ0dI9X8mRvz+8CzrTtoVdie4gcfXxtRhS5dmdB9ZndRYygG+YxrkSIywhy8aGauGKuV2xRV85Zh/bUWToXW8TrhCvCQxBXC3e7eyPP2sFXEnUvKopfsKOrqw4d44NL8uHzvxcv//7+1bTUff/K7L1/9dXvX8WvGuNFdVKWZW3JL9lS8S2XoaWSpmoz7UIG/Qbn+JC/9kL3KvkItdkzfg8zUn/De53OIYEHoteyXQmzyIkb3+gsrC6a1O9ddBJXRLv6quad2YjNTgNNUYn06oH0Gqbbtp35UOcPzcyHxqESTf5Qz3xo8Ydq5kP7AFAdTk9ebM00BD0EPQf5iY/8JNV/HwvWmnFB8aOivyDu6Z6Nfnw5bCANcYr+T+hCfb4aXLfCnQUpo1xeRmFfCtIGO8r8+BjK/GmDVJCxRSWqTxif9MwJSLBbLGIJ06BpJt6fT+DgiUpz0fFMqFU/8/Bs/QsR/CQO/OQFPMDGvF6lK025PbvryZ9ndtd97UHKmR0X3+jv8/wLEfhvir2txtL++O777/gV7qLG+//+3pzuDWDHq+lX71fsfRCXBwEc5MFImM9dsuXOcD28jMWG6Ym4pcK9rKjfxRnKS7TQzEquKb2FfFh8I5O98M2MiKiepP7p7TcFf323DAqr9a7ghQUCO+BFxueVlOrDuz0wll2NUJYhhYUlB84Vv1gGkg8sGuYeXc88EgvUgXx8NGCP9tpdfzN3lkJ2gDWr1y1evv9Uen9WnpbMLi5c719hIqR14b/5H2YPM5TPpl+ZkA4fghKeAyl/ZcL6eg1VBO7O7ZZL760yrOTnbvlus/wBe+YEFkW+lo4THu4VoNcF3kvq4HYCmZ4Wli7e5Tx/V3Cz14PM+OA7mlhx3Jf0trBzw2/K5dYhrQz+JgRgimT7t06Kxi+/kNr+yy8GaAZQXxEvNNDMJ868F3WBNJMWBkpdizNB7iYc3H8vSPkH3NpHxyznVv8ssRCo76Nwhn5ogfPheL43K5FvQzI2YFZZFN6sbu92zjY+msRfgNKc3Ys3BbPbYPEjKugah5dc6BwM5C/yAnyQOuEv6K1B3AWJDF1ZMcGwGNWcJX5MPpExTk5lv45u/wL0EpDvRLJI4pOBT9km2tiS+SQUachGkik3rEpz4jxZVBnFSL8SwuETWET/pWb97OPyA+MOr9949n7hjOwWT+Qmk/UZqNWiCB8qBpJEQ8cTZUVvz5bRVhUXxoRvIOnc14xXv0iPqJrlM9XnWbBmUmqelePRQ5sIoNMvPuDQd2foqRxa8fdusFcSzuzg9hwz1YwlJrX5FVs30rtQ+/PYzCV2gny5OaosJkH2m6c4STGwZCrdNijXKUdCkljjFCDJ5WxvyRMbqiHay5Y7plaom3TIG3z25PaX77jngTLX0dsnGtAu1SrJGF0W6bUTLUlsBws+mbuTNpcAh3k2HDodGO4tP7ldJrqRQyHzeNrOLEONFSrBiS8SeZID+ImvDKj8FiS+ITrFl/M8vvH4yKkfOSWUKJ/TBjbocH48RI6wIPspbqJwmUxldJoaNQWyBnnslHkPlQ9UeU7D0ur4seJIlPyQoPXunA11KUqHZGHW1OmxG8YDSKWSZKl/FqWFNdFnu1+AO0T+M/cgQimJ+k54nubxJ7lkms5laQjsFXMZMSw0+Qw6Z1E383n5pZfYFPHNqROITZl0VhzFcBnuwsIza7IyOxjpMmbiVd3i4dXGTOEeaGJ5n8uAA+tK3iM7c+gI7pVwaUDBNiDWKxIyQmnWu+Vgk9KsuS2E0W4R0uZp+BltX9GuwD0oEJfHjVXIINOAmt8b28Lv8NvvCvJWnXJhsN4tCp/CTVhY30Q7IGU0Zc0chnevXeOlUch5PEFnOiX5eBmssDTx2h7x3/PUjLpbbek03SSHq5Ier1xn6GkYfTadCJyy70ysskj5DJnmi1YF8zxMr06q/VBtXWS/eWwumsdOOzrjcnMWMV/PmoTOEawhDZ2jeEKYXLt40XJC6e2D6LhSq+n5lcx4siBOd2Weni6IkV3xAF2LZe9ceWecRJTzGnJGlPNa+kuk5LhFQoaLlBZ6eJHEccpb2eLuaPjVEJvEaAqV8Q23mTUREcKgJydvesVJbd6yHQS1P+0NL7EdF18Ipr6onTn5LTuv5WBSLeTOoFK4dAGUDNI/uYpt4eyscL++w/npud7yvnATuqtdYbem2UnzWdZQELOpgKeEATH3XP8KCwGbwKxqeSrcitlRLryZAUewQNndbguIWTwanl9vhG7SboBOGcBj+IK0At6bWwjxhVDkL1QBHebZlllx9k5PDewsam/4m7spYry9hdZ8uYNFCvSJjwfK4b80h8d+KMdq87WPfuKjf7ApXyX7enKQaDgzjG9WRDgSM92CUSJDB+v50exe36b05PIdxLuAYiXHzbsURW7DTUQK+LdS/8lsevO763hXQwUUfNzOrFg38H/lGAZJTGvrVjyYoLHY3ZoN28mt0A9OFG+FfqCtUCJ4J6KbG7BGPynWA30vcO9DGuzzPoclxzg3rEWptJcjN0OHFDTBeM/RpWE+AwBn9tQ05dPY51ipZezhT1AOV7g7qbctTFZzvno1bS7z0xz91knKiXLTQWkVlt7O7dmNCSi+tZKNJ+xq9tm1Sa9QJVMPFBHgXpl0l1PKzOYnWfva0WXSGFLi9In612cgey+dNbDCVckJpXFplaIxdZApId8kZZf4kFhQBhpKr8gn+VKUbBB9Ho5x6nPphaYLaq5SPYW4FoOcPNtFN23my2gg7fbyhcJgyruxeevAbo3TN8+95EGeTREaijhuJCpPiqfxFKPZLb/ysMXf5IyUhdMTvmjuE/4iZLZRuPRYboy/ZC03Wl7NnJPOdUAM14opwuCM+VQT57b05vj6Nf9JJx7dTBxzT2qQB6WIHHKRd57Af74FLWtd0a96mCfeuZux7V/uOCZNGmHanI8vPmS4zTxrwpcjGr4OQN2np3Hmrx3axn0OO0SQLpyK7kogPMt+IauTcvn/heVodLznONqonZSyClwprahW9kK0f7ZJLCAvQTW8KQk+3w2OgVViIR9WPe7XOyvG/QAk9LSoI84miFrVDZXFJCbs3FxpfzCanbm0qdem9FyuDBOLzxpBMz08pg7VHq8xja19L3GwSRkdY4vwnI9LP4Niwp3j91C6ARC6OQr7Mw2sSWPpEywcr09guRkaRZFZHSaQJy4yAxJKbTrgMwzaxi968WoP5c3IzTXgwyb4sNxcrSxBynsTdzryBt3vKeRQJomXebjTekF35BRVTmlEOE7TcltqBlj3umlXUBRfuG1UvjyzGyZWu3CH6F04OhWKfhdP5o+PkSl8O5Pkbs3x4gi9TyG+QblQBpZwB/IeSG5J0AGErFe5byYnBtTGoMaHMNBckOyW4n/Z3uyTbQr5Jq9dUXfc7jwkV3MSLx3lBTLbK0DmWUDQqSkNxNzM9OlyPt3nuZN5wp0MdbRoxQaVkDzJkoO+y3bAI9XCu8iOXbJ1+nLpTc8z7X+3LogrOguEJlDkvHtygn8pOxP8izxNoPBc7VW8hPekt1TUE8L0oulSYz4J95iLSq945l5c2GYJn1anHxXd1UU+hu6AvkfH2vF6VO/1a1t5cPXO0InmeSsWQ0kQosub07ACx7648NDLDVZCoNXzuRCgdYRdSWULVKAFFInQUhKsCwtYu0MreP36Naw/AXmiLR4dfPKhhLeysiC+MIV2hH74Euo54jkI0w0htoT96sZZyFvoI6HcrawAWkXyAXnhJmtRUIcpbtabsBDgpeJb8qGEXhea9cJfvvkzK+RCHw/4HVwCMvEoBXBMtNs7zpltHlR4GZfcDGq9C7nzO8c7y89XzslJMTgFZASnTmhFoJpcXFxb1yWgKsbHyjxfiuuWrvAOtSUoBrDgzfcvpbokxflWwmnF6A+Go/Hk6z+8+eOfvvn2u+9/+PPbdz/+9Jef//q3/3Q9H1qZL6Kr6+XNan37YbPd3X389Pn+HxW7Wqs3mq12p/TKEO6L6J/mpYlDTOfKhYMmjAs3NYnd5NTVDr58e7clxwIv3H0Kw1WhQhaaZq2rpnCKOmJ/0WYDyLWDhxQ7LbyosVqFsaq3YbVotGA5qNeAYOotUCarTSCbRlUdm7hw8GayCyfsuWde15fRGUT90lU3kAlzSAhK1+jksug1q/g36gFoZ/b+V+1UJ87Xapzhim9i1zaq/fjqGnV3hrSpaYc6hB6Zs8Fe5KuNtiHVuBUbFWRnBsF5ZnbxZ0A/dXffUF3djDsj3GD4vAZDU+7Q6TveQjk0EttfavN8a/A17nE6KYaGdTlN7KXl7rZf5VUoNDCZ5zqRR2qZBhoEDuz5Iz+YnzgJ1TY793+Cgbzly+4KUhsGggWZyhc7R8pphLfaHLYY8JJr0m8tj5kxJ0imjqa5hB9xKsE1eyk7QtfdJzbxnFksOhYjHQorlril2VrPG2jfXdGe0HOdAzr+oW54GV8PBBVobZ848EI6ua+nKHX7Ku0BcZ2AnF2VpNWdrAGaj/m1FPMTKp9TSV7vI9Q+mSy2JuhAAyUktiKyyaJ0/IH2HpLO7iGeWZcC+6EJFjx/ggX6BFsk0uXMN/5pis46qMwyDiqzc2YavKl0ph0JksUFOLCYJ2hkRsvGDH2ucnb8GCKyvkOGwgwfLcCFXNbGEufNLct/vC0nrWjaJv1shrdNJ/buAUNkFjetJDqFfZxF4gt5aohvhcTfp6fzC3k0JQfgUDgwU4vbwo1Y3NabIKRDFit0pFudrQHDS6ZkBFm5ewVWbJX4nuropswUYSlrp5iX7L0l15Yu+7Lo/ccbUdDxDxYtdSr9mWrrgo5MPyV80FtkoG+7G38hi81e6Bq00FyDli91XFqYz3An+nAX+ddnaGyQDVLKO0g4P+QzlPB5DZKZxMVQB72QtGRlJwzUDgbxCaFAsxyhbunSilpGtqiBp5FWs2h+t8FbBPH2KLx+KlQxGPmudnFBQsfJVie9O4jlKHtrktummbRcFrK17el1dL3rkj++vOfpkv9cx9O1/VP9TleW6TaqAG+24vO78NZl+6ym4mjPgagDJ4EZP8Dj4HbR4yP9sIwUnSWAzrErZhipR480hIIlKZZZSNZkED1/Pf5u/Lb/43j0y/dvR+O3Dt779f3bN1+/+a7/jUiqYra3Y8j07sdfvvn+5/HbXwbf//TdiPJ+M+5D6k8//KBSqwnoNRe6pM4XyTfJQnyph+hk5lyhPTgFEuh/W3raHtcPfJG+kMnSDVImekWifAn3uSiW7JgqlR5gUUi+YZ+zfF6v1p9WzOlxNziSDzijGYSX7RQxnWc3kYTyHnt2xPfHpFy4dsp5QjvClSNmzS0/R1Ay1aF830quL2njfnqtyRr2E15cKXeSlBNX5i4W7chmTmeFv9lO+HGgUYz2qZStfGGFac+j5TJrb54kJ57QrBYJGUEIA4EjEZPjx2cm+7pId08vIuQIq2LuycIgh1TuUa0CHiNylS/GZxTkL3V+63IqhL7LqaUXl/6A4sKhDMHGvokIrBFHhwIy74gbuBVlJzGLRK/lyTP/wES5DKdke5Sng/WLfR7YASe5HSy3zNHbICFiO86VOWdjrTz4K/Dray6Z3DvhfZkaBz2f7DbnxK2SYTY3Jn+dW2KvLjfO9rhUCqexefU6s3d9pIcLPU1oEM71/6Bu72M73lXO5WOwyMWzM+X4qM1bU89W9nNLZ2ZNLKSpc0UBkl6KzebvuKcyxZ5SCd9ZN20DT3lGiCOj/M40XyiSqy/L7YhSyTclhOk8eDWYE8TnVvnHGYj2wWGH9kjefe6nkBvoyF0BSeYaAzL78KjxrzF3nkEgytvVx9czfF1/j5JusmlFPjq4ae7nVe8npC+fVfuId/ktP6X+32BK2lTh/5N2igSV4It+POZLhCLrSCS3D6xbbDhH7gc2/oE+ZeRi4PRy9w69mDbOUpLN1cXm/Aq9kFg2Wl5eTS12Hr0+X6SMGmFqAV9k7BthZgmXHpxotpcL1VoReagWp0XaHTOx2C+ybpnpq9fEGxDQChtHtDbE8YIP4g0dky5H5p+KxxTz8HZ0IaNXJYJ8DS1fBQl0FURaKVEtP6xapCe73EHaJ9naYaF9Zn3msb0Vd8J9oPGvWFs0RsH/O3U5AN1L9xGvLbzC4AbpiS43DKw1PsBkfRKrTXhxZ/I6zKpFaLJGYd6WSlao3RBXyOayDBNy8NYlP0VAtGaljmk6t0CF4fni4u58AdSpGFu+7oMHskyTxWjIusaDHHyZGqrvvvPxcj0F5SUsAekJuicAfJwYsk8Lcyl3amZWCOqC9cm5ki9XwS/cOLHEEyOfxCFF5cRezRpsJmuQTgqu8P+2Ct7drrBaF5Qnqm4O8vU7Np6oiQqTs7KsUtWE/XT8feb4qhOVfLzIP3KCHFc9+U4W2gflFN1CAXtqbUsO/U0eYnU+wNcqMpvU4dZktAQUlz7S6mygaG0KFBhkvfAEIHUChGbxDnLXp9YOwajjAw7ioij072ADZ5AWe2JH4RuZdz8vrizvOWcPDxsfnJU1L948wRAOaPDOzT4rbeS6QNP5G2uGnhfiFrgLEIpzN7ewu8oIOKeVGf2I0VMYGPmHO3eJXsu2VZjzvW14nRg5CF8G04sDdfJIPF1rJa4Vb60THCsqs5mO+oF92KdEL1r+uI13t+4q5WqrXWp1LjftM8MQSzteUlfI5MRdQexuyX6iLmkzP1hPyZ7yHE1yKMdJ8Sy85CdH3M3OObwXTnjZ7vf5Zd6s6IXI+30ShzmHLVIXlbH6mbLsKoF8HpumU8q3nkXyk73yata1Qnn8IIOpjAqRVRWeNQktHRYvcrfGAYuQSQQdKb0xPDiG0ZT9UNIjuEiPYMrCH6YO2ulHDQMnYzcJeCsyI+ilNYIgz24iL7DRG9dP8klvmxiCmZMyZszM2PoSWEkNL0xr7fkKXpjV5jkj2VNme6mVyWbIkkYt0S9RHf2mErRJlSRi0H6k9+v3s/5yKaXpg94zSTG/l5OmHm5PDgl6khXxafe8Itv1TVjMPRnPO2smPY+gA54+QpOYeri7rRy1k00l3LR1Qk3bauaxIeRw/9EKwpxvfn5IH/WP6aO+9Ac/ptEiHcubC9KZTFN51Gl3TNAJZ7wuga8ZYssUX6jk8C64dJXT1eCZeayr+arxzKTpXDwJxLVO/JeuQjDzGuGrlF7eEJeb7vF+5MQgHrz9zM+6qynlmpzWgpwHToID7HyW4UeawZCdiw7Y/IAPKSvfQ/7s1Ow1RO7CFPiQOTyTXEFie+bTFkr0JM9ZQOb/ErOi3v7Ti8Yis2hkbFALsWYog/lcKqs6XnXG+SwLWvgiC1p41IK2f9EIoxlt4G4jP2tLw2ezn2VLC1O2tN3mzqfDAYkvT2rC4bM0YfGYVmy7cEE0dC+Su/5SInRBTcwTIWW+S3eqrH/qwKS8OBXK+toVvEcL4VWqal+E7r18voCmJIxDAlr4tIAW6vNr5iipWwkVAvbEOxGHbkfShFp2CjhwW1LP7WavSTpSWJ7tVSZehdHZNPYq9WPkHj5GnJKyz4pPwHxmq0mXlbyfKpyV6ntP9vLM7lZMC3lONyzjHxAdXigehf+MeBRPBXoNpph/Y5BE9IHq8VmlJBzHpB16/u7YbNNnVoLNKjrw8JrsMD27tPPJ5CN2rjvA+7gQz563EAdPLcThyxZi2dkQTVsHOhvKzmaIPhQapOptZsnOW+JN9g5WJzKZdWi15MEtbqwMpDu1nER0te6L5o644/ZZU2b5/Jmyj/2zj65fqWlx2MRJj7QetNuoczdHreILGNbFgWFdyGEN0sO6mFrXTqCNatYhQN3ECg1EF+oe5CgmlWvQTtE3XqtGUynVAdnzME+zDNITiG8dyt2Xz97Uggv6gYO5oVRH+WyptK7PEnAqxVMejk1f5jIzrVnuaVp5T8WVEjjDlLdAytxSKgZPk256zcwcTH6yFiDmVMO94Hn8PyEu+0d9FfxcX4WZ9GfMsVSRaHKljJ5Xh42eB2hd1rDfz4uHWnmuiVTV8LLtEhQ/3/ApmqwA+oI3m1K+dtqTTT5bTjXWIJ7fFAfq0CSIAfzypxYGTqB7qOsOed/iVYIbNLwX3RJH3FWwvimaXxW9M1e/P9HD0/PWXNxdMb8QQt413kGMLx8tnPmZfY5eWddWKHf48DkZ7WaA+fnsIqTrAKKij1cBLPH8KW5noRXdpcdYcc7Qr5INv8X0gci5BOAK5wBHriAPerX4sSNi4slP88GjJznxrRv1oOVLDoVk/DK1syEunw3REITHfqEDCKVke4TT2XINKCiGZ4H5qmqWAuvKiYqQEcfnJD7Jc4XXBPX87tXrSg9k1td2D3sZV9mdow9txq2kF17Iva0eeg53/a5/FlDpgDa0jpf2u6BE442jwd495JHm5nqkuUImd7RjF3MyirORKNRuPzLlZrz0Li7iJQZyS06Uwlt5c5XZ5IXMUIk4BnVmk4KL8lIxpBe7LyGNkEo3PPNe2dlZsFcHNY8Mvng4Ufnvbg+8Q3eiKW/GHUhm6Hnu7wxYP/D8sHusXlccFfdwK97PfQNOz+7HL79B/uvw/tN6ExwvIjKJUpmHRJ9V7lif/VSnk5dJC6dCl50KDeUmuTW6nACC72bmgtzHcfFmp4xtoo/AfVVsvaNTaDJ+5y0jX0S2O3enIstwZ3TlxcvKxVBeybzXjw9o3O/EOz2ly8Tv0Sve6J3AHGCX5DS35DtirmJvFmhF9lTtr5A7ZLWrXe+Lj7oDTdOvlfwVrA32nKwlssK0kDnwMXDxE6R9+XO3uRcF64mCuErJPKgnyN+EGPH74zoK5G+8WkflhwVVVNpIVErzS+aiWRRXC71WMKFKor6goURGGKXyC3rOysj27haWcG60mWiUf6u6SQhQWKOb2VQdhHvVC3r5VmGaXp4WDbQSDQjCUHjGlXt5H1cDOlmwFSXbiZKSILS+krISg+fdzeeqX3YlSQaAGHflY3eOEecscz+0gWJpTABxezOXRzpM0ev85VWkSf46uUkAePnoqgrUaxmG/m6BPE8IXDzgC+IzjJ9vjserL7TToSBPnvjlaPsGH4Wm98jf7dzNbvyugfcjJq5i9xyb3njR3gDCzdFsnV6mzh9yqsxe0r7UMVd0zxqNaqdpfmVXqvUSXkHfrFUrZqnZaNSa+v386oHumYXdn/OGQF73sRd4iVBOd5uWS5cNBMrKdzGD7vGdOB7qInH/XNMi0MQxUQcAszuUEQpY7mtnlsB4mCl9UqS+XDig6IRQvlWr1zTMeA4+nAJCFe7y4NH2+FMaekZsc59F5k2CDJFA8DGKFKElj4ZEnIkJeO8/f1n04pevo+2feBGD4QZNS4s2uwFE34bbcPMxDH4WWWaZtGZ3zmm0uHFq99rSe423M2DhRU5qsxslUjHfTSql2V3tn78q+5k3W9WT3yepazlwpfYOLc76Ufl6Wx7PbbRSb0Hk5Hh87LRkDGbD42OzIaOtygG28dqpt7l4IzHDEoylVmWm0uE/9LwD/hXJdrMCP14DBM0K3ioYe4y+dpKklqjVrojiNf7brsp24FctIQnwJZAXDk5q+fJDgU92ks/mUMwb6aTqOXkfdQnfPSMGYb5CtmGWmIdYfm45lfn/EI9hBhO/b+rnP/fhXtjVds+/dKfdefm79aq/9aMoxVD4knQE28x/EYQrCQ5V8sOhOm7zAZm9CJAP+YDMngMIsdCHA611X12+/9zvv/88aMB/+DusnL3/PGrC/zb8mMCPCfy4q1SHNoVNiowoMq5QZFyncEjhGMJaiz7UWnUKmxS2KOzzhxGFEwzb9LlNjdTafQqHFI4pqW9TWKPIpEFhCyP1tk0hVdmoYmWNmk2RRpPCDoZNTmpj+40RAdYYYzONCUcmVQibVYo06/il2RxTiFU2W1S+OapRiO03xxw2KaSsY8o6IVCakyGFmNSyKxRW8UOLYGzVRxTpYyWtAfahNaSCLQKrNalTSJ8nmNKuEGxtu0EhJVXrFLYxrPPnBkX6HBnQ90GTI4juTqWOkU6tQyElNSoUEu47TQSlw93ttOlLu8GRIYUIfadDHzo0HJ1+m0KCvjOgL4MqhU1Oora4+SEiqjOiqkaUMppQpjG1O6HSE/zdr1Cz/UqfQmy2T3js29Rsn7rdr1Kz/Rp9qVUprFHYoLBJIWWlPvcbHSrQGFKI4PRbNDB9ItQ+97bfHlFIwPU7BBB3t0/d7XN3+9TdPnW3P6B2B1yeOt2nTvdHlGnMIVU1wa8D7uGgMqQQezigHg64hwPq4YB7OKAeDqiHA+rhoMbFqVsDGsoB9WrQ4N8E+4AGdNCisE3luIcDmmUDnl8DGtBBp8qRBoVUb4dydajezphCArRPVfXrFBLpDPqUtc8VUv8H1PMh93NI/RxW6PuQOjrkKTGkjg65o0Pqz5D6M2SiHDaw5mGTilB/hkSZQ+7JkChzyD0ZUk+G3JMhjdWQx2pI4zPk8RkSfEMan+EI+zWk8RnS+AwnHCKyRwz9iKAfMfQjgn7E0I9qfQqxqlEdqxo1aJKNiAGNeBxGBPeIWd+ImN6IwR91KFuHvxArGA1qHBlQSDUPaUqPhph5XKH5OSaaGBNNjIkmxswFxnXKRaxx3KbP7TqFLQrbFPYpxMrHHQJ43KHPnQ5HEMZxn1ui4R4Ttxr3KReN9rg/oJCY2Zgmw5gmw5iQPSbQxwz6eEggcAdGQ0oaYRuTCpabMOiTeotCgmHSRKRPeFmY4DDbFWKDsO73MaxNMGxwUqNBYZ8jIwwR6RDSh2aTwjF9blUobFCkTbnaYwz7XNeQigxbFFJVI/4woXYnCL5drbcp7HMEs1UZlioOPYT0nSGqEkTVJn9v05c2f2nTlw5/QSRCWOVIg8I2RxDA6pC+D/k7gVkd8vcRtTmiSA0pFMIqRxoU8hecTHatTa3VkJ3bNe40rasQcrYJAlUnQrObOA4QTiiCxGs32/wF+YPd5AqaY4qMCcXNCXaxxcPVwtkDIX1p2YjvVpW/1ChS50iDIoyjFjXa4gFr0YC1GOoWEpfdGrUoxFxtrqyN8oXd5lxtJHkIWxRBTgAhAtge8HfqbocB7NiI3A6PXqeJfe+0OILLgt3hOjtI73aHK+gMgYfYfa6gbyP2+wxHv4Fl+jhRbObyNvFse1DnSB2rAXZMkX6FwjGFiNvBgOhigBKGPeT6h1UsPySxAf5gtiET1hDlKHvIAA6JsIbjDkVQGoOQMEg8DUKqc4LAjrjm0QArG3NkQqQyYVKZ2FjzhPs0qdOXOn8hYp8wuiaNFoUdCgcU8meilwnBN2H4JiiSQNjkyJBC7PmEKXoypO9D/j6k7zzzJih7QchfRtTMmL9QNycTrmBCFUw4Gwph1QoufhBOMKRZBn/wA3ARClsUIjKrtl2jsEFhh5NGGKKsBWGTwjaFXKLKnycUwcULwiFHsEWbhhz+0BdcH6o2EXjVxrGq8vjChMYvwxpHGhThbEOUrCEccIS+4MoEIcLKo1gdVRsUtihEkEZc16hJSSjGAm/gJFxxqqM+R/ocaXMEqx8N+MuAvgz4y4C+DPnLkL4M+cuQvoz4y4i+jPgLLqzVMQq8tQpNA/jTwrBqU6TawbDGERTYIGxzZIhhnb8guBCOOEK19fkLcuMac2P4g19sbodGpWZz1Tay9ppN/a3BHMNwwhEqUycU1kfIbes8EToTFPL7vNr067j09OsjjiBn7Df4SxMZW79pc8SeYIhLE4QDDOv8AVWJPjBOinSwPLPMPukM/ZaNTAr+UKRapQhSB4QDiuC49Fs0LvCnhSHpP/12xaawxpEGheJLn8IhRapVDBmcdquGYZvaaQ8oMuHIpEXhgEKEs0Pzot9B8gIJmMp3ULzod5ocaSEGOu06RXDx73eG2I/OmL8j+ULY5Ah9mXCdE+wU888+ifP9PgPYr1cprHMEoelza33UIyHsUzimJOSZ/T4KThA2KKRMgw59Rhmk38dlE0Kqd0Q47Y/oA0PZH1ONjIU+8hAQ7ZF44E+Twg5HEOSBzV9s+kLsEf5wpM0RysbYGuCCCyGNwwBlkf6gxV/GCA4zAJAMaxgOOIITDMIBRXA4JrxQTfq4Nk36LY6MYAJNBvyFAJ2w7gB/WhSOKJxQEmJ4wurEZFCjzDTb4M+QwjGG9QqFNoU1CusUNinrgD6MqBGSeWGiUPMjFCUmIxK8JyOUnCajCX8h+McM8hiXUwiptjHyZ2DciM7JBOVoYN8caVCkSdlohZjwCgF/WhT2OYKNTkb8ZURfRvxlNJy+svINI/8ac0flv9LcUeNI68W2jw5HSDBvDKgIdbKBUwPCOoUNCp8wlthsLCFThLScNDtsOUlYSzhC9hDW9pvjNoV5lhKygZABRtpIhHWEv+RYRJDVx/aPwVH7R3tEmk6b1Lz2mA0YzRqFbK0ge48ygNR+QwMIqTwdwnCHcNsZUkGa5co00jpkICFQxlyjsJDYbCGp/QvNJTWyk9RoQIktQ9iikDLVB/yB7BwN+4CBhVHbb1EbbYaaUPsbW1sIw32i3v6wxRH6wijuDxPmGEoitPYZrX0y4EnjjM3GmdpvbqkhKImrQtiikIozLgd1tt40KWwdsupQvYzXAZGsNPFU/1sMPQOOEBMZML8cEHUP2Ko5INSzPWhAND5gnA8I57wGwp/ar7cXUYSwOqS1Cv5Qtjpnq7NBqUFhM8e4RBHC65DxOiS8smIFf2q/jcWJRn9IXGDIiBoSooaMqOGQTVIE56ipm6foM9HrkHE3ZNwljFU2G6tqL7JcUYRQN2LUjQh1I0ZdyqjV0o1a1A6ji1SMtIWLgCLU/Xpr12hIYA65yRGBSZhhNQP+UFuMkxHhZMTYmNR0Y1lfN5Bhl8YNjtAy+V9vLaNWB4Ozo4Yy0rHgD33ntXg86hwwodltCvEza+3whyLE3Sc1Mq3VOGV8yNrGS9+EUDBpE1In1NUJd5W0dtC5mpo1DpVbZYfrjP7/ZEhrjDgy+W+3qtV1q1pdt6rVjlvVWlUKa5qFbZS2sLVQGLFbbHFpjXG825UB2dEq+KVts1HN7hwyxz1le+MynSpZ2GocqVGEeNLLrHIdprLOKGGiG+gmOmyUtUq7jzoshDQS/TaVYSrqdzrKktfnBkihtFnpkpY8JtYBmcAGTULLgPA5YAgHk5pmysN5aA95cIY0daRdL8eUxx0ZjqoU1s+U+W5IpDBEaUWZ8gitoG/9rzXlVThE+xYZ/6sV1FerFTS4Hjb0Mc+BPxQZU64xmeUquOP4P9IQ+HLjH5H3f7HxbzTmL6jdHbUETl5iCSSzYaf/P8QqmLQEkomwRZatZmukmQVRjPunLIHVVtbEx5EhmQUZ0DayxH6bzV559j622lVHmr0PF5C0vY8jZFbrkGjWJ2arzH4J416tqRv3yO7W4Aiymoxx7+wJW91Et9U1/4tsdfQF+ROECM1gwh+QAf+LjXj/DuY7hm+Myu9kXOVIlSKo40JIdj1ax+DP5LjFj2bGhCTVlPmvNvmtjYB4BvqL49MXx6cvjk9fHJ++OD59cXz64vj0xfHpf7fj0xdfpy++Ti/2dWo/x8Txxb0pbeH4LRybBl8cm744Nn1xbPri2PRcm8YjIA/U4kv4I5A8rAwoHFEEhwzCNkWwdQiHFI4onNCHOkUaXL5BkTZHkPuMRkSyoxH2azTmL2NcS0bjPkdQyQFUUGSCU3w0qXEE7QgjXjJHE3T7GPGaOJogjxhNuILJsEZhmyNUwcimyKghOmnrnaTCQ6akIa6REHIncSRGvFaMaJUY8fowoi3q0VgAicQxYoEbwCO4mhxptkSD1QRWGxS2KewzOikJt3AgbGuoZaRSpby0Aa00NaSiEjnibfwRrXAQ1ilsaLDbFKlyBJfbEa9qo9GAeoUUMyIxBjuFoc2DYVM/7QZHWhR2KFKjLwzSuDXMjOaQI0MqM+QyyNvU0FKXc7GGO4fx0NoChTUdhfW2hoMBdXsocSDy1zl/7SzGbJsjyAFHvAUGqGsTnmo8xohanqFAolUKKYlLjqil0ZCoaYSC1mg0IqoeDWN6GKNAjqijCC5sCjVolxuRwghhn5NGFE4YdRTpcKRP2QZiVowJdTQQE1xFISTStmm6cGMT5FkQ9hnB9KVGyKTRmtS4OBHAhGbtpEGZaLsZ8C9x3dBxXSN6qrcY8X0N8YxIwsNwSCRKwy1pq09UxXNpNBpoGKoSpdV1HtDv69O+IwBpEiB9MTepuclEI69JW2RsJSaYPrWqNEOQT8PUqVJSeyJKtbVSk45stKPX1RzHHR7Va9PHS8qDI9C2cZEagbaEIVNyu9mmsM8RykaK3qjdqk715iYSiJHeXHXMqbbOosb1pkjt66nEKNhGMRqj9DtiXw6YaCMNmYRsOdHqRAhNJhfU7yDkwZdIsQeXWmEaI0ElHS7VofrGFc5e1QEFRUKk6gxvLOdkdShSKRTEVp0k0E301RKcbqgRG82aYUewPTFWtQSlNogSG03OMoz5I4E87BOf6BOh9omJ9jtMx5SVTG0jMmVBSCvfgFc+WlGAwokGKsxYWxyh2c8L5MgmhmA3OTKkcKyx3NqAI2NtHST8jurEZMjygeyHwipPiwazAmamxJqH/IUYD1t+AMMUIckeZg+NGcMxodkLSxSP5lhbQYmyJ4zqCWF3wjxpQpxn0ufIkBjIsM6RgcC7TojMAeRag3OEshAdyRlf4QVTLCQ0havEJlHShpBYAS2x46pYYOhDrc4R+kJoHNeIk9Tpc53S65Re5/QRzxhqokFNNCgrEce4QQUaVKBBBUhGGTcof5PyNyl/k/I3aZzHRJbjJiObFoZxiyGjOTRudbR1sDXWWT41RXoJcHZqkbSxERkBcYA5Qtn6nG0gsNzUOdF41NTmpeQeTZ17iMGup7KM9bGySdqpJrO09MUV4BOpesGxPXqm63vrv839/Yvj+xfH9y+O718c3784vn9xfP/i+P7F8f2L4/v/bMf3Jm3C1ZAVf/GC//fzgu9/8YL/4gX/T3vB/3tsEf/Pc3z/TVzev7i5f3Fz/+Lm/sXN/d9mS3g0GR3dGB6Pn7k93P9tt4fFFlS/82WvOLFXnDDuU0hbnJXhs7aPa7yvQZQzrk1+xY5y879+R1nkJ8w2ea+pSftLLR6AQT+9vTyciJo6Gp7JVj/ijZkR9V1tPNe0jeeKttc85A2iIW0tcQNP7j+LnZPxb7ILPeZtJrGr19FwTyTw2+5PD7UNSNrnmdAYTciwNyLZWu1ft/RdbN7i5B0v2oGVm1ytet7+Nm9pS/bU0chA29OW4zlKTAiaKgPe4KbNObXbPdLGg/aexW53Q+zWdrTxGLR08u4k9sEp5H6RJ4FkdrXcHfJx59fskBNPGvJcFBvlCWyoXXNiIhzpt7T900Hzf+t+uuBGzU56c11NgoRLSzOz0y6WI0Lkr9h25/xjzvhvtPseL4wdgeAaccdRkzfJCWGj5kh3pOHd7zZF2pytTYsmbzSP+iPe1+URqn/Z4P/v2eCncJyYUrWmvpVPVD7mvo6bvONNnWjXeY+bF5GJvtUtK2onmFCTWRHvSxOB2QOetTaFNCrkGgCSJn/oH/Q/UBy6qTsj9LV1tdH54pnwv9QzAVNBfbvUhn48wVO6C+cSH6yw2nanikENgzoGDQyaGLQwaGPQsWDxqWBgYwAlqjVMa7csu1ptt61mo9rq4BOy+Oxrf7Nx74t2tW1a/Bgt/KRXcHx87c977XRa9CQMFH18hGizQdFOBWL43kaT/3Ya9BZNcLzO4Ok6+ZUPjx8JSbXg6q+yjEI/unGXo2ge7eiFlD+EnzlyBZHv/Z38hi+t/LyIduG7W9cPu0uI4tOPP4abm2jl7tab1Gsq8rmg7srKefGnu87L3Oze5mRudj+84FUW+YrbsUdZDr3EEsiHRxx6dDR+Xkc9KEZvkPP7aTQ848+3m3CLL42L5876EJmv8B2mzKcBvViYSR66y2U2cb0K6NVKN/ttIsDNfIgRJxK+geHauEsZW88jP6e+b0N8uTOT/F34KZPGb6lnkt+FH+7ClR9mPvy4iLaZxJ9y0fDTbeDuEjWot4vUe1zZF2KeM1Cj9c/4ZBrQ2I7eu5NoXG/erHIS00npwkfA8l4C1mC59q/TjQ3wPbd04lC8aJZOH4mXzTLp+R0e39zu7jOJCuG/Fj9vZumUb1wvXIZBOvktYSOd+o5Qk079EV+vyyRuMuD/xd1ErrcMgY0t3Y27i+kpFwU/R7vF84Zypj2Fg8P6+Oie0KCenvIo4pNrcibqre+1Fze1Rxf1kU9gTL2P7i5hsgInDbmdnpbS5dfTaZbtzo/hOGd8csfx+dgByLx1cL/X3jzX37TzxCNr+KCZR508AcToPUy8eebFnUrPEZdel1a9DNY0kxSu9SpxDA7UU4F6EPF7fobUlc82wdgm1r2Y7un5MVV318MVCNnmTp8T9GQZPxo85lcz6YWyHzZrIL4bfO5Sg687t3YbN1pGq3mc5j+5hkGZj+FmG2o/0y9+uqmVrODiK3f5i9lSPoDnOw97KOmRaOHiW/SBGZQX7vb7TyvowG242d3TC2/4nt2lO5VvPKO4YKyJ4wPGvRNGNL0rhQ/RmV365amHsXz9IanQmsmXBwloGBb1pKwP0owcHs9xX79+bVuB45c8i5+KNXtAC92i7wQl23LPHK9k5zWy4Efq6ClofPJ5tXNcfv/7Orx3vNTLoow5+ryit10tUXC3cDz+/Wnj3jo+/96EM/1pZg9khvz32ASvxxdKBd7cBN5koiLkLT04ZiSe/9KfN4Q81+X0QsvPpMn0H9wdEj8MGT7EigMYhVsDMnj6g2D08LR84Blnl3xm+dx9DSNwdubiG40eDCJjxHH8eBZlOeJNkTDIlaF86p0rDiHplbLERTZHimzC2yUIkqkSW34amghHPbjmfIBc+mPXCvk+vok9Dy8r09eu+kmTjF8MDYO3mOhcxl8t+dOeTi0kal/gBeg/VQyyOCi/q7IgiJ85tgXSdSUndyWR24bcbtyxHb9ALZFxObXm1gxo0kOueBJwIZMebS0gpsabDYycAQPt+ovh+oZe9oQvYbAtUF6YxzC2N7zo0CvMJwv13q32wjOTgE+PWMq0c/9idu6XHNucw0wOL32AdZ5GWcUKVMcRa/R++9w8x5cw3QBIWELluPETzsfaElVsi7LJhRk/qgdlbgBFDyE+QtzVXzSmR6kFv/AuXL2P/KI6wJkettcxYYiHprN5kN5Vrl7RT3fr8TGbBuOGjz2nUrlfAZLd9nYZAVF7lm2aXQ96vVcddNQTqb2oTHJeF6HPEJGC3Z5CxnfX0W0X3wguVP6/3q6vx3Ebh7/fp9h5GdtYzrR7j571FXdtURT30AO2LXAwjIETO4kbx87YTma3M/nuJfXHFillu33pPmRiipQoSqJ+JL0I/T72bCdU4Vz/RTstHb+vvGGNnRYeVNjnIjvZu40ZShKNpST5bzRVdSGLYNgKHZ6zDWztXttnL6EoLQ3HbrBQjdt1GQ0JuXg0mHrhoeZYunCeVFv/7Md1ii3UgBLPZcOV54QIeHyRyngDZDia+gEq8HAkleEJ8Ng1lbEstiP4/bYtEaBQ4/yALbuyYTMVBOSgX6b+D0JPbLNfDdXB26bRReCah/XNCcjRH/BhV3f0qAyDTB5N8LEeww0kEQjc0yvxPHiRXRoI9sCL89JA6AffNQNCg+bsdubTkE9Eh6kfLwIPFVMZOsL3Ckj/u23ZSoSolvc7/dvaAX6/xcrQD/dWAQlJt/wfjvVapT8s40xQHDLOTYPBL7ghVMoDKuCxVCpjK2r/acPbnWds9wPGNBhFQsgZhPzAD3VHsUo/uIwBYgRLdih1M0XgBi4syoIf1c+1ux1LiuVh8/FIC5daaWeZwnTLT+s8UrbRk/BbrIzH6nCYdFg658VARtGpH1eDlzZLA5k0kEm01E+rIc9U2oCL2pcn1bbrcVNjaNhMRp5TkEeFis4MBSEClrNLRQoPZFCR+vk8YAGGZZjvqf8NzRkN424lj0Rc/XYoD9SmviiKmfUyY/vNnbNPi4B+8dvG3JHzQC0soZR6GSbwE5NpKFkJH/BrWc2jsEdsPR1ppuoPPvGEVeplsAzHtyVdesv3CH4u0WVXP9cHjHwmptO1FpSxNKubICwc8+4WBORgWdhUZmWBJ9tSmXwDN++W8iwc/CJBhMzugkzspn6qFwJpvDSY2/M4+8Fn7HGV5B0nbziW60pF6gv+39Rt5aosCNEFuisoMo/aeoNdREOz3U1REcCPPosAj3lU69UdbeMiyluCqDGPjmiGw4gjUOqOOAVazKNy2J7UXAsJFHMr5AFET28BD7GdvCc2CFyYR+gt2xqPwDzuqLgWdGh0XlSWABFnvpi/cNDhrK8HDfOoqbDDkc6tanR6FxDxc6w+VvQMcQ0nom4kQL1tGkpYut2GgGIe0W+qI9eSCSWj2VynlhOQcTG7DxTzIoQLiSpRoDEjaAUKCQFRJAj68mhUWdGouA708qhyjnBxDd1xNlwMe6+R+cQoyyWo9gVSalo/NHbZaiYP7YkNxGAeLj9eN3byEJ2Uh1oWS+A+sf4umwv/rrIFUKDZgPLgBk93kDMEBD+z/ZwrHJf2R6b1n21BDxc6m8DHg/mVhbyCCfN5Ea+CQMnitjQHbzPYixHn6eE9e3Zmu/hozzvsHtTLbbYXbDr2k2Jz0F4eHfDRY+CQL4/2NZ3Ac9meyEIS7+EEOMC74lc9nJe7aeJCYDzR6EO8vJgR3exrnYlxnQOoTrK4gI5dRBLPscYAlHNPNKnOURyXVhAOZyLRGzqdZlwPDb3EoDY6VcJUZwuIC52I4jqaQ/Zyi9xPp3JsiFFAuLzwMFuumel88CkJ6EaiHKyxWTKgZg4/drkru6pVhx/XpGyb3/F74SE31pMH2lhrCK4x7z0GmPrBui7lawvwLiBjZbPFOEJzzphplxjN1fACqui1oY8tfTTZi84jrkGlCTe42Q79uU63F9jd4wGYeqrP2KpE5hTYeIkptwWmIltJUerQlZzLFArC3TejfqPH6S35xn2yKVE7BLxL4ObrJI1NRUoXTFS1E27eJRdYOcOrQhYb3Kl/rUC/mMAVKZPE5uu3c8b1Yf1++/D27TpZ6VxtSan6h7od6zeWklx0YY/qF1uoYKeqD0rJx8f1aVBzIX0Sp2hsXmzCHbzK/okrY9hVHrttxskOv3q/US857TwOSmHXcUVGp75tOpdIobGh4gZS9TfnFSBdiFGSRi5OnIoWcr++in6pQCitPqhsNzO8tk4F6wdtXjVnKnFen3OlXxbTBg5MXFXonCIoU8KoF9x6YgbUDRd+fKw/1uvTxHbuXLarwSnDnTpduq6gzni/YgGyeUVGOsCqQAprVWBe39OVpaYIlVIHvOleMdPdO2OGRA6HWvJJdT3eXZ9Cp9iqJARGdAru5jB1Yuol3vCThn6VPElUXONfi5MpHIPg3iZyPdS9qdx05pb+jdi5GRv0pbZ+PfT9ZOvXj4/P/bAni9GWk1Z0aNZual38lTKUDS7UqlzvNbG8n5+zLGrsGxLRN5JbowvyX+NcEWeydlIRbggpvHDOi0wdZR2OT18WEUU2Y5UqxI7N0xqXZ6pdvsRIJ8LWtmztbpQTjHrr76CBFXTwBC0cYEBPt8czPT2YfpdVUiIw0TUzOy27EHjxyHUg/0WnnKq8JKusO3/g5m7cdt5qWEyVj9V7Vxn22x9jqhFm2WRojaG1Vg1z2OPxXikEq4RvgCxbv762zrsAD2sTcF7U6zvqAFLfgR5V7fYLekRpY4Npnq0vtdFSm8QqQHJdplWAp6wzPnql3DLsM2fB86cCbvb0eoPYYMnMZilxZ243r/b+S7fv+me8vXC8NzTWm+jt09voPkI/nO2t79ZLEQ932bvkX9nXyjaHbJ8PBTr8Lj+gIhWbAr+DqyR52WaV6G3r9nZT5duCdXGMG1BERu3jJ6Bxk2SV6c1DPJAfAD+dxKvaQ3rOKPVbrHsKyCw7TnPPg+3sml0uTjeJ0lbp5ijGdnuFJ8nZxxf6J3ylh79OcHawzEf7xhleUVBCrV8qG+qNcbMxalFlmkIQqjbf9UWNsLDlpl7f3SXqjc0WcQ69G1Jv6O2yRQS3oN7wpe3zfWVq5Xd3Mw3nQUq16CcOgDcbeo4J/UWHPuQZPcgx6DXOCTyT12g9rzH4XuMpeyFfn57QYFnAdyBlhxsgIqYIvUg7n6vBfjNTbrnbaB238Wxog6FV8pCfF7dR3WQLIri9pce1/rPRf7a3t3ZlNHKtEojFId++vlb0J7m9/RgHPUfleI43T+q+Yy4poOLsh75ExdjTUXuY7PPaxkpdw6oh+ZfprtyDcWI3B3aAzZI9O0sWcIqV5xTH7MB9Ycd84YguqAv5ws7zhYe/4gtH7QsRRgjvNbne64hOcCrwHjzkR1Sk+YwvbPDs7vHK4r3tmS9s8n0hvN4INMLiwYgFcrwRuNdTB6SBfeL6PtVdSNI5VI7MPHArPCD2hJuidX1dA0e3lwMcE/J4bDdcEAN/+NRN5ccMwcWCRw707pVxhQN+56+BZROSftU48L8aHc3PPx3JTWbog+8pUzz0LUb+CBCr+3Xbd/X33bkZelWNcAGpDXvilwtCpOpCMR6Cpjj6aur7dvwK2YdPd8e+6dR/rkguDoqnjyT5xx9SVB3AzJABAA==
-</script>
-<script id="@tomlarkworthy/escodegen" 
-  type="text/plain"
-  data-mime="application/javascript"
->
-const _hsp23a = function _1(md){return(
-md`# [escodegen@2.1.0](https://github.com/estools/escodegen)
-
-JS AST to code (the inverse of Acorn)
-
-\`\`\`js
-import {escodegen} from '@tomlarkworthy/escodegen'
-\`\`\``
-)};
-const _rg6wi4 = async function _escodegen(Response,FileAttachment,DecompressionStream)
-{
-  const source = await new Response(
-    (
-      await FileAttachment("escodegen.browser.min.js.gz").stream()
-    ).pipeThrough(new DecompressionStream("gzip"))
-  ).text();
-  const fn = eval(source.replace(".call(this,this)", ""));
-  fn(window);
-  return window.escodegen;
-};
-
-export default function define(runtime, observer) {
-  const main = runtime.module();
-  const $def = (pid, name, deps, fn) => {
-    main.variable(observer(name)).define(name, deps, fn).pid = pid;
-  };
-  const fileAttachments = new Map(["escodegen.browser.min.js.gz"].map((name) => {
-    const module_name = "@tomlarkworthy/escodegen";
-    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
-    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
-    return [name, {url: blob_url, mimeType: mime}]
-  }));
-  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
-
-  $def("_hsp23a", null, ["md"], _hsp23a);  
-  $def("_rg6wi4", "escodegen", ["Response","FileAttachment","DecompressionStream"], _rg6wi4);
-  return main;
-}</script>
 
 <script id="@tomlarkworthy/exporter-3" 
   type="text/plain"
@@ -13379,8 +13356,8 @@ const _4zsqot = function _actionHandler(Inputs,getSourceModule,notebook_name,_ru
     }
   };
 };
-const _lb3gzc = function _exportToHTML(_runtime, cssForTheme, css, location, keepalive, exporter_module, $0) {
-    return async function exportToHTML({mains = new Map(), runtime = _runtime, options = {}} = {}) {
+const _lb3gzc = function _exportToHTML(_runtime,cssForTheme,css,location,keepalive,exporter_module,$0){return(
+async function exportToHTML({mains = new Map(), runtime = _runtime, options = {}} = {}) {
         let conf = { headless: false };
         try {
             conf = (await import('file://bootconf.json')).default;
@@ -13401,9 +13378,15 @@ const _lb3gzc = function _exportToHTML(_runtime, cssForTheme, css, location, kee
         if (options.tickDelayMs == null) {
             options.tickDelayMs = conf.tickDelayMs;
         }
+        // Prerender defaults ON (matching the exporter UI toggle); only an explicit
+        // "prerender": false in bootconf.json turns it off. Flag persists across re-exports.
         if (options.prerender == null) {
             options.prerender = conf.prerender !== false;
         }
+        // Snapshot the live lopepage-2 DOM (only when exporting this running notebook).
+        // The snapshot keeps its id="lopepage-2" and scoped styles unchanged; book() nests
+        // it in a Declarative Shadow DOM so it is invisible to the booting runtime's
+        // document queries (otherwise duplicated editors/inputs corrupt the boot).
         if (options.prerender && runtime === _runtime && options.prerenderHTML == null) {
             try {
                 const src = document.getElementById('lopepage-2');
@@ -13431,14 +13414,13 @@ const _lb3gzc = function _exportToHTML(_runtime, cssForTheme, css, location, kee
                     options.description = ogContent('meta[property="og:description"]') || ogContent('meta[name="description"]');
                 if (options.image == null)
                     options.image = ogContent('meta[property="og:image"]');
-                const managed = new Set([
-                    'viewport',
-                    'og:title',
-                    'og:type',
-                    'og:description',
-                    'description',
-                    'og:image'
-                ]);
+                // Preserve arbitrary <meta> across re-export (at:*, twitter:*, keywords,
+                // theme-color, custom module metadata, …). Skip charset/viewport and the
+                // og/description tags lopebook regenerates from title/description/image.
+                // Merge, don't replace: caller-supplied options.metas win for any key they
+                // define; scanned tags for every other key are preserved. Repeatable keys
+                // (at:alternate, at:author) survive via full key+content dedup.
+                const managed = new Set(['viewport', 'og:title', 'og:type', 'og:description', 'description', 'og:image']);
                 const provided = Array.isArray(options.metas) ? options.metas : [];
                 const ownedKeys = new Set(provided.map(m => m.key));
                 const seen = new Set(provided.map(m => `${ m.key }\n${ m.content }`));
@@ -13446,20 +13428,13 @@ const _lb3gzc = function _exportToHTML(_runtime, cssForTheme, css, location, kee
                 for (const el of document.head.querySelectorAll('meta[property], meta[name]')) {
                     const key = el.getAttribute('property') || el.getAttribute('name');
                     const content = el.getAttribute('content');
-                    if (key == null || content == null || managed.has(key) || ownedKeys.has(key))
-                        continue;
+                    if (key == null || content == null || managed.has(key) || ownedKeys.has(key)) continue;
                     const dedup = `${ key }\n${ content }`;
-                    if (seen.has(dedup))
-                        continue;
+                    if (seen.has(dedup)) continue;
                     seen.add(dedup);
-                    merged.push({
-                        key,
-                        isProperty: el.hasAttribute('property'),
-                        content
-                    });
+                    merged.push({ key, isProperty: el.hasAttribute('property'), content });
                 }
-                if (merged.length)
-                    options.metas = merged;
+                if (merged.length) options.metas = merged;
             } catch (_) {
             }
         }
@@ -13470,29 +13445,31 @@ const _lb3gzc = function _exportToHTML(_runtime, cssForTheme, css, location, kee
             options
         });
         return response;
+    }
+)};
+const _43zr7 = function _getSourceModule(notebook_name,main,_runtime)
+{
+  return async state => {
+    // source picker was removed; the exporter always serialises this notebook
+    if (!state.source || state.source == 'this notebook')
+      return {
+        notebook: notebook_name,
+        module: main,
+        runtime: _runtime
+      };
+    const url = state.source == 'a notebook url' ? state.notebook_url.child : state.top_100.child;
+    const notebook = url.trim().replace('', '');
+    const [{Runtime, Inspector}, {default: define}] = await Promise.all([
+      import('https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js'),
+      import(`https://api.observablehq.com/${ notebook }.js?v=4`)
+    ]);
+    const runtime = new Runtime();
+    return {
+      notebook,
+      module: runtime.module(define),
+      runtime
     };
-};
-const _43zr7 = function _getSourceModule(notebook_name, main, _runtime) {
-    return async state => {
-        if (!state.source || state.source == 'this notebook')
-            return {
-                notebook: notebook_name,
-                module: main,
-                runtime: _runtime
-            };
-        const url = state.source == 'a notebook url' ? state.notebook_url.child : state.top_100.child;
-        const notebook = url.trim().replace('', '');
-        const [{Runtime, Inspector}, {default: define}] = await Promise.all([
-            import('https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js'),
-            import(`https://api.observablehq.com/${ notebook }.js?v=4`)
-        ]);
-        const runtime = new Runtime();
-        return {
-            notebook,
-            module: runtime.module(define),
-            runtime
-        };
-    };
+  };
 };
 const _tpv4tl = function _createShowable(variable,view)
 {
@@ -14092,27 +14069,27 @@ ${ await generate_define(spec, variables, fileAttachments, { moduleNames }) }`
 const _19ft5zb = function _generate_definitions(variableToDefinition){return(
 variables => variables.map(v => variableToDefinition(v)).join('')
 )};
-const _u3aown = function _generate_define(variableToDefine) {
-    return async (spec, variables, fileAttachments, {moduleNames} = {}) => {
-        const fileAttachmentExpression = fileAttachments?.size ? `  const fileAttachments = new Map(${ JSON.stringify([...fileAttachments.keys()]) }.map((name) => {
+const _u3aown = function _generate_define(variableToDefine){return(
+async (spec, variables, fileAttachments, {moduleNames} = {}) => {
+  const fileAttachmentExpression = fileAttachments?.size ? `  const fileAttachments = new Map(${ JSON.stringify([...fileAttachments.keys()]) }.map((name) => {
     const module_name = "${ spec.name }";
     const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
     const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
     return [name, {url: blob_url, mimeType: mime}]
   }));
   main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));\n` : '';
-        const varLines = (await Promise.all(variables.map(v => variableToDefine(v, { moduleNames })))).flat();
-        const definedModules = new Set(varLines.filter(l => l.includes('runtime.module(')).map(l => {
-            const m = l.match(/main\.define\("module ([^"]+)"/);
-            return m ? m[1] : null;
-        }).filter(Boolean));
-        const referencedModules = new Set(varLines.map(l => {
-            const m = l.match(/\["module ([^"]+)", "@variable"\]/);
-            return m ? m[1] : null;
-        }).filter(Boolean));
-        const missingModules = [...referencedModules].filter(m => !definedModules.has(m));
-        const moduleDefineLines = missingModules.map(m => `  main.define("module ${ m }", async () => runtime.module((await importShim("/${ m }.js?v=4")).default));`);
-        return `export default function define(runtime, observer) {
+  const varLines = (await Promise.all(variables.map(v => variableToDefine(v, { moduleNames })))).flat();
+  const definedModules = new Set(varLines.filter(l => l.includes('runtime.module(')).map(l => {
+    const m = l.match(/main\.define\("module ([^"]+)"/);
+    return m ? m[1] : null;
+  }).filter(Boolean));
+  const referencedModules = new Set(varLines.map(l => {
+    const m = l.match(/\["module ([^"]+)", "@variable"\]/);
+    return m ? m[1] : null;
+  }).filter(Boolean));
+  const missingModules = [...referencedModules].filter(m => !definedModules.has(m));
+  const moduleDefineLines = missingModules.map(m => `  main.define("module ${ m }", async () => runtime.module((await importShim("/${ m }.js?v=4")).default));`);
+  return `export default function define(runtime, observer) {
   const main = runtime.module();
   const $def = (pid, name, deps, fn) => {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
@@ -14121,8 +14098,8 @@ ${ fileAttachmentExpression }${ moduleDefineLines.join('  \n') }
 ${ varLines.join('  \n') }
   return main;
 }`;
-    };
-};
+}
+)};
 const _1hslsmt = function _isLiveImport(){return(
 v => !v._name && v._definition?.toString().includes('observablehq' + '--inspect ' + 'observablehq--import')
 )};
@@ -14139,7 +14116,7 @@ function variableToDefinition(v) {
   return `const ${ pid(v) } = ${ restoreCanonicalImports(v._definition.toString()) };\n`;
 }
 )};
-const _1ohymeb = function _restoreCanonicalImports(acorn,escodegen){return(
+const _79c94t = function _restoreCanonicalImports(acorn){return(
 source => {
   if (!/\bimportShim\s*\(/.test(source))
     return source;
@@ -14156,15 +14133,31 @@ source => {
     console.warn('[exporter-3] importShim AST parse failed; leaving cell unchanged:', e.message);
     return source;
   }
+  // The rewrite is local: only the callee identifier changes, plus the parent
+  // URL Observable appends. Collect character ranges and splice them, rather
+  // than regenerating the cell, so comments, quote style and indentation
+  // survive. Same approach as the toolchain's source-preserving observableToJs.
+  const edits = [];
   const visit = node => {
     if (!node || typeof node !== 'object')
       return;
     if (node.type === 'CallExpression' && node.callee && node.callee.type === 'Identifier' && node.callee.name === 'importShim' && node.arguments.length >= 1) {
-      const spec = node.arguments[0];
-      for (const k of Object.keys(node))
-        delete node[k];
-      node.type = 'ImportExpression';
-      node.source = spec;
+      edits.push([
+        node.callee.start,
+        node.callee.end,
+        'import'
+      ]);
+      // Observable compiles a cell's `import(x)` to `importShim(x, "<notebook
+      // url>")`, where argument 2 is the es-module-shims parent. Native import
+      // takes an options object there, so a string second argument is dropped
+      // and an object one (import attributes) is kept.
+      const [spec, second] = node.arguments;
+      if (node.arguments.length === 2 && second.type === 'Literal' && typeof second.value === 'string')
+        edits.push([
+          spec.end,
+          second.end,
+          ''
+        ]);
     }
     for (const k of Object.keys(node)) {
       const v = node[k];
@@ -14175,7 +14168,11 @@ source => {
     }
   };
   visit(ast);
-  return escodegen.generate(ast);
+  let out = source;
+  // Descending, so earlier offsets stay valid as we rewrite.
+  for (const [start, end, text] of edits.sort((a, b) => b[0] - a[0]))
+    out = out.slice(0, start) + text + out.slice(end);
+  return out;
 }
 )};
 const _1g13ozv = function _variableToDefine(isLiveImport,isDynamicVar,isModuleVar,isImportBridged,findImportedName3,pid)
@@ -14403,6 +14400,46 @@ const _18z61zg = function _test_streaming_order_runtime(Runtime,streamingModuleO
   expect(order.join(',')).toBe('@u/app,@u/junk,@u/lib');
   // main first, then the rest alphabetically
   return 'ok';
+};
+const _1didxs7 = function _test_restoreCanonicalImports(restoreCanonicalImports,expect)
+{
+  const R = restoreCanonicalImports;
+  // Nothing to rewrite: identity.
+  expect(R('async () => 1 + 2')).toBe('async () => 1 + 2');
+  // Callee position becomes the canonical dynamic import.
+  expect(R('async () => await importShim("/@a/b.js?v=4")')).toBe('async () => await import("/@a/b.js?v=4")');
+  // Several calls of differing length: the offsets must stay valid.
+  expect(R('async () => [await importShim("a"), await importShim("bb")]')).toBe('async () => [await import("a"), await import("bb")]');
+  expect(R('async () => importShim(await importShim("inner"))')).toBe('async () => import(await import("inner"))');
+  // Argument 2 is the es-module-shims parent URL that Observable appends when
+  // it compiles a cell's own `import(x)`. Native import has no such parameter.
+  expect(R("f = () => importShim(objectURL, 'https://api.observablehq.com/@a/b.js?v=4')")).toBe('f = () => import(objectURL)');
+  expect(R('f = () => importShim(`${ nb }.js?v=4`, "https://api.observablehq.com/@a/b.js?v=4")')).toBe('f = () => import(`${ nb }.js?v=4`)');
+  // ...but a real options object is import attributes, and must survive.
+  expect(R("async () => await importShim(url, { with: { type: 'css' } })")).toBe("async () => await import(url, { with: { type: 'css' } })");
+  // Callee position only. A bare `import` identifier is a syntax error, so a
+  // reference passed as a value has to be left alone.
+  expect(R('async () => register(importShim, importShim("real"))')).toBe('async () => register(importShim, import("real"))');
+  expect(R('async () => window.importShim("x") + importShim("y")')).toBe('async () => window.importShim("x") + import("y")');
+  expect(R('async () => importShim() || importShim("x")')).toBe('async () => importShim() || import("x")');
+  // A string that merely mentions importShim is not a call.
+  expect(R('async () => { const s = "call importShim(x) later"; return importShim("real"); }')).toBe('async () => { const s = "call importShim(x) later"; return import("real"); }');
+};
+const _ogm44p = function _test_restoreCanonicalImports_preserves_source(expect,restoreCanonicalImports)
+{
+  // Only the callee identifier changes, so the rest survives byte-for-byte —
+  // escodegen used to reformat the whole cell.
+  const src = [
+    'function _f() {',
+    "  // keep  this   comment",
+    "  const s = 'single-quoted';   /* and this */",
+    '  return importShim("tpl");',
+    '}'
+  ].join('\n');
+  expect(restoreCanonicalImports(src)).toBe(src.replace('return importShim("tpl")', 'return import("tpl")'));
+  // Unparseable input falls back to the original source.
+  const broken = 'async () => importShim("unclosed';
+  expect(restoreCanonicalImports(broken)).toBe(broken);
 };
 const _1vgrzwk = function _isNotebook(){return(
 id => /^(@[^/]+\/[^/]+|d\/[a-f0-9]{16})$/.test(id)
@@ -14688,20 +14725,22 @@ const _1s9g3fb = function _networking_script(normalize,isNotebook){return(
     }
   })();`
 )};
-const _kfs9ca = function _lopebook(diskDataUrl, networking_script) {
-    return ({blocks = '', cssUrls = [], bootloader = '@tomlarkworthy/bootloader', title = 'Lopecode notebook', description, image, metas = [], head, bodyPrepend = ''} = {}) => {
-        const styleImports = cssUrls.map((url, i) => `  const style${ i } = await importShim(${ JSON.stringify(url) }, { with: { type: 'css' } });`).join('\n');
-        const styleAdopt = cssUrls.map((_, i) => `style${ i }.default`).join(',');
-        const attr = s => String(s).replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-        const ogTags = [
-            `<meta property="og:title" content="${ attr(title) }">`,
-            `<meta property="og:type" content="website">`,
-            description ? `<meta name="description" content="${ attr(description) }">` : '',
-            description ? `<meta property="og:description" content="${ attr(description) }">` : '',
-            image ? `<meta property="og:image" content="${ attr(image) }">` : '',
-            ...(metas || []).map(m => `<meta ${ m.isProperty ? 'property' : 'name' }="${ attr(m.key) }" content="${ attr(m.content) }">`)
-        ].filter(Boolean).join('\n  ');
-        return `<!DOCTYPE html>
+const _kfs9ca = function _lopebook(diskDataUrl,networking_script)
+{
+  return ({blocks = '', cssUrls = [], bootloader = '@tomlarkworthy/bootloader', title = 'Lopecode notebook', description, image, metas = [], head, bodyPrepend = ''} = {}) => {
+    const styleImports = cssUrls.map((url, i) => `  const style${ i } = await importShim(${ JSON.stringify(url) }, { with: { type: 'css' } });`).join('\n');
+    const styleAdopt = cssUrls.map((_, i) => `style${ i }.default`).join(',');
+    const attr = s => String(s).replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    const ogTags = [
+      `<meta property="og:title" content="${ attr(title) }">`,
+      `<meta property="og:type" content="website">`,
+      description ? `<meta name="description" content="${ attr(description) }">` : '',
+      description ? `<meta property="og:description" content="${ attr(description) }">` : '',
+      image ? `<meta property="og:image" content="${ attr(image) }">` : '',
+      // Preserved <meta> carried across re-export by exportToHTML's head scan.
+      ...(metas || []).map(m => `<meta ${ m.isProperty ? 'property' : 'name' }="${ attr(m.key) }" content="${ attr(m.content) }">`)
+    ].filter(Boolean).join('\n  ');
+    return `<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
@@ -14741,7 +14780,7 @@ ${ blocks }
 <script id="streaming_sentinel">window.__lopeStreaming = false;</scr\ipt>
 </body>
 </html>`;
-    };
+  };
 };
 const _li7wcc = function _lopemodule(TRACE_MODULE,CSS,arrayBufferToBase64,inlineModule,escapeScriptTags)
 {
@@ -14789,10 +14828,10 @@ async function arrayBufferToBase64(buffer) {
   return btoa(binary);
 }
 )};
-const _1miwrx0 = function _79(md){return(
+const _1iz5onh = function _81(md){return(
 md`### Global Output`
 )};
-const _g3fd9a = function _80(md){return(
+const _b9np5w = function _82(md){return(
 md`## Utils`
 )};
 const _fw7q7v = function _getCompactISODate(){return(
@@ -14807,7 +14846,7 @@ function getCompactISODate() {
   return `${ year }${ month }${ day }T${ hours }${ minutes }${ seconds }Z`;
 }
 )};
-const _os8ogr = function _82(md){return(
+const _7vqfq9 = function _84(md){return(
 md`## Additional Tests`
 )};
 const _8765p8 = function _diskDataUrl(disk_svg){return(
@@ -14837,7 +14876,6 @@ export default function define(runtime, observer) {
   main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
   main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
   main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
-  main.define("module @tomlarkworthy/escodegen", async () => runtime.module((await import("/@tomlarkworthy/escodegen.js?v=4")).default));  
   main.define("module @tomlarkworthy/view", async () => runtime.module((await import("/@tomlarkworthy/view.js?v=4")).default));  
   main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
   main.define("module @tomlarkworthy/local-storage-view", async () => runtime.module((await import("/@tomlarkworthy/local-storage-view.js?v=4")).default));  
@@ -14905,7 +14943,7 @@ export default function define(runtime, observer) {
   $def("_u3aown", "generate_define", ["variableToDefine"], _u3aown);  
   $def("_1hslsmt", "isLiveImport", [], _1hslsmt);  
   $def("_4i5mmq", "variableToDefinition", ["isModuleVar","isImportBridged","isLiveImport","isDynamicVar","pid","restoreCanonicalImports"], _4i5mmq);  
-  $def("_1ohymeb", "restoreCanonicalImports", ["acorn","escodegen"], _1ohymeb);  
+  $def("_79c94t", "restoreCanonicalImports", ["acorn"], _79c94t);  
   $def("_1g13ozv", "variableToDefine", ["isLiveImport","isDynamicVar","isModuleVar","isImportBridged","findImportedName3","pid"], _1g13ozv);  
   $def("_8rymrb", null, ["md"], _8rymrb);  
   $def("_g33g3u", "es_module_shims", [], _g33g3u);  
@@ -14918,16 +14956,18 @@ export default function define(runtime, observer) {
   $def("_1d9ux6v", "test_lopebook_main_at_top_with_sentinel", ["lopebook","expect"], _1d9ux6v);  
   $def("_13d3rb0", "test_streaming_order_prioritizes_mains", ["expect","streamingModuleOrder"], _13d3rb0);  
   $def("_18z61zg", "test_streaming_order_runtime", ["Runtime","streamingModuleOrder","expect"], _18z61zg);  
+  $def("_1didxs7", "test_restoreCanonicalImports", ["restoreCanonicalImports","expect"], _1didxs7);  
+  $def("_ogm44p", "test_restoreCanonicalImports_preserves_source", ["expect","restoreCanonicalImports"], _ogm44p);  
   $def("_1vgrzwk", "isNotebook", [], _1vgrzwk);  
   $def("_1s9g3fb", "networking_script", ["normalize","isNotebook"], _1s9g3fb);  
   $def("_kfs9ca", "lopebook", ["diskDataUrl","networking_script"], _kfs9ca);  
   $def("_li7wcc", "lopemodule", ["TRACE_MODULE","CSS","arrayBufferToBase64","inlineModule","escapeScriptTags"], _li7wcc);  
   $def("_19l1umr", "escapeScriptTags", [], _19l1umr);  
   $def("_xpg7uv", "arrayBufferToBase64", [], _xpg7uv);  
-  $def("_1miwrx0", null, ["md"], _1miwrx0);  
-  $def("_g3fd9a", null, ["md"], _g3fd9a);  
+  $def("_1iz5onh", null, ["md"], _1iz5onh);  
+  $def("_b9np5w", null, ["md"], _b9np5w);  
   $def("_fw7q7v", "getCompactISODate", [], _fw7q7v);  
-  $def("_os8ogr", null, ["md"], _os8ogr);  
+  $def("_7vqfq9", null, ["md"], _7vqfq9);  
   $def("_8765p8", "diskDataUrl", ["disk_svg"], _8765p8);  
   $def("_z4k2or", "viewof task", ["flowQueue"], _z4k2or);  
   $def("_ngmf1x", "task", ["Generators","viewof task"], _ngmf1x);  
@@ -14947,7 +14987,6 @@ export default function define(runtime, observer) {
   main.define("parser", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("parser", _));  
   main.define("decompress_url", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("decompress_url", _));  
   main.define("acorn", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("acorn", _));  
-  main.define("escodegen", ["module @tomlarkworthy/escodegen", "@variable"], (_, v) => v.import("escodegen", _));  
   main.define("view", ["module @tomlarkworthy/view", "@variable"], (_, v) => v.import("view", _));  
   main.define("variable", ["module @tomlarkworthy/view", "@variable"], (_, v) => v.import("variable", _));  
   main.define("bindOneWay", ["module @tomlarkworthy/view", "@variable"], (_, v) => v.import("bindOneWay", _));  
@@ -15116,231 +15155,232 @@ const _yqx7l8 = function _syncEnabled(notebookId,htl)
     return container;
 };
 const _xltqf6 = (G, _) => G.input(_);
-const _1nuhj4u = function _disassemble(htl, directory, notebookId, manifestWriter, readFile, writeFile, syncableModules, exportModuleJS, hashSource, currentModules, runtime, probeDefine, tag, $0) {
-    const container = htl.html`<div>
+const _1nuhj4u = function _disassemble(htl,directory,notebookId,manifestWriter,readFile,writeFile,syncableModules,exportModuleJS,hashSource,currentModules,runtime,probeDefine,tag,$0)
+{
+  const container = htl.html`<div>
     <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
       <button class="disassemble" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Disassemble to disk</button>
       <button class="sync" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Sync from disk</button>
     </div>
     <pre style="font-size: 12px; max-height: 300px; overflow-y: auto; margin-top: 8px;"></pre>
   </div>`;
-    const disBtn = container.querySelector('.disassemble');
-    const syncBtn = container.querySelector('.sync');
-    const status = container.querySelector('pre');
-    if (directory) {
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
+  const disBtn = container.querySelector('.disassemble');
+  const syncBtn = container.querySelector('.sync');
+  const status = container.querySelector('pre');
+  if (directory) {
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  }
+  const log = msg => {
+    status.textContent += msg + '\n';
+    status.scrollTop = status.scrollHeight;
+  };
+  const prefix = notebookId + '/';
+  disBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    disBtn.textContent = 'Disassembling...';
+    let ok = 0, fail = 0;
+    const manifestUpdates = {};
+    await manifestWriter(directory, prefix, null, readFile, writeFile);
+    log('cleared manifest');
+    for (const moduleId of syncableModules) {
+      try {
+        log('Exporting ' + moduleId + '...');
+        const result = await exportModuleJS(moduleId);
+        const path = prefix + moduleId + '.js';
+        await writeFile(directory, path, result.source);
+        manifestUpdates[moduleId] = hashSource(result.source);
+        log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
+        if (result.fileAttachments && result.fileAttachments.size) {
+          for (const [name, entry] of result.fileAttachments) {
+            try {
+              const resp = await fetch(entry.url);
+              const bytes = await resp.arrayBuffer();
+              await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
+              log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
+            } catch (e) {
+              log('  attachment FAILED: ' + name + ' - ' + e.message);
+            }
+          }
+        }
+        ok++;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
     }
-    const log = msg => {
-        status.textContent += msg + '\n';
-        status.scrollTop = status.scrollHeight;
+    try {
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const bootconf = document.querySelector('script[id="bootconf.json"]');
+      if (bootconf) {
+        await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
+        log('wrote ' + prefix + 'bootconf.json');
+      }
+    } catch (e) {
+      log('bootconf.json FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
+    disBtn.textContent = 'Disassembled ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  syncBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    syncBtn.textContent = 'Syncing from disk...';
+    status.textContent = '';
+    const nameToModule = new window.Map();
+    const nameToVars = new window.Map();
+    for (const [mod, info] of currentModules) {
+      if (info.name === 'bootloader' || info.name === 'builtin')
+        continue;
+      if (!info.name.includes('/') && !info.name.startsWith('d/'))
+        continue;
+      nameToModule.set(info.name, info.module);
+      const vars = new window.Map();
+      for (const v of runtime._variables) {
+        if (v._module !== info.module)
+          continue;
+        if (v._name)
+          vars.set(v._name, v);
+        if (v.pid)
+          vars.set('__pid__' + v.pid, v);
+      }
+      nameToVars.set(info.name, vars);
+    }
+    const applyModule = (moduleId, defineFn) => {
+      const mod = nameToModule.get(moduleId);
+      if (!mod)
+        return;
+      const existingVars = nameToVars.get(moduleId) || new window.Map();
+      const cells = probeDefine(defineFn);
+      const seenPids = new Set();
+      for (const cell of cells) {
+        if (cell.type === 'import')
+          continue;
+        if (!cell.pid)
+          continue;
+        seenPids.add(cell.pid);
+        const existing = existingVars.get('__pid__' + cell.pid);
+        if (!existing) {
+          const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+          const v = mod.variable();
+          v.define(cell.name, cell.inputs, taggedDefn);
+          v.pid = cell.pid;
+          existingVars.set('__pid__' + cell.pid, v);
+          if (cell.name)
+            existingVars.set(cell.name, v);
+          continue;
+        }
+        if (existing._definition) {
+          const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
+          const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+          const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+          if (inputsMatch && defnMatch)
+            continue;
+        }
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      }
+      const ordered = [];
+      for (const cell of cells) {
+        if (!cell.pid)
+          continue;
+        const v = existingVars.get('__pid__' + cell.pid);
+        if (v)
+          ordered.push(v);
+      }
+      if (ordered.length) {
+        const orderedSet = new Set(ordered);
+        const arr = [...runtime._variables];
+        let oi = 0;
+        for (let i = 0; i < arr.length; i++) {
+          if (orderedSet.has(arr[i]))
+            arr[i] = ordered[oi++];
+        }
+        while (oi < ordered.length)
+          arr.push(ordered[oi++]);
+        runtime._variables.clear();
+        for (const v of arr)
+          runtime._variables.add(v);
+      }
     };
-    const prefix = notebookId + '/';
-    disBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        disBtn.textContent = 'Disassembling...';
-        let ok = 0, fail = 0;
-        const manifestUpdates = {};
-        await manifestWriter(directory, prefix, null, readFile, writeFile);
-        log('cleared manifest');
-        for (const moduleId of syncableModules) {
+    const manifestUpdates = {};
+    let ok = 0, fail = 0;
+    for (const moduleId of syncableModules) {
+      try {
+        let file;
+        try {
+          file = await readFile(directory, prefix + moduleId + '.js');
+        } catch (e) {
+          file = null;
+        }
+        if (!file) {
+          log('  skip ' + moduleId + ' (no .js on disk)');
+          continue;
+        }
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const mod = await import(url);
+          if (typeof mod.default === 'function') {
+            applyModule(moduleId, mod.default);
+            log('  applied ' + moduleId);
             try {
-                log('Exporting ' + moduleId + '...');
-                const result = await exportModuleJS(moduleId);
-                const path = prefix + moduleId + '.js';
-                await writeFile(directory, path, result.source);
-                manifestUpdates[moduleId] = hashSource(result.source);
-                log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
-                if (result.fileAttachments && result.fileAttachments.size) {
-                    for (const [name, entry] of result.fileAttachments) {
-                        try {
-                            const resp = await fetch(entry.url);
-                            const bytes = await resp.arrayBuffer();
-                            await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
-                            log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
-                        } catch (e) {
-                            log('  attachment FAILED: ' + name + ' - ' + e.message);
-                        }
-                    }
-                }
-                ok++;
+              const after = await exportModuleJS(moduleId);
+              manifestUpdates[moduleId] = hashSource(after.source);
             } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
+              manifestUpdates[moduleId] = hashSource(diskText);
             }
+            ok++;
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
         }
-        try {
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const bootconf = document.querySelector('script[id="bootconf.json"]');
-            if (bootconf) {
-                await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
-                log('wrote ' + prefix + 'bootconf.json');
-            }
-        } catch (e) {
-            log('bootconf.json FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
-        disBtn.textContent = 'Disassembled ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    syncBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        syncBtn.textContent = 'Syncing from disk...';
-        status.textContent = '';
-        const nameToModule = new window.Map();
-        const nameToVars = new window.Map();
-        for (const [mod, info] of currentModules) {
-            if (info.name === 'bootloader' || info.name === 'builtin')
-                continue;
-            if (!info.name.includes('/') && !info.name.startsWith('d/'))
-                continue;
-            nameToModule.set(info.name, info.module);
-            const vars = new window.Map();
-            for (const v of runtime._variables) {
-                if (v._module !== info.module)
-                    continue;
-                if (v._name)
-                    vars.set(v._name, v);
-                if (v.pid)
-                    vars.set('__pid__' + v.pid, v);
-            }
-            nameToVars.set(info.name, vars);
-        }
-        const applyModule = (moduleId, defineFn) => {
-            const mod = nameToModule.get(moduleId);
-            if (!mod)
-                return;
-            const existingVars = nameToVars.get(moduleId) || new window.Map();
-            const cells = probeDefine(defineFn);
-            const seenPids = new Set();
-            for (const cell of cells) {
-                if (cell.type === 'import')
-                    continue;
-                if (!cell.pid)
-                    continue;
-                seenPids.add(cell.pid);
-                const existing = existingVars.get('__pid__' + cell.pid);
-                if (!existing) {
-                    const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                    const v = mod.variable();
-                    v.define(cell.name, cell.inputs, taggedDefn);
-                    v.pid = cell.pid;
-                    existingVars.set('__pid__' + cell.pid, v);
-                    if (cell.name)
-                        existingVars.set(cell.name, v);
-                    continue;
-                }
-                if (existing._definition) {
-                    const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
-                    const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                    const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                    if (inputsMatch && defnMatch)
-                        continue;
-                }
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            }
-            const ordered = [];
-            for (const cell of cells) {
-                if (!cell.pid)
-                    continue;
-                const v = existingVars.get('__pid__' + cell.pid);
-                if (v)
-                    ordered.push(v);
-            }
-            if (ordered.length) {
-                const orderedSet = new Set(ordered);
-                const arr = [...runtime._variables];
-                let oi = 0;
-                for (let i = 0; i < arr.length; i++) {
-                    if (orderedSet.has(arr[i]))
-                        arr[i] = ordered[oi++];
-                }
-                while (oi < ordered.length)
-                    arr.push(ordered[oi++]);
-                runtime._variables.clear();
-                for (const v of arr)
-                    runtime._variables.add(v);
-            }
-        };
-        const manifestUpdates = {};
-        let ok = 0, fail = 0;
-        for (const moduleId of syncableModules) {
-            try {
-                let file;
-                try {
-                    file = await readFile(directory, prefix + moduleId + '.js');
-                } catch (e) {
-                    file = null;
-                }
-                if (!file) {
-                    log('  skip ' + moduleId + ' (no .js on disk)');
-                    continue;
-                }
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
-                try {
-                    const mod = await import(url);
-                    if (typeof mod.default === 'function') {
-                        applyModule(moduleId, mod.default);
-                        log('  applied ' + moduleId);
-                        try {
-                            const after = await exportModuleJS(moduleId);
-                            manifestUpdates[moduleId] = hashSource(after.source);
-                        } catch (e) {
-                            manifestUpdates[moduleId] = hashSource(diskText);
-                        }
-                        ok++;
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
-            }
-        }
-        try {
-            await manifestWriter(directory, prefix, null, readFile, writeFile);
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const view = $0;
-            const cb = view && view.querySelector ? view.querySelector('input') : null;
-            if (cb && !cb.checked) {
-                cb.checked = true;
-                view.value = true;
-                view.dispatchEvent(new window.Event('input', { bubbles: true }));
-                log('enabled Sync toggle');
-            } else if (cb && cb.checked) {
-                log('Sync toggle already enabled');
-            }
-        } catch (e) {
-            log('toggle enable FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
-        syncBtn.textContent = 'Synced ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    container.value = undefined;
-    return container;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
+    }
+    try {
+      await manifestWriter(directory, prefix, null, readFile, writeFile);
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const view = $0;
+      const cb = view && view.querySelector ? view.querySelector('input') : null;
+      if (cb && !cb.checked) {
+        cb.checked = true;
+        view.value = true;
+        view.dispatchEvent(new window.Event('input', { bubbles: true }));
+        log('enabled Sync toggle');
+      } else if (cb && cb.checked) {
+        log('Sync toggle already enabled');
+      }
+    } catch (e) {
+      log('toggle enable FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
+    syncBtn.textContent = 'Synced ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  container.value = undefined;
+  return container;
 };
 const _eoa5ga = (G, _) => G.input(_);
 const _1jyon1g = function _syncStatus(htl,directory,syncableModules,notebookToFiles,filesToNotebook){return(
@@ -15706,341 +15746,342 @@ const _1bf1rb4 = function _fileSyncLastSeen(directory)
     void directory;
     return new window.Map();
 };
-const _19e6n4y = function _filesToNotebook(directory, syncArmed, currentModules, fileSyncLastSeen, notebookId, runtime, probeDefine, tag, readFile, exportModuleJS, importShim, manifestWriter, hashSource, writeFile, getFileAttachmentsMap, invalidation) {
-    if (!directory)
-        return 'Waiting for directory...';
-    if (!syncArmed || !syncArmed.armed)
-        return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
-    const SKIP = new Set([
-        'bootloader',
-        'builtin'
-    ]);
-    const syncableModules = [];
-    for (const [mod, info] of currentModules) {
-        if (SKIP.has(info.name))
-            continue;
-        if (!info.name.includes('/') && !info.name.startsWith('d/'))
-            continue;
-        syncableModules.push(info.name);
+const _19e6n4y = function _filesToNotebook(directory,syncArmed,currentModules,fileSyncLastSeen,notebookId,runtime,probeDefine,tag,readFile,exportModuleJS,importShim,manifestWriter,hashSource,writeFile,getFileAttachmentsMap,invalidation)
+{
+  if (!directory)
+    return 'Waiting for directory...';
+  if (!syncArmed || !syncArmed.armed)
+    return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
+  const SKIP = new Set([
+    'bootloader',
+    'builtin'
+  ]);
+  const syncableModules = [];
+  for (const [mod, info] of currentModules) {
+    if (SKIP.has(info.name))
+      continue;
+    if (!info.name.includes('/') && !info.name.startsWith('d/'))
+      continue;
+    syncableModules.push(info.name);
+  }
+  const syncableSet = new Set(syncableModules);
+  const lastSeen = fileSyncLastSeen;
+  const POLL_MS = 1000;
+  const prefix = notebookId + '/';
+  const nameToModule = new window.Map();
+  const nameToVars = new window.Map();
+  for (const [mod, info] of currentModules) {
+    if (!syncableSet.has(info.name))
+      continue;
+    nameToModule.set(info.name, info.module);
+    const vars = new window.Map();
+    for (const v of runtime._variables) {
+      if (v._module !== info.module)
+        continue;
+      if (v._name)
+        vars.set(v._name, v);
+      if (v.pid)
+        vars.set('__pid__' + v.pid, v);
     }
-    const syncableSet = new Set(syncableModules);
-    const lastSeen = fileSyncLastSeen;
-    const POLL_MS = 1000;
-    const prefix = notebookId + '/';
-    const nameToModule = new window.Map();
-    const nameToVars = new window.Map();
-    for (const [mod, info] of currentModules) {
-        if (!syncableSet.has(info.name))
-            continue;
-        nameToModule.set(info.name, info.module);
-        const vars = new window.Map();
-        for (const v of runtime._variables) {
-            if (v._module !== info.module)
-                continue;
-            if (v._name)
-                vars.set(v._name, v);
-            if (v.pid)
-                vars.set('__pid__' + v.pid, v);
-        }
-        nameToVars.set(info.name, vars);
+    nameToVars.set(info.name, vars);
+  }
+  let pollTimer;
+  const knownFilePids = new window.Map();
+  let knownDiskModules = null;
+  const getModuleFA = mod => {
+    for (const v of runtime._variables) {
+      if (v._module === mod && v._name === 'FileAttachment' && v._value)
+        return v._value;
     }
-    let pollTimer;
-    const knownFilePids = new window.Map();
-    let knownDiskModules = null;
-    const getModuleFA = mod => {
-        for (const v of runtime._variables) {
-            if (v._module === mod && v._name === 'FileAttachment' && v._value)
-                return v._value;
-        }
-        return null;
-    };
-    const getSubDir = async (dirHandle, path) => {
-        let current = dirHandle;
-        for (const part of path.split('/').filter(Boolean)) {
-            current = await current.getDirectoryHandle(part);
-        }
-        return current;
-    };
-    const applyModule = (moduleId, defineFn) => {
-        const mod = nameToModule.get(moduleId);
-        if (!mod)
-            return;
-        const existingVars = nameToVars.get(moduleId) || new window.Map();
-        const cells = probeDefine(defineFn);
-        let redefinedSelf = false;
-        const seenPids = new Set();
-        for (const cell of cells) {
-            if (cell.type === 'import')
-                continue;
-            if (!cell.pid)
-                continue;
-            seenPids.add(cell.pid);
-            const existing = existingVars.get('__pid__' + cell.pid);
-            if (!existing) {
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                const v = mod.variable();
-                v.define(cell.name, cell.inputs, taggedDefn);
-                v.pid = cell.pid;
-                existingVars.set('__pid__' + cell.pid, v);
-                if (cell.name)
-                    existingVars.set(cell.name, v);
-                console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
-                continue;
-            }
-            if (existing._definition) {
-                const existingInputNames = existing._inputs.map(function (v) {
-                    return typeof v === 'string' ? v : v._name;
-                });
-                const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                if (inputsMatch && defnMatch)
-                    continue;
-            }
-            const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-            existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
-                redefinedSelf = true;
-            }
-        }
-        const prevKnown = knownFilePids.get(moduleId);
-        if (prevKnown) {
-            for (const pid of prevKnown) {
-                if (seenPids.has(pid))
-                    continue;
-                const v = existingVars.get('__pid__' + pid);
-                if (!v)
-                    continue;
-                console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
-                v.delete();
-                existingVars.delete('__pid__' + pid);
-                if (v._name)
-                    existingVars.delete(v._name);
-            }
-        }
-        knownFilePids.set(moduleId, seenPids);
-        const ordered = [];
-        for (const cell of cells) {
-            if (!cell.pid)
-                continue;
-            const v = existingVars.get('__pid__' + cell.pid);
-            if (v)
-                ordered.push(v);
-        }
-        if (ordered.length) {
-            const orderedSet = new Set(ordered);
-            const arr = [...runtime._variables];
-            let oi = 0;
-            for (let i = 0; i < arr.length; i++) {
-                if (orderedSet.has(arr[i]))
-                    arr[i] = ordered[oi++];
-            }
-            while (oi < ordered.length)
-                arr.push(ordered[oi++]);
-            runtime._variables.clear();
-            for (const v of arr)
-                runtime._variables.add(v);
-        }
-        if (redefinedSelf) {
-            clearInterval(pollTimer);
-            console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
-        }
-    };
-    const pollModule = async moduleId => {
-        try {
-            let file;
+    return null;
+  };
+  const getSubDir = async (dirHandle, path) => {
+    let current = dirHandle;
+    for (const part of path.split('/').filter(Boolean)) {
+      current = await current.getDirectoryHandle(part);
+    }
+    return current;
+  };
+  const applyModule = (moduleId, defineFn) => {
+    const mod = nameToModule.get(moduleId);
+    if (!mod)
+      return;
+    const existingVars = nameToVars.get(moduleId) || new window.Map();
+    const cells = probeDefine(defineFn);
+    let redefinedSelf = false;
+    const seenPids = new Set();
+    for (const cell of cells) {
+      if (cell.type === 'import')
+        continue;
+      if (!cell.pid)
+        continue;
+      seenPids.add(cell.pid);
+      const existing = existingVars.get('__pid__' + cell.pid);
+      if (!existing) {
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        const v = mod.variable();
+        v.define(cell.name, cell.inputs, taggedDefn);
+        v.pid = cell.pid;
+        existingVars.set('__pid__' + cell.pid, v);
+        if (cell.name)
+          existingVars.set(cell.name, v);
+        console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
+        continue;
+      }
+      if (existing._definition) {
+        const existingInputNames = existing._inputs.map(function (v) {
+          return typeof v === 'string' ? v : v._name;
+        });
+        const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+        const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+        if (inputsMatch && defnMatch)
+          continue;
+      }
+      const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+      existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
+        redefinedSelf = true;
+      }
+    }
+    const prevKnown = knownFilePids.get(moduleId);
+    if (prevKnown) {
+      for (const pid of prevKnown) {
+        if (seenPids.has(pid))
+          continue;
+        const v = existingVars.get('__pid__' + pid);
+        if (!v)
+          continue;
+        console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
+        v.delete();
+        existingVars.delete('__pid__' + pid);
+        if (v._name)
+          existingVars.delete(v._name);
+      }
+    }
+    knownFilePids.set(moduleId, seenPids);
+    const ordered = [];
+    for (const cell of cells) {
+      if (!cell.pid)
+        continue;
+      const v = existingVars.get('__pid__' + cell.pid);
+      if (v)
+        ordered.push(v);
+    }
+    if (ordered.length) {
+      const orderedSet = new Set(ordered);
+      const arr = [...runtime._variables];
+      let oi = 0;
+      for (let i = 0; i < arr.length; i++) {
+        if (orderedSet.has(arr[i]))
+          arr[i] = ordered[oi++];
+      }
+      while (oi < ordered.length)
+        arr.push(ordered[oi++]);
+      runtime._variables.clear();
+      for (const v of arr)
+        runtime._variables.add(v);
+    }
+    if (redefinedSelf) {
+      clearInterval(pollTimer);
+      console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
+    }
+  };
+  const pollModule = async moduleId => {
+    try {
+      let file;
+      try {
+        file = await readFile(directory, prefix + moduleId + '.js');
+      } catch (e) {
+        file = null;
+      }
+      if (file) {
+        const prev = lastSeen.get(moduleId);
+        const changed = !prev || file.lastModified !== prev.lastModified;
+        if (changed) {
+          lastSeen.set(moduleId, { lastModified: file.lastModified });
+          const diskText = await file.text();
+          let needsApply = true;
+          try {
+            const runtimeResult = await exportModuleJS(moduleId);
+            if (runtimeResult.source === diskText)
+              needsApply = false;
+          } catch (e) {
+          }
+          if (needsApply) {
+            const blob = new window.Blob([diskText], { type: 'text/javascript' });
+            const url = window.URL.createObjectURL(blob);
             try {
-                file = await readFile(directory, prefix + moduleId + '.js');
-            } catch (e) {
-                file = null;
-            }
-            if (file) {
-                const prev = lastSeen.get(moduleId);
-                const changed = !prev || file.lastModified !== prev.lastModified;
-                if (changed) {
-                    lastSeen.set(moduleId, { lastModified: file.lastModified });
-                    const diskText = await file.text();
-                    let needsApply = true;
-                    try {
-                        const runtimeResult = await exportModuleJS(moduleId);
-                        if (runtimeResult.source === diskText)
-                            needsApply = false;
-                    } catch (e) {
-                    }
-                    if (needsApply) {
-                        const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                        const url = window.URL.createObjectURL(blob);
-                        try {
-                            const mod = await import(url);
-                            if (typeof mod.default === 'function') {
-                                applyModule(moduleId, mod.default);
-                                console.log('[file-sync] applied ' + moduleId + ' from disk');
-                                try {
-                                    const after = await exportModuleJS(moduleId);
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
-                                } catch (e) {
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                                }
-                            }
-                        } finally {
-                            window.URL.revokeObjectURL(url);
-                        }
-                    }
-                }
-            }
-        } catch (e) {
-            console.error('[file-sync] poll error for ' + moduleId + ':', e);
-        }
-        try {
-            const attachDir = await getSubDir(directory, prefix + moduleId);
-            const mod = nameToModule.get(moduleId);
-            const FA = mod ? getModuleFA(mod) : null;
-            const faMap = FA ? getFileAttachmentsMap(FA) : null;
-            if (faMap) {
-                for (const key of [...faMap.keys()]) {
-                    if (key.endsWith('.crswap') || key.startsWith('.'))
-                        faMap.delete(key);
-                }
-            }
-            for await (const [name, handle] of attachDir) {
-                if (handle.kind !== 'file')
-                    continue;
-                if (name.endsWith('.crswap') || name.startsWith('.'))
-                    continue;
-                const file = await handle.getFile();
-                const attKey = '__att__' + moduleId + '/' + name;
-                const prevA = lastSeen.get(attKey);
-                if (prevA && file.lastModified === prevA.lastModified)
-                    continue;
-                lastSeen.set(attKey, { lastModified: file.lastModified });
-                const bytes = new Uint8Array(await file.arrayBuffer());
-                const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
-                const blobUrl = window.URL.createObjectURL(blob);
-                if (faMap) {
-                    faMap.set(name, {
-                        url: blobUrl,
-                        mimeType: file.type || 'application/octet-stream'
-                    });
-                    console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
-                }
-                const scriptId = moduleId + '/' + encodeURIComponent(name);
-                const script = document.getElementById(scriptId);
-                if (script) {
-                    const b64 = btoa(String.fromCharCode.apply(null, bytes));
-                    script.textContent = b64;
-                    script.setAttribute('data-encoding', 'base64');
-                    script.setAttribute('data-mime', file.type || 'application/octet-stream');
-                }
-            }
-        } catch (e) {
-            if (e.name !== 'NotFoundError')
-                console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
-        }
-    };
-    const scanDiskModules = async () => {
-        const diskModules = new Set();
-        try {
-            const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
-            for await (const [orgName, orgHandle] of notebookDir) {
-                if (orgHandle.kind !== 'directory')
-                    continue;
-                if (orgName.startsWith('@')) {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add(orgName + '/' + fname.slice(0, -3));
-                    }
-                } else if (orgName === 'd') {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add('d/' + fname.slice(0, -3));
-                    }
-                }
-            }
-        } catch (e) {
-        }
-        return diskModules;
-    };
-    const poll = async () => {
-        for (const moduleId of syncableModules)
-            await pollModule(moduleId);
-        const diskModules = await scanDiskModules();
-        const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
-        if (newOnDisk.length)
-            console.log('[file-sync] new modules on disk:', newOnDisk);
-        for (const moduleId of diskModules) {
-            if (syncableSet.has(moduleId))
-                continue;
-            if (nameToModule.has(moduleId))
-                continue;
-            try {
-                const file = await readFile(directory, prefix + moduleId + '.js');
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
+              const mod = await import(url);
+              if (typeof mod.default === 'function') {
+                applyModule(moduleId, mod.default);
+                console.log('[file-sync] applied ' + moduleId + ' from disk');
                 try {
-                    const imported = await import(url);
-                    if (typeof imported.default === 'function') {
-                        const newMod = runtime.module(imported.default, () => null);
-                        runtime.mains.set(moduleId, newMod);
-                        nameToModule.set(moduleId, newMod);
-                        syncableModules.push(moduleId);
-                        syncableSet.add(moduleId);
-                        const vars = new window.Map();
-                        for (const v of runtime._variables) {
-                            if (v._module !== newMod)
-                                continue;
-                            if (v._name)
-                                vars.set(v._name, v);
-                            if (v.pid)
-                                vars.set('__pid__' + v.pid, v);
-                        }
-                        nameToVars.set(moduleId, vars);
-                        console.log('[file-sync] added new module from disk: ' + moduleId);
-                        try {
-                            await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                        } catch (e) {
-                            console.error('[file-sync] manifest update for new module failed:', e);
-                        }
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                console.error('[file-sync] failed to add module ' + moduleId + ':', e);
-            }
-        }
-        if (knownDiskModules) {
-            for (const moduleId of knownDiskModules) {
-                if (diskModules.has(moduleId))
-                    continue;
-                if (!nameToModule.has(moduleId))
-                    continue;
-                const mod = nameToModule.get(moduleId);
-                for (const v of [...runtime._variables]) {
-                    if (v._module === mod)
-                        v.delete();
-                }
-                runtime.mains.delete(moduleId);
-                nameToModule.delete(moduleId);
-                nameToVars.delete(moduleId);
-                knownFilePids.delete(moduleId);
-                const idx = syncableModules.indexOf(moduleId);
-                if (idx !== -1)
-                    syncableModules.splice(idx, 1);
-                syncableSet.delete(moduleId);
-                console.log('[file-sync] removed module: ' + moduleId);
-                try {
-                    await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+                  const after = await exportModuleJS(moduleId);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
                 } catch (e) {
-                    console.error('[file-sync] manifest remove failed:', e);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
                 }
+              }
+            } finally {
+              window.URL.revokeObjectURL(url);
             }
+          }
         }
-        knownDiskModules = diskModules;
-    };
-    pollTimer = setInterval(poll, POLL_MS);
-    poll();
-    invalidation.then(() => clearInterval(pollTimer));
-    return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
+      }
+    } catch (e) {
+      console.error('[file-sync] poll error for ' + moduleId + ':', e);
+    }
+    try {
+      const attachDir = await getSubDir(directory, prefix + moduleId);
+      const mod = nameToModule.get(moduleId);
+      const FA = mod ? getModuleFA(mod) : null;
+      const faMap = FA ? getFileAttachmentsMap(FA) : null;
+      if (faMap) {
+        for (const key of [...faMap.keys()]) {
+          if (key.endsWith('.crswap') || key.startsWith('.'))
+            faMap.delete(key);
+        }
+      }
+      for await (const [name, handle] of attachDir) {
+        if (handle.kind !== 'file')
+          continue;
+        if (name.endsWith('.crswap') || name.startsWith('.'))
+          continue;
+        const file = await handle.getFile();
+        const attKey = '__att__' + moduleId + '/' + name;
+        const prevA = lastSeen.get(attKey);
+        if (prevA && file.lastModified === prevA.lastModified)
+          continue;
+        lastSeen.set(attKey, { lastModified: file.lastModified });
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
+        const blobUrl = window.URL.createObjectURL(blob);
+        if (faMap) {
+          faMap.set(name, {
+            url: blobUrl,
+            mimeType: file.type || 'application/octet-stream'
+          });
+          console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
+        }
+        const scriptId = moduleId + '/' + encodeURIComponent(name);
+        const script = document.getElementById(scriptId);
+        if (script) {
+          const b64 = btoa(String.fromCharCode.apply(null, bytes));
+          script.textContent = b64;
+          script.setAttribute('data-encoding', 'base64');
+          script.setAttribute('data-mime', file.type || 'application/octet-stream');
+        }
+      }
+    } catch (e) {
+      if (e.name !== 'NotFoundError')
+        console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
+    }
+  };
+  const scanDiskModules = async () => {
+    const diskModules = new Set();
+    try {
+      const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
+      for await (const [orgName, orgHandle] of notebookDir) {
+        if (orgHandle.kind !== 'directory')
+          continue;
+        if (orgName.startsWith('@')) {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add(orgName + '/' + fname.slice(0, -3));
+          }
+        } else if (orgName === 'd') {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add('d/' + fname.slice(0, -3));
+          }
+        }
+      }
+    } catch (e) {
+    }
+    return diskModules;
+  };
+  const poll = async () => {
+    for (const moduleId of syncableModules)
+      await pollModule(moduleId);
+    const diskModules = await scanDiskModules();
+    const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
+    if (newOnDisk.length)
+      console.log('[file-sync] new modules on disk:', newOnDisk);
+    for (const moduleId of diskModules) {
+      if (syncableSet.has(moduleId))
+        continue;
+      if (nameToModule.has(moduleId))
+        continue;
+      try {
+        const file = await readFile(directory, prefix + moduleId + '.js');
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const imported = await import(url);
+          if (typeof imported.default === 'function') {
+            const newMod = runtime.module(imported.default, () => null);
+            runtime.mains.set(moduleId, newMod);
+            nameToModule.set(moduleId, newMod);
+            syncableModules.push(moduleId);
+            syncableSet.add(moduleId);
+            const vars = new window.Map();
+            for (const v of runtime._variables) {
+              if (v._module !== newMod)
+                continue;
+              if (v._name)
+                vars.set(v._name, v);
+              if (v.pid)
+                vars.set('__pid__' + v.pid, v);
+            }
+            nameToVars.set(moduleId, vars);
+            console.log('[file-sync] added new module from disk: ' + moduleId);
+            try {
+              await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
+            } catch (e) {
+              console.error('[file-sync] manifest update for new module failed:', e);
+            }
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
+        }
+      } catch (e) {
+        console.error('[file-sync] failed to add module ' + moduleId + ':', e);
+      }
+    }
+    if (knownDiskModules) {
+      for (const moduleId of knownDiskModules) {
+        if (diskModules.has(moduleId))
+          continue;
+        if (!nameToModule.has(moduleId))
+          continue;
+        const mod = nameToModule.get(moduleId);
+        for (const v of [...runtime._variables]) {
+          if (v._module === mod)
+            v.delete();
+        }
+        runtime.mains.delete(moduleId);
+        nameToModule.delete(moduleId);
+        nameToVars.delete(moduleId);
+        knownFilePids.delete(moduleId);
+        const idx = syncableModules.indexOf(moduleId);
+        if (idx !== -1)
+          syncableModules.splice(idx, 1);
+        syncableSet.delete(moduleId);
+        console.log('[file-sync] removed module: ' + moduleId);
+        try {
+          await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+        } catch (e) {
+          console.error('[file-sync] manifest remove failed:', e);
+        }
+      }
+    }
+    knownDiskModules = diskModules;
+  };
+  pollTimer = setInterval(poll, POLL_MS);
+  poll();
+  invalidation.then(() => clearInterval(pollTimer));
+  return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
 };
 const _1b4kluo = function _21(md){return(
 md`## How It Works
@@ -16089,195 +16130,237 @@ md`## TODO
 - **Import cell validation**: verify import bridges survive round-trip correctly
 - **Conflict resolution**: when both disk and runtime edit the same cell simultaneously, detect and surface the conflict instead of last-write-wins`
 )};
-const _qq3v7b = function _jbApply(importShim) {
-    let pidSeq = 0;
-    const genPid = () => '_jb' + (pidSeq++).toString(36) + Math.floor(Math.random() * 1000000).toString(36);
-    const hasVarInput = inputs => (inputs || []).some(iv => (typeof iv === 'string' ? iv : iv && iv._name) === '@variable');
-    const importPath = defn => {
-        const m = (defn ? defn.toString() : '').match(/import\(\s*["'`]([^"'`]+)["'`]/);
-        return m ? m[1] : null;
+const _qq3v7b = function _jbApply(importShim)
+{
+  // Pure factory so any notebook can reuse it over its own runtime/fs. Build with
+  // jbApply({ currentModules, runtime, probeDefine, createModule, obj_observer }) -> applyModule(moduleId, defineFn).
+  // The file is canonical: applyModule makes the live module MATCH the file — creating/updating user
+  // cells, wiring cross-module imports, and DELETING anything live the file no longer contains.
+  //
+  // Import plumbing is NOT skipped — it is HOW a cross-module import reaches the runtime, so the agent
+  // can add imports by editing the file. exportModuleJS emits each import as a pair:
+  //   main.define("module @x", () => <child module>)                                  // loader
+  //   main.define("name", ["module @x","@variable"], (_,v)=>v.import("remote",_))      // binding
+  // The loader's original definition closes over the file's throwaway probe-runtime, so we REBUILD it
+  // against the real runtime (resolve the already-loaded child module by id, else importShim its path).
+  // The binding references only its inputs, so its definition is reused verbatim.
+  //
+  // Anonymous cells (name == null: md headers, expression/display cells) are the MAJORITY of a notebook
+  // and ARE editable — matched by pid, never skipped.
+  let pidSeq = 0;
+  const genPid = () => '_jb' + (pidSeq++).toString(36) + Math.floor(Math.random() * 1000000).toString(36);
+  const hasVarInput = inputs => (inputs || []).some(iv => (typeof iv === 'string' ? iv : iv && iv._name) === '@variable');
+  const importPath = defn => {
+    const m = (defn ? defn.toString() : '').match(/import\(\s*["'`]([^"'`]+)["'`]/);
+    return m ? m[1] : null;
+  };
+  return function makeApply({currentModules, runtime, probeDefine, createModule, obj_observer} = {}) {
+    const resolveModule = moduleId => {
+      if (currentModules)
+        for (const [, info] of currentModules)
+          if (info.name === moduleId)
+            return info.module;
+      const r = runtime;
+      if (r.mains && r.mains.has(moduleId))
+        return r.mains.get(moduleId);
+      if (typeof createModule === 'function') {
+        try {
+          return createModule(moduleId, r);
+        } catch (e) {
+          return null;
+        }
+      }
+      return null;
     };
-    return function makeApply({currentModules, runtime, probeDefine, createModule, obj_observer} = {}) {
-        const resolveModule = moduleId => {
-            if (currentModules)
-                for (const [, info] of currentModules)
-                    if (info.name === moduleId)
-                        return info.module;
-            const r = runtime;
-            if (r.mains && r.mains.has(moduleId))
-                return r.mains.get(moduleId);
-            if (typeof createModule === 'function') {
-                try {
-                    return createModule(moduleId, r);
-                } catch (e) {
-                    return null;
-                }
-            }
-            return null;
+    // Observer factory for newly-created user cells. obj_observer (from runtime-sdk) is the runtime's
+    // __ojs_observer builtin (name => observerObject); fall back to the builtin scope. Kept available for
+    // F6, but the default below stays {} — see the new-cell branch.
+    const obsFactory = (() => {
+      if (typeof obj_observer === 'function')
+        return obj_observer;
+      try {
+        const f = runtime && runtime._builtin && runtime._builtin._scope.get('__ojs_observer');
+        return f && typeof f._value === 'function' ? f._value : null;
+      } catch (e) {
+        return null;
+      }
+    })();
+    return function applyModule(moduleId, defineFn) {
+      const mod = resolveModule(moduleId);
+      if (!mod)
+        return {
+          applied: false,
+          reason: 'module not loaded and cannot create: ' + moduleId
         };
-        const obsFactory = (() => {
-            if (typeof obj_observer === 'function')
-                return obj_observer;
-            try {
-                const f = runtime && runtime._builtin && runtime._builtin._scope.get('__ojs_observer');
-                return f && typeof f._value === 'function' ? f._value : null;
-            } catch (e) {
-                return null;
+      const existingByName = new Map();
+      const existingByPid = new Map();
+      for (const v of runtime._variables) {
+        if (v._module !== mod)
+          continue;
+        if (v._name)
+          existingByName.set(v._name, v);
+        if (v.pid)
+          existingByPid.set(v.pid, v);
+      }
+      const cells = probeDefine(defineFn);
+      const seenPids = new Set();
+      const seenNames = new Set();
+      // import plumbing tracked by name (loaders/bindings carry no pid)
+      let changes = 0;
+      for (const cell of cells) {
+        // injected builtin — the runtime provides it; never (re)define
+        if (cell.name === '@variable')
+          continue;
+        // F7 (rc5): plumbing is UPSERTED, not create-only. Create-only meant a once-broken import
+        // (wrong inputs, bad path) could never be FIXED by editing the file — the corrected loader/
+        // binding was skipped with "0 cells changed" and the module stayed wedged (observed: an agent
+        // wrote a binding missing "@variable", then spiralled for 35 steps because its fix never
+        // applied). Loaders carry a semantic _jbKey ('live:'/'path:' + target) because their installed
+        // definition is locally rebuilt (toString comparison is meaningless); loaders from the module's
+        // ORIGINAL define (no _jbKey) are left untouched to avoid recompute churn. Bindings compare
+        // inputs + definition like ordinary cells (their definitions are closure-safe file text).
+        const upsertLoader = (loaderName, defn) => {
+          seenNames.add(loaderName);
+          const spec = loaderName.slice('module '.length);
+          const child = resolveModule(spec);
+          const path = importPath(defn);
+          const key = child ? 'live:' + spec : path ? 'path:' + path : null;
+          if (key == null)
+            return;
+          const make = child ? () => child : async () => runtime.module((await import(path)).default);
+          const existing = existingByName.get(loaderName);
+          if (existing) {
+            if (existing._jbKey !== undefined && existing._jbKey !== key) {
+              existing.define(loaderName, [], make);
+              existing._jbKey = key;
+              changes++;
             }
-        })();
-        return function applyModule(moduleId, defineFn) {
-            const mod = resolveModule(moduleId);
-            if (!mod)
-                return {
-                    applied: false,
-                    reason: 'module not loaded and cannot create: ' + moduleId
-                };
-            const existingByName = new Map();
-            const existingByPid = new Map();
-            for (const v of runtime._variables) {
-                if (v._module !== mod)
-                    continue;
-                if (v._name)
-                    existingByName.set(v._name, v);
-                if (v.pid)
-                    existingByPid.set(v.pid, v);
-            }
-            const cells = probeDefine(defineFn);
-            const seenPids = new Set();
-            const seenNames = new Set();
-            let changes = 0;
-            for (const cell of cells) {
-                if (cell.name === '@variable')
-                    continue;
-                const upsertLoader = (loaderName, defn) => {
-                    seenNames.add(loaderName);
-                    const spec = loaderName.slice('module '.length);
-                    const child = resolveModule(spec);
-                    const path = importPath(defn);
-                    const key = child ? 'live:' + spec : path ? 'path:' + path : null;
-                    if (key == null)
-                        return;
-                    const make = child ? () => child : async () => runtime.module((await import(path)).default);
-                    const existing = existingByName.get(loaderName);
-                    if (existing) {
-                        if (existing._jbKey !== undefined && existing._jbKey !== key) {
-                            existing.define(loaderName, [], make);
-                            existing._jbKey = key;
-                            changes++;
-                        }
-                        return;
-                    }
-                    const v = mod.variable(null);
-                    v.define(loaderName, [], make);
-                    v._jbKey = key;
-                    existingByName.set(loaderName, v);
-                    changes++;
-                };
-                const upsertBinding = (name, inputs, defn) => {
-                    seenNames.add(name);
-                    const existing = existingByName.get(name);
-                    if (!existing) {
-                        const v = mod.variable(null);
-                        v.define(name, inputs, defn);
-                        existingByName.set(name, v);
-                        changes++;
-                        return;
-                    }
-                    const existingInputNames = (existing._inputs || []).map(iv => typeof iv === 'string' ? iv : iv._name);
-                    const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(inputs);
-                    const defnMatch = existing._definition && existing._definition.toString() === (defn ? defn.toString() : '');
-                    if (!(inputsMatch && defnMatch)) {
-                        existing.define(name, inputs, defn);
-                        changes++;
-                    }
-                };
-                if (cell.type === 'import') {
-                    const spec = cell.from;
-                    const child = spec && resolveModule(spec);
-                    if (!child)
-                        continue;
-                    const loaderName = 'module ' + spec;
-                    seenNames.add(loaderName);
-                    if (!existingByName.has(loaderName)) {
-                        const lv = mod.variable(null);
-                        lv.define(loaderName, [], () => child);
-                        lv._jbKey = 'live:' + spec;
-                        existingByName.set(loaderName, lv);
-                        changes++;
-                    }
-                    const alias = cell.alias || cell.remote;
-                    upsertBinding(alias, [
-                        loaderName,
-                        '@variable'
-                    ], (_, vv) => vv.import(cell.remote, _));
-                    continue;
-                }
-                if (cell.name && cell.name.startsWith('module ')) {
-                    upsertLoader(cell.name, cell.definition);
-                    continue;
-                }
-                if (hasVarInput(cell.inputs)) {
-                    if (cell.name)
-                        upsertBinding(cell.name, cell.inputs, cell.definition);
-                    continue;
-                }
-                let pid = cell.pid;
-                if (!pid) {
-                    const byName = cell.name && existingByName.get(cell.name);
-                    pid = byName && byName.pid || genPid();
-                }
-                seenPids.add(pid);
-                if (cell.name)
-                    seenNames.add(cell.name);
-                const existing = existingByPid.get(pid) || cell.name && existingByName.get(cell.name);
-                if (!existing) {
-                    const v = mod.variable({});
-                    v.define(cell.name, cell.inputs, cell.definition);
-                    v.pid = pid;
-                    existingByPid.set(pid, v);
-                    if (cell.name)
-                        existingByName.set(cell.name, v);
-                    changes++;
-                    continue;
-                }
-                const existingInputNames = (existing._inputs || []).map(iv => typeof iv === 'string' ? iv : iv._name);
-                const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                const defnMatch = existing._definition && existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                if (inputsMatch && defnMatch) {
-                    if (!existing.pid)
-                        existing.pid = pid;
-                    continue;
-                }
-                existing.define(cell.name, cell.inputs, cell.definition).pid = pid;
-                changes++;
-            }
-            for (const v of [...runtime._variables]) {
-                if (v._module !== mod)
-                    continue;
-                const name = v._name;
-                if (name === '@variable')
-                    continue;
-                if (name && seenNames.has(name))
-                    continue;
-                if (name && name.startsWith('module ') || hasVarInput(v._inputs)) {
-                    if (name) {
-                        v.delete();
-                        changes++;
-                    }
-                    continue;
-                }
-                if (!v.pid || seenPids.has(v.pid))
-                    continue;
-                v.delete();
-                changes++;
-            }
-            return {
-                applied: true,
-                moduleId,
-                changes
-            };
+            return;
+          }
+          const v = mod.variable(null);
+          v.define(loaderName, [], make);
+          v._jbKey = key;
+          existingByName.set(loaderName, v);
+          changes++;
         };
+        const upsertBinding = (name, inputs, defn) => {
+          seenNames.add(name);
+          const existing = existingByName.get(name);
+          if (!existing) {
+            const v = mod.variable(null);
+            v.define(name, inputs, defn);
+            existingByName.set(name, v);
+            changes++;
+            return;
+          }
+          const existingInputNames = (existing._inputs || []).map(iv => typeof iv === 'string' ? iv : iv._name);
+          const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(inputs);
+          const defnMatch = existing._definition && existing._definition.toString() === (defn ? defn.toString() : '');
+          if (!(inputsMatch && defnMatch)) {
+            existing.define(name, inputs, defn);
+            changes++;
+          }
+        };
+        // explicit module.variable().import(remote, alias, from) form
+        if (cell.type === 'import') {
+          const spec = cell.from;
+          const child = spec && resolveModule(spec);
+          if (!child)
+            continue;
+          const loaderName = 'module ' + spec;
+          seenNames.add(loaderName);
+          if (!existingByName.has(loaderName)) {
+            const lv = mod.variable(null);
+            lv.define(loaderName, [], () => child);
+            lv._jbKey = 'live:' + spec;
+            existingByName.set(loaderName, lv);
+            changes++;
+          }
+          const alias = cell.alias || cell.remote;
+          upsertBinding(alias, [
+            loaderName,
+            '@variable'
+          ], (_, vv) => vv.import(cell.remote, _));
+          continue;
+        }
+        // import-loader plumbing: "module @x" — rebuild against the REAL runtime
+        if (cell.name && cell.name.startsWith('module ')) {
+          upsertLoader(cell.name, cell.definition);
+          continue;
+        }
+        // import-binding: inputs include "@variable" — definition is closure-safe, reuse verbatim
+        if (hasVarInput(cell.inputs)) {
+          if (cell.name)
+            upsertBinding(cell.name, cell.inputs, cell.definition);
+          continue;
+        }
+        // ordinary user cell — match by pid; mint one for pid-less hand-written cells so re-applies dedupe
+        let pid = cell.pid;
+        if (!pid) {
+          const byName = cell.name && existingByName.get(cell.name);
+          pid = byName && byName.pid || genPid();
+        }
+        seenPids.add(pid);
+        if (cell.name)
+          seenNames.add(cell.name);
+        const existing = existingByPid.get(pid) || cell.name && existingByName.get(cell.name);
+        if (!existing) {
+          // Empty observer ({}) so a pane's visualizer can render the cell; mod.variable(null)
+          // (unobserved) lets the apply-time probe own it → element parented outside any pane → blank.
+          const v = mod.variable({});
+          v.define(cell.name, cell.inputs, cell.definition);
+          v.pid = pid;
+          existingByPid.set(pid, v);
+          if (cell.name)
+            existingByName.set(cell.name, v);
+          changes++;
+          continue;
+        }
+        const existingInputNames = (existing._inputs || []).map(iv => typeof iv === 'string' ? iv : iv._name);
+        const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+        const defnMatch = existing._definition && existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+        if (inputsMatch && defnMatch) {
+          if (!existing.pid)
+            existing.pid = pid;
+          continue;
+        }
+        existing.define(cell.name, cell.inputs, cell.definition).pid = pid;
+        changes++;
+      }
+      // F4: prune anything the file no longer contains — reload-proof, no cross-call state.
+      //   user cells   → pid-bearing vars not seen this apply
+      //   import plumbing → "module @x" loaders / "@variable"-wired bindings whose name not seen
+      for (const v of [...runtime._variables]) {
+        if (v._module !== mod)
+          continue;
+        const name = v._name;
+        if (name === '@variable')
+          continue;
+        if (name && seenNames.has(name))
+          continue;
+        // present in file (user cell or import binding/loader) → keep, even if it acquired a pid via persistentId
+        // removed import plumbing ("module @x" loader, or a "@variable"-wired binding)
+        if (name && name.startsWith('module ') || hasVarInput(v._inputs)) {
+          if (name) {
+            v.delete();
+            changes++;
+          }
+          continue;
+        }
+        if (!v.pid || seenPids.has(v.pid))
+          continue;
+        // keep pid-less and still-present user cells
+        v.delete();
+        // orphaned user cell (removed / renamed)
+        changes++;
+      }
+      return {
+        applied: true,
+        moduleId,
+        changes
+      };
     };
+  };
 };
 
 export default function define(runtime, observer) {
@@ -16809,20 +16892,20 @@ const _1aloau2 = (G, _) => G.input(_);
 const _7s1qq7 = function _6($0,sqrt){return(
 $0.resolve(Math.sqrt(sqrt))
 )};
-const _3iwba4 = async function _testing(flowQueue) {
-    flowQueue;
-    const [{Runtime}, {default: define}] = await Promise.all([
-        import('https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js'),
-        import(`https://api.observablehq.com/@tomlarkworthy/testing.js?v=3`)
-    ]);
-    const module = new Runtime().module(define);
-    return Object.fromEntries(await Promise.all([
-        'expect',
-        'createSuite'
-    ].map(n => module.value(n).then(v => [
-        n,
-        v
-    ]))));
+const _3iwba4 = async function _testing(flowQueue)
+{
+  flowQueue;
+  // load after implementation
+  const [{ Runtime }, { default: define }] = await Promise.all([
+    import("https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js"),
+    import(`https://api.observablehq.com/@tomlarkworthy/testing.js?v=3`)
+  ]);
+  const module = new Runtime().module(define);
+  return Object.fromEntries(
+    await Promise.all(
+      ["expect", "createSuite"].map((n) => module.value(n).then((v) => [n, v]))
+    )
+  );
 };
 const _j8s3j1 = function _suite(testing){return(
 testing.createSuite({ name: 'Unit Tests' })
@@ -17464,14 +17547,18 @@ FileAttachment("lm_popin_black.png").url()
 const _18kpe1x = function _lm_popout_black(FileAttachment){return(
 FileAttachment("lm_popout_black.png").url()
 )};
-const _1p7i538 = async function _gl(unzip, FileAttachment) {
-    const blob = await unzip(FileAttachment('golden-layout-2.6.0.js.gz'));
-    const objectURL = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
-    try {
-        return await import(objectURL);
-    } finally {
-        URL.revokeObjectURL(objectURL);
-    }
+const _1p7i538 = async function _gl(unzip,FileAttachment)
+{
+  const blob = await unzip(FileAttachment("golden-layout-2.6.0.js.gz"));
+
+  const objectURL = URL.createObjectURL(
+    new Blob([blob], { type: "application/javascript" })
+  );
+  try {
+    return await import(objectURL);
+  } finally {
+    URL.revokeObjectURL(objectURL); // Ensure URL is revoked after import
+  }
 };
 const _17n6uge = function _unzip(Response,DecompressionStream){return(
 async (attachment) =>
@@ -17869,23 +17956,35 @@ import {git, http} from "@tomlarkworthy/isomorphic-git-1-30-1"
 import {FS} from "@tomlarkworthy/lightning-fs-4-6-0"
 ~~~`
 )};
-const _vz8us1 = async function _git(unzip, FileAttachment) {
-    const blob = await unzip(FileAttachment('isomorphic-git-1@1.30.1.bundle.js.gz'));
-    const objectURL = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
-    try {
-        return await import(objectURL);
-    } finally {
-        URL.revokeObjectURL(objectURL);
-    }
+const _vz8us1 = async function _git(unzip,FileAttachment)
+{
+  const blob = await unzip(
+    FileAttachment("isomorphic-git-1@1.30.1.bundle.js.gz")
+  );
+
+  const objectURL = URL.createObjectURL(
+    new Blob([blob], { type: "application/javascript" })
+  );
+  try {
+    return await import(objectURL);
+  } finally {
+    URL.revokeObjectURL(objectURL);
+  }
 };
-const _2acekr = async function _http(unzip, FileAttachment) {
-    const blob = await unzip(FileAttachment('isomorphic-git-http-1.0.0-beta.36.js.gz'));
-    const objectURL = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
-    try {
-        return await import(objectURL);
-    } finally {
-        URL.revokeObjectURL(objectURL);
-    }
+const _2acekr = async function _http(unzip,FileAttachment)
+{
+  const blob = await unzip(
+    FileAttachment("isomorphic-git-http-1.0.0-beta.36.js.gz")
+  );
+
+  const objectURL = URL.createObjectURL(
+    new Blob([blob], { type: "application/javascript" })
+  );
+  try {
+    return await import(objectURL);
+  } finally {
+    URL.revokeObjectURL(objectURL);
+  }
 };
 const _1emihnv = function _4(md){return(
 md`
@@ -17959,15 +18058,21 @@ md`# jest-expect-standalone@24.0.2
 import {expect} from "@tomlarkworthy/jest-expect-standalone"
 ~~~`
 )};
-const _mh1f13 = async function _expect(unzip, FileAttachment) {
-    const blob = await unzip(FileAttachment('jest-expect-standalone-24.0.2.js.gz'));
-    const objectURL = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
-    try {
-        await import(objectURL);
-        return window.expect;
-    } finally {
-        URL.revokeObjectURL(objectURL);
-    }
+const _mh1f13 = async function _expect(unzip,FileAttachment)
+{
+  const blob = await unzip(
+    FileAttachment("jest-expect-standalone-24.0.2.js.gz")
+  );
+
+  const objectURL = URL.createObjectURL(
+    new Blob([blob], { type: "application/javascript" })
+  );
+  try {
+    await import(objectURL);
+    return window.expect;
+  } finally {
+    URL.revokeObjectURL(objectURL);
+  }
 };
 const _17n6uge = function _unzip(Response,DecompressionStream){return(
 async (attachment) =>
@@ -18012,14 +18117,18 @@ md`# [jszip@3.10.1](https://stuk.github.io/jszip/)
 import {JSZip} from "@tomlarkworthy/jszip-3-10-1"
 ~~~`
 )};
-const _umavbe = async function _JSZip(unzip, FileAttachment) {
-    const blob = await unzip(FileAttachment('jszip-3.10.1.min.js.gz'));
-    const objectURL = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
-    try {
-        return (await import(objectURL)).default;
-    } finally {
-        URL.revokeObjectURL(objectURL);
-    }
+const _umavbe = async function _JSZip(unzip,FileAttachment)
+{
+  const blob = await unzip(FileAttachment("jszip-3.10.1.min.js.gz"));
+
+  const objectURL = URL.createObjectURL(
+    new Blob([blob], { type: "application/javascript" })
+  );
+  try {
+    return (await import(objectURL)).default;
+  } finally {
+    URL.revokeObjectURL(objectURL); // Ensure URL is revoked after import
+  }
 };
 const _g5fwfs = function _unzip(Response,DecompressionStream){return(
 async (attachment) => {
@@ -18071,14 +18180,18 @@ import {FS} from "@tomlarkworthy/lightning-fs-4-6-0"
 import {git, http} from "@tomlarkworthy/isomorphic-git-1-30-1" 
 ~~~`
 )};
-const _1tds3ro = async function _FS(unzip, FileAttachment) {
-    const blob = await unzip(FileAttachment('lightning-fs-4.6.0.js.gz'));
-    const objectURL = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
-    try {
-        return (await import(objectURL)).default;
-    } finally {
-        URL.revokeObjectURL(objectURL);
-    }
+const _1tds3ro = async function _FS(unzip,FileAttachment)
+{
+  const blob = await unzip(FileAttachment("lightning-fs-4.6.0.js.gz"));
+
+  const objectURL = URL.createObjectURL(
+    new Blob([blob], { type: "application/javascript" })
+  );
+  try {
+    return (await import(objectURL)).default;
+  } finally {
+    URL.revokeObjectURL(objectURL);
+  }
 };
 const _dqri64 = function _3(md){return(
 md`
@@ -22008,182 +22121,205 @@ It's an effecient alternative to [moduleMap](https://observablehq.com/@tomlarkwo
 const _1eaa9lr = function _currentModules(modules){return(
 modules()
 )};
-const _dmem61 = function _modules(runtime, observeVariable, moduleTitle) {
-    const _runtime = runtime;
-    return function modules({runtime = _runtime, titleTimeoutMs = 2000, rescanMs = 1000, load = true} = {}) {
-        if (!runtime || !runtime._variables)
-            throw 'Invalid runtime passed to modules';
-        return async function* () {
-            const records = new Map();
-            const watchers = new Map();
-            const peeking = new Map();
-            let pending = false, wake = null, dirty = true;
-            const bump = () => {
-                pending = true;
-                if (wake) {
-                    const w = wake;
-                    wake = null;
-                    w();
-                }
-            };
-            const touch = () => {
-                dirty = true;
-                bump();
-            };
-            const slugFromDef = v => {
-                const m = v._definition && String(v._definition).match(/import(?:Shim)?\(\s*["'`]\/?([^"'`?]+?)\.js(?:[?"'`)]|$)/);
-                return m ? m[1].replace(/^\//, '') : null;
-            };
-            const scan = () => {
-                const out = new Map();
-                const put = (m, r) => {
-                    if (m && !out.has(m))
-                        out.set(m, r);
-                };
-                const builtin = runtime._builtin, bootloader = runtime.bootloader;
-                if (builtin)
-                    put(builtin, {
-                        name: 'builtin',
-                        title: 'Standard library'
-                    });
-                if (bootloader)
-                    put(bootloader, {
-                        name: 'bootloader',
-                        title: 'Bootloader'
-                    });
-                for (const [name, mod] of runtime.mains || new Map())
-                    put(mod, { name });
-                const imported = new Set((runtime._modules || new Map()).values());
-                const owners = new Set();
-                for (const v of runtime._variables)
-                    if (v._module)
-                        owners.add(v._module);
-                for (const m of owners)
-                    if (m !== builtin && m !== bootloader && !imported.has(m))
-                        put(m, { name: 'main' });
-                for (const v of runtime._variables) {
-                    if (!v._name || !v._name.startsWith('module ') || v._name.startsWith('module <unknown'))
-                        continue;
-                    const mod = v._value;
-                    if (mod && typeof mod === 'object')
-                        put(mod, {
-                            name: slugFromDef(v) || v._name.slice(7),
-                            variable: v
-                        });
-                    else if (load && !peeking.has(v))
-                        peeking.set(v, observeVariable(v, {
-                            fulfilled: bump,
-                            error: bump
-                        }));
-                }
-                return out;
-            };
-            const reconcile = () => {
-                const cand = scan();
-                for (const m of [...watchers.keys()]) {
-                    if (!cand.has(m)) {
-                        const cancel = watchers.get(m);
-                        watchers.delete(m);
-                        if (records.delete(m))
-                            touch();
-                        try {
-                            cancel();
-                        } catch (e) {
-                        }
-                    }
-                }
-                for (const [m, c] of cand) {
-                    if (watchers.has(m))
-                        continue;
-                    if (c.title != null) {
-                        records.set(m, {
-                            name: c.name,
-                            title: c.title,
-                            module: m,
-                            variable: c.variable
-                        });
-                        watchers.set(m, () => {
-                        });
-                        touch();
-                        continue;
-                    }
-                    const apply = title => {
-                        if (!watchers.has(m))
-                            return;
-                        const t = title ?? c.name;
-                        const prev = records.get(m);
-                        if (!prev) {
-                            records.set(m, {
-                                name: c.name,
-                                title: t,
-                                module: m,
-                                variable: c.variable
-                            });
-                            touch();
-                        } else if (prev.title !== t) {
-                            records.set(m, {
-                                ...prev,
-                                title: t
-                            });
-                            touch();
-                        }
-                    };
-                    const cancel = moduleTitle(m, apply);
-                    watchers.set(m, () => {
-                        try {
-                            cancel();
-                        } catch (e) {
-                        }
-                    });
-                    setTimeout(() => {
-                        if (watchers.has(m) && !records.has(m))
-                            apply(null);
-                    }, titleTimeoutMs);
-                }
-            };
-            let stopped = false;
-            (async () => {
-                while (!stopped) {
-                    try {
-                        reconcile();
-                    } catch (e) {
-                    }
-                    await new Promise(r => setTimeout(r, rescanMs));
-                }
-            })();
+const _dmem61 = function _modules(runtime,observeVariable,moduleTitle)
+{
+  const _runtime = runtime;
+  // default: the current runtime
+  return function modules({runtime = _runtime, titleTimeoutMs = 2000, rescanMs = 1000, load = true} = {}) {
+    if (!runtime || !runtime._variables)
+      throw 'Invalid runtime passed to modules';
+    return async function* () {
+      const records = new Map();
+      // module -> fully-formed record (title resolved before it lands here)
+      const watchers = new Map();
+      // module -> cancel fn (stops its title watch)
+      const peeking = new Map();
+      // unresolved `module X` variable -> stop fn (its force-load observer)
+      let pending = false, wake = null, dirty = true;
+      const bump = () => {
+        pending = true;
+        if (wake) {
+          const w = wake;
+          wake = null;
+          w();
+        }
+      };
+      const touch = () => {
+        dirty = true;
+        bump();
+      };
+      // Recover a module's @user/slug from its loader definition. On Observable's runtime the
+      // `module X` variable is named numerically ("module 1"), so v._name.slice(7) is a useless id;
+      // the real slug lives in the loader's import URL — import("/@user/slug.js?…") or
+      // importShim("/@user/slug.js", …). Matches both runtimes; null if no URL is found.
+      const slugFromDef = v => {
+        const m = v._definition && String(v._definition).match(/import(?:Shim)?\(\s*["'`]\/?([^"'`?]+?)\.js(?:[?"'`)]|$)/);
+        return m ? m[1].replace(/^\//, '') : null;
+      };
+      // Live candidate modules: Map<module, {name, variable?, title?}>. Side effect: force-loads
+      // unresolved `module X` variables via observe (which marks them reachable) so their modules
+      // become resolvable on a later scan.
+      const scan = () => {
+        const out = new Map();
+        const put = (m, r) => {
+          if (m && !out.has(m))
+            out.set(m, r);
+        };
+        const builtin = runtime._builtin, bootloader = runtime.bootloader;
+        if (builtin)
+          put(builtin, {
+            name: 'builtin',
+            title: 'Standard library'
+          });
+        if (bootloader)
+          put(bootloader, {
+            name: 'bootloader',
+            title: 'Bootloader'
+          });
+        for (const [name, mod] of runtime.mains || new Map())
+          put(mod, { name });
+        // main modules: variable-graph roots — own variables but aren't imported (nor builtin/
+        // bootloader). Catches the top-level main of a plain runtime where runtime.mains is empty.
+        const imported = new Set((runtime._modules || new Map()).values());
+        const owners = new Set();
+        for (const v of runtime._variables)
+          if (v._module)
+            owners.add(v._module);
+        for (const m of owners)
+          if (m !== builtin && m !== bootloader && !imported.has(m))
+            put(m, { name: 'main' });
+        // imported modules carried by `module X` variables
+        for (const v of runtime._variables) {
+          if (!v._name || !v._name.startsWith('module ') || v._name.startsWith('module <unknown'))
+            continue;
+          const mod = v._value;
+          if (mod && typeof mod === 'object')
+            put(mod, {
+              name: slugFromDef(v) || v._name.slice(7),
+              variable: v
+            });
+          else if (load && !peeking.has(v))
+            peeking.set(v, observeVariable(v, {
+              fulfilled: bump,
+              error: bump
+            }));
+        }
+        return out;
+      };
+      // Reconcile the snapshot with the live runtime each scan.
+      const reconcile = () => {
+        const cand = scan();
+        // DELETE: drop modules no longer present; cancel their title watcher.
+        for (const m of [...watchers.keys()]) {
+          if (!cand.has(m)) {
+            const cancel = watchers.get(m);
+            watchers.delete(m);
+            if (records.delete(m))
+              touch();
             try {
-                while (true) {
-                    pending = false;
-                    if (dirty) {
-                        dirty = false;
-                        yield new Map(records);
-                    }
-                    if (!pending)
-                        await new Promise(resolve => {
-                            wake = resolve;
-                            if (pending) {
-                                wake = null;
-                                resolve();
-                            }
-                        });
-                }
-            } finally {
-                stopped = true;
-                for (const cancel of watchers.values()) {
-                    try {
-                        cancel();
-                    } catch (e) {
-                    }
-                }
-                for (const stop of peeking.values()) {
-                    try {
-                        stop();
-                    } catch (e) {
-                    }
-                }
+              cancel();
+            } catch (e) {
             }
-        }();
-    };
+          }
+        }
+        // CREATE: start a persistent title watch for each new module. The module enters `records`
+        // only once its title resolves (or the timeout fires). Later title changes update in place.
+        for (const [m, c] of cand) {
+          if (watchers.has(m))
+            continue;
+          if (c.title != null) {
+            // static title (builtin / bootloader)
+            records.set(m, {
+              name: c.name,
+              title: c.title,
+              module: m,
+              variable: c.variable
+            });
+            watchers.set(m, () => {
+            });
+            touch();
+            continue;
+          }
+          const apply = title => {
+            if (!watchers.has(m))
+              return;
+            // module was pruned -> ignore late title callbacks
+            const t = title ?? c.name;
+            const prev = records.get(m);
+            if (!prev) {
+              records.set(m, {
+                name: c.name,
+                title: t,
+                module: m,
+                variable: c.variable
+              });
+              touch();
+            } else if (prev.title !== t) {
+              records.set(m, {
+                ...prev,
+                title: t
+              });
+              touch();
+            }
+          };
+          const cancel = moduleTitle(m, apply);
+          watchers.set(m, () => {
+            try {
+              cancel();
+            } catch (e) {
+            }
+          });
+          // title never resolved within the budget -> show the name so the module isn't withheld.
+          setTimeout(() => {
+            if (watchers.has(m) && !records.has(m))
+              apply(null);
+          }, titleTimeoutMs);
+        }
+      };
+      let stopped = false;
+      (async () => {
+        while (!stopped) {
+          try {
+            reconcile();
+          } catch (e) {
+          }
+          await new Promise(r => setTimeout(r, rescanMs));
+        }
+      })();
+      try {
+        while (true) {
+          pending = false;
+          if (dirty) {
+            dirty = false;
+            yield new Map(records);
+          }
+          // cumulative snapshot
+          if (!pending)
+            await new Promise(resolve => {
+              wake = resolve;
+              if (pending) {
+                wake = null;
+                resolve();
+              }
+            });
+        }
+      } finally {
+        stopped = true;
+        for (const cancel of watchers.values()) {
+          try {
+            cancel();
+          } catch (e) {
+          }
+        }
+        for (const stop of peeking.values()) {
+          try {
+            stop();
+          } catch (e) {
+          }
+        }
+      }
+    }();
+  };
 };
 const _up9atj = function _moduleTitle(observeVariable)
 {
@@ -22434,14 +22570,18 @@ observable.Library
 const _1iyzb44 = function _RuntimeError(observable){return(
 observable.RuntimeError
 )};
-const _b2ba5g = async function _observable(unzip, FileAttachment) {
-    const blob = await unzip(FileAttachment('runtime.js.gz'));
-    const objectURL = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
-    try {
-        return await import(objectURL);
-    } finally {
-        URL.revokeObjectURL(objectURL);
-    }
+const _b2ba5g = async function _observable(unzip,FileAttachment)
+{
+  const blob = await unzip(FileAttachment("runtime.js.gz"));
+
+  const objectURL = URL.createObjectURL(
+    new Blob([blob], { type: "application/javascript" })
+  );
+  try {
+    return await import(objectURL);
+  } finally {
+    URL.revokeObjectURL(objectURL);
+  }
 };
 const _17n6uge = function _unzip(Response,DecompressionStream){return(
 async (attachment) =>
@@ -22492,10 +22632,13 @@ runtime.Runtime
 const _bfntg8 = function _RuntimeError(runtime){return(
 runtime.RuntimeError
 )};
-const _axblun = async function _runtime(gunzipBase64ToBlob, source_gz) {
-    const blob = await gunzipBase64ToBlob(source_gz);
-    const url = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
-    return import(url);
+const _axblun = async function _runtime(gunzipBase64ToBlob,source_gz)
+{
+  const blob = await gunzipBase64ToBlob(source_gz);
+  const url = URL.createObjectURL(
+    new Blob([blob], { type: "application/javascript" })
+  );
+  return import(url);
 };
 const _1ljam5l = function _gunzipBase64ToBlob(DecompressionStream,Response){return(
 async (b64) => {
@@ -22595,7 +22738,8 @@ Then re-attach the resulting \`.js.gz\` files to this notebook
 (notebook menu → Attachments → drag-and-drop, replacing the existing
 attachments of the same name).`
 )};
-const _3cxbvl = async function _lr(unzip, FileAttachment) {
+const _3cxbvl = async function _lr(unzip,FileAttachment)
+{
     const blob = await unzip(FileAttachment('lezer-lr-bundled.js.gz'));
     const objectURL = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
     try {
@@ -22604,7 +22748,8 @@ const _3cxbvl = async function _lr(unzip, FileAttachment) {
         URL.revokeObjectURL(objectURL);
     }
 };
-const _1v8kgvh = async function _lezerhighlight(unzip, FileAttachment) {
+const _1v8kgvh = async function _lezerhighlight(unzip,FileAttachment)
+{
     const blob = await unzip(FileAttachment('lezer-highlight-bundled.js.gz'));
     const objectURL = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
     try {
@@ -24294,10 +24439,10 @@ md`### \`importShim\` polyfill
 
 Lopecode uses importShim which is not availible on Observablehq`
 )};
-const _12odeih = function _importShim() {
-    if (window.importShim)
-        return window.importShim;
-    return (url, options) => import(url);
+const _12odeih = function _importShim()
+{
+  if (window.importShim) return window.importShim;
+  return (url, options) => import(url);
 };
 const _1nrqtih = function _65(md){return(
 md`---`
@@ -28148,21 +28293,19 @@ md`## [Optional] Tests`
 const _11gtx14 = function _RUN_TESTS(){return(
 true
 )};
-const _46icxz = async function _testing(RUN_TESTS, invalidation) {
-    if (!RUN_TESTS)
-        return invalidation;
-    const [{Runtime}, {default: define}] = await Promise.all([
-        import('https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js'),
-        import(`https://api.observablehq.com/@tomlarkworthy/testing.js?v=3`)
-    ]);
-    const module = new Runtime().module(define);
-    return Object.fromEntries(await Promise.all([
-        'expect',
-        'createSuite'
-    ].map(n => module.value(n).then(v => [
-        n,
-        v
-    ]))));
+const _46icxz = async function _testing(RUN_TESTS,invalidation)
+{
+  if (!RUN_TESTS) return invalidation;
+  const [{ Runtime }, { default: define }] = await Promise.all([
+    import("https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js"),
+    import(`https://api.observablehq.com/@tomlarkworthy/testing.js?v=3`)
+  ]);
+  const module = new Runtime().module(define);
+  return Object.fromEntries(
+    await Promise.all(
+      ["expect", "createSuite"].map((n) => module.value(n).then((v) => [n, v]))
+    )
+  );
 };
 const _lf943y = function _suite(testing){return(
 testing.createSuite({
@@ -28398,13 +28541,14 @@ suite.test("Collection object creates matching keys", async () => {
   expect(v.value).toHaveProperty("a");
 })
 )};
-const _1qdb7yp = async function _toc() {
-    const [{Runtime}, {default: define}] = await Promise.all([
-        import('https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js'),
-        import(`https://api.observablehq.com/@nebrius/indented-toc.js?v=3`)
-    ]);
-    const module = new Runtime().module(define);
-    return module.value('toc');
+const _1qdb7yp = async function _toc()
+{
+  const [{ Runtime }, { default: define }] = await Promise.all([
+    import("https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js"),
+    import(`https://api.observablehq.com/@nebrius/indented-toc.js?v=3`)
+  ]);
+  const module = new Runtime().module(define);
+  return module.value("toc");
 };
 
 export default function define(runtime, observer) {

--- a/notebooks/@tomlarkworthy_observablejs-toolchain.json
+++ b/notebooks/@tomlarkworthy_observablejs-toolchain.json
@@ -7,7 +7,8 @@
       "@tomlarkworthy/observablejs-toolchain"
     ],
     "hash": "#view=S100(@tomlarkworthy/observablejs-toolchain,@tomlarkworthy/module-selection)",
-    "headless": true
+    "headless": true,
+    "prerender": true
   },
   "files": [
     "syntax.css"
@@ -21,6 +22,42 @@
     },
     "@observablehq/inspector@5.0.1": {
       "hash": "5658858e85affa2e1e5cd1052924c622"
+    },
+    "@tomlarkworthy/lopepage": {
+      "hash": "633f78d13e1da2ee746dc2c8598b5a24",
+      "dependsOn": [
+        "@tomlarkworthy/golden-layout-2-6-0",
+        "@tomlarkworthy/visualizer",
+        "@tomlarkworthy/module-selection",
+        "@tomlarkworthy/runtime-sdk",
+        "@tomlarkworthy/editor-5",
+        "@tomlarkworthy/exporter-3",
+        "d/57d79353bac56631@44",
+        "@tomlarkworthy/local-change-history",
+        "@tomlarkworthy/claude-code-pairing",
+        "@tomlarkworthy/command-palette"
+      ]
+    },
+    "@tomlarkworthy/observablejs-toolchain": {
+      "hash": "13bf44d8f1fcf6250272f65bb56fe457",
+      "files": [
+        "parser-6.1.0.js.gz"
+      ],
+      "dependsOn": [
+        "@tomlarkworthy/tests",
+        "@tomlarkworthy/cell-map",
+        "@tomlarkworthy/acorn-8-11-3",
+        "@tomlarkworthy/jest-expect-standalone",
+        "@tomlarkworthy/observable-runtime"
+      ],
+      "dependedBy": [
+        "@tomlarkworthy/cell-map",
+        "@tomlarkworthy/claude-code-pairing",
+        "@tomlarkworthy/editor-5",
+        "@tomlarkworthy/exporter-3",
+        "@tomlarkworthy/module-map",
+        "@tomlarkworthy/module-selection"
+      ]
     },
     "@mbostock/safe-local-storage": {
       "hash": "937d252019887842c8c48c634b76179a",
@@ -70,7 +107,7 @@
       ]
     },
     "@tomlarkworthy/claude-code-pairing": {
-      "hash": "9ef62cada1525cf5d4987907f0362236",
+      "hash": "8cdd769d2694a74bad1003b20625a618",
       "dependsOn": [
         "@tomlarkworthy/module-map",
         "@tomlarkworthy/exporter-3",
@@ -95,11 +132,13 @@
       ]
     },
     "@tomlarkworthy/command-palette": {
-      "hash": "4b7ce022a1bc9a4affa98c47552f828d",
+      "hash": "a3617c1f57904cbab42a34b069bf092a",
       "dependsOn": [
         "@tomlarkworthy/cell-map",
         "@tomlarkworthy/lopepage-urls",
-        "@tomlarkworthy/themes"
+        "@tomlarkworthy/themes",
+        "@tomlarkworthy/module-map",
+        "@tomlarkworthy/plugin-registry"
       ],
       "dependedBy": [
         "@tomlarkworthy/lopepage"
@@ -125,12 +164,13 @@
       ]
     },
     "@tomlarkworthy/editor-5": {
-      "hash": "fae9b418b3741f77d28809f38b3fe504",
+      "hash": "e6e33733479672bd1d82a0fb15e4eb11",
       "files": [
         "cell_options.json"
       ],
       "dependsOn": [
         "@tomlarkworthy/visualizer",
+        "@tomlarkworthy/modules",
         "@tomlarkworthy/reversible-attachment",
         "@tomlarkworthy/flow-queue",
         "@tomlarkworthy/cell-map",
@@ -161,10 +201,12 @@
     "@tomlarkworthy/exporter-3": {
       "hash": "bf04e9247f3cbb2ae5880d8b59250a4b",
       "dependsOn": [
+        "@tomlarkworthy/lopepage-urls",
         "@tomlarkworthy/observable-runtime-v6",
         "@tomlarkworthy/flow-queue",
         "@tomlarkworthy/cell-map",
         "@tomlarkworthy/observablejs-toolchain",
+        "@tomlarkworthy/escodegen",
         "@tomlarkworthy/view",
         "@tomlarkworthy/reversible-attachment",
         "@tomlarkworthy/local-storage-view",
@@ -172,8 +214,7 @@
         "@tomlarkworthy/module-map",
         "@tomlarkworthy/runtime-sdk",
         "@tomlarkworthy/jest-expect-standalone",
-        "@tomlarkworthy/themes",
-        "@tomlarkworthy/escodegen"
+        "@tomlarkworthy/themes"
       ],
       "dependedBy": [
         "@tomlarkworthy/claude-code-pairing",
@@ -183,7 +224,7 @@
       ]
     },
     "@tomlarkworthy/file-sync": {
-      "hash": "adcaf784830574cbacb4c069959714d6",
+      "hash": "089777c0a995824b4a16291c5ab6412b",
       "dependsOn": [
         "@tomlarkworthy/module-map",
         "@tomlarkworthy/exporter-3",
@@ -253,6 +294,15 @@
         "@tomlarkworthy/visualizer"
       ]
     },
+    "@tomlarkworthy/invoke-variable": {
+      "hash": "eb72dd569c9e7f0de6e0b518cbe12fb4",
+      "dependsOn": [
+        "@tomlarkworthy/runtime-sdk"
+      ],
+      "dependedBy": [
+        "@tomlarkworthy/module-map"
+      ]
+    },
     "@tomlarkworthy/isomorphic-git-1-30-1": {
       "hash": "16fa79b79fb4e9e1a2d03cfc9221147c",
       "files": [
@@ -293,7 +343,7 @@
       ]
     },
     "@tomlarkworthy/local-change-history": {
-      "hash": "ea8ffc1745c311432d4c097a64021ccd",
+      "hash": "052efa3aa9b37e17ea391c4a4dbde687",
       "dependsOn": [
         "@tomlarkworthy/runtime-sdk",
         "@tomlarkworthy/lightning-fs-4-6-0",
@@ -318,21 +368,6 @@
         "@tomlarkworthy/exporter-3"
       ]
     },
-    "@tomlarkworthy/lopepage": {
-      "hash": "633f78d13e1da2ee746dc2c8598b5a24",
-      "dependsOn": [
-        "@tomlarkworthy/golden-layout-2-6-0",
-        "@tomlarkworthy/visualizer",
-        "@tomlarkworthy/module-selection",
-        "@tomlarkworthy/runtime-sdk",
-        "@tomlarkworthy/editor-5",
-        "@tomlarkworthy/exporter-3",
-        "d/57d79353bac56631@44",
-        "@tomlarkworthy/local-change-history",
-        "@tomlarkworthy/claude-code-pairing",
-        "@tomlarkworthy/command-palette"
-      ]
-    },
     "@tomlarkworthy/lopepage-urls": {
       "hash": "28f1a31190b2a69e3c9d3ac522c41bd4",
       "dependsOn": [
@@ -343,6 +378,7 @@
         "@tomlarkworthy/cell-map",
         "@tomlarkworthy/command-palette",
         "@tomlarkworthy/editor-5",
+        "@tomlarkworthy/exporter-3",
         "@tomlarkworthy/module-map",
         "@tomlarkworthy/module-selection",
         "@tomlarkworthy/tests",
@@ -350,17 +386,19 @@
       ]
     },
     "@tomlarkworthy/module-map": {
-      "hash": "ddf9b08467025d702a130fbeab912da7",
+      "hash": "18f327c993e00ae2ab3ab0cb21a27492",
       "dependsOn": [
         "@tomlarkworthy/lopepage-urls",
         "@tomlarkworthy/flow-queue",
         "@tomlarkworthy/observablejs-toolchain",
         "@tomlarkworthy/runtime-sdk",
+        "@tomlarkworthy/invoke-variable",
         "@tomlarkworthy/spectral-layout"
       ],
       "dependedBy": [
         "@tomlarkworthy/cell-map",
         "@tomlarkworthy/claude-code-pairing",
+        "@tomlarkworthy/command-palette",
         "@tomlarkworthy/editor-5",
         "@tomlarkworthy/exporter-3",
         "@tomlarkworthy/file-sync",
@@ -385,6 +423,17 @@
         "@tomlarkworthy/lopepage"
       ]
     },
+    "@tomlarkworthy/modules": {
+      "hash": "383efc0f630704ea804c5ddf05ab44eb",
+      "dependsOn": [
+        "@tomlarkworthy/runtime-sdk",
+        "@tomlarkworthy/tests",
+        "@tomlarkworthy/observable-runtime-v6"
+      ],
+      "dependedBy": [
+        "@tomlarkworthy/editor-5"
+      ]
+    },
     "@tomlarkworthy/observable-runtime": {
       "hash": "4b60a23333fcadbc20650feae24d4039",
       "files": [
@@ -397,7 +446,8 @@
     "@tomlarkworthy/observable-runtime-v6": {
       "hash": "6bc9db7b1881559c4d30c39f692e3969",
       "dependedBy": [
-        "@tomlarkworthy/exporter-3"
+        "@tomlarkworthy/exporter-3",
+        "@tomlarkworthy/modules"
       ]
     },
     "@tomlarkworthy/observablehq-lezer": {
@@ -410,26 +460,10 @@
         "@tomlarkworthy/editor-5"
       ]
     },
-    "@tomlarkworthy/observablejs-toolchain": {
-      "hash": "f32ebdb36f6c4a6b214f26e4d81107e8",
-      "files": [
-        "acorn-walk-8.3.2.js.gz",
-        "parser-6.1.0.js.gz"
-      ],
-      "dependsOn": [
-        "@tomlarkworthy/tests",
-        "@tomlarkworthy/cell-map",
-        "@tomlarkworthy/acorn-8-11-3",
-        "@tomlarkworthy/jest-expect-standalone",
-        "@tomlarkworthy/observable-runtime"
-      ],
+    "@tomlarkworthy/plugin-registry": {
+      "hash": "428298afcf9c9c8bb13c412d7c23b191",
       "dependedBy": [
-        "@tomlarkworthy/cell-map",
-        "@tomlarkworthy/claude-code-pairing",
-        "@tomlarkworthy/editor-5",
-        "@tomlarkworthy/exporter-3",
-        "@tomlarkworthy/module-map",
-        "@tomlarkworthy/module-selection"
+        "@tomlarkworthy/command-palette"
       ]
     },
     "@tomlarkworthy/reversible-attachment": {
@@ -443,7 +477,7 @@
       ]
     },
     "@tomlarkworthy/runtime-sdk": {
-      "hash": "d6da0322104cb2ad8a836559a8e6cf15",
+      "hash": "9e3e70971cde0b4ebf012f3c1a280cc6",
       "dependsOn": [
         "@mootari/access-runtime"
       ],
@@ -456,11 +490,13 @@
         "@tomlarkworthy/file-sync",
         "@tomlarkworthy/fileattachments",
         "@tomlarkworthy/import-notebook",
+        "@tomlarkworthy/invoke-variable",
         "@tomlarkworthy/local-change-history",
         "@tomlarkworthy/lopepage",
         "@tomlarkworthy/lopepage-urls",
         "@tomlarkworthy/module-map",
         "@tomlarkworthy/module-selection",
+        "@tomlarkworthy/modules",
         "@tomlarkworthy/tests",
         "@tomlarkworthy/visualizer"
       ]
@@ -481,7 +517,7 @@
       ]
     },
     "@tomlarkworthy/summarizejs": {
-      "hash": "d5ca198f066bde101db6eed6086d55ed",
+      "hash": "6012d7554a1be7b899eb3e061154b130",
       "dependsOn": [
         "@tomlarkworthy/inspector"
       ],
@@ -501,11 +537,12 @@
       "dependedBy": [
         "@tomlarkworthy/cell-map",
         "@tomlarkworthy/lopepage-urls",
+        "@tomlarkworthy/modules",
         "@tomlarkworthy/observablejs-toolchain"
       ]
     },
     "@tomlarkworthy/themes": {
-      "hash": "0fe84814f727b3cc5f0f012ff9e556e9",
+      "hash": "e805ad68c19cf214655218d6cb106d70",
       "dependedBy": [
         "@tomlarkworthy/command-palette",
         "@tomlarkworthy/exporter-3"
@@ -519,7 +556,7 @@
       ]
     },
     "@tomlarkworthy/visualizer": {
-      "hash": "006c7bdb86aaefd18519862f541538d9",
+      "hash": "72308ea706602b6b9d1d4836c0c3eea6",
       "dependsOn": [
         "@tomlarkworthy/inspector",
         "@tomlarkworthy/runtime-sdk",
@@ -535,7 +572,7 @@
       "hash": "913f1f6b56a3bbdfca30148905419a98"
     },
     "@tomlarkworthy/bootloader": {
-      "hash": "c54b8a089b467872c8065bac24d1a9ff"
+      "hash": "8f696c43527a8ceadc35bd1192292b4e"
     }
   },
   "upstreams": {
@@ -543,6 +580,6 @@
       "@tomlarkworthy/observablejs-toolchain": "https://observablehq.com/@tomlarkworthy/observablejs-toolchain"
     }
   },
-  "observable_version": 7778,
-  "observable_update_time": "2026-05-24T20:18:47.180Z"
+  "observable_version": 7846,
+  "observable_update_time": "2026-07-23T02:22:34.695Z"
 }

--- a/notebooks/@tomlarkworthy_observablejs-toolchain.json
+++ b/notebooks/@tomlarkworthy_observablejs-toolchain.json
@@ -159,7 +159,7 @@
       ]
     },
     "@tomlarkworthy/exporter-3": {
-      "hash": "eabf840d33a73b98155cd648ff77a16f",
+      "hash": "bf04e9247f3cbb2ae5880d8b59250a4b",
       "dependsOn": [
         "@tomlarkworthy/observable-runtime-v6",
         "@tomlarkworthy/flow-queue",

--- a/notebooks/@tomlarkworthy_observablejs-toolchain.json
+++ b/notebooks/@tomlarkworthy_observablejs-toolchain.json
@@ -24,7 +24,7 @@
       "hash": "5658858e85affa2e1e5cd1052924c622"
     },
     "@tomlarkworthy/lopepage": {
-      "hash": "633f78d13e1da2ee746dc2c8598b5a24",
+      "hash": "ea085755ec5e24f0b29c4cc5f06a7a08",
       "dependsOn": [
         "@tomlarkworthy/golden-layout-2-6-0",
         "@tomlarkworthy/visualizer",
@@ -39,7 +39,7 @@
       ]
     },
     "@tomlarkworthy/observablejs-toolchain": {
-      "hash": "13bf44d8f1fcf6250272f65bb56fe457",
+      "hash": "ee645d9c91a19f749128621e7ec3f99f",
       "files": [
         "parser-6.1.0.js.gz"
       ],
@@ -72,7 +72,7 @@
       ]
     },
     "@tomlarkworthy/acorn-8-11-3": {
-      "hash": "7d7821979f30fc573f0305942ef16d3a",
+      "hash": "a2c4eb96cb067e559536d9f841c2a8e1",
       "files": [
         "acorn-8.11.3.js.gz",
         "acorn-walk-8.3.2.js.gz"
@@ -123,7 +123,7 @@
       ]
     },
     "@tomlarkworthy/codemirror-6-v2": {
-      "hash": "80378ba570b5e43e8f978aa58a7aff02",
+      "hash": "4c719107756989ca8470b2b034bf7511",
       "files": [
         "codemirror_javascript%405.js.gz"
       ],
@@ -189,24 +189,14 @@
         "@tomlarkworthy/lopepage"
       ]
     },
-    "@tomlarkworthy/escodegen": {
-      "hash": "d5e793114a390617e9a70bfdd61a42ec",
-      "files": [
-        "escodegen.browser.min.js.gz"
-      ],
-      "dependedBy": [
-        "@tomlarkworthy/exporter-3"
-      ]
-    },
     "@tomlarkworthy/exporter-3": {
-      "hash": "bf04e9247f3cbb2ae5880d8b59250a4b",
+      "hash": "9e5fcccf1ed23acb071ad881f1f2e1e0",
       "dependsOn": [
         "@tomlarkworthy/lopepage-urls",
         "@tomlarkworthy/observable-runtime-v6",
         "@tomlarkworthy/flow-queue",
         "@tomlarkworthy/cell-map",
         "@tomlarkworthy/observablejs-toolchain",
-        "@tomlarkworthy/escodegen",
         "@tomlarkworthy/view",
         "@tomlarkworthy/reversible-attachment",
         "@tomlarkworthy/local-storage-view",
@@ -224,7 +214,7 @@
       ]
     },
     "@tomlarkworthy/file-sync": {
-      "hash": "089777c0a995824b4a16291c5ab6412b",
+      "hash": "62a784a1a576c5e851d8be48957cd894",
       "dependsOn": [
         "@tomlarkworthy/module-map",
         "@tomlarkworthy/exporter-3",
@@ -248,7 +238,7 @@
       ]
     },
     "@tomlarkworthy/flow-queue": {
-      "hash": "97db7ca44c394ea3f73a3f60f0d2ef6c",
+      "hash": "dd7a035f809162d101be55d55be97880",
       "files": [
         "flowQuery%401.svg"
       ],
@@ -259,7 +249,7 @@
       ]
     },
     "@tomlarkworthy/golden-layout-2-6-0": {
-      "hash": "24f5fad01bd508dd1bc3a49a99002770",
+      "hash": "3331ddc9fc7e65a246bfc1137961c766",
       "files": [
         "golden-layout-2.6.0.js.gz",
         "lm_popout_black.png",
@@ -304,7 +294,7 @@
       ]
     },
     "@tomlarkworthy/isomorphic-git-1-30-1": {
-      "hash": "16fa79b79fb4e9e1a2d03cfc9221147c",
+      "hash": "0cb9679e97bac6b63cba20a792de5389",
       "files": [
         "isomorphic-git-1%401.30.1.bundle.js.gz",
         "isomorphic-git-http-1.0.0-beta.36.js.gz"
@@ -314,7 +304,7 @@
       ]
     },
     "@tomlarkworthy/jest-expect-standalone": {
-      "hash": "418ef3328580c7b2416be5b9fc940db4",
+      "hash": "bd4d80b0911cd2fc3cc10c4f007f447f",
       "files": [
         "jest-expect-standalone-24.0.2.js.gz"
       ],
@@ -325,7 +315,7 @@
       ]
     },
     "@tomlarkworthy/jszip-3-10-1": {
-      "hash": "2b119c57e9c2ce093b3a9c7d2932d010",
+      "hash": "b171464c98410d02c097e34a8f4d2b71",
       "files": [
         "jszip-3.10.1.min.js.gz"
       ],
@@ -334,7 +324,7 @@
       ]
     },
     "@tomlarkworthy/lightning-fs-4-6-0": {
-      "hash": "1f60955582df75104615d8061957d237",
+      "hash": "6eb7adeb763a8295f1bfab78e46f11af",
       "files": [
         "lightning-fs-4.6.0.js.gz"
       ],
@@ -424,7 +414,7 @@
       ]
     },
     "@tomlarkworthy/modules": {
-      "hash": "383efc0f630704ea804c5ddf05ab44eb",
+      "hash": "1a8195ade0cf1a14d350785eeec762cd",
       "dependsOn": [
         "@tomlarkworthy/runtime-sdk",
         "@tomlarkworthy/tests",
@@ -435,7 +425,7 @@
       ]
     },
     "@tomlarkworthy/observable-runtime": {
-      "hash": "4b60a23333fcadbc20650feae24d4039",
+      "hash": "e2e4c27c06b124cf3f3f880370d8755f",
       "files": [
         "runtime.js.gz"
       ],
@@ -444,14 +434,14 @@
       ]
     },
     "@tomlarkworthy/observable-runtime-v6": {
-      "hash": "6bc9db7b1881559c4d30c39f692e3969",
+      "hash": "cd421b0b3a2155578f1ef6d603b43258",
       "dependedBy": [
         "@tomlarkworthy/exporter-3",
         "@tomlarkworthy/modules"
       ]
     },
     "@tomlarkworthy/observablehq-lezer": {
-      "hash": "f827692f8b66b9b0f0cb8b9529f40815",
+      "hash": "49b46bb0bfedf68aea06e8d8a61d39d7",
       "files": [
         "lezer-lr-bundled.js.gz",
         "lezer-highlight-bundled.js.gz"
@@ -477,7 +467,7 @@
       ]
     },
     "@tomlarkworthy/runtime-sdk": {
-      "hash": "9e3e70971cde0b4ebf012f3c1a280cc6",
+      "hash": "3c906717b0856e9bd1b4126925d91cf1",
       "dependsOn": [
         "@mootari/access-runtime"
       ],
@@ -549,7 +539,7 @@
       ]
     },
     "@tomlarkworthy/view": {
-      "hash": "970bf1f386002336660773d1215dd61f",
+      "hash": "c8bc708ea9f194c66bc203be5ed9bde5",
       "dependedBy": [
         "@tomlarkworthy/exporter-3",
         "@tomlarkworthy/reversible-attachment"

--- a/notebooks/@tomlarkworthy_observablejs-toolchain.json
+++ b/notebooks/@tomlarkworthy_observablejs-toolchain.json
@@ -155,11 +155,11 @@
         "escodegen.browser.min.js.gz"
       ],
       "dependedBy": [
-        "@tomlarkworthy/observablejs-toolchain"
+        "@tomlarkworthy/exporter-3"
       ]
     },
     "@tomlarkworthy/exporter-3": {
-      "hash": "3872a7ba7029de95ffba3cdc17c0ce52",
+      "hash": "eabf840d33a73b98155cd648ff77a16f",
       "dependsOn": [
         "@tomlarkworthy/observable-runtime-v6",
         "@tomlarkworthy/flow-queue",
@@ -172,7 +172,8 @@
         "@tomlarkworthy/module-map",
         "@tomlarkworthy/runtime-sdk",
         "@tomlarkworthy/jest-expect-standalone",
-        "@tomlarkworthy/themes"
+        "@tomlarkworthy/themes",
+        "@tomlarkworthy/escodegen"
       ],
       "dependedBy": [
         "@tomlarkworthy/claude-code-pairing",
@@ -410,7 +411,7 @@
       ]
     },
     "@tomlarkworthy/observablejs-toolchain": {
-      "hash": "b89f6c3ca92136704f5c6c025db14cf0",
+      "hash": "f32ebdb36f6c4a6b214f26e4d81107e8",
       "files": [
         "acorn-walk-8.3.2.js.gz",
         "parser-6.1.0.js.gz"
@@ -418,7 +419,6 @@
       "dependsOn": [
         "@tomlarkworthy/tests",
         "@tomlarkworthy/cell-map",
-        "@tomlarkworthy/escodegen",
         "@tomlarkworthy/acorn-8-11-3",
         "@tomlarkworthy/jest-expect-standalone",
         "@tomlarkworthy/observable-runtime"

--- a/notebooks/jumpgates.html
+++ b/notebooks/jumpgates.html
@@ -11179,8 +11179,8 @@ const _4zsqot = function _actionHandler(Inputs,getSourceModule,notebook_name,_ru
     }
   };
 };
-const _dxt3kg = function _exportToHTML(_runtime, cssForTheme, css, location, keepalive, exporter_module, $0) {
-    return async function exportToHTML({mains = new Map(), runtime = _runtime, options = {}} = {}) {
+const _lb3gzc = function _exportToHTML(_runtime,cssForTheme,css,location,keepalive,exporter_module,$0){return(
+async function exportToHTML({mains = new Map(), runtime = _runtime, options = {}} = {}) {
         let conf = { headless: false };
         try {
             conf = (await import('file://bootconf.json')).default;
@@ -11201,9 +11201,15 @@ const _dxt3kg = function _exportToHTML(_runtime, cssForTheme, css, location, kee
         if (options.tickDelayMs == null) {
             options.tickDelayMs = conf.tickDelayMs;
         }
+        // Prerender defaults ON (matching the exporter UI toggle); only an explicit
+        // "prerender": false in bootconf.json turns it off. Flag persists across re-exports.
         if (options.prerender == null) {
-            options.prerender = conf.prerender;
+            options.prerender = conf.prerender !== false;
         }
+        // Snapshot the live lopepage-2 DOM (only when exporting this running notebook).
+        // The snapshot keeps its id="lopepage-2" and scoped styles unchanged; book() nests
+        // it in a Declarative Shadow DOM so it is invisible to the booting runtime's
+        // document queries (otherwise duplicated editors/inputs corrupt the boot).
         if (options.prerender && runtime === _runtime && options.prerenderHTML == null) {
             try {
                 const src = document.getElementById('lopepage-2');
@@ -11231,14 +11237,13 @@ const _dxt3kg = function _exportToHTML(_runtime, cssForTheme, css, location, kee
                     options.description = ogContent('meta[property="og:description"]') || ogContent('meta[name="description"]');
                 if (options.image == null)
                     options.image = ogContent('meta[property="og:image"]');
-                const managed = new Set([
-                    'viewport',
-                    'og:title',
-                    'og:type',
-                    'og:description',
-                    'description',
-                    'og:image'
-                ]);
+                // Preserve arbitrary <meta> across re-export (at:*, twitter:*, keywords,
+                // theme-color, custom module metadata, …). Skip charset/viewport and the
+                // og/description tags lopebook regenerates from title/description/image.
+                // Merge, don't replace: caller-supplied options.metas win for any key they
+                // define; scanned tags for every other key are preserved. Repeatable keys
+                // (at:alternate, at:author) survive via full key+content dedup.
+                const managed = new Set(['viewport', 'og:title', 'og:type', 'og:description', 'description', 'og:image']);
                 const provided = Array.isArray(options.metas) ? options.metas : [];
                 const ownedKeys = new Set(provided.map(m => m.key));
                 const seen = new Set(provided.map(m => `${ m.key }\n${ m.content }`));
@@ -11246,20 +11251,13 @@ const _dxt3kg = function _exportToHTML(_runtime, cssForTheme, css, location, kee
                 for (const el of document.head.querySelectorAll('meta[property], meta[name]')) {
                     const key = el.getAttribute('property') || el.getAttribute('name');
                     const content = el.getAttribute('content');
-                    if (key == null || content == null || managed.has(key) || ownedKeys.has(key))
-                        continue;
+                    if (key == null || content == null || managed.has(key) || ownedKeys.has(key)) continue;
                     const dedup = `${ key }\n${ content }`;
-                    if (seen.has(dedup))
-                        continue;
+                    if (seen.has(dedup)) continue;
                     seen.add(dedup);
-                    merged.push({
-                        key,
-                        isProperty: el.hasAttribute('property'),
-                        content
-                    });
+                    merged.push({ key, isProperty: el.hasAttribute('property'), content });
                 }
-                if (merged.length)
-                    options.metas = merged;
+                if (merged.length) options.metas = merged;
             } catch (_) {
             }
         }
@@ -11270,29 +11268,31 @@ const _dxt3kg = function _exportToHTML(_runtime, cssForTheme, css, location, kee
             options
         });
         return response;
+    }
+)};
+const _43zr7 = function _getSourceModule(notebook_name,main,_runtime)
+{
+  return async state => {
+    // source picker was removed; the exporter always serialises this notebook
+    if (!state.source || state.source == 'this notebook')
+      return {
+        notebook: notebook_name,
+        module: main,
+        runtime: _runtime
+      };
+    const url = state.source == 'a notebook url' ? state.notebook_url.child : state.top_100.child;
+    const notebook = url.trim().replace('', '');
+    const [{Runtime, Inspector}, {default: define}] = await Promise.all([
+      import('https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js'),
+      import(`https://api.observablehq.com/${ notebook }.js?v=4`)
+    ]);
+    const runtime = new Runtime();
+    return {
+      notebook,
+      module: runtime.module(define),
+      runtime
     };
-};
-const _43zr7 = function _getSourceModule(notebook_name, main, _runtime) {
-    return async state => {
-        if (!state.source || state.source == 'this notebook')
-            return {
-                notebook: notebook_name,
-                module: main,
-                runtime: _runtime
-            };
-        const url = state.source == 'a notebook url' ? state.notebook_url.child : state.top_100.child;
-        const notebook = url.trim().replace('', '');
-        const [{Runtime, Inspector}, {default: define}] = await Promise.all([
-            import('https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js'),
-            import(`https://api.observablehq.com/${ notebook }.js?v=4`)
-        ]);
-        const runtime = new Runtime();
-        return {
-            notebook,
-            module: runtime.module(define),
-            runtime
-        };
-    };
+  };
 };
 const _tpv4tl = function _createShowable(variable,view)
 {
@@ -11892,27 +11892,27 @@ ${ await generate_define(spec, variables, fileAttachments, { moduleNames }) }`
 const _19ft5zb = function _generate_definitions(variableToDefinition){return(
 variables => variables.map(v => variableToDefinition(v)).join('')
 )};
-const _u3aown = function _generate_define(variableToDefine) {
-    return async (spec, variables, fileAttachments, {moduleNames} = {}) => {
-        const fileAttachmentExpression = fileAttachments?.size ? `  const fileAttachments = new Map(${ JSON.stringify([...fileAttachments.keys()]) }.map((name) => {
+const _u3aown = function _generate_define(variableToDefine){return(
+async (spec, variables, fileAttachments, {moduleNames} = {}) => {
+  const fileAttachmentExpression = fileAttachments?.size ? `  const fileAttachments = new Map(${ JSON.stringify([...fileAttachments.keys()]) }.map((name) => {
     const module_name = "${ spec.name }";
     const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
     const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
     return [name, {url: blob_url, mimeType: mime}]
   }));
   main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));\n` : '';
-        const varLines = (await Promise.all(variables.map(v => variableToDefine(v, { moduleNames })))).flat();
-        const definedModules = new Set(varLines.filter(l => l.includes('runtime.module(')).map(l => {
-            const m = l.match(/main\.define\("module ([^"]+)"/);
-            return m ? m[1] : null;
-        }).filter(Boolean));
-        const referencedModules = new Set(varLines.map(l => {
-            const m = l.match(/\["module ([^"]+)", "@variable"\]/);
-            return m ? m[1] : null;
-        }).filter(Boolean));
-        const missingModules = [...referencedModules].filter(m => !definedModules.has(m));
-        const moduleDefineLines = missingModules.map(m => `  main.define("module ${ m }", async () => runtime.module((await importShim("/${ m }.js?v=4")).default));`);
-        return `export default function define(runtime, observer) {
+  const varLines = (await Promise.all(variables.map(v => variableToDefine(v, { moduleNames })))).flat();
+  const definedModules = new Set(varLines.filter(l => l.includes('runtime.module(')).map(l => {
+    const m = l.match(/main\.define\("module ([^"]+)"/);
+    return m ? m[1] : null;
+  }).filter(Boolean));
+  const referencedModules = new Set(varLines.map(l => {
+    const m = l.match(/\["module ([^"]+)", "@variable"\]/);
+    return m ? m[1] : null;
+  }).filter(Boolean));
+  const missingModules = [...referencedModules].filter(m => !definedModules.has(m));
+  const moduleDefineLines = missingModules.map(m => `  main.define("module ${ m }", async () => runtime.module((await importShim("/${ m }.js?v=4")).default));`);
+  return `export default function define(runtime, observer) {
   const main = runtime.module();
   const $def = (pid, name, deps, fn) => {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
@@ -11921,8 +11921,8 @@ ${ fileAttachmentExpression }${ moduleDefineLines.join('  \n') }
 ${ varLines.join('  \n') }
   return main;
 }`;
-    };
-};
+}
+)};
 const _1hslsmt = function _isLiveImport(){return(
 v => !v._name && v._definition?.toString().includes('observablehq' + '--inspect ' + 'observablehq--import')
 )};
@@ -11939,7 +11939,7 @@ function variableToDefinition(v) {
   return `const ${ pid(v) } = ${ restoreCanonicalImports(v._definition.toString()) };\n`;
 }
 )};
-const _1ohymeb = function _restoreCanonicalImports(acorn,escodegen){return(
+const _79c94t = function _restoreCanonicalImports(acorn){return(
 source => {
   if (!/\bimportShim\s*\(/.test(source))
     return source;
@@ -11956,15 +11956,31 @@ source => {
     console.warn('[exporter-3] importShim AST parse failed; leaving cell unchanged:', e.message);
     return source;
   }
+  // The rewrite is local: only the callee identifier changes, plus the parent
+  // URL Observable appends. Collect character ranges and splice them, rather
+  // than regenerating the cell, so comments, quote style and indentation
+  // survive. Same approach as the toolchain's source-preserving observableToJs.
+  const edits = [];
   const visit = node => {
     if (!node || typeof node !== 'object')
       return;
     if (node.type === 'CallExpression' && node.callee && node.callee.type === 'Identifier' && node.callee.name === 'importShim' && node.arguments.length >= 1) {
-      const spec = node.arguments[0];
-      for (const k of Object.keys(node))
-        delete node[k];
-      node.type = 'ImportExpression';
-      node.source = spec;
+      edits.push([
+        node.callee.start,
+        node.callee.end,
+        'import'
+      ]);
+      // Observable compiles a cell's `import(x)` to `importShim(x, "<notebook
+      // url>")`, where argument 2 is the es-module-shims parent. Native import
+      // takes an options object there, so a string second argument is dropped
+      // and an object one (import attributes) is kept.
+      const [spec, second] = node.arguments;
+      if (node.arguments.length === 2 && second.type === 'Literal' && typeof second.value === 'string')
+        edits.push([
+          spec.end,
+          second.end,
+          ''
+        ]);
     }
     for (const k of Object.keys(node)) {
       const v = node[k];
@@ -11975,7 +11991,11 @@ source => {
     }
   };
   visit(ast);
-  return escodegen.generate(ast);
+  let out = source;
+  // Descending, so earlier offsets stay valid as we rewrite.
+  for (const [start, end, text] of edits.sort((a, b) => b[0] - a[0]))
+    out = out.slice(0, start) + text + out.slice(end);
+  return out;
 }
 )};
 const _1g13ozv = function _variableToDefine(isLiveImport,isDynamicVar,isModuleVar,isImportBridged,findImportedName3,pid)
@@ -12203,6 +12223,46 @@ const _18z61zg = function _test_streaming_order_runtime(Runtime,streamingModuleO
   expect(order.join(',')).toBe('@u/app,@u/junk,@u/lib');
   // main first, then the rest alphabetically
   return 'ok';
+};
+const _1didxs7 = function _test_restoreCanonicalImports(restoreCanonicalImports,expect)
+{
+  const R = restoreCanonicalImports;
+  // Nothing to rewrite: identity.
+  expect(R('async () => 1 + 2')).toBe('async () => 1 + 2');
+  // Callee position becomes the canonical dynamic import.
+  expect(R('async () => await importShim("/@a/b.js?v=4")')).toBe('async () => await import("/@a/b.js?v=4")');
+  // Several calls of differing length: the offsets must stay valid.
+  expect(R('async () => [await importShim("a"), await importShim("bb")]')).toBe('async () => [await import("a"), await import("bb")]');
+  expect(R('async () => importShim(await importShim("inner"))')).toBe('async () => import(await import("inner"))');
+  // Argument 2 is the es-module-shims parent URL that Observable appends when
+  // it compiles a cell's own `import(x)`. Native import has no such parameter.
+  expect(R("f = () => importShim(objectURL, 'https://api.observablehq.com/@a/b.js?v=4')")).toBe('f = () => import(objectURL)');
+  expect(R('f = () => importShim(`${ nb }.js?v=4`, "https://api.observablehq.com/@a/b.js?v=4")')).toBe('f = () => import(`${ nb }.js?v=4`)');
+  // ...but a real options object is import attributes, and must survive.
+  expect(R("async () => await importShim(url, { with: { type: 'css' } })")).toBe("async () => await import(url, { with: { type: 'css' } })");
+  // Callee position only. A bare `import` identifier is a syntax error, so a
+  // reference passed as a value has to be left alone.
+  expect(R('async () => register(importShim, importShim("real"))')).toBe('async () => register(importShim, import("real"))');
+  expect(R('async () => window.importShim("x") + importShim("y")')).toBe('async () => window.importShim("x") + import("y")');
+  expect(R('async () => importShim() || importShim("x")')).toBe('async () => importShim() || import("x")');
+  // A string that merely mentions importShim is not a call.
+  expect(R('async () => { const s = "call importShim(x) later"; return importShim("real"); }')).toBe('async () => { const s = "call importShim(x) later"; return import("real"); }');
+};
+const _ogm44p = function _test_restoreCanonicalImports_preserves_source(expect,restoreCanonicalImports)
+{
+  // Only the callee identifier changes, so the rest survives byte-for-byte —
+  // escodegen used to reformat the whole cell.
+  const src = [
+    'function _f() {',
+    "  // keep  this   comment",
+    "  const s = 'single-quoted';   /* and this */",
+    '  return importShim("tpl");',
+    '}'
+  ].join('\n');
+  expect(restoreCanonicalImports(src)).toBe(src.replace('return importShim("tpl")', 'return import("tpl")'));
+  // Unparseable input falls back to the original source.
+  const broken = 'async () => importShim("unclosed';
+  expect(restoreCanonicalImports(broken)).toBe(broken);
 };
 const _1vgrzwk = function _isNotebook(){return(
 id => /^(@[^/]+\/[^/]+|d\/[a-f0-9]{16})$/.test(id)
@@ -12488,20 +12548,22 @@ const _1s9g3fb = function _networking_script(normalize,isNotebook){return(
     }
   })();`
 )};
-const _kfs9ca = function _lopebook(diskDataUrl, networking_script) {
-    return ({blocks = '', cssUrls = [], bootloader = '@tomlarkworthy/bootloader', title = 'Lopecode notebook', description, image, metas = [], head, bodyPrepend = ''} = {}) => {
-        const styleImports = cssUrls.map((url, i) => `  const style${ i } = await importShim(${ JSON.stringify(url) }, { with: { type: 'css' } });`).join('\n');
-        const styleAdopt = cssUrls.map((_, i) => `style${ i }.default`).join(',');
-        const attr = s => String(s).replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-        const ogTags = [
-            `<meta property="og:title" content="${ attr(title) }">`,
-            `<meta property="og:type" content="website">`,
-            description ? `<meta name="description" content="${ attr(description) }">` : '',
-            description ? `<meta property="og:description" content="${ attr(description) }">` : '',
-            image ? `<meta property="og:image" content="${ attr(image) }">` : '',
-            ...(metas || []).map(m => `<meta ${ m.isProperty ? 'property' : 'name' }="${ attr(m.key) }" content="${ attr(m.content) }">`)
-        ].filter(Boolean).join('\n  ');
-        return `<!DOCTYPE html>
+const _kfs9ca = function _lopebook(diskDataUrl,networking_script)
+{
+  return ({blocks = '', cssUrls = [], bootloader = '@tomlarkworthy/bootloader', title = 'Lopecode notebook', description, image, metas = [], head, bodyPrepend = ''} = {}) => {
+    const styleImports = cssUrls.map((url, i) => `  const style${ i } = await importShim(${ JSON.stringify(url) }, { with: { type: 'css' } });`).join('\n');
+    const styleAdopt = cssUrls.map((_, i) => `style${ i }.default`).join(',');
+    const attr = s => String(s).replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    const ogTags = [
+      `<meta property="og:title" content="${ attr(title) }">`,
+      `<meta property="og:type" content="website">`,
+      description ? `<meta name="description" content="${ attr(description) }">` : '',
+      description ? `<meta property="og:description" content="${ attr(description) }">` : '',
+      image ? `<meta property="og:image" content="${ attr(image) }">` : '',
+      // Preserved <meta> carried across re-export by exportToHTML's head scan.
+      ...(metas || []).map(m => `<meta ${ m.isProperty ? 'property' : 'name' }="${ attr(m.key) }" content="${ attr(m.content) }">`)
+    ].filter(Boolean).join('\n  ');
+    return `<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
@@ -12541,7 +12603,7 @@ ${ blocks }
 <script id="streaming_sentinel">window.__lopeStreaming = false;</scr\ipt>
 </body>
 </html>`;
-    };
+  };
 };
 const _li7wcc = function _lopemodule(TRACE_MODULE,CSS,arrayBufferToBase64,inlineModule,escapeScriptTags)
 {
@@ -12589,10 +12651,10 @@ async function arrayBufferToBase64(buffer) {
   return btoa(binary);
 }
 )};
-const _1miwrx0 = function _79(md){return(
+const _1iz5onh = function _81(md){return(
 md`### Global Output`
 )};
-const _g3fd9a = function _80(md){return(
+const _b9np5w = function _82(md){return(
 md`## Utils`
 )};
 const _fw7q7v = function _getCompactISODate(){return(
@@ -12607,7 +12669,7 @@ function getCompactISODate() {
   return `${ year }${ month }${ day }T${ hours }${ minutes }${ seconds }Z`;
 }
 )};
-const _os8ogr = function _82(md){return(
+const _7vqfq9 = function _84(md){return(
 md`## Additional Tests`
 )};
 const _8765p8 = function _diskDataUrl(disk_svg){return(
@@ -12663,7 +12725,7 @@ export default function define(runtime, observer) {
   $def("_1u2ju69", "forkAnchor", ["exportAnchor"], _1u2ju69);  
   $def("_1a8n42w", "downloadAnchor", ["exportAnchor"], _1a8n42w);  
   $def("_4zsqot", "actionHandler", ["Inputs","getSourceModule","notebook_name","_runtime","exportToHTML","htmlToConsoleSnippet","copyTextToClipboard","view","linkTo","location","getCompactISODate"], _4zsqot);  
-  $def("_dxt3kg", "exportToHTML", ["_runtime","cssForTheme","css","location","keepalive","exporter_module","viewof task"], _dxt3kg);  
+  $def("_lb3gzc", "exportToHTML", ["_runtime","cssForTheme","css","location","keepalive","exporter_module","viewof task"], _lb3gzc);  
   $def("_43zr7", "getSourceModule", ["notebook_name","main","_runtime"], _43zr7);  
   $def("_tpv4tl", "createShowable", ["variable","view"], _tpv4tl);  
   $def("_rnq9mt", "reportValidity", [], _rnq9mt);  
@@ -12704,7 +12766,7 @@ export default function define(runtime, observer) {
   $def("_u3aown", "generate_define", ["variableToDefine"], _u3aown);  
   $def("_1hslsmt", "isLiveImport", [], _1hslsmt);  
   $def("_4i5mmq", "variableToDefinition", ["isModuleVar","isImportBridged","isLiveImport","isDynamicVar","pid","restoreCanonicalImports"], _4i5mmq);  
-  $def("_1ohymeb", "restoreCanonicalImports", ["acorn","escodegen"], _1ohymeb);  
+  $def("_79c94t", "restoreCanonicalImports", ["acorn"], _79c94t);  
   $def("_1g13ozv", "variableToDefine", ["isLiveImport","isDynamicVar","isModuleVar","isImportBridged","findImportedName3","pid"], _1g13ozv);  
   $def("_8rymrb", null, ["md"], _8rymrb);  
   $def("_g33g3u", "es_module_shims", [], _g33g3u);  
@@ -12717,16 +12779,18 @@ export default function define(runtime, observer) {
   $def("_1d9ux6v", "test_lopebook_main_at_top_with_sentinel", ["lopebook","expect"], _1d9ux6v);  
   $def("_13d3rb0", "test_streaming_order_prioritizes_mains", ["expect","streamingModuleOrder"], _13d3rb0);  
   $def("_18z61zg", "test_streaming_order_runtime", ["Runtime","streamingModuleOrder","expect"], _18z61zg);  
+  $def("_1didxs7", "test_restoreCanonicalImports", ["restoreCanonicalImports","expect"], _1didxs7);  
+  $def("_ogm44p", "test_restoreCanonicalImports_preserves_source", ["expect","restoreCanonicalImports"], _ogm44p);  
   $def("_1vgrzwk", "isNotebook", [], _1vgrzwk);  
   $def("_1s9g3fb", "networking_script", ["normalize","isNotebook"], _1s9g3fb);  
   $def("_kfs9ca", "lopebook", ["diskDataUrl","networking_script"], _kfs9ca);  
   $def("_li7wcc", "lopemodule", ["TRACE_MODULE","CSS","arrayBufferToBase64","inlineModule","escapeScriptTags"], _li7wcc);  
   $def("_19l1umr", "escapeScriptTags", [], _19l1umr);  
   $def("_xpg7uv", "arrayBufferToBase64", [], _xpg7uv);  
-  $def("_1miwrx0", null, ["md"], _1miwrx0);  
-  $def("_g3fd9a", null, ["md"], _g3fd9a);  
+  $def("_1iz5onh", null, ["md"], _1iz5onh);  
+  $def("_b9np5w", null, ["md"], _b9np5w);  
   $def("_fw7q7v", "getCompactISODate", [], _fw7q7v);  
-  $def("_os8ogr", null, ["md"], _os8ogr);  
+  $def("_7vqfq9", null, ["md"], _7vqfq9);  
   $def("_8765p8", "diskDataUrl", ["disk_svg"], _8765p8);  
   $def("_z4k2or", "viewof task", ["flowQueue"], _z4k2or);  
   $def("_ngmf1x", "task", ["Generators","viewof task"], _ngmf1x);  
@@ -12746,7 +12810,6 @@ export default function define(runtime, observer) {
   main.define("parser", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("parser", _));  
   main.define("decompress_url", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("decompress_url", _));  
   main.define("acorn", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("acorn", _));  
-  main.define("escodegen", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("escodegen", _));  
   main.define("view", ["module @tomlarkworthy/view", "@variable"], (_, v) => v.import("view", _));  
   main.define("variable", ["module @tomlarkworthy/view", "@variable"], (_, v) => v.import("variable", _));  
   main.define("bindOneWay", ["module @tomlarkworthy/view", "@variable"], (_, v) => v.import("bindOneWay", _));  
@@ -12774,7 +12837,8 @@ export default function define(runtime, observer) {
   main.define("css", ["module @tomlarkworthy/themes", "@variable"], (_, v) => v.import("css", _));  
   main.define("cssForTheme", ["module @tomlarkworthy/themes", "@variable"], (_, v) => v.import("cssForTheme", _));
   return main;
-}</script>
+}
+</script>
 
 <script id="@tomlarkworthy/file-sync" 
   type="text/plain"

--- a/notebooks/jumpgates.html
+++ b/notebooks/jumpgates.html
@@ -9,6 +9,7 @@
   <link rel="icon" href="data:image/svg+xml;base64,PHN2ZyBmaWxsPSJ3aGl0ZSIgd2lkdGg9IjUwcHgiIGhlaWdodD0iNTBweCIgdmlld0JveD0iMCAwIDY0IDY0IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxyZWN0IGhlaWdodD0iNCIgd2lkdGg9IjQiIHg9IjIwIiB5PSI1MCI+PC9yZWN0PjxyZWN0IGhlaWdodD0iNCIgd2lkdGg9IjE2IiB4PSIyOCIgeT0iNTAiPjwvcmVjdD48cGF0aCBkPSJNMzIsMzhhOCw4LDAsMSwwLTgtOEE4LjAwOSw4LjAwOSwwLDAsMCwzMiwzOFptMC0xMmE0LDQsMCwxLDEtNCw0QTQsNCwwLDAsMSwzMiwyNloiPjwvcGF0aD48cGF0aCBkPSJNNiw2Mkg1OGEyLDIsMCwwLDAsMi0yVjE1YTIsMiwwLDAsMC0uNTg2LTEuNDE0bC0xMS0xMUEyLDIsMCwwLDAsNDcsMkg2QTIsMiwwLDAsMCw0LDRWNjBBMiwyLDAsMCwwLDYsNjJabTQyLTRIMTZWNDZINDhaTTE2LDZIMzF2NGg0VjZoNHY4SDE2Wk04LDZoNFYxNmEyLDIsMCwwLDAsMiwySDQxYTIsMiwwLDAsMCwyLTJWNmgzLjE3Mkw1NiwxNS44MjlWNThINTJWNDRhMiwyLDAsMCwwLTItMkgxNGEyLDIsMCwwLDAtMiwyVjU4SDhaIj48L3BhdGg+PC9zdmc+">
 </head>
 <body>
+
 <script id="networking_script">
   const normalize = url => url.replace(/^(?:https:\/\/api\.observablehq\.com)?\/(.*?)\.js(?:\?.*)?$/, '$1').replace(/^(d\/[a-f0-9]{16})@\d+$/, '$1');
   const isNotebook = id => /^(@[^/]+\/[^/]+|d\/[a-f0-9]{16})$/.test(id);
@@ -1628,15 +1629,15 @@ async (directoryHandle, export_spec) => {
     logLine('Export complete.');
 }
 )};
-const _4i01c0 = function _main_defines(export_spec) {
-    return Promise.all(export_spec.additionalMains.map(async main => {
-        main = main.trim().replace('https://observablehq.com/', '');
-        return [
-            main,
-            (await import(`https://api.observablehq.com/${ main }.js?v=4&resolutions=0000000000000000`)).default
-        ];
-    }));
-};
+const _4i01c0 = function _main_defines(export_spec){return(
+Promise.all(export_spec.additionalMains.map(async main => {
+    main = main.trim().replace('https://observablehq.com/', '');
+    return [
+        main,
+        (await import(`https://api.observablehq.com/${ main }.js?v=4&resolutions=0000000000000000`)).default
+    ];
+}))
+)};
 const _1nal4ub = function _19(md){return(
 md`## Single Export task
 
@@ -1652,7 +1653,8 @@ const _1l7yayf = (G, _) => G.input(_);
 const _vif85g = function _21(exportTask){return(
 exportTask
 )};
-const _1s847dr = async function _source_define(exportTask, $0) {
+const _1s847dr = async function _source_define(exportTask,$0)
+{
     exportTask;
     try {
         return await Promise.all(exportTask.sources.map(async name => [
@@ -1685,11 +1687,12 @@ main_defines.map(([name, define]) => [
     embedded_runtime.module(define)
 ])
 )};
-const _1j2bxxb = function _export_state(exportTask){return(
+const _1dnymu8 = function _export_state(exportTask){return(
 {
     title: exportTask.sources[0],
     hash: `#view=S100(${ exportTask.sources[0] },@tomlarkworthy/module-selection)`,
-    theme: 'parchment'
+    theme: 'parchment',
+    prerender: true
 }
 )};
 const _1quwq5k = function _export_out(exportToHTML,embedded_runtime,additional_mains,source_module,export_state,$0){return(
@@ -1773,7 +1776,7 @@ export default function define(runtime, observer) {
   $def("_5jffio", "embedded_runtime", ["exportTask","Library","Runtime","invalidation"], _5jffio);  
   $def("_fkqljs", "source_module", ["source_define","embedded_runtime"], _fkqljs);  
   $def("_z83z54", "additional_mains", ["main_defines","embedded_runtime"], _z83z54);  
-  $def("_1j2bxxb", "export_state", ["exportTask"], _1j2bxxb);  
+  $def("_1dnymu8", "export_state", ["exportTask"], _1dnymu8);  
   $def("_1quwq5k", "export_out", ["exportToHTML","embedded_runtime","additional_mains","source_module","export_state","mutable output"], _1quwq5k);  
   $def("_1uq2lig", "initial output", [], _1uq2lig);  
   $def("_1bm14tj", "mutable output", ["Mutable","initial output"], _1bm14tj);  
@@ -1975,12 +1978,14 @@ const _i3c3vr = function _embedded_runtime(Library,Runtime,invalidation)
     invalidation.then(() => runtime.dispose());
     return runtime;
 };
-const _1tujgle = async function _frame_define(load_source, frame_notebook) {
+const _1tujgle = async function _frame_define(load_source,frame_notebook)
+{
     if (!load_source)
         throw 'Load source not ticked';
     return (await import(`https://api.observablehq.com/${ frame_notebook }.js?v=4&resolutions=0000000000000000`)).default;
 };
-const _60o1g4 = function _source_defines(load_source, sources) {
+const _60o1g4 = function _source_defines(load_source,sources)
+{
     if (!load_source)
         throw 'Load source not ticked';
     document.querySelectorAll('script[type="text/plain"]').forEach(el => el.remove());
@@ -3618,7 +3623,8 @@ const _1ey5aow = function _dragOutGrips(layout,invalidation)
     });
     return 'drag-out grips installed';
 };
-const _1gkn0mq = function _dropInHandler(location, setHashURL, runtime, page, invalidation) {
+const _1gkn0mq = function _dropInHandler(location,setHashURL,runtime,page,invalidation)
+{
     const STYLE_ID = 'lopepage-dropzone-style';
     const oldStyle = document.getElementById(STYLE_ID);
     if (oldStyle)
@@ -4299,12 +4305,12 @@ md`# [Acorn@8.11.3](https://github.com/acornjs/acorn) & acorn-walk@8.2.2
 import { acorn } from "@tomlarkworthy/acorn-8-11-3"
 \`\`\``
 )};
-const _1xdqqxo = function _acorn(acorn_url) {
-    return import(acorn_url);
-};
-const _vctqpi = function _acorn_walk(acorn_walk_url) {
-    return import(acorn_walk_url);
-};
+const _1xdqqxo = function _acorn(acorn_url){return(
+import(acorn_url)
+)};
+const _vctqpi = function _acorn_walk(acorn_walk_url){return(
+import(acorn_walk_url)
+)};
 const _1c0mco9 = async function _acorn_walk_url(unzip,FileAttachment)
 {
   const blob = await unzip(FileAttachment("acorn-walk-8.3.2.js.gz"));
@@ -6643,212 +6649,227 @@ function handleCommand(cmd) {
     return handler(cmd, rt);
 }
 )};
-const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation)
+const _11jras6 = function _cc_ws(cc_config,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,sessionStorage,invalidation)
 {
-    return function () {
-        var port = cc_config.port, host = cc_config.host;
-        var ws = null;
-        var paired = false;
-        function connect(token) {
-            if (ws) {
-                ws.close();
-                ws = null;
-            }
-            if (token) {
-                try {
-                    sessionStorage.setItem('lopecode_cc_token', token);
-                } catch (e) {
-                }
-                var hash = location.hash || '#';
-                if (/[&?]cc=/.test(hash)) {
-                    hash = hash.replace(/([&?])cc=[^&]*/, '$1cc=' + token);
-                } else {
-                    hash += (hash.length > 1 ? '&' : '') + 'cc=' + token;
-                }
-                try {
-                    window.history.replaceState(null, '', hash);
-                } catch (e) {
-                }
-            }
-            var connectPort = port;
-            if (token) {
-                var parts = token.match(/^LOPE-(\d+)-[A-Z0-9]+$/);
-                if (parts)
-                    connectPort = parseInt(parts[1], 10);
-            }
-            cc_status.value = 'connecting';
-            cc_status.dispatchEvent(new Event('input'));
-            ws = new WebSocket('ws://' + host + ':' + connectPort + '/ws');
-            ws.onopen = function () {
-                if (token) {
-                    cc_status.value = 'pairing';
-                    cc_status.dispatchEvent(new Event('input'));
-                    var toolDescriptors = [];
-                    var _mcpToolsVal = $0 && $0.value;
-                    if (_mcpToolsVal && _mcpToolsVal.size > 0) {
-                        _mcpToolsVal.forEach(function (t, name) {
-                            toolDescriptors.push({
-                                name: name,
-                                description: t.description,
-                                inputSchema: t.inputSchema
-                            });
-                        });
-                    }
-                    ws.send(JSON.stringify({
-                        type: 'pair',
-                        token: token,
-                        url: cc_notebook_id,
-                        title: document.title || 'Untitled',
-                        tools: toolDescriptors
-                    }));
-                }
-            };
-            ws.onmessage = function (event) {
-                var msg;
-                try {
-                    msg = JSON.parse(event.data);
-                } catch (e) {
-                    return;
-                }
-                switch (msg.type) {
-                case 'paired':
-                    paired = true;
-                    cc_status.value = 'connected';
-                    cc_status.dispatchEvent(new Event('input'));
-                    // Provide send callback to watchers
-                    cc_watchers.setSend(function (m) {
-                        if (paired && ws)
-                            ws.send(JSON.stringify(m));
-                    });
-                    var modules = [];
-                    var rt = window.__ojs_runtime;
-                    if (rt) {
-                        var seen = new Set();
-                        for (var v of rt._variables) {
-                            var name = v._module && v._module._name;
-                            if (name && !seen.has(name)) {
-                                seen.add(name);
-                                modules.push(name);
-                            }
-                        }
-                    }
-                    ws.send(JSON.stringify({
-                        type: 'notebook-info',
-                        url: cc_notebook_id,
-                        title: document.title,
-                        modules: modules,
-                        hash: location.hash
-                    }));
-                    // Set up watches from cc_watches
-                    var rt2 = window.__ojs_runtime;
-                    if (rt2) {
-                        var initialWatches = $1.value || [];
-                        for (var i = 0; i < initialWatches.length; i++) {
-                            cc_watchers.watchVariable(rt2, initialWatches[i].name, initialWatches[i].module);
-                        }
-                    }
-                    break;
-                case 'pair-failed':
-                    paired = false;
-                    cc_status.value = 'disconnected';
-                    cc_status.dispatchEvent(new Event('input'));
-                    break;
-                case 'reply':
-                    var msgs = cc_messages.value.concat([{
-                            role: 'assistant',
-                            content: msg.markdown,
-                            timestamp: Date.now()
-                        }]);
-                    cc_messages.value = msgs;
-                    cc_messages.dispatchEvent(new Event('input'));
-                    break;
-                case 'tool-activity':
-                    // Update the activity status bar (not the chat messages)
-                    var activityEntry = {
-                        tool_name: msg.tool_name,
-                        content: msg.summary,
-                        timestamp: msg.timestamp || Date.now()
-                    };
-                    cc_activity.value = cc_activity.value.concat([activityEntry]).slice(-20);
-                    cc_activity.dispatchEvent(new Event('input'));
-                    break;
-                case 'command':
-                    Promise.resolve(cc_command_handlers(msg)).then(function (result) {
-                        ws.send(JSON.stringify({
-                            type: 'command-result',
-                            id: msg.id,
-                            ok: result.ok,
-                            result: result.result,
-                            error: result.error
-                        }));
-                    }).catch(function (e) {
-                        ws.send(JSON.stringify({
-                            type: 'command-result',
-                            id: msg.id,
-                            ok: false,
-                            error: e.message
-                        }));
-                    });
-                    break;
-                case 'assistant-text':
-                    // Side-comment: Claude's CLI text output from session log
-                    var sideMsg = cc_messages.value.concat([{
-                            role: 'side',
-                            content: msg.text,
-                            timestamp: msg.timestamp || Date.now()
-                        }]);
-                    cc_messages.value = sideMsg;
-                    cc_messages.dispatchEvent(new Event('input'));
-                    break;
-                }
-            };
-            ws.onclose = function () {
-                paired = false;
-                cc_watchers.setSend(null);
-                cc_status.value = 'disconnected';
-                cc_status.dispatchEvent(new Event('input'));
-                ws = null;
-            };
-            ws.onerror = function () {
-            };
+  return (function () {
+    var port = cc_config.port,
+      host = cc_config.host;
+    var ws = null;
+    var paired = false;
+    function connect(token) {
+      if (ws) {
+        ws.close();
+        ws = null;
+      }
+      if (token) {
+        try {
+          window.sessionStorage.setItem("lopecode_cc_token", token);
+        } catch (e) {}
+        var hash = location.hash || "#";
+        if (/[&?]cc=/.test(hash)) {
+          hash = hash.replace(/([&?])cc=[^&]*/, "$1cc=" + token);
+        } else {
+          hash += (hash.length > 1 ? "&" : "") + "cc=" + token;
         }
-        // Auto-connect: check hash param first, then sessionStorage fallback
-        (function autoConnect() {
-            var token = null;
-            var hash = location.hash || '';
-            var match = hash.match(/[&?]cc=(LOPE-[A-Z0-9-]+)/);
-            if (match) {
-                token = match[1];
-            }
-            if (!token) {
-                try {
-                    token = sessionStorage.getItem('lopecode_cc_token');
-                } catch (e) {
+        try {
+          window.history.replaceState(null, "", hash);
+        } catch (e) {}
+      }
+      var connectPort = port;
+      if (token) {
+        var parts = token.match(/^LOPE-(\d+)-[A-Z0-9]+$/);
+        if (parts) connectPort = parseInt(parts[1], 10);
+      }
+      cc_status.value = "connecting";
+      cc_status.dispatchEvent(new Event("input"));
+      ws = new WebSocket("ws://" + host + ":" + connectPort + "/ws");
+      ws.onopen = function () {
+        if (token) {
+          cc_status.value = "pairing";
+          cc_status.dispatchEvent(new Event("input"));
+          var toolDescriptors = [];
+          var _mcpToolsVal = $0 && $0.value;
+          if (_mcpToolsVal && _mcpToolsVal.size > 0) {
+            _mcpToolsVal.forEach(function (t, name) {
+              toolDescriptors.push({
+                name: name,
+                description: t.description,
+                inputSchema: t.inputSchema
+              });
+            });
+          }
+          ws.send(
+            JSON.stringify({
+              type: "pair",
+              token: token,
+              url: cc_notebook_id,
+              title: document.title || "Untitled",
+              tools: toolDescriptors
+            })
+          );
+        }
+      };
+      ws.onmessage = function (event) {
+        var msg;
+        try {
+          msg = JSON.parse(event.data);
+        } catch (e) {
+          return;
+        }
+        switch (msg.type) {
+          case "paired":
+            paired = true;
+            cc_status.value = "connected";
+            cc_status.dispatchEvent(new Event("input"));
+            // Provide send callback to watchers
+            cc_watchers.setSend(function (m) {
+              if (paired && ws) ws.send(JSON.stringify(m));
+            });
+            var modules = [];
+            var rt = window.__ojs_runtime;
+            if (rt) {
+              var seen = new Set();
+              for (var v of rt._variables) {
+                var name = v._module && v._module._name;
+                if (name && !seen.has(name)) {
+                  seen.add(name);
+                  modules.push(name);
                 }
+              }
             }
-            if (token) {
-                setTimeout(function () {
-                    connect(token);
-                }, 500);
+            ws.send(
+              JSON.stringify({
+                type: "notebook-info",
+                url: cc_notebook_id,
+                title: document.title,
+                modules: modules,
+                hash: location.hash
+              })
+            );
+            // Set up watches from cc_watches
+            var rt2 = window.__ojs_runtime;
+            if (rt2) {
+              var initialWatches = $1.value || [];
+              for (var i = 0; i < initialWatches.length; i++) {
+                cc_watchers.watchVariable(
+                  rt2,
+                  initialWatches[i].name,
+                  initialWatches[i].module
+                );
+              }
             }
-        }());
-        invalidation.then(function () {
-            cc_watchers.setSend(null);
-            if (ws) {
-                ws.close();
-                ws = null;
-            }
-        });
-        return {
-            connect: connect,
-            get paired() {
-                return paired;
-            },
-            get ws() {
-                return ws;
-            }
-        };
-    }();
+            break;
+          case "pair-failed":
+            paired = false;
+            cc_status.value = "disconnected";
+            cc_status.dispatchEvent(new Event("input"));
+            break;
+          case "reply":
+            var msgs = cc_messages.value.concat([
+              {
+                role: "assistant",
+                content: msg.markdown,
+                timestamp: Date.now()
+              }
+            ]);
+            cc_messages.value = msgs;
+            cc_messages.dispatchEvent(new Event("input"));
+            break;
+          case "tool-activity":
+            // Update the activity status bar (not the chat messages)
+            var activityEntry = {
+              tool_name: msg.tool_name,
+              content: msg.summary,
+              timestamp: msg.timestamp || Date.now()
+            };
+            cc_activity.value = cc_activity.value
+              .concat([activityEntry])
+              .slice(-20);
+            cc_activity.dispatchEvent(new Event("input"));
+            break;
+          case "command":
+            Promise.resolve(cc_command_handlers(msg))
+              .then(function (result) {
+                ws.send(
+                  JSON.stringify({
+                    type: "command-result",
+                    id: msg.id,
+                    ok: result.ok,
+                    result: result.result,
+                    error: result.error
+                  })
+                );
+              })
+              .catch(function (e) {
+                ws.send(
+                  JSON.stringify({
+                    type: "command-result",
+                    id: msg.id,
+                    ok: false,
+                    error: e.message
+                  })
+                );
+              });
+            break;
+          case "assistant-text":
+            // Side-comment: Claude's CLI text output from session log
+            var sideMsg = cc_messages.value.concat([
+              {
+                role: "side",
+                content: msg.text,
+                timestamp: msg.timestamp || Date.now()
+              }
+            ]);
+            cc_messages.value = sideMsg;
+            cc_messages.dispatchEvent(new Event("input"));
+            break;
+        }
+      };
+      ws.onclose = function () {
+        paired = false;
+        cc_watchers.setSend(null);
+        cc_status.value = "disconnected";
+        cc_status.dispatchEvent(new Event("input"));
+        ws = null;
+      };
+      ws.onerror = function () {};
+    }
+    // Auto-connect: check hash param first, then sessionStorage fallback
+    (function autoConnect() {
+      var token = null;
+      var hash = location.hash || "";
+      var match = hash.match(/[&?]cc=(LOPE-[A-Z0-9-]+)/);
+      if (match) {
+        token = match[1];
+      }
+      if (!token) {
+        try {
+          token = sessionStorage.getItem("lopecode_cc_token");
+        } catch (e) {}
+      }
+      if (token) {
+        setTimeout(function () {
+          connect(token);
+        }, 500);
+      }
+    })();
+    invalidation.then(function () {
+      cc_watchers.setSend(null);
+      if (ws) {
+        ws.close();
+        ws = null;
+      }
+    });
+    return {
+      connect: connect,
+      get paired() {
+        return paired;
+      },
+      get ws() {
+        return ws;
+      }
+    };
+  })();
 };
 const _agu8h7 = function _cc_doc_side_effects(md){return(
 md`---
@@ -7318,7 +7339,7 @@ export default function define(runtime, observer) {
   $def("_bzq7u5", null, ["viewof mcpTools","fileSyncTools","Event"], _bzq7u5);  
   $def("_npplqm", "cc_handle_call_tool", ["viewof mcpTools","cc_watchers","runtime"], _npplqm);  
   $def("_ptgn2x", "cc_command_handlers", ["runtime","cc_handle_get_variable","cc_handle_define_variable","cc_handle_define_cell","cc_handle_delete_variable","cc_handle_delete_cell","cc_handle_update_cell","cc_handle_list_variables","cc_handle_list_cells","cc_handle_run_tests","cc_handle_create_module","cc_handle_delete_module","cc_handle_eval","cc_handle_fork","cc_handle_export_module","cc_handle_watch","cc_handle_unwatch","cc_handle_call_tool"], _ptgn2x);  
-  $def("_1s8ywlt", "cc_ws", ["cc_config","sessionStorage","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1s8ywlt);  
+  $def("_11jras6", "cc_ws", ["cc_config","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","sessionStorage","invalidation"], _11jras6);  
   $def("_agu8h7", "cc_doc_side_effects", ["md"], _agu8h7);  
   $def("_d9cyj2", "cc_change_forwarder", ["cc_ws","history","invalidation"], _d9cyj2);  
   $def("_56tjlo", "cc_voice", ["voiceEnabled","KeyboardEvent","SpeechSynthesisUtterance","invalidation"], _56tjlo);  
@@ -7483,15 +7504,19 @@ codemirror.EditorView.theme({
 const _12m5h41 = function _9(md){return(
 md`---`
 )};
-const _1d6o6ga = async function _codemirror(unzip, FileAttachment) {
-    const blob = await unzip(FileAttachment('codemirror_javascript@5.js.gz'));
-    const objectURL = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
-    try {
-        console.log('Loading codemirror from', objectURL);
-        return await import(objectURL);
-    } finally {
-        URL.revokeObjectURL(objectURL);
-    }
+const _1d6o6ga = async function _codemirror(unzip,FileAttachment)
+{
+  const blob = await unzip(FileAttachment("codemirror_javascript@5.js.gz"));
+
+  const objectURL = URL.createObjectURL(
+    new Blob([blob], { type: "application/javascript" })
+  );
+  try {
+    console.log("Loading codemirror from", objectURL);
+    return await import(objectURL);
+  } finally {
+    URL.revokeObjectURL(objectURL); // Ensure URL is revoked after import
+  }
 };
 const _g5fwfs = function _unzip(Response,DecompressionStream){return(
 async (attachment) => {
@@ -7534,80 +7559,64 @@ export default function define(runtime, observer) {
   type="text/plain"
   data-mime="application/javascript"
 >
-const _13upker = function _1(md){return(
+const _tku1if = function _1(md){return(
 md`# Command Palette
 
-Plugin-driven command palette. Press **Cmd+K** (Mac) or **Ctrl+K** to open.
+Plugin-driven command palette. Press **Cmd+K** (Mac) or **Ctrl+K** to open, or pick **Command palette** from the lopepage-2 burger menu (registered on the shared \`"lp2-menu"\` plugin bus).
 
 \`\`\`js
 import {commandPaletteOverlay, commandPaletteStyles, commandPaletteKeybinding} from "@tomlarkworthy/command-palette"
 \`\`\`
 
-## Registering a plugin
+## Registering a command provider
 
-A plugin is a function \`(query: string) => Command[]\` where \`Command = {label, href, hint?, module?, badge?, snippet?, score?}\`. Plugins run on every keystroke; results are merged and sorted by \`score\` (descending).
+A provider is a function \`(query: string) => Command[]\` where \`Command = {label, href, hint?, module?, badge?, snippet?, score?}\`. Providers run on every keystroke; results are merged and sorted by \`score\` (descending).
+
+Providers register on the shared [\`@tomlarkworthy/plugin-registry\`](https://observablehq.com/@tomlarkworthy/plugin-registry) set named \`"lopecode_commands"\` — no import of this notebook needed, so any notebook can extend the palette:
 
 \`\`\`js
-import {viewof commands as commandsView} from "@tomlarkworthy/command-palette"
+import {plugins} from "@tomlarkworthy/plugin-registry"
 {
-  const myPlugin = (q) => [{label: "Hello " + q, href: "#" + q, score: 100}];
-  const unregister = commandsView.addCommand(myPlugin);
-  invalidation.then(unregister);
+  const provider = (q) => [{label: "Hello " + q, href: "#" + q, score: 100}];
+  plugins.add("lopecode_commands", provider, {invalidation});
 }
 \`\`\`
 
-## Built-in plugins
+## Built-in providers
 
 - **Module finder** — type a module name to open it.
 - **Cell search** — type to find cells across all loaded modules.`
 )};
-const _1eng7wy = function _commands(Inputs,Event)
-{
-    const input = Inputs.input([]);
-    input.addCommand = function (plugin) {
-        input.value.push(plugin);
-        input.dispatchEvent(new Event('input'));
-        return () => {
-            const i = input.value.indexOf(plugin);
-            if (i >= 0) {
-                input.value.splice(i, 1);
-                input.dispatchEvent(new Event('input'));
-            }
-        };
-    };
-    return input;
-};
-const _7bve6u = (G, _) => G.input(_);
-const _bpk8h7 = function _searchIndex(liveCellMap,modules){return(
+const _yavx6b = function _searchIndex(liveCellMap,modules){return(
 (() => {
-    const index = [];
-    for (const [mod, cells] of liveCellMap.entries()) {
-        const moduleName = modules?.get(mod)?.name ?? '<unknown>';
-        for (const cell of cells) {
-            if (!cell.name && cell.type !== 'import')
-                continue;
-            let source = null;
-            try {
-                const v = cell.variables?.[0];
-                if (v?._definition)
-                    source = v._definition.toString();
-            } catch (e) {
-            }
-            index.push({
-                module: moduleName,
-                name: cell.name ?? null,
-                type: cell.type ?? 'simple',
-                source
-            });
-        }
+  const index = [];
+  for (const [mod, cells] of liveCellMap.entries()) {
+    const moduleName = modules?.get(mod)?.name ?? '<unknown>';
+    for (const cell of cells) {
+      if (!cell.name && cell.type !== 'import')
+        continue;
+      let source = null;
+      try {
+        const v = cell.variables?.[0];
+        if (v?._definition)
+          source = v._definition.toString();
+      } catch (e) {
+      }
+      index.push({
+        module: moduleName,
+        name: cell.name ?? null,
+        type: cell.type ?? 'simple',
+        source
+      });
     }
-    return index;
+  }
+  return index;
 })()
 )};
-const _1ptnr90 = function _commandPaletteStyles(theme_assets,htl)
+const _rmjyys = function _commandPaletteStyles(theme_assets,htl)
 {
-    theme_assets;
-    return htl.html`<style>
+  theme_assets;
+  return htl.html`<style>
 .command-palette-overlay {
   position: fixed;
   inset: 0;
@@ -7729,15 +7738,15 @@ const _1ptnr90 = function _commandPaletteStyles(theme_assets,htl)
 }
 </style>`;
 };
-const _fomuvm = function _commandPaletteOverlay($0,Node,invalidation)
+const _1q8grv4 = function _commandPaletteOverlay(Node,invalidation)
 {
-    const $commands = $0;
-    let selectedIdx = 0;
-    let results = [];
-    const overlay = document.createElement('div');
-    overlay.className = 'command-palette-overlay';
-    overlay.hidden = true;
-    overlay.innerHTML = `<div class="command-palette-box">
+  let selectedIdx = 0;
+  let results = [];
+  let providers = [];
+  const overlay = document.createElement('div');
+  overlay.className = 'command-palette-overlay';
+  overlay.hidden = true;
+  overlay.innerHTML = `<div class="command-palette-box">
       <input class="command-palette-input" placeholder="Type a command..." autocomplete="off" />
       <div class="command-palette-results"></div>
       <div class="command-palette-hint">
@@ -7746,147 +7755,156 @@ const _fomuvm = function _commandPaletteOverlay($0,Node,invalidation)
         <span><kbd>Esc</kbd> close</span>
       </div>
     </div>`;
-    const input = overlay.querySelector('.command-palette-input');
-    const resultsContainer = overlay.querySelector('.command-palette-results');
-    function search(query) {
-        if (!query || query.length < 1)
-            return [];
-        const plugins = $commands.value || [];
-        let all = [];
-        for (const plugin of plugins) {
-            try {
-                const out = plugin(query);
-                if (Array.isArray(out))
-                    all = all.concat(out);
-            } catch (e) {
-                console.error('[command-palette] plugin error:', e);
-            }
-        }
-        all.sort((a, b) => (b.score ?? 0) - (a.score ?? 0));
-        return all.slice(0, 50);
+  const input = overlay.querySelector('.command-palette-input');
+  const resultsContainer = overlay.querySelector('.command-palette-results');
+  function search(query) {
+    if (!query || query.length < 1)
+      return [];
+    let all = [];
+    for (const provider of providers) {
+      try {
+        const out = provider(query);
+        if (Array.isArray(out))
+          all = all.concat(out);
+      } catch (e) {
+        console.error('[command-palette] provider error:', e);
+      }
     }
-    function render() {
-        resultsContainer.innerHTML = '';
-        if (results.length === 0 && input.value.length > 0) {
-            resultsContainer.innerHTML = '<div class="command-palette-empty">No results found</div>';
-            return;
+    all.sort((a, b) => (b.score ?? 0) - (a.score ?? 0));
+    return all.slice(0, 50);
+  }
+  function render() {
+    resultsContainer.innerHTML = '';
+    if (results.length === 0 && input.value.length > 0) {
+      resultsContainer.innerHTML = '<div class="command-palette-empty">No results found</div>';
+      return;
+    }
+    results.forEach((r, i) => {
+      const row = document.createElement('a');
+      row.className = 'command-palette-result' + (i === selectedIdx ? ' selected' : '');
+      row.href = r.href || '#';
+      row.style.textDecoration = 'none';
+      row.style.color = 'inherit';
+      if (r.module) {
+        const modSpan = document.createElement('span');
+        modSpan.className = 'command-palette-module';
+        modSpan.textContent = r.module;
+        row.appendChild(modSpan);
+      }
+      const labelSpan = document.createElement('span');
+      labelSpan.className = 'command-palette-label';
+      labelSpan.textContent = r.label ?? '';
+      row.appendChild(labelSpan);
+      if (r.badge) {
+        const badgeSpan = document.createElement('span');
+        badgeSpan.className = 'command-palette-badge';
+        badgeSpan.textContent = r.badge;
+        row.appendChild(badgeSpan);
+      }
+      if (r.hint) {
+        const hintSpan = document.createElement('span');
+        hintSpan.className = 'command-palette-hint-right';
+        hintSpan.textContent = r.hint;
+        row.appendChild(hintSpan);
+      }
+      row.addEventListener('click', e => {
+        e.preventDefault();
+        close();
+        window.location.href = row.href;
+      });
+      resultsContainer.appendChild(row);
+      if (r.snippet) {
+        const snippet = document.createElement('div');
+        snippet.className = 'command-palette-snippet';
+        if (i === selectedIdx)
+          snippet.style.background = '#eef4ff';
+        if (typeof r.snippet === 'string') {
+          snippet.textContent = r.snippet;
+        } else if (r.snippet instanceof Node) {
+          snippet.appendChild(r.snippet);
         }
-        results.forEach((r, i) => {
-            const row = document.createElement('a');
-            row.className = 'command-palette-result' + (i === selectedIdx ? ' selected' : '');
-            row.href = r.href || '#';
-            row.style.textDecoration = 'none';
-            row.style.color = 'inherit';
-            if (r.module) {
-                const modSpan = document.createElement('span');
-                modSpan.className = 'command-palette-module';
-                modSpan.textContent = r.module;
-                row.appendChild(modSpan);
-            }
-            const labelSpan = document.createElement('span');
-            labelSpan.className = 'command-palette-label';
-            labelSpan.textContent = r.label ?? '';
-            row.appendChild(labelSpan);
-            if (r.badge) {
-                const badgeSpan = document.createElement('span');
-                badgeSpan.className = 'command-palette-badge';
-                badgeSpan.textContent = r.badge;
-                row.appendChild(badgeSpan);
-            }
-            if (r.hint) {
-                const hintSpan = document.createElement('span');
-                hintSpan.className = 'command-palette-hint-right';
-                hintSpan.textContent = r.hint;
-                row.appendChild(hintSpan);
-            }
-            row.addEventListener('click', e => {
-                e.preventDefault();
-                close();
-                window.location.href = row.href;
-            });
-            resultsContainer.appendChild(row);
-            if (r.snippet) {
-                const snippet = document.createElement('div');
-                snippet.className = 'command-palette-snippet';
-                if (i === selectedIdx)
-                    snippet.style.background = '#eef4ff';
-                if (typeof r.snippet === 'string') {
-                    snippet.textContent = r.snippet;
-                } else if (r.snippet instanceof Node) {
-                    snippet.appendChild(r.snippet);
-                }
-                snippet.addEventListener('click', e => {
-                    e.preventDefault();
-                    close();
-                    window.location.href = row.href;
-                });
-                resultsContainer.appendChild(snippet);
-            }
+        snippet.addEventListener('click', e => {
+          e.preventDefault();
+          close();
+          window.location.href = row.href;
         });
-    }
-    function open() {
-        overlay.hidden = false;
-        input.value = '';
-        results = [];
-        selectedIdx = 0;
-        render();
-        requestAnimationFrame(() => input.focus());
-    }
-    function close() {
-        overlay.hidden = true;
-        input.blur();
-    }
-    function navigateToSelected() {
-        if (results[selectedIdx]) {
-            const r = results[selectedIdx];
-            close();
-            window.location.href = r.href || '#';
-        }
-    }
-    input.addEventListener('input', () => {
-        results = search(input.value);
-        selectedIdx = 0;
-        render();
+        resultsContainer.appendChild(snippet);
+      }
     });
-    input.addEventListener('keydown', e => {
-        if (e.key === 'ArrowDown') {
-            e.preventDefault();
-            selectedIdx = Math.min(selectedIdx + 1, results.length - 1);
-            render();
-            const sel = resultsContainer.querySelector('.selected');
-            if (sel)
-                sel.scrollIntoView({ block: 'nearest' });
-        } else if (e.key === 'ArrowUp') {
-            e.preventDefault();
-            selectedIdx = Math.max(selectedIdx - 1, 0);
-            render();
-            const sel = resultsContainer.querySelector('.selected');
-            if (sel)
-                sel.scrollIntoView({ block: 'nearest' });
-        } else if (e.key === 'Enter') {
-            e.preventDefault();
-            navigateToSelected();
-        } else if (e.key === 'Escape') {
-            e.preventDefault();
-            close();
-        }
-    });
-    overlay.addEventListener('click', e => {
-        if (e.target === overlay)
-            close();
-    });
-    invalidation.then(() => overlay.remove());
-    overlay._openPalette = open;
-    overlay._closePalette = close;
-    overlay._isOpen = () => !overlay.hidden;
-    return overlay;
+  }
+  function open() {
+    overlay.hidden = false;
+    input.value = '';
+    results = [];
+    selectedIdx = 0;
+    render();
+    requestAnimationFrame(() => input.focus());
+  }
+  function close() {
+    overlay.hidden = true;
+    input.blur();
+  }
+  function navigateToSelected() {
+    if (results[selectedIdx]) {
+      const r = results[selectedIdx];
+      close();
+      window.location.href = r.href || '#';
+    }
+  }
+  input.addEventListener('input', () => {
+    results = search(input.value);
+    selectedIdx = 0;
+    render();
+  });
+  input.addEventListener('keydown', e => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      selectedIdx = Math.min(selectedIdx + 1, results.length - 1);
+      render();
+      const sel = resultsContainer.querySelector('.selected');
+      if (sel)
+        sel.scrollIntoView({ block: 'nearest' });
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      selectedIdx = Math.max(selectedIdx - 1, 0);
+      render();
+      const sel = resultsContainer.querySelector('.selected');
+      if (sel)
+        sel.scrollIntoView({ block: 'nearest' });
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      navigateToSelected();
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      close();
+    }
+  });
+  overlay.addEventListener('click', e => {
+    if (e.target === overlay)
+      close();
+  });
+  invalidation.then(() => overlay.remove());
+  overlay._openPalette = open;
+  overlay._closePalette = close;
+  overlay._isOpen = () => !overlay.hidden;
+  // Stable setter fed by command_provider_sync; re-searches live if the palette is open.
+  overlay._setProviders = arr => {
+    providers = arr || [];
+    if (!overlay.hidden) {
+      results = search(input.value);
+      selectedIdx = 0;
+      render();
+    }
+  };
+  return overlay;
 };
-const _mqy6k9 = function _commandPaletteKeybinding(cellSearchPlugin,moduleFinderPlugin,commandPaletteOverlay,invalidation)
+const _1vuj6tn = function _commandPaletteKeybinding(cellSearchPlugin,moduleFinderPlugin,command_provider_sync,commandPaletteOverlay,invalidation)
 {
   cellSearchPlugin;
   moduleFinderPlugin;
-  const handler = (e) => {
-    if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+  command_provider_sync;
+  const handler = e => {
+    if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
       e.preventDefault();
       e.stopPropagation();
       if (commandPaletteOverlay._isOpen()) {
@@ -7896,24 +7914,23 @@ const _mqy6k9 = function _commandPaletteKeybinding(cellSearchPlugin,moduleFinder
       }
     }
   };
-  document.addEventListener("keydown", handler, true);
-  invalidation.then(() =>
-    document.removeEventListener("keydown", handler, true)
-  );
+  document.addEventListener('keydown', handler, true);
+  invalidation.then(() => document.removeEventListener('keydown', handler, true));
   return null;
 };
-const _k261kj = function _cellSearchPlugin(searchIndex,linkTo,$0,invalidation)
+const _104tbig = function _cellSearchPlugin(searchIndex,linkTo,plugins,invalidation)
 {
-  const plugin = (query) => {
-    if (!query || query.length < 1) return [];
+  const plugin = query => {
+    if (!query || query.length < 1)
+      return [];
     const q = query.toLowerCase();
     const out = [];
     for (const entry of searchIndex) {
       let score = 0;
       let nameMatch = false;
       let sourceMatch = false;
-      const name = String(entry.name ?? "").toLowerCase();
-      const mod = String(entry.module ?? "").toLowerCase();
+      const name = String(entry.name ?? '').toLowerCase();
+      const mod = String(entry.module ?? '').toLowerCase();
       if (name.length && name.startsWith(q)) {
         score += 150;
         nameMatch = true;
@@ -7928,50 +7945,42 @@ const _k261kj = function _cellSearchPlugin(searchIndex,linkTo,$0,invalidation)
         score += 10;
         sourceMatch = true;
       }
-      if (score === 0) continue;
-      const nameStr = String(entry.name ?? "");
-      const modStr = String(entry.module ?? "");
-      const href = linkTo(nameStr ? modStr + "#" + nameStr : modStr);
+      if (score === 0)
+        continue;
+      const nameStr = String(entry.name ?? '');
+      const modStr = String(entry.module ?? '');
+      const href = linkTo(nameStr ? modStr + '#' + nameStr : modStr);
       let snippet = null;
       if (entry.source) {
         const src = String(entry.source);
         const idx = src.toLowerCase().indexOf(q);
         const frag = document.createDocumentFragment();
         if (idx >= 0) {
-          const start = Math.max(
-            0,
-            src.lastIndexOf("\n", Math.max(0, idx - 40)) + 1
-          );
-          const endNL = src.indexOf("\n", idx + query.length + 40);
-          const lineEnd =
-            endNL < 0 ? Math.min(src.length, idx + query.length + 80) : endNL;
+          const start = Math.max(0, src.lastIndexOf('\n', Math.max(0, idx - 40)) + 1);
+          const endNL = src.indexOf('\n', idx + query.length + 40);
+          const lineEnd = endNL < 0 ? Math.min(src.length, idx + query.length + 80) : endNL;
           const before = src.slice(start, idx);
           const match = src.slice(idx, idx + query.length);
           const after = src.slice(idx + query.length, lineEnd);
           if (start > 0)
-            frag.appendChild(document.createTextNode("\u2026" + before));
-          else frag.appendChild(document.createTextNode(before));
-          const mark = document.createElement("mark");
+            frag.appendChild(document.createTextNode('\u2026' + before));
+          else
+            frag.appendChild(document.createTextNode(before));
+          const mark = document.createElement('mark');
           mark.textContent = match;
           frag.appendChild(mark);
-          frag.appendChild(
-            document.createTextNode(
-              after + (lineEnd < src.length ? "\u2026" : "")
-            )
-          );
+          frag.appendChild(document.createTextNode(after + (lineEnd < src.length ? '\u2026' : '')));
         } else {
-          const firstLine = src.slice(0, src.indexOf("\n", 0));
-          frag.appendChild(
-            document.createTextNode((firstLine || src).slice(0, 120))
-          );
+          const firstLine = src.slice(0, src.indexOf('\n', 0));
+          frag.appendChild(document.createTextNode((firstLine || src).slice(0, 120)));
         }
         snippet = frag;
       }
       out.push({
-        label: nameStr || "(anonymous)",
+        label: nameStr || '(anonymous)',
         module: modStr,
-        badge: entry.type && entry.type !== "simple" ? entry.type : null,
-        hint: sourceMatch && !nameMatch ? "source" : null,
+        badge: entry.type && entry.type !== 'simple' ? entry.type : null,
+        hint: sourceMatch && !nameMatch ? 'source' : null,
         snippet,
         href,
         score
@@ -7979,37 +7988,69 @@ const _k261kj = function _cellSearchPlugin(searchIndex,linkTo,$0,invalidation)
     }
     return out;
   };
-  const unregister = $0.addCommand(plugin);
-  invalidation.then(unregister);
-  return "cell-search plugin registered";
+  plugins.add('lopecode_commands', plugin, { invalidation });
+  return 'cell-search plugin registered';
 };
-const _lq3msy = function _moduleFinderPlugin(modules,linkTo,$0,invalidation)
+const _1opf5e1 = function _moduleFinderPlugin(currentModules,linkTo,plugins,invalidation)
 {
-  const plugin = (query) => {
-    if (!query || query.length < 1) return [];
+  // Use the REACTIVE module set (module-map currentModules), not cell-map's one-shot `modules` snapshot,
+  // so modules created live (e.g. by robocoop-4) are immediately findable. This cell recomputes whenever
+  // currentModules changes; the old plugin is unregistered via invalidation before the new one registers.
+  const plugin = query => {
+    if (!query || query.length < 1)
+      return [];
     const q = query.toLowerCase();
     const out = [];
-    for (const [, info] of modules.entries()) {
-      const name = info?.name ?? "";
-      if (!name) continue;
+    for (const [, info] of currentModules.entries()) {
+      const name = info?.name ?? '';
+      if (!name)
+        continue;
       const lower = name.toLowerCase();
       let score = 0;
-      if (lower === q) score = 1000;
-      else if (lower.startsWith(q)) score = 800;
-      else if (lower.includes(q)) score = 600;
-      if (score === 0) continue;
+      if (lower === q)
+        score = 1000;
+      else if (lower.startsWith(q))
+        score = 800;
+      else if (lower.includes(q))
+        score = 600;
+      if (score === 0)
+        continue;
       out.push({
         label: name,
         href: linkTo(name),
-        hint: "open module",
+        hint: 'open module',
         score
       });
     }
     return out;
   };
-  const unregister = $0.addCommand(plugin);
-  invalidation.then(unregister);
-  return "module-finder plugin registered";
+  plugins.add('lopecode_commands', plugin, { invalidation });
+  return 'module-finder plugin registered';
+};
+const _1seh1ei = function _cp_menu_register(plugins,commandPaletteOverlay,invalidation)
+{
+  // Surface the palette in the lopepage-2 burger menu so it's discoverable without knowing the
+  // Cmd/Ctrl+K shortcut. Registers straight onto the shared plugin-registry "lp2-menu" set — no
+  // import of lopepage-2; a notebook opts in by adding both modules to its bootconf mains.
+  const isMac = /Mac|iP(hone|ad|od)/.test(navigator.platform || navigator.userAgent || '');
+  plugins.add('lp2-menu', {
+    id: 'command-palette',
+    order: 3,
+    label: 'Command palette  ' + (isMac ? '\u2318K' : 'Ctrl+K'),
+    svg: '<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.3"><circle cx="7" cy="7" r="4.2"/><path d="M10.2 10.2 14 14"/></svg>',
+    action: () => commandPaletteOverlay._openPalette()
+  }, { invalidation });
+  return 'registered: command-palette menu item';
+};
+const _7c6wp9 = function _commandProviders(plugins){return(
+plugins.get('lopecode_commands')
+)};
+const _13y9cxb = function _command_provider_sync(commandPaletteOverlay,commandProviders)
+{
+  // Push the current provider set (from the "lopecode_commands" bus) into the stable overlay,
+  // so the overlay is built once yet always searches the live set. Recomputes on every add/remove.
+  commandPaletteOverlay._setProviders(commandProviders);
+  return `command providers: ${ commandProviders.length }`;
 };
 
 export default function define(runtime, observer) {
@@ -8021,20 +8062,25 @@ export default function define(runtime, observer) {
   main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
   main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
   main.define("module @tomlarkworthy/themes", async () => runtime.module((await import("/@tomlarkworthy/themes.js?v=4")).default));  
-  $def("_13upker", null, ["md"], _13upker);  
-  $def("_1eng7wy", "viewof commands", ["Inputs","Event"], _1eng7wy);  
-  $def("_7bve6u", "commands", ["Generators","viewof commands"], _7bve6u);  
-  $def("_bpk8h7", "searchIndex", ["liveCellMap","modules"], _bpk8h7);  
-  $def("_1ptnr90", "commandPaletteStyles", ["theme_assets","htl"], _1ptnr90);  
-  $def("_fomuvm", "commandPaletteOverlay", ["viewof commands","Node","invalidation"], _fomuvm);  
-  $def("_mqy6k9", "commandPaletteKeybinding", ["cellSearchPlugin","moduleFinderPlugin","commandPaletteOverlay","invalidation"], _mqy6k9);  
-  $def("_k261kj", "cellSearchPlugin", ["searchIndex","linkTo","viewof commands","invalidation"], _k261kj);  
-  $def("_lq3msy", "moduleFinderPlugin", ["modules","linkTo","viewof commands","invalidation"], _lq3msy);  
+  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
+  main.define("module @tomlarkworthy/plugin-registry", async () => runtime.module((await import("/@tomlarkworthy/plugin-registry.js?v=4")).default));  
+  $def("_tku1if", null, ["md"], _tku1if);  
+  $def("_yavx6b", "searchIndex", ["liveCellMap","modules"], _yavx6b);  
+  $def("_rmjyys", "commandPaletteStyles", ["theme_assets","htl"], _rmjyys);  
+  $def("_1q8grv4", "commandPaletteOverlay", ["Node","invalidation"], _1q8grv4);  
+  $def("_1vuj6tn", "commandPaletteKeybinding", ["cellSearchPlugin","moduleFinderPlugin","command_provider_sync","commandPaletteOverlay","invalidation"], _1vuj6tn);  
+  $def("_104tbig", "cellSearchPlugin", ["searchIndex","linkTo","plugins","invalidation"], _104tbig);  
+  $def("_1opf5e1", "moduleFinderPlugin", ["currentModules","linkTo","plugins","invalidation"], _1opf5e1);  
   main.define("viewof liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("viewof liveCellMap", _));  
   main.define("liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("liveCellMap", _));  
   main.define("modules", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("modules", _));  
   main.define("linkTo", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("linkTo", _));  
-  main.define("theme_assets", ["module @tomlarkworthy/themes", "@variable"], (_, v) => v.import("theme_assets", _));
+  main.define("theme_assets", ["module @tomlarkworthy/themes", "@variable"], (_, v) => v.import("theme_assets", _));  
+  main.define("currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("currentModules", _));  
+  main.define("plugins", ["module @tomlarkworthy/plugin-registry", "@variable"], (_, v) => v.import("plugins", _));  
+  $def("_1seh1ei", "cp_menu_register", ["plugins","commandPaletteOverlay","invalidation"], _1seh1ei);  
+  $def("_7c6wp9", "commandProviders", ["plugins"], _7c6wp9);  
+  $def("_13y9cxb", "command_provider_sync", ["commandPaletteOverlay","commandProviders"], _13y9cxb);
   return main;
 }</script>
 <script id="@tomlarkworthy/dataflow-templating/dataflow_templating%401.svg" 
@@ -8639,10 +8685,10 @@ function divToVar(runtime, div) {
   }
 }
 )};
-const _1usw8c2 = function _attachContextManu(Inputs,isOnObservableCom){return(
+const _8yv93h = async function _attachContextManu(Inputs,optionsFile,isOnObservableCom){return(
 Inputs.toggle({
-  label: "attach menu",
-  value: !isOnObservableCom()
+  label: 'attach menu',
+  value: (await optionsFile.json())?.__attachMenu ?? !isOnObservableCom()
 })
 )};
 const _1oaz8r1 = (G, _) => G.input(_);
@@ -8679,7 +8725,7 @@ lookupVariable(
   editorModule
 )
 )};
-const _1q95xt6 = function _cellEditor(cloneDataflow,editorTemplate,shellTemplate,getOption,Event,setOption,createCell,findCell,pinOnCreate){return(
+const _1p2yypw = function _cellEditor(cloneDataflow,editorTemplate,shellTemplate,createCell,findCell,dragReorder,pinOnCreate,getOption,Event,setOption){return(
 (variable, {
     pinned = undefined
 } = {}) => {
@@ -8768,6 +8814,20 @@ const _1q95xt6 = function _cellEditor(cloneDataflow,editorTemplate,shellTemplate
                             createCell({ cell: findCell(variable) });
                         });
                         hotbar.prepend(add);
+                    }
+                    // Drag the whole hotbar to reorder this cell (alternative to up/down arrows).
+                    if (hotbar && !hotbar.dataset.reorderable) {
+                        hotbar.dataset.reorderable = '1';
+                        hotbar.style.cursor = 'grab';
+                        const grip = document.createElement('span');
+                        grip.className = 'reorder-grip';
+                        grip.textContent = '⠿'; // ⠿ drag handle
+                        grip.title = 'Drag to reorder cell';
+                        // Float left so the grip sits at the far edge of the full-width
+                        // bar, while ➕/edit stay right-aligned via the shell's text-align.
+                        grip.style.cssText = 'float: left; margin-left: 4px; opacity: 0.55;';
+                        hotbar.prepend(grip);
+                        dragReorder(variable, hotbar);
                     }
                     if (body)
                         syncOpen();
@@ -9261,9 +9321,6 @@ async (cell, amount) =>
     }
   })
 )};
-const _pinoncr = function _pinOnCreate(){return(
-new Set()  // variable pids to open (pin) their editor as soon as the cell mounts
-)};
 const _19znal9 = function _createCell($0){return(
 async ({cell, source = "{}" } = {}) =>
   $0.send({
@@ -9325,7 +9382,7 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _2pkmxz = async function _command_processor(command,$0,compile_and_update,remove_variables,$1,findCellIndex,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2,pinOnCreate)
+const _g08ji8 = async function _command_processor(command,$0,compile_and_update,pinOnCreate,selectVariable,remove_variables,$1,findCellIndex,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,findCell,$2)
 {
     if (command.processed)
         return;
@@ -9381,6 +9438,35 @@ const _2pkmxz = async function _command_processor(command,$0,compile_and_update,
                     });
                 }
             }
+        }
+        result = true;
+    } else if (command.command == 'moveCellBeside') {
+        // Drag-drop reorder: place cell's variables immediately before (or, with
+        // placeAfter, after) the anchor cell that `target` belongs to. Repositions by
+        // variable identity, not cell index, so hidden/import/template variables
+        // between visible cells don't skew the destination. The anchor is resolved to
+        // its whole cell so multi-variable cells (viewof/mutable) aren't split, and a
+        // drop past the last visible cell anchors to it (placeAfter) rather than to the
+        // module's far-off last dynamic variable.
+        const { cell, target, placeAfter } = command.args;
+        const anchorCell = findCell(target);
+        const arr = Array.from(runtime._variables);
+        const groupSet = new Set(cell.variables);
+        const group = arr.filter(v => groupSet.has(v));
+        const without = arr.filter(v => !groupSet.has(v));
+        let insertAt = -1;
+        if (anchorCell?.variables?.length) {
+            const idxs = anchorCell.variables
+                .map(v => without.indexOf(v))
+                .filter(i => i >= 0);
+            if (idxs.length)
+                insertAt = placeAfter ? Math.max(...idxs) + 1 : Math.min(...idxs);
+        }
+        if (insertAt >= 0 && group.length) {
+            without.splice(insertAt, 0, ...group);
+            runtime._variables.clear();
+            without.forEach(v => runtime._variables.add(v));
+            await selectVariable(cell.variables[0], cell.dom);
         }
         result = true;
     }
@@ -10055,13 +10141,14 @@ const _w5q3yf = function _editorModule(thisModule){return(
 thisModule()
 )};
 const _18kaj2p = (G, _) => G.input(_);
-const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_options)
+const _yeikvo = function _editor_jobs(command_processor,submit_summary,save_options,persist_attach_menu)
 {
   //editedCell;
   command_processor;
   submit_summary;
   save_options;
-  return "editor_jobs";
+  persist_attach_menu;
+  return 'editor_jobs';
 };
 const _1whoy5n = function _91(md){return(
 md`### Apply Update`
@@ -10369,6 +10456,197 @@ const _bz6mai = function _test_completion_identifier_deferred(completionFixture)
     throw new Error('bare identifier (no dot) must defer');
   return 'identifier / no-dot bases deferred to the identifier-chain path';
 };
+const _y8yyf = function _pinOnCreate()
+{
+  return new Set()  // variable pids to open (pin) their editor as soon as the cell mounts
+;
+};
+const _y040tx = function _persist_attach_menu($0,attachContextManu,Event)
+{
+  // Bake the global edit-mode flag into cell_options.json so it survives export/fork.
+  // Depends on `viewof options` (element, stable), not `options` (value), so this
+  // write does not re-trigger itself; save_options then persists the attachment.
+  $0.value.__attachMenu = attachContextManu;
+  $0.dispatchEvent(new Event('input'));
+  return 'persist_attach_menu';
+};
+const _1jn7thk = function _moveCellBeside($0){return(
+async (cell, target, placeAfter = false) =>
+  $0.send({
+    command: "moveCellBeside",
+    args: {
+      cell,
+      target,
+      placeAfter
+    }
+  })
+)};
+const _2rhl00 = function _dragReorder(divToVar,runtime,moveCellBeside,findCell){return(
+(variable, handle) => {
+  if (!document.getElementById('lope-reorder-style')) {
+    const s = document.createElement('style');
+    s.id = 'lope-reorder-style';
+    s.textContent =
+      'body.lope-reordering, body.lope-reordering * { user-select: none !important; cursor: grabbing !important; }';
+    document.head.appendChild(s);
+  }
+
+  const THRESH = 5;
+  let pointerId = null, dragging = false, startX = 0, startY = 0;
+  let cells = null, ownIndex = -1, scroller = null, indicator = null;
+  const blockSelect = (ev) => ev.preventDefault();
+
+  // Same-module visible cells in DOM order; one entry per rendered .observablehq div.
+  const getModuleCells = () => {
+    const mod = variable._module;
+    const out = [];
+    for (const div of document.querySelectorAll('.observablehq')) {
+      const v = divToVar(runtime, div);
+      if (v && v._module === mod) out.push({ div, v });
+    }
+    return out;
+  };
+
+  const ensureIndicator = () => {
+    if (indicator) return indicator;
+    indicator = document.createElement('div');
+    indicator.style.cssText =
+      'position: fixed; height: 0; z-index: 2147483646; pointer-events: none;' +
+      'border-top: 2px solid var(--theme-foreground-focus, #3b5bdb);';
+    document.body.appendChild(indicator);
+    return indicator;
+  };
+  const removeIndicator = () => { if (indicator) { indicator.remove(); indicator = null; } };
+
+  // gap 0..N: how many cells sit above pointer Y (by their vertical midpoint).
+  const gapAt = (y) => {
+    for (let i = 0; i < cells.length; i++) {
+      const r = cells[i].div.getBoundingClientRect();
+      if (y < r.top + r.height / 2) return i;
+    }
+    return cells.length;
+  };
+
+  const drawIndicator = (g) => {
+    const ind = ensureIndicator();
+    const ref = cells[Math.min(ownIndex, cells.length - 1)].div.getBoundingClientRect();
+    const y = g < cells.length
+      ? cells[g].div.getBoundingClientRect().top
+      : cells[cells.length - 1].div.getBoundingClientRect().bottom;
+    ind.style.left = ref.left + 'px';
+    ind.style.width = ref.width + 'px';
+    ind.style.top = (y - 1) + 'px';
+  };
+
+  const autoScroll = (y) => {
+    if (!scroller) return;
+    const r = scroller.getBoundingClientRect
+      ? scroller.getBoundingClientRect()
+      : { top: 0, bottom: window.innerHeight };
+    const M = 36;
+    let dy = 0;
+    if (y < r.top + M) dy = -Math.ceil((r.top + M - y) / 3);
+    else if (y > r.bottom - M) dy = Math.ceil((y - (r.bottom - M)) / 3);
+    if (dy && scroller.scrollBy) scroller.scrollBy({ top: dy });
+  };
+
+  const beginDrag = () => {
+    cells = getModuleCells();
+    ownIndex = cells.findIndex(c => c.v === variable);
+    if (ownIndex < 0) return false;
+    dragging = true;
+    scroller = cells[ownIndex].div.closest('.lm_content')
+      || document.scrollingElement || document.documentElement;
+    document.body.classList.add('lope-reordering');
+    handle.style.cursor = 'grabbing';
+    // Drop any selection the gesture already started and block new ones for the drag.
+    const sel = window.getSelection && window.getSelection();
+    if (sel && sel.removeAllRanges) sel.removeAllRanges();
+    document.addEventListener('selectstart', blockSelect, true);
+    return true;
+  };
+
+  const onMove = (e) => {
+    if (pointerId == null) return;
+    if (!dragging) {
+      if (Math.abs(e.clientX - startX) < THRESH && Math.abs(e.clientY - startY) < THRESH) return;
+      if (!beginDrag()) return;
+    }
+    e.preventDefault();
+    drawIndicator(gapAt(e.clientY));
+    autoScroll(e.clientY);
+  };
+
+  const teardown = () => {
+    if (pointerId != null && handle.releasePointerCapture) {
+      try { handle.releasePointerCapture(pointerId); } catch (_) {}
+    }
+    handle.removeEventListener('pointermove', onMove);
+    handle.removeEventListener('pointerup', onUp);
+    handle.removeEventListener('pointercancel', onCancel);
+    document.removeEventListener('selectstart', blockSelect, true);
+    handle.style.cursor = '';
+    document.body.classList.remove('lope-reordering');
+    removeIndicator();
+  };
+
+  const onUp = (e) => {
+    const wasDragging = dragging;
+    let target, placeAfter = false, ownDiv = null, doMove = false;
+    if (wasDragging) {
+      ownDiv = cells[ownIndex].div;
+      const g = gapAt(e.clientY);
+      // Drop in own slot (just above or below self) is a no-op.
+      if (g !== ownIndex && g !== ownIndex + 1) {
+        doMove = true;
+        if (g < cells.length) {
+          target = cells[g].v;         // insert before the cell now at the gap
+        } else {
+          target = cells[cells.length - 1].v;  // dropped past the last visible cell
+          placeAfter = true;
+        }
+      }
+    }
+    teardown();
+    pointerId = null; dragging = false; cells = null; ownIndex = -1; scroller = null;
+    if (wasDragging) {
+      // Suppress the click that would otherwise toggle the editor open/closed.
+      const stop = (ev) => { ev.stopPropagation(); ev.preventDefault(); };
+      handle.addEventListener('click', stop, { capture: true, once: true });
+      setTimeout(() => handle.removeEventListener('click', stop, { capture: true }), 0);
+      if (doMove) moveCellBeside(findCell(variable, ownDiv), target, placeAfter);
+    }
+  };
+
+  const onCancel = () => {
+    teardown();
+    pointerId = null; dragging = false; cells = null; ownIndex = -1; scroller = null;
+  };
+
+  const onDown = (e) => {
+    if (e.button != null && e.button !== 0) return;
+    if (e.target && e.target.closest && e.target.closest('.add-cell-btn')) return;
+    pointerId = e.pointerId;
+    startX = e.clientX; startY = e.clientY;
+    dragging = false;
+    if (handle.setPointerCapture) { try { handle.setPointerCapture(e.pointerId); } catch (_) {} }
+    handle.addEventListener('pointermove', onMove);
+    handle.addEventListener('pointerup', onUp);
+    handle.addEventListener('pointercancel', onCancel);
+  };
+
+  handle.addEventListener('pointerdown', onDown);
+  // Suppress the native text-selection drag that would otherwise start on press.
+  // mousedown-preventDefault leaves `click` intact (same trick as the add button).
+  handle.addEventListener('mousedown', e => {
+    if (!(e.target && e.target.closest && e.target.closest('.add-cell-btn'))) e.preventDefault();
+  });
+  handle.addEventListener('selectstart', blockSelect);
+  handle.style.touchAction = 'none';
+  handle.style.userSelect = 'none';
+  return () => handle.removeEventListener('pointerdown', onDown);
+}
+)};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -10384,6 +10662,7 @@ export default function define(runtime, observer) {
   main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
 
   main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
+  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));  
   main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
   main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
   main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
@@ -10408,11 +10687,11 @@ export default function define(runtime, observer) {
   $def("_hdieof", "editors", [], _hdieof);  
   $def("_ipx6cz", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","editors","cellEditor"], _ipx6cz);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
-  $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
+  $def("_8yv93h", "viewof attachContextManu", ["Inputs","optionsFile","isOnObservableCom"], _8yv93h);  
   $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
   $def("_16ks4jz", null, ["md"], _16ks4jz);  
   $def("_199ztvl", "hotbarTemplate", ["lookupVariable","editorModule"], _199ztvl);  
-  $def("_1q95xt6", "cellEditor", ["cloneDataflow","editorTemplate","shellTemplate","getOption","Event","setOption","createCell","findCell","pinOnCreate"], _1q95xt6);
+  $def("_1p2yypw", "cellEditor", ["cloneDataflow","editorTemplate","shellTemplate","createCell","findCell","dragReorder","pinOnCreate","getOption","Event","setOption"], _1p2yypw);  
   $def("_x5ixji", "hotbar_shell", ["viewof edit","Event","htl","edit"], _x5ixji);  
   $def("_1ed5zb9", "editor_panel", ["viewof editedCell","htl","toolbar","nav","reversibleAttach","combine","code_editor"], _1ed5zb9);  
   $def("_yk7udl", "shellTemplate", ["viewof editedCell","editedCell","selectVariable","viewof edit","edit","hotbar_shell","lookupVariable","editorModule"], _yk7udl);  
@@ -10457,8 +10736,7 @@ export default function define(runtime, observer) {
   $def("_xvo1n6", "code_editor", ["code_editor_view"], _xvo1n6);  
   $def("_1imarq2", null, ["md"], _1imarq2);  
   $def("_470wv4", "moveCell", ["viewof command"], _470wv4);  
-  $def("_pinoncr", "pinOnCreate", [], _pinoncr);
-  $def("_19znal9", "createCell", ["viewof command"], _19znal9);
+  $def("_19znal9", "createCell", ["viewof command"], _19znal9);  
   $def("_d9nzys", "deleteCell", ["viewof command"], _d9nzys);  
   $def("_1toku21", null, ["md"], _1toku21);  
   $def("_d7ouqx", "viewof command", ["flowQueue"], _d7ouqx);  
@@ -10468,7 +10746,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_2pkmxz", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","viewof liveCellMap","findCellIndex","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command","pinOnCreate"], _2pkmxz);  
+  $def("_g08ji8", "command_processor", ["command","viewof edit","compile_and_update","pinOnCreate","selectVariable","remove_variables","viewof liveCellMap","findCellIndex","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","findCell","viewof command"], _g08ji8);  
   $def("_8iz5z2", null, ["md"], _8iz5z2);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -10498,11 +10776,12 @@ export default function define(runtime, observer) {
   $def("_1mfm13h", "normalizeObservableClipboardCell", ["inferCellGroupNameFromOJS","escapeTemplateLiteral"], _1mfm13h);  
   $def("_1pa2xc8", "readObservableClipboardCells", ["globalThis"], _1pa2xc8);  
   $def("_1w99cbu", "pasteObservableCellsIntoModule", ["viewof liveCellMap","normalizeObservableClipboardCell","findCell","compile_and_update"], _1w99cbu);  
-  $def("_z9vacx", null, ["md"], _z9vacx);
-  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);
+  $def("_z9vacx", null, ["md"], _z9vacx);  
+  main.define("modules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", "modules", _));  
+  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);  
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
-  $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
+  $def("_yeikvo", "editor_jobs", ["command_processor","submit_summary","save_options","persist_attach_menu"], _yeikvo);  
   $def("_1whoy5n", null, ["md"], _1whoy5n);  
   $def("_gk83fp", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _gk83fp);  
   $def("_1g3bdxp", null, ["md"], _1g3bdxp);  
@@ -10557,9 +10836,7 @@ export default function define(runtime, observer) {
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
-  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));
-  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));
-  main.define("modules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", "modules", _));
+  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
   $def("_lbftlp", "literalCompletions", ["codemirror"], _lbftlp);  
   $def("_scoiwp", "completionFixture", ["EditorState","observableJS_language","literalCompletions"], _scoiwp);  
   $def("_160qhf1", "test_completion_string_literal", ["completionFixture"], _160qhf1);  
@@ -10569,56 +10846,11 @@ export default function define(runtime, observer) {
   $def("_quyccp", "test_completion_bool_template_regexp", ["completionFixture"], _quyccp);  
   $def("_1cn3ucr", "test_completion_parenthesised_unwrap", ["completionFixture"], _1cn3ucr);  
   $def("_15vxhca", "test_completion_never_evaluates", ["completionFixture"], _15vxhca);  
-  $def("_bz6mai", "test_completion_identifier_deferred", ["completionFixture"], _bz6mai);
-  return main;
-}</script>
-<script id="@tomlarkworthy/escodegen/escodegen.browser.min.js.gz" 
-  type="text/plain"
-  data-encoding="base64"
-  data-mime="application/gzip"
->
-H4sICLP7DWcCA2VzY29kZWdlbi5icm93c2VyLm1pbi5qcwDsvQl3G7mxKPxXqJw8NXvYotncSanNy3XiZLbYM5nkysy83ki2RJEySdlWJL7f/tUCoNELKWkyuTf3fvY5hgg0lkKhUKgqFIDi7G7l76L1quiZD/J3wS16VmA+RLPiw768cLfff1r9sFnfhpvdfdl3l8uiC3/8RWh5prkJd3cbKMIpl970/KO7KYSOW96E2/XyYwg1n0NNJ6G5W2zWnwqr8FNhvNmsN0Vj4kbLMCjs1gWRt3CzDu6WYcEoQSGsx3ceoqDrWZvww120CbuuNYMiK/cmhMTw8+16s9t2H/bWcu0GYdA9sa1bdxOudt3A8hfRMoDf3cvp/jw4PQ3KMqV8e7ddFH1uYeZ45e0y8sNixfLKS3e7e7MKws/fz4rGK8Ms2eZ5poeOXxZNWyHjI07wrfj3DPADUYbNOalYeVXs3TJ3eutAP0QO/imQ4uhjxMAcHBZRFTTcUxForvtxHQWFClYahLNopddp+eaDntfx9wL1Ko8r2y24DmDFethFu2XYNTwYz224MayP4WYLGbvGR7tarlbLdtWwxMcu9DtcfcRBcjfzjzAa1ir8vPsx8q+7gPlw9+bmJgwidxc+PuoNwpcfo5twfbcrulbF3Fv+p6CrMsQAwYdFEG26OpJcx9vv90XzXHYXxnK3Xi+3r4A0Nvdnt+totStfbQ1LlfKtwAqtmflworVh3G3Dwna3ifydce6Vw62/DsJ5uHJcqFDFqCLftOIE0XUYcgBib1oaGMlSqi0g13Tz15Dwe+uP1o/W0lpZE6tv/WS5Fes7y7WtCGjrL5Zbtf5kuTVra/1sDayhdW+5dcttWB+tkfW19Vfre2tj/c36T+sHa2792XKb1i/WjfUP6xvLbVluO9W9ePIvtPG+LY8/3wId4uimSA6obXd/G5r7uGQnUfLdDgb1BjD+dEFXDehDBLMP5u/qbrm0PHcb8i+Y1fKnv77BSnGuz9abG3fXlWUetrt7JMsC/DO4MMy54Opuu/v2brmLljAEQ1V6D3T4CZO6xvuVYW1vXR/LGtbVFigZagdOcXfjIQXb1iL8DJPYj27cJUY/3K134bZrbKPVfBkaOPTubQjzZ4tfAUKobBdzo0W4hdwwEbbhTeSvl+sVx9wZwLPyAU0rFxFBJQDb4eZjOFi6q+tvALwtwXqz/kf3ASvehItwhcMRDwwgGhjJz9Fu0Yf4fCXRs4V0hOnrcBVu3N16QzVt13cbP/zWvWV0qujb9XqXSsIqh0CuWBnMsRBG6yNFNu4n7ABMew8Av9GLUX6M7+Px/QNwGaAM5ioG0Bowf/fRqZy7r/H/69eObXklxzPdU/v0tOjjT8l2fY1Mopi+Xl2+37xfTV/NyzAQwCI0atohC8C2gA2UYbGY7xaKh5+eLss4AcvRFnH7Y7i5iVaImqIHy4O7Qej7UN2Zber06QF/kJUy9IVoVfBML0PaJsJ/6U4dD4K8TrzltVXFQ23O4LRYzwBuxzHW3hXg2zg9xaZgJFc+fvqeUk9PT4qJ5LfhHMjB3BOAlh+DGJhBPohOAPBZIayCPVihEdbeW/oLnKyLf523sPiriK+64mlouYLihBRYiy1Ymq0AV3r/xIH8mcX+u7ubEFhNYRntgBqXhU+LNbCfj+7yLixE28J37ncGCQr+ReXx0QcUVE5P7VcQe3FVq3DuIqWK+qAq+1VFCir9noHUaXR/6hl2WK9UjC78LeEPzO0BfZZ86+Snx0dJPBc1WdY7D4GkIikflA3TOumfniZIp2JCe/X26WmI7QKqQwcECyVkAF1ZQJeUsglvl8B0ikZYMiwDwLVmkLcYgOyk2oBU8zVgojhzSq6oIwCpBCpxldwSQKXha4eynUE6w30WntmQrVSMM4amqiSESsySAY0GMBE/gWgUolinzQFRTSmAyUB9Ms/OAkkGwYkj2wsysMzER7fkQAdKM9NStV1IrD4+upDFf22HdvX09Ft3tyjPlmsYXR8b87G0Y1Q+w2CUd+t3sEit5kW7aZrpeoCaS64o4TmuaekE6oPsoISmont6VsXK29VatVf0esYdjP3793cg5hVdmW5UK9U2pMOfjmF2Md0GgqS/NSpFhWQZuwL0BCkbyMtQlmeb9c1Q4DHBmNzrYsDzZQ6zZQFzJrI8mDU+Ep7rBHFHYVDKzE5JCp8DfmGh8xfFV+9fFS///mr6lfn7V0B8cyV+05RfOPNLewrDYYBo4eBKhAESYOTICiVHDC+i81IpNL34izb4IQiuPRw/QCFKiFST2S3Oeh50ulMjgsQUjNZbPRxpQApFOzZ/rQCR6hXQt6pkJCBHltwShou9kuViVIEwa0nmorg3jlEP2vEMHpcqRmYc6eDvndFFIkhQDER+ugXWNwR5ABDbh7F8XW00ejTyJaMC/wxBvYqmSh7VCQR6otaLES//o2ge7ZBtQvmKgMPGyOfKgCjjM1WaU6VOCTfI9WnUCScCJe/hn3Euku1KnLyKU2tx6kalIuXG6XdEwtq3WvJbxzjPsNQ3K3+9wRV+eV/wQQvaRrMIVDMkCRBlQMbXoV9JOnaBhmFlJOLznO9w3QrWdx6IRD3jd0b3d8bvgBiB7QCNCbJzL0IgO+48LEIJhoNE4ji1jvkAXPh3IHFvQvd6L1h4rY7JUKNI9glzMPlLrqQfrxSU9Nm/lmAiUwc4adbRZKigsE1Q+/B7HoPnX8wBPF+MTQI8H3kugVcqwfRZwoojMAyglUpRIqneOj3tmx7PCvXlkOzhmsxggBIeoAxRx7m/Xu2i1V24l6VjUnyD4i4O0OYHkPzG7xq8qMNS5F7Uqo+PJ0WkchvTOMF9bVeBd3LtOLWSPcOlIG4P8hzgZABE6JwU9XF+fKSYe7dbg6wSXSxwEQt7ME5dGELrpBj2Ft1ImQlmJa/EiA9oEQTmlz8AWeQzqjuwsDKyanWYnSH2UaDZtA5CroSX0kyjj0AnY2BSSjTNJ1mPZSaQTvubjXsP40B/i6hrBxB2vRxx74pFXxy+gRJBDhVn4kHxxERRRJfw/qjJIEgPrvOwjy0Ty7XP5Xo4pf9YJHmcggF0zC2jweTxkSrucg4qU0YNYVdGJcjSE0BFubtZWQPA8kmlJ77QGsGVdDO1xh2+i3XzWW+GClX8bYFqNqM8pNmoMBY6KEvqC6BcqJAN9y6DaRdWwSsYMD3PPJHHhzyuk1zGpCgEApPnzJNyGlNUvcbkVG8AKeEP7/HxiYl25LMnZjLOf4+YeAMAs+5wRZ92VcGfFyC5vkONk+b+Mb6QV8Y7UgbICRqExiAEgXyq6zGfYl3jcmW50/jLWulM566zslYlZ2J5xZVprRx9Vb4tJrUgpWCd2aDHgRx5duaaRxhdUskChkS8XM1OVdmZ3uiH4jVaRljPwKk6t9BcsrAise5cl7e3oAqAcAQq4aNQDHEx+Y709/K3/b/+8pf+Nz+NgYGjOORlFqM5qWuaJBxcSNrShlsbgQQpgcgLC0Bw7r8OWLUClANgKAWz3a0HktnK8kA2AyJFdvmVgSISsK2CgSiegWTlo+p7dgb9clbmIUAjmAKfSE0T4oUPTVukoQ16UflqHa2KINJ3I4nSlbOwPJEOUoRGC2MWsJDlkDkGwcLRMnD8UPondUoybuMVimucRgxIrqt6umjz/vGRWfIKWbJcnLdlttaU2VhTzrfLnJ6CYr96v5m+Enq9AKMHVGC8+kq1VTK+eoVGt24mUSMcQI80OwRANJ51a32wbqwlmc/WQEAba2uFpCMCot0AmIoAYwuaSTpJjMXrCiHt1nGte1DjiQAzeS8rKIVfTkHU8Mrh510IfQ7euqs5iB2o+NGvhTMsb++8LXOzCMvMIADW5xQXSt5fvZrDbL+cSsUHFD2gJ5dt2H+gUQW1Dm2MlPKpOIY5Cv+6Ms9CfeMv1hpW3QDoa+4c6uM5kP95UCqZeV0LplofNok+rFH7UH3YHO7Dk+AjkOfbROUzrDyCgCrfvqBylqCeGqo/4ZiLmXBd/mGznm/cG0zz1sG9ttDAKsENMIHruLV2xStga9oShcuBnvsZeAdOcgjvS+cS25lSO8tUO8scqD5BLrSCi8itSTIcdHPj4qxTleOcv6dW018QPf+GRHyuhvSDc5LFunXjQK0Fw4IV66qIa501mSZykNmDhiLd47yxyGAFBuNDD2RYFDyAerD6Lv29mWqAWjfYB0oXXYI1BlaF+Rnw+hywyegBmREfsfFQWwvf8D6FlFo9WK94HfZhiQjOXZiyQ1wMHOK+IIKUSiIDrM8XHmUIGbxIWws+oJkEVwO5EF/4vUujCOizDNOAnmlMdRYLzbHmFyRWYBhuXsF8fQXzqXVaq6LSqoQ/8myKm1hGRKBmsfLvX27L0uIMU0CzlTL1GT3PgZ7MUJEMy+/CD3chyM5QGdkEcJ1DFQeGD1UUGCTQdsMAs5yw6KwndbUKsFY006Bl64qMGTG4tyDtxrHPmi0XxpYEZEu3AH2r26NAbne39yu/Z9Afo1T0eiAodkEaMLRl7J1uzp5LUz7QD7DA9T/KGSO/QlgPxIzSLFGXO5cWW0AnL5oWKsfnSYhYp0JgT/wybjrc7cKApqfWPmZ5Bx3GZrqGkTS8bYuuNN6QURWVjluLNoiUIiMrC9VGETR4QzZb2oPKZoy3PCCnNkJzM2vQ+Gl1vVp/AgkIZDQyrHcLKCikd552uM/GoC4c3Ieyrqy50koEZRQFsYVCeNFoDvCwSEk2tAvlyLympQrjjhQW5W2lvKKUgzMiB31bBE5pWhNIymkiW7GcBytRR3cFbHBihTmtIG8NQTg8VPexklY/LoSbZdZPcVxumlluxen3Tuyu+qJtoVnfwTdpQYhz8K6a5dpxdfHGGqxCKlVs3KGlQSbR9l0Mr9iCAxRHzsyZOCsHKfQvcX5tY85yq1o9aofO+pOWmt6ps9wafFV7YtbP0CHSjMMybVWC7hyW1T6aNVQxVBmsew2OzHbf6enwhJV5a+tARahSyB3l3h9xI0FWW35Hv77DHbc/0p40EvsvYiv/Fec7u3FvtZ+07QxadFwUKN6B+XptWoMe6thqQcLdv3eyreIDOl7gWMEfsdVHO4ZaNzG+R94ru0rc9vR0XsaGt+HunZ5e1BGUKhNXou1C9uZdrklbMdEq8IDqWfdKNwzciN3N/cF6sIy5/zGLNdA6Ni76M4TaT4E1EMBy8t+BBrN9tYy8V/RL5r12fiy/u1/t3M8wkx8kr+pWrL9F4TLo2pa2WWtb0PEgQspyl92q1Qce9mkimBTEh2sX2oLSNeub9Tzy3eX3b7t1+bv/3ajbsAbR7lO0DeFDU/7+K0RaMoK52tb4w50LK/V9t2O9DZeuaNGuyFzv/vBm8mPXBugChOdj2LWrFmlpsMD7LqfULODE6xUaP3jf2q5b/U9uBB1pWD+t3M09/vhhvd3Nos9du2l9f8sNDRdutIIh6tota+jCdLHb1nfhp67dsX505/Mw+DG8uQWowm61Yn0b0u571bZ+2ADXgEqr1b31e+fB6PWQa0ikWMbjI8YVZixgrVoCdByyYIJCkWX8XYv/lYpoCVQC+CmkSHxZxkkq7mQzJBOibTK22iWyX2DmeAws43U64cLJZMmkRKtsijQaZuq70PpIAw01vs5Ly0ksYZIkCss4S0a/wmiSTCzj/+QlvspL/IrKJ4lqb30EEXLkVK2vnbr1V6dtfe8AKW2cWtX6m9OsW//pjB6/tn5wPj6OQJCHEGJ/dj5abtP52voFEr4GNeCj9Q/4tbG+AWnfbcHP7y23DX/+at0C713v1riIAle594AFr/1rzelJ7j8FIIaGzm4RbZW86oDwJfxQHh9P3LSuZrmxIkm1KgkHRPLe5czCynLFH98EaTsuPL653d0nChvnRre4LmpOSoFzGYF6ER6oz5wCSw7M/YH+vrubwRx1ND8oKbg5Wf1E2bcPd++kqDCTY0MBDecEEOBas2mX/q6mXQgj+JsEUPblB3e3CzcrfVR0RUVDVWyL7aEY3k2gOCE4kgSf25rkuD+4oPpvE/5v5LtiISksUEBd4Maq1nqCYcetQXfJjQ8FkRPyAnOB8rdoFJC/NcuCSaYFajtOteNE0Kvz+gsa6iXJ6hXT+lzUMptTNtWxjvY0tD2uxgYavJxanrAnFA3hwEbgotBKW7u4b4OeCgl4z33QQnH7ZoFQyzKX/rQnakuMSrwAxlD7UytREPisAYt4nBWEfbObV5sglURV6YKWX7IvAvTY4L5Z6JxwroYo1ZtUPoWRchk9P0QMMY7FyRArMpiGqfYkj1PaYB3cJ/w7pQeP0noTfUwSKOSHJp+mQWlEmSkjiuG8NgjeMB58LZfvHJo9HlnD0ni1NB8Nkyzj0hHGeDDIJE7WBJ+sCQoIH20j2kDGTEk247ZR6czH4Bt0/cGeTtYbxX8czaHSsyKp6l5ChS7KJz0D5gIo2qBmlwxKMUDZxjSzNCsBjFPRd4n/BKdFY8ZsFyP8L+4mckGFGYX+0mVgeokConei3DUoUaW7Ymzm8nNYtsgbxFWSCe4b09wrbPn5I4MFYWRQriJad50F7vTij0v8daDYJpovdtmZgkO1V6AeGKDo8PhIf7M/hff66qJsGZex9Se2qF4ayRZzAPazoGoVTI2DAMWFnITXL24MxGYbvfILD+fOo/PRtD4UL48BRDh3TWtWmpdSq7uWM0iC7popBuWlliWli+Z4Yp+4Vej16Ybckc4NLBjPgofkqtzVVs+ZtpTBrHwwrGiakm5SJJwxf9/TjHaFAdi/tKdnPtDo6yraL4OEPRjTSzbnsUEMgaiyTRa5/alim4HJHvlza2EtrWsyLV47N9bs9K+Q+/rR+d4EOa9iLZwEUOfziwWsOXMT4Zo7wvOMcuCCmdnYIdgPfMWkpKU72x/qzaG+IPkeqPvx8U1RII32HFQ+lYQ7CHN09juR8M/P7GnG+IzSA3+d5shXbxJluW5bNTdPNwddWKA1GvG7Ma2DNcOw95ZOrpApi1jXZnfpHJBEtUxqwJdm7kZGEQYSxvTM7slSJTsHm560Y3fVL9PCoqpLcWeyKHxTTGOEkKR+eshwJaCfisae1su9NcAN69yZpdt1l64XLnsG7W6T2ZESyB5cIu6gpjY6fnA+I/tlj2YBcsp5bovSiecZjcqs+e2iCxgKJ9q5CmWWV3zj4Fq5kJqT9PWp0JaRPmuDixltr2Q2ePzDcgduuyTMvjANQaCbKf4f4aAd2YSLVCurWBba85pBXdaW8rye64LZpUF+cgZKylFAWze4yh6WnKIgBTzS1/YOXROxIuJMAA7zn61xpKa4ENRI9hZtwfdjAWOWv5rq0gYt4//gZXwkzZlPUNsWpsknxDn86VGYQ18uSuLKQGrmEdlo/TM6W+S05llqmwIwEqwFMrICyE2slApROa3aKlnStBA7lwY5eBgs7h3BMbofJMcLRaJ0N0Bfx9mC25wwHnfbUMeY9D48JlPSNDkXikeP1hEfa5MA5s4GkT0LHrKw+Z27CWglPlCWMqTKerSB54fFqlWxjEI0K6ANEzUtBdA05ofpwXDVYCCLHIXe3XwebnLHVQkwRiCyZXDqAkaTho9cMiSpZ0yH6EasLx6YvH7MtvjMHaAp9mN3fBCi/tG9EbPHELon8oQOkIEmiJu9nBmuzyUtLyKv+xRD0POnhNosndEM5e5+Bxw9eElnrWWCAOM+J2DovahzyIZuQ58sEMi79KjulifQ+kAEDay2q2dMWDS4cwMktncyR+8pHCbqSvHXblE1blrarItlYN4cV2sD2zRyeqLsGhnGunwSLD+zZgkjhBsbF16wbpWEKCL2NQSCLg30eDWOKB+yQGri5/CzhFKeIEHTorlJ49RfLnNJUJuhigQBLNqLtp6E0n0WlJ45JTDi829pPuEnzljNYrdFtacsz6s0TLTb81KO+5Xk1Kg59zXY7duu1vJ9MY/7b5q68+thINoEhMyaC0eb4ahXDoNB36vPBCeS4PiWy+e20jhhrwSxC39inydc0HVv1CS6zLgEu540aU4pP5CAPRmfU1nGQxR7GCB2JKyu5ZbykOcnkYeZ6HDBIfT5Jp85O4Y+mADigJ12IuWwWUCzrSWpGQRGJzXTrewRMiK4Gbn6LiiM2Lm4dnoanH6PtvW4/piHfsMn4k5PhW9AIhf5e+h+Aq4Te/mkV5yAdiLyGEHAa9GbG156nxCYU2vPoWXi0oioPsP6Z1kYAo5uVLLCKbH1FEvW7Og3mgSh1h0lzl8+a+lJ8/ipaeFqkW4VRfyThAuhZZhPgYarPXk3pBfFy5n1K4FTbnWwJD+kIJA+2HRsslc8rkk8f82LG9yjLd1MbGKl1MV40QNJhRTH7IJ8UH18ekF+Son8FQsy9kgpYL/VWhwgGeGCm7Yzrzfd7C6lB0Ldx968+5+xL1e0ina9y8NLbRSk7Y8w+XC/5dj6jJWmi027B3Zisi1ke5PgHL610Nbtq2LsYZ22iGvbjF7aOKTINuUMm2eZ8kjPiaeEbqA/nN+aO7Z1nQIrNkhek0EyA/b8uWATBb4MbrFH9STkYgmbW9eWh76kCe4MbNOnfQo8C7EAerrpfmPldvK13VsXr8wuDJGVv0wseJn4ER3zjmtylwA9+e8ZR+jO3czviIZSczdPNPxxc5+rfM7iVSlgx39cJ3ab+1z7Av4FnRbdww9aFigPHjouL9xVsAT2YspThSj0yMSMGnFckZTFkI+iUg1JMxBCltE/wg3IKSUbFpGAvYUPQaZVIe0fZrwbjEdLyAwQBn8QGdE9WyhA4YvADX81lGECOJJABdgoHqZOyalPeQj+dfj959GbwW7heS2zqSRu9TltqYbU1nKqvFh7MG2ZS9EqO1I1z853nyJUt/MUqJWcLOT0AOxCCHIwNMkdIphCW6pG2qyW+fJwEG39TYTS9CrPskaySClCM5Nf9t1tyFMJd4A82vURqXKsPdr28UwvtYUROJ8OmTtFDZceb0O4ct+JVvrg0EofL6iJzQCFPTxYriPuViJuRhx2lZKAE8gjWiZbY492aQ0E8CAGszZJQF3XoKMH0nDVRYM0zQ503V5tKe9OnrsIUHGIkxP2l7QrT3HmLHUCShUEItLszJ6DRyxx4hw42RALTivnBgYvUIMX4ODdniIRr2gEZzCCy/zhiwGAMVwlLN0ez1vR/OxQ83tWXma5C8SVvkBER3ZFUb2YSXqPXmJBJncs5+p0A8z2xqIDg9Rpr+wuUWqCWpQckJ3CMQKIhRxmGlpGN1G5pl7EOFBWJOJhxmH+paqx2FJExXDTYolkm4VXz28e8/fQ4BW2Tt2vI1+1PD4+5OkhnDo8loX5z3EHjqO+GST8fqNJXQc2q4SQrIb+P2NKNc6NGA8YsZhSclQt/7l0dbTyu9tAp6knq+f8hxow9QbQz+kpF5GATc1qTN+snthdStBerpdPEb1e8fS4qJrq/X72G9S7niXr/QZ3UMPgCfE1sdMK/Ng6sD8i6wUJVRwv1Ol6Ls1xeJVSvHOa2DUFmr/80+lp8LrSQ9Wmaxh4GBOvc8PLtIRp7eRPfJCd+GpxRtzlniQE9o3wjnkoeJp/AOdzNZcBmprsoSC/5nsoxGXzPBT0svGOe35z4eHlXJUAwR6FBtZ88NYZsq/TOhCmD9jd92SxXK8CX3kV+AmvghihMZx5XgXpXlDH1E9f86EFqhWD/6QdXXp3xkZO6x1ZfO9I+4oCdHmFP3hwzMp1GMStfCgBlPeWqnzSn0CqWz0USsSG22+inXUvZXWlPNXt8I7wc/l+Yn/Xf+nS/AJmRudj/ilIoYInAOVb4P5ZUPeW6xU1zzLdWcy09Dse44MqcVpXc6qcW4v4Jga+Zy6G7WKO3sHkL+fhiWq8RwXv+IlN0Fv9OCjdqXLcqJgoSxfW6dYksjDAXPfTDr0C4XhsM4G5vXbmJq9/Sefyw77K5GnpCs9Jt4yOjmiVE57lB/xwDzXzoXhsxmKP9fos4RUkDwvl1Q+1JzwatewX/nNcGtUEUUdsyLfR6B03amoyXMrREQt3jxeOJcUcJ0mtB4RicbInH7l+gpHJwcF9j16PfPUenb8JzjSI0HkmcTrAJwynP+j1R/FtJFegFuNdJPN4a/33l3GbUzxal4Dgq6+MXliWJ6MC6zrne9ANSrYVXES8en885o8taPEKQOLD7PrlONqW0jy+CEfcTnPsjhsFUnJXyuzBtObLbLQ+dj0H7/WJU47Dy5MGb3Sxkl1/ZdAFDAf8yF8ZqJEruHj3j3tjXKRLyn3MGn0+OTszekVPM+96sQM6Ak/30yWBidCr86Q4O/1o8kl4j0/CF5PZHh8TYGHS6akBYsbs9G+JcsiKQKMkX6FlLt3ShTbxuXfhmnBsfxGvfA5D6X38A0wUHyDhWRJvZvTKsQWcznII48ClIdfsrTGNbSqslj/lg50ojKp41ic74+MwSxtSUH2wotNR7wOd5qZeLMyudvEAYAsPDOYvRSSvhOX00cILl6f4SF4g/py1xcrWY3naOuLnZcCtme/CT/nQLXVbggc845rvIg3y8A5s4Or0ayC4vwAh03boL90/026SsQqPWMWDmAYAELJpnRShJpAM/wKiLF5Vo+2nqdGPHB9GOnrOSAfPG+koPdJu9iQMjzLCuQTE8eHO/NVrlu9veXjtUFIS0VAAJPVD98+4z64uL8D5/8TceMbZAw9FKDrVkLhgAtqbd3/RlOQpKsnFE71JCeThrXqVQ23Tx/cE+BmHAT9xDe0FqmSvLgHWv8qbk3z9orLk3ZWJi/XihQEP56n4a6dKpsLMxbaxLQ0vr1J9jvvaQ7R2DQ21nzXE4d4ZUwJTAKwDSAw7V54XSa7kQeoKUJIrpdAobgAp30DxhFsDpXRRJ8If2sEs7dyWKi0hS9YgU6mWGHiLZUoBO4oiPx0SFALrJrahEweIqdk7wpU0VUq69oKOD8AZZKULNHGTPNwuA03eiH/LcawK2x5mvs6SERCiNsbX2n15eOtPajXWrs7zxdV5vrw6D39ER6/O849fnReZvbw9WC+2N3kx8TBm0ERDp+kPScFBxuMqCJd4OzT6zRn3WPQrvMOVfxpoJxXYf4Y/tzZQBAS7dDN8nEDaAJ4yOySoqvtJF6hDL2Hu0KE0vFCFT6c9T+WmNrD5pObDyUSkZNN7WhehK3BAMoUlWRNjnweEJNap+g0kd0TJSBQWEjHSui4+xx9QKD+uU2nYzDGYTDW3iEBJg8qKkjjOGbHns55llvR9PqCskfsz7VcKF4ijqiVlTJ9MRrBFHflS4rW1lDo4yYkJE4NfBvLWb7FCj/IFesRlvrzGu8EvYdWzvF5EhkTNPnEtbsSxrsS90hXQZDJVnC8urkCIWJjxl8vFVM1ir3dN9wLJbbYDXnJxyYxsgV7Garm5Nq1FyQYuc5Vwn6LUi0QaXqQUdWd8gufJ7SgF7UqHlk8Sml3jcmqg0Wy7Gy+zBrN4SOlQcOmAG4wkdHmwJp9dBbH8/7/6mAms9ot1MMIXUaK0zVNdbuZpOLiEddndRb4xRQVURkp4hwCZmchjBVfIebgjfUzGtxDv+XT6ldKSfdVOqOL38B5f34kvuzoy0cWllNMu1O3O0Urz/IqfU6/FOiltE2SEoiS/Ptr1S9Ft1Nh/WwhhSd4u1psd+ib0RKq6RjSexGIKGD1meOl0WV+SYLvPB7VLEh5QU+9fMg7dyxfUd9zAFfc0weJAxeUnPfJZAjB76RqJC9wi5Uor5NIojNk9bhhlkoHXJ4zPwACOqjdQMnOaAretgcCiYuqiZpDasgvHDBYO4V2FJwVR9AXZ1NSVUXZxmzk2rCw5IJ/PaG2ZmTH3l66eT4I+yzh4zjJLxK8/KYgWigf0kcT7lSFpCovEw97QbcvPWf2fNiyjJyazASaRTK0+Xmgrlww8M41ryI3y0jnxs2iV1/kCwHwxHz4Skc2Gvr8mepAkCSJI3I9KcwHfVYtn/0nyZhI6GA0CTXxbJ0oSSyenRZAlliRLAFSphhcHGj4JYh6EbwOcVMTTANra+ZAr3lzJSbVQx1MXuUAF5GOkvIy93pUuI9zkSzQa6PmuxovfXFgRR1h/hJF/Usg3kD6AXN/h6n4oDy39kCkey0PE/JnO6+V70R8pA2IKzrXl2neXqnzW1b2bfKAtPtz2Fbk5+VSNz9Vk75OYlQx3a+CdG6XPdD+vOraQ04B4/401iKDMpwfCALfcPdraxw2tINmUi03hNyB8zoRGE6nD6q2jcuDLs1NPt06tpJvm01Rh8KtbFyanAyYWugo89ViUsXE/oT3759NTOvVr7jb3D8Q4fqbLDD6ZyplAs6Z6OVYuT9m15PKqZBioZk9nTPF6i32cHM7Dzz16J4Z/l2+ZA5b0tNnSnW+7ypqjjGdeNI9WOyMWTtSEKuGDPW6ZM/TkD5Eqy9O9n+KlqGzlyk60VsJCTi5hv+u5V8dyeev1MnRXCtKesdvchSBNzFx0quq616r03lK3vD5z+3KY/2KcugXrwHddBllaN7EnaAQEc5VyGddGOwc82gbBXf9LA73f8craFzxjR9rKCy8jiq8XsoSHNig9Ga/LgAzhMkPM8CNi+L5zdaBFyp5h7FbwuvL4+OLu9aQupa724VsnZhHuhiplj30Nj9/LxEVSUEm3vvjyJfPlY/D4+CvGIK0jPkEkAFtXXt6ToEnyaXjKqPf0tUwuclJ1C1NWIXrGBUzoZXsYC8nLl0T/vfJ61kOnsi5uKMrUw5XIq5gSEoPuyaj2xd5BKTc4bpK4JJvEMy2IKaUkeRvnIXuFPE/h/HA+Ox0BnbjOn+W22zHnAneu3Zl0ON+HO3cboQ2Qr/+03KY5Te7JJcGkaw4VzEdxIxkwrT2qTGZ9PLQpa/xfzcuawNy+dAtVFOMtNdlDbedUKUq/f9AP9jznuKmo9OD5OzOzE/t/eeZ9S3faPim+EQwCV2olYbnqOe4u8mRm0XjOMfAkX6E7LgTteGaeY1Nci5l7DZjm65QQg5TdSbsagq9MfHyMtQ4rvoIeha+UtBR/NHvuhhl7kfd6YMUQzehHwPBaxpA2Z/hqeTzdkQt1zg13+bfSUFvMbKeUJdGci81RM5afcwY5+/oF+pJGtPkkdwOTe4bxDViuM+hRjeJVy7fIy4qv3m9Lv39l4Zs0vnrvMk7EXrtk23frTvoZX/mE7157ibeSfIm3ol7ipQfIEu/wVuJ3eCvJd3jtxDu8NjTeoKvfxZ3coBCL96zptmeo4tqdh3TTOV2dLT5qLnsOFQLh1PUX0hnU+TGVADl+UO8L8Ouq+Mpi/Fg0auKT799+2//xl2/ffPdm8jfHrcdJo/Gk/9M3P75z3EbmUekkiMmJh1TiysfGnQd6Ot1Qr1BDh0I8lUN7t11jPPy2/46iBcxQUNf9G9ZifRPeQiNdY7Hb3XZfvZqDkHBHO+x4UTa/rh1Xe+NGK60duhTbg6SHcCux1jXKryDpVZxCuVSZ+LtWyZ4egN+CPPnNm+H4u3fj8uDdCNTot+P+6Ntx+SaA3x66h6faNhI4msYvllfLdrkCra7m9NbyA17u3TVeO01I3VM3dvAfcncvBfL+dre9uw4L7+7+cXcdQUnIs+wadzBD3RXoGaH7H3NMQswY1qfQy8PYEEhvFy75bmZjPwUSv11vI8D0ffeBXisw5rj9d7dZPgvhZcy9h8G8xbvrVn6EXYnvL+8af2+Uq9RPvq4cEiBarmLCLS4+kFCHBBsqkRv5o0RlRnyHPIgz/69SblLmIPyYzOf66w2g9e9tqK0OYw6LrBdtAkiplevlFg7P+lO4OQPtLdriY+z+MoLpAXX+HQYCQQQuExE4BLCB0bPws7+8C1ArknAbyNXWq6vtWQhdvP+0CDf0uVLuYCvzu+Wt6BNmxuhZuF1G3FKTW+LkmzU0gaktznwTraIbgI0gqpYbhsQIHrzmBmwDWQi0S6WgY4AJ9DlbIaqBIM+qZ3wdFOSj6QSIQa+MLrVYwGGJkCjvVtHuDD8Y8gv+thBMkUAQA3WAioh182sWNPYijanbu4uWwdkN3gYOsyZxQX0Z55B/tY1m9wUYvQIo0YuuqAMQDyNwu4ZGoJ7C60LmDfsy1MmTF1s4XvmL68b5vE+ysme+YJBUCHDx9svqrQKlYBx9EwEv7I+jZ4rVcW/NnOosrQ2cwPgK9Uua8EWZTAuyMtUAvsvw3JoxS7JGLP08rOZVo1CLzxNfWdfaeXyPlhRhqiLZzV8AVcDSivtw7M6vP+MA682ek/G5DseVb1TiQxlCD+KnJvFt4PiTp1flBPonsYWHjNiZ6R945wWf14PVXrzbcnpKmd0gKIZ87n326ykizKWI4MkKkd2KCqy586r4ftN7vzJfWQvHRu944/e//320jccNosa5R++X5rzC4cQP1xTX1k1icFbxg37CfoUGVoFEx7lbMTUE5oww4pvxO36hc90L+JXAa0uWQZsE/zrnEvi4jocOsBs0mLnLb/jZUBkd8qOh+CAwWyVBlhVIp5LQ2bV4Jmpu0qPUS0e3ycQ9i13XL6So2fMvw1Jp2lW92LOlFB/swTEwHx/jV4y8UrC3rhybHvpdECrkp5tyCCIZYPKWnpTTrtXFS91P4sdXry7UY0dhgD01V8WFtURPkatSCWvWn0EE6KYIAd8eRtfFFiuWVgMj5ywyzzFrnCkvC1SeSbawdRDmF440e+z5ocosnDxYElK06kYXmfrMFOBiiI8BjzrDcdhzId8DyMwEYNDVeOJBkdNThVJBkvISQphr8ilLfMtNkCG9IDmG4SumL+b3nJsk45nQbVfnnuQDxWv1Cw3pktKp5cy7NK64/HW2tzxNFQMI9ennEcmkn/I1vVwgFR/CvRLChXoT2gOe9fgofUA147LpCf4leax0guOi8YNXP0JZ8egVKLehD6gvuIWYpVgFrtEqrEFZxCfWANYCtBZn2UJ6ILJty4Wv17uCUYodoBGMJDJAh0ah7xkIQYsJbbbpb8UG+FZscHZmUgdFZYCKYPocxCSxcrfaLqLZ7t8EMZ/c5bWOFWlWOI/xgHfhJrug3WnEr24mPqOx2eM3FLB2qLKLB+1RJUdl/oEpv6utmShAigR6J4sX2a624Fqkyqi1dG8me4ETJK8XKGzlw47bttLfnLxyfBhh/yKAwfaxS5r1SvXLj+/+DmGyHsqSFDTUg7JZ3OuWBx362Kkohdi8npzZ8cX0jPSEQQPr6uYQZe9ZNTuqNlFRdn4bRiILdz/ZzzTHSsxClAFyJLHLAE09UJCtPZ45dfws5b5LSm9avXMeWsZiRVwblKEC7yI892C4k8jwpnT3WToxp0Vo5pxFBnZ5QCebbTGnO+Z5EppZGoJ5MWAhSnV5Bk2aeULqJX6ZpmaAtIs5CblEPHps6POfJ6XO7b0SLHnkC5pX40GB7lrWzw+aGQZPY1tO38oeJhXytRl6wwRoMAr5nbg5/4n4z1VC4skBEVe+B488sUtOLPAJ6QftmtiwFmUAREKvWMRvrnoRfk4xLPL4GNFvzv/4eEUxkgXRfAgLoJS8JNNShl4pRXYfqNNugnHJGveWEi5EPi+Rz1P5iL25grcBmlQ7cwEqiSqCF14JIBGnFbNLd3IkgH1mq9QSDQEOTkyiM5J1r2PPpuX5DEg04Xk/Q1MquutS1SBhylpxuSC3V0C8Xns3+O9Eqak+lEp7MatypnPycLmfL2tBeaZ4Jkl6vM/f761IV4a95yu0SuNSrd9ZrvXR+qQpGcsiHWBmdakQAa9Xr43iu7RSBlFnn2K/qJrM6KfFDSFq/M4ouSXjd4UIZIfCJvxwF21Q7hA1lfU32AP9aVd+K1k7Jdd72PqLEJFObxPc7Rbwqzq1FuvtDn7VphbadOFXHX659LUx3fO7h7rKnmVbQCJUMz/iKmN4RBe3n+hRd0A2tihz4O+S8R/kcoTty3T8TZtLAAmnoRskxyndjevA34lXYkPpiOU7VzBzAoiiHBHSqJyEXEA+p3vuO5xCmh+emwUh09sCDe7w+laQqXz1CPGr0qt49kXWgl56nsXi5xzFzzmIn5Ezw0v5aIejbPRmUgGZWzDBOBWSF6VSd4G3XhR5K6RXjDOWbGuBahnwDS3VqkIa1B/f9gDNs0rzyuCbaA0+13WNDi58WiqECU49dHzLK+ILrb5+e/AcyXUuS84dKqPVhHGxeKJ2jx5DuJwiFVN+HgBQ9hCC2enpyUyMuxm7ExVlmiIKGDCkSahlho5WTKTXZjwJuP4TSRYnbmLYOJk65DJ0dI9X8mRvz+8CzrTtoVdie4gcfXxtRhS5dmdB9ZndRYygG+YxrkSIywhy8aGauGKuV2xRV85Zh/bUWToXW8TrhCvCQxBXC3e7eyPP2sFXEnUvKopfsKOrqw4d44NL8uHzvxcv//7+1bTUff/K7L1/9dXvX8WvGuNFdVKWZW3JL9lS8S2XoaWSpmoz7UIG/Qbn+JC/9kL3KvkItdkzfg8zUn/De53OIYEHoteyXQmzyIkb3+gsrC6a1O9ddBJXRLv6quad2YjNTgNNUYn06oH0Gqbbtp35UOcPzcyHxqESTf5Qz3xo8Ydq5kP7AFAdTk9ebM00BD0EPQf5iY/8JNV/HwvWmnFB8aOivyDu6Z6Nfnw5bCANcYr+T+hCfb4aXLfCnQUpo1xeRmFfCtIGO8r8+BjK/GmDVJCxRSWqTxif9MwJSLBbLGIJ06BpJt6fT+DgiUpz0fFMqFU/8/Bs/QsR/CQO/OQFPMDGvF6lK025PbvryZ9ndtd97UHKmR0X3+jv8/wLEfhvir2txtL++O777/gV7qLG+//+3pzuDWDHq+lX71fsfRCXBwEc5MFImM9dsuXOcD28jMWG6Ym4pcK9rKjfxRnKS7TQzEquKb2FfFh8I5O98M2MiKiepP7p7TcFf323DAqr9a7ghQUCO+BFxueVlOrDuz0wll2NUJYhhYUlB84Vv1gGkg8sGuYeXc88EgvUgXx8NGCP9tpdfzN3lkJ2gDWr1y1evv9Uen9WnpbMLi5c719hIqR14b/5H2YPM5TPpl+ZkA4fghKeAyl/ZcL6eg1VBO7O7ZZL760yrOTnbvlus/wBe+YEFkW+lo4THu4VoNcF3kvq4HYCmZ4Wli7e5Tx/V3Cz14PM+OA7mlhx3Jf0trBzw2/K5dYhrQz+JgRgimT7t06Kxi+/kNr+yy8GaAZQXxEvNNDMJ868F3WBNJMWBkpdizNB7iYc3H8vSPkH3NpHxyznVv8ssRCo76Nwhn5ogfPheL43K5FvQzI2YFZZFN6sbu92zjY+msRfgNKc3Ys3BbPbYPEjKugah5dc6BwM5C/yAnyQOuEv6K1B3AWJDF1ZMcGwGNWcJX5MPpExTk5lv45u/wL0EpDvRLJI4pOBT9km2tiS+SQUachGkik3rEpz4jxZVBnFSL8SwuETWET/pWb97OPyA+MOr9949n7hjOwWT+Qmk/UZqNWiCB8qBpJEQ8cTZUVvz5bRVhUXxoRvIOnc14xXv0iPqJrlM9XnWbBmUmqelePRQ5sIoNMvPuDQd2foqRxa8fdusFcSzuzg9hwz1YwlJrX5FVs30rtQ+/PYzCV2gny5OaosJkH2m6c4STGwZCrdNijXKUdCkljjFCDJ5WxvyRMbqiHay5Y7plaom3TIG3z25PaX77jngTLX0dsnGtAu1SrJGF0W6bUTLUlsBws+mbuTNpcAh3k2HDodGO4tP7ldJrqRQyHzeNrOLEONFSrBiS8SeZID+ImvDKj8FiS+ITrFl/M8vvH4yKkfOSWUKJ/TBjbocH48RI6wIPspbqJwmUxldJoaNQWyBnnslHkPlQ9UeU7D0ur4seJIlPyQoPXunA11KUqHZGHW1OmxG8YDSKWSZKl/FqWFNdFnu1+AO0T+M/cgQimJ+k54nubxJ7lkms5laQjsFXMZMSw0+Qw6Z1E383n5pZfYFPHNqROITZl0VhzFcBnuwsIza7IyOxjpMmbiVd3i4dXGTOEeaGJ5n8uAA+tK3iM7c+gI7pVwaUDBNiDWKxIyQmnWu+Vgk9KsuS2E0W4R0uZp+BltX9GuwD0oEJfHjVXIINOAmt8b28Lv8NvvCvJWnXJhsN4tCp/CTVhY30Q7IGU0Zc0chnevXeOlUch5PEFnOiX5eBmssDTx2h7x3/PUjLpbbek03SSHq5Ier1xn6GkYfTadCJyy70ysskj5DJnmi1YF8zxMr06q/VBtXWS/eWwumsdOOzrjcnMWMV/PmoTOEawhDZ2jeEKYXLt40XJC6e2D6LhSq+n5lcx4siBOd2Weni6IkV3xAF2LZe9ceWecRJTzGnJGlPNa+kuk5LhFQoaLlBZ6eJHEccpb2eLuaPjVEJvEaAqV8Q23mTUREcKgJydvesVJbd6yHQS1P+0NL7EdF18Ipr6onTn5LTuv5WBSLeTOoFK4dAGUDNI/uYpt4eyscL++w/npud7yvnATuqtdYbem2UnzWdZQELOpgKeEATH3XP8KCwGbwKxqeSrcitlRLryZAUewQNndbguIWTwanl9vhG7SboBOGcBj+IK0At6bWwjxhVDkL1QBHebZlllx9k5PDewsam/4m7spYry9hdZ8uYNFCvSJjwfK4b80h8d+KMdq87WPfuKjf7ApXyX7enKQaDgzjG9WRDgSM92CUSJDB+v50exe36b05PIdxLuAYiXHzbsURW7DTUQK+LdS/8lsevO763hXQwUUfNzOrFg38H/lGAZJTGvrVjyYoLHY3ZoN28mt0A9OFG+FfqCtUCJ4J6KbG7BGPynWA30vcO9DGuzzPoclxzg3rEWptJcjN0OHFDTBeM/RpWE+AwBn9tQ05dPY51ipZezhT1AOV7g7qbctTFZzvno1bS7z0xz91knKiXLTQWkVlt7O7dmNCSi+tZKNJ+xq9tm1Sa9QJVMPFBHgXpl0l1PKzOYnWfva0WXSGFLi9In612cgey+dNbDCVckJpXFplaIxdZApId8kZZf4kFhQBhpKr8gn+VKUbBB9Ho5x6nPphaYLaq5SPYW4FoOcPNtFN23my2gg7fbyhcJgyruxeevAbo3TN8+95EGeTREaijhuJCpPiqfxFKPZLb/ysMXf5IyUhdMTvmjuE/4iZLZRuPRYboy/ZC03Wl7NnJPOdUAM14opwuCM+VQT57b05vj6Nf9JJx7dTBxzT2qQB6WIHHKRd57Af74FLWtd0a96mCfeuZux7V/uOCZNGmHanI8vPmS4zTxrwpcjGr4OQN2np3Hmrx3axn0OO0SQLpyK7kogPMt+IauTcvn/heVodLznONqonZSyClwprahW9kK0f7ZJLCAvQTW8KQk+3w2OgVViIR9WPe7XOyvG/QAk9LSoI84miFrVDZXFJCbs3FxpfzCanbm0qdem9FyuDBOLzxpBMz08pg7VHq8xja19L3GwSRkdY4vwnI9LP4Niwp3j91C6ARC6OQr7Mw2sSWPpEywcr09guRkaRZFZHSaQJy4yAxJKbTrgMwzaxi968WoP5c3IzTXgwyb4sNxcrSxBynsTdzryBt3vKeRQJomXebjTekF35BRVTmlEOE7TcltqBlj3umlXUBRfuG1UvjyzGyZWu3CH6F04OhWKfhdP5o+PkSl8O5Pkbs3x4gi9TyG+QblQBpZwB/IeSG5J0AGErFe5byYnBtTGoMaHMNBckOyW4n/Z3uyTbQr5Jq9dUXfc7jwkV3MSLx3lBTLbK0DmWUDQqSkNxNzM9OlyPt3nuZN5wp0MdbRoxQaVkDzJkoO+y3bAI9XCu8iOXbJ1+nLpTc8z7X+3LogrOguEJlDkvHtygn8pOxP8izxNoPBc7VW8hPekt1TUE8L0oulSYz4J95iLSq945l5c2GYJn1anHxXd1UU+hu6AvkfH2vF6VO/1a1t5cPXO0InmeSsWQ0kQosub07ACx7648NDLDVZCoNXzuRCgdYRdSWULVKAFFInQUhKsCwtYu0MreP36Naw/AXmiLR4dfPKhhLeysiC+MIV2hH74Euo54jkI0w0htoT96sZZyFvoI6HcrawAWkXyAXnhJmtRUIcpbtabsBDgpeJb8qGEXhea9cJfvvkzK+RCHw/4HVwCMvEoBXBMtNs7zpltHlR4GZfcDGq9C7nzO8c7y89XzslJMTgFZASnTmhFoJpcXFxb1yWgKsbHyjxfiuuWrvAOtSUoBrDgzfcvpbokxflWwmnF6A+Go/Hk6z+8+eOfvvn2u+9/+PPbdz/+9Jef//q3/3Q9H1qZL6Kr6+XNan37YbPd3X389Pn+HxW7Wqs3mq12p/TKEO6L6J/mpYlDTOfKhYMmjAs3NYnd5NTVDr58e7clxwIv3H0Kw1WhQhaaZq2rpnCKOmJ/0WYDyLWDhxQ7LbyosVqFsaq3YbVotGA5qNeAYOotUCarTSCbRlUdm7hw8GayCyfsuWde15fRGUT90lU3kAlzSAhK1+jksug1q/g36gFoZ/b+V+1UJ87Xapzhim9i1zaq/fjqGnV3hrSpaYc6hB6Zs8Fe5KuNtiHVuBUbFWRnBsF5ZnbxZ0A/dXffUF3djDsj3GD4vAZDU+7Q6TveQjk0EttfavN8a/A17nE6KYaGdTlN7KXl7rZf5VUoNDCZ5zqRR2qZBhoEDuz5Iz+YnzgJ1TY793+Cgbzly+4KUhsGggWZyhc7R8pphLfaHLYY8JJr0m8tj5kxJ0imjqa5hB9xKsE1eyk7QtfdJzbxnFksOhYjHQorlril2VrPG2jfXdGe0HOdAzr+oW54GV8PBBVobZ848EI6ua+nKHX7Ku0BcZ2AnF2VpNWdrAGaj/m1FPMTKp9TSV7vI9Q+mSy2JuhAAyUktiKyyaJ0/IH2HpLO7iGeWZcC+6EJFjx/ggX6BFsk0uXMN/5pis46qMwyDiqzc2YavKl0ph0JksUFOLCYJ2hkRsvGDH2ucnb8GCKyvkOGwgwfLcCFXNbGEufNLct/vC0nrWjaJv1shrdNJ/buAUNkFjetJDqFfZxF4gt5aohvhcTfp6fzC3k0JQfgUDgwU4vbwo1Y3NabIKRDFit0pFudrQHDS6ZkBFm5ewVWbJX4nuropswUYSlrp5iX7L0l15Yu+7Lo/ccbUdDxDxYtdSr9mWrrgo5MPyV80FtkoG+7G38hi81e6Bq00FyDli91XFqYz3An+nAX+ddnaGyQDVLKO0g4P+QzlPB5DZKZxMVQB72QtGRlJwzUDgbxCaFAsxyhbunSilpGtqiBp5FWs2h+t8FbBPH2KLx+KlQxGPmudnFBQsfJVie9O4jlKHtrktummbRcFrK17el1dL3rkj++vOfpkv9cx9O1/VP9TleW6TaqAG+24vO78NZl+6ym4mjPgagDJ4EZP8Dj4HbR4yP9sIwUnSWAzrErZhipR480hIIlKZZZSNZkED1/Pf5u/Lb/43j0y/dvR+O3Dt779f3bN1+/+a7/jUiqYra3Y8j07sdfvvn+5/HbXwbf//TdiPJ+M+5D6k8//KBSqwnoNRe6pM4XyTfJQnyph+hk5lyhPTgFEuh/W3raHtcPfJG+kMnSDVImekWifAn3uSiW7JgqlR5gUUi+YZ+zfF6v1p9WzOlxNziSDzijGYSX7RQxnWc3kYTyHnt2xPfHpFy4dsp5QjvClSNmzS0/R1Ay1aF830quL2njfnqtyRr2E15cKXeSlBNX5i4W7chmTmeFv9lO+HGgUYz2qZStfGGFac+j5TJrb54kJ57QrBYJGUEIA4EjEZPjx2cm+7pId08vIuQIq2LuycIgh1TuUa0CHiNylS/GZxTkL3V+63IqhL7LqaUXl/6A4sKhDMHGvokIrBFHhwIy74gbuBVlJzGLRK/lyTP/wES5DKdke5Sng/WLfR7YASe5HSy3zNHbICFiO86VOWdjrTz4K/Dray6Z3DvhfZkaBz2f7DbnxK2SYTY3Jn+dW2KvLjfO9rhUCqexefU6s3d9pIcLPU1oEM71/6Bu72M73lXO5WOwyMWzM+X4qM1bU89W9nNLZ2ZNLKSpc0UBkl6KzebvuKcyxZ5SCd9ZN20DT3lGiCOj/M40XyiSqy/L7YhSyTclhOk8eDWYE8TnVvnHGYj2wWGH9kjefe6nkBvoyF0BSeYaAzL78KjxrzF3nkEgytvVx9czfF1/j5JusmlFPjq4ae7nVe8npC+fVfuId/ktP6X+32BK2lTh/5N2igSV4It+POZLhCLrSCS3D6xbbDhH7gc2/oE+ZeRi4PRy9w69mDbOUpLN1cXm/Aq9kFg2Wl5eTS12Hr0+X6SMGmFqAV9k7BthZgmXHpxotpcL1VoReagWp0XaHTOx2C+ybpnpq9fEGxDQChtHtDbE8YIP4g0dky5H5p+KxxTz8HZ0IaNXJYJ8DS1fBQl0FURaKVEtP6xapCe73EHaJ9naYaF9Zn3msb0Vd8J9oPGvWFs0RsH/O3U5AN1L9xGvLbzC4AbpiS43DKw1PsBkfRKrTXhxZ/I6zKpFaLJGYd6WSlao3RBXyOayDBNy8NYlP0VAtGaljmk6t0CF4fni4u58AdSpGFu+7oMHskyTxWjIusaDHHyZGqrvvvPxcj0F5SUsAekJuicAfJwYsk8Lcyl3amZWCOqC9cm5ki9XwS/cOLHEEyOfxCFF5cRezRpsJmuQTgqu8P+2Ct7drrBaF5Qnqm4O8vU7Np6oiQqTs7KsUtWE/XT8feb4qhOVfLzIP3KCHFc9+U4W2gflFN1CAXtqbUsO/U0eYnU+wNcqMpvU4dZktAQUlz7S6mygaG0KFBhkvfAEIHUChGbxDnLXp9YOwajjAw7ioij072ADZ5AWe2JH4RuZdz8vrizvOWcPDxsfnJU1L948wRAOaPDOzT4rbeS6QNP5G2uGnhfiFrgLEIpzN7ewu8oIOKeVGf2I0VMYGPmHO3eJXsu2VZjzvW14nRg5CF8G04sDdfJIPF1rJa4Vb60THCsqs5mO+oF92KdEL1r+uI13t+4q5WqrXWp1LjftM8MQSzteUlfI5MRdQexuyX6iLmkzP1hPyZ7yHE1yKMdJ8Sy85CdH3M3OObwXTnjZ7vf5Zd6s6IXI+30ShzmHLVIXlbH6mbLsKoF8HpumU8q3nkXyk73yata1Qnn8IIOpjAqRVRWeNQktHRYvcrfGAYuQSQQdKb0xPDiG0ZT9UNIjuEiPYMrCH6YO2ulHDQMnYzcJeCsyI+ilNYIgz24iL7DRG9dP8klvmxiCmZMyZszM2PoSWEkNL0xr7fkKXpjV5jkj2VNme6mVyWbIkkYt0S9RHf2mErRJlSRi0H6k9+v3s/5yKaXpg94zSTG/l5OmHm5PDgl6khXxafe8Itv1TVjMPRnPO2smPY+gA54+QpOYeri7rRy1k00l3LR1Qk3bauaxIeRw/9EKwpxvfn5IH/WP6aO+9Ac/ptEiHcubC9KZTFN51Gl3TNAJZ7wuga8ZYssUX6jk8C64dJXT1eCZeayr+arxzKTpXDwJxLVO/JeuQjDzGuGrlF7eEJeb7vF+5MQgHrz9zM+6qynlmpzWgpwHToID7HyW4UeawZCdiw7Y/IAPKSvfQ/7s1Ow1RO7CFPiQOTyTXEFie+bTFkr0JM9ZQOb/ErOi3v7Ti8Yis2hkbFALsWYog/lcKqs6XnXG+SwLWvgiC1p41IK2f9EIoxlt4G4jP2tLw2ezn2VLC1O2tN3mzqfDAYkvT2rC4bM0YfGYVmy7cEE0dC+Su/5SInRBTcwTIWW+S3eqrH/qwKS8OBXK+toVvEcL4VWqal+E7r18voCmJIxDAlr4tIAW6vNr5iipWwkVAvbEOxGHbkfShFp2CjhwW1LP7WavSTpSWJ7tVSZehdHZNPYq9WPkHj5GnJKyz4pPwHxmq0mXlbyfKpyV6ntP9vLM7lZMC3lONyzjHxAdXigehf+MeBRPBXoNpph/Y5BE9IHq8VmlJBzHpB16/u7YbNNnVoLNKjrw8JrsMD27tPPJ5CN2rjvA+7gQz563EAdPLcThyxZi2dkQTVsHOhvKzmaIPhQapOptZsnOW+JN9g5WJzKZdWi15MEtbqwMpDu1nER0te6L5o644/ZZU2b5/Jmyj/2zj65fqWlx2MRJj7QetNuoczdHreILGNbFgWFdyGEN0sO6mFrXTqCNatYhQN3ECg1EF+oe5CgmlWvQTtE3XqtGUynVAdnzME+zDNITiG8dyt2Xz97Uggv6gYO5oVRH+WyptK7PEnAqxVMejk1f5jIzrVnuaVp5T8WVEjjDlLdAytxSKgZPk256zcwcTH6yFiDmVMO94Hn8PyEu+0d9FfxcX4WZ9GfMsVSRaHKljJ5Xh42eB2hd1rDfz4uHWnmuiVTV8LLtEhQ/3/ApmqwA+oI3m1K+dtqTTT5bTjXWIJ7fFAfq0CSIAfzypxYGTqB7qOsOed/iVYIbNLwX3RJH3FWwvimaXxW9M1e/P9HD0/PWXNxdMb8QQt413kGMLx8tnPmZfY5eWddWKHf48DkZ7WaA+fnsIqTrAKKij1cBLPH8KW5noRXdpcdYcc7Qr5INv8X0gci5BOAK5wBHriAPerX4sSNi4slP88GjJznxrRv1oOVLDoVk/DK1syEunw3REITHfqEDCKVke4TT2XINKCiGZ4H5qmqWAuvKiYqQEcfnJD7Jc4XXBPX87tXrSg9k1td2D3sZV9mdow9txq2kF17Iva0eeg53/a5/FlDpgDa0jpf2u6BE442jwd495JHm5nqkuUImd7RjF3MyirORKNRuPzLlZrz0Li7iJQZyS06Uwlt5c5XZ5IXMUIk4BnVmk4KL8lIxpBe7LyGNkEo3PPNe2dlZsFcHNY8Mvng4Ufnvbg+8Q3eiKW/GHUhm6Hnu7wxYP/D8sHusXlccFfdwK97PfQNOz+7HL79B/uvw/tN6ExwvIjKJUpmHRJ9V7lif/VSnk5dJC6dCl50KDeUmuTW6nACC72bmgtzHcfFmp4xtoo/AfVVsvaNTaDJ+5y0jX0S2O3enIstwZ3TlxcvKxVBeybzXjw9o3O/EOz2ly8Tv0Sve6J3AHGCX5DS35DtirmJvFmhF9lTtr5A7ZLWrXe+Lj7oDTdOvlfwVrA32nKwlssK0kDnwMXDxE6R9+XO3uRcF64mCuErJPKgnyN+EGPH74zoK5G+8WkflhwVVVNpIVErzS+aiWRRXC71WMKFKor6goURGGKXyC3rOysj27haWcG60mWiUf6u6SQhQWKOb2VQdhHvVC3r5VmGaXp4WDbQSDQjCUHjGlXt5H1cDOlmwFSXbiZKSILS+krISg+fdzeeqX3YlSQaAGHflY3eOEecscz+0gWJpTABxezOXRzpM0ev85VWkSf46uUkAePnoqgrUaxmG/m6BPE8IXDzgC+IzjJ9vjserL7TToSBPnvjlaPsGH4Wm98jf7dzNbvyugfcjJq5i9xyb3njR3gDCzdFsnV6mzh9yqsxe0r7UMVd0zxqNaqdpfmVXqvUSXkHfrFUrZqnZaNSa+v386oHumYXdn/OGQF73sRd4iVBOd5uWS5cNBMrKdzGD7vGdOB7qInH/XNMi0MQxUQcAszuUEQpY7mtnlsB4mCl9UqS+XDig6IRQvlWr1zTMeA4+nAJCFe7y4NH2+FMaekZsc59F5k2CDJFA8DGKFKElj4ZEnIkJeO8/f1n04pevo+2feBGD4QZNS4s2uwFE34bbcPMxDH4WWWaZtGZ3zmm0uHFq99rSe423M2DhRU5qsxslUjHfTSql2V3tn78q+5k3W9WT3yepazlwpfYOLc76Ufl6Wx7PbbRSb0Hk5Hh87LRkDGbD42OzIaOtygG28dqpt7l4IzHDEoylVmWm0uE/9LwD/hXJdrMCP14DBM0K3ioYe4y+dpKklqjVrojiNf7brsp24FctIQnwJZAXDk5q+fJDgU92ks/mUMwb6aTqOXkfdQnfPSMGYb5CtmGWmIdYfm45lfn/EI9hBhO/b+rnP/fhXtjVds+/dKfdefm79aq/9aMoxVD4knQE28x/EYQrCQ5V8sOhOm7zAZm9CJAP+YDMngMIsdCHA611X12+/9zvv/88aMB/+DusnL3/PGrC/zb8mMCPCfy4q1SHNoVNiowoMq5QZFyncEjhGMJaiz7UWnUKmxS2KOzzhxGFEwzb9LlNjdTafQqHFI4pqW9TWKPIpEFhCyP1tk0hVdmoYmWNmk2RRpPCDoZNTmpj+40RAdYYYzONCUcmVQibVYo06/il2RxTiFU2W1S+OapRiO03xxw2KaSsY8o6IVCakyGFmNSyKxRW8UOLYGzVRxTpYyWtAfahNaSCLQKrNalTSJ8nmNKuEGxtu0EhJVXrFLYxrPPnBkX6HBnQ90GTI4juTqWOkU6tQyElNSoUEu47TQSlw93ttOlLu8GRIYUIfadDHzo0HJ1+m0KCvjOgL4MqhU1Oora4+SEiqjOiqkaUMppQpjG1O6HSE/zdr1Cz/UqfQmy2T3js29Rsn7rdr1Kz/Rp9qVUprFHYoLBJIWWlPvcbHSrQGFKI4PRbNDB9ItQ+97bfHlFIwPU7BBB3t0/d7XN3+9TdPnW3P6B2B1yeOt2nTvdHlGnMIVU1wa8D7uGgMqQQezigHg64hwPq4YB7OKAeDqiHA+rhoMbFqVsDGsoB9WrQ4N8E+4AGdNCisE3luIcDmmUDnl8DGtBBp8qRBoVUb4dydajezphCArRPVfXrFBLpDPqUtc8VUv8H1PMh93NI/RxW6PuQOjrkKTGkjg65o0Pqz5D6M2SiHDaw5mGTilB/hkSZQ+7JkChzyD0ZUk+G3JMhjdWQx2pI4zPk8RkSfEMan+EI+zWk8RnS+AwnHCKyRwz9iKAfMfQjgn7E0I9qfQqxqlEdqxo1aJKNiAGNeBxGBPeIWd+ImN6IwR91KFuHvxArGA1qHBlQSDUPaUqPhph5XKH5OSaaGBNNjIkmxswFxnXKRaxx3KbP7TqFLQrbFPYpxMrHHQJ43KHPnQ5HEMZxn1ui4R4Ttxr3KReN9rg/oJCY2Zgmw5gmw5iQPSbQxwz6eEggcAdGQ0oaYRuTCpabMOiTeotCgmHSRKRPeFmY4DDbFWKDsO73MaxNMGxwUqNBYZ8jIwwR6RDSh2aTwjF9blUobFCkTbnaYwz7XNeQigxbFFJVI/4woXYnCL5drbcp7HMEs1UZlioOPYT0nSGqEkTVJn9v05c2f2nTlw5/QSRCWOVIg8I2RxDA6pC+D/k7gVkd8vcRtTmiSA0pFMIqRxoU8hecTHatTa3VkJ3bNe40rasQcrYJAlUnQrObOA4QTiiCxGs32/wF+YPd5AqaY4qMCcXNCXaxxcPVwtkDIX1p2YjvVpW/1ChS50iDIoyjFjXa4gFr0YC1GOoWEpfdGrUoxFxtrqyN8oXd5lxtJHkIWxRBTgAhAtge8HfqbocB7NiI3A6PXqeJfe+0OILLgt3hOjtI73aHK+gMgYfYfa6gbyP2+wxHv4Fl+jhRbObyNvFse1DnSB2rAXZMkX6FwjGFiNvBgOhigBKGPeT6h1UsPySxAf5gtiET1hDlKHvIAA6JsIbjDkVQGoOQMEg8DUKqc4LAjrjm0QArG3NkQqQyYVKZ2FjzhPs0qdOXOn8hYp8wuiaNFoUdCgcU8meilwnBN2H4JiiSQNjkyJBC7PmEKXoypO9D/j6k7zzzJih7QchfRtTMmL9QNycTrmBCFUw4Gwph1QoufhBOMKRZBn/wA3ARClsUIjKrtl2jsEFhh5NGGKKsBWGTwjaFXKLKnycUwcULwiFHsEWbhhz+0BdcH6o2EXjVxrGq8vjChMYvwxpHGhThbEOUrCEccIS+4MoEIcLKo1gdVRsUtihEkEZc16hJSSjGAm/gJFxxqqM+R/ocaXMEqx8N+MuAvgz4y4C+DPnLkL4M+cuQvoz4y4i+jPgLLqzVMQq8tQpNA/jTwrBqU6TawbDGERTYIGxzZIhhnb8guBCOOEK19fkLcuMac2P4g19sbodGpWZz1Tay9ppN/a3BHMNwwhEqUycU1kfIbes8EToTFPL7vNr067j09OsjjiBn7Df4SxMZW79pc8SeYIhLE4QDDOv8AVWJPjBOinSwPLPMPukM/ZaNTAr+UKRapQhSB4QDiuC49Fs0LvCnhSHpP/12xaawxpEGheJLn8IhRapVDBmcdquGYZvaaQ8oMuHIpEXhgEKEs0Pzot9B8gIJmMp3ULzod5ocaSEGOu06RXDx73eG2I/OmL8j+ULY5Ah9mXCdE+wU888+ifP9PgPYr1cprHMEoelza33UIyHsUzimJOSZ/T4KThA2KKRMgw59Rhmk38dlE0Kqd0Q47Y/oA0PZH1ONjIU+8hAQ7ZF44E+Twg5HEOSBzV9s+kLsEf5wpM0RysbYGuCCCyGNwwBlkf6gxV/GCA4zAJAMaxgOOIITDMIBRXA4JrxQTfq4Nk36LY6MYAJNBvyFAJ2w7gB/WhSOKJxQEmJ4wurEZFCjzDTb4M+QwjGG9QqFNoU1CusUNinrgD6MqBGSeWGiUPMjFCUmIxK8JyOUnCajCX8h+McM8hiXUwiptjHyZ2DciM7JBOVoYN8caVCkSdlohZjwCgF/WhT2OYKNTkb8ZURfRvxlNJy+svINI/8ac0flv9LcUeNI68W2jw5HSDBvDKgIdbKBUwPCOoUNCp8wlthsLCFThLScNDtsOUlYSzhC9hDW9pvjNoV5lhKygZABRtpIhHWEv+RYRJDVx/aPwVH7R3tEmk6b1Lz2mA0YzRqFbK0ge48ygNR+QwMIqTwdwnCHcNsZUkGa5co00jpkICFQxlyjsJDYbCGp/QvNJTWyk9RoQIktQ9iikDLVB/yB7BwN+4CBhVHbb1EbbYaaUPsbW1sIw32i3v6wxRH6wijuDxPmGEoitPYZrX0y4EnjjM3GmdpvbqkhKImrQtiikIozLgd1tt40KWwdsupQvYzXAZGsNPFU/1sMPQOOEBMZML8cEHUP2Ko5INSzPWhAND5gnA8I57wGwp/ar7cXUYSwOqS1Cv5Qtjpnq7NBqUFhM8e4RBHC65DxOiS8smIFf2q/jcWJRn9IXGDIiBoSooaMqOGQTVIE56ipm6foM9HrkHE3ZNwljFU2G6tqL7JcUYRQN2LUjQh1I0ZdyqjV0o1a1A6ji1SMtIWLgCLU/Xpr12hIYA65yRGBSZhhNQP+UFuMkxHhZMTYmNR0Y1lfN5Bhl8YNjtAy+V9vLaNWB4Ozo4Yy0rHgD33ntXg86hwwodltCvEza+3whyLE3Sc1Mq3VOGV8yNrGS9+EUDBpE1In1NUJd5W0dtC5mpo1DpVbZYfrjP7/ZEhrjDgy+W+3qtV1q1pdt6rVjlvVWlUKa5qFbZS2sLVQGLFbbHFpjXG825UB2dEq+KVts1HN7hwyxz1le+MynSpZ2GocqVGEeNLLrHIdprLOKGGiG+gmOmyUtUq7jzoshDQS/TaVYSrqdzrKktfnBkihtFnpkpY8JtYBmcAGTULLgPA5YAgHk5pmysN5aA95cIY0daRdL8eUxx0ZjqoU1s+U+W5IpDBEaUWZ8gitoG/9rzXlVThE+xYZ/6sV1FerFTS4Hjb0Mc+BPxQZU64xmeUquOP4P9IQ+HLjH5H3f7HxbzTmL6jdHbUETl5iCSSzYaf/P8QqmLQEkomwRZatZmukmQVRjPunLIHVVtbEx5EhmQUZ0DayxH6bzV559j622lVHmr0PF5C0vY8jZFbrkGjWJ2arzH4J416tqRv3yO7W4Aiymoxx7+wJW91Et9U1/4tsdfQF+ROECM1gwh+QAf+LjXj/DuY7hm+Myu9kXOVIlSKo40JIdj1ax+DP5LjFj2bGhCTVlPmvNvmtjYB4BvqL49MXx6cvjk9fHJ++OD59cXz64vj0xfHpf7fj0xdfpy++Ti/2dWo/x8Txxb0pbeH4LRybBl8cm744Nn1xbPri2PRcm8YjIA/U4kv4I5A8rAwoHFEEhwzCNkWwdQiHFI4onNCHOkUaXL5BkTZHkPuMRkSyoxH2azTmL2NcS0bjPkdQyQFUUGSCU3w0qXEE7QgjXjJHE3T7GPGaOJogjxhNuILJsEZhmyNUwcimyKghOmnrnaTCQ6akIa6REHIncSRGvFaMaJUY8fowoi3q0VgAicQxYoEbwCO4mhxptkSD1QRWGxS2KewzOikJt3AgbGuoZaRSpby0Aa00NaSiEjnibfwRrXAQ1ilsaLDbFKlyBJfbEa9qo9GAeoUUMyIxBjuFoc2DYVM/7QZHWhR2KFKjLwzSuDXMjOaQI0MqM+QyyNvU0FKXc7GGO4fx0NoChTUdhfW2hoMBdXsocSDy1zl/7SzGbJsjyAFHvAUGqGsTnmo8xohanqFAolUKKYlLjqil0ZCoaYSC1mg0IqoeDWN6GKNAjqijCC5sCjVolxuRwghhn5NGFE4YdRTpcKRP2QZiVowJdTQQE1xFISTStmm6cGMT5FkQ9hnB9KVGyKTRmtS4OBHAhGbtpEGZaLsZ8C9x3dBxXSN6qrcY8X0N8YxIwsNwSCRKwy1pq09UxXNpNBpoGKoSpdV1HtDv69O+IwBpEiB9MTepuclEI69JW2RsJSaYPrWqNEOQT8PUqVJSeyJKtbVSk45stKPX1RzHHR7Va9PHS8qDI9C2cZEagbaEIVNyu9mmsM8RykaK3qjdqk715iYSiJHeXHXMqbbOosb1pkjt66nEKNhGMRqj9DtiXw6YaCMNmYRsOdHqRAhNJhfU7yDkwZdIsQeXWmEaI0ElHS7VofrGFc5e1QEFRUKk6gxvLOdkdShSKRTEVp0k0E301RKcbqgRG82aYUewPTFWtQSlNogSG03OMoz5I4E87BOf6BOh9omJ9jtMx5SVTG0jMmVBSCvfgFc+WlGAwokGKsxYWxyh2c8L5MgmhmA3OTKkcKyx3NqAI2NtHST8jurEZMjygeyHwipPiwazAmamxJqH/IUYD1t+AMMUIckeZg+NGcMxodkLSxSP5lhbQYmyJ4zqCWF3wjxpQpxn0ufIkBjIsM6RgcC7TojMAeRag3OEshAdyRlf4QVTLCQ0havEJlHShpBYAS2x46pYYOhDrc4R+kJoHNeIk9Tpc53S65Re5/QRzxhqokFNNCgrEce4QQUaVKBBBUhGGTcof5PyNyl/k/I3aZzHRJbjJiObFoZxiyGjOTRudbR1sDXWWT41RXoJcHZqkbSxERkBcYA5Qtn6nG0gsNzUOdF41NTmpeQeTZ17iMGup7KM9bGySdqpJrO09MUV4BOpesGxPXqm63vrv839/Yvj+xfH9y+O718c3784vn9xfP/i+P7F8f2L4/v/bMf3Jm3C1ZAVf/GC//fzgu9/8YL/4gX/T3vB/3tsEf/Pc3z/TVzev7i5f3Fz/+Lm/sXN/d9mS3g0GR3dGB6Pn7k93P9tt4fFFlS/82WvOLFXnDDuU0hbnJXhs7aPa7yvQZQzrk1+xY5y879+R1nkJ8w2ea+pSftLLR6AQT+9vTyciJo6Gp7JVj/ijZkR9V1tPNe0jeeKttc85A2iIW0tcQNP7j+LnZPxb7ILPeZtJrGr19FwTyTw2+5PD7UNSNrnmdAYTciwNyLZWu1ft/RdbN7i5B0v2oGVm1ytet7+Nm9pS/bU0chA29OW4zlKTAiaKgPe4KbNObXbPdLGg/aexW53Q+zWdrTxGLR08u4k9sEp5H6RJ4FkdrXcHfJx59fskBNPGvJcFBvlCWyoXXNiIhzpt7T900Hzf+t+uuBGzU56c11NgoRLSzOz0y6WI0Lkr9h25/xjzvhvtPseL4wdgeAaccdRkzfJCWGj5kh3pOHd7zZF2pytTYsmbzSP+iPe1+URqn/Z4P/v2eCncJyYUrWmvpVPVD7mvo6bvONNnWjXeY+bF5GJvtUtK2onmFCTWRHvSxOB2QOetTaFNCrkGgCSJn/oH/Q/UBy6qTsj9LV1tdH54pnwv9QzAVNBfbvUhn48wVO6C+cSH6yw2nanikENgzoGDQyaGLQwaGPQsWDxqWBgYwAlqjVMa7csu1ptt61mo9rq4BOy+Oxrf7Nx74t2tW1a/Bgt/KRXcHx87c977XRa9CQMFH18hGizQdFOBWL43kaT/3Ya9BZNcLzO4Ok6+ZUPjx8JSbXg6q+yjEI/unGXo2ge7eiFlD+EnzlyBZHv/Z38hi+t/LyIduG7W9cPu0uI4tOPP4abm2jl7tab1Gsq8rmg7srKefGnu87L3Oze5mRudj+84FUW+YrbsUdZDr3EEsiHRxx6dDR+Xkc9KEZvkPP7aTQ848+3m3CLL42L5876EJmv8B2mzKcBvViYSR66y2U2cb0K6NVKN/ttIsDNfIgRJxK+geHauEsZW88jP6e+b0N8uTOT/F34KZPGb6lnkt+FH+7ClR9mPvy4iLaZxJ9y0fDTbeDuEjWot4vUe1zZF2KeM1Cj9c/4ZBrQ2I7eu5NoXG/erHIS00npwkfA8l4C1mC59q/TjQ3wPbd04lC8aJZOH4mXzTLp+R0e39zu7jOJCuG/Fj9vZumUb1wvXIZBOvktYSOd+o5Qk079EV+vyyRuMuD/xd1ErrcMgY0t3Y27i+kpFwU/R7vF84Zypj2Fg8P6+Oie0KCenvIo4pNrcibqre+1Fze1Rxf1kU9gTL2P7i5hsgInDbmdnpbS5dfTaZbtzo/hOGd8csfx+dgByLx1cL/X3jzX37TzxCNr+KCZR508AcToPUy8eebFnUrPEZdel1a9DNY0kxSu9SpxDA7UU4F6EPF7fobUlc82wdgm1r2Y7un5MVV318MVCNnmTp8T9GQZPxo85lcz6YWyHzZrIL4bfO5Sg687t3YbN1pGq3mc5j+5hkGZj+FmG2o/0y9+uqmVrODiK3f5i9lSPoDnOw97KOmRaOHiW/SBGZQX7vb7TyvowG242d3TC2/4nt2lO5VvPKO4YKyJ4wPGvRNGNL0rhQ/RmV365amHsXz9IanQmsmXBwloGBb1pKwP0owcHs9xX79+bVuB45c8i5+KNXtAC92i7wQl23LPHK9k5zWy4Efq6ClofPJ5tXNcfv/7Orx3vNTLoow5+ryit10tUXC3cDz+/Wnj3jo+/96EM/1pZg9khvz32ASvxxdKBd7cBN5koiLkLT04ZiSe/9KfN4Q81+X0QsvPpMn0H9wdEj8MGT7EigMYhVsDMnj6g2D08LR84Blnl3xm+dx9DSNwdubiG40eDCJjxHH8eBZlOeJNkTDIlaF86p0rDiHplbLERTZHimzC2yUIkqkSW34amghHPbjmfIBc+mPXCvk+vok9Dy8r09eu+kmTjF8MDYO3mOhcxl8t+dOeTi0kal/gBeg/VQyyOCi/q7IgiJ85tgXSdSUndyWR24bcbtyxHb9ALZFxObXm1gxo0kOueBJwIZMebS0gpsabDYycAQPt+ovh+oZe9oQvYbAtUF6YxzC2N7zo0CvMJwv13q32wjOTgE+PWMq0c/9idu6XHNucw0wOL32AdZ5GWcUKVMcRa/R++9w8x5cw3QBIWELluPETzsfaElVsi7LJhRk/qgdlbgBFDyE+QtzVXzSmR6kFv/AuXL2P/KI6wJkettcxYYiHprN5kN5Vrl7RT3fr8TGbBuOGjz2nUrlfAZLd9nYZAVF7lm2aXQ96vVcddNQTqb2oTHJeF6HPEJGC3Z5CxnfX0W0X3wguVP6/3q6vx3Ebh7/fp9h5GdtYzrR7j571FXdtURT30AO2LXAwjIETO4kbx87YTma3M/nuJfXHFillu33pPmRiipQoSqJ+JL0I/T72bCdU4Vz/RTstHb+vvGGNnRYeVNjnIjvZu40ZShKNpST5bzRVdSGLYNgKHZ6zDWztXttnL6EoLQ3HbrBQjdt1GQ0JuXg0mHrhoeZYunCeVFv/7Md1ii3UgBLPZcOV54QIeHyRyngDZDia+gEq8HAkleEJ8Ng1lbEstiP4/bYtEaBQ4/yALbuyYTMVBOSgX6b+D0JPbLNfDdXB26bRReCah/XNCcjRH/BhV3f0qAyDTB5N8LEeww0kEQjc0yvxPHiRXRoI9sCL89JA6AffNQNCg+bsdubTkE9Eh6kfLwIPFVMZOsL3Ckj/u23ZSoSolvc7/dvaAX6/xcrQD/dWAQlJt/wfjvVapT8s40xQHDLOTYPBL7ghVMoDKuCxVCpjK2r/acPbnWds9wPGNBhFQsgZhPzAD3VHsUo/uIwBYgRLdih1M0XgBi4syoIf1c+1ux1LiuVh8/FIC5daaWeZwnTLT+s8UrbRk/BbrIzH6nCYdFg658VARtGpH1eDlzZLA5k0kEm01E+rIc9U2oCL2pcn1bbrcVNjaNhMRp5TkEeFis4MBSEClrNLRQoPZFCR+vk8YAGGZZjvqf8NzRkN424lj0Rc/XYoD9SmviiKmfUyY/vNnbNPi4B+8dvG3JHzQC0soZR6GSbwE5NpKFkJH/BrWc2jsEdsPR1ppuoPPvGEVeplsAzHtyVdesv3CH4u0WVXP9cHjHwmptO1FpSxNKubICwc8+4WBORgWdhUZmWBJ9tSmXwDN++W8iwc/CJBhMzugkzspn6qFwJpvDSY2/M4+8Fn7HGV5B0nbziW60pF6gv+39Rt5aosCNEFuisoMo/aeoNdREOz3U1REcCPPosAj3lU69UdbeMiyluCqDGPjmiGw4gjUOqOOAVazKNy2J7UXAsJFHMr5AFET28BD7GdvCc2CFyYR+gt2xqPwDzuqLgWdGh0XlSWABFnvpi/cNDhrK8HDfOoqbDDkc6tanR6FxDxc6w+VvQMcQ0nom4kQL1tGkpYut2GgGIe0W+qI9eSCSWj2VynlhOQcTG7DxTzIoQLiSpRoDEjaAUKCQFRJAj68mhUWdGouA708qhyjnBxDd1xNlwMe6+R+cQoyyWo9gVSalo/NHbZaiYP7YkNxGAeLj9eN3byEJ2Uh1oWS+A+sf4umwv/rrIFUKDZgPLgBk93kDMEBD+z/ZwrHJf2R6b1n21BDxc6m8DHg/mVhbyCCfN5Ea+CQMnitjQHbzPYixHn6eE9e3Zmu/hozzvsHtTLbbYXbDr2k2Jz0F4eHfDRY+CQL4/2NZ3Ac9meyEIS7+EEOMC74lc9nJe7aeJCYDzR6EO8vJgR3exrnYlxnQOoTrK4gI5dRBLPscYAlHNPNKnOURyXVhAOZyLRGzqdZlwPDb3EoDY6VcJUZwuIC52I4jqaQ/Zyi9xPp3JsiFFAuLzwMFuumel88CkJ6EaiHKyxWTKgZg4/drkru6pVhx/XpGyb3/F74SE31pMH2lhrCK4x7z0GmPrBui7lawvwLiBjZbPFOEJzzphplxjN1fACqui1oY8tfTTZi84jrkGlCTe42Q79uU63F9jd4wGYeqrP2KpE5hTYeIkptwWmIltJUerQlZzLFArC3TejfqPH6S35xn2yKVE7BLxL4ObrJI1NRUoXTFS1E27eJRdYOcOrQhYb3Kl/rUC/mMAVKZPE5uu3c8b1Yf1++/D27TpZ6VxtSan6h7od6zeWklx0YY/qF1uoYKeqD0rJx8f1aVBzIX0Sp2hsXmzCHbzK/okrY9hVHrttxskOv3q/US857TwOSmHXcUVGp75tOpdIobGh4gZS9TfnFSBdiFGSRi5OnIoWcr++in6pQCitPqhsNzO8tk4F6wdtXjVnKnFen3OlXxbTBg5MXFXonCIoU8KoF9x6YgbUDRd+fKw/1uvTxHbuXLarwSnDnTpduq6gzni/YgGyeUVGOsCqQAprVWBe39OVpaYIlVIHvOleMdPdO2OGRA6HWvJJdT3eXZ9Cp9iqJARGdAru5jB1Yuol3vCThn6VPElUXONfi5MpHIPg3iZyPdS9qdx05pb+jdi5GRv0pbZ+PfT9ZOvXj4/P/bAni9GWk1Z0aNZual38lTKUDS7UqlzvNbG8n5+zLGrsGxLRN5JbowvyX+NcEWeydlIRbggpvHDOi0wdZR2OT18WEUU2Y5UqxI7N0xqXZ6pdvsRIJ8LWtmztbpQTjHrr76CBFXTwBC0cYEBPt8czPT2YfpdVUiIw0TUzOy27EHjxyHUg/0WnnKq8JKusO3/g5m7cdt5qWEyVj9V7Vxn22x9jqhFm2WRojaG1Vg1z2OPxXikEq4RvgCxbv762zrsAD2sTcF7U6zvqAFLfgR5V7fYLekRpY4Npnq0vtdFSm8QqQHJdplWAp6wzPnql3DLsM2fB86cCbvb0eoPYYMnMZilxZ243r/b+S7fv+me8vXC8NzTWm+jt09voPkI/nO2t79ZLEQ932bvkX9nXyjaHbJ8PBTr8Lj+gIhWbAr+DqyR52WaV6G3r9nZT5duCdXGMG1BERu3jJ6Bxk2SV6c1DPJAfAD+dxKvaQ3rOKPVbrHsKyCw7TnPPg+3sml0uTjeJ0lbp5ijGdnuFJ8nZxxf6J3ylh79OcHawzEf7xhleUVBCrV8qG+qNcbMxalFlmkIQqjbf9UWNsLDlpl7f3SXqjc0WcQ69G1Jv6O2yRQS3oN7wpe3zfWVq5Xd3Mw3nQUq16CcOgDcbeo4J/UWHPuQZPcgx6DXOCTyT12g9rzH4XuMpeyFfn57QYFnAdyBlhxsgIqYIvUg7n6vBfjNTbrnbaB238Wxog6FV8pCfF7dR3WQLIri9pce1/rPRf7a3t3ZlNHKtEojFId++vlb0J7m9/RgHPUfleI43T+q+Yy4poOLsh75ExdjTUXuY7PPaxkpdw6oh+ZfprtyDcWI3B3aAzZI9O0sWcIqV5xTH7MB9Ycd84YguqAv5ws7zhYe/4gtH7QsRRgjvNbne64hOcCrwHjzkR1Sk+YwvbPDs7vHK4r3tmS9s8n0hvN4INMLiwYgFcrwRuNdTB6SBfeL6PtVdSNI5VI7MPHArPCD2hJuidX1dA0e3lwMcE/J4bDdcEAN/+NRN5ccMwcWCRw707pVxhQN+56+BZROSftU48L8aHc3PPx3JTWbog+8pUzz0LUb+CBCr+3Xbd/X33bkZelWNcAGpDXvilwtCpOpCMR6Cpjj6aur7dvwK2YdPd8e+6dR/rkguDoqnjyT5xx9SVB3AzJABAA==
-</script>
-<script id="@tomlarkworthy/escodegen" 
-  type="text/plain"
-  data-mime="application/javascript"
->
-const _hsp23a = function _1(md){return(
-md`# [escodegen@2.1.0](https://github.com/estools/escodegen)
-
-JS AST to code (the inverse of Acorn)
-
-\`\`\`js
-import {escodegen} from '@tomlarkworthy/escodegen'
-\`\`\``
-)};
-const _rg6wi4 = async function _escodegen(Response,FileAttachment,DecompressionStream)
-{
-  const source = await new Response(
-    (
-      await FileAttachment("escodegen.browser.min.js.gz").stream()
-    ).pipeThrough(new DecompressionStream("gzip"))
-  ).text();
-  const fn = eval(source.replace(".call(this,this)", ""));
-  fn(window);
-  return window.escodegen;
-};
-
-export default function define(runtime, observer) {
-  const main = runtime.module();
-  const $def = (pid, name, deps, fn) => {
-    main.variable(observer(name)).define(name, deps, fn).pid = pid;
-  };
-  const fileAttachments = new Map(["escodegen.browser.min.js.gz"].map((name) => {
-    const module_name = "@tomlarkworthy/escodegen";
-    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
-    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
-    return [name, {url: blob_url, mimeType: mime}]
-  }));
-  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
-
-  $def("_hsp23a", null, ["md"], _hsp23a);  
-  $def("_rg6wi4", "escodegen", ["Response","FileAttachment","DecompressionStream"], _rg6wi4);
+  $def("_bz6mai", "test_completion_identifier_deferred", ["completionFixture"], _bz6mai);  
+  $def("_y8yyf", "pinOnCreate", [], _y8yyf);  
+  $def("_y040tx", "persist_attach_menu", ["viewof options","attachContextManu","Event"], _y040tx);  
+  $def("_1jn7thk", "moveCellBeside", ["viewof command"], _1jn7thk);  
+  $def("_2rhl00", "dragReorder", ["divToVar","runtime","moveCellBeside","findCell"], _2rhl00);
   return main;
 }</script>
 
@@ -12837,8 +13069,7 @@ export default function define(runtime, observer) {
   main.define("css", ["module @tomlarkworthy/themes", "@variable"], (_, v) => v.import("css", _));  
   main.define("cssForTheme", ["module @tomlarkworthy/themes", "@variable"], (_, v) => v.import("cssForTheme", _));
   return main;
-}
-</script>
+}</script>
 
 <script id="@tomlarkworthy/file-sync" 
   type="text/plain"
@@ -12979,231 +13210,232 @@ const _yqx7l8 = function _syncEnabled(notebookId,htl)
     return container;
 };
 const _xltqf6 = (G, _) => G.input(_);
-const _1mb10vh = function _disassemble(htl, directory, notebookId, manifestWriter, readFile, writeFile, syncableModules, exportModuleJS, hashSource, currentModules, runtime, probeDefine, tag, importShim, $0) {
-    const container = htl.html`<div>
+const _1nuhj4u = function _disassemble(htl,directory,notebookId,manifestWriter,readFile,writeFile,syncableModules,exportModuleJS,hashSource,currentModules,runtime,probeDefine,tag,$0)
+{
+  const container = htl.html`<div>
     <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
       <button class="disassemble" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Disassemble to disk</button>
       <button class="sync" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Sync from disk</button>
     </div>
     <pre style="font-size: 12px; max-height: 300px; overflow-y: auto; margin-top: 8px;"></pre>
   </div>`;
-    const disBtn = container.querySelector('.disassemble');
-    const syncBtn = container.querySelector('.sync');
-    const status = container.querySelector('pre');
-    if (directory) {
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
+  const disBtn = container.querySelector('.disassemble');
+  const syncBtn = container.querySelector('.sync');
+  const status = container.querySelector('pre');
+  if (directory) {
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  }
+  const log = msg => {
+    status.textContent += msg + '\n';
+    status.scrollTop = status.scrollHeight;
+  };
+  const prefix = notebookId + '/';
+  disBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    disBtn.textContent = 'Disassembling...';
+    let ok = 0, fail = 0;
+    const manifestUpdates = {};
+    await manifestWriter(directory, prefix, null, readFile, writeFile);
+    log('cleared manifest');
+    for (const moduleId of syncableModules) {
+      try {
+        log('Exporting ' + moduleId + '...');
+        const result = await exportModuleJS(moduleId);
+        const path = prefix + moduleId + '.js';
+        await writeFile(directory, path, result.source);
+        manifestUpdates[moduleId] = hashSource(result.source);
+        log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
+        if (result.fileAttachments && result.fileAttachments.size) {
+          for (const [name, entry] of result.fileAttachments) {
+            try {
+              const resp = await fetch(entry.url);
+              const bytes = await resp.arrayBuffer();
+              await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
+              log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
+            } catch (e) {
+              log('  attachment FAILED: ' + name + ' - ' + e.message);
+            }
+          }
+        }
+        ok++;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
     }
-    const log = msg => {
-        status.textContent += msg + '\n';
-        status.scrollTop = status.scrollHeight;
+    try {
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const bootconf = document.querySelector('script[id="bootconf.json"]');
+      if (bootconf) {
+        await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
+        log('wrote ' + prefix + 'bootconf.json');
+      }
+    } catch (e) {
+      log('bootconf.json FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
+    disBtn.textContent = 'Disassembled ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  syncBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    syncBtn.textContent = 'Syncing from disk...';
+    status.textContent = '';
+    const nameToModule = new window.Map();
+    const nameToVars = new window.Map();
+    for (const [mod, info] of currentModules) {
+      if (info.name === 'bootloader' || info.name === 'builtin')
+        continue;
+      if (!info.name.includes('/') && !info.name.startsWith('d/'))
+        continue;
+      nameToModule.set(info.name, info.module);
+      const vars = new window.Map();
+      for (const v of runtime._variables) {
+        if (v._module !== info.module)
+          continue;
+        if (v._name)
+          vars.set(v._name, v);
+        if (v.pid)
+          vars.set('__pid__' + v.pid, v);
+      }
+      nameToVars.set(info.name, vars);
+    }
+    const applyModule = (moduleId, defineFn) => {
+      const mod = nameToModule.get(moduleId);
+      if (!mod)
+        return;
+      const existingVars = nameToVars.get(moduleId) || new window.Map();
+      const cells = probeDefine(defineFn);
+      const seenPids = new Set();
+      for (const cell of cells) {
+        if (cell.type === 'import')
+          continue;
+        if (!cell.pid)
+          continue;
+        seenPids.add(cell.pid);
+        const existing = existingVars.get('__pid__' + cell.pid);
+        if (!existing) {
+          const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+          const v = mod.variable();
+          v.define(cell.name, cell.inputs, taggedDefn);
+          v.pid = cell.pid;
+          existingVars.set('__pid__' + cell.pid, v);
+          if (cell.name)
+            existingVars.set(cell.name, v);
+          continue;
+        }
+        if (existing._definition) {
+          const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
+          const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+          const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+          if (inputsMatch && defnMatch)
+            continue;
+        }
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      }
+      const ordered = [];
+      for (const cell of cells) {
+        if (!cell.pid)
+          continue;
+        const v = existingVars.get('__pid__' + cell.pid);
+        if (v)
+          ordered.push(v);
+      }
+      if (ordered.length) {
+        const orderedSet = new Set(ordered);
+        const arr = [...runtime._variables];
+        let oi = 0;
+        for (let i = 0; i < arr.length; i++) {
+          if (orderedSet.has(arr[i]))
+            arr[i] = ordered[oi++];
+        }
+        while (oi < ordered.length)
+          arr.push(ordered[oi++]);
+        runtime._variables.clear();
+        for (const v of arr)
+          runtime._variables.add(v);
+      }
     };
-    const prefix = notebookId + '/';
-    disBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        disBtn.textContent = 'Disassembling...';
-        let ok = 0, fail = 0;
-        const manifestUpdates = {};
-        await manifestWriter(directory, prefix, null, readFile, writeFile);
-        log('cleared manifest');
-        for (const moduleId of syncableModules) {
+    const manifestUpdates = {};
+    let ok = 0, fail = 0;
+    for (const moduleId of syncableModules) {
+      try {
+        let file;
+        try {
+          file = await readFile(directory, prefix + moduleId + '.js');
+        } catch (e) {
+          file = null;
+        }
+        if (!file) {
+          log('  skip ' + moduleId + ' (no .js on disk)');
+          continue;
+        }
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const mod = await import(url);
+          if (typeof mod.default === 'function') {
+            applyModule(moduleId, mod.default);
+            log('  applied ' + moduleId);
             try {
-                log('Exporting ' + moduleId + '...');
-                const result = await exportModuleJS(moduleId);
-                const path = prefix + moduleId + '.js';
-                await writeFile(directory, path, result.source);
-                manifestUpdates[moduleId] = hashSource(result.source);
-                log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
-                if (result.fileAttachments && result.fileAttachments.size) {
-                    for (const [name, entry] of result.fileAttachments) {
-                        try {
-                            const resp = await fetch(entry.url);
-                            const bytes = await resp.arrayBuffer();
-                            await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
-                            log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
-                        } catch (e) {
-                            log('  attachment FAILED: ' + name + ' - ' + e.message);
-                        }
-                    }
-                }
-                ok++;
+              const after = await exportModuleJS(moduleId);
+              manifestUpdates[moduleId] = hashSource(after.source);
             } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
+              manifestUpdates[moduleId] = hashSource(diskText);
             }
+            ok++;
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
         }
-        try {
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const bootconf = document.querySelector('script[id="bootconf.json"]');
-            if (bootconf) {
-                await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
-                log('wrote ' + prefix + 'bootconf.json');
-            }
-        } catch (e) {
-            log('bootconf.json FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
-        disBtn.textContent = 'Disassembled ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    syncBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        syncBtn.textContent = 'Syncing from disk...';
-        status.textContent = '';
-        const nameToModule = new window.Map();
-        const nameToVars = new window.Map();
-        for (const [mod, info] of currentModules) {
-            if (info.name === 'bootloader' || info.name === 'builtin')
-                continue;
-            if (!info.name.includes('/') && !info.name.startsWith('d/'))
-                continue;
-            nameToModule.set(info.name, info.module);
-            const vars = new window.Map();
-            for (const v of runtime._variables) {
-                if (v._module !== info.module)
-                    continue;
-                if (v._name)
-                    vars.set(v._name, v);
-                if (v.pid)
-                    vars.set('__pid__' + v.pid, v);
-            }
-            nameToVars.set(info.name, vars);
-        }
-        const applyModule = (moduleId, defineFn) => {
-            const mod = nameToModule.get(moduleId);
-            if (!mod)
-                return;
-            const existingVars = nameToVars.get(moduleId) || new window.Map();
-            const cells = probeDefine(defineFn);
-            const seenPids = new Set();
-            for (const cell of cells) {
-                if (cell.type === 'import')
-                    continue;
-                if (!cell.pid)
-                    continue;
-                seenPids.add(cell.pid);
-                const existing = existingVars.get('__pid__' + cell.pid);
-                if (!existing) {
-                    const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                    const v = mod.variable();
-                    v.define(cell.name, cell.inputs, taggedDefn);
-                    v.pid = cell.pid;
-                    existingVars.set('__pid__' + cell.pid, v);
-                    if (cell.name)
-                        existingVars.set(cell.name, v);
-                    continue;
-                }
-                if (existing._definition) {
-                    const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
-                    const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                    const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                    if (inputsMatch && defnMatch)
-                        continue;
-                }
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            }
-            const ordered = [];
-            for (const cell of cells) {
-                if (!cell.pid)
-                    continue;
-                const v = existingVars.get('__pid__' + cell.pid);
-                if (v)
-                    ordered.push(v);
-            }
-            if (ordered.length) {
-                const orderedSet = new Set(ordered);
-                const arr = [...runtime._variables];
-                let oi = 0;
-                for (let i = 0; i < arr.length; i++) {
-                    if (orderedSet.has(arr[i]))
-                        arr[i] = ordered[oi++];
-                }
-                while (oi < ordered.length)
-                    arr.push(ordered[oi++]);
-                runtime._variables.clear();
-                for (const v of arr)
-                    runtime._variables.add(v);
-            }
-        };
-        const manifestUpdates = {};
-        let ok = 0, fail = 0;
-        for (const moduleId of syncableModules) {
-            try {
-                let file;
-                try {
-                    file = await readFile(directory, prefix + moduleId + '.js');
-                } catch (e) {
-                    file = null;
-                }
-                if (!file) {
-                    log('  skip ' + moduleId + ' (no .js on disk)');
-                    continue;
-                }
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
-                try {
-                    const mod = await import(url);
-                    if (typeof mod.default === 'function') {
-                        applyModule(moduleId, mod.default);
-                        log('  applied ' + moduleId);
-                        try {
-                            const after = await exportModuleJS(moduleId);
-                            manifestUpdates[moduleId] = hashSource(after.source);
-                        } catch (e) {
-                            manifestUpdates[moduleId] = hashSource(diskText);
-                        }
-                        ok++;
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
-            }
-        }
-        try {
-            await manifestWriter(directory, prefix, null, readFile, writeFile);
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const view = $0;
-            const cb = view && view.querySelector ? view.querySelector('input') : null;
-            if (cb && !cb.checked) {
-                cb.checked = true;
-                view.value = true;
-                view.dispatchEvent(new window.Event('input', { bubbles: true }));
-                log('enabled Sync toggle');
-            } else if (cb && cb.checked) {
-                log('Sync toggle already enabled');
-            }
-        } catch (e) {
-            log('toggle enable FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
-        syncBtn.textContent = 'Synced ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    container.value = undefined;
-    return container;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
+    }
+    try {
+      await manifestWriter(directory, prefix, null, readFile, writeFile);
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const view = $0;
+      const cb = view && view.querySelector ? view.querySelector('input') : null;
+      if (cb && !cb.checked) {
+        cb.checked = true;
+        view.value = true;
+        view.dispatchEvent(new window.Event('input', { bubbles: true }));
+        log('enabled Sync toggle');
+      } else if (cb && cb.checked) {
+        log('Sync toggle already enabled');
+      }
+    } catch (e) {
+      log('toggle enable FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
+    syncBtn.textContent = 'Synced ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  container.value = undefined;
+  return container;
 };
 const _eoa5ga = (G, _) => G.input(_);
 const _1jyon1g = function _syncStatus(htl,directory,syncableModules,notebookToFiles,filesToNotebook){return(
@@ -13569,341 +13801,342 @@ const _1bf1rb4 = function _fileSyncLastSeen(directory)
     void directory;
     return new window.Map();
 };
-const _43mwl9 = function _filesToNotebook(directory, syncArmed, currentModules, fileSyncLastSeen, notebookId, runtime, probeDefine, tag, readFile, exportModuleJS, manifestWriter, hashSource, writeFile, getFileAttachmentsMap, invalidation) {
-    if (!directory)
-        return 'Waiting for directory...';
-    if (!syncArmed || !syncArmed.armed)
-        return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
-    const SKIP = new Set([
-        'bootloader',
-        'builtin'
-    ]);
-    const syncableModules = [];
-    for (const [mod, info] of currentModules) {
-        if (SKIP.has(info.name))
-            continue;
-        if (!info.name.includes('/') && !info.name.startsWith('d/'))
-            continue;
-        syncableModules.push(info.name);
+const _19e6n4y = function _filesToNotebook(directory,syncArmed,currentModules,fileSyncLastSeen,notebookId,runtime,probeDefine,tag,readFile,exportModuleJS,importShim,manifestWriter,hashSource,writeFile,getFileAttachmentsMap,invalidation)
+{
+  if (!directory)
+    return 'Waiting for directory...';
+  if (!syncArmed || !syncArmed.armed)
+    return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
+  const SKIP = new Set([
+    'bootloader',
+    'builtin'
+  ]);
+  const syncableModules = [];
+  for (const [mod, info] of currentModules) {
+    if (SKIP.has(info.name))
+      continue;
+    if (!info.name.includes('/') && !info.name.startsWith('d/'))
+      continue;
+    syncableModules.push(info.name);
+  }
+  const syncableSet = new Set(syncableModules);
+  const lastSeen = fileSyncLastSeen;
+  const POLL_MS = 1000;
+  const prefix = notebookId + '/';
+  const nameToModule = new window.Map();
+  const nameToVars = new window.Map();
+  for (const [mod, info] of currentModules) {
+    if (!syncableSet.has(info.name))
+      continue;
+    nameToModule.set(info.name, info.module);
+    const vars = new window.Map();
+    for (const v of runtime._variables) {
+      if (v._module !== info.module)
+        continue;
+      if (v._name)
+        vars.set(v._name, v);
+      if (v.pid)
+        vars.set('__pid__' + v.pid, v);
     }
-    const syncableSet = new Set(syncableModules);
-    const lastSeen = fileSyncLastSeen;
-    const POLL_MS = 1000;
-    const prefix = notebookId + '/';
-    const nameToModule = new window.Map();
-    const nameToVars = new window.Map();
-    for (const [mod, info] of currentModules) {
-        if (!syncableSet.has(info.name))
-            continue;
-        nameToModule.set(info.name, info.module);
-        const vars = new window.Map();
-        for (const v of runtime._variables) {
-            if (v._module !== info.module)
-                continue;
-            if (v._name)
-                vars.set(v._name, v);
-            if (v.pid)
-                vars.set('__pid__' + v.pid, v);
-        }
-        nameToVars.set(info.name, vars);
+    nameToVars.set(info.name, vars);
+  }
+  let pollTimer;
+  const knownFilePids = new window.Map();
+  let knownDiskModules = null;
+  const getModuleFA = mod => {
+    for (const v of runtime._variables) {
+      if (v._module === mod && v._name === 'FileAttachment' && v._value)
+        return v._value;
     }
-    let pollTimer;
-    const knownFilePids = new window.Map();
-    let knownDiskModules = null;
-    const getModuleFA = mod => {
-        for (const v of runtime._variables) {
-            if (v._module === mod && v._name === 'FileAttachment' && v._value)
-                return v._value;
-        }
-        return null;
-    };
-    const getSubDir = async (dirHandle, path) => {
-        let current = dirHandle;
-        for (const part of path.split('/').filter(Boolean)) {
-            current = await current.getDirectoryHandle(part);
-        }
-        return current;
-    };
-    const applyModule = (moduleId, defineFn) => {
-        const mod = nameToModule.get(moduleId);
-        if (!mod)
-            return;
-        const existingVars = nameToVars.get(moduleId) || new window.Map();
-        const cells = probeDefine(defineFn);
-        let redefinedSelf = false;
-        const seenPids = new Set();
-        for (const cell of cells) {
-            if (cell.type === 'import')
-                continue;
-            if (!cell.pid)
-                continue;
-            seenPids.add(cell.pid);
-            const existing = existingVars.get('__pid__' + cell.pid);
-            if (!existing) {
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                const v = mod.variable();
-                v.define(cell.name, cell.inputs, taggedDefn);
-                v.pid = cell.pid;
-                existingVars.set('__pid__' + cell.pid, v);
-                if (cell.name)
-                    existingVars.set(cell.name, v);
-                console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
-                continue;
-            }
-            if (existing._definition) {
-                const existingInputNames = existing._inputs.map(function (v) {
-                    return typeof v === 'string' ? v : v._name;
-                });
-                const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                if (inputsMatch && defnMatch)
-                    continue;
-            }
-            const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-            existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
-                redefinedSelf = true;
-            }
-        }
-        const prevKnown = knownFilePids.get(moduleId);
-        if (prevKnown) {
-            for (const pid of prevKnown) {
-                if (seenPids.has(pid))
-                    continue;
-                const v = existingVars.get('__pid__' + pid);
-                if (!v)
-                    continue;
-                console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
-                v.delete();
-                existingVars.delete('__pid__' + pid);
-                if (v._name)
-                    existingVars.delete(v._name);
-            }
-        }
-        knownFilePids.set(moduleId, seenPids);
-        const ordered = [];
-        for (const cell of cells) {
-            if (!cell.pid)
-                continue;
-            const v = existingVars.get('__pid__' + cell.pid);
-            if (v)
-                ordered.push(v);
-        }
-        if (ordered.length) {
-            const orderedSet = new Set(ordered);
-            const arr = [...runtime._variables];
-            let oi = 0;
-            for (let i = 0; i < arr.length; i++) {
-                if (orderedSet.has(arr[i]))
-                    arr[i] = ordered[oi++];
-            }
-            while (oi < ordered.length)
-                arr.push(ordered[oi++]);
-            runtime._variables.clear();
-            for (const v of arr)
-                runtime._variables.add(v);
-        }
-        if (redefinedSelf) {
-            clearInterval(pollTimer);
-            console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
-        }
-    };
-    const pollModule = async moduleId => {
-        try {
-            let file;
+    return null;
+  };
+  const getSubDir = async (dirHandle, path) => {
+    let current = dirHandle;
+    for (const part of path.split('/').filter(Boolean)) {
+      current = await current.getDirectoryHandle(part);
+    }
+    return current;
+  };
+  const applyModule = (moduleId, defineFn) => {
+    const mod = nameToModule.get(moduleId);
+    if (!mod)
+      return;
+    const existingVars = nameToVars.get(moduleId) || new window.Map();
+    const cells = probeDefine(defineFn);
+    let redefinedSelf = false;
+    const seenPids = new Set();
+    for (const cell of cells) {
+      if (cell.type === 'import')
+        continue;
+      if (!cell.pid)
+        continue;
+      seenPids.add(cell.pid);
+      const existing = existingVars.get('__pid__' + cell.pid);
+      if (!existing) {
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        const v = mod.variable();
+        v.define(cell.name, cell.inputs, taggedDefn);
+        v.pid = cell.pid;
+        existingVars.set('__pid__' + cell.pid, v);
+        if (cell.name)
+          existingVars.set(cell.name, v);
+        console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
+        continue;
+      }
+      if (existing._definition) {
+        const existingInputNames = existing._inputs.map(function (v) {
+          return typeof v === 'string' ? v : v._name;
+        });
+        const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+        const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+        if (inputsMatch && defnMatch)
+          continue;
+      }
+      const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+      existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
+        redefinedSelf = true;
+      }
+    }
+    const prevKnown = knownFilePids.get(moduleId);
+    if (prevKnown) {
+      for (const pid of prevKnown) {
+        if (seenPids.has(pid))
+          continue;
+        const v = existingVars.get('__pid__' + pid);
+        if (!v)
+          continue;
+        console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
+        v.delete();
+        existingVars.delete('__pid__' + pid);
+        if (v._name)
+          existingVars.delete(v._name);
+      }
+    }
+    knownFilePids.set(moduleId, seenPids);
+    const ordered = [];
+    for (const cell of cells) {
+      if (!cell.pid)
+        continue;
+      const v = existingVars.get('__pid__' + cell.pid);
+      if (v)
+        ordered.push(v);
+    }
+    if (ordered.length) {
+      const orderedSet = new Set(ordered);
+      const arr = [...runtime._variables];
+      let oi = 0;
+      for (let i = 0; i < arr.length; i++) {
+        if (orderedSet.has(arr[i]))
+          arr[i] = ordered[oi++];
+      }
+      while (oi < ordered.length)
+        arr.push(ordered[oi++]);
+      runtime._variables.clear();
+      for (const v of arr)
+        runtime._variables.add(v);
+    }
+    if (redefinedSelf) {
+      clearInterval(pollTimer);
+      console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
+    }
+  };
+  const pollModule = async moduleId => {
+    try {
+      let file;
+      try {
+        file = await readFile(directory, prefix + moduleId + '.js');
+      } catch (e) {
+        file = null;
+      }
+      if (file) {
+        const prev = lastSeen.get(moduleId);
+        const changed = !prev || file.lastModified !== prev.lastModified;
+        if (changed) {
+          lastSeen.set(moduleId, { lastModified: file.lastModified });
+          const diskText = await file.text();
+          let needsApply = true;
+          try {
+            const runtimeResult = await exportModuleJS(moduleId);
+            if (runtimeResult.source === diskText)
+              needsApply = false;
+          } catch (e) {
+          }
+          if (needsApply) {
+            const blob = new window.Blob([diskText], { type: 'text/javascript' });
+            const url = window.URL.createObjectURL(blob);
             try {
-                file = await readFile(directory, prefix + moduleId + '.js');
-            } catch (e) {
-                file = null;
-            }
-            if (file) {
-                const prev = lastSeen.get(moduleId);
-                const changed = !prev || file.lastModified !== prev.lastModified;
-                if (changed) {
-                    lastSeen.set(moduleId, { lastModified: file.lastModified });
-                    const diskText = await file.text();
-                    let needsApply = true;
-                    try {
-                        const runtimeResult = await exportModuleJS(moduleId);
-                        if (runtimeResult.source === diskText)
-                            needsApply = false;
-                    } catch (e) {
-                    }
-                    if (needsApply) {
-                        const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                        const url = window.URL.createObjectURL(blob);
-                        try {
-                            const mod = await window.importShim(url, 'file://@tomlarkworthy/file-sync');
-                            if (typeof mod.default === 'function') {
-                                applyModule(moduleId, mod.default);
-                                console.log('[file-sync] applied ' + moduleId + ' from disk');
-                                try {
-                                    const after = await exportModuleJS(moduleId);
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
-                                } catch (e) {
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                                }
-                            }
-                        } finally {
-                            window.URL.revokeObjectURL(url);
-                        }
-                    }
-                }
-            }
-        } catch (e) {
-            console.error('[file-sync] poll error for ' + moduleId + ':', e);
-        }
-        try {
-            const attachDir = await getSubDir(directory, prefix + moduleId);
-            const mod = nameToModule.get(moduleId);
-            const FA = mod ? getModuleFA(mod) : null;
-            const faMap = FA ? getFileAttachmentsMap(FA) : null;
-            if (faMap) {
-                for (const key of [...faMap.keys()]) {
-                    if (key.endsWith('.crswap') || key.startsWith('.'))
-                        faMap.delete(key);
-                }
-            }
-            for await (const [name, handle] of attachDir) {
-                if (handle.kind !== 'file')
-                    continue;
-                if (name.endsWith('.crswap') || name.startsWith('.'))
-                    continue;
-                const file = await handle.getFile();
-                const attKey = '__att__' + moduleId + '/' + name;
-                const prevA = lastSeen.get(attKey);
-                if (prevA && file.lastModified === prevA.lastModified)
-                    continue;
-                lastSeen.set(attKey, { lastModified: file.lastModified });
-                const bytes = new Uint8Array(await file.arrayBuffer());
-                const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
-                const blobUrl = window.URL.createObjectURL(blob);
-                if (faMap) {
-                    faMap.set(name, {
-                        url: blobUrl,
-                        mimeType: file.type || 'application/octet-stream'
-                    });
-                    console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
-                }
-                const scriptId = moduleId + '/' + encodeURIComponent(name);
-                const script = document.getElementById(scriptId);
-                if (script) {
-                    const b64 = btoa(String.fromCharCode.apply(null, bytes));
-                    script.textContent = b64;
-                    script.setAttribute('data-encoding', 'base64');
-                    script.setAttribute('data-mime', file.type || 'application/octet-stream');
-                }
-            }
-        } catch (e) {
-            if (e.name !== 'NotFoundError')
-                console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
-        }
-    };
-    const scanDiskModules = async () => {
-        const diskModules = new Set();
-        try {
-            const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
-            for await (const [orgName, orgHandle] of notebookDir) {
-                if (orgHandle.kind !== 'directory')
-                    continue;
-                if (orgName.startsWith('@')) {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add(orgName + '/' + fname.slice(0, -3));
-                    }
-                } else if (orgName === 'd') {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add('d/' + fname.slice(0, -3));
-                    }
-                }
-            }
-        } catch (e) {
-        }
-        return diskModules;
-    };
-    const poll = async () => {
-        for (const moduleId of syncableModules)
-            await pollModule(moduleId);
-        const diskModules = await scanDiskModules();
-        const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
-        if (newOnDisk.length)
-            console.log('[file-sync] new modules on disk:', newOnDisk);
-        for (const moduleId of diskModules) {
-            if (syncableSet.has(moduleId))
-                continue;
-            if (nameToModule.has(moduleId))
-                continue;
-            try {
-                const file = await readFile(directory, prefix + moduleId + '.js');
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
+              const mod = await import(url);
+              if (typeof mod.default === 'function') {
+                applyModule(moduleId, mod.default);
+                console.log('[file-sync] applied ' + moduleId + ' from disk');
                 try {
-                    const imported = await window.importShim(url, 'file://@tomlarkworthy/file-sync');
-                    if (typeof imported.default === 'function') {
-                        const newMod = runtime.module(imported.default, () => null);
-                        runtime.mains.set(moduleId, newMod);
-                        nameToModule.set(moduleId, newMod);
-                        syncableModules.push(moduleId);
-                        syncableSet.add(moduleId);
-                        const vars = new window.Map();
-                        for (const v of runtime._variables) {
-                            if (v._module !== newMod)
-                                continue;
-                            if (v._name)
-                                vars.set(v._name, v);
-                            if (v.pid)
-                                vars.set('__pid__' + v.pid, v);
-                        }
-                        nameToVars.set(moduleId, vars);
-                        console.log('[file-sync] added new module from disk: ' + moduleId);
-                        try {
-                            await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                        } catch (e) {
-                            console.error('[file-sync] manifest update for new module failed:', e);
-                        }
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                console.error('[file-sync] failed to add module ' + moduleId + ':', e);
-            }
-        }
-        if (knownDiskModules) {
-            for (const moduleId of knownDiskModules) {
-                if (diskModules.has(moduleId))
-                    continue;
-                if (!nameToModule.has(moduleId))
-                    continue;
-                const mod = nameToModule.get(moduleId);
-                for (const v of [...runtime._variables]) {
-                    if (v._module === mod)
-                        v.delete();
-                }
-                runtime.mains.delete(moduleId);
-                nameToModule.delete(moduleId);
-                nameToVars.delete(moduleId);
-                knownFilePids.delete(moduleId);
-                const idx = syncableModules.indexOf(moduleId);
-                if (idx !== -1)
-                    syncableModules.splice(idx, 1);
-                syncableSet.delete(moduleId);
-                console.log('[file-sync] removed module: ' + moduleId);
-                try {
-                    await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+                  const after = await exportModuleJS(moduleId);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
                 } catch (e) {
-                    console.error('[file-sync] manifest remove failed:', e);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
                 }
+              }
+            } finally {
+              window.URL.revokeObjectURL(url);
             }
+          }
         }
-        knownDiskModules = diskModules;
-    };
-    pollTimer = setInterval(poll, POLL_MS);
-    poll();
-    invalidation.then(() => clearInterval(pollTimer));
-    return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
+      }
+    } catch (e) {
+      console.error('[file-sync] poll error for ' + moduleId + ':', e);
+    }
+    try {
+      const attachDir = await getSubDir(directory, prefix + moduleId);
+      const mod = nameToModule.get(moduleId);
+      const FA = mod ? getModuleFA(mod) : null;
+      const faMap = FA ? getFileAttachmentsMap(FA) : null;
+      if (faMap) {
+        for (const key of [...faMap.keys()]) {
+          if (key.endsWith('.crswap') || key.startsWith('.'))
+            faMap.delete(key);
+        }
+      }
+      for await (const [name, handle] of attachDir) {
+        if (handle.kind !== 'file')
+          continue;
+        if (name.endsWith('.crswap') || name.startsWith('.'))
+          continue;
+        const file = await handle.getFile();
+        const attKey = '__att__' + moduleId + '/' + name;
+        const prevA = lastSeen.get(attKey);
+        if (prevA && file.lastModified === prevA.lastModified)
+          continue;
+        lastSeen.set(attKey, { lastModified: file.lastModified });
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
+        const blobUrl = window.URL.createObjectURL(blob);
+        if (faMap) {
+          faMap.set(name, {
+            url: blobUrl,
+            mimeType: file.type || 'application/octet-stream'
+          });
+          console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
+        }
+        const scriptId = moduleId + '/' + encodeURIComponent(name);
+        const script = document.getElementById(scriptId);
+        if (script) {
+          const b64 = btoa(String.fromCharCode.apply(null, bytes));
+          script.textContent = b64;
+          script.setAttribute('data-encoding', 'base64');
+          script.setAttribute('data-mime', file.type || 'application/octet-stream');
+        }
+      }
+    } catch (e) {
+      if (e.name !== 'NotFoundError')
+        console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
+    }
+  };
+  const scanDiskModules = async () => {
+    const diskModules = new Set();
+    try {
+      const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
+      for await (const [orgName, orgHandle] of notebookDir) {
+        if (orgHandle.kind !== 'directory')
+          continue;
+        if (orgName.startsWith('@')) {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add(orgName + '/' + fname.slice(0, -3));
+          }
+        } else if (orgName === 'd') {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add('d/' + fname.slice(0, -3));
+          }
+        }
+      }
+    } catch (e) {
+    }
+    return diskModules;
+  };
+  const poll = async () => {
+    for (const moduleId of syncableModules)
+      await pollModule(moduleId);
+    const diskModules = await scanDiskModules();
+    const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
+    if (newOnDisk.length)
+      console.log('[file-sync] new modules on disk:', newOnDisk);
+    for (const moduleId of diskModules) {
+      if (syncableSet.has(moduleId))
+        continue;
+      if (nameToModule.has(moduleId))
+        continue;
+      try {
+        const file = await readFile(directory, prefix + moduleId + '.js');
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const imported = await import(url);
+          if (typeof imported.default === 'function') {
+            const newMod = runtime.module(imported.default, () => null);
+            runtime.mains.set(moduleId, newMod);
+            nameToModule.set(moduleId, newMod);
+            syncableModules.push(moduleId);
+            syncableSet.add(moduleId);
+            const vars = new window.Map();
+            for (const v of runtime._variables) {
+              if (v._module !== newMod)
+                continue;
+              if (v._name)
+                vars.set(v._name, v);
+              if (v.pid)
+                vars.set('__pid__' + v.pid, v);
+            }
+            nameToVars.set(moduleId, vars);
+            console.log('[file-sync] added new module from disk: ' + moduleId);
+            try {
+              await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
+            } catch (e) {
+              console.error('[file-sync] manifest update for new module failed:', e);
+            }
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
+        }
+      } catch (e) {
+        console.error('[file-sync] failed to add module ' + moduleId + ':', e);
+      }
+    }
+    if (knownDiskModules) {
+      for (const moduleId of knownDiskModules) {
+        if (diskModules.has(moduleId))
+          continue;
+        if (!nameToModule.has(moduleId))
+          continue;
+        const mod = nameToModule.get(moduleId);
+        for (const v of [...runtime._variables]) {
+          if (v._module === mod)
+            v.delete();
+        }
+        runtime.mains.delete(moduleId);
+        nameToModule.delete(moduleId);
+        nameToVars.delete(moduleId);
+        knownFilePids.delete(moduleId);
+        const idx = syncableModules.indexOf(moduleId);
+        if (idx !== -1)
+          syncableModules.splice(idx, 1);
+        syncableSet.delete(moduleId);
+        console.log('[file-sync] removed module: ' + moduleId);
+        try {
+          await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+        } catch (e) {
+          console.error('[file-sync] manifest remove failed:', e);
+        }
+      }
+    }
+    knownDiskModules = diskModules;
+  };
+  pollTimer = setInterval(poll, POLL_MS);
+  poll();
+  invalidation.then(() => clearInterval(pollTimer));
+  return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
 };
 const _1b4kluo = function _21(md){return(
 md`## How It Works
@@ -13952,6 +14185,238 @@ md`## TODO
 - **Import cell validation**: verify import bridges survive round-trip correctly
 - **Conflict resolution**: when both disk and runtime edit the same cell simultaneously, detect and surface the conflict instead of last-write-wins`
 )};
+const _qq3v7b = function _jbApply(importShim)
+{
+  // Pure factory so any notebook can reuse it over its own runtime/fs. Build with
+  // jbApply({ currentModules, runtime, probeDefine, createModule, obj_observer }) -> applyModule(moduleId, defineFn).
+  // The file is canonical: applyModule makes the live module MATCH the file — creating/updating user
+  // cells, wiring cross-module imports, and DELETING anything live the file no longer contains.
+  //
+  // Import plumbing is NOT skipped — it is HOW a cross-module import reaches the runtime, so the agent
+  // can add imports by editing the file. exportModuleJS emits each import as a pair:
+  //   main.define("module @x", () => <child module>)                                  // loader
+  //   main.define("name", ["module @x","@variable"], (_,v)=>v.import("remote",_))      // binding
+  // The loader's original definition closes over the file's throwaway probe-runtime, so we REBUILD it
+  // against the real runtime (resolve the already-loaded child module by id, else importShim its path).
+  // The binding references only its inputs, so its definition is reused verbatim.
+  //
+  // Anonymous cells (name == null: md headers, expression/display cells) are the MAJORITY of a notebook
+  // and ARE editable — matched by pid, never skipped.
+  let pidSeq = 0;
+  const genPid = () => '_jb' + (pidSeq++).toString(36) + Math.floor(Math.random() * 1000000).toString(36);
+  const hasVarInput = inputs => (inputs || []).some(iv => (typeof iv === 'string' ? iv : iv && iv._name) === '@variable');
+  const importPath = defn => {
+    const m = (defn ? defn.toString() : '').match(/import\(\s*["'`]([^"'`]+)["'`]/);
+    return m ? m[1] : null;
+  };
+  return function makeApply({currentModules, runtime, probeDefine, createModule, obj_observer} = {}) {
+    const resolveModule = moduleId => {
+      if (currentModules)
+        for (const [, info] of currentModules)
+          if (info.name === moduleId)
+            return info.module;
+      const r = runtime;
+      if (r.mains && r.mains.has(moduleId))
+        return r.mains.get(moduleId);
+      if (typeof createModule === 'function') {
+        try {
+          return createModule(moduleId, r);
+        } catch (e) {
+          return null;
+        }
+      }
+      return null;
+    };
+    // Observer factory for newly-created user cells. obj_observer (from runtime-sdk) is the runtime's
+    // __ojs_observer builtin (name => observerObject); fall back to the builtin scope. Kept available for
+    // F6, but the default below stays {} — see the new-cell branch.
+    const obsFactory = (() => {
+      if (typeof obj_observer === 'function')
+        return obj_observer;
+      try {
+        const f = runtime && runtime._builtin && runtime._builtin._scope.get('__ojs_observer');
+        return f && typeof f._value === 'function' ? f._value : null;
+      } catch (e) {
+        return null;
+      }
+    })();
+    return function applyModule(moduleId, defineFn) {
+      const mod = resolveModule(moduleId);
+      if (!mod)
+        return {
+          applied: false,
+          reason: 'module not loaded and cannot create: ' + moduleId
+        };
+      const existingByName = new Map();
+      const existingByPid = new Map();
+      for (const v of runtime._variables) {
+        if (v._module !== mod)
+          continue;
+        if (v._name)
+          existingByName.set(v._name, v);
+        if (v.pid)
+          existingByPid.set(v.pid, v);
+      }
+      const cells = probeDefine(defineFn);
+      const seenPids = new Set();
+      const seenNames = new Set();
+      // import plumbing tracked by name (loaders/bindings carry no pid)
+      let changes = 0;
+      for (const cell of cells) {
+        // injected builtin — the runtime provides it; never (re)define
+        if (cell.name === '@variable')
+          continue;
+        // F7 (rc5): plumbing is UPSERTED, not create-only. Create-only meant a once-broken import
+        // (wrong inputs, bad path) could never be FIXED by editing the file — the corrected loader/
+        // binding was skipped with "0 cells changed" and the module stayed wedged (observed: an agent
+        // wrote a binding missing "@variable", then spiralled for 35 steps because its fix never
+        // applied). Loaders carry a semantic _jbKey ('live:'/'path:' + target) because their installed
+        // definition is locally rebuilt (toString comparison is meaningless); loaders from the module's
+        // ORIGINAL define (no _jbKey) are left untouched to avoid recompute churn. Bindings compare
+        // inputs + definition like ordinary cells (their definitions are closure-safe file text).
+        const upsertLoader = (loaderName, defn) => {
+          seenNames.add(loaderName);
+          const spec = loaderName.slice('module '.length);
+          const child = resolveModule(spec);
+          const path = importPath(defn);
+          const key = child ? 'live:' + spec : path ? 'path:' + path : null;
+          if (key == null)
+            return;
+          const make = child ? () => child : async () => runtime.module((await import(path)).default);
+          const existing = existingByName.get(loaderName);
+          if (existing) {
+            if (existing._jbKey !== undefined && existing._jbKey !== key) {
+              existing.define(loaderName, [], make);
+              existing._jbKey = key;
+              changes++;
+            }
+            return;
+          }
+          const v = mod.variable(null);
+          v.define(loaderName, [], make);
+          v._jbKey = key;
+          existingByName.set(loaderName, v);
+          changes++;
+        };
+        const upsertBinding = (name, inputs, defn) => {
+          seenNames.add(name);
+          const existing = existingByName.get(name);
+          if (!existing) {
+            const v = mod.variable(null);
+            v.define(name, inputs, defn);
+            existingByName.set(name, v);
+            changes++;
+            return;
+          }
+          const existingInputNames = (existing._inputs || []).map(iv => typeof iv === 'string' ? iv : iv._name);
+          const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(inputs);
+          const defnMatch = existing._definition && existing._definition.toString() === (defn ? defn.toString() : '');
+          if (!(inputsMatch && defnMatch)) {
+            existing.define(name, inputs, defn);
+            changes++;
+          }
+        };
+        // explicit module.variable().import(remote, alias, from) form
+        if (cell.type === 'import') {
+          const spec = cell.from;
+          const child = spec && resolveModule(spec);
+          if (!child)
+            continue;
+          const loaderName = 'module ' + spec;
+          seenNames.add(loaderName);
+          if (!existingByName.has(loaderName)) {
+            const lv = mod.variable(null);
+            lv.define(loaderName, [], () => child);
+            lv._jbKey = 'live:' + spec;
+            existingByName.set(loaderName, lv);
+            changes++;
+          }
+          const alias = cell.alias || cell.remote;
+          upsertBinding(alias, [
+            loaderName,
+            '@variable'
+          ], (_, vv) => vv.import(cell.remote, _));
+          continue;
+        }
+        // import-loader plumbing: "module @x" — rebuild against the REAL runtime
+        if (cell.name && cell.name.startsWith('module ')) {
+          upsertLoader(cell.name, cell.definition);
+          continue;
+        }
+        // import-binding: inputs include "@variable" — definition is closure-safe, reuse verbatim
+        if (hasVarInput(cell.inputs)) {
+          if (cell.name)
+            upsertBinding(cell.name, cell.inputs, cell.definition);
+          continue;
+        }
+        // ordinary user cell — match by pid; mint one for pid-less hand-written cells so re-applies dedupe
+        let pid = cell.pid;
+        if (!pid) {
+          const byName = cell.name && existingByName.get(cell.name);
+          pid = byName && byName.pid || genPid();
+        }
+        seenPids.add(pid);
+        if (cell.name)
+          seenNames.add(cell.name);
+        const existing = existingByPid.get(pid) || cell.name && existingByName.get(cell.name);
+        if (!existing) {
+          // Empty observer ({}) so a pane's visualizer can render the cell; mod.variable(null)
+          // (unobserved) lets the apply-time probe own it → element parented outside any pane → blank.
+          const v = mod.variable({});
+          v.define(cell.name, cell.inputs, cell.definition);
+          v.pid = pid;
+          existingByPid.set(pid, v);
+          if (cell.name)
+            existingByName.set(cell.name, v);
+          changes++;
+          continue;
+        }
+        const existingInputNames = (existing._inputs || []).map(iv => typeof iv === 'string' ? iv : iv._name);
+        const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+        const defnMatch = existing._definition && existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+        if (inputsMatch && defnMatch) {
+          if (!existing.pid)
+            existing.pid = pid;
+          continue;
+        }
+        existing.define(cell.name, cell.inputs, cell.definition).pid = pid;
+        changes++;
+      }
+      // F4: prune anything the file no longer contains — reload-proof, no cross-call state.
+      //   user cells   → pid-bearing vars not seen this apply
+      //   import plumbing → "module @x" loaders / "@variable"-wired bindings whose name not seen
+      for (const v of [...runtime._variables]) {
+        if (v._module !== mod)
+          continue;
+        const name = v._name;
+        if (name === '@variable')
+          continue;
+        if (name && seenNames.has(name))
+          continue;
+        // present in file (user cell or import binding/loader) → keep, even if it acquired a pid via persistentId
+        // removed import plumbing ("module @x" loader, or a "@variable"-wired binding)
+        if (name && name.startsWith('module ') || hasVarInput(v._inputs)) {
+          if (name) {
+            v.delete();
+            changes++;
+          }
+          continue;
+        }
+        if (!v.pid || seenPids.has(v.pid))
+          continue;
+        // keep pid-less and still-present user cells
+        v.delete();
+        // orphaned user cell (removed / renamed)
+        changes++;
+      }
+      return {
+        applied: true,
+        moduleId,
+        changes
+      };
+    };
+  };
+};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -13969,7 +14434,7 @@ export default function define(runtime, observer) {
   $def("_jnt0bt", "directory", ["Generators","viewof directory"], _jnt0bt);  
   $def("_yqx7l8", "viewof syncEnabled", ["notebookId","htl"], _yqx7l8);  
   $def("_xltqf6", "syncEnabled", ["Generators","viewof syncEnabled"], _xltqf6);  
-  $def("_1mb10vh", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","importShim","viewof syncEnabled"], _1mb10vh);  
+  $def("_1nuhj4u", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","viewof syncEnabled"], _1nuhj4u);  
   $def("_eoa5ga", "disassemble", ["Generators","viewof disassemble"], _eoa5ga);  
   $def("_1jyon1g", "syncStatus", ["htl","directory","syncableModules","notebookToFiles","filesToNotebook"], _1jyon1g);  
   $def("_1dl3i63", null, ["md"], _1dl3i63);  
@@ -13986,7 +14451,7 @@ export default function define(runtime, observer) {
   $def("_1cy7bqk", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1cy7bqk);  
   $def("_3zm0bx", "notebookToFiles", ["directory","syncArmed","currentModules","notebookId","exportModuleJS","writeFile","manifestWriter","hashSource","readFile","onCodeChange","invalidation"], _3zm0bx);  
   $def("_1bf1rb4", "fileSyncLastSeen", ["directory"], _1bf1rb4);  
-  $def("_43mwl9", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _43mwl9);  
+  $def("_19e6n4y", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","importShim","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _19e6n4y);  
   $def("_1b4kluo", null, ["md"], _1b4kluo);  
   $def("_1h2nj16", null, ["md"], _1h2nj16);  
   main.define("viewof currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("viewof currentModules", _));  
@@ -13996,7 +14461,8 @@ export default function define(runtime, observer) {
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("importShim", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("importShim", _));  
   main.define("tag", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("tag", _));  
-  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));
+  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));  
+  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);
   return main;
 }</script>
 
@@ -14481,20 +14947,20 @@ const _1aloau2 = (G, _) => G.input(_);
 const _7s1qq7 = function _6($0,sqrt){return(
 $0.resolve(Math.sqrt(sqrt))
 )};
-const _3iwba4 = async function _testing(flowQueue) {
-    flowQueue;
-    const [{Runtime}, {default: define}] = await Promise.all([
-        import('https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js'),
-        import(`https://api.observablehq.com/@tomlarkworthy/testing.js?v=3`)
-    ]);
-    const module = new Runtime().module(define);
-    return Object.fromEntries(await Promise.all([
-        'expect',
-        'createSuite'
-    ].map(n => module.value(n).then(v => [
-        n,
-        v
-    ]))));
+const _3iwba4 = async function _testing(flowQueue)
+{
+  flowQueue;
+  // load after implementation
+  const [{ Runtime }, { default: define }] = await Promise.all([
+    import("https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js"),
+    import(`https://api.observablehq.com/@tomlarkworthy/testing.js?v=3`)
+  ]);
+  const module = new Runtime().module(define);
+  return Object.fromEntries(
+    await Promise.all(
+      ["expect", "createSuite"].map((n) => module.value(n).then((v) => [n, v]))
+    )
+  );
 };
 const _j8s3j1 = function _suite(testing){return(
 testing.createSuite({ name: 'Unit Tests' })
@@ -15136,14 +15602,18 @@ FileAttachment("lm_popin_black.png").url()
 const _18kpe1x = function _lm_popout_black(FileAttachment){return(
 FileAttachment("lm_popout_black.png").url()
 )};
-const _1p7i538 = async function _gl(unzip, FileAttachment) {
-    const blob = await unzip(FileAttachment('golden-layout-2.6.0.js.gz'));
-    const objectURL = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
-    try {
-        return await import(objectURL);
-    } finally {
-        URL.revokeObjectURL(objectURL);
-    }
+const _1p7i538 = async function _gl(unzip,FileAttachment)
+{
+  const blob = await unzip(FileAttachment("golden-layout-2.6.0.js.gz"));
+
+  const objectURL = URL.createObjectURL(
+    new Blob([blob], { type: "application/javascript" })
+  );
+  try {
+    return await import(objectURL);
+  } finally {
+    URL.revokeObjectURL(objectURL); // Ensure URL is revoked after import
+  }
 };
 const _17n6uge = function _unzip(Response,DecompressionStream){return(
 async (attachment) =>
@@ -15372,6 +15842,146 @@ export default function define(runtime, observer) {
   $def("_b5ui8y", "isnode", ["Element","Text"], _b5ui8y);
   return main;
 }</script>
+
+<script id="@tomlarkworthy/invoke-variable" 
+  type="text/plain"
+  data-mime="application/javascript"
+>
+const _zkje0r = function _1(md){return(
+md`# \`invokeVariable(<name>, <module>, overrides = {})\`
+
+Test individual variables by calling them with injected values. Lets you test different scenarios without changing your core logic. Pairs with [@tomlarkworthy/tester](https://observablehq.com/@tomlarkworthy/tester)`
+)};
+const _swiym2 = function _invokeVariable(lookupVariable)
+{
+  return async function invokeVariable(name, module, overrides = {}) {
+    if (overrides == null || typeof overrides !== 'object')
+      throw new TypeError('invokeVariable(name, module, {overrides}): overrides must be an object');
+    // Accept a Variable reference directly as the first arg (skip the lookupVariable stall when
+    // the caller already holds it); otherwise resolve by (name, module).
+    let variable;
+    if (name && typeof name === 'object' && typeof name._definition !== 'undefined') {
+      variable = name;
+      module = module ?? variable._module;
+    } else {
+      if (typeof name !== 'string' || !name.length)
+        throw new TypeError('invokeVariable(name, module, \u2026): name must be a non-empty string');
+      if (!module)
+        throw new TypeError('invokeVariable(name, module, \u2026): module is required');
+      variable = await lookupVariable(name, module);
+      if (!variable)
+        throw new Error(`invokeVariable: variable "${ name }" not found in module`);
+    }
+    module = module ?? variable._module;
+    const label = variable._name ?? (typeof name === 'string' ? name : '(anonymous)');
+    const inputs = Array.isArray(variable._inputs) ? variable._inputs : [];
+    const inputNames = inputs.map(v => v?._name);
+    for (const k of Object.keys(overrides)) {
+      if (!inputNames.includes(k)) {
+        throw new Error(`invokeVariable("${ label }"): override "${ k }" was provided but is not a declared dependency. Declared dependencies: ${ inputNames.filter(Boolean).join(', ') }`);
+      }
+    }
+    const hasOwn = (o, k) => Object.prototype.hasOwnProperty.call(o, k);
+    const resolveDependency = async depName => {
+      if (hasOwn(overrides, depName))
+        return overrides[depName];
+      const scopeVar = module?._scope?.get?.(depName) ?? module?._runtime?._builtin?._scope?.get?.(depName);
+      if (scopeVar) {
+        if (scopeVar._value !== undefined)
+          return scopeVar._value;
+        if (scopeVar._promise && typeof scopeVar._promise?.then === 'function')
+          return await scopeVar._promise;
+      }
+      if (typeof module?.value === 'function') {
+        try {
+          return await module.value(depName);
+        } catch (e) {
+        }
+      }
+      if (module?._runtime && typeof module._runtime._global === 'function') {
+        try {
+          const g = module._runtime._global(depName);
+          if (g !== undefined)
+            return g;
+        } catch (e) {
+        }
+      }
+      throw new Error(`invokeVariable("${ label }"): could not resolve dependency "${ depName }" (no override and not found in module/builtins/global)`);
+    };
+    const args = [];
+    for (const dep of inputs) {
+      const depName = dep?._name;
+      if (!depName) {
+        args.push(undefined);
+        continue;
+      }
+      args.push(await resolveDependency(depName));
+    }
+    const def = variable._definition;
+    if (typeof def !== 'function') {
+      throw new Error(`invokeVariable("${ label }"): target variable does not have an invokable function definition`);
+    }
+    return def(...args);
+  };
+};
+const _jtrr9m = function _3(md){return(
+md`### Example
+
+let c = a + b`
+)};
+const _1v2c0s1 = function _a(){return(
+1
+)};
+const _ywl8oh = function _b(){return(
+3
+)};
+const _1mc3tpl = function _c(a,b){return(
+a + b
+)};
+const _o5e50u = function _7(md){return(
+md`If we invoke c without any overrides we get the notebook behaviour (i.e. the answer is 4, as a is 1 and b is 3)`
+)};
+const _tnoyf9 = function _8(invokeVariable,invokeVariableModule){return(
+invokeVariable("c", invokeVariableModule)
+)};
+const _smh5by = function _9(md){return(
+md`But we can set b to 20, and then we get the answer 21.`
+)};
+const _d996jo = function _10(invokeVariable,invokeVariableModule){return(
+invokeVariable("c", invokeVariableModule, { b: 20 })
+)};
+const _qh0yhm = function _11(md){return(
+md`To call invokeVariable we need a reference to the module, which we can obtain with thisModule() (see runtime-sdk)`
+)};
+const _1hy0qcz = function _invokeVariableModule(thisModule){return(
+thisModule()
+)};
+const _jno7wc = (G, _) => G.input(_);
+
+export default function define(runtime, observer) {
+  const main = runtime.module();
+  const $def = (pid, name, deps, fn) => {
+    main.variable(observer(name)).define(name, deps, fn).pid = pid;
+  };
+
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  $def("_zkje0r", null, ["md"], _zkje0r);  
+  $def("_swiym2", "invokeVariable", ["lookupVariable"], _swiym2);  
+  $def("_jtrr9m", null, ["md"], _jtrr9m);  
+  $def("_1v2c0s1", "a", [], _1v2c0s1);  
+  $def("_ywl8oh", "b", [], _ywl8oh);  
+  $def("_1mc3tpl", "c", ["a","b"], _1mc3tpl);  
+  $def("_o5e50u", null, ["md"], _o5e50u);  
+  $def("_tnoyf9", null, ["invokeVariable","invokeVariableModule"], _tnoyf9);  
+  $def("_smh5by", null, ["md"], _smh5by);  
+  $def("_d996jo", null, ["invokeVariable","invokeVariableModule"], _d996jo);  
+  $def("_qh0yhm", null, ["md"], _qh0yhm);  
+  $def("_1hy0qcz", "viewof invokeVariableModule", ["thisModule"], _1hy0qcz);  
+  $def("_jno7wc", "invokeVariableModule", ["Generators","viewof invokeVariableModule"], _jno7wc);  
+  main.define("lookupVariable", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("lookupVariable", _));  
+  main.define("thisModule", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("thisModule", _));
+  return main;
+}</script>
 <script id="@tomlarkworthy/isomorphic-git-1-30-1/isomorphic-git-1%401.30.1.bundle.js.gz" 
   type="text/plain"
   data-encoding="base64"
@@ -15401,23 +16011,35 @@ import {git, http} from "@tomlarkworthy/isomorphic-git-1-30-1"
 import {FS} from "@tomlarkworthy/lightning-fs-4-6-0"
 ~~~`
 )};
-const _vz8us1 = async function _git(unzip, FileAttachment) {
-    const blob = await unzip(FileAttachment('isomorphic-git-1@1.30.1.bundle.js.gz'));
-    const objectURL = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
-    try {
-        return await import(objectURL);
-    } finally {
-        URL.revokeObjectURL(objectURL);
-    }
+const _vz8us1 = async function _git(unzip,FileAttachment)
+{
+  const blob = await unzip(
+    FileAttachment("isomorphic-git-1@1.30.1.bundle.js.gz")
+  );
+
+  const objectURL = URL.createObjectURL(
+    new Blob([blob], { type: "application/javascript" })
+  );
+  try {
+    return await import(objectURL);
+  } finally {
+    URL.revokeObjectURL(objectURL);
+  }
 };
-const _2acekr = async function _http(unzip, FileAttachment) {
-    const blob = await unzip(FileAttachment('isomorphic-git-http-1.0.0-beta.36.js.gz'));
-    const objectURL = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
-    try {
-        return await import(objectURL);
-    } finally {
-        URL.revokeObjectURL(objectURL);
-    }
+const _2acekr = async function _http(unzip,FileAttachment)
+{
+  const blob = await unzip(
+    FileAttachment("isomorphic-git-http-1.0.0-beta.36.js.gz")
+  );
+
+  const objectURL = URL.createObjectURL(
+    new Blob([blob], { type: "application/javascript" })
+  );
+  try {
+    return await import(objectURL);
+  } finally {
+    URL.revokeObjectURL(objectURL);
+  }
 };
 const _1emihnv = function _4(md){return(
 md`
@@ -15491,15 +16113,21 @@ md`# jest-expect-standalone@24.0.2
 import {expect} from "@tomlarkworthy/jest-expect-standalone"
 ~~~`
 )};
-const _mh1f13 = async function _expect(unzip, FileAttachment) {
-    const blob = await unzip(FileAttachment('jest-expect-standalone-24.0.2.js.gz'));
-    const objectURL = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
-    try {
-        await import(objectURL);
-        return window.expect;
-    } finally {
-        URL.revokeObjectURL(objectURL);
-    }
+const _mh1f13 = async function _expect(unzip,FileAttachment)
+{
+  const blob = await unzip(
+    FileAttachment("jest-expect-standalone-24.0.2.js.gz")
+  );
+
+  const objectURL = URL.createObjectURL(
+    new Blob([blob], { type: "application/javascript" })
+  );
+  try {
+    await import(objectURL);
+    return window.expect;
+  } finally {
+    URL.revokeObjectURL(objectURL);
+  }
 };
 const _17n6uge = function _unzip(Response,DecompressionStream){return(
 async (attachment) =>
@@ -15544,14 +16172,18 @@ md`# [jszip@3.10.1](https://stuk.github.io/jszip/)
 import {JSZip} from "@tomlarkworthy/jszip-3-10-1"
 ~~~`
 )};
-const _umavbe = async function _JSZip(unzip, FileAttachment) {
-    const blob = await unzip(FileAttachment('jszip-3.10.1.min.js.gz'));
-    const objectURL = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
-    try {
-        return (await import(objectURL)).default;
-    } finally {
-        URL.revokeObjectURL(objectURL);
-    }
+const _umavbe = async function _JSZip(unzip,FileAttachment)
+{
+  const blob = await unzip(FileAttachment("jszip-3.10.1.min.js.gz"));
+
+  const objectURL = URL.createObjectURL(
+    new Blob([blob], { type: "application/javascript" })
+  );
+  try {
+    return (await import(objectURL)).default;
+  } finally {
+    URL.revokeObjectURL(objectURL); // Ensure URL is revoked after import
+  }
 };
 const _g5fwfs = function _unzip(Response,DecompressionStream){return(
 async (attachment) => {
@@ -15603,14 +16235,18 @@ import {FS} from "@tomlarkworthy/lightning-fs-4-6-0"
 import {git, http} from "@tomlarkworthy/isomorphic-git-1-30-1" 
 ~~~`
 )};
-const _1tds3ro = async function _FS(unzip, FileAttachment) {
-    const blob = await unzip(FileAttachment('lightning-fs-4.6.0.js.gz'));
-    const objectURL = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
-    try {
-        return (await import(objectURL)).default;
-    } finally {
-        URL.revokeObjectURL(objectURL);
-    }
+const _1tds3ro = async function _FS(unzip,FileAttachment)
+{
+  const blob = await unzip(FileAttachment("lightning-fs-4.6.0.js.gz"));
+
+  const objectURL = URL.createObjectURL(
+    new Blob([blob], { type: "application/javascript" })
+  );
+  try {
+    return (await import(objectURL)).default;
+  } finally {
+    URL.revokeObjectURL(objectURL);
+  }
 };
 const _dqri64 = function _3(md){return(
 md`
@@ -16665,7 +17301,7 @@ async function listBranches({repo} = {}) {
   }
 }
 )};
-const _1bvisll = function _listFiles(ensure_branch,git,fs){return(
+const _bvp3oz = function _listFiles(ensure_branch,git,fs){return(
 async function listFiles({repo, branch, ref} = {}) {
   if (!repo)
     throw new Error('repo is required');
@@ -16684,7 +17320,6 @@ async function listFiles({repo, branch, ref} = {}) {
     });
   } catch (err) {
     console.error(err);
-    debugger;
     return [];
   }
 }
@@ -16842,91 +17477,105 @@ function read(def) {
 const _1l4hr6l = function _49(md){return(
 md`## History API Functions`
 )};
-const _zanj5n = function _revertVariables(getVariableByPersistentId,runtime,realize){return(
-async entries => {
-  const out = [];
-  for (const e of entries ?? []) {
-    const pid = e?.pid ?? null;
-    if (!pid)
-      continue;
-    const variable = getVariableByPersistentId(pid, runtime) || null;
-    if (!variable) {
-      out.push({
-        pid,
-        ok: false,
-        reason: 'no runtime variable'
-      });
-      continue;
-    }
-    const prev = e?.previous ?? null;
-    if (!prev) {
-      if (e?.op === 'new') {
-        try {
-          variable.delete?.();
-          out.push({
-            pid,
-            ok: true,
-            action: 'delete'
-          });
-        } catch (err) {
-          out.push({
-            pid,
-            ok: false,
-            action: 'delete',
-            reason: String(err?.message ?? err)
-          });
-        }
-      } else {
+const _1hhkam2 = function _revertVariables(getVariableByPersistentId,runtime,history,initial_state,realize)
+{
+  return async entries => {
+    const out = [];
+    // For each selected change, restore its variable to the state it had
+    // immediately BEFORE that change. Reconstructed from the history log +
+    // initial_state, since entries carry no `previous` field.
+    for (const e of entries ?? []) {
+      const pid = e?.pid ?? null;
+      if (!pid)
+        continue;
+      const variable = getVariableByPersistentId(pid, runtime) || null;
+      if (!variable) {
         out.push({
           pid,
           ok: false,
-          reason: 'no previous snapshot'
+          reason: 'no runtime variable'
+        });
+        continue;
+      }
+      // find the prior snapshot for this pid: the last same-pid entry before `e`
+      const at = history.indexOf(e);
+      const upTo = at === -1 ? history.length - 1 : at - 1;
+      let prev = null, firstForPid = null;
+      for (let idx = 0; idx <= upTo; idx++) {
+        const h = history[idx];
+        if (h?.pid !== pid)
+          continue;
+        if (firstForPid === null)
+          firstForPid = h;
+        prev = h;
+      }
+      if (!prev) {
+        // nothing earlier for this pid — either it existed before recording,
+        // or this change first created it (op 'new') so reverting deletes it
+        const base = initial_state instanceof Map ? initial_state.get(pid) ?? null : null;
+        if (e?.op === 'new' || !base) {
+          try {
+            variable.delete?.();
+            out.push({
+              pid,
+              ok: true,
+              action: 'delete'
+            });
+          } catch (err) {
+            out.push({
+              pid,
+              ok: false,
+              action: 'delete',
+              reason: String(err?.message ?? err)
+            });
+          }
+          continue;
+        }
+        prev = base;
+      }
+      const def = (await realize([prev._definition ?? ''], runtime))[0];
+      if (!def) {
+        out.push({
+          pid,
+          ok: false,
+          reason: 'could not realize previous definition'
+        });
+        continue;
+      }
+      const name = ((typeof prev._name === 'string' && prev._name.length) ? prev._name : null) ?? ((typeof variable._name === 'string' && variable._name.length) ? variable._name : null) ?? pid;
+      try {
+        variable.define(name, Array.isArray(prev._inputs) ? prev._inputs : [], def);
+        out.push({
+          pid,
+          ok: true,
+          action: 'define'
+        });
+      } catch (err) {
+        out.push({
+          pid,
+          ok: false,
+          action: 'define',
+          reason: String(err?.message ?? err)
         });
       }
-      continue;
     }
-    const def = (await realize([prev._definition ?? ''], runtime))[0];
-    if (!def) {
-      out.push({
-        pid,
-        ok: false,
-        reason: 'could not realize previous definition'
-      });
-      continue;
+    return out;
+  };
+};
+const _41vg0h = function _rewindToTime(history,applyHistoryState)
+{
+  return function rewindToTime(time) {
+    // history is sorted ascending by t; index = number of changes at or before `time`
+    let index = 0;
+    for (const entry of history) {
+      if ((entry?.t ?? 0) <= time)
+        index++;
+      else
+        break;
     }
-    const name = ((typeof prev._name === 'string' && prev._name.length) ? prev._name : null) ?? ((typeof variable._name === 'string' && variable._name.length) ? variable._name : null) ?? pid;
-    try {
-      variable.define(name, Array.isArray(prev._inputs) ? prev._inputs : [], def);
-      out.push({
-        pid,
-        ok: true,
-        action: 'define'
-      });
-    } catch (err) {
-      out.push({
-        pid,
-        ok: false,
-        action: 'define',
-        reason: String(err?.message ?? err)
-      });
-    }
-  }
-  return out;
-}
-)};
-const _1cvp8ui = function _rewindToTime(history,revertVariables){return(
-function (time) {
-  const byPid = new Map();
-  for (const entry of history) {
-    if (entry?.t > time) {
-      const pid = entry?.pid;
-      if (pid && !byPid.has(pid))
-        byPid.set(pid, entry);
-    }
-  }
-  revertVariables(Array.from(byPid.values()));
-}
-)};
+    return applyHistoryState(index);
+  };
+};
 const _1rfq6xd = function _52(md){return(
 md`## State`
 )};
@@ -16972,7 +17621,7 @@ const _qu2y2k = function _historyUtils(){return(
   }
 }
 )};
-const _84fm9q = function _change_listener(runtime,$0,persistentId,historyUtils,$1,read,onCodeChange,identity,modules,$2,Event,invalidation)
+const _5czkc4 = function _change_listener(runtime,$0,persistentId,historyUtils,$1,read,onCodeChange,playback_suspend,identity,modules,$2,Event,invalidation)
 {
   // scan the runtime for things that were loaded before we attached the hook
   if (!this) {
@@ -16988,6 +17637,9 @@ const _84fm9q = function _change_listener(runtime,$0,persistentId,historyUtils,$
     return read(currDef) ?? read(prevDef) ?? null;
   };
   const stop = onCodeChange(({variable, previous, t}) => {
+    // playback drives defines/deletes; suppress recording while it runs
+    if (playback_suspend && Date.now() < playback_suspend.until)
+      return;
     let v = variable || previous.variable;
     // lazyImport
     // Suprised the do not referentially match
@@ -17002,6 +17654,9 @@ const _84fm9q = function _change_listener(runtime,$0,persistentId,historyUtils,$
     const moduleName = modules.get(module)?.name || 'unknown';
     const prov = inferProvenance(variable, previous);
     const source = prov?.source ?? 'runtime';
+    // playback replays existing history; never record it as a fresh change
+    if (source === 'playback')
+      return;
     if (variable && !previous) {
       // new variable
       // record it as a base state
@@ -17435,6 +18090,120 @@ const _1tpet0t = function _historyModule(thisModule){return(
 thisModule()
 )};
 const _1ryokzy = (G, _) => G.input(_);
+const _sjnusq = function _playback(history,html,applyHistoryState,Event,invalidation)
+{
+  const n = history.length;
+  const form = html`<form style="display:flex;gap:.4em;align-items:center;font:13px system-ui,sans-serif;flex-wrap:wrap">
+    <button type=button name=first title="start">⏮</button>
+    <button type=button name=prev title="previous change">◀</button>
+    <button type=button name=play title="play / pause">▶ play</button>
+    <button type=button name=next title="next change">▶</button>
+    <button type=button name=last title="latest">⏭</button>
+    <input type=range name=range min=0 max=${ n } step=1 value=${ n } style="flex:1;min-width:120px">
+    <output name=out style="font:12px monospace">${ n } / ${ n }</output>
+  </form>`;
+  let value = n, timer = null;
+  const stop = () => {
+    if (timer) {
+      clearInterval(timer);
+      timer = null;
+      form.play.textContent = '\u25B6 play';
+    }
+  };
+  const go = async v => {
+    value = Math.max(0, Math.min(n, v | 0));
+    form.range.value = value;
+    form.out.value = `${ value } / ${ n }`;
+    form.value = value;
+    await applyHistoryState(value);
+    form.dispatchEvent(new Event('input', { bubbles: true }));
+  };
+  form.range.oninput = () => go(+form.range.value);
+  form.first.onclick = () => go(0);
+  form.prev.onclick = () => go(value - 1);
+  form.next.onclick = () => go(value + 1);
+  form.last.onclick = () => go(n);
+  form.play.onclick = () => {
+    if (timer)
+      return stop();
+    form.play.textContent = '\u23F8 pause';
+    timer = setInterval(() => go(value >= n ? 0 : value + 1), 700);
+  };
+  invalidation.then(stop);
+  form.value = value;
+  return form;
+};
+const _x7pc8l = (G, _) => G.input(_);
+const _ncb8n9 = function _applyHistoryState(modules,playback_suspend,history,initial_state,getVariableByPersistentId,runtime,replay_pid_map,realize,tag)
+{
+  const moduleByName = new Map();
+  if (modules instanceof Map)
+    for (const [m, meta] of modules)
+      if (meta?.name)
+        moduleByName.set(meta.name, m);
+  const defaultMod = moduleByName.get('main') ?? (modules instanceof Map ? modules.keys().next().value : null) ?? null;
+  // Reconstruct notebook state after the first `index` recorded changes, from the
+  // history log + initial_state base snapshots. Entries carry no `previous` field,
+  // so this also drives git-replayed history.
+  return async function applyHistoryState(index) {
+    // Suspend recording for the apply + a grace window: playback's redefines/deletes
+    // fire onCodeChange asynchronously and must not be logged as fresh changes.
+    playback_suspend.until = Date.now() + 4000;
+    const i = Math.max(0, Math.min(index | 0, history.length));
+    const byPid = new Map();
+    history.forEach((h, idx) => {
+      if (!h?.pid)
+        return;
+      let g = byPid.get(h.pid);
+      if (!g)
+        byPid.set(h.pid, g = {
+          first: h,
+          last: null
+        });
+      if (idx < i)
+        g.last = h;
+    });
+    for (const [pid, {first, last}] of byPid) {
+      const del = last ? last.op === 'del' : first.op === 'new';
+      const snap = del ? null : last ?? initial_state.get(pid) ?? null;
+      let v = getVariableByPersistentId(pid, runtime) ?? replay_pid_map.get(pid) ?? null;
+      if (del) {
+        if (v) {
+          try {
+            v.delete?.();
+          } catch {
+          }
+          replay_pid_map.delete(pid);
+        }
+        continue;
+      }
+      if (!snap)
+        continue;
+      if (!v) {
+        const mod = moduleByName.get((last ?? first)?.module ?? 'main') ?? defaultMod;
+        if (!mod)
+          continue;
+        replay_pid_map.set(pid, v = mod.variable());
+      }
+      let def = null;
+      try {
+        def = (await realize([snap._definition ?? ''], runtime))[0] ?? null;
+      } catch {
+      }
+      if (!def)
+        continue;
+      v.define(snap._name || pid, Array.isArray(snap._inputs) ? snap._inputs : [], tag(def, {
+        source: 'playback',
+        pid
+      }));
+    }
+    playback_suspend.until = Date.now() + 500;
+    return i;
+  };
+};
+const _v5cr66 = function _playback_suspend(){return(
+{ until: 0 }
+)};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -17491,7 +18260,7 @@ export default function define(runtime, observer) {
   $def("_1c4d7y5", "setFilesAndCommit", ["ensure_branch","git","fs","ensure_dir"], _1c4d7y5);  
   $def("_veyumo", "listRepos", ["fs"], _veyumo);  
   $def("_1rusr2m", "listBranches", ["ensure_repo","git","fs"], _1rusr2m);  
-  $def("_1bvisll", "listFiles", ["ensure_branch","git","fs"], _1bvisll);  
+  $def("_bvp3oz", "listFiles", ["ensure_branch","git","fs"], _bvp3oz);  
   $def("_xl9zth", "listCommits", ["ensure_branch","git","fs"], _xl9zth);  
   $def("_h6ylpe", "getCommitChanges", ["git","fs"], _h6ylpe);  
   $def("_fw7q7v", "getCompactISODate", [], _fw7q7v);  
@@ -17500,12 +18269,12 @@ export default function define(runtime, observer) {
   $def("_1intaie", "tag", [], _1intaie);  
   $def("_ziwv9c", "read", [], _ziwv9c);  
   $def("_1l4hr6l", null, ["md"], _1l4hr6l);  
-  $def("_zanj5n", "revertVariables", ["getVariableByPersistentId","runtime","realize"], _zanj5n);  
-  $def("_1cvp8ui", "rewindToTime", ["history","revertVariables"], _1cvp8ui);  
+  $def("_1hhkam2", "revertVariables", ["getVariableByPersistentId","runtime","history","initial_state","realize"], _1hhkam2);  
+  $def("_41vg0h", "rewindToTime", ["history","applyHistoryState"], _41vg0h);  
   $def("_1rfq6xd", null, ["md"], _1rfq6xd);  
   $def("_lh9ssh", "config", ["notebook_title","ensure_branch"], _lh9ssh);  
   $def("_qu2y2k", "historyUtils", [], _qu2y2k);  
-  $def("_84fm9q", "change_listener", ["runtime","viewof initial_state","persistentId","historyUtils","viewof module_load_time","read","onCodeChange","identity","modules","viewof history","Event","invalidation"], _84fm9q);  
+  $def("_5czkc4", "change_listener", ["runtime","viewof initial_state","persistentId","historyUtils","viewof module_load_time","read","onCodeChange","playback_suspend","identity","modules","viewof history","Event","invalidation"], _5czkc4);  
   $def("_1gmcocx", null, ["Inputs","history"], _1gmcocx);  
   $def("_ztvqq8", null, ["md"], _ztvqq8);  
   $def("_1klmxot", "commit_watermarks", [], _1klmxot);  
@@ -17544,7 +18313,11 @@ export default function define(runtime, observer) {
   main.define("http", ["module @tomlarkworthy/isomorphic-git-1-30-1", "@variable"], (_, v) => v.import("http", _));  
   main.define("JSZip", ["module @tomlarkworthy/jszip-3-10-1", "@variable"], (_, v) => v.import("JSZip", _));  
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
-  main.define("notebook_title", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("notebook_title", _));
+  main.define("notebook_title", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("notebook_title", _));  
+  $def("_sjnusq", "viewof playback", ["history","html","applyHistoryState","Event","invalidation"], _sjnusq);  
+  $def("_x7pc8l", "playback", ["Generators","viewof playback"], _x7pc8l);  
+  $def("_ncb8n9", "applyHistoryState", ["modules","playback_suspend","history","initial_state","getVariableByPersistentId","runtime","replay_pid_map","realize","tag"], _ncb8n9);  
+  $def("_v5cr66", "playback_suspend", [], _v5cr66);
   return main;
 }</script>
 
@@ -18369,35 +19142,33 @@ module -> {
 }
 \`\`\``
 )};
-const _1798myt = function _moduleMap(runtime,keepalive,myModule,$0){return(
-async (
-  _runtime = runtime,
-  {
-    cache = new Map() // module -> {name}
-  } = {}
-) => {
-  if (!_runtime || !_runtime._variables)
-    throw "Invalid runtime passed to moduleMap";
-  keepalive(myModule, "submit_summary");
-  keepalive(myModule, "sync_modules");
-  keepalive(myModule, "currentModules");
-  return await $0.send({
-    runtime: _runtime,
-    cache: cache
-  });
-}
-)};
+const _1hn3uql = function _moduleMap(runtime,keepalive,myModule,$0)
+{
+  return async (_runtime = runtime, {
+    cache = new Map()  // module -> {name}
+  } = {}) => {
+    if (!_runtime || !_runtime._variables)
+      throw 'Invalid runtime passed to moduleMap';
+    keepalive(myModule, 'submit_summary');
+    keepalive(myModule, 'sync_modules');
+    keepalive(myModule, 'currentModules');
+    return await $0.send({
+      runtime: _runtime,
+      cache: cache
+    });
+  };
+};
 const _1yso65r = function _5(md){return(
 md`### \`currentModules\``
 )};
-const _1fcoh6x = async function _sync_modules(runtime_variables,moduleMap,_,$0,Event)
+const _1e3kr85 = async function _sync_modules(runtime_variables,moduleMap,_,$0,Event)
 {
   runtime_variables;
   const latest = await moduleMap();
   let dirty = !this || !_.isEqual(new Set(latest.keys()), new Set(this.keys()));
   if (dirty) {
     $0.value = latest;
-    $0.dispatchEvent(new Event("input"));
+    $0.dispatchEvent(new Event('input'));
   }
   return $0.value;
 };
@@ -18405,261 +19176,260 @@ const _wi39n0 = async function _currentModules(Inputs,moduleMap){return(
 Inputs.input(await moduleMap())
 )};
 const _1gxgyd6 = (G, _) => G.input(_);
-const _1qag34d = function _8(Inputs,currentModules){return(
+const _1kxoygl = function _8(Inputs,currentModules){return(
 Inputs.table([...currentModules.values()], {
   format: {
-    dom: (d) => d.innerHTML,
+    dom: d => d.innerHTML,
     specifiers: JSON.stringify,
-    variable: (v) => v._name
+    variable: v => v._name
   }
 })
 )};
 const _1xamz8j = function _9(md){return(
 md`### Visualization`
 )};
-const _1n4p4hn = function _tipTitle(){return(
-([k, c]) => 
-`${k}\ndependsOn: [\n  ${(c[3].dependsOn || []).join(
-  "\n  "
-)}\n]\ndependedBy: [\n  ${(c[3].dependedBy || []).join("\n  ")}\n]`
+const _1sglrv3 = function _tipTitle(){return(
+([k, c]) => `${ k }\ndependsOn: [\n  ${ (c[3].dependsOn || []).join('\n  ') }\n]\ndependedBy: [\n  ${ (c[3].dependedBy || []).join('\n  ') }\n]`
 )};
-const _1kdcb71 = function _visualizeModules(currentModules,htl,d3,spectralCircleOrder,improveOrderSifting,bestOfRandomOrders,Plot,tipTitle,linkTo,isOnObservableCom)
-{
-  return ({ useSpectral = true } = {}) => {
-    const modules = [...currentModules.values()].filter((m) => m && m.name);
-    const n = modules.length;
-    if (n === 0) return htl.svg`<svg width="1" height="1"></svg>`;
-
-    const indexOf = new Map(modules.map((m, i) => [m.name, i]));
-
-    const undirectedEdges = [];
-    const seen = new Set();
+const _5zbe1k = function _visualizeModules(currentModules,htl,d3,spectralCircleOrder,improveOrderSifting,bestOfRandomOrders,Plot,tipTitle,linkTo,isOnObservableCom){return(
+({
+  useSpectral = true
+} = {}) => {
+  const modules = [...currentModules.values()].filter(m => m && m.name);
+  const n = modules.length;
+  if (n === 0)
+    return htl.svg`<svg width="1" height="1"></svg>`;
+  const indexOf = new Map(modules.map((m, i) => [
+    m.name,
+    i
+  ]));
+  const undirectedEdges = [];
+  const seen = new Set();
+  for (let i = 0; i < n; i++) {
+    const from = modules[i];
+    for (const toName of from.dependsOn || []) {
+      const j = indexOf.get(toName);
+      if (j == null || j === i)
+        continue;
+      const a = Math.min(i, j), b = Math.max(i, j);
+      const k = `${ a },${ b }`;
+      if (seen.has(k))
+        continue;
+      seen.add(k);
+      undirectedEdges.push([
+        a,
+        b
+      ]);
+    }
+  }
+  const buildCSRLocal = (n, edges) => {
+    const adj = Array.from({ length: n }, () => []);
+    for (const [a0, b0] of edges) {
+      const a = a0 | 0, b = b0 | 0;
+      if (a === b)
+        continue;
+      if (a < 0 || b < 0 || a >= n || b >= n)
+        continue;
+      adj[a].push(b);
+      adj[b].push(a);
+    }
+    const deg = new Float64Array(n);
+    let nnz = 0;
     for (let i = 0; i < n; i++) {
-      const from = modules[i];
-      for (const toName of from.dependsOn || []) {
-        const j = indexOf.get(toName);
-        if (j == null || j === i) continue;
-        const a = Math.min(i, j),
-          b = Math.max(i, j);
-        const k = `${a},${b}`;
-        if (seen.has(k)) continue;
-        seen.add(k);
-        undirectedEdges.push([a, b]);
+      const row = adj[i];
+      row.sort((x, y) => x - y);
+      let w = 0;
+      for (let j = 0; j < row.length; j++)
+        if (w === 0 || row[j] !== row[w - 1])
+          row[w++] = row[j];
+      row.length = w;
+      deg[i] = w;
+      nnz += w;
+    }
+    const rowPtr = new Int32Array(n + 1);
+    const colIdx = new Int32Array(nnz);
+    const val = new Float64Array(nnz);
+    let p = 0;
+    for (let i = 0; i < n; i++) {
+      rowPtr[i] = p;
+      const row = adj[i];
+      for (let j = 0; j < row.length; j++) {
+        colIdx[p] = row[j];
+        val[p] = 1;
+        p++;
       }
     }
-
-    const buildCSRLocal = (n, edges) => {
-      const adj = Array.from({ length: n }, () => []);
-      for (const [a0, b0] of edges) {
-        const a = a0 | 0,
-          b = b0 | 0;
-        if (a === b) continue;
-        if (a < 0 || b < 0 || a >= n || b >= n) continue;
-        adj[a].push(b);
-        adj[b].push(a);
-      }
-      const deg = new Float64Array(n);
-      let nnz = 0;
-      for (let i = 0; i < n; i++) {
-        const row = adj[i];
-        row.sort((x, y) => x - y);
-        let w = 0;
-        for (let j = 0; j < row.length; j++)
-          if (w === 0 || row[j] !== row[w - 1]) row[w++] = row[j];
-        row.length = w;
-        deg[i] = w;
-        nnz += w;
-      }
-      const rowPtr = new Int32Array(n + 1);
-      const colIdx = new Int32Array(nnz);
-      const val = new Float64Array(nnz);
-      let p = 0;
-      for (let i = 0; i < n; i++) {
-        rowPtr[i] = p;
-        const row = adj[i];
-        for (let j = 0; j < row.length; j++) {
-          colIdx[p] = row[j];
-          val[p] = 1;
-          p++;
-        }
-      }
-      rowPtr[n] = p;
-      return { n, rowPtr, colIdx, val, deg };
+    rowPtr[n] = p;
+    return {
+      n,
+      rowPtr,
+      colIdx,
+      val,
+      deg
     };
-
-    const crossingsCountLocal = (n, edges, order) => {
-      const pos = new Int32Array(n);
-      for (let i = 0; i < n; i++) pos[order[i]] = i;
-
-      const intervals = [];
-      for (const [a0, b0] of edges) {
-        const a = a0 | 0,
-          b = b0 | 0;
-        if (a === b) continue;
-        const i = pos[a],
-          j = pos[b];
-        const s = Math.min(i, j),
-          t = Math.max(i, j);
-        if (s === t) continue;
-        intervals.push([s, t]);
-      }
-
-      intervals.sort((p, q) => p[0] - q[0] || p[1] - q[1]);
-      const bit = new Int32Array(n + 1);
-      const add = (i) => {
-        for (let x = i + 1; x <= n; x += x & -x) bit[x]++;
-      };
-      const sum = (i) => {
-        let s = 0;
-        for (let x = i + 1; x > 0; x -= x & -x) s += bit[x];
-        return s;
-      };
-      const range = (l, r) => (r < l ? 0 : sum(r) - (l > 0 ? sum(l - 1) : 0));
-
-      let crossings = 0;
-      let k = 0;
-      while (k < intervals.length) {
-        const s = intervals[k][0];
-        let k2 = k;
-        while (k2 < intervals.length && intervals[k2][0] === s) k2++;
-        for (let t = k; t < k2; t++)
-          crossings += range(s + 1, intervals[t][1] - 1);
-        for (let t = k; t < k2; t++) add(intervals[t][1]);
-        k = k2;
-      }
-      return crossings;
+  };
+  const crossingsCountLocal = (n, edges, order) => {
+    const pos = new Int32Array(n);
+    for (let i = 0; i < n; i++)
+      pos[order[i]] = i;
+    const intervals = [];
+    for (const [a0, b0] of edges) {
+      const a = a0 | 0, b = b0 | 0;
+      if (a === b)
+        continue;
+      const i = pos[a], j = pos[b];
+      const s = Math.min(i, j), t = Math.max(i, j);
+      if (s === t)
+        continue;
+      intervals.push([
+        s,
+        t
+      ]);
+    }
+    intervals.sort((p, q) => p[0] - q[0] || p[1] - q[1]);
+    const bit = new Int32Array(n + 1);
+    const add = i => {
+      for (let x = i + 1; x <= n; x += x & -x)
+        bit[x]++;
     };
-
-    let orderIdx;
-    if (n <= 2 || undirectedEdges.length === 0 || !useSpectral) {
-      orderIdx = Int32Array.from(d3.range(n));
-    } else {
-      const csr = buildCSRLocal(n, undirectedEdges);
-
-      const spectral = spectralCircleOrder(csr, {
-        alpha: 0.92,
-        maxIters: 80,
-        tol: 1e-4,
-        seed: 1,
-        passesOrtho: 1
-      });
-
-      const sifted = improveOrderSifting(n, undirectedEdges, spectral.order, {
-        passes: 1,
-        vertexSequence: "order"
-      });
-
-      const baseline = bestOfRandomOrders(n, undirectedEdges, {
-        R: Math.min(n, 12),
-        seed: 1,
-        postSiftPasses: 0
-      });
-
-      const cSift = crossingsCountLocal(n, undirectedEdges, sifted.order);
-      orderIdx =
-        baseline?.order && baseline.crossings < cSift
-          ? baseline.order
-          : sifted.order;
+    const sum = i => {
+      let s = 0;
+      for (let x = i + 1; x > 0; x -= x & -x)
+        s += bit[x];
+      return s;
+    };
+    const range = (l, r) => r < l ? 0 : sum(r) - (l > 0 ? sum(l - 1) : 0);
+    let crossings = 0;
+    let k = 0;
+    while (k < intervals.length) {
+      const s = intervals[k][0];
+      let k2 = k;
+      while (k2 < intervals.length && intervals[k2][0] === s)
+        k2++;
+      for (let t = k; t < k2; t++)
+        crossings += range(s + 1, intervals[t][1] - 1);
+      for (let t = k; t < k2; t++)
+        add(intervals[t][1]);
+      k = k2;
     }
-
-    const R = 100;
-    const nodes = new Map();
-    for (let p = 0; p < n; p++) {
-      const vid = orderIdx[p] | 0;
-      const a = (p * 2 * Math.PI) / n;
-      const [x, y] = d3.pointRadial(a, R);
-      const deg = (p * 360) / n;
-      nodes.set(modules[vid].name, [x, y, deg, modules[vid]]);
-    }
-
-    const edges = modules.flatMap((from) =>
-      (from.dependsOn || [])
-        .filter((to) => nodes.has(to))
-        .map((to) => [
-          [from.name, nodes.get(from.name)],
-          [to, nodes.get(to)]
-        ])
-    );
-
-    const plot = Plot.plot({
-      inset: 180,
-      aspectRatio: 1,
-      axis: null,
-      marks: [
-        () => htl.svg`<defs>
+    return crossings;
+  };
+  let orderIdx;
+  if (n <= 2 || undirectedEdges.length === 0 || !useSpectral) {
+    orderIdx = Int32Array.from(d3.range(n));
+  } else {
+    const csr = buildCSRLocal(n, undirectedEdges);
+    const spectral = spectralCircleOrder(csr, {
+      alpha: 0.92,
+      maxIters: 80,
+      tol: 0.0001,
+      seed: 1,
+      passesOrtho: 1
+    });
+    const sifted = improveOrderSifting(n, undirectedEdges, spectral.order, {
+      passes: 1,
+      vertexSequence: 'order'
+    });
+    const baseline = bestOfRandomOrders(n, undirectedEdges, {
+      R: Math.min(n, 12),
+      seed: 1,
+      postSiftPasses: 0
+    });
+    const cSift = crossingsCountLocal(n, undirectedEdges, sifted.order);
+    orderIdx = baseline?.order && baseline.crossings < cSift ? baseline.order : sifted.order;
+  }
+  const R = 100;
+  const nodes = new Map();
+  for (let p = 0; p < n; p++) {
+    const vid = orderIdx[p] | 0;
+    const a = p * 2 * Math.PI / n;
+    const [x, y] = d3.pointRadial(a, R);
+    const deg = p * 360 / n;
+    nodes.set(modules[vid].name, [
+      x,
+      y,
+      deg,
+      modules[vid]
+    ]);
+  }
+  const edges = modules.flatMap(from => (from.dependsOn || []).filter(to => nodes.has(to)).map(to => [
+    [
+      from.name,
+      nodes.get(from.name)
+    ],
+    [
+      to,
+      nodes.get(to)
+    ]
+  ]));
+  const plot = Plot.plot({
+    inset: 180,
+    aspectRatio: 1,
+    axis: null,
+    marks: [
+      () => htl.svg`<defs>
           <linearGradient id="gradient">
             <stop offset="15%" stop-color="red" />
             <stop offset="100%" stop-color="gold" />
           </linearGradient>
         </defs>`,
-        Plot.arrow(edges, {
-          x1: ([[, [x1]]]) => x1,
-          y1: ([[, [, y1]]]) => y1,
-          x2: ([, [, [x2]]]) => x2,
-          y2: ([, [, [, y2]]]) => y2,
-          bend: true,
-          stroke: "url(#gradient)",
-          strokeOpacity: 0.5,
-          strokeLinejoin: "miter",
-          headLength: 3,
-          inset: 5
-        }),
-        Plot.text(
-          [...nodes.entries()].filter(([, c]) => c[2] > 180),
-          {
-            textAnchor: "end",
-            x: ([, c]) => c[0],
-            y: ([, c]) => c[1],
-            rotate: ([, c]) => -c[2] - (c[2] > 180 ? 90 : -90),
-            text: ([k]) => k
-          }
-        ),
-        Plot.text(
-          [...nodes.entries()].filter(([, c]) => c[2] <= 180),
-          {
-            fontSize: 12,
-            textAnchor: "start",
-            x: ([, c]) => c[0],
-            y: ([, c]) => c[1],
-            rotate: ([, c]) => -c[2] - (c[2] > 180 ? 90 : -90),
-            text: ([k]) => k
-          }
-        ),
-        Plot.tip(
-          nodes.entries(),
-          Plot.pointer({
-            x: ([, c]) => c[0],
-            y: ([, c]) => c[1],
-            title: tipTitle,
-            maxRadius: Infinity
-          })
-        )
-      ]
-    });
-
-    const xmlns = "http://www.w3.org/2000/svg";
-    const xlink = "http://www.w3.org/1999/xlink";
-    for (const text of plot.querySelectorAll("text")) {
-      const moduleName = text.textContent;
-      let url;
-      try {
-        url = linkTo(moduleName);
-      } catch {
-        continue;
-      }
-      const a = document.createElementNS(xmlns, "a");
-      a.setAttributeNS(null, "href", url);
-      a.setAttributeNS(xlink, "href", url);
-      text.parentNode.insertBefore(a, text);
-      if (isOnObservableCom()) {
-        a.setAttribute("target", "_blank");
-      }
-      a.appendChild(text);
+      Plot.arrow(edges, {
+        x1: ([[, [x1]]]) => x1,
+        y1: ([[, [, y1]]]) => y1,
+        x2: ([, [, [x2]]]) => x2,
+        y2: ([, [, [, y2]]]) => y2,
+        bend: true,
+        stroke: 'url(#gradient)',
+        strokeOpacity: 0.5,
+        strokeLinejoin: 'miter',
+        headLength: 3,
+        inset: 5
+      }),
+      Plot.text([...nodes.entries()].filter(([, c]) => c[2] > 180), {
+        textAnchor: 'end',
+        x: ([, c]) => c[0],
+        y: ([, c]) => c[1],
+        rotate: ([, c]) => -c[2] - (c[2] > 180 ? 90 : -90),
+        text: ([k]) => k
+      }),
+      Plot.text([...nodes.entries()].filter(([, c]) => c[2] <= 180), {
+        fontSize: 12,
+        textAnchor: 'start',
+        x: ([, c]) => c[0],
+        y: ([, c]) => c[1],
+        rotate: ([, c]) => -c[2] - (c[2] > 180 ? 90 : -90),
+        text: ([k]) => k
+      }),
+      Plot.tip(nodes.entries(), Plot.pointer({
+        x: ([, c]) => c[0],
+        y: ([, c]) => c[1],
+        title: tipTitle,
+        maxRadius: Infinity
+      }))
+    ]
+  });
+  const xmlns = 'http://www.w3.org/2000/svg';
+  const xlink = 'http://www.w3.org/1999/xlink';
+  for (const text of plot.querySelectorAll('text')) {
+    const moduleName = text.textContent;
+    let url;
+    try {
+      url = linkTo(moduleName);
+    } catch {
+      continue;
     }
-
-    return plot;
-  };
-};
+    const a = document.createElementNS(xmlns, 'a');
+    a.setAttributeNS(null, 'href', url);
+    a.setAttributeNS(xlink, 'href', url);
+    text.parentNode.insertBefore(a, text);
+    if (isOnObservableCom()) {
+      a.setAttribute('target', '_blank');
+    }
+    a.appendChild(text);
+  }
+  return plot;
+}
+)};
 const _hgwvol = function _12(md){return(
 md`### Random helpers`
 )};
@@ -18670,88 +19440,85 @@ const _1cir47e = (G, _) => G.input(_);
 const _1nfaybn = function _tag(){return(
 Symbol()
 )};
-const _17qqkoj = function _forcePeek()
+const _1lkbrun = function _forcePeek()
 {
   //console.log("force peek");
-  return (variable, { forever = false } = {}) => {
-    if (variable._value) return variable._value;
+  return (variable, {
+    forever = false
+  } = {}) => {
+    if (variable._value)
+      return variable._value;
     let peeker;
     const promise = new Promise((fulfilled, rejected) => {
-      peeker = variable._module
-        .variable({
-          fulfilled,
-          rejected
-        })
-        .define([variable._name], (m) => m);
+      peeker = variable._module.variable({
+        fulfilled,
+        rejected
+      }).define([variable._name], m => m);
     });
-    if (!forever) promise.finally((v) => peeker.delete());
-    return Promise.race([promise, new Promise((_, r) => setTimeout(r, 1000))]);
+    if (!forever)
+      promise.finally(v => peeker.delete());
+    return Promise.race([
+      promise,
+      new Promise((_, r) => setTimeout(r, 1000))
+    ]);
   };
 };
-const _v9hg2i = function _observe(){return(
+const _1qva85d = function _observe(){return(
 (module, variable_name, observer) => {
-  const variable = module
-    .variable(observer)
-    .define(`dynamic observe ${variable_name}`, [variable_name], (m) => m);
+  const variable = module.variable(observer).define(`dynamic observe ${ variable_name }`, [variable_name], m => m);
   return () => variable.delete();
 }
 )};
 const _1bm642i = function _17(md){return(
 md`### Implementation`
 )};
-const _oothhq = function _queue(flowQueue){return(
-flowQueue({ timeout_ms: 15000, dedupe: true })
+const _1f31b1g = function _queue(flowQueue){return(
+flowQueue({
+  timeout_ms: 15000,
+  dedupe: true
+})
 )};
 const _648shl = (G, _) => G.input(_);
 const _1acbzli = function _19(md){return(
 md`We resolve what we can using variables named with prefix \`module\` that hold module values. We \`forcePeek\` the variables to make them resolve, which forces loading of the modules.`
 )};
-const _10dhunq = async function _module_definition_variables(notebookImports,queue)
+const _1g0cuj1 = async function _module_definition_variables(notebookImports,queue)
 {
-  console.log("module_definition_variables");
+  console.log('module_definition_variables');
   notebookImports;
   queue;
   let last_module_count = -1;
   let module_definition_variables = [];
   while (last_module_count < module_definition_variables.length) {
     last_module_count = module_definition_variables.length;
-    module_definition_variables = (
-      await Promise.all(
-        [...queue.runtime._variables]
-          .filter((v) => v._name && v._name.startsWith("module "))
-          .filter((v) => !v._name.startsWith("module <unknown"))
-          .map(async (v) => {
-            try {
-              v._value = await Promise.race([
-                v._definition(),
-                new Promise((_, reject) =>
-                  setTimeout(() => reject(new Error("timeout")), 1000)
-                )
-              ]);
-              return [v];
-            } catch (err) {
-              console.error("error loading module", v._name, err);
-              return [];
-            }
-          })
-      )
-    ).flat();
+    module_definition_variables = (await Promise.all([...queue.runtime._variables].filter(v => v._name && v._name.startsWith('module ')).filter(v => !v._name.startsWith('module <unknown')).map(async v => {
+      try {
+        v._value = await Promise.race([
+          v._definition(),
+          new Promise((_, reject) => setTimeout(() => reject(new Error('timeout')), 1000))
+        ]);
+        return [v];
+      } catch (err) {
+        console.error('error loading module', v._name, err);
+        return [];
+      }
+    }))).flat();
   }
   return module_definition_variables;
 };
-const _dcxoxy = function _modules(module_definition_variables,queue)
+const _17frsyf = function _modules(module_definition_variables,queue)
 {
-  console.log("modules");
+  console.log('modules');
   module_definition_variables;
-  return [...new Set([...queue.runtime._variables].map((v) => v._module))];
+  return [...new Set([...queue.runtime._variables].map(v => v._module))];
 };
 const _1dqpbvy = function _builtin(queue){return(
 queue.runtime._builtin
 )};
-const _ir3ob0 = function _main_modules(queue,modules,builtin)
+const _13mmmk9 = function _main_modules(queue,modules,builtin)
 {
   const imports = new Set(queue.runtime._modules.values());
-  return modules.filter((m) => !imports.has(m) && m !== builtin);
+  return modules.filter(m => !imports.has(m) && m !== builtin);
 };
 const _yflsv5 = function _bootloaded_mains(queue){return(
 queue.runtime.mains || new Map()
@@ -18759,16 +19526,16 @@ queue.runtime.mains || new Map()
 const _ox2g3b = function _bootloader(queue){return(
 queue.runtime.bootloader
 )};
-const _1turw8j = function _resolve_modules(modules,module_definition_variables,findModuleName)
+const _10ufqkh = function _resolve_modules(modules,module_definition_variables,findModuleName)
 {
-  console.log("resolve_modules");
+  console.log('resolve_modules');
   const module_definitions = new Map();
   const unresolved = [];
-  modules.forEach((m) => {
-    const md = module_definition_variables.find((md) => md._value == m);
+  modules.forEach(m => {
+    const md = module_definition_variables.find(md => md._value == m);
     if (md) {
       module_definitions.set(m, {
-        type: "module variable",
+        type: 'module variable',
         name: findModuleName(md._module._scope, m),
         variable: md
       });
@@ -18776,239 +19543,218 @@ const _1turw8j = function _resolve_modules(modules,module_definition_variables,f
       unresolved.push(m);
     }
   });
-  return { module_definitions, unresolved };
+  return {
+    module_definitions,
+    unresolved
+  };
 };
 const _9fbvam = function _27(md){return(
 md`modules imported via notebook imports do not have module variables, so they are trickier to figure out. We can sniff the page DOM to find the import expressions, and try to map them to the modules we could to resolve earlier`
 )};
-const _1h0lryb = function _notebookImports(main,parser)
+const _1t4ga3d = function _notebookImports(main,parser)
 {
-  console.log("notebookImports");
+  console.log('notebookImports');
   main;
-  return new Map(
-    [...document.querySelectorAll(".observablehq--import")]
-      .map((dom) => [dom, parser.parseCell(dom.textContent)])
-      .map(([dom, node]) => [
-        dom.parentElement,
-        node.body.specifiers.map((s) => ({
-          name: node.body.source.value,
-          dom: dom.parentElement,
-          ast: s,
-          local: s.local.name,
-          imported: s.imported.name
-        }))
-      ])
-  );
+  return new Map([...document.querySelectorAll('.observablehq--import')].map(dom => [
+    dom,
+    parser.parseCell(dom.textContent)
+  ]).map(([dom, node]) => [
+    dom.parentElement,
+    node.body.specifiers.map(s => ({
+      name: node.body.source.value,
+      dom: dom.parentElement,
+      ast: s,
+      local: s.local.name,
+      imported: s.imported.name
+    }))
+  ]));
 };
-const _7t198q = function _notebookImportVariables(runtime,notebookImports)
+const _994hn4 = function _notebookImportVariables(runtime,notebookImports)
 {
-  console.log("notebookImportVariables");
+  console.log('notebookImportVariables');
   return [
-    ...[...runtime._variables] // Observable DOM nodes are referenced in runtime variables
-      .filter(
-        (v) =>
-          v._observer &&
-          v._observer._node &&
-          notebookImports.get(v._observer._node)
-      )
-      .map((v) => ({
-        variable: v,
-        notebookImports: notebookImports.get(v._observer._node)
-      })),
-    ...[
-      ...[...notebookImports.entries()] // visualizer DOM nodes have the variable attached
-        .filter(([pi, vars]) => pi.variable)
-        .map(([pi, vars]) => ({
-          variable: pi.variable,
-          notebookImports: vars
-        }))
-    ]
-  ].sort((a, b) => b.notebookImports.length - a.notebookImports.length); // sort by complexity
+    ...[...runtime._variables]  // Observable DOM nodes are referenced in runtime variables
+.filter(v => v._observer && v._observer._node && notebookImports.get(v._observer._node)).map(v => ({
+      variable: v,
+      notebookImports: notebookImports.get(v._observer._node)
+    })),
+    ...[...[...notebookImports.entries()]  // visualizer DOM nodes have the variable attached
+.filter(([pi, vars]) => pi.variable).map(([pi, vars]) => ({
+        variable: pi.variable,
+        notebookImports: vars
+      }))]
+  ].sort((a, b) => b.notebookImports.length - a.notebookImports.length);  // sort by complexity
 };
-const _1lyens8 = function _pageImportMatch(){return(
-async (notebookImportVariables, modules) => {
-  console.log("pageImportMatch");
-  const backupHas = Map.prototype.has; // Save the original `has` method on Map.prototype
-
-  let currentImport = undefined;
-  const matches = new Map();
-  // Override `Map.prototype.has` to intercept calls to `has` on any Map instance
-  Map.prototype.has = function (...args) {
-    const module = modules.find((m) => m._scope == this);
-    if (currentImport && module) {
-      matches.set(module, {
-        name: currentImport.notebookImports[0].name,
-        type: "notebook import",
-        module: module,
-        dependsOn: [],
-        dependedBy: [],
-        dom: currentImport.notebookImports[0].dom,
-        specifiers: currentImport.notebookImports.map((pi) => ({
-          local: pi.local,
-          imported: pi.imported,
-          variable: pi.variable
-        }))
-      });
-    }
-    return backupHas.call(this, ...args); // Call the original `has` method
-  };
-
-  // Iterate through the notebook imports and define them while capturing `has` calls
-
-  await notebookImportVariables.reduce((chain, pageImportVariable) => {
-    // Call the definition chain
-    return chain.then(async () => {
-      currentImport = pageImportVariable;
-      try {
-        await pageImportVariable.variable._definition();
-      } catch (err) {
-        console.warn(err);
-      }
-      currentImport = undefined;
-    });
-  }, Promise.resolve());
-
-  // Restore the original `has` method after the operations are done
-  Map.prototype.has = backupHas;
-
-  return matches;
-}
-)};
-const _1akt4kz = function _notebookImportMatches(pageImportMatch,notebookImportVariables,modules)
+const _xanizk = function _pageImportMatch()
 {
-  console.log("notebookImportMatches");
+  return async (notebookImportVariables, modules) => {
+    console.log('pageImportMatch');
+    const backupHas = Map.prototype.has;
+    // Save the original `has` method on Map.prototype
+    let currentImport = undefined;
+    const matches = new Map();
+    // Override `Map.prototype.has` to intercept calls to `has` on any Map instance
+    Map.prototype.has = function (...args) {
+      const module = modules.find(m => m._scope == this);
+      if (currentImport && module) {
+        matches.set(module, {
+          name: currentImport.notebookImports[0].name,
+          type: 'notebook import',
+          module: module,
+          dependsOn: [],
+          dependedBy: [],
+          dom: currentImport.notebookImports[0].dom,
+          specifiers: currentImport.notebookImports.map(pi => ({
+            local: pi.local,
+            imported: pi.imported,
+            variable: pi.variable
+          }))
+        });
+      }
+      return backupHas.call(this, ...args);  // Call the original `has` method
+    };
+    // Iterate through the notebook imports and define them while capturing `has` calls
+    await notebookImportVariables.reduce((chain, pageImportVariable) => {
+      // Call the definition chain
+      return chain.then(async () => {
+        currentImport = pageImportVariable;
+        try {
+          await pageImportVariable.variable._definition();
+        } catch (err) {
+          console.warn(err);
+        }
+        currentImport = undefined;
+      });
+    }, Promise.resolve());
+    // Restore the original `has` method after the operations are done
+    Map.prototype.has = backupHas;
+    return matches;
+  };
+};
+const _1q5pc6n = function _notebookImportMatches(pageImportMatch,notebookImportVariables,modules)
+{
+  console.log('notebookImportMatches');
   return pageImportMatch(notebookImportVariables, modules);
 };
-const _1ang0sg = function _moduleTitle(observeVariable){return(
-async function moduleTitle(module) {
-  const runtime = module._runtime;
-  const vars = [...runtime._variables].filter(
-    (v) => v && v._module === module && v._definition
-  );
-  const candidates = vars.filter((v) => {
-    const n = v._name;
-    if (v._type != 1) return false;
-    if (n == null) return true;
-    if (typeof n !== "string") return true;
-    if (n.startsWith("dynamic observe ")) return false;
-    if (n.startsWith("module ")) return false;
-    return true;
-  });
-
-  if (candidates.length === 0) return null;
-
-  const first = candidates.find(
-    (v) => typeof v._id === "number" && Number.isFinite(v._id)
-  )
-    ? candidates.reduce((a, b) =>
-        (a._id ?? Infinity) <= (b._id ?? Infinity) ? a : b
-      )
-    : candidates[0];
-
-  const extract = (v) => {
-    // instanceof cannot be used hear for cross realm
-    if (v == null) return null;
-    if (typeof v === "string") return v.trim() || null;
-    if (v.tagName) {
-      if (v.tagName == "H1") return v.textContent;
-      const h1 = v.querySelector?.("h1");
-      if (h1) return (h1.textContent ?? "").trim() || null;
+const _12o3fj5 = function _moduleTitle(observeVariable)
+{
+  return async function moduleTitle(module) {
+    const runtime = module._runtime;
+    const vars = [...runtime._variables].filter(v => v && v._module === module && v._definition);
+    const candidates = vars.filter(v => {
+      const n = v._name;
+      if (v._type != 1)
+        return false;
+      if (n == null)
+        return true;
+      if (typeof n !== 'string')
+        return true;
+      if (n.startsWith('dynamic observe '))
+        return false;
+      if (n.startsWith('module '))
+        return false;
+      return true;
+    });
+    if (candidates.length === 0)
       return null;
-    }
-    if (v.textContent) return (v.textContent ?? "").trim() || null;
-    const maybeNode = v?.nodeType ? v : null;
-    if (maybeNode?.tagName) return extract(maybeNode);
-    return null;
-  };
-
-  // Read the title WITHOUT re-executing the cell. invokeVariable calls the cell's _definition
-  // directly, bypassing the runtime — for element cells (`htl.html`…${sharedNode}…``) that builds
-  // a *duplicate*, unmanaged DOM subtree and moves shared singleton nodes (e.g. golden-layout's
-  // base_css <style>) out of the live page, breaking the frame. Instead:
-  //  1. If already computed, read the settled _value (fast path, most modules — zero side-effects).
-  //  2. Else force the RUNTIME to compute the *single managed* variable via observe(): it marks the
-  //     existing variable reachable and replays its value, adding no intermediate variable (no
-  //     variable-set churn) and building only the one runtime-owned instance (no duplicate). We
-  //     attach a one-shot observer and fire its invalidation on first settle so it detaches again.
-  if (first._value !== undefined) return extract(first._value);
-  const peekValue = (v) =>
-    new Promise((resolve, reject) => {
+    const first = candidates.find(v => typeof v._id === 'number' && Number.isFinite(v._id)) ? candidates.reduce((a, b) => (a._id ?? Infinity) <= (b._id ?? Infinity) ? a : b) : candidates[0];
+    const extract = v => {
+      // instanceof cannot be used hear for cross realm
+      if (v == null)
+        return null;
+      if (typeof v === 'string')
+        return v.trim() || null;
+      if (v.tagName) {
+        if (v.tagName == 'H1')
+          return v.textContent;
+        const h1 = v.querySelector?.('h1');
+        if (h1)
+          return (h1.textContent ?? '').trim() || null;
+        return null;
+      }
+      if (v.textContent)
+        return (v.textContent ?? '').trim() || null;
+      const maybeNode = v?.nodeType ? v : null;
+      if (maybeNode?.tagName)
+        return extract(maybeNode);
+      return null;
+    };
+    // Read the title WITHOUT re-executing the cell. invokeVariable calls the cell's _definition
+    // directly, bypassing the runtime — for element cells (`htl.html`…${sharedNode}…``) that builds
+    // a *duplicate*, unmanaged DOM subtree and moves shared singleton nodes (e.g. golden-layout's
+    // base_css <style>) out of the live page, breaking the frame. Instead:
+    //  1. If already computed, read the settled _value (fast path, most modules — zero side-effects).
+    //  2. Else force the RUNTIME to compute the *single managed* variable via observe(): it marks the
+    //     existing variable reachable and replays its value, adding no intermediate variable (no
+    //     variable-set churn) and building only the one runtime-owned instance (no duplicate). We
+    //     attach a one-shot observer and fire its invalidation on first settle so it detaches again.
+    if (first._value !== undefined)
+      return extract(first._value);
+    const peekValue = v => new Promise((resolve, reject) => {
       let settled = false;
       let fireInvalidation;
-      const invalidation = new Promise((r) => (fireInvalidation = r));
+      const invalidation = new Promise(r => fireInvalidation = r);
       const finish = (fn, arg) => {
-        if (settled) return;
+        if (settled)
+          return;
         settled = true;
         fireInvalidation();
         fn(arg);
       };
-      observeVariable(
-        v,
-        {
-          fulfilled: (value) => finish(resolve, value),
-          rejected: (err) => finish(reject, err),
-          pending: () => {}
-        },
-        { invalidation }
-      );
+      observeVariable(v, {
+        fulfilled: value => finish(resolve, value),
+        rejected: err => finish(reject, err),
+        pending: () => {
+        }
+      }, { invalidation });
     });
-  try {
-    return extract(await peekValue(first));
-  } catch (err) {
-    return "Err";
-  }
-}
-)};
-const _197sgjt = async function _titles(modules,moduleTitle)
+    try {
+      return extract(await peekValue(first));
+    } catch (err) {
+      return 'Err';
+    }
+  };
+};
+const _ze3jk0 = async function _titles(modules,moduleTitle)
 {
-  const map = new Map(
-    await Promise.all(
-      [...modules].map(async (m) => [
-        m,
-        await Promise.race([
-          moduleTitle(m),
-          new Promise((resolve) =>
-            setTimeout(() => resolve("<TIMEOUT LOADING TITLE>"), 250)
-          )
-        ]).catch((e) => `err: ${e}`)
-      ])
-    )
-  );
+  const map = new Map(await Promise.all([...modules].map(async m => [
+    m,
+    await Promise.race([
+      moduleTitle(m),
+      new Promise(resolve => setTimeout(() => resolve('<TIMEOUT LOADING TITLE>'), 250))
+    ]).catch(e => `err: ${ e }`)
+  ])));
   return map;
 };
-const _11z3pt0 = function _summary(main_modules,titles,bootloader,builtin,queue,notebookImportMatches,bootloaded_mains,resolve_modules,module_definition_variables)
+const _pnpoh8 = function _summary(main_modules,titles,bootloader,builtin,queue,notebookImportMatches,bootloaded_mains,resolve_modules,module_definition_variables)
 {
-  console.log("generate summary");
+  console.log('generate summary');
   const modules = new Map([
-    ...main_modules.map((main_module) => [
+    ...main_modules.map(main_module => [
       main_module,
       {
-        name: "main",
+        name: 'main',
         module: main_module,
         title: titles.get(main_module),
         dependsOn: [],
         dependedBy: []
       }
     ]),
-    ...(bootloader
-      ? [
-          [
-            bootloader,
-            {
-              name: "bootloader",
-              title: "Bootloader",
-              module: bootloader,
-              dependsOn: [],
-              dependedBy: []
-            }
-          ]
-        ]
-      : []),
+    ...bootloader ? [[
+        bootloader,
+        {
+          name: 'bootloader',
+          title: 'Bootloader',
+          module: bootloader,
+          dependsOn: [],
+          dependedBy: []
+        }
+      ]] : [],
     [
       builtin,
       {
-        name: "builtin",
-        title: "Standard library",
+        name: 'builtin',
+        title: 'Standard library',
         module: builtin,
         dependsOn: [],
         dependedBy: []
@@ -19040,30 +19786,21 @@ const _11z3pt0 = function _summary(main_modules,titles,bootloader,builtin,queue,
   ]);
   // add cross links
   // notebookImportVariables[0].variable._module == main
-  [...notebookImportMatches.keys()].forEach((m) => {
+  [...notebookImportMatches.keys()].forEach(m => {
     const hostModule = modules.get(main_modules[0]);
     const importedModule = modules.get(m);
     if (!hostModule?.dependsOn || !importedModule?.dependedBy) {
-      console.error(
-        "error building module dependancy map",
-        hostModule,
-        importedModule
-      );
+      console.error('error building module dependancy map', hostModule, importedModule);
       return;
     }
     hostModule.dependsOn.push(importedModule.name);
     importedModule.dependedBy.push(main_modules[0].name);
   });
-
-  module_definition_variables.forEach((v) => {
+  module_definition_variables.forEach(v => {
     const hostModule = modules.get(v._module);
     const importedModule = modules.get(v._value);
     if (!hostModule?.dependsOn || !importedModule?.dependedBy) {
-      console.error(
-        "error building module dependancy map",
-        hostModule,
-        importedModule
-      );
+      console.error('error building module dependancy map', hostModule, importedModule);
       return;
     }
     hostModule.dependsOn.push(importedModule.name);
@@ -19071,11 +19808,11 @@ const _11z3pt0 = function _summary(main_modules,titles,bootloader,builtin,queue,
   });
   return modules;
 };
-const _1pou2g6 = function _submit_summary(resolve_modules,queue,notebookImports,$0,summary)
+const _hhecn4 = function _submit_summary(resolve_modules,queue,notebookImports,$0,summary)
 {
   resolve_modules;
   queue;
-  console.log("submit_summary");
+  console.log('submit_summary');
   notebookImports;
   $0.resolve(summary);
 };
@@ -19089,47 +19826,47 @@ export default function define(runtime, observer) {
   main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
   main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
   main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));
-  main.define("module @tomlarkworthy/invoke-variable", async () => runtime.module((await import("/@tomlarkworthy/invoke-variable.js?v=4")).default));
-  main.define("module @tomlarkworthy/spectral-layout", async () => runtime.module((await import("/@tomlarkworthy/spectral-layout.js?v=4")).default));
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/invoke-variable", async () => runtime.module((await import("/@tomlarkworthy/invoke-variable.js?v=4")).default));  
+  main.define("module @tomlarkworthy/spectral-layout", async () => runtime.module((await import("/@tomlarkworthy/spectral-layout.js?v=4")).default));  
   $def("_1w9yf3l", null, ["md"], _1w9yf3l);  
   $def("_b6n8js", null, ["visualizeModules"], _b6n8js);  
   $def("_1sznqfl", null, ["md"], _1sznqfl);  
-  $def("_1798myt", "moduleMap", ["runtime","keepalive","myModule","viewof queue"], _1798myt);  
+  $def("_1hn3uql", "moduleMap", ["runtime","keepalive","myModule","viewof queue"], _1hn3uql);  
   $def("_1yso65r", null, ["md"], _1yso65r);  
-  $def("_1fcoh6x", "sync_modules", ["runtime_variables","moduleMap","_","viewof currentModules","Event"], _1fcoh6x);  
+  $def("_1e3kr85", "sync_modules", ["runtime_variables","moduleMap","_","viewof currentModules","Event"], _1e3kr85);  
   $def("_wi39n0", "viewof currentModules", ["Inputs","moduleMap"], _wi39n0);  
   $def("_1gxgyd6", "currentModules", ["Generators","viewof currentModules"], _1gxgyd6);  
-  $def("_1qag34d", null, ["Inputs","currentModules"], _1qag34d);  
+  $def("_1kxoygl", null, ["Inputs","currentModules"], _1kxoygl);  
   $def("_1xamz8j", null, ["md"], _1xamz8j);  
-  $def("_1n4p4hn", "tipTitle", [], _1n4p4hn);  
-  $def("_1kdcb71", "visualizeModules", ["currentModules","htl","d3","spectralCircleOrder","improveOrderSifting","bestOfRandomOrders","Plot","tipTitle","linkTo","isOnObservableCom"], _1kdcb71);  
+  $def("_1sglrv3", "tipTitle", [], _1sglrv3);  
+  $def("_5zbe1k", "visualizeModules", ["currentModules","htl","d3","spectralCircleOrder","improveOrderSifting","bestOfRandomOrders","Plot","tipTitle","linkTo","isOnObservableCom"], _5zbe1k);  
   $def("_hgwvol", null, ["md"], _hgwvol);  
   $def("_14bivfb", "viewof myModule", ["thisModule"], _14bivfb);  
   $def("_1cir47e", "myModule", ["Generators","viewof myModule"], _1cir47e);  
   $def("_1nfaybn", "tag", [], _1nfaybn);  
-  $def("_17qqkoj", "forcePeek", [], _17qqkoj);  
-  $def("_v9hg2i", "observe", [], _v9hg2i);  
+  $def("_1lkbrun", "forcePeek", [], _1lkbrun);  
+  $def("_1qva85d", "observe", [], _1qva85d);  
   $def("_1bm642i", null, ["md"], _1bm642i);  
-  $def("_oothhq", "viewof queue", ["flowQueue"], _oothhq);  
+  $def("_1f31b1g", "viewof queue", ["flowQueue"], _1f31b1g);  
   $def("_648shl", "queue", ["Generators","viewof queue"], _648shl);  
   $def("_1acbzli", null, ["md"], _1acbzli);  
-  $def("_10dhunq", "module_definition_variables", ["notebookImports","queue"], _10dhunq);  
-  $def("_dcxoxy", "modules", ["module_definition_variables","queue"], _dcxoxy);  
+  $def("_1g0cuj1", "module_definition_variables", ["notebookImports","queue"], _1g0cuj1);  
+  $def("_17frsyf", "modules", ["module_definition_variables","queue"], _17frsyf);  
   $def("_1dqpbvy", "builtin", ["queue"], _1dqpbvy);  
-  $def("_ir3ob0", "main_modules", ["queue","modules","builtin"], _ir3ob0);  
+  $def("_13mmmk9", "main_modules", ["queue","modules","builtin"], _13mmmk9);  
   $def("_yflsv5", "bootloaded_mains", ["queue"], _yflsv5);  
   $def("_ox2g3b", "bootloader", ["queue"], _ox2g3b);  
-  $def("_1turw8j", "resolve_modules", ["modules","module_definition_variables","findModuleName"], _1turw8j);  
+  $def("_10ufqkh", "resolve_modules", ["modules","module_definition_variables","findModuleName"], _10ufqkh);  
   $def("_9fbvam", null, ["md"], _9fbvam);  
-  $def("_1h0lryb", "notebookImports", ["main","parser"], _1h0lryb);  
-  $def("_7t198q", "notebookImportVariables", ["runtime","notebookImports"], _7t198q);  
-  $def("_1lyens8", "pageImportMatch", [], _1lyens8);  
-  $def("_1akt4kz", "notebookImportMatches", ["pageImportMatch","notebookImportVariables","modules"], _1akt4kz);  
-  $def("_1ang0sg", "moduleTitle", ["observeVariable"], _1ang0sg);
-  $def("_197sgjt", "titles", ["modules","moduleTitle"], _197sgjt);  
-  $def("_11z3pt0", "summary", ["main_modules","titles","bootloader","builtin","queue","notebookImportMatches","bootloaded_mains","resolve_modules","module_definition_variables"], _11z3pt0);  
-  $def("_1pou2g6", "submit_summary", ["resolve_modules","queue","notebookImports","viewof queue","summary"], _1pou2g6);  
+  $def("_1t4ga3d", "notebookImports", ["main","parser"], _1t4ga3d);  
+  $def("_994hn4", "notebookImportVariables", ["runtime","notebookImports"], _994hn4);  
+  $def("_xanizk", "pageImportMatch", [], _xanizk);  
+  $def("_1q5pc6n", "notebookImportMatches", ["pageImportMatch","notebookImportVariables","modules"], _1q5pc6n);  
+  $def("_12o3fj5", "moduleTitle", ["observeVariable"], _12o3fj5);  
+  $def("_ze3jk0", "titles", ["modules","moduleTitle"], _ze3jk0);  
+  $def("_pnpoh8", "summary", ["main_modules","titles","bootloader","builtin","queue","notebookImportMatches","bootloaded_mains","resolve_modules","module_definition_variables"], _pnpoh8);  
+  $def("_hhecn4", "submit_summary", ["resolve_modules","queue","notebookImports","viewof queue","summary"], _hhecn4);  
   main.define("linkTo", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("linkTo", _));  
   main.define("flowQueue", ["module @tomlarkworthy/flow-queue", "@variable"], (_, v) => v.import("flowQueue", _));  
   main.define("parser", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("parser", _));  
@@ -19143,8 +19880,8 @@ export default function define(runtime, observer) {
   main.define("isOnObservableCom", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("isOnObservableCom", _));  
   main.define("viewof runtime_variables", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("viewof runtime_variables", _));  
   main.define("runtime_variables", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime_variables", _));  
-  main.define("observeVariable", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("observe", "observeVariable", _));
-  main.define("invokeVariable", ["module @tomlarkworthy/invoke-variable", "@variable"], (_, v) => v.import("invokeVariable", _));
+  main.define("observeVariable", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("observe", "observeVariable", _));  
+  main.define("invokeVariable", ["module @tomlarkworthy/invoke-variable", "@variable"], (_, v) => v.import("invokeVariable", _));  
   main.define("spectralCircleOrder", ["module @tomlarkworthy/spectral-layout", "@variable"], (_, v) => v.import("spectralCircleOrder", _));  
   main.define("improveOrderSifting", ["module @tomlarkworthy/spectral-layout", "@variable"], (_, v) => v.import("improveOrderSifting", _));  
   main.define("bestOfRandomOrders", ["module @tomlarkworthy/spectral-layout", "@variable"], (_, v) => v.import("bestOfRandomOrders", _));
@@ -19423,6 +20160,441 @@ export default function define(runtime, observer) {
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));
   return main;
 }</script>
+
+<script id="@tomlarkworthy/modules" 
+  type="text/plain"
+  data-mime="application/javascript"
+>
+const _s7bl1p = function _1(md){return(
+md`# Modules
+
+\`modules(options?)\` is an async generator that yields a **cumulative \`Map\`** (module → \`{name, title, module, variable}\`) of every fully-formed record known so far, growing as modules resolve. 
+
+It's an effecient alternative to [moduleMap](https://observablehq.com/@tomlarkworthy/module-map) that blocks until all modules are loaded.
+`
+)};
+const _1eaa9lr = function _currentModules(modules){return(
+modules()
+)};
+const _dmem61 = function _modules(runtime,observeVariable,moduleTitle)
+{
+  const _runtime = runtime;
+  // default: the current runtime
+  return function modules({runtime = _runtime, titleTimeoutMs = 2000, rescanMs = 1000, load = true} = {}) {
+    if (!runtime || !runtime._variables)
+      throw 'Invalid runtime passed to modules';
+    return async function* () {
+      const records = new Map();
+      // module -> fully-formed record (title resolved before it lands here)
+      const watchers = new Map();
+      // module -> cancel fn (stops its title watch)
+      const peeking = new Map();
+      // unresolved `module X` variable -> stop fn (its force-load observer)
+      let pending = false, wake = null, dirty = true;
+      const bump = () => {
+        pending = true;
+        if (wake) {
+          const w = wake;
+          wake = null;
+          w();
+        }
+      };
+      const touch = () => {
+        dirty = true;
+        bump();
+      };
+      // Recover a module's @user/slug from its loader definition. On Observable's runtime the
+      // `module X` variable is named numerically ("module 1"), so v._name.slice(7) is a useless id;
+      // the real slug lives in the loader's import URL — import("/@user/slug.js?…") or
+      // importShim("/@user/slug.js", …). Matches both runtimes; null if no URL is found.
+      const slugFromDef = v => {
+        const m = v._definition && String(v._definition).match(/import(?:Shim)?\(\s*["'`]\/?([^"'`?]+?)\.js(?:[?"'`)]|$)/);
+        return m ? m[1].replace(/^\//, '') : null;
+      };
+      // Live candidate modules: Map<module, {name, variable?, title?}>. Side effect: force-loads
+      // unresolved `module X` variables via observe (which marks them reachable) so their modules
+      // become resolvable on a later scan.
+      const scan = () => {
+        const out = new Map();
+        const put = (m, r) => {
+          if (m && !out.has(m))
+            out.set(m, r);
+        };
+        const builtin = runtime._builtin, bootloader = runtime.bootloader;
+        if (builtin)
+          put(builtin, {
+            name: 'builtin',
+            title: 'Standard library'
+          });
+        if (bootloader)
+          put(bootloader, {
+            name: 'bootloader',
+            title: 'Bootloader'
+          });
+        for (const [name, mod] of runtime.mains || new Map())
+          put(mod, { name });
+        // main modules: variable-graph roots — own variables but aren't imported (nor builtin/
+        // bootloader). Catches the top-level main of a plain runtime where runtime.mains is empty.
+        const imported = new Set((runtime._modules || new Map()).values());
+        const owners = new Set();
+        for (const v of runtime._variables)
+          if (v._module)
+            owners.add(v._module);
+        for (const m of owners)
+          if (m !== builtin && m !== bootloader && !imported.has(m))
+            put(m, { name: 'main' });
+        // imported modules carried by `module X` variables
+        for (const v of runtime._variables) {
+          if (!v._name || !v._name.startsWith('module ') || v._name.startsWith('module <unknown'))
+            continue;
+          const mod = v._value;
+          if (mod && typeof mod === 'object')
+            put(mod, {
+              name: slugFromDef(v) || v._name.slice(7),
+              variable: v
+            });
+          else if (load && !peeking.has(v))
+            peeking.set(v, observeVariable(v, {
+              fulfilled: bump,
+              error: bump
+            }));
+        }
+        return out;
+      };
+      // Reconcile the snapshot with the live runtime each scan.
+      const reconcile = () => {
+        const cand = scan();
+        // DELETE: drop modules no longer present; cancel their title watcher.
+        for (const m of [...watchers.keys()]) {
+          if (!cand.has(m)) {
+            const cancel = watchers.get(m);
+            watchers.delete(m);
+            if (records.delete(m))
+              touch();
+            try {
+              cancel();
+            } catch (e) {
+            }
+          }
+        }
+        // CREATE: start a persistent title watch for each new module. The module enters `records`
+        // only once its title resolves (or the timeout fires). Later title changes update in place.
+        for (const [m, c] of cand) {
+          if (watchers.has(m))
+            continue;
+          if (c.title != null) {
+            // static title (builtin / bootloader)
+            records.set(m, {
+              name: c.name,
+              title: c.title,
+              module: m,
+              variable: c.variable
+            });
+            watchers.set(m, () => {
+            });
+            touch();
+            continue;
+          }
+          const apply = title => {
+            if (!watchers.has(m))
+              return;
+            // module was pruned -> ignore late title callbacks
+            const t = title ?? c.name;
+            const prev = records.get(m);
+            if (!prev) {
+              records.set(m, {
+                name: c.name,
+                title: t,
+                module: m,
+                variable: c.variable
+              });
+              touch();
+            } else if (prev.title !== t) {
+              records.set(m, {
+                ...prev,
+                title: t
+              });
+              touch();
+            }
+          };
+          const cancel = moduleTitle(m, apply);
+          watchers.set(m, () => {
+            try {
+              cancel();
+            } catch (e) {
+            }
+          });
+          // title never resolved within the budget -> show the name so the module isn't withheld.
+          setTimeout(() => {
+            if (watchers.has(m) && !records.has(m))
+              apply(null);
+          }, titleTimeoutMs);
+        }
+      };
+      let stopped = false;
+      (async () => {
+        while (!stopped) {
+          try {
+            reconcile();
+          } catch (e) {
+          }
+          await new Promise(r => setTimeout(r, rescanMs));
+        }
+      })();
+      try {
+        while (true) {
+          pending = false;
+          if (dirty) {
+            dirty = false;
+            yield new Map(records);
+          }
+          // cumulative snapshot
+          if (!pending)
+            await new Promise(resolve => {
+              wake = resolve;
+              if (pending) {
+                wake = null;
+                resolve();
+              }
+            });
+        }
+      } finally {
+        stopped = true;
+        for (const cancel of watchers.values()) {
+          try {
+            cancel();
+          } catch (e) {
+          }
+        }
+        for (const stop of peeking.values()) {
+          try {
+            stop();
+          } catch (e) {
+          }
+        }
+      }
+    }();
+  };
+};
+const _up9atj = function _moduleTitle(observeVariable)
+{
+  return function moduleTitle(module, onTitle) {
+    // Observes a module's title-defining cell and calls onTitle(title|null) on every change.
+    // Returns a cancel fn. The fixed observe() forces a lazy title cell to compute (and replays
+    // the current value on attach), so no in-module forcing helper is needed — works for named
+    // and anonymous cells alike, even in a fresh runtime nothing else observes.
+    const rt = module._runtime;
+    const candidates = [...rt._variables].filter(v => {
+      if (!v || v._module !== module || !v._definition || v._type != 1)
+        return false;
+      const n = v._name;
+      if (typeof n === 'string' && (n.startsWith('dynamic observe ') || n.startsWith('module ')))
+        return false;
+      return true;
+    });
+    if (candidates.length === 0) {
+      onTitle(null);
+      return () => {
+      };
+    }
+    const first = candidates.reduce((a, b) => (a._id ?? Infinity) <= (b._id ?? Infinity) ? a : b);
+    const extract = v => {
+      if (v == null)
+        return null;
+      if (typeof v === 'string')
+        return v.trim() || null;
+      if (v.tagName) {
+        if (v.tagName == 'H1')
+          return v.textContent;
+        const h1 = v.querySelector?.('h1');
+        if (h1)
+          return (h1.textContent ?? '').trim() || null;
+        return null;
+      }
+      if (v.textContent)
+        return (v.textContent ?? '').trim() || null;
+      return null;
+    };
+    const stop = observeVariable(first, {
+      fulfilled: value => onTitle(extract(value)),
+      error: () => onTitle('Err')
+    });
+    return () => {
+      try {
+        stop();
+      } catch (e) {
+      }
+    };
+  };
+};
+const _qpensj = function _5(Inputs,currentModules){return(
+Inputs.table([...currentModules.values()], {
+  columns: [
+    'name',
+    'title'
+  ],
+  format: { name: x => x }
+})
+)};
+const _1x0q6zt = function _7(md){return(
+md`## Tests`
+)};
+const _e0sbyj = function _8(tests,modulesModule){return(
+tests({
+  filter: (t) => t.variable._module == modulesModule
+})
+)};
+const _p3rq3v = function _modulesModule(thisModule){return(
+thisModule()
+)};
+const _16g1ab = (G, _) => G.input(_);
+const _cayyvt = function _testRuntime(Runtime){return(
+new Runtime()
+)};
+const _1j4p6g3 = function _testModulesLatest(modules,testRuntime){return(
+modules({
+  runtime: testRuntime
+})
+)};
+const _1oq6y7s = function _newModule(testRuntime)
+{
+  const m = testRuntime.module();
+  m.variable().define("greeting", [], () => {
+    const div = document.createElement("div");
+    div.innerHTML = "<h1>New Module</h1>";
+    return div;
+  });
+  return m;
+};
+const _1li1bty = function _test_detectsBuiltin(testModulesLatest)
+{
+  if (![...testModulesLatest.values()].find((m) => m.name == "builtin"))
+    throw Error();
+  return "ok";
+};
+const _vr1kp6 = function _test_detectsNewModule(testModulesLatest,newModule)
+{
+  const rec = testModulesLatest.get(newModule);
+  if (!rec) throw Error("newModule not detected yet");
+  if (rec.title !== "New Module")
+    throw Error(
+      "expected title 'New Module', got " + JSON.stringify(rec.title)
+    );
+  return "ok";
+};
+const _1p0sqk = async function _test_reflectsDelete(Runtime,modules)
+{
+  const rt = new Runtime();
+  const gen = modules({
+    runtime: rt,
+    rescanMs: 100,
+    titleTimeoutMs: 500
+  });
+  let snap = new Map();
+  (async () => {
+    for await (const s of gen) snap = s;
+  })();
+  const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+  const waitFor = async (pred, ms = 3000) => {
+    const t0 = Date.now();
+    while (Date.now() - t0 < ms) {
+      if (pred()) return true;
+      await wait(50);
+    }
+    return false;
+  };
+  try {
+    const m = rt.module();
+    m.variable().define("title", [], () => {
+      const d = document.createElement("div");
+      d.innerHTML = "<h1>Temp</h1>";
+      return d;
+    });
+    if (!(await waitFor(() => snap.has(m))))
+      throw Error("create not reflected");
+    for (const v of [...rt._variables]) if (v._module === m) v.delete();
+    if (!(await waitFor(() => !snap.has(m))))
+      throw Error("delete not reflected");
+    return "ok";
+  } finally {
+    if (gen.return) gen.return();
+  }
+};
+const _1315qaf = async function _test_reflectsTitleUpdate(Runtime,modules)
+{
+  const rt = new Runtime();
+  const gen = modules({
+    runtime: rt,
+    rescanMs: 100,
+    titleTimeoutMs: 500
+  });
+  let snap = new Map();
+  (async () => {
+    for await (const s of gen) snap = s;
+  })();
+  const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+  const waitFor = async (pred, ms = 3000) => {
+    const t0 = Date.now();
+    while (Date.now() - t0 < ms) {
+      if (pred()) return true;
+      await wait(50);
+    }
+    return false;
+  };
+  try {
+    const m = rt.module();
+    const tv = m.variable().define("title", [], () => {
+      const d = document.createElement("div");
+      d.innerHTML = "<h1>First</h1>";
+      return d;
+    });
+    if (!(await waitFor(() => snap.get(m)?.title === "First")))
+      throw Error("initial title not detected");
+    tv.define("title", [], () => {
+      const d = document.createElement("div");
+      d.innerHTML = "<h1>Second</h1>";
+      return d;
+    });
+    if (!(await waitFor(() => snap.get(m)?.title === "Second")))
+      throw Error("title update not reflected");
+    return "ok";
+  } finally {
+    if (gen.return) gen.return();
+  }
+};
+
+export default function define(runtime, observer) {
+  const main = runtime.module();
+  const $def = (pid, name, deps, fn) => {
+    main.variable(observer(name)).define(name, deps, fn).pid = pid;
+  };
+
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
+  main.define("module @tomlarkworthy/observable-runtime-v6", async () => runtime.module((await import("/@tomlarkworthy/observable-runtime-v6.js?v=4")).default));  
+  $def("_s7bl1p", null, ["md"], _s7bl1p);  
+  $def("_1eaa9lr", "currentModules", ["modules"], _1eaa9lr);  
+  $def("_dmem61", "modules", ["runtime","observeVariable","moduleTitle"], _dmem61);  
+  $def("_up9atj", "moduleTitle", ["observeVariable"], _up9atj);  
+  $def("_qpensj", null, ["Inputs","currentModules"], _qpensj);  
+  main.define("observeVariable", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("observe", "observeVariable", _));  
+  main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
+  main.define("thisModule", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("thisModule", _));  
+  $def("_1x0q6zt", null, ["md"], _1x0q6zt);  
+  $def("_e0sbyj", null, ["tests","modulesModule"], _e0sbyj);  
+  main.define("tests", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("tests", _));  
+  main.define("Runtime", ["module @tomlarkworthy/observable-runtime-v6", "@variable"], (_, v) => v.import("Runtime", _));  
+  $def("_p3rq3v", "viewof modulesModule", ["thisModule"], _p3rq3v);  
+  $def("_16g1ab", "modulesModule", ["Generators","viewof modulesModule"], _16g1ab);  
+  $def("_cayyvt", "testRuntime", ["Runtime"], _cayyvt);  
+  $def("_1j4p6g3", "testModulesLatest", ["modules","testRuntime"], _1j4p6g3);  
+  $def("_1oq6y7s", "newModule", ["testRuntime"], _1oq6y7s);  
+  $def("_1li1bty", "test_detectsBuiltin", ["testModulesLatest"], _1li1bty);  
+  $def("_vr1kp6", "test_detectsNewModule", ["testModulesLatest","newModule"], _vr1kp6);  
+  $def("_1p0sqk", "test_reflectsDelete", ["Runtime","modules"], _1p0sqk);  
+  $def("_1315qaf", "test_reflectsTitleUpdate", ["Runtime","modules"], _1315qaf);
+  return main;
+}</script>
 <script id="@tomlarkworthy/native-file-system-adapter/native-file-system-adapter%401.js.gz" 
   type="text/plain"
   data-encoding="base64"
@@ -19482,15 +20654,19 @@ directoryhandle ? Array.fromAsync(directoryhandle.values()) : []
 const _qlnjkc = function _6(Inputs,files){return(
 Inputs.table(files)
 )};
-const _1yojz19 = async function _filesystem(unzip, FileAttachment) {
-    const blob = await unzip(FileAttachment('native-file-system-adapter@1.js.gz'));
-    debugger;
-    const objectURL = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
-    try {
-        return await import(objectURL);
-    } finally {
-        URL.revokeObjectURL(objectURL);
-    }
+const _1yojz19 = async function _filesystem(unzip,FileAttachment)
+{
+  const blob = await unzip(FileAttachment("native-file-system-adapter@1.js.gz"));
+  debugger;
+
+  const objectURL = URL.createObjectURL(
+    new Blob([blob], { type: "application/javascript" })
+  );
+  try {
+    return await import(objectURL);
+  } finally {
+    URL.revokeObjectURL(objectURL); // Ensure URL is revoked after import
+  }
 };
 const _17n6uge = function _unzip(Response,DecompressionStream){return(
 async (attachment) =>
@@ -19555,14 +20731,18 @@ observable.Library
 const _1iyzb44 = function _RuntimeError(observable){return(
 observable.RuntimeError
 )};
-const _b2ba5g = async function _observable(unzip, FileAttachment) {
-    const blob = await unzip(FileAttachment('runtime.js.gz'));
-    const objectURL = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
-    try {
-        return await import(objectURL);
-    } finally {
-        URL.revokeObjectURL(objectURL);
-    }
+const _b2ba5g = async function _observable(unzip,FileAttachment)
+{
+  const blob = await unzip(FileAttachment("runtime.js.gz"));
+
+  const objectURL = URL.createObjectURL(
+    new Blob([blob], { type: "application/javascript" })
+  );
+  try {
+    return await import(objectURL);
+  } finally {
+    URL.revokeObjectURL(objectURL);
+  }
 };
 const _17n6uge = function _unzip(Response,DecompressionStream){return(
 async (attachment) =>
@@ -19613,10 +20793,13 @@ runtime.Runtime
 const _bfntg8 = function _RuntimeError(runtime){return(
 runtime.RuntimeError
 )};
-const _axblun = async function _runtime(gunzipBase64ToBlob, source_gz) {
-    const blob = await gunzipBase64ToBlob(source_gz);
-    const url = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
-    return import(url);
+const _axblun = async function _runtime(gunzipBase64ToBlob,source_gz)
+{
+  const blob = await gunzipBase64ToBlob(source_gz);
+  const url = URL.createObjectURL(
+    new Blob([blob], { type: "application/javascript" })
+  );
+  return import(url);
 };
 const _1ljam5l = function _gunzipBase64ToBlob(DecompressionStream,Response){return(
 async (b64) => {
@@ -19716,7 +20899,8 @@ Then re-attach the resulting \`.js.gz\` files to this notebook
 (notebook menu → Attachments → drag-and-drop, replacing the existing
 attachments of the same name).`
 )};
-const _3cxbvl = async function _lr(unzip, FileAttachment) {
+const _3cxbvl = async function _lr(unzip,FileAttachment)
+{
     const blob = await unzip(FileAttachment('lezer-lr-bundled.js.gz'));
     const objectURL = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
     try {
@@ -19725,7 +20909,8 @@ const _3cxbvl = async function _lr(unzip, FileAttachment) {
         URL.revokeObjectURL(objectURL);
     }
 };
-const _1v8kgvh = async function _lezerhighlight(unzip, FileAttachment) {
+const _1v8kgvh = async function _lezerhighlight(unzip,FileAttachment)
+{
     const blob = await unzip(FileAttachment('lezer-highlight-bundled.js.gz'));
     const objectURL = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
     try {
@@ -20100,13 +21285,6 @@ export default function define(runtime, observer) {
   $def("_104y7ux", "observable_lezer_parser", ["lezerhighlight","lr"], _104y7ux);
   return main;
 }</script>
-<script id="@tomlarkworthy/observablejs-toolchain/acorn-walk-8.3.2.js.gz" 
-  type="text/plain"
-  data-encoding="base64"
-  data-mime="application/gzip"
->
-H4sICB8jLWcCA2Fjb3JuLXdhbGtAOC4zLjIuanMApVlbU+O4En6fX2E4VZQza5wAs8yC8XK47FZRNbcC5mydonhQbDnRjC17JRkmh+S/n5bkm2zHITsvjNWt7v76olYrM3779o311rrMaRjj0JourG/8GsfkiVk5J3Rm3aZxnGfW06H7/sQ9sBANrXvMOGbW06/uwYl76Er5z4zMCEWxFZEYn1pjmiVjFKSM7j+j+Pu/f3OP3MNxSLgYy7WbfOMgJQWvU+vT53uwha272xvrmYi5FS4oSkiA4nhhzTDFDAmAJjXzHetjyrBFaJSyBAmS0lNrLkTGT8fj5+dn9xsPFXg3SJOxcmCfM7Iv1e4XaveVIrA9fhPlNJA6LGELBzvUYU46eqHLpU39ZOQ02MBwyOjlCTEL+WS5ZK5YZNijD+hR8cTIwfC9t4cLymgFKtW/lRbcNCI1Ef/h0VtnDek93EelNSfz2Y7vkwfixpjOwKODRy/b2yNulvO5zUYOfeANOFzB0ZTlkgB+R+9OM7sHHu3Co+eRDYTl8ikloTUZnTJvpwFT7R69kAfYgRXER0UTSjs2tDNbjF4YFjmju1wwSMyu70uRNLLEebnNxuUmC/vAX52K5bJilrydyWolAaZ+xQJzoxcxJ9ylaYh94ahvLqByfLzyKhik4+QWCfCa8SWQCra3Z2NF4EDwWU9UUWmwritPYXdU9ncMowj0KKOZz6usBz1ZD8ysZ49KGFClDVRIJd3JgArQnMDMfQMjLzASDQDkbCQDAh7ZZOQJtngxcXJQqnAGflYFh0S2TfM49n0saRB7Js58PAI0mkwlGdPwd58CET0Ej0oVoO7IQe57BIEqJYkdAPyRmLP02aL42UqlHuUV/A2QCOay2ACPgEYB+mggqywdFZUlPC0qVnUIsjoEkCjwm4L7EAci89UNQF+iZAB27MKB33GB+Uz5QRoponYm4bfwI4Uf/VP8wT/AX+DVIHvdKZ3x8d5eAbuN2mu4tvopF/KmC+rkecXulj9Oy5WscqUI/ahbnNpN6Ye9Ay7qNqFoijOS/smqAj73a+/AqC7ThnsOrzFHuvFIa9T/PP2GA+EGDEPXsaEAIPRwTdmSC40G4I7oA3v0BfypXKt1xdp/SJ9SWjN+lAzV9BL/ZeUl7heWzhhK/MS9jNPg+53sdAmmAgjymwSKbDRIqaLC40+gKwh3moYLj52lRW/x2C/+gUSQAkaQ2K307oL7jtat7cSw+iPJxKIm/ZCkHxnDnIPJJqQviMHHHHPyPxzWW4BzNUeENihtwGWcbOHiapdEVssANDB8E9UG20qktMBctOUcyQhSyvHfOci1HHaEi2KBGQWKrI/Gsh0asP8BTTFMUOtBNDyRUe9RcQmVY2TyKqWC0BybIf4LhplhX1NVib3erjF9BxNSsEErjG8BIwmMebSj22sXVoA45t3K0nOFrC6PqJTIwJLe5FQqEajkPmkkykNnvNSLiorlMHh1KrZ27QrwdLwSFQQxDKHyqoawxaG5VZlvJva/BMfmObh4RkQMnAMoPjbLpXhRisWq7yjcy95qdATgo/CPeGNhDmpli+H6mMqO0z1DcySfFkzDLhbQ34ATyRcDdISCVy176vNKXilXMcp7s5ghaIVaifqUCr4gIQ/rcNn/NYe3QDNS12mLtFUrWWPlz5StVyhcQkmRVPkl5UHgBj5V+IYrFDbkWVg1KP29JbYbozSB8HlDK41x1IIpqfACnIutTZOuid3/IEbQNMbXOIghnZK3K18D6io/19fjqd7eqdJrPM1nM8zMlvlnYaKhceAYKN8Krtbag2jj1RrWe/n6bqE7RFt/ynoDT0Kzsvtqpx2Q0pG+wgsLUVNtp+upM8WHOl4lu2rku3ljnzdxnbYroRDvVsJNCHtIRDBrF4BTVUll+3T3I06mmDUsdYT0jlqkmLUaKSixyLIxdquJ5xbO4JZ9tI4NyF8whhbr3G3HHWtDG65RdYOahqQlPY2+1lTG0gwzQTbc2btf9L6FjCzRkbXlzZxkucChvsy/40VPGyDuE4pzbACFlDUCWuvUevqDuDKGTJWUe3jrG5fpXQ4gfZk/gUrEKqEq/AO37E9mwDh7dRK2MDiUB7NllOfanCIY3Py9nJ4OKGcjNcwEeJuQVFsHO0InFPc4yWI49R8IJBLFG+38nSNOBqNQShCQQC1k5AyVYqQQQw9kGFl5rmWhfKWILYwAflVX60CgNs1Pl6Sj80M6kz9zblBaXrede7X3xlVdBr5nVAIxq6Mir2sLTXPmALXWFrxRQiJ1bPTjlS+wDtt4dbXNf8LP5nsSxUM4SGQri7AL455hqkwgH7XrseJsVfXtG2mb55ow+mrVGxZ9YYB1ysQnlOCwOaOUjGscoTwWQ+OLMbBogw1CYbPHRn3HLpeGCIwV542L/rTtHE9zFhRzq/5e79hFHA9jx2pbGalyJZ8Zw+pvEh2e1491PMOBmkgGe9NrrG6oik3idyUQv3ZDZbnLkDnjGQqwwapmK/kDDSNPkCmDVnZq2Q/vEQzVYdUpNxx0NOs9yKql9/aQGHFu1q0ivep3IalQ7W7oev2wKwtRTgtKrCjGaj3wmqltXcL6J39nK3uFmKdwtCI5yusolMNLL7HHSbNh9A1iQo9hekM1kRkJ8fTxecEW4pb85ZbDe8RJ5GqKOHYC+QV4wk9piC8iiKOTGSSW5jR0uEETTt5cX2KIEHaIouVx7KDy66I0GElKgr6Da/KL4SBnnDzBu0IuOYFSxCVWK9Slb8n/MPDejMf/svTx+YiyjNDZ19sP/pgn42gSTN4fTw7fhYfRydFheHz07t0xOkYBmh5hdDJ5Nwl/C8LjSXR4go6O8WSCDkHz++gwPJkERweBm6Ds/8t9I8syHQAA
-</script>
 <script id="@tomlarkworthy/observablejs-toolchain/parser-6.1.0.js.gz" 
   type="text/plain"
   data-encoding="base64"
@@ -20253,11 +21431,11 @@ Promise.all(
     })
 )
 )};
-const _18xo2td = function _test_all_cells_roundtrippable(roundtripped)
+const _1shi9or = function _test_all_cells_roundtrippable(roundtripped)
 {
   const errored = roundtripped.filter((cell) => cell.error);
   if (errored.length > 0) throw JSON.stringify(errored, null, 2);
-  return `${roundtripped} cells decompiled, recompiled and decompiled again without error`;
+  return `${roundtripped.length} cells decompiled, recompiled and decompiled again without error`;
 };
 const _14nox99 = function _21(md){return(
 md`## Reference Data`
@@ -20740,9 +21918,9 @@ notebook_semantics_document.nodes.map((s) => ({
 const _1oevsow = function _28(md){return(
 md`### Runtime Representation (v4)`
 )};
-const _11lfflk = function _notebook_semantics_module() {
-    return import('https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4');
-};
+const _11lfflk = function _notebook_semantics_module(){return(
+import("https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4")
+)};
 const _gjten6 = function _31(md){return(
 md`### Imports`
 )};
@@ -20808,7 +21986,7 @@ const _1v1d8m3 = async function _test_decompile_import_variable(decompile,import
   expect(decompiled).toEqual(`import {dep} from "@tomlarkworthy/dependancy"`);
   return "ok";
 };
-const _fiyb80 = async function _test_decompile_dollar_in_string_literal(decompile,expect)
+const _1ybjsqg = async function _test_decompile_dollar_in_string_literal(decompile,expect)
 {
   // Regression: $N inside a string/regex/template literal must NOT be substituted
   // with `viewof X` / `mutable X`. This is the cc_ws bug — regex backref $1
@@ -20822,7 +22000,7 @@ const _fiyb80 = async function _test_decompile_dollar_in_string_literal(decompil
       _inputs: ["viewof a", "viewof b"]
     }
   ]);
-  expect(decompiled).toEqual(`demo = 'x'.replace(/x/, '$1y')`);
+  expect(decompiled).toEqual(`demo = "x".replace(/x/, '$1y')`);
   return "ok";
 };
 const _wgfrtq = async function _test_decompile_import_variable_alias(decompile,importFake,expect)
@@ -20952,20 +22130,18 @@ const _v4p1js = async function _test_decompile_constant(decompile,expect)
   expect(decompiled).toEqual(`v = 1`);
   return "ok";
 };
-const _pcs4h = async function _test_decompile_string_literal(decompile,expect)
+const _1puzspw = async function _test_decompile_string_literal(decompile,expect)
 {
   const decompiled = await decompile([
     {
       _name: "v",
-      _definition: function _3() {
-        ("");
-      },
+      _definition: `function _3() {\n  ("");\n}`,
       _inputs: []
     }
   ]);
-  expect(decompiled).toEqual(`v = {
-  '';
-}`);
+  // decompile preserves the original expression verbatim (source-slicing), so the
+  // parenthesized string and quote style survive — no escodegen re-quoting.
+  expect(decompiled).toEqual(`v = {\n  ("");\n}`);
   return "ok";
 };
 const _a2zh99 = async function _test_decompile_html_cell(decompile,expect)
@@ -20980,7 +22156,7 @@ const _a2zh99 = async function _test_decompile_html_cell(decompile,expect)
   expect(decompiled).toEqual(`html = htl.html\`<div>\``);
   return "ok";
 };
-const _pyp280 = async function _test_decompile_class(decompile,expect)
+const _1pt67ao = async function _test_decompile_class(decompile,expect)
 {
   const decompiled = await decompile([
     {
@@ -20991,8 +22167,7 @@ class myclass {}
       _inputs: []
     }
   ]);
-  expect(decompiled).toEqual(`myclass = class myclass {
-}`);
+  expect(decompiled).toEqual(`myclass = class myclass {}`);
   return "ok";
 };
 const _kf8c3f = function _test_decompile_class_with_property(decompile){return(
@@ -21033,7 +22208,7 @@ x
   expect(decompiled).toEqual(`v = x`);
   return "ok";
 };
-const _4rsshj = async function _test_decompile_block(decompile,expect)
+const _14nvmno = async function _test_decompile_block(decompile,expect)
 {
   const decompiled = await decompile([
     {
@@ -21047,12 +22222,12 @@ const _4rsshj = async function _test_decompile_block(decompile,expect)
     }
   ]);
   expect(decompiled).toEqual(`v = {
-  '';
+  ("");
   return x + y;
 }`);
   return "ok";
 };
-const _o7o1wl = async function _test_decompile_comments(decompile,expect)
+const _5kd9if = async function _test_decompile_comments(decompile,expect)
 {
   const decompiled = await decompile([
     {
@@ -21067,7 +22242,7 @@ const _o7o1wl = async function _test_decompile_comments(decompile,expect)
   ]);
   expect(decompiled).toEqual(`comments = {
   // a comment
-  return '';
+  return "";
 }`);
   return "ok";
 };
@@ -21088,7 +22263,7 @@ const _1yn35e3 = async function _test_decompile_generator(decompile,expect)
 }`);
   return "ok";
 };
-const _135eswd = async function _test_decompile_function(decompile,expect)
+const _10wf7cf = async function _test_decompile_function(decompile,expect)
 {
   const decompiled = await decompile([
     {
@@ -21099,11 +22274,10 @@ function () {}
       _inputs: []
     }
   ]);
-  expect(decompiled).toEqual(`_function = function () {
-}`);
+  expect(decompiled).toEqual(`_function = function () {}`);
   return "ok";
 };
-const _1pitq2 = async function _test_decompile_async_function(decompile,expect)
+const _1191zxm = async function _test_decompile_async_function(decompile,expect)
 {
   const decompiled = await decompile([
     {
@@ -21114,11 +22288,10 @@ async function () {}
       _inputs: []
     }
   ]);
-  expect(decompiled).toEqual(`asyncfunction = async function () {
-}`);
+  expect(decompiled).toEqual(`asyncfunction = async function () {}`);
   return "ok";
 };
-const _1kxe1b2 = async function _test_decompile_named_function(decompile,expect)
+const _vpu09i = async function _test_decompile_named_function(decompile,expect)
 {
   const decompiled = await decompile([
     {
@@ -21129,8 +22302,7 @@ function foo() {}
       _inputs: []
     }
   ]);
-  expect(decompiled).toEqual(`named_function = function foo() {
-}`);
+  expect(decompiled).toEqual(`named_function = function foo() {}`);
   return "ok";
 };
 const _1pghf4f = async function _test_decompile_this_reference(decompile,expect)
@@ -21147,7 +22319,7 @@ const _1pghf4f = async function _test_decompile_this_reference(decompile,expect)
   expect(decompiled).toEqual(`thisReference = (this || 0) + 1`);
   return "ok";
 };
-const _4aeghn = async function _test_decompile_lambda(decompile,expect)
+const _rajn7p = async function _test_decompile_lambda(decompile,expect)
 {
   const decompiled = await decompile([
     {
@@ -21158,8 +22330,7 @@ const _4aeghn = async function _test_decompile_lambda(decompile,expect)
       _inputs: []
     }
   ]);
-  expect(decompiled).toEqual(`lambda = () => {
-}`);
+  expect(decompiled).toEqual(`lambda = () => {}`);
   return "ok";
 };
 const _12ec5zd = async function _test_decompile_error(decompile,expect)
@@ -21179,7 +22350,7 @@ const _12ec5zd = async function _test_decompile_error(decompile,expect)
 }`);
   return "ok";
 };
-const _3bj09h = async function _test_decompile_error_object(decompile,expect)
+const _1c93ef9 = async function _test_decompile_error_object(decompile,expect)
 {
   const decompiled = await decompile([
     {
@@ -21192,7 +22363,7 @@ const _3bj09h = async function _test_decompile_error_object(decompile,expect)
     }
   ]);
   expect(decompiled).toEqual(`error_obj = {
-  throw { foo: 'bar' };
+  throw { foo: "bar" };
 }`);
   return "ok";
 };
@@ -21254,7 +22425,7 @@ _
   expect(decompiled).toEqual(`inbuilt = _`);
   return "ok";
 };
-const _1uv76xx = async function _test_decompile_fileattachment(decompile,expect)
+const _4z1dnp = async function _test_decompile_fileattachment(decompile,expect)
 {
   const decompiled = await decompile([
     {
@@ -21265,7 +22436,7 @@ FileAttachment("empty")
       _inputs: []
     }
   ]);
-  expect(decompiled).toEqual(`file = FileAttachment('empty')`);
+  expect(decompiled).toEqual(`file = FileAttachment("empty")`);
   return "ok";
 };
 const _g4z6de = async function _test_decompile_mutable_dependancy(decompile,expect)
@@ -21338,7 +22509,7 @@ view
   expect(decompiled).toEqual(`viewofdatadep = view`);
   return "ok";
 };
-const _ehz2xk = async function _test_decompile_viewof_param(decompile,expect)
+const _b0y8zg = async function _test_decompile_viewof_param(decompile,expect)
 {
   // Lopecode compiled form uses viewof_X as parameter name instead of $N
   const decompiled = await decompile([
@@ -21354,7 +22525,7 @@ const _ehz2xk = async function _test_decompile_viewof_param(decompile,expect)
   ]);
   expect(decompiled).toEqual(`foo = {
   viewof bar.value = x;
-  viewof bar.dispatchEvent(new Event('input'));
+  viewof bar.dispatchEvent(new Event("input"));
 }`);
   return "ok";
 };
@@ -21371,7 +22542,7 @@ dep
   expect(decompiled).toEqual(`dep`);
   return "ok";
 };
-const _1jggajo = async function _test_decompile_import_mutable(decompile,expect)
+const _1eqf4jq = async function _test_decompile_import_mutable(decompile,expect)
 {
   const decompiled = await decompile([
     {
@@ -21381,11 +22552,11 @@ const _1jggajo = async function _test_decompile_import_mutable(decompile,expect)
     }
   ]);
   expect(decompiled).toEqual(
-    `mutable mutabledep = v.import('mutable mutabledep', _)`
+    `mutable mutabledep = v.import("mutable mutabledep", _)`
   );
   return "ok";
 };
-const _di0abi = async function _test_decompile_import_viewof(decompile,expect)
+const _3damo4 = async function _test_decompile_import_viewof(decompile,expect)
 {
   const decompiled = await decompile([
     {
@@ -21394,10 +22565,10 @@ const _di0abi = async function _test_decompile_import_viewof(decompile,expect)
       _inputs: []
     }
   ]);
-  expect(decompiled).toEqual(`viewof viewdep = v.import('viewof viewdep', _)`);
+  expect(decompiled).toEqual(`viewof viewdep = v.import("viewof viewdep", _)`);
   return "ok";
 };
-const _14o5oio = async function _test_decompile_viewof_data(decompile,expect)
+const _1l9xqsw = async function _test_decompile_viewof_data(decompile,expect)
 {
   const decompiled = await decompile([
     {
@@ -21406,10 +22577,10 @@ const _14o5oio = async function _test_decompile_viewof_data(decompile,expect)
       _inputs: []
     }
   ]);
-  expect(decompiled).toEqual(`viewdep = v.import('viewdep', _)`);
+  expect(decompiled).toEqual(`viewdep = v.import("viewdep", _)`);
   return "ok";
 };
-const _1lv4syw = async function _test_decompile_import_alias(decompile,expect)
+const _1cggvdk = async function _test_decompile_import_alias(decompile,expect)
 {
   const decompiled = await decompile([
     {
@@ -21418,10 +22589,10 @@ const _1lv4syw = async function _test_decompile_import_alias(decompile,expect)
       _inputs: []
     }
   ]);
-  expect(decompiled).toEqual(`dep_alias = v.import('dep', 'dep_alias', _)`);
+  expect(decompiled).toEqual(`dep_alias = v.import("dep", "dep_alias", _)`);
   return "ok";
 };
-const _l8b8hu = async function _test_decompile_import_mutable_alias(decompile,expect)
+const _xcwq4 = async function _test_decompile_import_mutable_alias(decompile,expect)
 {
   const decompiled = await decompile([
     {
@@ -21431,11 +22602,11 @@ const _l8b8hu = async function _test_decompile_import_mutable_alias(decompile,ex
     }
   ]);
   expect(decompiled).toEqual(
-    `mutable aslias_mutabledep = v.import('mutable mutabledep', 'mutable aslias_mutabledep', _)`
+    `mutable aslias_mutabledep = v.import("mutable mutabledep", "mutable aslias_mutabledep", _)`
   );
   return "ok";
 };
-const _1g5n3sa = async function _test_decompile_import_mutable_data_alias(decompile,expect)
+const _1868h0w = async function _test_decompile_import_mutable_data_alias(decompile,expect)
 {
   const decompiled = await decompile([
     {
@@ -21445,11 +22616,11 @@ const _1g5n3sa = async function _test_decompile_import_mutable_data_alias(decomp
     }
   ]);
   expect(decompiled).toEqual(
-    `aslias_mutabledep = v.import('mutabledep', 'aslias_mutabledep', _)`
+    `aslias_mutabledep = v.import("mutabledep", "aslias_mutabledep", _)`
   );
   return "ok";
 };
-const _1lnngk6 = async function _test_decompile_import_viewof_alias(decompile,expect)
+const _1afcxhk = async function _test_decompile_import_viewof_alias(decompile,expect)
 {
   const decompiled = await decompile([
     {
@@ -21459,11 +22630,11 @@ const _1lnngk6 = async function _test_decompile_import_viewof_alias(decompile,ex
     }
   ]);
   expect(decompiled).toEqual(
-    `viewof aslias_viewdep = v.import('viewof viewdep', 'viewof aslias_viewdep', _)`
+    `viewof aslias_viewdep = v.import("viewof viewdep", "viewof aslias_viewdep", _)`
   );
   return "ok";
 };
-const _1na1e5i = async function _test_decompile_import_viewof_data_alias(decompile,expect)
+const _1sl510 = async function _test_decompile_import_viewof_data_alias(decompile,expect)
 {
   const decompiled = await decompile([
     {
@@ -21473,31 +22644,18 @@ const _1na1e5i = async function _test_decompile_import_viewof_data_alias(decompi
     }
   ]);
   expect(decompiled).toEqual(
-    `aslias_viewdep = v.import('viewdep', 'aslias_viewdep', _)`
+    `aslias_viewdep = v.import("viewdep", "aslias_viewdep", _)`
   );
   return "ok";
 };
 const _17dwb6r = function _80(md){return(
 md`### The Decompiler`
 )};
-const _1vs6mei = function _82(md){return(
+const _1ngipml = function _81(md){return(
 md`### \`decompile\``
 )};
-const _1g89k6a = function _escodegenOptions(escodegen){return(
-{
-  comment: true,
-  format: {
-    ...escodegen.FORMAT_DEFAULTS,
-    indent: {
-      ...escodegen.FORMAT_DEFAULTS.indent,
-      style: "  "
-    }
-  }
-}
-)};
-const _llvq9s = function _decompile(decompileImport,formatImportDeclaration,acorn,escodegen,escodegenOptions)
-{
-  return async function decompile(variables) {
+const _2d5g1 = function _decompile(decompileImport,formatImportDeclaration,acorn){return(
+async function decompile(variables) {
     if (!variables || variables.length === 0)
       throw new Error("no variables to decompile");
     const importInfo = await decompileImport(variables);
@@ -21523,14 +22681,13 @@ const _llvq9s = function _decompile(decompileImport,formatImportDeclaration,acor
     const wrappedCode = "(" + compiled + ")";
     const comments = [],
       tokens = [];
-    let parsed = acorn.parse(wrappedCode, {
+    const parsed = acorn.parse(wrappedCode, {
       ecmaVersion: 2022,
       sourceType: "module",
       ranges: true,
       onComment: comments,
       onToken: tokens
     });
-    parsed = escodegen.attachComments(parsed, comments, tokens);
     const functionExpression = parsed.body[0].expression;
     const body = functionExpression.body;
     // Extract parameter names from AST for underscore-encoded name fixup
@@ -21549,102 +22706,128 @@ const _llvq9s = function _decompile(decompileImport,formatImportDeclaration,acor
         varName = name.replace(/^viewof /, "");
       }
     }
-    // Build $N → placeholder map. Walking the AST and renaming Identifier nodes
-    // BEFORE escodegen.generate keeps us out of string literals, regex literals,
-    // and template element cooked text — which is where naive replaceAll on $N
-    // used to corrupt regex backreferences (e.g. '$1cc=' + token).
-    const placeholders = [];
-    {
-      let id = 0;
-      inputs.forEach((input) => {
-        if (input && input.startsWith("mutable ")) {
-          placeholders.push({
-            key: `$${id++}`,
-            ph: `__OJS_DOLLAR_${placeholders.length}__`,
-            value: input,
-            mutable: true
-          });
-        } else if (
-          input &&
-          (input.startsWith("viewof ") || input === "@variable")
-        ) {
-          placeholders.push({
-            key: `$${id++}`,
-            ph: `__OJS_DOLLAR_${placeholders.length}__`,
-            value: input,
-            mutable: false
-          });
-        }
-      });
-    }
-    const byKey = new Map(placeholders.map((p) => [p.key, p]));
-    const renameDollarIdentifiers = (node) => {
-      if (!node || typeof node !== "object") return;
-      if (node.type === "Identifier") {
-        const p = byKey.get(node.name);
-        if (p) node.name = p.ph;
-        return;
-      }
-      for (const k in node) {
-        if (k === "loc" || k === "range") continue;
-        const c = node[k];
-        if (Array.isArray(c)) c.forEach(renameDollarIdentifiers);
-        else if (c && typeof c === "object" && c.type)
-          renameDollarIdentifiers(c);
-      }
-    };
-    renameDollarIdentifiers(body);
-    let expression = "";
+    // Pick the source range to return: the single returned expression for a
+    // normal `{ return <expr> }` cell, otherwise the whole body. We SLICE the
+    // original text rather than regenerate via escodegen, so comments, quote
+    // style, whitespace, ASI-sensitive grouping and class fields all survive
+    // byte-for-byte. (Regeneration was the root of the ASI, quote-drift and
+    // class-property-shim-gap bugs.)
+    let sliceNode = body;
+    let wrapObjectLiteral = false;
     if (
       body.type === "BlockStatement" &&
       body.body.length === 1 &&
       body.body[0].type === "ReturnStatement" &&
-      comments.length === 0
+      body.body[0].argument
     ) {
-      if (wrappedCode[body.body[0].argument.start] === "{") {
-        expression = `(${escodegen.generate(
-          body.body[0].argument,
-          escodegenOptions
-        )})`;
-      } else {
-        expression = escodegen.generate(
-          body.body[0].argument,
-          escodegenOptions
-        );
-      }
-    } else {
-      expression = escodegen.generate(body, escodegenOptions);
-    }
-    let source = `${varName ? `${prefix}${varName} = ` : ""}${expression}`;
-    // Substitute placeholders back to Observable-flavored names. Placeholders are
-    // unique tokens we just inserted, so this string-level substitution is safe.
-    for (const p of placeholders) {
-      if (p.mutable) {
-        source = source.replaceAll(`${p.ph}.value`, p.value);
-      } else {
-        source = source.replaceAll(p.ph, p.value);
+      const arg = body.body[0].argument;
+      // Unwrap `{ return <arg> }` to <arg> only when every comment lives INSIDE
+      // <arg>, so it survives the arg slice (a returned function's own comments
+      // are kept this way). A comment anywhere else in the block — before
+      // `return`, in the compiler's `return( … )` auto-wrap slot, or trailing
+      // after the value — would be dropped by unwrapping, so keep the (ASI-safe)
+      // block form to preserve it and round-trip exactly.
+      const hasCommentOutsideArg = comments.some(
+        (c) =>
+          c.start >= body.start &&
+          c.end <= body.end &&
+          (c.end <= arg.start || c.start >= arg.end)
+      );
+      if (!hasCommentOutsideArg) {
+        sliceNode = arg;
+        wrapObjectLiteral = wrappedCode[arg.start] === "{";
       }
     }
-    // Restore any unconsumed placeholders (bare $N reference to a mutable input).
-    for (const p of placeholders) {
-      if (p.mutable) source = source.replaceAll(p.ph, p.key);
+    const sliceStart = sliceNode.start;
+    const sliceEnd = sliceNode.end;
+
+    // $N → Observable name. Positional over the qualifying inputs, matching the
+    // compiler's convention (same counting the old placeholder pass used).
+    const dollarValue = new Map();
+    {
+      let id = 0;
+      inputs.forEach((input) => {
+        if (input && input.startsWith("mutable ")) {
+          dollarValue.set(`$${id++}`, { name: input, mutable: true });
+        } else if (
+          input &&
+          (input.startsWith("viewof ") || input === "@variable")
+        ) {
+          dollarValue.set(`$${id++}`, { name: input, mutable: false });
+        }
+      });
     }
-    // Fix underscore-encoded viewof/mutable parameter names (lopecode compiled form)
+    // Underscore-encoded viewof/mutable params (lopecode compiled form) → spaced.
+    const underscoreParam = new Map();
     inputs.forEach((input, i) => {
       if (
         input &&
         (input.startsWith("viewof ") || input.startsWith("mutable "))
       ) {
         const underscoreForm = input.replace(" ", "_");
-        if (params[i] === underscoreForm) {
-          source = source.replaceAll(underscoreForm, input);
-        }
+        if (params[i] === underscoreForm) underscoreParam.set(underscoreForm, input);
       }
     });
+
+    // Collect identifier-node range rewrites within the sliced expression only.
+    // Keyed on Identifier/MemberExpression nodes, so string, regex and template
+    // text is never touched (this is what the old string replaceAll corrupted).
+    const edits = [];
+    const consumed = new Set();
+    const collect = (node) => {
+      if (!node || typeof node !== "object" || typeof node.type !== "string")
+        return;
+      // mutable `$N.value` → `mutable foo` (replace the whole member expression)
+      if (
+        node.type === "MemberExpression" &&
+        !node.computed &&
+        node.object &&
+        node.object.type === "Identifier" &&
+        node.property &&
+        node.property.type === "Identifier" &&
+        node.property.name === "value"
+      ) {
+        const dv = dollarValue.get(node.object.name);
+        if (dv && dv.mutable) {
+          edits.push({ start: node.start, end: node.end, text: dv.name });
+          consumed.add(node.object);
+        }
+      } else if (node.type === "Identifier" && !consumed.has(node)) {
+        const dv = dollarValue.get(node.name);
+        if (dv) {
+          // Non-mutable $N → input name. Bare mutable $N (no `.value`) stays $N.
+          if (!dv.mutable) edits.push({ start: node.start, end: node.end, text: dv.name });
+        } else if (underscoreParam.has(node.name)) {
+          edits.push({ start: node.start, end: node.end, text: underscoreParam.get(node.name) });
+        }
+      }
+      for (const k in node) {
+        if (k === "loc" || k === "range" || k === "start" || k === "end")
+          continue;
+        const c = node[k];
+        if (Array.isArray(c)) c.forEach(collect);
+        else if (c && typeof c === "object" && typeof c.type === "string")
+          collect(c);
+      }
+    };
+    collect(sliceNode);
+
+    // Apply edits right-to-left (descending start) so offsets stay valid.
+    let expression = wrappedCode.slice(sliceStart, sliceEnd);
+    edits
+      .sort((a, b) => b.start - a.start)
+      .forEach((e) => {
+        const s = e.start - sliceStart;
+        const t = e.end - sliceStart;
+        expression = expression.slice(0, s) + e.text + expression.slice(t);
+      });
+    if (wrapObjectLiteral) expression = `(${expression})`;
+
+    const source = `${varName ? `${prefix}${varName} = ` : ""}${expression}`;
     return source;
-  };
-};
-const _1pvis67 = function _85(md){return(
+  }
+)};
+const _1x0pvrl = function _83(md){return(
 md`### \`extractModuleInfo\` 
 static analysis of module imports`
 )};
@@ -21735,7 +22918,7 @@ const _iigmyv = function _test_extractModuleInfo_alias_hack(expect,extractModule
   });
   return "ok";
 };
-const _1tggbee = function _92(md){return(
+const _7t42k8 = function _90(md){return(
 md`### \`findModuleName\` and \`findImportedName\``
 )};
 const _kiaw33 = function _import_ast_example(parser){return(
@@ -21743,44 +22926,65 @@ parser.parseCell(
   'import {runtime, viewof main as foo} from "@mootari/access-runtime"'
 )
 )};
-const _1n7gw17 = function _findModuleName(extractModuleInfo) {
-    return (scope, module, {
-        unknown_id = Math.random()
-    } = {}) => {
-        try {
-            const scopedVariables = [...scope.values()];
-            const candidates = scopedVariables.filter(v => v && v._value === module && typeof v._name === 'string' && v._name.startsWith('module ') && !v._name.startsWith('module <unknown'));
-            const pickBestInfo = dfn => {
-                const s = String(dfn ?? '');
-                const m = s.match(/\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/);
-                const firstArg = m?.[2];
-                const info1 = firstArg ? extractModuleInfo(firstArg) : {};
-                if (info1?.id || info1?.notebook)
-                    return info1;
-                return extractModuleInfo(s);
-            };
-            for (const v of candidates) {
-                const info = pickBestInfo(v._definition?.toString?.());
-                if (info?.namespace)
-                    return `@${ info.namespace }/${ info.notebook }`;
-                if (info?.id)
-                    return `d/${ info.id }@${ info.version }`;
-            }
-            const any = scopedVariables.find(v => v && v._value === module);
-            if (any) {
-                const info = pickBestInfo(any._definition?.toString?.());
-                if (info?.namespace)
-                    return `@${ info.namespace }/${ info.notebook }`;
-                if (info?.id)
-                    return `d/${ info.id }@${ info.version }`;
-            }
-            return `<unknown ${ unknown_id }>`;
-        } catch (e) {
-            debugger;
-            return 'error';
-        }
+const _1n7gw17 = function _findModuleName(extractModuleInfo){return(
+(scope, module, { unknown_id = Math.random() } = {}) => {
+  try {
+    const scopedVariables = [...scope.values()];
+
+    // Prefer variables that *define* a module and have a real module-loader name.
+    const candidates = scopedVariables.filter(
+      (v) =>
+        v &&
+        v._value === module &&
+        typeof v._name === "string" &&
+        v._name.startsWith("module ") &&
+        !v._name.startsWith("module <unknown")
+    );
+
+    const pickBestInfo = (dfn) => {
+      // Avoid the parentUrl (2nd arg) confusing module identification.
+      // Typical patterns:
+      //   importShim("/d/<id>@<ver>.js?v=4", "https://api.observablehq.com/@ns/name.js?v=4")
+      //   import("/d/<id>@<ver>.js?v=4")
+      // Prefer the *first argument* inside importShim(...) / import(...) when present.
+      const s = String(dfn ?? "");
+
+      // Try to capture the first string literal argument to importShim(...) or import(...)
+      // Tolerates quotes ", ', ` and both importShim and plain import.
+      const m = s.match(
+        /\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/
+      );
+      const firstArg = m?.[2];
+
+      const info1 = firstArg ? extractModuleInfo(firstArg) : {};
+      if (info1?.id || info1?.notebook) return info1;
+
+      // Fallback: parse the whole definition string.
+      return extractModuleInfo(s);
     };
-};
+
+    // Try module loader cells first.
+    for (const v of candidates) {
+      const info = pickBestInfo(v._definition?.toString?.());
+      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
+      if (info?.id) return `d/${info.id}@${info.version}`;
+    }
+
+    // Fallback: any scoped variable with _value==module.
+    const any = scopedVariables.find((v) => v && v._value === module);
+    if (any) {
+      const info = pickBestInfo(any._definition?.toString?.());
+      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
+      if (info?.id) return `d/${info.id}@${info.version}`;
+    }
+
+    return `<unknown ${unknown_id}>`;
+  } catch (e) {
+    debugger;
+    return "error";
+  }
+}
+)};
 const _i47chb = function _findImportedName(){return(
 async (v) => {
   if (v._inputs.length == 1 && v._inputs[0]._name === "@variable") {
@@ -21801,10 +23005,10 @@ async (v) => {
   return v._name;
 }
 )};
-const _1effqg = function _96(md){return(
+const _ed3cy2 = function _94(md){return(
 md`### \`decompileImport\``
 )};
-const _b7vai6 = function _decompileImport(findModuleName,findImportedName)
+const _1a4j4gm = function _decompileImport(findModuleName,findImportedName)
 {
   return async function decompileImport(variables, options = {}) {
     if (!variables || variables.length === 0)
@@ -21843,7 +23047,7 @@ const _b7vai6 = function _decompileImport(findModuleName,findImportedName)
       if (!Array.isArray(inputs) || inputs.length !== 2)
         return false;
       const [i0, i1] = inputs;
-      return !!(i0 && typeof i0 === 'object' && typeof i0._name === 'string' && i0._name.startsWith('module @') && i1 && typeof i1 === 'object' && i1._name === '@variable');
+      return !!(i0 && typeof i0 === 'object' && typeof i0._name === 'string' && i0._name.startsWith('module ') && i1 && typeof i1 === 'object' && i1._name === '@variable');
     };
     const isStageC = v => {
       const inputs = v?._inputs;
@@ -21976,32 +23180,8 @@ const _1u6sfri = async function _test_decompileImport_alias(importFake,decompile
 
   return "ok";
 };
-const _1lqhutp = function _102(md){return(
+const _1lti0tv = function _100(md){return(
 md`## Javascript Source Normalization`
-)};
-const _ikzxev = function _normalizeJavascriptSource(acorn,escodegen){return(
-(source) => {
-  var comments = [];
-  var tokens = [];
-
-  var ast = acorn.parse(source, {
-    ranges: true,
-    onComment: comments,
-    onToken: tokens
-  });
-
-  escodegen.attachComments(ast, comments, tokens);
-  return escodegen.generate(ast, {
-    comment: true
-  });
-}
-)};
-const _az8lo6 = function _normalizeVariables(variableToObject,normalizeJavascriptSource){return(
-(variables) =>
-  variables.map(variableToObject).map((v) => ({
-    ...v,
-    _definition: normalizeJavascriptSource(v._definition)
-  }))
 )};
 const _3knb9v = function _variableToObject(){return(
 (v) => ({
@@ -22010,7 +23190,7 @@ const _3knb9v = function _variableToObject(){return(
   _inputs: v._inputs.map((v) => v._name || v)
 })
 )};
-const _263fcv = function _106(md){return(
+const _autn1v = function _102(md){return(
 md`## Observable Source Normalization`
 )};
 const _7zpsl9 = function _normalizeObservableSourceSelector(Inputs,notebook_semantics_source){return(
@@ -22020,94 +23200,10 @@ Inputs.select(
 )
 )};
 const _1ex8kus = (G, _) => G.input(_);
-const _17petbz = function _108(normalizeObservableSource,normalizeObservableSourceSelector){return(
-normalizeObservableSource(normalizeObservableSourceSelector)
-)};
 const _b2d0zc = function _parsed(parser,normalizeObservableSourceSelector){return(
 parser.parseCell(normalizeObservableSourceSelector)
 )};
-const _qtgjo9 = function _generate(escodegen){return(
-function generate(node, source) {
-  if (node.type == "Cell") {
-    if (
-      node.body.type != "BlockStatement" &&
-      source &&
-      source[node.body.start] == "{"
-    ) {
-      return `${node.id ? `${generate(node.id)} = ` : ""}(${escodegen.generate(
-        node.body
-      )})`;
-    } else {
-      return `${node.id ? `${generate(node.id)} = ` : ""}${escodegen.generate(
-        node.body
-      )}`;
-    }
-  } else if (node.type == "Identifier") {
-    return escodegen.generate(node);
-  } else if (node.type == "ViewExpression") {
-  } else {
-    throw node.type;
-  }
-}
-)};
-const _104j23i = function _normalizeObservableSource(parser,generate){return(
-{
-  prompt:
-    'I see some of the test are failing because the AST generator uses a different set of quotes than the original source and various formatting quirks. This should not count as failure. I would suggest normalizing. Its not super easy because source code is not vanilla JS, we need to normalize just the bit after the block expression, and replace the "viewof XX" and "mutable XXX" macros with a placeholder whic we can normalize and then undo. Write the normalizeObservableSource.',
-  time: 1729097489369
-} &&
-  function normalizeObservableSource(source) {
-    // Replace viewof and mutable with placeholders
-    const viewofRegex = /viewof\s+([a-zA-Z_][a-zA-Z0-9_]*)/g;
-    const mutableRegex = /mutable\s+([a-zA-Z_][a-zA-Z0-9_]*)/g;
-
-    // Temporary placeholders
-    const VIEWOF_PLACEHOLDER = "__VIEWOF_PLACEHOLDER__";
-    const MUTABLE_PLACEHOLDER = "__MUTABLE_PLACEHOLDER__";
-
-    // Maps to store original names
-    const viewOfMap = new Map();
-    const mutableMap = new Map();
-
-    // Replace viewof XX with placeholder and store mapping
-    source = source.replace(viewofRegex, (match, p1) => {
-      const placeholder = `${VIEWOF_PLACEHOLDER}_${p1}`;
-      viewOfMap.set(placeholder, p1);
-      return placeholder;
-    });
-
-    // Replace mutable XXX with placeholder and store mapping
-    source = source.replace(mutableRegex, (match, p1) => {
-      const placeholder = `${MUTABLE_PLACEHOLDER}_${p1}`;
-      mutableMap.set(placeholder, p1);
-      return placeholder;
-    });
-
-    // Normalize quotes: convert all to single quotes
-    const comments = [],
-      tokens = [];
-    const cell = parser.parseCell(source, {
-      ranges: true,
-      onComment: comments,
-      onToken: tokens
-    });
-    
-
-    source = generate(cell, source);
-
-    // Restore original viewof and mutable identifiers
-    viewOfMap.forEach((original, placeholder) => {
-      source = source.replaceAll(placeholder, `viewof ${original}`);
-    });
-
-    mutableMap.forEach((original, placeholder) => {
-      source = source.replaceAll(placeholder, `mutable ${original}`);
-    });
-
-    return source;
-  }
-)};
-const _vle3wv = function _112(md){return(
+const _14qm8or = function _105(md){return(
 md`## The Compiler
 
 `
@@ -22175,14 +23271,14 @@ const _x7zc8w = async function _test_compile_integer(compile,expect)
   ]);
   return "ok";
 };
-const _1u7hlem = async function _test_compile_string(compile,expect)
+const _1qp2ggw = async function _test_compile_string(compile,expect)
 {
   const compiled = await compile(`""`);
   expect(compiled).toEqual([
     {
       _name: null,
       _inputs: [],
-      _definition: "function _anonymous() {return ('');}"
+      _definition: `function _anonymous() {return ("");}`
     }
   ]);
   return "ok";
@@ -22199,14 +23295,14 @@ const _151bijp = async function _test_compile_obj_literal(compile,expect)
   ]);
   return "ok";
 };
-const _ti9okn = async function _test_compile_assignment(compile,expect)
+const _17z4vyt = async function _test_compile_assignment(compile,expect)
 {
   const compiled = await compile(`x = ""`);
   expect(compiled).toEqual([
     {
       _name: "x",
       _inputs: [],
-      _definition: "function _x() {return ('');}"
+      _definition: `function _x() {return ("");}`
     }
   ]);
   return "ok";
@@ -22223,7 +23319,7 @@ const _1eb8vq = async function _test_compile_dependancy(compile,expect)
   ]);
   return "ok";
 };
-const _acs4l0 = async function _test_compile_block_dependancy(compile,expect)
+const _5b8x33 = async function _test_compile_block_dependancy(compile,expect)
 {
   const compiled = await compile(`z = {
   ("");
@@ -22233,12 +23329,12 @@ const _acs4l0 = async function _test_compile_block_dependancy(compile,expect)
     {
       _name: "z",
       _inputs: ["x", "y"],
-      _definition: "function _z(x,y) {\n    '';\n    return x + y;\n}"
+      _definition: `function _z(x,y) {\n  ("");\n  return x + y;\n}`
     }
   ]);
   return "ok";
 };
-const _125ljg9 = async function _test_compile_comments(compile,expect)
+const _9s1umz = async function _test_compile_comments(compile,expect)
 {
   const compiled = await compile(`comments = {
   // a comment
@@ -22248,12 +23344,12 @@ const _125ljg9 = async function _test_compile_comments(compile,expect)
     {
       _name: "comments",
       _inputs: [],
-      _definition: "function _comments() {\n    // a comment\n    return '';\n}"
+      _definition: `function _comments() {\n  // a comment\n  return "";\n}`
     }
   ]);
   return "ok";
 };
-const _li37je = async function _test_compile_generator(compile,expect)
+const _1rbs7b6 = async function _test_compile_generator(compile,expect)
 {
   const compiled = await compile(`generator = {
   yield x + y;
@@ -22262,24 +23358,24 @@ const _li37je = async function _test_compile_generator(compile,expect)
     {
       _name: "generator",
       _inputs: ["x", "y"],
-      _definition: "function* _generator(x,y) {\n    yield x + y;\n}"
+      _definition: "function* _generator(x,y) {\n  yield x + y;\n}"
     }
   ]);
   return "ok";
 };
-const _em4em6 = async function _test_compile_function(compile,expect)
+const _1gaxmhs = async function _test_compile_function(compile,expect)
 {
   const compiled = await compile(`_function = function () {}`);
   expect(compiled).toEqual([
     {
       _name: "_function",
       _inputs: [],
-      _definition: "function __function() {return (function () {\n});}"
+      _definition: "function __function() {return (function () {});}"
     }
   ]);
   return "ok";
 };
-const _w3atfb = async function _test_compile_async_function(compile,expect)
+const _2ozyn1 = async function _test_compile_async_function(compile,expect)
 {
   const compiled = await compile(`asyncfunction = async function () {}`);
   expect(compiled).toEqual([
@@ -22287,19 +23383,19 @@ const _w3atfb = async function _test_compile_async_function(compile,expect)
       _name: "asyncfunction",
       _inputs: [],
       _definition:
-        "function _asyncfunction() {return (async function () {\n});}"
+        "function _asyncfunction() {return (async function () {});}"
     }
   ]);
   return "ok";
 };
-const _14gl6yr = async function _test_compile_named_function(compile,expect)
+const _1jn3lk9 = async function _test_compile_named_function(compile,expect)
 {
   const compiled = await compile(`named_function = function foo() {}`);
   expect(compiled).toEqual([
     {
       _name: "named_function",
       _inputs: [],
-      _definition: "function _named_function() {return (function foo() {\n});}"
+      _definition: "function _named_function() {return (function foo() {});}"
     }
   ]);
   return "ok";
@@ -22316,19 +23412,19 @@ const _z3bqb8 = async function _test_compile_this_reference(compile,expect)
   ]);
   return "ok";
 };
-const _1sou7t0 = async function _test_compile_lambda(compile,expect)
+const _1lyze5m = async function _test_compile_lambda(compile,expect)
 {
   const compiled = await compile(`lambda = () => {}`);
   expect(compiled).toEqual([
     {
       _name: "lambda",
       _inputs: [],
-      _definition: "function _lambda() {return (() => {\n});}"
+      _definition: "function _lambda() {return (() => {});}"
     }
   ]);
   return "ok";
 };
-const _1o1u737 = async function _test_compile_error(compile,expect)
+const _12k1xub = async function _test_compile_error(compile,expect)
 {
   const compiled = await compile(`error = {
   throw new Error();
@@ -22337,7 +23433,7 @@ const _1o1u737 = async function _test_compile_error(compile,expect)
     {
       _name: "error",
       _inputs: [],
-      _definition: "function _error() {\n    throw new Error();\n}"
+      _definition: "function _error() {\n  throw new Error();\n}"
     }
   ]);
   return "ok";
@@ -22415,7 +23511,7 @@ const _78egw8 = async function _test_compile_builtin(compile,expect)
   ]);
   return "ok";
 };
-const _lflzev = async function _test_compile_fileattachment(compile,expect)
+const _1o65727 = async function _test_compile_fileattachment(compile,expect)
 {
   const compiled = await compile(`file = FileAttachment("empty")`);
   expect(compiled).toEqual([
@@ -22423,12 +23519,12 @@ const _lflzev = async function _test_compile_fileattachment(compile,expect)
       _name: "file",
       _inputs: ["FileAttachment"],
       _definition:
-        "function _file(FileAttachment) {return (FileAttachment('empty'));}"
+        `function _file(FileAttachment) {return (FileAttachment("empty"));}`
     }
   ]);
   return "ok";
 };
-const _1e555b1 = async function _test_compile_mutable_dep(compile,expect)
+const _14c9yxp = async function _test_compile_mutable_dep(compile,expect)
 {
   const compiled = await compile(`mutable_dep = {
   viewof view;
@@ -22441,12 +23537,12 @@ const _1e555b1 = async function _test_compile_mutable_dep(compile,expect)
       _name: "mutable_dep",
       _inputs: ["viewof view", "lambda", "mutable q"],
       _definition:
-        "function _mutable_dep($0,lambda,$1) {\n    $0;\n    lambda;\n    $1.value;\n    return $1.value;\n}"
+        "function _mutable_dep($0,lambda,$1) {\n  $0;\n  lambda;\n  $1.value;\n  return $1.value;\n}"
     }
   ]);
   return "ok";
 };
-const _1a2af6 = async function _test_compile_mutable_dep2(compile,expect)
+const _133w84q = async function _test_compile_mutable_dep2(compile,expect)
 {
   const compiled = await compile(`mutable_dep_2 = {
   file;
@@ -22457,7 +23553,7 @@ const _1a2af6 = async function _test_compile_mutable_dep2(compile,expect)
       _name: "mutable_dep_2",
       _inputs: ["file", "q"],
       _definition:
-        "function _mutable_dep_2(file,q) {\n    file;\n    return q + 1;\n}"
+        "function _mutable_dep_2(file,q) {\n  file;\n  return q + 1;\n}"
     }
   ]);
   return "ok";
@@ -22498,14 +23594,14 @@ const _1y1h47u = async function _test_compile_dep(compile,expect)
   ]);
   return "ok";
 };
-const _kwdsyz = async function _test_compile_class(compile,expect)
+const _1r711sh = async function _test_compile_class(compile,expect)
 {
   const compiled = await compile(`v = class {}`);
   expect(compiled).toEqual([
     {
       _name: "v",
       _inputs: [],
-      _definition: `function _v() {return (class {\n});}`
+      _definition: `function _v() {return (class {});}`
     }
   ]);
   return "ok";
@@ -22546,7 +23642,7 @@ Inputs.textarea({
   label: "compile test template"
 })
 )};
-const _1lmax86 = async function _test_compile_import_plain_single(compile,expect)
+const _1vg114c = async function _test_compile_import_plain_single(compile,expect)
 {
   const compiled = await compile(
     `import {dep} from "@tomlarkworthy/dependancy";`
@@ -22555,7 +23651,7 @@ const _1lmax86 = async function _test_compile_import_plain_single(compile,expect
     {
       _name: "module @tomlarkworthy/dependancy",
       _inputs: [],
-      _definition: `async () => runtime.module((await import("@tomlarkworthy/dependancy")).default)`
+      _definition: `async () => runtime.module((await import("/@tomlarkworthy/dependancy.js?v=4")).default)`
     },
     {
       _name: "dep",
@@ -22565,7 +23661,7 @@ const _1lmax86 = async function _test_compile_import_plain_single(compile,expect
   ]);
   return "ok";
 };
-const _17sgzdm = async function _test_compile_import_view_data_alias_single(compile,expect)
+const _18h6y38 = async function _test_compile_import_view_data_alias_single(compile,expect)
 {
   const compiled = await compile(
     `import {viewdep as aslias_viewdep_data} from "@tomlarkworthy/dependancy";`
@@ -22574,7 +23670,7 @@ const _17sgzdm = async function _test_compile_import_view_data_alias_single(comp
     {
       _name: "module @tomlarkworthy/dependancy",
       _inputs: [],
-      _definition: `async () => runtime.module((await import("@tomlarkworthy/dependancy")).default)`
+      _definition: `async () => runtime.module((await import("/@tomlarkworthy/dependancy.js?v=4")).default)`
     },
     {
       _name: "aslias_viewdep_data",
@@ -22584,7 +23680,7 @@ const _17sgzdm = async function _test_compile_import_view_data_alias_single(comp
   ]);
   return "ok";
 };
-const _1tqj4tp = async function _test_compile_import_mutable_data_alias_single(compile,expect)
+const _1svcdun = async function _test_compile_import_mutable_data_alias_single(compile,expect)
 {
   const compiled = await compile(
     `import {mutabledep as aslias_mutabledep_data} from "@tomlarkworthy/dependancy";`
@@ -22593,7 +23689,7 @@ const _1tqj4tp = async function _test_compile_import_mutable_data_alias_single(c
     {
       _name: "module @tomlarkworthy/dependancy",
       _inputs: [],
-      _definition: `async () => runtime.module((await import("@tomlarkworthy/dependancy")).default)`
+      _definition: `async () => runtime.module((await import("/@tomlarkworthy/dependancy.js?v=4")).default)`
     },
     {
       _name: "aslias_mutabledep_data",
@@ -22603,7 +23699,7 @@ const _1tqj4tp = async function _test_compile_import_mutable_data_alias_single(c
   ]);
   return "ok";
 };
-const _hv0te2 = async function _test_compile_import_mutable_single(compile,expect)
+const _tb4ops = async function _test_compile_import_mutable_single(compile,expect)
 {
   const compiled = await compile(
     `import {mutable mutabledep} from "@tomlarkworthy/dependancy";`
@@ -22612,7 +23708,7 @@ const _hv0te2 = async function _test_compile_import_mutable_single(compile,expec
     {
       _name: "module @tomlarkworthy/dependancy",
       _inputs: [],
-      _definition: `async () => runtime.module((await import("@tomlarkworthy/dependancy")).default)`
+      _definition: `async () => runtime.module((await import("/@tomlarkworthy/dependancy.js?v=4")).default)`
     },
     {
       _name: "mutable mutabledep",
@@ -22622,7 +23718,7 @@ const _hv0te2 = async function _test_compile_import_mutable_single(compile,expec
   ]);
   return "ok";
 };
-const _1mltqmr = async function _test_compile_import_viewof_single(compile,expect)
+const _vuzib9 = async function _test_compile_import_viewof_single(compile,expect)
 {
   const compiled = await compile(
     `import {viewof viewdep} from "@tomlarkworthy/dependancy";`
@@ -22631,7 +23727,7 @@ const _1mltqmr = async function _test_compile_import_viewof_single(compile,expec
     {
       _name: "module @tomlarkworthy/dependancy",
       _inputs: [],
-      _definition: `async () => runtime.module((await import("@tomlarkworthy/dependancy")).default)`
+      _definition: `async () => runtime.module((await import("/@tomlarkworthy/dependancy.js?v=4")).default)`
     },
     {
       _name: "viewof viewdep",
@@ -22641,7 +23737,7 @@ const _1mltqmr = async function _test_compile_import_viewof_single(compile,expec
   ]);
   return "ok";
 };
-const _1d18obr = async function _test_compile_import_alias_single(compile,expect)
+const _6ewshd = async function _test_compile_import_alias_single(compile,expect)
 {
   const compiled = await compile(
     `import {dep as dep_alias} from "@tomlarkworthy/dependancy";`
@@ -22650,7 +23746,7 @@ const _1d18obr = async function _test_compile_import_alias_single(compile,expect
     {
       _name: "module @tomlarkworthy/dependancy",
       _inputs: [],
-      _definition: `async () => runtime.module((await import("@tomlarkworthy/dependancy")).default)`
+      _definition: `async () => runtime.module((await import("/@tomlarkworthy/dependancy.js?v=4")).default)`
     },
     {
       _name: "dep_alias",
@@ -22660,7 +23756,7 @@ const _1d18obr = async function _test_compile_import_alias_single(compile,expect
   ]);
   return "ok";
 };
-const _1b5ghef = async function _test_compile_import_notebook(compile,expect)
+const _36migr = async function _test_compile_import_notebook(compile,expect)
 {
   const compiled = await compile(
     `import {escodegen} from "@tomlarkworthy/escodegen"`
@@ -22670,7 +23766,7 @@ const _1b5ghef = async function _test_compile_import_notebook(compile,expect)
       _name: `module @tomlarkworthy/escodegen`,
       _inputs: [],
       _definition:
-        'async () => runtime.module((await import("@tomlarkworthy/escodegen")).default)'
+        'async () => runtime.module((await import("/@tomlarkworthy/escodegen.js?v=4")).default)'
     },
     {
       _name: `escodegen`,
@@ -22690,13 +23786,13 @@ Inputs.select(
 )
 )};
 const _1e5ax6f = (G, _) => G.input(_);
-const _18e5b93 = function _153(test_case){return(
+const _7eic89 = function _146(test_case){return(
 test_case.value
 )};
 const _16q6oyc = async function _compiled(compile,test_case){return(
 await compile(test_case.value)
 )};
-const _1191170 = function _155(parser,test_case)
+const _61dayu = function _148(parser,test_case)
 {
   const comments = [];
   const tokens = [];
@@ -22712,27 +23808,10 @@ const _1191170 = function _155(parser,test_case)
     tokens
   };
 };
-const _1gh543z = function _compiled_selector(Inputs,compiled){return(
-Inputs.radio(compiled, {
-  format: (v) => v._name,
-  value: compiled[0]
-})
-)};
-const _1dmmuaf = (G, _) => G.input(_);
-const _1klx74n = function _157(compiled_selector,normalizeJavascriptSource){return(
-JSON.stringify(
-  {
-    ...compiled_selector,
-    _definition: normalizeJavascriptSource(compiled_selector._definition)
-  },
-  null,
-  2
-)
-)};
-const _eom91x = function _158(compile,test_case){return(
+const _cevs6r = function _149(compile,test_case){return(
 compile(test_case.value)
 )};
-const _ttos3c = function _compile(parser,observableToJs){return(
+const _mliwy8 = function _compile(parser,observableToJs){return(
 function compile(source, {
   anonymousName = '_anonymous'
 } = {}) {
@@ -22919,9 +23998,9 @@ function compile(source, {
     if (!_definition) {
       let functionBody;
       if (cell.body.type === 'BlockStatement') {
-        functionBody = observableToJs(cell.body, inputToArgMap, comments, tokens);
+        functionBody = observableToJs(cell.body, inputToArgMap, source);
       } else {
-        const bodyCode = observableToJs(cell.body, inputToArgMap, comments, tokens);
+        const bodyCode = observableToJs(cell.body, inputToArgMap, source);
         functionBody = `{return (${ bodyCode });}`;
       }
       _definition = `${ cell.async ? 'async ' : '' }function${ cell.generator ? '*' : '' } ${ v.functionName }(${ v.inputs.join(',') }) ${ functionBody }`;
@@ -22934,34 +24013,38 @@ function compile(source, {
   });
 }
 )};
-const _1v1i7wl = function _observableToJs(acorn_walk,parser,escodegen){return(
-(ast, inputMap, comments, tokens) => {
-  // Replace ViewExpression with their id so they are removed from
-  // source and replaced with a JS compatible one
-  const offset = 0;
+const _16p8atj = function _observableToJs(acorn_walk,parser){return(
+(ast, inputMap, source) => {
+  // Source-preserving: slice the original body text verbatim and splice only the
+  // Observable-specific macro ranges (`viewof foo` → $N, `mutable foo` →
+  // $N.value). Regenerating via escodegen used to drop the ASI-protecting paren
+  // in `return( … )`, normalize quotes, respace `${ x }`, and reindent — all
+  // avoided by never regenerating. Ranges are offsets into `source`.
+  const edits = [];
   acorn_walk.ancestor(
     ast,
     {
-      ViewExpression(node, ancestors) {
-        const reference = "viewof " + node.id.name;
-        node.type = "Identifier";
-        node.name = inputMap[node.id.name];
+      ViewExpression(node) {
+        edits.push({ start: node.start, end: node.end, text: inputMap[node.id.name] });
       },
-      MutableExpression(node, ancestors) {
-        const reference = "mutable " + node.id.name;
-        node.type = "Identifier";
-        // hack as ".value" is not valid identifier, but escodegen allows it
-        node.name = inputMap[node.id.name] + ".value";
+      MutableExpression(node) {
+        // ".value" is not a valid identifier but is valid member access here.
+        edits.push({ start: node.start, end: node.end, text: inputMap[node.id.name] + ".value" });
       }
     },
     parser.walk
   );
-  escodegen.attachComments(ast, comments, tokens);
-  const js = escodegen.generate(ast, { comment: true });
-  return js;
+  const base = ast.start;
+  let out = source.slice(ast.start, ast.end);
+  edits
+    .sort((a, b) => b.start - a.start)
+    .forEach((e) => {
+      out = out.slice(0, e.start - base) + e.text + out.slice(e.end - base);
+    });
+  return out;
 }
 )};
-const _1ayjluu = function _161(md){return(
+const _1hd7px0 = function _152(md){return(
 md`### Bundled deps`
 )};
 const _xhj6b8 = function _decompress_url(DecompressionStream,TextDecoderStream,TransformStream,TextEncoderStream,Response){return(
@@ -22998,19 +24081,19 @@ async (attachment, overrides) => {
   return URL.createObjectURL(blob);
 }
 )};
-const _s9w7ha = async function _parser(decompress_url, FileAttachment, acorn_url, acorn_walk_url) {
-    return import(await decompress_url(FileAttachment('parser-6.1.0.js.gz'), {
-        '/npm/acorn@8.11.3/+esm': acorn_url,
-        '/npm/acorn-walk@8.3.2/+esm': acorn_walk_url
-    }));
-};
-const _1rc67k0 = function _stageB_importFake()
+const _s9w7ha = async function _parser(decompress_url,FileAttachment,acorn_url,acorn_walk_url){return(
+import(await decompress_url(FileAttachment("parser-6.1.0.js.gz"), {
+    "/npm/acorn@8.11.3/+esm": acorn_url,
+    "/npm/acorn-walk@8.3.2/+esm": acorn_walk_url
+  }))
+)};
+const _j9n5de = function _stageB_importFake()
 {
-  return // Builds a Stage B (pre-observation, API-loaded) import group as POJOs.
+  // Builds a Stage B (pre-observation, API-loaded) import group as POJOs.
   // Mirrors what `runtime.define("name", ["module @X", "@variable"], (_, v) => v.import("name", _))`
   // produces structurally. Used by the test_decompileImport_stageB_* tests to
   // avoid spinning up a real Observable runtime per case.
-  function stageB_importFake(module_name, specifiers) {
+  return function stageB_importFake(module_name, specifiers) {
     const importerModule = { _scope: new Map() };
     const stitch = {
       _name: `module ${ module_name }`,
@@ -23164,10 +24247,10 @@ const _rk7ku3 = async function _test_decompileImport_compile_roundtrip_single(co
   expect(formatImportDeclaration(info)).toEqual(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
   return 'ok';
 };
-const _xynplo = async function _test_decompileImport_stageB_order_independent(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+const _1numivw = async function _test_decompileImport_stageB_order_independent(stageB_importFake,decompileImport,expect,formatImportDeclaration)
 {
   // The detection uses .find — it shouldn't matter whether the stitch is at
-  // index 0 or the aliases come first. Verify by reversing the array.
+  // index 0 or the aliases come first. Verify by moving it to the end.
   const vars = stageB_importFake('@user/y', [
     {
       imported: 'a',
@@ -23178,8 +24261,11 @@ const _xynplo = async function _test_decompileImport_stageB_order_independent(st
       local: 'b'
     }
   ]);
-  const reversed = [...vars].reverse();
-  const info = await decompileImport(reversed);
+  const [stitch, ...aliases] = vars;
+  const info = await decompileImport([
+    ...aliases,
+    stitch
+  ]);
   expect(info.meta.detection.stage).toEqual('B');
   expect(formatImportDeclaration(info)).toEqual(`import {a, b} from "@user/y"`);
   return 'ok';
@@ -23196,13 +24282,143 @@ const _16fpgac = async function _test_decompileImport_stageB_notebook_id(stageB_
   expect(formatImportDeclaration(info)).toEqual(`import {hash} from "d/57d79353bac56631@44"`);
   return 'ok';
 };
+const _r2e0wl = function _test_extractModuleInfo_new_id_resolutions(expect,extractModuleInfo)
+{
+  // new.observablehq.com d/<id>@<ver> import with resolutions=.
+  expect(
+    extractModuleInfo(
+      'async () => runtime.module((await import("/d/e1c39d41e8e944b0@939.js?v=4&resolutions=a6a56ee61aba9799@437")).default)'
+    )
+  ).toEqual({ id: "e1c39d41e8e944b0", version: "939" });
+  return "ok";
+};
+const _1pg1y6s = function _test_extractModuleInfo_new_slug_resolutions(expect,extractModuleInfo)
+{
+  // new.observablehq.com slug import carries a resolutions= param.
+  expect(
+    extractModuleInfo(
+      'async () => runtime.module((await import("/@mootari/access-runtime.js?v=4&resolutions=98f34e974bb2e4bc@1392")).default)'
+    )
+  ).toEqual({ namespace: "mootari", notebook: "access-runtime", version: "1392" });
+  return "ok";
+};
+const _1vh26m0 = function _test_findModuleName_classic_bundle(expect,findModuleName)
+{
+  // classic observablehq.com bundles imports; the holder def is a bare slug import.
+  const m = {}; // module sentinel
+  const scope = new Map([
+    ["module 1", { _name: "module 1", _value: m,
+      _definition: 'async () => runtime.module((await import("@tomlarkworthy/flow-queue")).default)' }]
+  ]);
+  expect(findModuleName(scope, m)).toEqual("@tomlarkworthy/flow-queue");
+  return "ok";
+};
+const _1ltqcwj = function _test_findModuleName_kit_slug(expect,findModuleName)
+{
+  // Notebook Kit compiles observable imports to import("https://api.observablehq.com/@u/nb.js?v=4").
+  const m = {}; // module sentinel
+  const scope = new Map([
+    ["module 1", { _name: "module 1", _value: m,
+      _definition: 'async (__ojs_runtime) => __ojs_runtime.module((await import("https://api.observablehq.com/@d3/color-legend.js?v=4")).default)' }]
+  ]);
+  expect(findModuleName(scope, m)).toEqual("@d3/color-legend");
+  return "ok";
+};
+const _wq4poo = function _test_findModuleName_new_id(expect,findModuleName)
+{
+  const m = {}; // module sentinel
+  const scope = new Map([
+    ["module 1", { _name: "module 1", _value: m,
+      _definition: 'async () => runtime.module((await import("/d/e1c39d41e8e944b0@939.js?v=4&resolutions=a6a56ee61aba9799@437")).default)' }]
+  ]);
+  expect(findModuleName(scope, m)).toEqual("d/e1c39d41e8e944b0@939");
+  return "ok";
+};
+const _1j0hksu = function _test_findModuleName_new_slug(expect,findModuleName)
+{
+  const m = {}; // module sentinel
+  const scope = new Map([
+    ["module 1", { _name: "module 1", _value: m,
+      _definition: 'async () => runtime.module((await import("/@mootari/access-runtime.js?v=4&resolutions=98f34e974bb2e4bc@1392")).default)' }]
+  ]);
+  expect(findModuleName(scope, m)).toEqual("@mootari/access-runtime");
+  return "ok";
+};
+const _3en7eq = async function _test_decompile_leading_comment(decompile,expect,compile)
+{
+  // Regression: a comment in the compiler's auto-wrap slot (`return( // note\n42 )`)
+  // is preserved in ASI-safe block form — never the hazardous `return` + comment
+  // + newline WITHOUT the paren that evaluated to undefined on ObservableHQ.
+  const src = await decompile([
+    { _name: "c", _definition: `function _c(){return( // note\n42\n)}`, _inputs: [] }
+  ]);
+  expect(src).toEqual(`c = {return( // note\n42\n)}`);
+  // It keeps the ASI-protecting paren and round-trips through compile to 42.
+  const cell = compile(src);
+  const first = Array.isArray(cell) ? cell[0] : cell;
+  const def = first._definition || (first.cells && first.cells[0]._definition);
+  expect(eval(`(${def})`)()).toEqual(42);
+  return "ok";
+};
+const _z17nwa = async function _test_decompile_trailing_comment(decompile,expect)
+{
+  // Regression: a comment that survives compile inside the block (trailing on the
+  // return line, or before the closing brace) must survive decompile too — don't
+  // unwrap a single-return block when a comment sits outside the returned value.
+  const trailing = await decompile([
+    { _name: "x", _definition: `function _x(){\n  return 1; // done\n}`, _inputs: [] }
+  ]);
+  expect(trailing).toEqual(`x = {\n  return 1; // done\n}`);
+  const tail = await decompile([
+    { _name: "y", _definition: `function _y(){\n  return 1;\n  // tail\n}`, _inputs: [] }
+  ]);
+  expect(tail).toEqual(`y = {\n  return 1;\n  // tail\n}`);
+  return "ok";
+};
+const _q5y9bo = async function _test_decompile_param_in_string(decompile,expect)
+{
+  // Regression: renaming an underscore-encoded viewof/mutable param must rewrite
+  // only identifier references, never same-spelled text inside a string literal
+  // (range-based splice, not the old source.replaceAll).
+  const decompiled = await decompile([
+    {
+      _name: "u",
+      _definition: `function _u(viewof_x){return(\n"viewof_x literal" + viewof_x\n)}`,
+      _inputs: ["viewof x"]
+    }
+  ]);
+  expect(decompiled).toEqual(`u = "viewof_x literal" + viewof x`);
+  return "ok";
+};
+const _fm2sgc = async function _test_decompile_class_property_field(decompile,expect)
+{
+  // Regression: a class field declaration must decompile cleanly. Source-slicing
+  // sidesteps the escodegen shim gap that threw "this[d] is not a function".
+  const decompiled = await decompile([
+    {
+      _name: "Cls",
+      _definition: `function _Cls(){return(\nclass Cls {\n  d;\n}\n)}`,
+      _inputs: []
+    }
+  ]);
+  expect(decompiled).toEqual(`Cls = class Cls {\n  d;\n}`);
+  return "ok";
+};
+const _1xp8nli = async function _test_compile_preserves_formatting(compile,expect)
+{
+  // Source-preserving compile keeps quote style and template spacing verbatim;
+  // escodegen used to re-quote ("h1" -> 'h1') and respace (${s} -> ${ s }).
+  const compiled = await compile('x = { const s = "h1"; return `${s}`; }');
+  expect(compiled[0]._definition).toEqual('function _x() { const s = "h1"; return `${s}`; }');
+  return "ok";
+};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
   const $def = (pid, name, deps, fn) => {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
-  const fileAttachments = new Map(["acorn-walk-8.3.2.js.gz","parser-6.1.0.js.gz"].map((name) => {
+  const fileAttachments = new Map(["parser-6.1.0.js.gz"].map((name) => {
     const module_name = "@tomlarkworthy/observablejs-toolchain";
     const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
     const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
@@ -23212,7 +24428,6 @@ export default function define(runtime, observer) {
 
   main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
   main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
-  main.define("module @tomlarkworthy/escodegen", async () => runtime.module((await import("/@tomlarkworthy/escodegen.js?v=4")).default));  
   main.define("module @tomlarkworthy/acorn-8-11-3", async () => runtime.module((await import("/@tomlarkworthy/acorn-8-11-3.js?v=4")).default));  
   main.define("module @tomlarkworthy/jest-expect-standalone", async () => runtime.module((await import("/@tomlarkworthy/jest-expect-standalone.js?v=4")).default));  
   main.define("module @tomlarkworthy/observable-runtime", async () => runtime.module((await import("/@tomlarkworthy/observable-runtime.js?v=4")).default));  
@@ -23238,7 +24453,7 @@ export default function define(runtime, observer) {
   $def("_x55zzr", "test_decompiled_cells_recompilable", ["all_compiled"], _x55zzr);  
   $def("_100n7xr", null, ["md"], _100n7xr);  
   $def("_1nm57o2", "roundtripped", ["all_compiled","decompile"], _1nm57o2);  
-  $def("_18xo2td", "test_all_cells_roundtrippable", ["roundtripped"], _18xo2td);  
+  $def("_1shi9or", "test_all_cells_roundtrippable", ["roundtripped"], _1shi9or);  
   $def("_14nox99", null, ["md"], _14nox99);  
   $def("_1d3zr3i", null, ["md"], _1d3zr3i);  
   $def("_12sqt9", "dependancy_document", [], _12sqt9);  
@@ -23258,132 +24473,122 @@ export default function define(runtime, observer) {
   $def("_25tjxa", "test_decompile_syntax_error_roundtrip", ["compile","decompile","expect"], _25tjxa);  
   $def("_1jyrnzq", "test_decompile_$variable", ["decompile","expect"], _1jyrnzq);  
   $def("_1v1d8m3", "test_decompile_import_variable", ["decompile","importFake","expect"], _1v1d8m3);  
-  $def("_fiyb80", "test_decompile_dollar_in_string_literal", ["decompile","expect"], _fiyb80);  
+  $def("_1ybjsqg", "test_decompile_dollar_in_string_literal", ["decompile","expect"], _1ybjsqg);  
   $def("_wgfrtq", "test_decompile_import_variable_alias", ["decompile","importFake","expect"], _wgfrtq);  
   $def("_1a8gnrc", "test_decompile_import_many", ["decompile","importFake","expect"], _1a8gnrc);  
   $def("_7stpu3", "test_decompile_markdown_cell", ["decompile","expect"], _7stpu3);  
   $def("_v4p1js", "test_decompile_constant", ["decompile","expect"], _v4p1js);  
-  $def("_pcs4h", "test_decompile_string_literal", ["decompile","expect"], _pcs4h);  
+  $def("_1puzspw", "test_decompile_string_literal", ["decompile","expect"], _1puzspw);  
   $def("_a2zh99", "test_decompile_html_cell", ["decompile","expect"], _a2zh99);  
-  $def("_pyp280", "test_decompile_class", ["decompile","expect"], _pyp280);  
+  $def("_1pt67ao", "test_decompile_class", ["decompile","expect"], _1pt67ao);  
   $def("_kf8c3f", "test_decompile_class_with_property", ["decompile"], _kf8c3f);  
   $def("_4vunhm", "test_decompile_object_literal", ["decompile","expect"], _4vunhm);  
   $def("_s14e29", "test_decompile_reference", ["decompile","expect"], _s14e29);  
-  $def("_4rsshj", "test_decompile_block", ["decompile","expect"], _4rsshj);  
-  $def("_o7o1wl", "test_decompile_comments", ["decompile","expect"], _o7o1wl);  
+  $def("_14nvmno", "test_decompile_block", ["decompile","expect"], _14nvmno);  
+  $def("_5kd9if", "test_decompile_comments", ["decompile","expect"], _5kd9if);  
   $def("_1yn35e3", "test_decompile_generator", ["decompile","expect"], _1yn35e3);  
-  $def("_135eswd", "test_decompile_function", ["decompile","expect"], _135eswd);  
-  $def("_1pitq2", "test_decompile_async_function", ["decompile","expect"], _1pitq2);  
-  $def("_1kxe1b2", "test_decompile_named_function", ["decompile","expect"], _1kxe1b2);  
+  $def("_10wf7cf", "test_decompile_function", ["decompile","expect"], _10wf7cf);  
+  $def("_1191zxm", "test_decompile_async_function", ["decompile","expect"], _1191zxm);  
+  $def("_vpu09i", "test_decompile_named_function", ["decompile","expect"], _vpu09i);  
   $def("_1pghf4f", "test_decompile_this_reference", ["decompile","expect"], _1pghf4f);  
-  $def("_4aeghn", "test_decompile_lambda", ["decompile","expect"], _4aeghn);  
+  $def("_rajn7p", "test_decompile_lambda", ["decompile","expect"], _rajn7p);  
   $def("_12ec5zd", "test_decompile_error", ["decompile","expect"], _12ec5zd);  
-  $def("_3bj09h", "test_decompile_error_object", ["decompile","expect"], _3bj09h);  
+  $def("_1c93ef9", "test_decompile_error_object", ["decompile","expect"], _1c93ef9);  
   $def("_6iufw4", null, ["md"], _6iufw4);  
   $def("_15idqib", "test_decompile_anon_error_dep", ["decompile","expect"], _15idqib);  
   $def("_mhm98c", "test_decompile_viewof", ["decompile","expect"], _mhm98c);  
   $def("_15kgqrr", "test_decompile_mutable", ["decompile","expect"], _15kgqrr);  
   $def("_1onyv5c", "test_decompile_builtin", ["decompile","expect"], _1onyv5c);  
-  $def("_1uv76xx", "test_decompile_fileattachment", ["decompile","expect"], _1uv76xx);  
+  $def("_4z1dnp", "test_decompile_fileattachment", ["decompile","expect"], _4z1dnp);  
   $def("_g4z6de", "test_decompile_mutable_dependancy", ["decompile","expect"], _g4z6de);  
   $def("_qo8sdl", "test_decompile_mutable_dependancy_2", ["decompile","expect"], _qo8sdl);  
   $def("_15kwaz1", "test_decompile_viewof_dep", ["decompile","expect"], _15kwaz1);  
   $def("_1qjzk2s", "test_decompile_viewof_data_dep", ["decompile","expect"], _1qjzk2s);  
-  $def("_ehz2xk", "test_decompile_viewof_param", ["decompile","expect"], _ehz2xk);  
+  $def("_b0y8zg", "test_decompile_viewof_param", ["decompile","expect"], _b0y8zg);  
   $def("_oilkc0", "test_decompile_anon_dep", ["decompile","expect"], _oilkc0);  
-  $def("_1jggajo", "test_decompile_import_mutable", ["decompile","expect"], _1jggajo);  
-  $def("_di0abi", "test_decompile_import_viewof", ["decompile","expect"], _di0abi);  
-  $def("_14o5oio", "test_decompile_viewof_data", ["decompile","expect"], _14o5oio);  
-  $def("_1lv4syw", "test_decompile_import_alias", ["decompile","expect"], _1lv4syw);  
-  $def("_l8b8hu", "test_decompile_import_mutable_alias", ["decompile","expect"], _l8b8hu);  
-  $def("_1g5n3sa", "test_decompile_import_mutable_data_alias", ["decompile","expect"], _1g5n3sa);  
-  $def("_1lnngk6", "test_decompile_import_viewof_alias", ["decompile","expect"], _1lnngk6);  
-  $def("_1na1e5i", "test_decompile_import_viewof_data_alias", ["decompile","expect"], _1na1e5i);  
+  $def("_1eqf4jq", "test_decompile_import_mutable", ["decompile","expect"], _1eqf4jq);  
+  $def("_3damo4", "test_decompile_import_viewof", ["decompile","expect"], _3damo4);  
+  $def("_1l9xqsw", "test_decompile_viewof_data", ["decompile","expect"], _1l9xqsw);  
+  $def("_1cggvdk", "test_decompile_import_alias", ["decompile","expect"], _1cggvdk);  
+  $def("_xcwq4", "test_decompile_import_mutable_alias", ["decompile","expect"], _xcwq4);  
+  $def("_1868h0w", "test_decompile_import_mutable_data_alias", ["decompile","expect"], _1868h0w);  
+  $def("_1afcxhk", "test_decompile_import_viewof_alias", ["decompile","expect"], _1afcxhk);  
+  $def("_1sl510", "test_decompile_import_viewof_data_alias", ["decompile","expect"], _1sl510);  
   $def("_17dwb6r", null, ["md"], _17dwb6r);  
-  main.define("escodegen", ["module @tomlarkworthy/escodegen", "@variable"], (_, v) => v.import("escodegen", _));  
-  $def("_1vs6mei", null, ["md"], _1vs6mei);  
-  $def("_1g89k6a", "escodegenOptions", ["escodegen"], _1g89k6a);  
-  $def("_llvq9s", "decompile", ["decompileImport","formatImportDeclaration","acorn","escodegen","escodegenOptions"], _llvq9s);  
-  $def("_1pvis67", null, ["md"], _1pvis67);  
+  $def("_1ngipml", null, ["md"], _1ngipml);  
+  $def("_2d5g1", "decompile", ["decompileImport","formatImportDeclaration","acorn"], _2d5g1);  
+  $def("_1x0pvrl", null, ["md"], _1x0pvrl);  
   $def("_183j58u", "extractModuleInfo", [], _183j58u);  
   $def("_w445v0", "test_extractModuleInfo_notebook_resolution", ["expect","extractModuleInfo"], _w445v0);  
   $def("_uzqj4w", "test_extractModuleInfo_id_version_resolution", ["expect","extractModuleInfo"], _uzqj4w);  
   $def("_1sruec2", "test_extractModuleInfo_id_version", ["expect","extractModuleInfo"], _1sruec2);  
   $def("_ipn8zp", "test_extractModuleInfo_test_4", ["expect","extractModuleInfo"], _ipn8zp);  
   $def("_iigmyv", "test_extractModuleInfo_alias_hack", ["expect","extractModuleInfo"], _iigmyv);  
-  $def("_1tggbee", null, ["md"], _1tggbee);  
+  $def("_7t42k8", null, ["md"], _7t42k8);  
   $def("_kiaw33", "import_ast_example", ["parser"], _kiaw33);  
   $def("_1n7gw17", "findModuleName", ["extractModuleInfo"], _1n7gw17);  
   $def("_i47chb", "findImportedName", [], _i47chb);  
-  $def("_1effqg", null, ["md"], _1effqg);  
-  $def("_b7vai6", "decompileImport", ["findModuleName","findImportedName"], _b7vai6);  
+  $def("_ed3cy2", null, ["md"], _ed3cy2);  
+  $def("_1a4j4gm", "decompileImport", ["findModuleName","findImportedName"], _1a4j4gm);  
   $def("_1sylz7j", "formatImportDeclaration", [], _1sylz7j);  
   $def("_13dctdn", "test_decompileImport_basic", ["importFake","decompileImport","expect"], _13dctdn);  
   $def("_ujr0xn", "test_formatImportDeclaration_roundtrip", ["importFake","decompileImport","expect","formatImportDeclaration","decompile"], _ujr0xn);  
   $def("_1u6sfri", "test_decompileImport_alias", ["importFake","decompileImport","expect","formatImportDeclaration"], _1u6sfri);  
-  $def("_1lqhutp", null, ["md"], _1lqhutp);  
-  $def("_ikzxev", "normalizeJavascriptSource", ["acorn","escodegen"], _ikzxev);  
-  $def("_az8lo6", "normalizeVariables", ["variableToObject","normalizeJavascriptSource"], _az8lo6);  
+  $def("_1lti0tv", null, ["md"], _1lti0tv);  
   $def("_3knb9v", "variableToObject", [], _3knb9v);  
-  $def("_263fcv", null, ["md"], _263fcv);  
+  $def("_autn1v", null, ["md"], _autn1v);  
   $def("_7zpsl9", "viewof normalizeObservableSourceSelector", ["Inputs","notebook_semantics_source"], _7zpsl9);  
   $def("_1ex8kus", "normalizeObservableSourceSelector", ["Generators","viewof normalizeObservableSourceSelector"], _1ex8kus);  
-  $def("_17petbz", null, ["normalizeObservableSource","normalizeObservableSourceSelector"], _17petbz);  
   $def("_b2d0zc", "parsed", ["parser","normalizeObservableSourceSelector"], _b2d0zc);  
-  $def("_qtgjo9", "generate", ["escodegen"], _qtgjo9);  
-  $def("_104j23i", "normalizeObservableSource", ["parser","generate"], _104j23i);  
-  $def("_vle3wv", null, ["md"], _vle3wv);  
+  $def("_14qm8or", null, ["md"], _14qm8or);  
   $def("_10ofthe", "test_async_interpolation", ["compile"], _10ofthe);  
   $def("_1gb7c3c", "test_compile_syntax_error_viewof", ["compile","expect"], _1gb7c3c);  
   $def("_69vyub", "test_compile_syntax_error_anonymous", ["compile","expect"], _69vyub);  
   $def("_1c9p3om", "test_compile_syntax_error_named", ["compile","expect"], _1c9p3om);  
   $def("_x7zc8w", "test_compile_integer", ["compile","expect"], _x7zc8w);  
-  $def("_1u7hlem", "test_compile_string", ["compile","expect"], _1u7hlem);  
+  $def("_1qp2ggw", "test_compile_string", ["compile","expect"], _1qp2ggw);  
   $def("_151bijp", "test_compile_obj_literal", ["compile","expect"], _151bijp);  
-  $def("_ti9okn", "test_compile_assignment", ["compile","expect"], _ti9okn);  
+  $def("_17z4vyt", "test_compile_assignment", ["compile","expect"], _17z4vyt);  
   $def("_1eb8vq", "test_compile_dependancy", ["compile","expect"], _1eb8vq);  
-  $def("_acs4l0", "test_compile_block_dependancy", ["compile","expect"], _acs4l0);  
-  $def("_125ljg9", "test_compile_comments", ["compile","expect"], _125ljg9);  
-  $def("_li37je", "test_compile_generator", ["compile","expect"], _li37je);  
-  $def("_em4em6", "test_compile_function", ["compile","expect"], _em4em6);  
-  $def("_w3atfb", "test_compile_async_function", ["compile","expect"], _w3atfb);  
-  $def("_14gl6yr", "test_compile_named_function", ["compile","expect"], _14gl6yr);  
+  $def("_5b8x33", "test_compile_block_dependancy", ["compile","expect"], _5b8x33);  
+  $def("_9s1umz", "test_compile_comments", ["compile","expect"], _9s1umz);  
+  $def("_1rbs7b6", "test_compile_generator", ["compile","expect"], _1rbs7b6);  
+  $def("_1gaxmhs", "test_compile_function", ["compile","expect"], _1gaxmhs);  
+  $def("_2ozyn1", "test_compile_async_function", ["compile","expect"], _2ozyn1);  
+  $def("_1jn3lk9", "test_compile_named_function", ["compile","expect"], _1jn3lk9);  
   $def("_z3bqb8", "test_compile_this_reference", ["compile","expect"], _z3bqb8);  
-  $def("_1sou7t0", "test_compile_lambda", ["compile","expect"], _1sou7t0);  
-  $def("_1o1u737", "test_compile_error", ["compile","expect"], _1o1u737);  
+  $def("_1lyze5m", "test_compile_lambda", ["compile","expect"], _1lyze5m);  
+  $def("_12k1xub", "test_compile_error", ["compile","expect"], _12k1xub);  
   $def("_y271kb", "test_compile_viewof", ["compile","expect"], _y271kb);  
   $def("_1q4asyp", "test_compile_viewof_and_value_coexist", ["compile","expect"], _1q4asyp);  
   $def("_189jvkd", "test_compile_mutable", ["compile","expect"], _189jvkd);  
   $def("_78egw8", "test_compile_builtin", ["compile","expect"], _78egw8);  
-  $def("_lflzev", "test_compile_fileattachment", ["compile","expect"], _lflzev);  
-  $def("_1e555b1", "test_compile_mutable_dep", ["compile","expect"], _1e555b1);  
-  $def("_1a2af6", "test_compile_mutable_dep2", ["compile","expect"], _1a2af6);  
+  $def("_1o65727", "test_compile_fileattachment", ["compile","expect"], _1o65727);  
+  $def("_14c9yxp", "test_compile_mutable_dep", ["compile","expect"], _14c9yxp);  
+  $def("_133w84q", "test_compile_mutable_dep2", ["compile","expect"], _133w84q);  
   $def("_ql80wk", "test_compile_inline_viewof", ["compile","expect"], _ql80wk);  
   $def("_1k420gu", "test_compile_view_dep", ["compile","expect"], _1k420gu);  
   $def("_1y1h47u", "test_compile_dep", ["compile","expect"], _1y1h47u);  
-  $def("_kwdsyz", "test_compile_class", ["compile","expect"], _kwdsyz);  
+  $def("_1r711sh", "test_compile_class", ["compile","expect"], _1r711sh);  
   $def("_33oop5", "test_compile_event", ["compile","expect"], _33oop5);  
   $def("_9phvzk", "test_compile_tagged_literal", ["compile","expect"], _9phvzk);  
   $def("_1q0pie3", "compile_unit_test_template", ["Inputs","test_case","compiled"], _1q0pie3);  
-  $def("_1lmax86", "test_compile_import_plain_single", ["compile","expect"], _1lmax86);  
-  $def("_17sgzdm", "test_compile_import_view_data_alias_single", ["compile","expect"], _17sgzdm);  
-  $def("_1tqj4tp", "test_compile_import_mutable_data_alias_single", ["compile","expect"], _1tqj4tp);  
-  $def("_hv0te2", "test_compile_import_mutable_single", ["compile","expect"], _hv0te2);  
-  $def("_1mltqmr", "test_compile_import_viewof_single", ["compile","expect"], _1mltqmr);  
-  $def("_1d18obr", "test_compile_import_alias_single", ["compile","expect"], _1d18obr);  
-  $def("_1b5ghef", "test_compile_import_notebook", ["compile","expect"], _1b5ghef);  
+  $def("_1vg114c", "test_compile_import_plain_single", ["compile","expect"], _1vg114c);  
+  $def("_18h6y38", "test_compile_import_view_data_alias_single", ["compile","expect"], _18h6y38);  
+  $def("_1svcdun", "test_compile_import_mutable_data_alias_single", ["compile","expect"], _1svcdun);  
+  $def("_tb4ops", "test_compile_import_mutable_single", ["compile","expect"], _tb4ops);  
+  $def("_vuzib9", "test_compile_import_viewof_single", ["compile","expect"], _vuzib9);  
+  $def("_6ewshd", "test_compile_import_alias_single", ["compile","expect"], _6ewshd);  
+  $def("_36migr", "test_compile_import_notebook", ["compile","expect"], _36migr);  
   $def("_1nps9cr", "viewof test_case", ["Inputs","notebook_semantics_source"], _1nps9cr);  
   $def("_1e5ax6f", "test_case", ["Generators","viewof test_case"], _1e5ax6f);  
-  $def("_18e5b93", null, ["test_case"], _18e5b93);  
+  $def("_7eic89", null, ["test_case"], _7eic89);  
   $def("_16q6oyc", "compiled", ["compile","test_case"], _16q6oyc);  
-  $def("_1191170", null, ["parser","test_case"], _1191170);  
-  $def("_1gh543z", "viewof compiled_selector", ["Inputs","compiled"], _1gh543z);  
-  $def("_1dmmuaf", "compiled_selector", ["Generators","viewof compiled_selector"], _1dmmuaf);  
-  $def("_1klx74n", null, ["compiled_selector","normalizeJavascriptSource"], _1klx74n);  
-  $def("_eom91x", null, ["compile","test_case"], _eom91x);  
-  $def("_ttos3c", "compile", ["parser","observableToJs"], _ttos3c);  
-  $def("_1v1i7wl", "observableToJs", ["acorn_walk","parser","escodegen"], _1v1i7wl);  
-  $def("_1ayjluu", null, ["md"], _1ayjluu);  
+  $def("_61dayu", null, ["parser","test_case"], _61dayu);  
+  $def("_cevs6r", null, ["compile","test_case"], _cevs6r);  
+  $def("_mliwy8", "compile", ["parser","observableToJs"], _mliwy8);  
+  $def("_16p8atj", "observableToJs", ["acorn_walk","parser"], _16p8atj);  
+  $def("_1hd7px0", null, ["md"], _1hd7px0);  
   $def("_xhj6b8", "decompress_url", ["DecompressionStream","TextDecoderStream","TransformStream","TextEncoderStream","Response"], _xhj6b8);  
   $def("_s9w7ha", "parser", ["decompress_url","FileAttachment","acorn_url","acorn_walk_url"], _s9w7ha);  
   main.define("acorn", ["module @tomlarkworthy/acorn-8-11-3", "@variable"], (_, v) => v.import("acorn", _));  
@@ -23395,7 +24600,7 @@ export default function define(runtime, observer) {
   main.define("Inspector", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Inspector", _));  
   main.define("Library", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Library", _));  
   main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));  
-  $def("_1rc67k0", "stageB_importFake", [], _1rc67k0);  
+  $def("_j9n5de", "stageB_importFake", [], _j9n5de);  
   $def("_1d53asg", "test_decompileImport_stageB_single", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1d53asg);  
   $def("_hv5gag", "test_decompileImport_stageB_aliased", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _hv5gag);  
   $def("_avc18y", "test_decompileImport_stageB_multiple", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _avc18y);  
@@ -23404,8 +24609,260 @@ export default function define(runtime, observer) {
   $def("_qwlsf2", "test_decompileImport_stageB_mutable", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _qwlsf2);  
   $def("_sy7jfx", "test_decompileImport_returns_null_for_non_import", ["decompileImport","expect"], _sy7jfx);  
   $def("_rk7ku3", "test_decompileImport_compile_roundtrip_single", ["compile","expect","stageB_importFake","decompileImport","formatImportDeclaration"], _rk7ku3);  
-  $def("_xynplo", "test_decompileImport_stageB_order_independent", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _xynplo);  
-  $def("_16fpgac", "test_decompileImport_stageB_notebook_id", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16fpgac);
+  $def("_1numivw", "test_decompileImport_stageB_order_independent", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1numivw);  
+  $def("_16fpgac", "test_decompileImport_stageB_notebook_id", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16fpgac);  
+  $def("_r2e0wl", "test_extractModuleInfo_new_id_resolutions", ["expect","extractModuleInfo"], _r2e0wl);  
+  $def("_1pg1y6s", "test_extractModuleInfo_new_slug_resolutions", ["expect","extractModuleInfo"], _1pg1y6s);  
+  $def("_1vh26m0", "test_findModuleName_classic_bundle", ["expect","findModuleName"], _1vh26m0);  
+  $def("_1ltqcwj", "test_findModuleName_kit_slug", ["expect","findModuleName"], _1ltqcwj);  
+  $def("_wq4poo", "test_findModuleName_new_id", ["expect","findModuleName"], _wq4poo);  
+  $def("_1j0hksu", "test_findModuleName_new_slug", ["expect","findModuleName"], _1j0hksu);  
+  $def("_3en7eq", "test_decompile_leading_comment", ["decompile","expect","compile"], _3en7eq);  
+  $def("_z17nwa", "test_decompile_trailing_comment", ["decompile","expect"], _z17nwa);  
+  $def("_q5y9bo", "test_decompile_param_in_string", ["decompile","expect"], _q5y9bo);  
+  $def("_fm2sgc", "test_decompile_class_property_field", ["decompile","expect"], _fm2sgc);  
+  $def("_1xp8nli", "test_compile_preserves_formatting", ["compile","expect"], _1xp8nli);
+  return main;
+}</script>
+
+<script id="@tomlarkworthy/plugin-registry" 
+  type="text/plain"
+  data-mime="application/javascript"
+>
+const _1ej2r92 = function _intro(md){return(
+md`# Plugin Registry
+
+A foundational notebook for **decoupled reactive plugin wiring**.
+
+Consumers get a realtime stream of all registered providers under a name. Providers can register themselves under a name. Neither has direct references between each other. This allows you to add more consumers and providers without changing individual providers and consumers. Useful for reactive plugin systems like audio instruments, dyamic menus, LLM tools and entity component systems.
+`
+)};
+const _16jmxgh = function _diagram(htl){return(
+htl.html`<svg viewBox="0 0 720 300" width="100%" style="max-width:720px;font-family:system-ui,sans-serif">
+  <defs>
+    <marker id="pr-arr" markerWidth="9" markerHeight="9" refX="7" refY="4" orient="auto">
+      <path d="M0,0 L8,4 L0,8 Z" fill="var(--theme-foreground,#333)"></path>
+    </marker>
+    <style>
+      .pr-box{fill:var(--theme-background-alt,#f4f4f6);stroke:var(--theme-foreground-faint,#bbb);stroke-width:1.5}
+      .pr-hub{fill:var(--theme-foreground-faintest,#eef);stroke:var(--theme-foreground,#556);stroke-width:2}
+      .pr-t{fill:var(--theme-foreground,#222);font-size:13px}
+      .pr-s{fill:var(--theme-foreground-muted,#666);font-size:11px}
+      .pr-e{stroke:var(--theme-foreground,#333);stroke-width:1.5;fill:none;marker-end:url(#pr-arr)}
+    </style>
+  </defs>
+
+  <rect class="pr-box" x="10"  y="30"  width="170" height="48" rx="8"></rect>
+  <text class="pr-t" x="95" y="52" text-anchor="middle">Provider A</text>
+  <text class="pr-s" x="95" y="68" text-anchor="middle">plugins.add("x", v)</text>
+  <rect class="pr-box" x="10"  y="120" width="170" height="48" rx="8"></rect>
+  <text class="pr-t" x="95" y="142" text-anchor="middle">Provider B</text>
+  <text class="pr-s" x="95" y="158" text-anchor="middle">plugins.add("x", v, {invalidation})</text>
+  <text class="pr-s" x="95" y="215" text-anchor="middle">…N providers</text>
+
+  <rect class="pr-hub" x="270" y="78"  width="180" height="112" rx="10"></rect>
+  <text class="pr-t" x="360" y="104" text-anchor="middle" style="font-weight:600">plugins</text>
+  <text class="pr-s" x="360" y="128" text-anchor="middle">Map&lt;name, Set&lt;value&gt;&gt;</text>
+  <text class="pr-s" x="360" y="150" text-anchor="middle">add(name, value)</text>
+  <text class="pr-s" x="360" y="168" text-anchor="middle">get(name) → Generator</text>
+
+  <rect class="pr-box" x="540" y="30"  width="170" height="48" rx="8"></rect>
+  <text class="pr-t" x="625" y="52" text-anchor="middle">Consumer 1</text>
+  <text class="pr-s" x="625" y="68" text-anchor="middle">plugins.get("x")</text>
+  <rect class="pr-box" x="540" y="120" width="170" height="48" rx="8"></rect>
+  <text class="pr-t" x="625" y="142" text-anchor="middle">Consumer 2 (V2)</text>
+  <text class="pr-s" x="625" y="158" text-anchor="middle">plugins.get("x")</text>
+  <text class="pr-s" x="625" y="215" text-anchor="middle">…M consumers</text>
+
+  <path class="pr-e" d="M180,54 C225,54 235,116 268,126"></path>
+  <path class="pr-e" d="M180,144 C225,144 240,138 268,140"></path>
+  <path class="pr-e" d="M452,128 C500,116 510,54 538,54"></path>
+  <path class="pr-e" d="M452,142 C500,144 510,144 538,144"></path>
+</svg>`
+)};
+const _xnvzuh = function _contracts(md){return(
+md`## Contracts
+
+| Guarantee | How |
+|---|---|
+| **Named sets** | \`plugins\` maps a name → a set of values. Providers \`add\`, consumers \`get\`; they coordinate only by name. |
+| **Reactive** | \`get(name)\` is a Generator that yields the current set and re-yields on every add/remove for that name. |
+| **N↔M decoupling** | Providers and consumers share only \`plugins\`. Any number of each; a name is the whole contract. |
+| **Auto-cleanup** | \`add\` returns \`remove()\`. Pass \`{invalidation}\` (a cell's disposal promise) to remove automatically when the provider cell re-runs. |
+| **No leaks** | \`get\`'s Generator unsubscribes on disposal; per-name listeners are dropped when the last consumer leaves. |
+| **Eventual convergence** | Each consumer gets the current set immediately on \`get\`, then a full-set snapshot on every change — so any interleaving of add/remove/get converges. |`
+)};
+const _1ua5hud = function _apiReference(md){return(
+md`## API reference
+
+The whole API is two methods on \`plugins\`.
+
+**\`plugins.add(name, value, options?)\`** → \`remove()\`
+Add \`value\` to the set stored under \`name\` (creating the set on first use). Returns a \`remove()\` function
+that takes this value back out. \`options.invalidation\` (optional, may be null/omitted) is a promise — when
+it settles the value is removed automatically; pass a provider cell's built-in \`invalidation\` so re-running
+the cell replaces rather than duplicates. \`value\` is anything; for shared views it is commonly a factory
+\`() => element\` that each consumer calls to get its own instance.
+
+**\`plugins.get(name)\`** → Generator&lt;value[]&gt;
+Return a reactive Generator of the values currently in \`name\`'s set. It yields the current set immediately
+(so a late consumer still converges), then re-yields the full set on every add/remove. Use it from a cell
+and that cell recomputes on each change. Call it from as many consumers as you like (e.g. a module and its
+V2) — each call is an independent Generator that cleans up when its cell is torn down.`
+)};
+const _1pzt22q = function _createPlugins(Generators)
+{
+  return function createPlugins() {
+    const sets = new Map();
+    // name -> Set<value>
+    const listeners = new Map();
+    // name -> Set<() => void>
+    const notify = name => {
+      const ls = listeners.get(name);
+      if (ls)
+        for (const l of [...ls])
+          l();  // copy: a consumer may (un)subscribe while notifying
+    };
+    const add = (name, value, options) => {
+      let set = sets.get(name);
+      if (!set)
+        sets.set(name, set = new Set());
+      set.add(value);
+      notify(name);
+      const remove = () => {
+        const s = sets.get(name);
+        if (s && s.delete(value)) {
+          if (s.size === 0)
+            sets.delete(name);
+          notify(name);
+        }
+      };
+      const invalidation = options && options.invalidation;
+      if (invalidation)
+        Promise.resolve(invalidation).then(remove, remove);
+      return remove;
+    };
+    const get = name => Generators.observe(change => {
+      const push = () => change([...sets.get(name) ?? []]);
+      push();
+      // current set immediately → converges
+      let ls = listeners.get(name);
+      if (!ls)
+        listeners.set(name, ls = new Set());
+      ls.add(push);
+      return () => {
+        ls.delete(push);
+        if (ls.size === 0)
+          listeners.delete(name);
+      };  // leak-safe
+    });
+    return {
+      add,
+      get,
+      listenerCount: name => listeners.get(name)?.size ?? 0
+    };
+  };
+};
+const _1qu8dwj = function _plugins(createPlugins){return(
+createPlugins()
+)};
+const _a7p1z5 = function _testsHeader(md){return(
+md`## Tests`
+)};
+const _15xl311 = function _test_get_reflects_add(createPlugins){return(
+(async () => {
+  const p = createPlugins();
+  const gen = p.get('x');
+  if ((await (await gen.next()).value).length !== 0)
+    throw new Error('new set should start empty');
+  p.add('x', 1);
+  const after = await (await gen.next()).value;
+  if (after.length !== 1 || after[0] !== 1)
+    throw new Error('get did not reflect the add');
+  gen.return();
+  return '\u2705 get(name) yields the named set and updates on add';
+})()
+)};
+const _122zyhz = function _test_multi_provider_and_convergence(createPlugins)
+{
+  return (async () => {
+    const p = createPlugins();
+    const a = p.get('x'), b = p.get('x');
+    // two independent consumers
+    await (await a.next()).value;
+    await (await b.next()).value;
+    p.add('x', 'one');
+    // provider 1
+    p.add('x', 'two');
+    // provider 2
+    const va = (await (await a.next()).value).slice().sort().join(',');
+    const vb = (await (await b.next()).value).slice().sort().join(',');
+    if (va !== 'one,two' || vb !== 'one,two')
+      throw new Error('consumers did not converge to the full set');
+    a.return();
+    b.return();
+    return '\u2705 multiple providers accumulate; all consumers converge';
+  })();
+};
+const _1lojas7 = function _test_remove_and_names_isolated(createPlugins){return(
+(async () => {
+  const p = createPlugins();
+  const gx = p.get('x'), gy = p.get('y');
+  await (await gx.next()).value;
+  await (await gy.next()).value;
+  const remove = p.add('x', 1);
+  p.add('y', 2);
+  if ((await (await gx.next()).value).join() !== '1')
+    throw new Error('x set wrong');
+  if ((await (await gy.next()).value).join() !== '2')
+    throw new Error('names are not isolated');
+  remove();
+  if ((await (await gx.next()).value).length !== 0)
+    throw new Error('remove() did not take the value out');
+  gx.return();
+  gy.return();
+  return '\u2705 remove() works and names are isolated';
+})()
+)};
+const _8240yg = function _test_invalidation_and_no_leak(createPlugins){return(
+(async () => {
+  const p = createPlugins();
+  let settle;
+  p.add('x', 1, { invalidation: new Promise(r => settle = r) });
+  const gen = p.get('x');
+  if ((await (await gen.next()).value).length !== 1)
+    throw new Error('value should be present before invalidation');
+  if (p.listenerCount('x') !== 1)
+    throw new Error('get should have registered a listener');
+  settle();
+  await Promise.resolve();
+  await Promise.resolve();
+  if ((await (await gen.next()).value).length !== 0)
+    throw new Error('invalidation did not remove the value');
+  gen.return();
+  if (p.listenerCount('x') !== 0)
+    throw new Error('disposing the Generator leaked a listener');
+  return '\u2705 {invalidation} auto-removes and get() leaks no listeners';
+})()
+)};
+
+export default function define(runtime, observer) {
+  const main = runtime.module();
+  const $def = (pid, name, deps, fn) => {
+    main.variable(observer(name)).define(name, deps, fn).pid = pid;
+  };
+
+  $def("_1ej2r92", "intro", ["md"], _1ej2r92);  
+  $def("_16jmxgh", "diagram", ["htl"], _16jmxgh);  
+  $def("_xnvzuh", "contracts", ["md"], _xnvzuh);  
+  $def("_1ua5hud", "apiReference", ["md"], _1ua5hud);  
+  $def("_1pzt22q", "createPlugins", ["Generators"], _1pzt22q);  
+  $def("_1qu8dwj", "plugins", ["createPlugins"], _1qu8dwj);  
+  $def("_a7p1z5", "testsHeader", ["md"], _a7p1z5);  
+  $def("_15xl311", "test_get_reflects_add", ["createPlugins"], _15xl311);  
+  $def("_122zyhz", "test_multi_provider_and_convergence", ["createPlugins"], _122zyhz);  
+  $def("_1lojas7", "test_remove_and_names_isolated", ["createPlugins"], _1lojas7);  
+  $def("_8240yg", "test_invalidation_and_no_leak", ["createPlugins"], _8240yg);
   return main;
 }</script>
 
@@ -23754,7 +25211,7 @@ const _nv232r = function _check_for_code_change(runtime_variables,codeChangeList
 const _ya86a1 = function _21(md){return(
 md`### observe(variable)
 
-This was monstrously difficult to develop. Installs a single dispatcher observer per variable holding an explicit listener list; each \`observe\` call adds a listener and returns a cancel that removes it, so attach/cancel can interleave in any order (views remount). A pre-existing observer (e.g. a bootloader Inspector) is kept as a permanent first listener. Delivery of \`["fulfilled", "rejected", "pending"]\` runs in attach order; for element values, a listener with \`detachNodes: true\` detaches the node from its current parent before adopting, so the last-attached view owns the node. When the observer attaches, if the variable is already fulfilled, the observer is signalled.
+This was monstrously difficult to develop. Taps a variable, intercepting all observer calls \`["fulfilled", "rejected", "pending"]\` whilst preserving the behaviour of the existing observer attached to the variable. If \`detachNodes\` is \`true\` and the existing observer hosts a DOM node, the additional variable "steals" it for it's DOM tree. When the observer attaches, if the variable is already fulfilled, the observer is signalled.
 
 Unobserved variables are marked as reachable and become active when observed.`
 )};
@@ -23768,240 +25225,240 @@ const _1hx65vf = function _no_observer(main)
     variable.delete();
     return symbol;
 };
-const _duwj4o = function _observe(Element,Text,trace_variable,$0,no_observer,queueMicrotask)
+const _18fhvl5 = function _observe(Element,Text,trace_variable,$0,no_observer,queueMicrotask)
 {
-    // Multiple views may observe one variable (a lopepage pane + an embedding widget).
-    // Views remount, so cancels arrive in any order. A single dispatcher observer per
-    // variable holds an explicit listener list: attach = push, cancel = splice. Delivery
-    // runs in attach order, so for element values the last-attached view adopts last and
-    // owns the node. (The previous design wrapped observer methods in place and each
-    // cancel restored the methods captured at ITS attach time — correct only for LIFO
-    // cancel order; any remount orphaned the surviving listener.)
-    const DISPATCH = '__observe_listeners__';
-    // cross realm support: no_observer is a Symbol compared by description
-    return function observe(v, observer, {invalidation, detachNodes = false} = {}) {
-        const observe_id = `${ v?._name || '<anon>' }@${ Date.now() }@${ Math.random().toString(16).slice(2) }`;
-        const snapshot = (extra = {}) => ({
-            t: Date.now(),
-            observe_id,
-            var_name: v?._name,
-            var_version: v?._version,
-            var_reachable: v?._reachable,
-            has_observer: v?._observer != null,
-            observer_has_node: !!observer?._node,
-            v_value_defined: v?._value !== undefined,
-            v_value_ctor: v?._value?.constructor?.name,
-            v_value_is_node: v?._value instanceof Element || v?._value instanceof Text || false,
-            v_promise: !!v?._promise,
-            listener_count: v?._observer?.[DISPATCH]?.length,
+  // Multiple views may observe one variable (a lopepage pane + an embedding widget).
+  // Views remount, so cancels arrive in any order. A single dispatcher observer per
+  // variable holds an explicit listener list: attach = push, cancel = splice. Delivery
+  // runs in attach order, so for element values the last-attached view adopts last and
+  // owns the node. (The previous design wrapped observer methods in place and each
+  // cancel restored the methods captured at ITS attach time — correct only for LIFO
+  // cancel order; any remount orphaned the surviving listener.)
+  const DISPATCH = '__observe_listeners__';
+  // cross realm support: no_observer is a Symbol compared by description
+  return function observe(v, observer, {invalidation, detachNodes = false} = {}) {
+    const observe_id = `${ v?._name || '<anon>' }@${ Date.now() }@${ Math.random().toString(16).slice(2) }`;
+    const snapshot = (extra = {}) => ({
+      t: Date.now(),
+      observe_id,
+      var_name: v?._name,
+      var_version: v?._version,
+      var_reachable: v?._reachable,
+      has_observer: v?._observer != null,
+      observer_has_node: !!observer?._node,
+      v_value_defined: v?._value !== undefined,
+      v_value_ctor: v?._value?.constructor?.name,
+      v_value_is_node: v?._value instanceof Element || v?._value instanceof Text || false,
+      v_promise: !!v?._promise,
+      listener_count: v?._observer?.[DISPATCH]?.length,
+      ...extra
+    });
+    const emit = (event, extra = {}) => {
+      if (v?._name !== trace_variable)
+        return;
+      try {
+        $0.value = $0.value.concat([snapshot({
+            event,
             ...extra
-        });
-        const emit = (event, extra = {}) => {
-            if (v?._name !== trace_variable)
-                return;
-            try {
-                $0.value = $0.value.concat([snapshot({
-                        event,
-                        ...extra
-                    })]);
-            } catch {
-            }
-        };
-        emit('observe:begin', { detachNodes });
-        const isNode = value => value instanceof Element || value instanceof Text;
-        // Detach an element value from wherever it currently lives so this listener's
-        // fulfilled can adopt it into its own node.
-        const stealFor = (l, value, reason) => {
-            const canSteal = l.detachNodes && isNode(value) && l.observer?._node && l.observer._node !== value.parentNode;
-            emit('observe:steal_check', {
-                reason,
-                canSteal,
-                value_ctor: value?.constructor?.name,
-                value_parent: value?.parentNode?.constructor?.name
-            });
-            if (canSteal) {
-                try {
-                    value.remove();
-                } catch {
-                }
-                emit('observe:steal_detached', { reason });
-            }
-        };
-        // --- ensure dispatcher installed ---
-        let dispatch = v._observer && v._observer[DISPATCH] ? v._observer : null;
-        if (!dispatch) {
-            const listeners = [];
-            const deliver = type => (...args) => {
-                emit(`observe:deliver:${ type }`, { arg0_ctor: args[0]?.constructor?.name });
-                for (const l of [...listeners]) {
-                    try {
-                        if (type === 'fulfilled') {
-                            stealFor(l, args[0], 'deliver');
-                            l.observer.fulfilled?.(args[0], v?._name);
-                        } else if (type === 'rejected')
-                            l.observer.rejected?.(args[0], v?._name);
-                        else
-                            l.observer.pending?.();
-                    } catch (e) {
-                        emit(`observe:deliver:${ type }:listener_error`, { message: String(e) });
-                    }
-                }
-            };
-            const previous = v._observer;
-            dispatch = {
-                [DISPATCH]: listeners,
-                // Preserve the `variable._observer._node` contract editors (divToVar),
-                // module-map, and observablehq.com key on. The pre-existing observer
-                // (e.g. the notebook Inspector) owns the canonical node; otherwise the
-                // last-attached listener that has one (the view that adopted the value).
-                get _node() {
-                    const base = listeners.find(l => l.base);
-                    if (base?.observer?._node != null)
-                        return base.observer._node;
-                    for (let i = listeners.length - 1; i >= 0; i--) {
-                        const n = listeners[i].observer?._node;
-                        if (n != null)
-                            return n;
-                    }
-                    return undefined;
-                },
-                __restore: () => {
-                    if (v._observer === dispatch)
-                        v._observer = previous;
-                },
-                pending: deliver('pending'),
-                fulfilled: deliver('fulfilled'),
-                rejected: deliver('rejected')
-            };
-            const hasExistingObserver = previous != null && previous?.description !== no_observer.description;
-            if (hasExistingObserver) {
-                // pre-existing real observer (e.g. bootloader Inspector) stays first, permanently
-                listeners.push({
-                    observer: previous,
-                    detachNodes: false,
-                    base: true
-                });
-                emit('observe:attach:base_listener_kept');
-            }
-            if (v && !v._reachable) {
-                v._reachable = true;
-                v._module._runtime._dirty.add(v);
-                v._module._runtime._updates.add(v);
-                emit('observe:attach:marked_reachable');
-            }
-            v._observer = dispatch;
-            emit('observe:attach:dispatcher_installed', { hasExistingObserver });
-        }
-        // --- attach this listener ---
-        const listeners = dispatch[DISPATCH];
-        const entry = {
-            observer,
-            detachNodes
-        };
-        listeners.push(entry);
-        emit('observe:attach:listener_added');
-        let cancelled = false;
-        const cancel = () => {
-            emit('observe:cancel_called');
-            if (cancelled)
-                return;
-            cancelled = true;
-            const i = listeners.indexOf(entry);
-            if (i >= 0)
-                listeners.splice(i, 1);
-            if (!listeners.some(l => !l.base)) {
-                // no external listeners left: hand the variable back
-                dispatch.__restore();
-                emit('observe:cancel:dispatcher_removed');
-            }
-        };
-        if (invalidation)
-            Promise.resolve(invalidation).then(() => {
-                emit('observe:invalidation_fired');
-                cancel();
-            });
-        // --- CATCH-UP REPLAY (BUG FIX) ---
-        // Snapshot version to avoid replaying stale results.
-        const versionAtAttach = v?._version;
-        emit('observe:catchup:scheduled', { versionAtAttach });
-        queueMicrotask(() => {
-            emit('observe:catchup:microtask_start', { cancelled });
-            if (cancelled)
-                return;
-            // mimic inspector: mark pending first
-            try {
-                observer.pending?.();
-                emit('observe:catchup:pending_sent');
-            } catch (e) {
-                emit('observe:catchup:pending_error', { message: String(e) });
-            }
-            // IMPORTANT: read CURRENT value at replay time
-            const valueNow = v?._value;
-            emit('observe:catchup:valueNow_snapshot', {
-                valueNow_defined: valueNow !== undefined,
-                valueNow_ctor: valueNow?.constructor?.name,
-                v_version_now: v?._version,
-                valueNow_outerHTML_prefix: v?._observer?._node?.outerHTML
-            });
-            if (valueNow !== undefined) {
-                if (v?._version !== versionAtAttach) {
-                    emit('observe:catchup:stale_skip_valueNow');
-                    return;
-                }
-                stealFor(entry, valueNow, 'catchup:valueNow');
-                try {
-                    observer.fulfilled?.(valueNow, v?._name);
-                    emit('observe:catchup:fulfilled_sent_valueNow');
-                } catch (e) {
-                    emit('observe:catchup:fulfilled_error_valueNow', { message: String(e) });
-                }
-                return;
-            }
-            // optional fallback: attach-time promise (or current promise)
-            const p = v?._promise;
-            if (!p || typeof p.then !== 'function') {
-                emit('observe:catchup:no_value_no_promise');
-                return;
-            }
-            emit('observe:catchup:await_promise');
-            Promise.resolve(p).then(value => {
-                emit('observe:catchup:promise_fulfilled', {
-                    value_defined: value !== undefined,
-                    value_ctor: value?.constructor?.name,
-                    v_version_now: v?._version
-                });
-                if (cancelled)
-                    return;
-                if (v?._version !== versionAtAttach) {
-                    emit('observe:catchup:stale_skip_promise');
-                    return;
-                }
-                if (value === undefined)
-                    return;
-                stealFor(entry, value, 'catchup:promise');
-                try {
-                    observer.fulfilled?.(value, v?._name);
-                    emit('observe:catchup:fulfilled_sent_promise');
-                } catch (e) {
-                    emit('observe:catchup:fulfilled_error_promise', { message: String(e) });
-                }
-            }, error => {
-                emit('observe:catchup:promise_rejected', { v_version_now: v?._version });
-                if (cancelled)
-                    return;
-                if (v?._version !== versionAtAttach)
-                    return;
-                try {
-                    observer.rejected?.(error, v?._name);
-                    emit('observe:catchup:rejected_sent_promise');
-                } catch (e) {
-                    emit('observe:catchup:rejected_error_promise', { message: String(e) });
-                }
-            });
-        });
-        emit('observe:end');
-        return cancel;
+          })]);
+      } catch {
+      }
     };
+    emit('observe:begin', { detachNodes });
+    const isNode = value => value instanceof Element || value instanceof Text;
+    // Detach an element value from wherever it currently lives so this listener's
+    // fulfilled can adopt it into its own node.
+    const stealFor = (l, value, reason) => {
+      const canSteal = l.detachNodes && isNode(value) && l.observer?._node && l.observer._node !== value.parentNode;
+      emit('observe:steal_check', {
+        reason,
+        canSteal,
+        value_ctor: value?.constructor?.name,
+        value_parent: value?.parentNode?.constructor?.name
+      });
+      if (canSteal) {
+        try {
+          value.remove();
+        } catch {
+        }
+        emit('observe:steal_detached', { reason });
+      }
+    };
+    // --- ensure dispatcher installed ---
+    let dispatch = v._observer && v._observer[DISPATCH] ? v._observer : null;
+    if (!dispatch) {
+      const listeners = [];
+      const deliver = type => (...args) => {
+        emit(`observe:deliver:${ type }`, { arg0_ctor: args[0]?.constructor?.name });
+        for (const l of [...listeners]) {
+          try {
+            if (type === 'fulfilled') {
+              stealFor(l, args[0], 'deliver');
+              l.observer.fulfilled?.(args[0], v?._name);
+            } else if (type === 'rejected')
+              l.observer.rejected?.(args[0], v?._name);
+            else
+              l.observer.pending?.();
+          } catch (e) {
+            emit(`observe:deliver:${ type }:listener_error`, { message: String(e) });
+          }
+        }
+      };
+      const previous = v._observer;
+      dispatch = {
+        [DISPATCH]: listeners,
+        // Preserve the `variable._observer._node` contract editors (divToVar),
+        // module-map, and observablehq.com key on. The pre-existing observer
+        // (e.g. the notebook Inspector) owns the canonical node; otherwise the
+        // last-attached listener that has one (the view that adopted the value).
+        get _node() {
+          const base = listeners.find(l => l.base);
+          if (base?.observer?._node != null)
+            return base.observer._node;
+          for (let i = listeners.length - 1; i >= 0; i--) {
+            const n = listeners[i].observer?._node;
+            if (n != null)
+              return n;
+          }
+          return undefined;
+        },
+        __restore: () => {
+          if (v._observer === dispatch)
+            v._observer = previous;
+        },
+        pending: deliver('pending'),
+        fulfilled: deliver('fulfilled'),
+        rejected: deliver('rejected')
+      };
+      const hasExistingObserver = previous != null && previous?.description !== no_observer.description;
+      if (hasExistingObserver) {
+        // pre-existing real observer (e.g. bootloader Inspector) stays first, permanently
+        listeners.push({
+          observer: previous,
+          detachNodes: false,
+          base: true
+        });
+        emit('observe:attach:base_listener_kept');
+      }
+      if (v && !v._reachable) {
+        v._reachable = true;
+        v._module._runtime._dirty.add(v);
+        v._module._runtime._updates.add(v);
+        emit('observe:attach:marked_reachable');
+      }
+      v._observer = dispatch;
+      emit('observe:attach:dispatcher_installed', { hasExistingObserver });
+    }
+    // --- attach this listener ---
+    const listeners = dispatch[DISPATCH];
+    const entry = {
+      observer,
+      detachNodes
+    };
+    listeners.push(entry);
+    emit('observe:attach:listener_added');
+    let cancelled = false;
+    const cancel = () => {
+      emit('observe:cancel_called');
+      if (cancelled)
+        return;
+      cancelled = true;
+      const i = listeners.indexOf(entry);
+      if (i >= 0)
+        listeners.splice(i, 1);
+      if (!listeners.some(l => !l.base)) {
+        // no external listeners left: hand the variable back
+        dispatch.__restore();
+        emit('observe:cancel:dispatcher_removed');
+      }
+    };
+    if (invalidation)
+      Promise.resolve(invalidation).then(() => {
+        emit('observe:invalidation_fired');
+        cancel();
+      });
+    // --- CATCH-UP REPLAY (BUG FIX) ---
+    // Snapshot version to avoid replaying stale results.
+    const versionAtAttach = v?._version;
+    emit('observe:catchup:scheduled', { versionAtAttach });
+    queueMicrotask(() => {
+      emit('observe:catchup:microtask_start', { cancelled });
+      if (cancelled)
+        return;
+      // mimic inspector: mark pending first
+      try {
+        observer.pending?.();
+        emit('observe:catchup:pending_sent');
+      } catch (e) {
+        emit('observe:catchup:pending_error', { message: String(e) });
+      }
+      // IMPORTANT: read CURRENT value at replay time
+      const valueNow = v?._value;
+      emit('observe:catchup:valueNow_snapshot', {
+        valueNow_defined: valueNow !== undefined,
+        valueNow_ctor: valueNow?.constructor?.name,
+        v_version_now: v?._version,
+        valueNow_outerHTML_prefix: v?._observer?._node?.outerHTML
+      });
+      if (valueNow !== undefined) {
+        if (v?._version !== versionAtAttach) {
+          emit('observe:catchup:stale_skip_valueNow');
+          return;
+        }
+        stealFor(entry, valueNow, 'catchup:valueNow');
+        try {
+          observer.fulfilled?.(valueNow, v?._name);
+          emit('observe:catchup:fulfilled_sent_valueNow');
+        } catch (e) {
+          emit('observe:catchup:fulfilled_error_valueNow', { message: String(e) });
+        }
+        return;
+      }
+      // optional fallback: attach-time promise (or current promise)
+      const p = v?._promise;
+      if (!p || typeof p.then !== 'function') {
+        emit('observe:catchup:no_value_no_promise');
+        return;
+      }
+      emit('observe:catchup:await_promise');
+      Promise.resolve(p).then(value => {
+        emit('observe:catchup:promise_fulfilled', {
+          value_defined: value !== undefined,
+          value_ctor: value?.constructor?.name,
+          v_version_now: v?._version
+        });
+        if (cancelled)
+          return;
+        if (v?._version !== versionAtAttach) {
+          emit('observe:catchup:stale_skip_promise');
+          return;
+        }
+        if (value === undefined)
+          return;
+        stealFor(entry, value, 'catchup:promise');
+        try {
+          observer.fulfilled?.(value, v?._name);
+          emit('observe:catchup:fulfilled_sent_promise');
+        } catch (e) {
+          emit('observe:catchup:fulfilled_error_promise', { message: String(e) });
+        }
+      }, error => {
+        emit('observe:catchup:promise_rejected', { v_version_now: v?._version });
+        if (cancelled)
+          return;
+        if (v?._version !== versionAtAttach)
+          return;
+        try {
+          observer.rejected?.(error, v?._name);
+          emit('observe:catchup:rejected_sent_promise');
+        } catch (e) {
+          emit('observe:catchup:rejected_error_promise', { message: String(e) });
+        }
+      });
+    });
+    emit('observe:end');
+    return cancel;
+  };
 };
 const _16ohhcn = function _observeOld(trace_variable,_,no_observer,isnode,toObject,queueMicrotask,getPromiseState)
 {
@@ -24012,7 +25469,7 @@ const _16ohhcn = function _observeOld(trace_variable,_,no_observer,isnode,toObje
             invalidation.then(onCancel);
         if (v?._name === trace_variable) {
             console.log('observe', trace_variable, v);
-            void 0;
+            debugger;
         }
         if (_.isEqual(v._observer, {}) || v._observer === no_observer) {
             // No existing observer, so we install one
@@ -24036,7 +25493,7 @@ const _16ohhcn = function _observeOld(trace_variable,_,no_observer,isnode,toObje
                 const old = v._observer[type];
                 v._observer[type] = (...args) => {
                     if (v?._name === trace_variable) {
-                        void 0;
+                        debugger;
                         console.log(trace_variable, type, ...args);
                     }
                     // The old is often a prototype, so we use Reflect to call it
@@ -24063,7 +25520,7 @@ const _16ohhcn = function _observeOld(trace_variable,_,no_observer,isnode,toObje
                 cancels.add(() => v._observer[type] = old);
             });
             if (v?._name === trace_variable) {
-                void 0;
+                debugger;
                 console.log(`checking`, trace_variable, v, toObject(v), v._value);
             }
         }
@@ -24085,7 +25542,7 @@ const _16ohhcn = function _observeOld(trace_variable,_,no_observer,isnode,toObje
             // either in pending or error state, we can check by racing a promise
             getPromiseState(v._promise).then(({state, error, value}) => {
                 if (v?._name === trace_variable) {
-                    void 0;
+                    debugger;
                 }
                 if (state == 'rejected') {
                     if (observer.rejected)
@@ -24225,7 +25682,7 @@ Keep a named cell evaluated without a direct dataflow dependancy. Useful to keep
 const _12v8rf5 = function _keepalive(){return(
 (module, variable_name) => {
     if (variable_name === undefined)
-        void 0;
+        debugger;
     const name = `dynamic observe ${ variable_name }`;
     console.log(`keepalive: ${ name }`);
     if (module._scope.has(name))
@@ -24482,10 +25939,10 @@ md`### \`importShim\` polyfill
 
 Lopecode uses importShim which is not availible on Observablehq`
 )};
-const _12odeih = function _importShim() {
-    if (window.importShim)
-        return window.importShim;
-    return (url, options) => import(url);
+const _12odeih = function _importShim()
+{
+  if (window.importShim) return window.importShim;
+  return (url, options) => import(url);
 };
 const _1nrqtih = function _65(md){return(
 md`---`
@@ -24540,7 +25997,7 @@ export default function define(runtime, observer) {
   $def("_ya86a1", null, ["md"], _ya86a1);  
   $def("_tgfgv9", "trace_variable", [], _tgfgv9);  
   $def("_1hx65vf", "no_observer", ["main"], _1hx65vf);  
-  $def("_duwj4o", "observe", ["Element","Text","trace_variable","mutable trace_history","no_observer","queueMicrotask"], _duwj4o);  
+  $def("_18fhvl5", "observe", ["Element","Text","trace_variable","mutable trace_history","no_observer","queueMicrotask"], _18fhvl5);  
   $def("_16ohhcn", "observeOld", ["trace_variable","_","no_observer","isnode","toObject","queueMicrotask","getPromiseState"], _16ohhcn);  
   $def("_2kni3y", null, ["md"], _2kni3y);  
   $def("_1utnee9", "descendants", [], _1utnee9);  
@@ -26232,10 +27689,14 @@ const _1rosxg0 = function _data(){return(
   instance: new URL("https://google.com")
 }
 )};
-const _ygg2hv = function _summarizeJS(html,inspect,postProcess,MouseEvent){return(
+const _p715nx = function _summarizeJS(Node,html,inspect,postProcess,MouseEvent){return(
 function summarizeJS(value, { max_size = 5000 } = {}) {
   // Render the inspected HTML into a temporary <div>
-  const inspection = html`<div>${inspect(value)}`;
+  const inspected =
+    typeof Node !== "undefined" && value instanceof Node
+      ? value.cloneNode(true)
+      : value;
+  const inspection = html`<div>${inspect(inspected)}`;
   let text = postProcess(inspection);
   let prior = undefined;
 
@@ -26341,7 +27802,7 @@ export default function define(runtime, observer) {
   main.define("Inspector", ["module @tomlarkworthy/inspector", "@variable"], (_, v) => v.import("Inspector", _));  
   main.define("src", ["module @tomlarkworthy/inspector", "@variable"], (_, v) => v.import("src", _));  
   $def("_1rosxg0", "data", [], _1rosxg0);  
-  $def("_ygg2hv", "summarizeJS", ["html","inspect","postProcess","MouseEvent"], _ygg2hv);  
+  $def("_p715nx", "summarizeJS", ["Node","html","inspect","postProcess","MouseEvent"], _p715nx);  
   $def("_wtf5dq", "walked", ["postProcess","inspect","data"], _wtf5dq);  
   $def("_1l6vroc", "postProcess", ["walk"], _1l6vroc);  
   $def("_1brf10r", "TEXT", [], _1brf10r);  
@@ -28525,21 +29986,19 @@ md`## [Optional] Tests`
 const _11gtx14 = function _RUN_TESTS(){return(
 true
 )};
-const _46icxz = async function _testing(RUN_TESTS, invalidation) {
-    if (!RUN_TESTS)
-        return invalidation;
-    const [{Runtime}, {default: define}] = await Promise.all([
-        import('https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js'),
-        import(`https://api.observablehq.com/@tomlarkworthy/testing.js?v=3`)
-    ]);
-    const module = new Runtime().module(define);
-    return Object.fromEntries(await Promise.all([
-        'expect',
-        'createSuite'
-    ].map(n => module.value(n).then(v => [
-        n,
-        v
-    ]))));
+const _46icxz = async function _testing(RUN_TESTS,invalidation)
+{
+  if (!RUN_TESTS) return invalidation;
+  const [{ Runtime }, { default: define }] = await Promise.all([
+    import("https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js"),
+    import(`https://api.observablehq.com/@tomlarkworthy/testing.js?v=3`)
+  ]);
+  const module = new Runtime().module(define);
+  return Object.fromEntries(
+    await Promise.all(
+      ["expect", "createSuite"].map((n) => module.value(n).then((v) => [n, v]))
+    )
+  );
 };
 const _lf943y = function _suite(testing){return(
 testing.createSuite({
@@ -28775,13 +30234,14 @@ suite.test("Collection object creates matching keys", async () => {
   expect(v.value).toHaveProperty("a");
 })
 )};
-const _1qdb7yp = async function _toc() {
-    const [{Runtime}, {default: define}] = await Promise.all([
-        import('https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js'),
-        import(`https://api.observablehq.com/@nebrius/indented-toc.js?v=3`)
-    ]);
-    const module = new Runtime().module(define);
-    return module.value('toc');
+const _1qdb7yp = async function _toc()
+{
+  const [{ Runtime }, { default: define }] = await Promise.all([
+    import("https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js"),
+    import(`https://api.observablehq.com/@nebrius/indented-toc.js?v=3`)
+  ]);
+  const module = new Runtime().module(define);
+  return module.value("toc");
 };
 
 export default function define(runtime, observer) {
@@ -29210,7 +30670,7 @@ const _1xdl683 = function _renderImportCell(navHref){return(
   return span;
 }
 )};
-const _17pe3vk = function _syncers(observe,inspectors,$0,liveCellMap,createImportCellHeader,renderImportCell,variablesForCell,visualizers,$1)
+const _bbb3dg = function _syncers(observe,inspectors,$0,liveCellMap,createImportCellHeader,renderImportCell,variablesForCell,visualizers,$1)
 {
   const syncers = this || new Map();
 
@@ -29246,7 +30706,14 @@ const _17pe3vk = function _syncers(observe,inspectors,$0,liveCellMap,createImpor
       root,
       remove: () => {
         observers.delete(v);
-        observer?._node?.remove?.();
+        const node = observer?._node;
+        if (node) {
+          // Detach the variable's live element value
+          const val = v?._value;
+          if (val && val.nodeType && val.parentNode === node)
+            node.removeChild(val);
+          node.remove();
+        }
         unobserve?.();
       }
     };
@@ -29424,7 +30891,7 @@ export default function define(runtime, observer) {
   $def("_zodkh8", "createImportCellHeader", [], _zodkh8);  
   $def("_526jo", "variablesForCell", [], _526jo);  
   $def("_1xdl683", "renderImportCell", ["navHref"], _1xdl683);  
-  $def("_17pe3vk", "syncers", ["observe","inspectors","viewof visualizersToDelete","liveCellMap","createImportCellHeader","renderImportCell","variablesForCell","visualizers","viewof visualizers"], _17pe3vk);  
+  $def("_bbb3dg", "syncers", ["observe","inspectors","viewof visualizersToDelete","liveCellMap","createImportCellHeader","renderImportCell","variablesForCell","visualizers","viewof visualizers"], _bbb3dg);  
   $def("_een5pq", null, ["md"], _een5pq);  
   $def("_1wiz55o", "backgroundJobs", ["keepalive","visualizerModule"], _1wiz55o);  
   $def("_1oonsyz", "viewof visualizerModule", ["thisModule"], _1oonsyz);  
@@ -29505,167 +30972,6 @@ export default function define(runtime, observer) {
   return main;
 }</script>
 
-<script id="@tomlarkworthy/invoke-variable" 
-  type="text/plain"
-  data-mime="application/javascript"
->
-const _zkje0r = function _1(md){return(
-md`# \`invokeVariable(<name>, <module>, overrides = {})\`
-
-Test individual variables by calling them with injected values. Lets you test different scenarios without changing your core logic. Pairs with [@tomlarkworthy/tester](https://observablehq.com/@tomlarkworthy/tester)`
-)};
-const _kfe4ll = function _invokeVariable(lookupVariable){return(
-async function invokeVariable(name, module, overrides = {}) {
-  if (overrides == null || typeof overrides !== "object")
-    throw new TypeError(
-      "invokeVariable(name, module, {overrides}): overrides must be an object"
-    );
-
-  // Accept a Variable reference directly as the first arg (skip the lookupVariable stall when
-  // the caller already holds it); otherwise resolve by (name, module).
-  let variable;
-  if (name && typeof name === "object" && typeof name._definition !== "undefined") {
-    variable = name;
-    module = module ?? variable._module;
-  } else {
-    if (typeof name !== "string" || !name.length)
-      throw new TypeError(
-        "invokeVariable(name, module, …): name must be a non-empty string"
-      );
-    if (!module)
-      throw new TypeError("invokeVariable(name, module, …): module is required");
-    variable = await lookupVariable(name, module);
-    if (!variable)
-      throw new Error(`invokeVariable: variable "${name}" not found in module`);
-  }
-  module = module ?? variable._module;
-  const label = variable._name ?? (typeof name === "string" ? name : "(anonymous)");
-
-  const inputs = Array.isArray(variable._inputs) ? variable._inputs : [];
-  const inputNames = inputs.map((v) => v?._name);
-
-  for (const k of Object.keys(overrides)) {
-    if (!inputNames.includes(k)) {
-      throw new Error(
-        `invokeVariable("${label}"): override "${k}" was provided but is not a declared dependency. Declared dependencies: ${inputNames
-          .filter(Boolean)
-          .join(", ")}`
-      );
-    }
-  }
-
-  const hasOwn = (o, k) => Object.prototype.hasOwnProperty.call(o, k);
-
-  const resolveDependency = async (depName) => {
-    if (hasOwn(overrides, depName)) return overrides[depName];
-
-    const scopeVar =
-      module?._scope?.get?.(depName) ??
-      module?._runtime?._builtin?._scope?.get?.(depName);
-
-    if (scopeVar) {
-      if (scopeVar._value !== undefined) return scopeVar._value;
-      if (scopeVar._promise && typeof scopeVar._promise?.then === "function")
-        return await scopeVar._promise;
-    }
-
-    if (typeof module?.value === "function") {
-      try {
-        return await module.value(depName);
-      } catch (e) {}
-    }
-
-    if (module?._runtime && typeof module._runtime._global === "function") {
-      try {
-        const g = module._runtime._global(depName);
-        if (g !== undefined) return g;
-      } catch (e) {}
-    }
-
-    throw new Error(
-      `invokeVariable("${label}"): could not resolve dependency "${depName}" (no override and not found in module/builtins/global)`
-    );
-  };
-
-  const args = [];
-  for (const dep of inputs) {
-    const depName = dep?._name;
-    if (!depName) {
-      args.push(undefined);
-      continue;
-    }
-    args.push(await resolveDependency(depName));
-  }
-
-  const def = variable._definition;
-  if (typeof def !== "function") {
-    throw new Error(
-      `invokeVariable("${label}"): target variable does not have an invokable function definition`
-    );
-  }
-  return def(...args);
-}
-)};
-const _jtrr9m = function _3(md){return(
-md`### Example
-
-let c = a + b`
-)};
-const _1v2c0s1 = function _a(){return(
-1
-)};
-const _ywl8oh = function _b(){return(
-3
-)};
-const _1mc3tpl = function _c(a,b){return(
-a + b
-)};
-const _o5e50u = function _7(md){return(
-md`If we invoke c without any overrides we get the notebook behaviour (i.e. the answer is 4, as a is 1 and b is 3)`
-)};
-const _tnoyf9 = function _8(invokeVariable,invokeVariableModule){return(
-invokeVariable("c", invokeVariableModule)
-)};
-const _smh5by = function _9(md){return(
-md`But we can set b to 20, and then we get the answer 21.`
-)};
-const _d996jo = function _10(invokeVariable,invokeVariableModule){return(
-invokeVariable("c", invokeVariableModule, { b: 20 })
-)};
-const _qh0yhm = function _11(md){return(
-md`To call invokeVariable we need a reference to the module, which we can obtain with thisModule() (see runtime-sdk)`
-)};
-const _1hy0qcz = function _invokeVariableModule(thisModule){return(
-thisModule()
-)};
-const _jno7wc = (G, _) => G.input(_);
-
-export default function define(runtime, observer) {
-  const main = runtime.module();
-  const $def = (pid, name, deps, fn) => {
-    main.variable(observer(name)).define(name, deps, fn).pid = pid;
-  };
-
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
-  $def("_zkje0r", null, ["md"], _zkje0r);  
-  $def("_kfe4ll", "invokeVariable", ["lookupVariable"], _kfe4ll);  
-  $def("_jtrr9m", null, ["md"], _jtrr9m);  
-  $def("_1v2c0s1", "a", [], _1v2c0s1);  
-  $def("_ywl8oh", "b", [], _ywl8oh);  
-  $def("_1mc3tpl", "c", ["a","b"], _1mc3tpl);  
-  $def("_o5e50u", null, ["md"], _o5e50u);  
-  $def("_tnoyf9", null, ["invokeVariable","invokeVariableModule"], _tnoyf9);  
-  $def("_smh5by", null, ["md"], _smh5by);  
-  $def("_d996jo", null, ["invokeVariable","invokeVariableModule"], _d996jo);  
-  $def("_qh0yhm", null, ["md"], _qh0yhm);  
-  $def("_1hy0qcz", "viewof invokeVariableModule", ["thisModule"], _1hy0qcz);  
-  $def("_jno7wc", "invokeVariableModule", ["Generators","viewof invokeVariableModule"], _jno7wc);  
-  main.define("lookupVariable", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("lookupVariable", _));  
-  main.define("thisModule", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("thisModule", _));
-  return main;
-}
-</script>
-
 <!-- Bootloader -->
 <script id="bootconf.json"
         type="text/plain"
@@ -29674,7 +30980,8 @@ export default function define(runtime, observer) {
 {
   "mains": ["@tomlarkworthy/lopepage","@tomlarkworthy/bulk-jumpgate","@tomlarkworthy/jumpgate"],
   "hash": "#view=S100(@tomlarkworthy/bulk-jumpgate,@tomlarkworthy/module-selection)",
-  "headless": true
+  "headless": true,
+  "prerender": true
 }
 </script>
 <script id="@tomlarkworthy/bootloader" 
@@ -29730,68 +31037,68 @@ function _define_builtins(__ojs_runtime,stdlib,library,inputs)
 
 function _boot(define_builtins,conf,__ojs_runtime,location,__ojs_observer)
 {
-  define_builtins;
-  const tickMode = conf.tick;
-  if (tickMode && tickMode !== 'raf') {
-    let tick;
-    if (tickMode === 'messageChannel') {
-      const ch = new window.MessageChannel();
-      const q = [];
-      ch.port1.onmessage = () => {
-        const f = q.shift();
-        if (f)
-          f();
-      };
-      tick = cb => {
-        q.push(cb);
-        ch.port2.postMessage(0);
-      };
-    } else if (tickMode === 'microtask') {
-      tick = cb => window.queueMicrotask(cb);
-    } else if (tickMode === 'timeout') {
-      const delay = Number(conf.tickDelayMs) || 0;
-      tick = cb => setTimeout(cb, delay);
-    } else {
-      console.warn('[bootloader] unknown tick mode: ' + tickMode);
-    }
-    if (tick) {
-      const Runtime = Object.getPrototypeOf(__ojs_runtime).constructor;
-      Runtime.prototype._computeSoon = function () {
-        return new Promise(tick).then(() => this._disposed ? undefined : this._computeNow());
-      };
-      const suffix = tickMode === 'timeout' ? ' delayMs=' + (Number(conf.tickDelayMs) || 0) : '';
-      console.log('[bootloader] tick=' + tickMode + suffix);
-    }
-  }
-  if (conf.hash && !location.hash) {
-    location.hash = conf.hash;
-  }
-  const observer = conf.headless ? () => ({}) : __ojs_observer;
-  __ojs_runtime.mains = new Map();
-  window.__ojs_runtime = __ojs_runtime;
-  conf.mains.map(async name => {
-    console.log(`Bootloader: loading ${ name }`);
-    const module = await import(name);
-    const ojs_module = __ojs_runtime.module(module.default, observer);
-    if (conf.headless) {
-        // runtime.module() applies the observer only on first instantiation; if another main
-        // imported this module as a dependency first (e.g. save-in-place imports lopepage-2),
-        // the dedup drops the observer and the page's output cell is never observed -> blank
-        // page. Re-observe the module's unobserved cells IN PLACE (set the observer + mark
-        // dirty so the reachability pass enqueues them) so the mount is reachable regardless
-        // of load order, without adding synthetic variables the exporter would serialize.
-        let __reobserved = false;
-        for (const __v of __ojs_runtime._variables) {
-            if (__v._module === ojs_module && typeof __v._observer === 'symbol') {
-                __v._observer = observer(__v._name);
-                __ojs_runtime._dirty.add(__v);
-                __reobserved = true;
-            }
+    define_builtins;
+    const tickMode = conf.tick;
+    if (tickMode && tickMode !== 'raf') {
+        let tick;
+        if (tickMode === 'messageChannel') {
+            const ch = new window.MessageChannel();
+            const q = [];
+            ch.port1.onmessage = () => {
+                const f = q.shift();
+                if (f)
+                    f();
+            };
+            tick = cb => {
+                q.push(cb);
+                ch.port2.postMessage(0);
+            };
+        } else if (tickMode === 'microtask') {
+            tick = cb => window.queueMicrotask(cb);
+        } else if (tickMode === 'timeout') {
+            const delay = Number(conf.tickDelayMs) || 0;
+            tick = cb => setTimeout(cb, delay);
+        } else {
+            console.warn('[bootloader] unknown tick mode: ' + tickMode);
         }
-        if (__reobserved) __ojs_runtime._compute();
+        if (tick) {
+            const Runtime = Object.getPrototypeOf(__ojs_runtime).constructor;
+            Runtime.prototype._computeSoon = function () {
+                return new Promise(tick).then(() => this._disposed ? undefined : this._computeNow());
+            };
+            const suffix = tickMode === 'timeout' ? ' delayMs=' + (Number(conf.tickDelayMs) || 0) : '';
+            console.log('[bootloader] tick=' + tickMode + suffix);
+        }
     }
-    __ojs_runtime.mains.set(name, ojs_module);
-  });
+    if (conf.hash && !location.hash) {
+        location.hash = conf.hash;
+    }
+    const observer = conf.headless ? () => ({}) : __ojs_observer;
+    __ojs_runtime.mains = new Map();
+    window.__ojs_runtime = __ojs_runtime;
+    conf.mains.map(async name => {
+        console.log(`Bootloader: loading ${ name }`);
+        const module = await import(name);
+        const ojs_module = __ojs_runtime.module(module.default, observer);
+        if (conf.headless) {
+            // runtime.module() applies the observer only on first instantiation; if another main
+            // imported this module as a dependency first (e.g. save-in-place imports lopepage-2),
+            // the dedup drops the observer and the page's output cell is never observed -> blank
+            // page. Re-observe the module's unobserved cells IN PLACE (set the observer + mark
+            // dirty so the reachability pass enqueues them) so the mount is reachable regardless
+            // of load order, without adding synthetic variables the exporter would serialize.
+            let __reobserved = false;
+            for (const __v of __ojs_runtime._variables) {
+                if (__v._module === ojs_module && typeof __v._observer === 'symbol') {
+                    __v._observer = observer(__v._name);
+                    __ojs_runtime._dirty.add(__v);
+                    __reobserved = true;
+                }
+            }
+            if (__reobserved) __ojs_runtime._compute();
+        }
+        __ojs_runtime.mains.set(name, ojs_module);
+    });
 }
 
 

--- a/notebooks/jumpgates.json
+++ b/notebooks/jumpgates.json
@@ -1,5 +1,5 @@
 {
-  "notebook": "jumpgates.selfexport",
+  "notebook": "jumpgates-new",
   "title": "@tomlarkworthy/bulk-jumpgate",
   "bootconf": {
     "mains": [
@@ -8,7 +8,8 @@
       "@tomlarkworthy/jumpgate"
     ],
     "hash": "#view=S100(@tomlarkworthy/bulk-jumpgate,@tomlarkworthy/module-selection)",
-    "headless": true
+    "headless": true,
+    "prerender": true
   },
   "files": [
     "syntax.css"
@@ -24,7 +25,7 @@
       "hash": "5658858e85affa2e1e5cd1052924c622"
     },
     "@tomlarkworthy/bulk-jumpgate": {
-      "hash": "9e7d89fa0e77a2cc7eedb70ab6ed0a9e",
+      "hash": "c1ee86262119996737b0d8a92104cc08",
       "dependsOn": [
         "@tomlarkworthy/runtime-sdk",
         "@tomlarkworthy/flow-queue",
@@ -36,7 +37,7 @@
       ]
     },
     "@tomlarkworthy/jumpgate": {
-      "hash": "ac1667be7ab7a77537abd6b292727cf5",
+      "hash": "3f5e5510011d1f22fa3dc17104e09ce8",
       "files": [
         "image%20(7)%20(1).png"
       ],
@@ -56,7 +57,7 @@
       ]
     },
     "@tomlarkworthy/lopepage": {
-      "hash": "633f78d13e1da2ee746dc2c8598b5a24",
+      "hash": "ea085755ec5e24f0b29c4cc5f06a7a08",
       "dependsOn": [
         "@tomlarkworthy/golden-layout-2-6-0",
         "@tomlarkworthy/visualizer",
@@ -86,7 +87,7 @@
       ]
     },
     "@tomlarkworthy/acorn-8-11-3": {
-      "hash": "7d7821979f30fc573f0305942ef16d3a",
+      "hash": "a2c4eb96cb067e559536d9f841c2a8e1",
       "files": [
         "acorn-8.11.3.js.gz",
         "acorn-walk-8.3.2.js.gz"
@@ -121,7 +122,7 @@
       ]
     },
     "@tomlarkworthy/claude-code-pairing": {
-      "hash": "9ef62cada1525cf5d4987907f0362236",
+      "hash": "8cdd769d2694a74bad1003b20625a618",
       "dependsOn": [
         "@tomlarkworthy/module-map",
         "@tomlarkworthy/exporter-3",
@@ -137,7 +138,7 @@
       ]
     },
     "@tomlarkworthy/codemirror-6-v2": {
-      "hash": "80378ba570b5e43e8f978aa58a7aff02",
+      "hash": "4c719107756989ca8470b2b034bf7511",
       "files": [
         "codemirror_javascript%405.js.gz"
       ],
@@ -146,11 +147,13 @@
       ]
     },
     "@tomlarkworthy/command-palette": {
-      "hash": "4b7ce022a1bc9a4affa98c47552f828d",
+      "hash": "a3617c1f57904cbab42a34b069bf092a",
       "dependsOn": [
         "@tomlarkworthy/cell-map",
         "@tomlarkworthy/lopepage-urls",
-        "@tomlarkworthy/themes"
+        "@tomlarkworthy/themes",
+        "@tomlarkworthy/module-map",
+        "@tomlarkworthy/plugin-registry"
       ],
       "dependedBy": [
         "@tomlarkworthy/lopepage"
@@ -176,12 +179,13 @@
       ]
     },
     "@tomlarkworthy/editor-5": {
-      "hash": "a2515020f8ebd02054039cc37c1f9f07",
+      "hash": "e6e33733479672bd1d82a0fb15e4eb11",
       "files": [
         "cell_options.json"
       ],
       "dependsOn": [
         "@tomlarkworthy/visualizer",
+        "@tomlarkworthy/modules",
         "@tomlarkworthy/reversible-attachment",
         "@tomlarkworthy/flow-queue",
         "@tomlarkworthy/cell-map",
@@ -200,18 +204,10 @@
         "@tomlarkworthy/lopepage"
       ]
     },
-    "@tomlarkworthy/escodegen": {
-      "hash": "d5e793114a390617e9a70bfdd61a42ec",
-      "files": [
-        "escodegen.browser.min.js.gz"
-      ],
-      "dependedBy": [
-        "@tomlarkworthy/observablejs-toolchain"
-      ]
-    },
     "@tomlarkworthy/exporter-3": {
-      "hash": "a03eb2facd6eb3d78e35024417e0ec11",
+      "hash": "9e5fcccf1ed23acb071ad881f1f2e1e0",
       "dependsOn": [
+        "@tomlarkworthy/lopepage-urls",
         "@tomlarkworthy/observable-runtime-v6",
         "@tomlarkworthy/flow-queue",
         "@tomlarkworthy/cell-map",
@@ -235,7 +231,7 @@
       ]
     },
     "@tomlarkworthy/file-sync": {
-      "hash": "adcaf784830574cbacb4c069959714d6",
+      "hash": "62a784a1a576c5e851d8be48957cd894",
       "dependsOn": [
         "@tomlarkworthy/module-map",
         "@tomlarkworthy/exporter-3",
@@ -260,7 +256,7 @@
       ]
     },
     "@tomlarkworthy/flow-queue": {
-      "hash": "97db7ca44c394ea3f73a3f60f0d2ef6c",
+      "hash": "dd7a035f809162d101be55d55be97880",
       "files": [
         "flowQuery%401.svg"
       ],
@@ -273,7 +269,7 @@
       ]
     },
     "@tomlarkworthy/golden-layout-2-6-0": {
-      "hash": "24f5fad01bd508dd1bc3a49a99002770",
+      "hash": "3331ddc9fc7e65a246bfc1137961c766",
       "files": [
         "golden-layout-2.6.0.js.gz",
         "lm_popout_black.png",
@@ -309,8 +305,17 @@
         "@tomlarkworthy/visualizer"
       ]
     },
+    "@tomlarkworthy/invoke-variable": {
+      "hash": "eb72dd569c9e7f0de6e0b518cbe12fb4",
+      "dependsOn": [
+        "@tomlarkworthy/runtime-sdk"
+      ],
+      "dependedBy": [
+        "@tomlarkworthy/module-map"
+      ]
+    },
     "@tomlarkworthy/isomorphic-git-1-30-1": {
-      "hash": "16fa79b79fb4e9e1a2d03cfc9221147c",
+      "hash": "0cb9679e97bac6b63cba20a792de5389",
       "files": [
         "isomorphic-git-1%401.30.1.bundle.js.gz",
         "isomorphic-git-http-1.0.0-beta.36.js.gz"
@@ -321,7 +326,7 @@
       ]
     },
     "@tomlarkworthy/jest-expect-standalone": {
-      "hash": "418ef3328580c7b2416be5b9fc940db4",
+      "hash": "bd4d80b0911cd2fc3cc10c4f007f447f",
       "files": [
         "jest-expect-standalone-24.0.2.js.gz"
       ],
@@ -333,7 +338,7 @@
       ]
     },
     "@tomlarkworthy/jszip-3-10-1": {
-      "hash": "2b119c57e9c2ce093b3a9c7d2932d010",
+      "hash": "b171464c98410d02c097e34a8f4d2b71",
       "files": [
         "jszip-3.10.1.min.js.gz"
       ],
@@ -342,7 +347,7 @@
       ]
     },
     "@tomlarkworthy/lightning-fs-4-6-0": {
-      "hash": "1f60955582df75104615d8061957d237",
+      "hash": "6eb7adeb763a8295f1bfab78e46f11af",
       "files": [
         "lightning-fs-4.6.0.js.gz"
       ],
@@ -352,7 +357,7 @@
       ]
     },
     "@tomlarkworthy/local-change-history": {
-      "hash": "ea8ffc1745c311432d4c097a64021ccd",
+      "hash": "052efa3aa9b37e17ea391c4a4dbde687",
       "dependsOn": [
         "@tomlarkworthy/runtime-sdk",
         "@tomlarkworthy/lightning-fs-4-6-0",
@@ -389,6 +394,7 @@
         "@tomlarkworthy/cell-map",
         "@tomlarkworthy/command-palette",
         "@tomlarkworthy/editor-5",
+        "@tomlarkworthy/exporter-3",
         "@tomlarkworthy/module-map",
         "@tomlarkworthy/module-selection",
         "@tomlarkworthy/tests",
@@ -396,18 +402,20 @@
       ]
     },
     "@tomlarkworthy/module-map": {
-      "hash": "8d9f5df63bdf6a27c6c9882acf9d6501",
+      "hash": "18f327c993e00ae2ab3ab0cb21a27492",
       "dependsOn": [
         "@tomlarkworthy/lopepage-urls",
         "@tomlarkworthy/flow-queue",
         "@tomlarkworthy/observablejs-toolchain",
         "@tomlarkworthy/runtime-sdk",
+        "@tomlarkworthy/invoke-variable",
         "@tomlarkworthy/spectral-layout"
       ],
       "dependedBy": [
         "@tomlarkworthy/bulk-jumpgate",
         "@tomlarkworthy/cell-map",
         "@tomlarkworthy/claude-code-pairing",
+        "@tomlarkworthy/command-palette",
         "@tomlarkworthy/editor-5",
         "@tomlarkworthy/exporter-3",
         "@tomlarkworthy/file-sync",
@@ -433,8 +441,19 @@
         "@tomlarkworthy/lopepage"
       ]
     },
+    "@tomlarkworthy/modules": {
+      "hash": "1a8195ade0cf1a14d350785eeec762cd",
+      "dependsOn": [
+        "@tomlarkworthy/runtime-sdk",
+        "@tomlarkworthy/tests",
+        "@tomlarkworthy/observable-runtime-v6"
+      ],
+      "dependedBy": [
+        "@tomlarkworthy/editor-5"
+      ]
+    },
     "@tomlarkworthy/native-file-system-adapter": {
-      "hash": "8f6a2b4c072b492dcb114bdf21242cf3",
+      "hash": "973f2a71ee2975755fa41420f21828e5",
       "files": [
         "native-file-system-adapter%401.js.gz"
       ],
@@ -446,7 +465,7 @@
       ]
     },
     "@tomlarkworthy/observable-runtime": {
-      "hash": "4b60a23333fcadbc20650feae24d4039",
+      "hash": "e2e4c27c06b124cf3f3f880370d8755f",
       "files": [
         "runtime.js.gz"
       ],
@@ -457,13 +476,14 @@
       ]
     },
     "@tomlarkworthy/observable-runtime-v6": {
-      "hash": "6bc9db7b1881559c4d30c39f692e3969",
+      "hash": "cd421b0b3a2155578f1ef6d603b43258",
       "dependedBy": [
-        "@tomlarkworthy/exporter-3"
+        "@tomlarkworthy/exporter-3",
+        "@tomlarkworthy/modules"
       ]
     },
     "@tomlarkworthy/observablehq-lezer": {
-      "hash": "f827692f8b66b9b0f0cb8b9529f40815",
+      "hash": "49b46bb0bfedf68aea06e8d8a61d39d7",
       "files": [
         "lezer-lr-bundled.js.gz",
         "lezer-highlight-bundled.js.gz"
@@ -473,15 +493,13 @@
       ]
     },
     "@tomlarkworthy/observablejs-toolchain": {
-      "hash": "b89f6c3ca92136704f5c6c025db14cf0",
+      "hash": "ee645d9c91a19f749128621e7ec3f99f",
       "files": [
-        "acorn-walk-8.3.2.js.gz",
         "parser-6.1.0.js.gz"
       ],
       "dependsOn": [
         "@tomlarkworthy/tests",
         "@tomlarkworthy/cell-map",
-        "@tomlarkworthy/escodegen",
         "@tomlarkworthy/acorn-8-11-3",
         "@tomlarkworthy/jest-expect-standalone",
         "@tomlarkworthy/observable-runtime"
@@ -495,6 +513,12 @@
         "@tomlarkworthy/module-selection"
       ]
     },
+    "@tomlarkworthy/plugin-registry": {
+      "hash": "428298afcf9c9c8bb13c412d7c23b191",
+      "dependedBy": [
+        "@tomlarkworthy/command-palette"
+      ]
+    },
     "@tomlarkworthy/reversible-attachment": {
       "hash": "bd5c80a260b0ab92fd01205320224d30",
       "dependsOn": [
@@ -506,7 +530,7 @@
       ]
     },
     "@tomlarkworthy/runtime-sdk": {
-      "hash": "a43c34b9eb2d7000763b6b2758e0a17d",
+      "hash": "3c906717b0856e9bd1b4126925d91cf1",
       "dependsOn": [
         "@mootari/access-runtime"
       ],
@@ -520,12 +544,14 @@
         "@tomlarkworthy/file-sync",
         "@tomlarkworthy/fileattachments",
         "@tomlarkworthy/import-notebook",
+        "@tomlarkworthy/invoke-variable",
         "@tomlarkworthy/jumpgate",
         "@tomlarkworthy/local-change-history",
         "@tomlarkworthy/lopepage",
         "@tomlarkworthy/lopepage-urls",
         "@tomlarkworthy/module-map",
         "@tomlarkworthy/module-selection",
+        "@tomlarkworthy/modules",
         "@tomlarkworthy/native-file-system-adapter",
         "@tomlarkworthy/tests",
         "@tomlarkworthy/visualizer"
@@ -547,7 +573,7 @@
       ]
     },
     "@tomlarkworthy/summarizejs": {
-      "hash": "d5ca198f066bde101db6eed6086d55ed",
+      "hash": "6012d7554a1be7b899eb3e061154b130",
       "dependsOn": [
         "@tomlarkworthy/inspector"
       ],
@@ -567,6 +593,7 @@
       "dependedBy": [
         "@tomlarkworthy/cell-map",
         "@tomlarkworthy/lopepage-urls",
+        "@tomlarkworthy/modules",
         "@tomlarkworthy/observablejs-toolchain"
       ]
     },
@@ -587,14 +614,14 @@
       ]
     },
     "@tomlarkworthy/view": {
-      "hash": "970bf1f386002336660773d1215dd61f",
+      "hash": "c8bc708ea9f194c66bc203be5ed9bde5",
       "dependedBy": [
         "@tomlarkworthy/exporter-3",
         "@tomlarkworthy/reversible-attachment"
       ]
     },
     "@tomlarkworthy/visualizer": {
-      "hash": "006c7bdb86aaefd18519862f541538d9",
+      "hash": "72308ea706602b6b9d1d4836c0c3eea6",
       "dependsOn": [
         "@tomlarkworthy/inspector",
         "@tomlarkworthy/runtime-sdk",
@@ -610,7 +637,7 @@
       "hash": "913f1f6b56a3bbdfca30148905419a98"
     },
     "@tomlarkworthy/bootloader": {
-      "hash": "c54b8a089b467872c8065bac24d1a9ff"
+      "hash": "8f696c43527a8ceadc35bd1192292b4e"
     }
   },
   "upstreams": {
@@ -619,6 +646,6 @@
       "@tomlarkworthy/jumpgate": "https://observablehq.com/@tomlarkworthy/jumpgate"
     }
   },
-  "observable_version": 654,
-  "observable_update_time": "2026-05-16T05:43:50.964Z"
+  "observable_version": 655,
+  "observable_update_time": "2026-07-22T18:26:11.367Z"
 }


### PR DESCRIPTION
## What

Three related cleanups to `@tomlarkworthy/observablejs-toolchain`, plus the one
consumer change they force.

### 1. escodegen removed

`observableToJs` was refactored to slice original source by AST range instead of
regenerating it, so nothing in the toolchain regenerates code any more. Everything
escodegen still touched was vestigial or a demo:

| Cell | Why it went |
|---|---|
| `escodegenOptions` | only consumer was `decompile`, which never called it |
| `generate` | only consumer was `normalizeObservableSource` |
| `normalizeObservableSource` + demo cell | normalisation existed to paper over escodegen's re-quoting/respacing; source-preserving decompile makes it moot |
| `normalizeJavascriptSource` | same |
| `normalizeVariables` | nothing consumed it |
| `compiled_selector` (+ `viewof`) + its JSON demo cell | only consumer was the `normalizeJavascriptSource` demo |
| `decompile(…, escodegen, escodegenOptions)` | both parameters unused |
| `import {escodegen} from "@tomlarkworthy/escodegen"` | no remaining users |

None of those names is imported by any consumer — checked all 218 bundles that
carry the toolchain; the only imported names are `parser`, `compile`, `decompile`,
`cellMap`, `acorn`, `variableToObject`, `findModuleName`, `findImportedName`,
`decompileImport`, `sourceModule`, `decompress_url`, and `escodegen`.

That last one is the exception: **`@tomlarkworthy/exporter-3`** was importing
`escodegen` *through* the toolchain (a pass-through re-export) and uses it in
`restoreCanonicalImports`. It now imports `@tomlarkworthy/escodegen` directly.

> ⚠️ The toolchain and exporter-3 must move together. A bundle with the new
> toolchain and an old exporter-3 will fail to resolve `escodegen`. Both are
> updated in this notebook here; the same pairing applies to the ObservableHQ push
> and to any downstream re-jumpgate.

### 2. `stageB_importFake` was silently `undefined`

```js
return // Builds a Stage B (pre-observation, API-loaded) import group as POJOs.
// Mirrors what `runtime.define(...)` produces structurally...
function stageB_importFake(module_name, specifiers) { … }
```

`return` followed by a newline is `return;` — the four comment lines and the
function declaration after it were dead. All 9 `test_decompileImport_stageB_*`
tests failed with "stageB_importFake is not a function". The comments now live
inside the body.

With those tests actually running, two more defects surfaced:

- **`isStageB` rejected notebook-id imports.** Detection required the stitch
  variable to be named `module @…`, so `import {x} from "d/<hash>@<v>"` — whose
  stitch is `module d/<hash>@<v>` — fell through to `return null`. Relaxed to
  `module `, which matches the specifier filter a few lines below.
- **`test_decompileImport_stageB_order_independent` was over-specified.** It
  reversed the whole variable array, which reverses the aliases too;
  `decompileImport` reports specifiers in array order, so `{b, a}` was correct
  output. The test now moves only the stitch, which is what its own comment
  describes ("it shouldn't matter whether the stitch is at index 0").

### 3. `test_compile_import_*` expectations aligned

7 tests still expected the bare specifier:

```diff
- async () => runtime.module((await import("@tomlarkworthy/dependancy")).default)
+ async () => runtime.module((await import("/@tomlarkworthy/dependancy.js?v=4")).default)
```

`compile()` has emitted the decorated form since #181. **`compile()` is untouched
here** — this is a test-only change. Probed in a live bundle: bare,
`/x.js?v=4`, and the full `https://api.observablehq.com/x.js?v=4` all resolve
through the es-module-shims `resolve` hook (only an undecorated `/@user/x` 404s),
so the emitted form is not load-bearing and there was no reason to change runtime
behaviour to satisfy a test.

## Verification

- **108/108 tests pass** (baseline on `main`: 92/108 — 9 stageB + 7 compile_import).
- Re-verified after a **self-export round-trip** through exporter-3: the exported
  bundle still boots, still passes 108/108, `escodegen` still resolves inside
  exporter-3, and `@tomlarkworthy/escodegen` is still bundled (now pulled in via
  exporter-3 rather than the toolchain).
- Notebook is 145 lines lighter.

## Not included

- The module-store copies under `modules/@tomlarkworthy/` in the dev repo are not
  updated here (different repo, and `exporter-3.js` there already carries
  unrelated uncommitted edits).
- Not yet pushed to ObservableHQ and not propagated to the other 217 bundles —
  those carry a consistent old toolchain + old exporter-3 pair and are unaffected
  until re-jumpgated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)