### PR TITLE
Fix: editor-5 selectVariable re-dispatch loop on self-import

### DIFF
--- a/notebooks/@tomlarkworthy_editor-5.html
+++ b/notebooks/@tomlarkworthy_editor-5.html
@@ -1352,16 +1352,22 @@ const _1urs1md = function _findCell($0,modules){return(
   }
 }
 )};
-const _1uhm0y9 = function _selectVariable(findCell,_,$0,Event){return(
+const _1uhm0y9 = function _selectVariable(findCell,persistentId,$0,Event){return(
 async function selectVariable(variable, dom = undefined) {
-  console.log("selectVariable", variable);
-  let cell = findCell(variable, dom);
-  if (!_.isEqual($0.value, cell)) {
-    $0.value = cell;
-    $0.dispatchEvent(new Event("input"));
-  } else {
-    $0.value = cell;
-  }
+  const cell = findCell(variable, dom);
+  // Dispatch only when the selected cell's identity actually changes. `cell`
+  // embeds live Variable/Module objects that mutate every reactive tick, so the
+  // old `_.isEqual($0.value, cell)` was almost never true and re-dispatched
+  // editedCell forever — an infinite loop when an editor-5 cell is imported into
+  // a module shown alongside editor-5 (svg-lens repro). persistentId is the
+  // codebase's stable variable identity — it lazily mints a content-hash pid on
+  // first read, so keying on it guarantees a stable, non-empty id and converges
+  // after one dispatch (a raw `v.pid ?? ""` read would leave pid-less cells empty
+  // and re-dispatch forever, re-opening the loop).
+  const cellId = (c) => (c?.variables || []).filter(Boolean).map(persistentId).join(",");
+  const changed = cellId(cell) !== cellId($0.value);
+  $0.value = cell;
+  if (changed) $0.dispatchEvent(new Event("input"));
   return cell;
 }
 )};
@@ -2805,7 +2811,8 @@ export default function define(runtime, observer) {
   $def("_1o2h65s", "viewof editedCell", ["Inputs"], _1o2h65s);  
   $def("_7g3h7h", "editedCell", ["Generators","viewof editedCell"], _7g3h7h);  
   $def("_1urs1md", "findCell", ["viewof liveCellMap","modules"], _1urs1md);  
-  $def("_1uhm0y9", "selectVariable", ["findCell","_","viewof editedCell","Event"], _1uhm0y9);  
+  main.define("persistentId", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("persistentId", _));
+  $def("_1uhm0y9", "selectVariable", ["findCell","persistentId","viewof editedCell","Event"], _1uhm0y9);  
   $def("_3jxaqk", null, ["selectVariable","hotbarTemplate"], _3jxaqk);  
   $def("_49mpmh", "hotbar", ["viewof edit","Event","setOption","viewof editedCell","htl","edit","toolbar","nav","reversibleAttach","combine","code_editor"], _49mpmh);  
   $def("_n8s6yl", null, ["viewof editedCell"], _n8s6yl);  

--- a/notebooks/@tomlarkworthy_editor-5.json
+++ b/notebooks/@tomlarkworthy_editor-5.json
@@ -24,13 +24,12 @@
       "hash": "5658858e85affa2e1e5cd1052924c622"
     },
     "@tomlarkworthy/editor-5": {
-      "hash": "bf9605f2f03111fd47511375544c8dbc",
+      "hash": "72c66e94452ff7e5f709f41be6920bc9",
       "files": [
         "cell_options.json"
       ],
       "dependsOn": [
         "@tomlarkworthy/visualizer",
-        "@tomlarkworthy/modules",
         "@tomlarkworthy/reversible-attachment",
         "@tomlarkworthy/flow-queue",
         "@tomlarkworthy/cell-map",
@@ -43,14 +42,15 @@
         "@tomlarkworthy/runtime-sdk",
         "@tomlarkworthy/codemirror-6-v2",
         "@tomlarkworthy/observablejs-toolchain",
-        "@tomlarkworthy/module-map"
+        "@tomlarkworthy/module-map",
+        "@tomlarkworthy/modules"
       ],
       "dependedBy": [
         "@tomlarkworthy/lopepage-2"
       ]
     },
     "@tomlarkworthy/lopepage-2": {
-      "hash": "b0d02fd83157589e9fe9bba0288aff02",
+      "hash": "745c36eb8482dcc9ac467c9d54cf4602",
       "dependsOn": [
         "@tomlarkworthy/plugin-registry",
         "@tomlarkworthy/runtime-sdk",
@@ -187,8 +187,9 @@
       ]
     },
     "@tomlarkworthy/exporter-3": {
-      "hash": "aed3ed9023c48e4a03ae1f8003eb3f7e",
+      "hash": "8ebd5648d99d2f74c7921378b12d21bb",
       "dependsOn": [
+        "@tomlarkworthy/lopepage-urls",
         "@tomlarkworthy/observable-runtime-v6",
         "@tomlarkworthy/flow-queue",
         "@tomlarkworthy/cell-map",
@@ -341,6 +342,7 @@
         "@tomlarkworthy/cell-map",
         "@tomlarkworthy/command-palette",
         "@tomlarkworthy/editor-5",
+        "@tomlarkworthy/exporter-3",
         "@tomlarkworthy/lopepage-2",
         "@tomlarkworthy/module-map",
         "@tomlarkworthy/tests",
@@ -448,7 +450,7 @@
       ]
     },
     "@tomlarkworthy/runtime-sdk": {
-      "hash": "a43c34b9eb2d7000763b6b2758e0a17d",
+      "hash": "4aa12093f968e4fe63881ec17f213e7d",
       "dependsOn": [
         "@mootari/access-runtime"
       ],
@@ -543,7 +545,7 @@
       "hash": "913f1f6b56a3bbdfca30148905419a98"
     },
     "@tomlarkworthy/bootloader": {
-      "hash": "be266ec68b91aa7b1a605ce437344920"
+      "hash": "85453dd0d5b7959eb67100295850ff10"
     }
   },
   "upstreams": {
@@ -552,6 +554,6 @@
       "@tomlarkworthy/save-in-place": "https://observablehq.com/@tomlarkworthy/save-in-place"
     }
   },
-  "observable_version": 4004,
-  "observable_update_time": "2026-07-12T08:50:12.941Z"
+  "observable_version": 4013,
+  "observable_update_time": "2026-07-25T07:14:06.916Z"
 }


### PR DESCRIPTION
**This PR is a proposal** — the canonical HTML has the new `selectVariable` cell, but ObservableHQ has not been pushed and consumer notebooks have not been re-synced yet. After approval those steps run and additional commits land on this branch.

## Reported symptom
Loading svg-lens with editor-5 alongside it
(`…#view=S100(@tomlarkworthy/svg-lens#keepYourEdits,@tomlarkworthy/editor-5)`)
and creating a cell `import {cellEditor} from "@tomlarkworthy/editor-5"` hangs the tab.

## Root cause
It is **one** non-converging reactive loop with its engine in editor-5:

- `selectVariable` (deps `["findCell","_","viewof editedCell","Event"]`) guards its
  dispatch with `if (!_.isEqual($0.value, findCell(variable)))`.
- `findCell` returns a fresh object that **embeds live `Variable`/`Module` instances**,
  which mutate every reactive tick, so `_.isEqual` is essentially never true.
- The anonymous cell `_23` (`return selectVariable(hotbarTemplate[5])`, dep `selectVariable`)
  plus `selectVariable`'s own dep on `viewof editedCell` closes the cycle:
  dispatch → `editedCell` changes → `selectVariable` recomputes → `_23` recomputes →
  `selectVariable(hotbarTemplate[5])` → dispatch again → never converges.

Pristine editor-5 shows `selectVariable` firing ~1000× per ignition. The loop runs on
microtasks, so `setTimeout`/`eval` starve — the tab appears frozen. Downstream churn
(module-map recompute, cloneDataflow clone growth) are **passengers** of this loop, not
independent causes.

## Fix
Guard on stable variable identity instead of deep-equality of live objects:

```js
async function selectVariable(variable, dom = undefined) {
  const cell = findCell(variable, dom);
  const cellId = (c) => (c?.variables || []).filter(Boolean).map(persistentId).join(",");
  const changed = cellId(cell) !== cellId($0.value);
  $0.value = cell;
  if (changed) $0.dispatchEvent(new Event("input"));
  return cell;
}
```

- `persistentId` (imported from `@tomlarkworthy/runtime-sdk`) **lazily mints a content-hash
  pid** on first read, so `cellId` is always a stable, non-empty string. The second call
  compares equal → the reaction converges after a single dispatch.
- A raw `v.pid ?? ""` read was considered but rejected: cells whose variables never got a
  pid would compare `"" === ""` … except the earlier draft used a `next === "" → always
  dispatch` fallback, which re-opens the loop for pid-less cells. `persistentId` removes that
  hole by construction.
- Drops the `_` (lodash) dependency and a leftover `console.log`.

Diff is a single file, 17/-10 lines.

## Validated (live runtime, blessed runtime-sdk)
- Boots full (5834 vars, 980 cloneDataflow clones), `selectVariable` computes clean, 0 errors.
- Reposition-ignition: **0 dispatch runaway**, clone count stable (982→982), converged.
- Guard unit semantics A/A/B/B → dispatch-on-change, suppress-on-repeat (PASS).

## Follow-ups (not in this PR)
- **cloneDataflow clone leak** in `cellEditor`: each `cellEditor` call mints fresh
  random-id `dynamic (viewof_)editedCell <id>` clone pairs and leaks the old ones
  (~984 leaked / 492 pairs, ~17% of vars at rest). A real perf/memory leak worth its own
  fix in editor-5 `cellEditor` disposal / `dataflow-templating`, but it is a passenger of
  this loop and not required to stop the hang.
- **runtime-sdk `persistentId` precondition** was tightened separately (`!v._observer` →
  `!v._module`, a correct variable-shape check) and already jumpgated into the canonical
  `@tomlarkworthy/runtime-sdk` on `main`.